### PR TITLE
Fix incorrect symbol returning issue when using `symbol()` for typesdescs

### DIFF
--- a/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/invoker/classload/ImportsManager.java
+++ b/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/invoker/classload/ImportsManager.java
@@ -48,12 +48,6 @@ import java.util.regex.Pattern;
  */
 public class ImportsManager {
     private static final QuotedIdentifier ANON_SOURCE = new QuotedIdentifier("$");
-    // Regex patterns
-    private static final Pattern CLONEABLE_SIGNATURE_PATTERN =
-            Pattern.compile("readonly\\|xml<[^>]*>\\|ballerina/lang\\.value:[0-9]\\.[0-9]\\" +
-                                    ".[0-9]:Cloneable\\[]\\|map<ballerina/lang\\.value:[0-9]\\.[0-9]\\" +
-                                    ".[0-9]:Cloneable>\\|table<map<ballerina/lang\\.value:[0-9]\\.[0-9]\\" +
-                                    ".[0-9]:Cloneable>>");
     private static final Pattern FULLY_QUALIFIED_MODULE_ID_PATTERN =
             Pattern.compile("([\\w]+)/([\\w.]+):([^:]+):([\\w]+)[|]?");
     // Special imports
@@ -237,13 +231,8 @@ public class ImportsManager {
      */
     protected String extractImportsFromType(TypeSymbol typeSymbol, Set<QuotedIdentifier> imports) {
         String text = typeSymbol.signature();
-
-        // Replace all Cloneable with a qualified signature
-        String cloneableReplacedText = CLONEABLE_SIGNATURE_PATTERN.matcher(text)
-                .replaceAll(CLONEABLE_TYPE_DEF);
-
         StringBuilder newText = new StringBuilder();
-        Matcher matcher = FULLY_QUALIFIED_MODULE_ID_PATTERN.matcher(cloneableReplacedText);
+        Matcher matcher = FULLY_QUALIFIED_MODULE_ID_PATTERN.matcher(text);
         int nextStart = 0;
         // Matching Fully-Qualified-Module-IDs (eg.`abc/mod1:1.0.0`)
         // Purpose is to transform `int|abc/mod1:1.0.0:Person` into `int|mod1:Person` or `int|Person`

--- a/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/invoker/classload/ImportsManager.java
+++ b/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/invoker/classload/ImportsManager.java
@@ -50,7 +50,7 @@ public class ImportsManager {
     private static final QuotedIdentifier ANON_SOURCE = new QuotedIdentifier("$");
     // Regex patterns
     private static final Pattern CLONEABLE_SIGNATURE_PATTERN =
-            Pattern.compile("readonly\\|xml<[^>]*>\\|\\(Cloneable\\)\\[]\\|map<Cloneable>\\|table<map<Cloneable>>");
+            Pattern.compile("readonly\\|xml<[^>]*>\\|Cloneable\\[]\\|map<Cloneable>\\|table<map<Cloneable>>");
     private static final Pattern FULLY_QUALIFIED_MODULE_ID_PATTERN =
             Pattern.compile("([\\w]+)/([\\w.]+):([^:]+):([\\w]+)[|]?");
     // Special imports

--- a/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/invoker/classload/ImportsManager.java
+++ b/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/invoker/classload/ImportsManager.java
@@ -50,7 +50,10 @@ public class ImportsManager {
     private static final QuotedIdentifier ANON_SOURCE = new QuotedIdentifier("$");
     // Regex patterns
     private static final Pattern CLONEABLE_SIGNATURE_PATTERN =
-            Pattern.compile("readonly\\|xml<[^>]*>\\|Cloneable\\[]\\|map<Cloneable>\\|table<map<Cloneable>>");
+            Pattern.compile("readonly\\|xml<[^>]*>\\|ballerina/lang\\.value:[0-9]\\.[0-9]\\" +
+                                    ".[0-9]:Cloneable\\[]\\|map<ballerina/lang\\.value:[0-9]\\.[0-9]\\" +
+                                    ".[0-9]:Cloneable>\\|table<map<ballerina/lang\\.value:[0-9]\\.[0-9]\\" +
+                                    ".[0-9]:Cloneable>>");
     private static final Pattern FULLY_QUALIFIED_MODULE_ID_PATTERN =
             Pattern.compile("([\\w]+)/([\\w.]+):([^:]+):([\\w]+)[|]?");
     // Special imports

--- a/compiler/ballerina-lang/spotbugs-exclude.xml
+++ b/compiler/ballerina-lang/spotbugs-exclude.xml
@@ -84,7 +84,7 @@
     </Match>
     <Match>
         <Package name="io.ballerina.compiler.api.impl" />
-        <Bug pattern="BC_UNCONFIRMED_CAST, UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR" />
+        <Bug pattern="BC_UNCONFIRMED_CAST, UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR, BC_UNCONFIRMED_CAST_OF_RETURN_VALUE" />
     </Match>
     <Match>
         <Package name="io.ballerina.compiler.api.impl.symbols" />

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
@@ -332,7 +332,7 @@ public class BallerinaSemanticModel implements SemanticModel {
     }
 
     private boolean isTypeSymbol(BSymbol symbol) {
-        return symbol instanceof org.ballerinalang.model.symbols.TypeSymbol && !Symbols.isTagOn(symbol, PACKAGE)
+        return symbol instanceof BTypeSymbol && !Symbols.isTagOn(symbol, PACKAGE)
                 && !Symbols.isTagOn(symbol, ANNOTATION);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
@@ -17,11 +17,9 @@
  */
 package io.ballerina.compiler.api.impl;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.impl.symbols.AbstractTypeSymbol;
 import io.ballerina.compiler.api.impl.symbols.BallerinaSymbol;
-import io.ballerina.compiler.api.impl.symbols.BallerinaTypeReferenceTypeSymbol;
 import io.ballerina.compiler.api.impl.symbols.TypesFactory;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
@@ -276,9 +274,8 @@ public class BallerinaSemanticModel implements SemanticModel {
                 !(compilationUnit.getPackageID().equals(symbolAtCursor.pkgID)
                         && compilationUnit.getName().equals(symbolAtCursor.pos.lineRange().filePath())
                         && PositionUtil.withinBlock(position, symbolAtCursor.pos))) {
-            ModuleID moduleID = new BallerinaModuleID(symbolAtCursor.pkgID);
-            return Optional.of(new BallerinaTypeReferenceTypeSymbol(this.compilerContext, moduleID, symbolAtCursor.type,
-                                                                    symbolAtCursor.getName().getValue()));
+            return Optional.ofNullable(
+                    typesFactory.getTypeDescriptor(symbolAtCursor.type, (BTypeSymbol) symbolAtCursor));
         }
 
         return Optional.ofNullable(symbolFactory.getBCompiledSymbol(symbolAtCursor, symbolAtCursor.name.value));
@@ -335,7 +332,7 @@ public class BallerinaSemanticModel implements SemanticModel {
     }
 
     private boolean isTypeSymbol(BSymbol symbol) {
-        return symbol instanceof BTypeSymbol && !Symbols.isTagOn(symbol, PACKAGE)
+        return symbol instanceof org.ballerinalang.model.symbols.TypeSymbol && !Symbols.isTagOn(symbol, PACKAGE)
                 && !Symbols.isTagOn(symbol, ANNOTATION);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
@@ -403,7 +403,8 @@ public class SymbolFactory {
             symbolBuilder.withQualifier(Qualifier.PUBLIC);
         }
 
-        return symbolBuilder.withTypeDescriptor(typesFactory.getTypeDescriptor(typeSymbol.type, true)).build();
+        return symbolBuilder.withTypeDescriptor(typesFactory.getTypeDescriptor(typeSymbol.type, typeSymbol, true))
+                .build();
     }
 
     public BallerinaEnumSymbol createEnumSymbol(BEnumSymbol enumSymbol, String name) {
@@ -425,12 +426,12 @@ public class SymbolFactory {
 
         return symbolBuilder
                 .withMembers(members)
-                .withTypeDescriptor(typesFactory.getTypeDescriptor(enumSymbol.type, true))
+                .withTypeDescriptor(typesFactory.getTypeDescriptor(enumSymbol.type, enumSymbol, true))
                 .build();
     }
 
     public BallerinaClassSymbol createClassSymbol(BClassSymbol classSymbol, String name) {
-        TypeSymbol type = typesFactory.getTypeDescriptor(classSymbol.type, true);
+        TypeSymbol type = typesFactory.getTypeDescriptor(classSymbol.type, classSymbol, true);
         return createClassSymbol(classSymbol, name, type);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
@@ -1163,6 +1163,10 @@ class SymbolFinder extends BaseVisitor {
         lookupNode(tableType.constraint);
         lookupNode(tableType.tableKeySpecifier);
         lookupNode(tableType.tableKeyTypeConstraint);
+
+        if (this.symbolAtCursor == null) {
+            this.symbolAtCursor = tableType.type.type.tsymbol;
+        }
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
@@ -1152,6 +1152,10 @@ class SymbolFinder extends BaseVisitor {
     public void visit(BLangStreamType streamType) {
         lookupNode(streamType.constraint);
         lookupNode(streamType.error);
+
+        if (symbolAtCursor == null) {
+            this.symbolAtCursor = streamType.type.type.tsymbol;
+        }
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntersectionTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntersectionTypeSymbol.java
@@ -71,7 +71,9 @@ public class BallerinaIntersectionTypeSymbol extends AbstractTypeSymbol implemen
         }
 
         TypesFactory typesFactory = TypesFactory.getInstance(this.context);
-        this.effectiveType = typesFactory.getTypeDescriptor(((BIntersectionType) this.getBType()).effectiveType,
+        BType effectiveType = ((BIntersectionType) this.getBType()).effectiveType;
+        this.effectiveType = typesFactory.getTypeDescriptor(effectiveType,
+                                                            effectiveType != null ? effectiveType.tsymbol : null,
                                                             false, false);
         return this.effectiveType;
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeReferenceTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeReferenceTypeSymbol.java
@@ -27,6 +27,7 @@ import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.tools.diagnostics.Location;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BPackageSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Names;
@@ -50,18 +51,20 @@ public class BallerinaTypeReferenceTypeSymbol extends AbstractTypeSymbol impleme
     private ModuleSymbol module;
     private Symbol definition;
     private boolean moduleEvaluated;
+    private BTypeSymbol tSymbol;
 
     public BallerinaTypeReferenceTypeSymbol(CompilerContext context, ModuleID moduleID, BType bType,
-                                            String definitionName) {
+                                            BTypeSymbol tSymbol) {
         super(context, TypeDescKind.TYPE_REFERENCE, bType);
-        this.definitionName = definitionName;
+        this.definitionName = tSymbol != null ? tSymbol.getName().getValue() : null;
+        this.tSymbol = tSymbol;
     }
 
     @Override
     public TypeSymbol typeDescriptor() {
         if (this.typeDescriptorImpl == null) {
             TypesFactory typesFactory = TypesFactory.getInstance(this.context);
-            this.typeDescriptorImpl = typesFactory.getTypeDescriptor(this.getBType(), true);
+            this.typeDescriptorImpl = typesFactory.getTypeDescriptor(this.getBType(), this.tSymbol, true);
         }
 
         return this.typeDescriptorImpl;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/TypesFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/TypesFactory.java
@@ -328,7 +328,7 @@ public class TypesFactory {
             return false;
         }
 
-        if ((tSymbol.flags & Flags.ANONYMOUS) == Flags.ANONYMOUS) {
+        if (Symbols.isFlagOn(tSymbol.flags, Flags.ANONYMOUS)) {
             return false;
         }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/TypesFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/TypesFactory.java
@@ -71,16 +71,34 @@ import java.util.Set;
 import static org.ballerinalang.model.types.TypeKind.OBJECT;
 import static org.ballerinalang.model.types.TypeKind.PARAMETERIZED;
 import static org.ballerinalang.model.types.TypeKind.RECORD;
-import static org.wso2.ballerinalang.compiler.util.TypeTags.FINITE;
+import static org.wso2.ballerinalang.compiler.util.TypeTags.ANY;
+import static org.wso2.ballerinalang.compiler.util.TypeTags.ANYDATA;
+import static org.wso2.ballerinalang.compiler.util.TypeTags.BOOLEAN;
+import static org.wso2.ballerinalang.compiler.util.TypeTags.BYTE;
+import static org.wso2.ballerinalang.compiler.util.TypeTags.DECIMAL;
+import static org.wso2.ballerinalang.compiler.util.TypeTags.ERROR;
+import static org.wso2.ballerinalang.compiler.util.TypeTags.FLOAT;
+import static org.wso2.ballerinalang.compiler.util.TypeTags.FUTURE;
+import static org.wso2.ballerinalang.compiler.util.TypeTags.HANDLE;
+import static org.wso2.ballerinalang.compiler.util.TypeTags.INT;
+import static org.wso2.ballerinalang.compiler.util.TypeTags.JSON;
+import static org.wso2.ballerinalang.compiler.util.TypeTags.MAP;
+import static org.wso2.ballerinalang.compiler.util.TypeTags.NEVER;
+import static org.wso2.ballerinalang.compiler.util.TypeTags.NIL;
 import static org.wso2.ballerinalang.compiler.util.TypeTags.NONE;
+import static org.wso2.ballerinalang.compiler.util.TypeTags.READONLY;
 import static org.wso2.ballerinalang.compiler.util.TypeTags.SEMANTIC_ERROR;
 import static org.wso2.ballerinalang.compiler.util.TypeTags.SIGNED16_INT;
 import static org.wso2.ballerinalang.compiler.util.TypeTags.SIGNED32_INT;
 import static org.wso2.ballerinalang.compiler.util.TypeTags.SIGNED8_INT;
-import static org.wso2.ballerinalang.compiler.util.TypeTags.UNION;
+import static org.wso2.ballerinalang.compiler.util.TypeTags.STREAM;
+import static org.wso2.ballerinalang.compiler.util.TypeTags.STRING;
+import static org.wso2.ballerinalang.compiler.util.TypeTags.TABLE;
+import static org.wso2.ballerinalang.compiler.util.TypeTags.TYPEDESC;
 import static org.wso2.ballerinalang.compiler.util.TypeTags.UNSIGNED16_INT;
 import static org.wso2.ballerinalang.compiler.util.TypeTags.UNSIGNED32_INT;
 import static org.wso2.ballerinalang.compiler.util.TypeTags.UNSIGNED8_INT;
+import static org.wso2.ballerinalang.compiler.util.TypeTags.XML;
 import static org.wso2.ballerinalang.compiler.util.TypeTags.XML_COMMENT;
 import static org.wso2.ballerinalang.compiler.util.TypeTags.XML_ELEMENT;
 import static org.wso2.ballerinalang.compiler.util.TypeTags.XML_PI;
@@ -314,7 +332,7 @@ public class TypesFactory {
             return false;
         }
 
-        if ((bType.tag == UNION || bType.tag == FINITE) && !tSymbol.name.value.isEmpty()) {
+        if (!isBuiltinNamedType(bType.tag) && !tSymbol.name.value.isEmpty()) {
             return true;
         }
 
@@ -396,5 +414,34 @@ public class TypesFactory {
 
     private static boolean isCustomError(BTypeSymbol tSymbol) {
         return tSymbol.kind == SymbolKind.ERROR && !Names.ERROR.equals(tSymbol.name);
+    }
+
+    private static boolean isBuiltinNamedType(int tag) {
+        switch (tag) {
+            case INT:
+            case BYTE:
+            case FLOAT:
+            case DECIMAL:
+            case STRING:
+            case BOOLEAN:
+            case JSON:
+            case XML:
+            case NIL:
+            case ANY:
+            case ANYDATA:
+            case HANDLE:
+            case READONLY:
+            case NEVER:
+            case MAP:
+            case STREAM:
+            case TYPEDESC:
+            case TABLE:
+            case ERROR:
+            case FUTURE:
+            case SEMANTIC_ERROR:
+                return true;
+        }
+
+        return false;
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/TypesFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/TypesFactory.java
@@ -324,7 +324,10 @@ public class TypesFactory {
     }
 
     private static boolean isTypeReference(BType bType, BTypeSymbol tSymbol, boolean rawTypeOnly) {
-        if (rawTypeOnly || tSymbol == null) {
+        // Not considering type params as type refs for now because having it in the typedesc form will make more
+        // sense for end users of the API consumers (e.g., VS Code plugin users). This probably can be removed once
+        // https://github.com/ballerina-platform/ballerina-lang/issues/18150 is fixed.
+        if (rawTypeOnly || tSymbol == null || Symbols.isFlagOn(tSymbol.flags, Flags.TYPE_PARAM)) {
             return false;
         }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/TypesFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/TypesFactory.java
@@ -167,6 +167,7 @@ public class TypesFactory {
             Optional<BIntersectionType> intersectionType = ((IntersectableReferenceType) bType).getIntersectionType();
             if (intersectionType.isPresent()) {
                 bType = intersectionType.get();
+                tSymbol = bType.tsymbol;
             }
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -2070,8 +2070,7 @@ public class SymbolResolver extends BLangNodeVisitor {
 
         BTypeSymbol intersectionTypeSymbol = Symbols.createTypeSymbol(SymTag.INTERSECTION_TYPE,
                                                                       Flags.asMask(EnumSet.of(Flag.PUBLIC)),
-                                                                      null,
-                                                                      pkgId, null, owner,
+                                                                      Names.EMPTY, pkgId, null, owner,
                                                                       symTable.builtinPos, VIRTUAL);
 
         BIntersectionType intersectionType = new BIntersectionType(intersectionTypeSymbol, constituentBTypes,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -4534,7 +4534,7 @@ public class Types {
 
     public BErrorType createErrorType(BType detailType, long flags, SymbolEnv env) {
         String name = anonymousModelHelper.getNextAnonymousIntersectionErrorTypeName(env.enclPkg.packageID);
-        BErrorTypeSymbol errorTypeSymbol = Symbols.createErrorSymbol(flags, names.fromString(name),
+        BErrorTypeSymbol errorTypeSymbol = Symbols.createErrorSymbol(flags | Flags.ANONYMOUS, names.fromString(name),
                                                                      env.enclPkg.symbol.pkgID, null,
                                                                      env.scope.owner, symTable.builtinPos, VIRTUAL);
         errorTypeSymbol.scope = new Scope(errorTypeSymbol);

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/remote_action_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/remote_action_config1.json
@@ -6,13 +6,13 @@
   "source": "action_node_context/source/remote_action_source1.bal",
   "items": [
     {
-      "label": "post(string path, string|xml<xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text>|json|byte[] message, string targetType)(module1:Response)",
+      "label": "post(string path, RequestMessage message, string targetType)(module1:Response)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThe `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n  \n**Params**  \n- `string` path: Resource path  \n- `string|xml<xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text>|json|byte[]` message: An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`  \n- `string` targetType: Specifies the target type(Defaultable)  \n  \n**Returns** `module1:Response`   \n- The response for the request  \n  \n"
+          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThe `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n  \n**Params**  \n- `string` path: Resource path  \n- `RequestMessage` message: An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`  \n- `string` targetType: Specifies the target type(Defaultable)  \n  \n**Returns** `module1:Response`   \n- The response for the request  \n  \n"
         }
       },
       "sortText": "C",

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/remote_action_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/remote_action_config2.json
@@ -6,13 +6,13 @@
   "source": "action_node_context/source/remote_action_source2.bal",
   "items": [
     {
-      "label": "post(string path, string|xml<xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text>|json|byte[] message, string targetType)(module1:Response)",
+      "label": "post(string path, RequestMessage message, string targetType)(module1:Response)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThe `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n  \n**Params**  \n- `string` path: Resource path  \n- `string|xml<xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text>|json|byte[]` message: An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`  \n- `string` targetType: Specifies the target type(Defaultable)  \n  \n**Returns** `module1:Response`   \n- The response for the request  \n  \n"
+          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThe `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n  \n**Params**  \n- `string` path: Resource path  \n- `RequestMessage` message: An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`  \n- `string` targetType: Specifies the target type(Defaultable)  \n  \n**Returns** `module1:Response`   \n- The response for the request  \n  \n"
         }
       },
       "sortText": "C",

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/remote_action_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/remote_action_config3.json
@@ -6,13 +6,13 @@
   "source": "action_node_context/source/remote_action_source3.bal",
   "items": [
     {
-      "label": "post(string path, string|xml<xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text>|json|byte[] message, string targetType)(mod:Response)",
+      "label": "post(string path, RequestMessage message, string targetType)(mod:Response)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThe `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n  \n**Params**  \n- `string` path: Resource path  \n- `string|xml<xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text>|json|byte[]` message: An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`  \n- `string` targetType: Specifies the target type(Defaultable)  \n  \n**Returns** `mod:Response`   \n- The response for the request  \n  \n"
+          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThe `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n  \n**Params**  \n- `string` path: Resource path  \n- `RequestMessage` message: An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`  \n- `string` targetType: Specifies the target type(Defaultable)  \n  \n**Returns** `mod:Response`   \n- The response for the request  \n  \n"
         }
       },
       "sortText": "C",

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/remote_action_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/remote_action_config4.json
@@ -6,13 +6,13 @@
   "source": "action_node_context/source/remote_action_source4.bal",
   "items": [
     {
-      "label": "post(string path, string|xml<xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text>|json|byte[] message, string targetType)(mod:Response)",
+      "label": "post(string path, RequestMessage message, string targetType)(mod:Response)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThe `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n  \n**Params**  \n- `string` path: Resource path  \n- `string|xml<xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text>|json|byte[]` message: An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`  \n- `string` targetType: Specifies the target type(Defaultable)  \n  \n**Returns** `mod:Response`   \n- The response for the request  \n  \n"
+          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThe `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n  \n**Params**  \n- `string` path: Resource path  \n- `RequestMessage` message: An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`  \n- `string` targetType: Specifies the target type(Defaultable)  \n  \n**Returns** `mod:Response`   \n- The response for the request  \n  \n"
         }
       },
       "sortText": "C",

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/remote_action_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/remote_action_config5.json
@@ -6,13 +6,13 @@
   "source": "action_node_context/source/remote_action_source5.bal",
   "items": [
     {
-      "label": "post(string path, string|xml<xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text>|json|byte[] message, string targetType)(module1:Response)",
+      "label": "post(string path, RequestMessage message, string targetType)(module1:Response)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThe `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n  \n**Params**  \n- `string` path: Resource path  \n- `string|xml<xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text>|json|byte[]` message: An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`  \n- `string` targetType: Specifies the target type(Defaultable)  \n  \n**Returns** `module1:Response`   \n- The response for the request  \n  \n"
+          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThe `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n  \n**Params**  \n- `string` path: Resource path  \n- `RequestMessage` message: An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`  \n- `string` targetType: Specifies the target type(Defaultable)  \n  \n**Returns** `module1:Response`   \n- The response for the request  \n  \n"
         }
       },
       "sortText": "C",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config1.json
@@ -66,13 +66,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "reduce(function () func, any|error initial)(any|error)",
+      "label": "reduce(function () func, Type1 initial)(Type1)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `any|error` initial: initial value for the first argument of combining function `func`  \n  \n**Returns** `any|error`   \n- result of combining the members of `m` using `func`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `Type1` initial: initial value for the first argument of combining function `func`  \n  \n**Returns** `Type1`   \n- result of combining the members of `m` using `func`  \n  \n"
         }
       },
       "sortText": "D",
@@ -153,13 +153,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "remove(string k)(any|error)",
+      "label": "remove(string k)(Type)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- the member of `m` that had key `k`  \nThis removes the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type`   \n- the member of `m` that had key `k`  \nThis removes the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
         }
       },
       "sortText": "D",
@@ -172,13 +172,13 @@
       }
     },
     {
-      "label": "filter(function () func)(map<any|error>)",
+      "label": "filter(function () func)(map<Type>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<any|error>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<Type>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
         }
       },
       "sortText": "D",
@@ -191,13 +191,13 @@
       }
     },
     {
-      "label": "removeIfHasKey(string k)(any|error?)",
+      "label": "removeIfHasKey(string k)(Type?)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
         }
       },
       "sortText": "D",
@@ -210,13 +210,13 @@
       }
     },
     {
-      "label": "iterator()(object {public isolated function next() returns record {| any|error value; |}? ;})",
+      "label": "iterator()(object {public isolated function next() returns record {| Type value; |}? ;})",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| any|error value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| Type value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
         }
       },
       "sortText": "D",
@@ -225,13 +225,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "entries()(map<[string, any|error]>)",
+      "label": "entries()(map<[string, Type]>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, any|error]>`   \n- a new map of [key, member] pairs  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, Type]>`   \n- a new map of [key, member] pairs  \n  \n"
         }
       },
       "sortText": "D",
@@ -255,13 +255,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "get(string k)(any|error)",
+      "label": "get(string k)(Type)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- member with key `k`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type`   \n- member with key `k`  \n  \n"
         }
       },
       "sortText": "D",
@@ -274,13 +274,13 @@
       }
     },
     {
-      "label": "toArray()((any|error)[])",
+      "label": "toArray()(Type[])",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- an array whose members are the members of `m`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `Type[]`   \n- an array whose members are the members of `m`  \n  \n"
         }
       },
       "sortText": "D",
@@ -289,13 +289,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)(map<any|error>)",
+      "label": "map(function () func)(map<Type1>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<any|error>`   \n- new map containing result of applying function `func` to each member  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<Type1>`   \n- new map containing result of applying function `func` to each member  \n  \n"
         }
       },
       "sortText": "D",
@@ -327,13 +327,13 @@
       }
     },
     {
-      "label": "cloneReadOnly()(Cloneable & readonly)",
+      "label": "cloneReadOnly()(CloneableType & readonly)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable & readonly`   \n- immutable clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType & readonly`   \n- immutable clone of `v`  \n  \n"
         }
       },
       "sortText": "D",
@@ -387,13 +387,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "clone()(Cloneable)",
+      "label": "clone()(CloneableType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- clone of `v`  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config1.json
@@ -66,13 +66,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "reduce(function () func, Type1 initial)(Type1)",
+      "label": "reduce(function () func, any|error initial)(any|error)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `Type1` initial: initial value for the first argument of combining function `func`  \n  \n**Returns** `Type1`   \n- result of combining the members of `m` using `func`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `any|error` initial: initial value for the first argument of combining function `func`  \n  \n**Returns** `any|error`   \n- result of combining the members of `m` using `func`  \n  \n"
         }
       },
       "sortText": "D",
@@ -153,13 +153,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "remove(string k)(Type)",
+      "label": "remove(string k)(any|error)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type`   \n- the member of `m` that had key `k`  \nThis removes the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- the member of `m` that had key `k`  \nThis removes the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
         }
       },
       "sortText": "D",
@@ -172,13 +172,13 @@
       }
     },
     {
-      "label": "filter(function () func)(map<Type>)",
+      "label": "filter(function () func)(map<any|error>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<Type>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<any|error>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
         }
       },
       "sortText": "D",
@@ -191,13 +191,13 @@
       }
     },
     {
-      "label": "removeIfHasKey(string k)(Type?)",
+      "label": "removeIfHasKey(string k)(any|error?)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
         }
       },
       "sortText": "D",
@@ -210,13 +210,13 @@
       }
     },
     {
-      "label": "iterator()(object {public isolated function next() returns record {| Type value; |}? ;})",
+      "label": "iterator()(object {public isolated function next() returns record {| any|error value; |}? ;})",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| Type value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| any|error value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
         }
       },
       "sortText": "D",
@@ -225,13 +225,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "entries()(map<[string, Type]>)",
+      "label": "entries()(map<[string, any|error]>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, Type]>`   \n- a new map of [key, member] pairs  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, any|error]>`   \n- a new map of [key, member] pairs  \n  \n"
         }
       },
       "sortText": "D",
@@ -255,13 +255,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "get(string k)(Type)",
+      "label": "get(string k)(any|error)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type`   \n- member with key `k`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- member with key `k`  \n  \n"
         }
       },
       "sortText": "D",
@@ -274,13 +274,13 @@
       }
     },
     {
-      "label": "toArray()(Type[])",
+      "label": "toArray()((any|error)[])",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `Type[]`   \n- an array whose members are the members of `m`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- an array whose members are the members of `m`  \n  \n"
         }
       },
       "sortText": "D",
@@ -289,13 +289,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)(map<Type1>)",
+      "label": "map(function () func)(map<any|error>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<Type1>`   \n- new map containing result of applying function `func` to each member  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<any|error>`   \n- new map containing result of applying function `func` to each member  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config10.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config10.json
@@ -25,13 +25,13 @@
       }
     },
     {
-      "label": "cloneReadOnly()(Cloneable & readonly)",
+      "label": "cloneReadOnly()(CloneableType & readonly)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable & readonly`   \n- immutable clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType & readonly`   \n- immutable clone of `v`  \n  \n"
         }
       },
       "sortText": "D",
@@ -85,13 +85,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "clone()(Cloneable)",
+      "label": "clone()(CloneableType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- clone of `v`  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config11.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config11.json
@@ -22,13 +22,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "reduce(function () func, Type1 initial)(Type1)",
+      "label": "reduce(function () func, any|error initial)(any|error)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `Type1` initial: initial value for the first argument of combining function `func`  \n  \n**Returns** `Type1`   \n- result of combining the members of `m` using `func`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `any|error` initial: initial value for the first argument of combining function `func`  \n  \n**Returns** `any|error`   \n- result of combining the members of `m` using `func`  \n  \n"
         }
       },
       "sortText": "D",
@@ -109,13 +109,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "remove(string k)(Type)",
+      "label": "remove(string k)(any|error)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type`   \n- the member of `m` that had key `k`  \nThis removes the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- the member of `m` that had key `k`  \nThis removes the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
         }
       },
       "sortText": "D",
@@ -128,13 +128,13 @@
       }
     },
     {
-      "label": "filter(function () func)(map<Type>)",
+      "label": "filter(function () func)(map<any|error>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<Type>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<any|error>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
         }
       },
       "sortText": "D",
@@ -147,13 +147,13 @@
       }
     },
     {
-      "label": "removeIfHasKey(string k)(Type?)",
+      "label": "removeIfHasKey(string k)(any|error?)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
         }
       },
       "sortText": "D",
@@ -166,13 +166,13 @@
       }
     },
     {
-      "label": "iterator()(object {public isolated function next() returns record {| Type value; |}? ;})",
+      "label": "iterator()(object {public isolated function next() returns record {| any|error value; |}? ;})",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| Type value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| any|error value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
         }
       },
       "sortText": "D",
@@ -181,13 +181,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "entries()(map<[string, Type]>)",
+      "label": "entries()(map<[string, any|error]>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, Type]>`   \n- a new map of [key, member] pairs  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, any|error]>`   \n- a new map of [key, member] pairs  \n  \n"
         }
       },
       "sortText": "D",
@@ -211,13 +211,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "get(string k)(Type)",
+      "label": "get(string k)(any|error)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type`   \n- member with key `k`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- member with key `k`  \n  \n"
         }
       },
       "sortText": "D",
@@ -230,13 +230,13 @@
       }
     },
     {
-      "label": "toArray()(Type[])",
+      "label": "toArray()((any|error)[])",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `Type[]`   \n- an array whose members are the members of `m`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- an array whose members are the members of `m`  \n  \n"
         }
       },
       "sortText": "D",
@@ -245,13 +245,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)(map<Type1>)",
+      "label": "map(function () func)(map<any|error>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<Type1>`   \n- new map containing result of applying function `func` to each member  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<any|error>`   \n- new map containing result of applying function `func` to each member  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config11.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config11.json
@@ -22,13 +22,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "reduce(function () func, any|error initial)(any|error)",
+      "label": "reduce(function () func, Type1 initial)(Type1)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `any|error` initial: initial value for the first argument of combining function `func`  \n  \n**Returns** `any|error`   \n- result of combining the members of `m` using `func`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `Type1` initial: initial value for the first argument of combining function `func`  \n  \n**Returns** `Type1`   \n- result of combining the members of `m` using `func`  \n  \n"
         }
       },
       "sortText": "D",
@@ -109,13 +109,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "remove(string k)(any|error)",
+      "label": "remove(string k)(Type)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- the member of `m` that had key `k`  \nThis removes the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type`   \n- the member of `m` that had key `k`  \nThis removes the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
         }
       },
       "sortText": "D",
@@ -128,13 +128,13 @@
       }
     },
     {
-      "label": "filter(function () func)(map<any|error>)",
+      "label": "filter(function () func)(map<Type>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<any|error>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<Type>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
         }
       },
       "sortText": "D",
@@ -147,13 +147,13 @@
       }
     },
     {
-      "label": "removeIfHasKey(string k)(any|error?)",
+      "label": "removeIfHasKey(string k)(Type?)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
         }
       },
       "sortText": "D",
@@ -166,13 +166,13 @@
       }
     },
     {
-      "label": "iterator()(object {public isolated function next() returns record {| any|error value; |}? ;})",
+      "label": "iterator()(object {public isolated function next() returns record {| Type value; |}? ;})",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| any|error value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| Type value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
         }
       },
       "sortText": "D",
@@ -181,13 +181,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "entries()(map<[string, any|error]>)",
+      "label": "entries()(map<[string, Type]>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, any|error]>`   \n- a new map of [key, member] pairs  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, Type]>`   \n- a new map of [key, member] pairs  \n  \n"
         }
       },
       "sortText": "D",
@@ -211,13 +211,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "get(string k)(any|error)",
+      "label": "get(string k)(Type)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- member with key `k`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type`   \n- member with key `k`  \n  \n"
         }
       },
       "sortText": "D",
@@ -230,13 +230,13 @@
       }
     },
     {
-      "label": "toArray()((any|error)[])",
+      "label": "toArray()(Type[])",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- an array whose members are the members of `m`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `Type[]`   \n- an array whose members are the members of `m`  \n  \n"
         }
       },
       "sortText": "D",
@@ -245,13 +245,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)(map<any|error>)",
+      "label": "map(function () func)(map<Type1>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<any|error>`   \n- new map containing result of applying function `func` to each member  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<Type1>`   \n- new map containing result of applying function `func` to each member  \n  \n"
         }
       },
       "sortText": "D",
@@ -283,13 +283,13 @@
       }
     },
     {
-      "label": "cloneReadOnly()(Cloneable & readonly)",
+      "label": "cloneReadOnly()(CloneableType & readonly)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable & readonly`   \n- immutable clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType & readonly`   \n- immutable clone of `v`  \n  \n"
         }
       },
       "sortText": "D",
@@ -343,13 +343,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "clone()(Cloneable)",
+      "label": "clone()(CloneableType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- clone of `v`  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config13.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config13.json
@@ -25,13 +25,13 @@
       }
     },
     {
-      "label": "cloneReadOnly()(Cloneable & readonly)",
+      "label": "cloneReadOnly()(CloneableType & readonly)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable & readonly`   \n- immutable clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType & readonly`   \n- immutable clone of `v`  \n  \n"
         }
       },
       "sortText": "D",
@@ -85,13 +85,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "clone()(Cloneable)",
+      "label": "clone()(CloneableType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- clone of `v`  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config16.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config16.json
@@ -93,13 +93,13 @@
       }
     },
     {
-      "label": "cloneReadOnly()(Cloneable & readonly)",
+      "label": "cloneReadOnly()(CloneableType & readonly)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable & readonly`   \n- immutable clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType & readonly`   \n- immutable clone of `v`  \n  \n"
         }
       },
       "sortText": "D",
@@ -191,13 +191,13 @@
       }
     },
     {
-      "label": "clone()(Cloneable)",
+      "label": "clone()(CloneableType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- clone of `v`  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config17.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config17.json
@@ -6,13 +6,13 @@
   "source": "expression_context/source/field_access_ctx_source17.bal",
   "items": [
     {
-      "label": "next()(record {| Type value; |}?)",
+      "label": "next()(record {| any|error value; |}?)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array:1.1.0_  \n  \n  \n  \n  \n**Returns** `record {| Type value; |}?`   \n  \n"
+          "value": "**Package:** _ballerina/lang.array:1.1.0_  \n  \n  \n  \n  \n**Returns** `record {| any|error value; |}?`   \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config17.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config17.json
@@ -6,13 +6,13 @@
   "source": "expression_context/source/field_access_ctx_source17.bal",
   "items": [
     {
-      "label": "next()(record {| any|error value; |}?)",
+      "label": "next()(record {| Type value; |}?)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array:1.1.0_  \n  \n  \n  \n  \n**Returns** `record {| any|error value; |}?`   \n  \n"
+          "value": "**Package:** _ballerina/lang.array:1.1.0_  \n  \n  \n  \n  \n**Returns** `record {| Type value; |}?`   \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config18.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config18.json
@@ -93,13 +93,13 @@
       }
     },
     {
-      "label": "cloneReadOnly()(Cloneable & readonly)",
+      "label": "cloneReadOnly()(CloneableType & readonly)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable & readonly`   \n- immutable clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType & readonly`   \n- immutable clone of `v`  \n  \n"
         }
       },
       "sortText": "D",
@@ -191,13 +191,13 @@
       }
     },
     {
-      "label": "clone()(Cloneable)",
+      "label": "clone()(CloneableType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- clone of `v`  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config19.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config19.json
@@ -350,13 +350,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "fromJsonFloatString()(()|boolean|string|float|JsonFloat[]|map<JsonFloat>|error)",
+      "label": "fromJsonFloatString()(JsonFloat|error)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nParses a string in JSON format, using float to represent numbers.\nReturns an error if the string cannot be parsed.\n  \n  \n  \n**Returns** `()|boolean|string|float|JsonFloat[]|map<JsonFloat>|error`   \n- `str` parsed to JsonFloat or error  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nParses a string in JSON format, using float to represent numbers.\nReturns an error if the string cannot be parsed.\n  \n  \n  \n**Returns** `JsonFloat|error`   \n- `str` parsed to JsonFloat or error  \n  \n"
         }
       },
       "sortText": "D",
@@ -365,13 +365,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "fromJsonDecimalString()(()|boolean|string|decimal|JsonDecimal[]|map<JsonDecimal>|error)",
+      "label": "fromJsonDecimalString()(JsonDecimal|error)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nParses a string in JSON format, using decimal to represent numbers.\nReturns an error if the string cannot be parsed.\n  \n  \n  \n**Returns** `()|boolean|string|decimal|JsonDecimal[]|map<JsonDecimal>|error`   \n- `str` parsed to JsonDecimal or error  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nParses a string in JSON format, using decimal to represent numbers.\nReturns an error if the string cannot be parsed.\n  \n  \n  \n**Returns** `JsonDecimal|error`   \n- `str` parsed to JsonDecimal or error  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config19.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config19.json
@@ -350,13 +350,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "fromJsonFloatString()(()|boolean|string|float|(JsonFloat)[]|map<JsonFloat>|error)",
+      "label": "fromJsonFloatString()(()|boolean|string|float|JsonFloat[]|map<JsonFloat>|error)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nParses a string in JSON format, using float to represent numbers.\nReturns an error if the string cannot be parsed.\n  \n  \n  \n**Returns** `()|boolean|string|float|(JsonFloat)[]|map<JsonFloat>|error`   \n- `str` parsed to JsonFloat or error  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nParses a string in JSON format, using float to represent numbers.\nReturns an error if the string cannot be parsed.\n  \n  \n  \n**Returns** `()|boolean|string|float|JsonFloat[]|map<JsonFloat>|error`   \n- `str` parsed to JsonFloat or error  \n  \n"
         }
       },
       "sortText": "D",
@@ -365,13 +365,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "fromJsonDecimalString()(()|boolean|string|decimal|(JsonDecimal)[]|map<JsonDecimal>|error)",
+      "label": "fromJsonDecimalString()(()|boolean|string|decimal|JsonDecimal[]|map<JsonDecimal>|error)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nParses a string in JSON format, using decimal to represent numbers.\nReturns an error if the string cannot be parsed.\n  \n  \n  \n**Returns** `()|boolean|string|decimal|(JsonDecimal)[]|map<JsonDecimal>|error`   \n- `str` parsed to JsonDecimal or error  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nParses a string in JSON format, using decimal to represent numbers.\nReturns an error if the string cannot be parsed.\n  \n  \n  \n**Returns** `()|boolean|string|decimal|JsonDecimal[]|map<JsonDecimal>|error`   \n- `str` parsed to JsonDecimal or error  \n  \n"
         }
       },
       "sortText": "D",
@@ -380,13 +380,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "cloneReadOnly()(Cloneable & readonly)",
+      "label": "cloneReadOnly()(CloneableType & readonly)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable & readonly`   \n- immutable clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType & readonly`   \n- immutable clone of `v`  \n  \n"
         }
       },
       "sortText": "D",
@@ -497,13 +497,13 @@
       }
     },
     {
-      "label": "clone()(Cloneable)",
+      "label": "clone()(CloneableType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- clone of `v`  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config2.json
@@ -66,13 +66,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "reduce(function () func, any|error initial)(any|error)",
+      "label": "reduce(function () func, Type1 initial)(Type1)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `any|error` initial: initial value for the first argument of combining function `func`  \n  \n**Returns** `any|error`   \n- result of combining the members of `m` using `func`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `Type1` initial: initial value for the first argument of combining function `func`  \n  \n**Returns** `Type1`   \n- result of combining the members of `m` using `func`  \n  \n"
         }
       },
       "sortText": "D",
@@ -153,13 +153,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "remove(string k)(any|error)",
+      "label": "remove(string k)(Type)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- the member of `m` that had key `k`  \nThis removes the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type`   \n- the member of `m` that had key `k`  \nThis removes the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
         }
       },
       "sortText": "D",
@@ -172,13 +172,13 @@
       }
     },
     {
-      "label": "filter(function () func)(map<any|error>)",
+      "label": "filter(function () func)(map<Type>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<any|error>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<Type>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
         }
       },
       "sortText": "D",
@@ -191,13 +191,13 @@
       }
     },
     {
-      "label": "removeIfHasKey(string k)(any|error?)",
+      "label": "removeIfHasKey(string k)(Type?)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
         }
       },
       "sortText": "D",
@@ -210,13 +210,13 @@
       }
     },
     {
-      "label": "iterator()(object {public isolated function next() returns record {| any|error value; |}? ;})",
+      "label": "iterator()(object {public isolated function next() returns record {| Type value; |}? ;})",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| any|error value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| Type value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
         }
       },
       "sortText": "D",
@@ -225,13 +225,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "entries()(map<[string, any|error]>)",
+      "label": "entries()(map<[string, Type]>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, any|error]>`   \n- a new map of [key, member] pairs  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, Type]>`   \n- a new map of [key, member] pairs  \n  \n"
         }
       },
       "sortText": "D",
@@ -255,13 +255,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "get(string k)(any|error)",
+      "label": "get(string k)(Type)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- member with key `k`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type`   \n- member with key `k`  \n  \n"
         }
       },
       "sortText": "D",
@@ -274,13 +274,13 @@
       }
     },
     {
-      "label": "toArray()((any|error)[])",
+      "label": "toArray()(Type[])",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- an array whose members are the members of `m`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `Type[]`   \n- an array whose members are the members of `m`  \n  \n"
         }
       },
       "sortText": "D",
@@ -289,13 +289,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)(map<any|error>)",
+      "label": "map(function () func)(map<Type1>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<any|error>`   \n- new map containing result of applying function `func` to each member  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<Type1>`   \n- new map containing result of applying function `func` to each member  \n  \n"
         }
       },
       "sortText": "D",
@@ -327,13 +327,13 @@
       }
     },
     {
-      "label": "cloneReadOnly()(Cloneable & readonly)",
+      "label": "cloneReadOnly()(CloneableType & readonly)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable & readonly`   \n- immutable clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType & readonly`   \n- immutable clone of `v`  \n  \n"
         }
       },
       "sortText": "D",
@@ -387,13 +387,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "clone()(Cloneable)",
+      "label": "clone()(CloneableType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- clone of `v`  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config2.json
@@ -66,13 +66,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "reduce(function () func, Type1 initial)(Type1)",
+      "label": "reduce(function () func, any|error initial)(any|error)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `Type1` initial: initial value for the first argument of combining function `func`  \n  \n**Returns** `Type1`   \n- result of combining the members of `m` using `func`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `any|error` initial: initial value for the first argument of combining function `func`  \n  \n**Returns** `any|error`   \n- result of combining the members of `m` using `func`  \n  \n"
         }
       },
       "sortText": "D",
@@ -153,13 +153,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "remove(string k)(Type)",
+      "label": "remove(string k)(any|error)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type`   \n- the member of `m` that had key `k`  \nThis removes the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- the member of `m` that had key `k`  \nThis removes the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
         }
       },
       "sortText": "D",
@@ -172,13 +172,13 @@
       }
     },
     {
-      "label": "filter(function () func)(map<Type>)",
+      "label": "filter(function () func)(map<any|error>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<Type>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<any|error>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
         }
       },
       "sortText": "D",
@@ -191,13 +191,13 @@
       }
     },
     {
-      "label": "removeIfHasKey(string k)(Type?)",
+      "label": "removeIfHasKey(string k)(any|error?)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
         }
       },
       "sortText": "D",
@@ -210,13 +210,13 @@
       }
     },
     {
-      "label": "iterator()(object {public isolated function next() returns record {| Type value; |}? ;})",
+      "label": "iterator()(object {public isolated function next() returns record {| any|error value; |}? ;})",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| Type value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| any|error value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
         }
       },
       "sortText": "D",
@@ -225,13 +225,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "entries()(map<[string, Type]>)",
+      "label": "entries()(map<[string, any|error]>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, Type]>`   \n- a new map of [key, member] pairs  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, any|error]>`   \n- a new map of [key, member] pairs  \n  \n"
         }
       },
       "sortText": "D",
@@ -255,13 +255,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "get(string k)(Type)",
+      "label": "get(string k)(any|error)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type`   \n- member with key `k`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- member with key `k`  \n  \n"
         }
       },
       "sortText": "D",
@@ -274,13 +274,13 @@
       }
     },
     {
-      "label": "toArray()(Type[])",
+      "label": "toArray()((any|error)[])",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `Type[]`   \n- an array whose members are the members of `m`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- an array whose members are the members of `m`  \n  \n"
         }
       },
       "sortText": "D",
@@ -289,13 +289,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)(map<Type1>)",
+      "label": "map(function () func)(map<any|error>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<Type1>`   \n- new map containing result of applying function `func` to each member  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<any|error>`   \n- new map containing result of applying function `func` to each member  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config20.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config20.json
@@ -93,13 +93,13 @@
       }
     },
     {
-      "label": "cloneReadOnly()(Cloneable & readonly)",
+      "label": "cloneReadOnly()(CloneableType & readonly)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable & readonly`   \n- immutable clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType & readonly`   \n- immutable clone of `v`  \n  \n"
         }
       },
       "sortText": "D",
@@ -191,13 +191,13 @@
       }
     },
     {
-      "label": "clone()(Cloneable)",
+      "label": "clone()(CloneableType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- clone of `v`  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config26.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config26.json
@@ -350,13 +350,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "fromJsonFloatString()(()|boolean|string|float|JsonFloat[]|map<JsonFloat>|error)",
+      "label": "fromJsonFloatString()(JsonFloat|error)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nParses a string in JSON format, using float to represent numbers.\nReturns an error if the string cannot be parsed.\n  \n  \n  \n**Returns** `()|boolean|string|float|JsonFloat[]|map<JsonFloat>|error`   \n- `str` parsed to JsonFloat or error  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nParses a string in JSON format, using float to represent numbers.\nReturns an error if the string cannot be parsed.\n  \n  \n  \n**Returns** `JsonFloat|error`   \n- `str` parsed to JsonFloat or error  \n  \n"
         }
       },
       "sortText": "D",
@@ -365,13 +365,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "fromJsonDecimalString()(()|boolean|string|decimal|JsonDecimal[]|map<JsonDecimal>|error)",
+      "label": "fromJsonDecimalString()(JsonDecimal|error)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nParses a string in JSON format, using decimal to represent numbers.\nReturns an error if the string cannot be parsed.\n  \n  \n  \n**Returns** `()|boolean|string|decimal|JsonDecimal[]|map<JsonDecimal>|error`   \n- `str` parsed to JsonDecimal or error  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nParses a string in JSON format, using decimal to represent numbers.\nReturns an error if the string cannot be parsed.\n  \n  \n  \n**Returns** `JsonDecimal|error`   \n- `str` parsed to JsonDecimal or error  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config26.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config26.json
@@ -350,13 +350,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "fromJsonFloatString()(()|boolean|string|float|(JsonFloat)[]|map<JsonFloat>|error)",
+      "label": "fromJsonFloatString()(()|boolean|string|float|JsonFloat[]|map<JsonFloat>|error)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nParses a string in JSON format, using float to represent numbers.\nReturns an error if the string cannot be parsed.\n  \n  \n  \n**Returns** `()|boolean|string|float|(JsonFloat)[]|map<JsonFloat>|error`   \n- `str` parsed to JsonFloat or error  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nParses a string in JSON format, using float to represent numbers.\nReturns an error if the string cannot be parsed.\n  \n  \n  \n**Returns** `()|boolean|string|float|JsonFloat[]|map<JsonFloat>|error`   \n- `str` parsed to JsonFloat or error  \n  \n"
         }
       },
       "sortText": "D",
@@ -365,13 +365,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "fromJsonDecimalString()(()|boolean|string|decimal|(JsonDecimal)[]|map<JsonDecimal>|error)",
+      "label": "fromJsonDecimalString()(()|boolean|string|decimal|JsonDecimal[]|map<JsonDecimal>|error)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nParses a string in JSON format, using decimal to represent numbers.\nReturns an error if the string cannot be parsed.\n  \n  \n  \n**Returns** `()|boolean|string|decimal|(JsonDecimal)[]|map<JsonDecimal>|error`   \n- `str` parsed to JsonDecimal or error  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nParses a string in JSON format, using decimal to represent numbers.\nReturns an error if the string cannot be parsed.\n  \n  \n  \n**Returns** `()|boolean|string|decimal|JsonDecimal[]|map<JsonDecimal>|error`   \n- `str` parsed to JsonDecimal or error  \n  \n"
         }
       },
       "sortText": "D",
@@ -380,13 +380,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "cloneReadOnly()(Cloneable & readonly)",
+      "label": "cloneReadOnly()(CloneableType & readonly)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable & readonly`   \n- immutable clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType & readonly`   \n- immutable clone of `v`  \n  \n"
         }
       },
       "sortText": "D",
@@ -497,13 +497,13 @@
       }
     },
     {
-      "label": "clone()(Cloneable)",
+      "label": "clone()(CloneableType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- clone of `v`  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config27.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config27.json
@@ -93,13 +93,13 @@
       }
     },
     {
-      "label": "cloneReadOnly()(Cloneable & readonly)",
+      "label": "cloneReadOnly()(CloneableType & readonly)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable & readonly`   \n- immutable clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType & readonly`   \n- immutable clone of `v`  \n  \n"
         }
       },
       "sortText": "D",
@@ -191,13 +191,13 @@
       }
     },
     {
-      "label": "clone()(Cloneable)",
+      "label": "clone()(CloneableType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- clone of `v`  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config3.json
@@ -22,13 +22,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "reduce(function () func, Type1 initial)(Type1)",
+      "label": "reduce(function () func, any|error initial)(any|error)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `Type1` initial: initial value for the first argument of combining function `func`  \n  \n**Returns** `Type1`   \n- result of combining the members of `m` using `func`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `any|error` initial: initial value for the first argument of combining function `func`  \n  \n**Returns** `any|error`   \n- result of combining the members of `m` using `func`  \n  \n"
         }
       },
       "sortText": "D",
@@ -109,13 +109,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "remove(string k)(Type)",
+      "label": "remove(string k)(any|error)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type`   \n- the member of `m` that had key `k`  \nThis removes the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- the member of `m` that had key `k`  \nThis removes the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
         }
       },
       "sortText": "D",
@@ -128,13 +128,13 @@
       }
     },
     {
-      "label": "filter(function () func)(map<Type>)",
+      "label": "filter(function () func)(map<any|error>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<Type>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<any|error>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
         }
       },
       "sortText": "D",
@@ -147,13 +147,13 @@
       }
     },
     {
-      "label": "removeIfHasKey(string k)(Type?)",
+      "label": "removeIfHasKey(string k)(any|error?)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
         }
       },
       "sortText": "D",
@@ -166,13 +166,13 @@
       }
     },
     {
-      "label": "iterator()(object {public isolated function next() returns record {| Type value; |}? ;})",
+      "label": "iterator()(object {public isolated function next() returns record {| any|error value; |}? ;})",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| Type value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| any|error value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
         }
       },
       "sortText": "D",
@@ -181,13 +181,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "entries()(map<[string, Type]>)",
+      "label": "entries()(map<[string, any|error]>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, Type]>`   \n- a new map of [key, member] pairs  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, any|error]>`   \n- a new map of [key, member] pairs  \n  \n"
         }
       },
       "sortText": "D",
@@ -211,13 +211,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "get(string k)(Type)",
+      "label": "get(string k)(any|error)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type`   \n- member with key `k`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- member with key `k`  \n  \n"
         }
       },
       "sortText": "D",
@@ -230,13 +230,13 @@
       }
     },
     {
-      "label": "toArray()(Type[])",
+      "label": "toArray()((any|error)[])",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `Type[]`   \n- an array whose members are the members of `m`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- an array whose members are the members of `m`  \n  \n"
         }
       },
       "sortText": "D",
@@ -245,13 +245,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)(map<Type1>)",
+      "label": "map(function () func)(map<any|error>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<Type1>`   \n- new map containing result of applying function `func` to each member  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<any|error>`   \n- new map containing result of applying function `func` to each member  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config3.json
@@ -22,13 +22,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "reduce(function () func, any|error initial)(any|error)",
+      "label": "reduce(function () func, Type1 initial)(Type1)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `any|error` initial: initial value for the first argument of combining function `func`  \n  \n**Returns** `any|error`   \n- result of combining the members of `m` using `func`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `Type1` initial: initial value for the first argument of combining function `func`  \n  \n**Returns** `Type1`   \n- result of combining the members of `m` using `func`  \n  \n"
         }
       },
       "sortText": "D",
@@ -109,13 +109,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "remove(string k)(any|error)",
+      "label": "remove(string k)(Type)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- the member of `m` that had key `k`  \nThis removes the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type`   \n- the member of `m` that had key `k`  \nThis removes the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
         }
       },
       "sortText": "D",
@@ -128,13 +128,13 @@
       }
     },
     {
-      "label": "filter(function () func)(map<any|error>)",
+      "label": "filter(function () func)(map<Type>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<any|error>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<Type>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
         }
       },
       "sortText": "D",
@@ -147,13 +147,13 @@
       }
     },
     {
-      "label": "removeIfHasKey(string k)(any|error?)",
+      "label": "removeIfHasKey(string k)(Type?)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
         }
       },
       "sortText": "D",
@@ -166,13 +166,13 @@
       }
     },
     {
-      "label": "iterator()(object {public isolated function next() returns record {| any|error value; |}? ;})",
+      "label": "iterator()(object {public isolated function next() returns record {| Type value; |}? ;})",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| any|error value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| Type value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
         }
       },
       "sortText": "D",
@@ -181,13 +181,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "entries()(map<[string, any|error]>)",
+      "label": "entries()(map<[string, Type]>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, any|error]>`   \n- a new map of [key, member] pairs  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, Type]>`   \n- a new map of [key, member] pairs  \n  \n"
         }
       },
       "sortText": "D",
@@ -211,13 +211,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "get(string k)(any|error)",
+      "label": "get(string k)(Type)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- member with key `k`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type`   \n- member with key `k`  \n  \n"
         }
       },
       "sortText": "D",
@@ -230,13 +230,13 @@
       }
     },
     {
-      "label": "toArray()((any|error)[])",
+      "label": "toArray()(Type[])",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- an array whose members are the members of `m`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `Type[]`   \n- an array whose members are the members of `m`  \n  \n"
         }
       },
       "sortText": "D",
@@ -245,13 +245,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)(map<any|error>)",
+      "label": "map(function () func)(map<Type1>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<any|error>`   \n- new map containing result of applying function `func` to each member  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<Type1>`   \n- new map containing result of applying function `func` to each member  \n  \n"
         }
       },
       "sortText": "D",
@@ -283,13 +283,13 @@
       }
     },
     {
-      "label": "cloneReadOnly()(Cloneable & readonly)",
+      "label": "cloneReadOnly()(CloneableType & readonly)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable & readonly`   \n- immutable clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType & readonly`   \n- immutable clone of `v`  \n  \n"
         }
       },
       "sortText": "D",
@@ -343,13 +343,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "clone()(Cloneable)",
+      "label": "clone()(CloneableType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- clone of `v`  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config4.json
@@ -126,13 +126,13 @@
       }
     },
     {
-      "label": "iterator()(object {public isolated function next() returns record {| ItemType value; |}? ;})",
+      "label": "iterator()(object {public isolated function next() returns record {| xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text value; |}? ;})",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml:0.8.0_  \n  \nReturns an iterator over the xml items of `x`\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| ItemType value; |}? ;}`   \n- iterator object  \nEach item is represented by an xml singleton.  \n  \n"
+          "value": "**Package:** _ballerina/lang.xml:0.8.0_  \n  \nReturns an iterator over the xml items of `x`\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text value; |}? ;}`   \n- iterator object  \nEach item is represented by an xml singleton.  \n  \n"
         }
       },
       "sortText": "D",
@@ -156,13 +156,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "slice(int startIndex, int endIndex)(xml<ItemType>)",
+      "label": "slice(int startIndex, int endIndex)(xml<xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml:0.8.0_  \n  \nReturns a subsequence of an xml value.\n  \n**Params**  \n- `int` startIndex: start index, inclusive  \n- `int` endIndex: end index, exclusive(Defaultable)  \n  \n**Returns** `xml<ItemType>`   \n- a subsequence of `x` consisting of items with index >= startIndex and < endIndex  \n  \n"
+          "value": "**Package:** _ballerina/lang.xml:0.8.0_  \n  \nReturns a subsequence of an xml value.\n  \n**Params**  \n- `int` startIndex: start index, inclusive  \n- `int` endIndex: end index, exclusive(Defaultable)  \n  \n**Returns** `xml<xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text>`   \n- a subsequence of `x` consisting of items with index >= startIndex and < endIndex  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config4.json
@@ -126,13 +126,13 @@
       }
     },
     {
-      "label": "iterator()(object {public isolated function next() returns record {| xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text value; |}? ;})",
+      "label": "iterator()(object {public isolated function next() returns record {| ItemType value; |}? ;})",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml:0.8.0_  \n  \nReturns an iterator over the xml items of `x`\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text value; |}? ;}`   \n- iterator object  \nEach item is represented by an xml singleton.  \n  \n"
+          "value": "**Package:** _ballerina/lang.xml:0.8.0_  \n  \nReturns an iterator over the xml items of `x`\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| ItemType value; |}? ;}`   \n- iterator object  \nEach item is represented by an xml singleton.  \n  \n"
         }
       },
       "sortText": "D",
@@ -156,13 +156,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "slice(int startIndex, int endIndex)(xml<xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text>)",
+      "label": "slice(int startIndex, int endIndex)(xml<ItemType>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml:0.8.0_  \n  \nReturns a subsequence of an xml value.\n  \n**Params**  \n- `int` startIndex: start index, inclusive  \n- `int` endIndex: end index, exclusive(Defaultable)  \n  \n**Returns** `xml<xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text>`   \n- a subsequence of `x` consisting of items with index >= startIndex and < endIndex  \n  \n"
+          "value": "**Package:** _ballerina/lang.xml:0.8.0_  \n  \nReturns a subsequence of an xml value.\n  \n**Params**  \n- `int` startIndex: start index, inclusive  \n- `int` endIndex: end index, exclusive(Defaultable)  \n  \n**Returns** `xml<ItemType>`   \n- a subsequence of `x` consisting of items with index >= startIndex and < endIndex  \n  \n"
         }
       },
       "sortText": "D",
@@ -300,13 +300,13 @@
       }
     },
     {
-      "label": "cloneReadOnly()(Cloneable & readonly)",
+      "label": "cloneReadOnly()(CloneableType & readonly)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable & readonly`   \n- immutable clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType & readonly`   \n- immutable clone of `v`  \n  \n"
         }
       },
       "sortText": "D",
@@ -360,13 +360,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "clone()(Cloneable)",
+      "label": "clone()(CloneableType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- clone of `v`  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config5.json
@@ -14,13 +14,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "reduce(function () func, Type1 initial)(Type1)",
+      "label": "reduce(function () func, any|error initial)(any|error)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `Type1` initial: initial value for the first argument of combining function `func`  \n  \n**Returns** `Type1`   \n- result of combining the members of `m` using `func`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `any|error` initial: initial value for the first argument of combining function `func`  \n  \n**Returns** `any|error`   \n- result of combining the members of `m` using `func`  \n  \n"
         }
       },
       "sortText": "D",
@@ -101,13 +101,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "remove(string k)(Type)",
+      "label": "remove(string k)(any|error)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type`   \n- the member of `m` that had key `k`  \nThis removes the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- the member of `m` that had key `k`  \nThis removes the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
         }
       },
       "sortText": "D",
@@ -120,13 +120,13 @@
       }
     },
     {
-      "label": "filter(function () func)(map<Type>)",
+      "label": "filter(function () func)(map<any|error>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<Type>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<any|error>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
         }
       },
       "sortText": "D",
@@ -139,13 +139,13 @@
       }
     },
     {
-      "label": "removeIfHasKey(string k)(Type?)",
+      "label": "removeIfHasKey(string k)(any|error?)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
         }
       },
       "sortText": "D",
@@ -158,13 +158,13 @@
       }
     },
     {
-      "label": "iterator()(object {public isolated function next() returns record {| Type value; |}? ;})",
+      "label": "iterator()(object {public isolated function next() returns record {| any|error value; |}? ;})",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| Type value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| any|error value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
         }
       },
       "sortText": "D",
@@ -173,13 +173,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "entries()(map<[string, Type]>)",
+      "label": "entries()(map<[string, any|error]>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, Type]>`   \n- a new map of [key, member] pairs  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, any|error]>`   \n- a new map of [key, member] pairs  \n  \n"
         }
       },
       "sortText": "D",
@@ -203,13 +203,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "get(string k)(Type)",
+      "label": "get(string k)(any|error)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type`   \n- member with key `k`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- member with key `k`  \n  \n"
         }
       },
       "sortText": "D",
@@ -222,13 +222,13 @@
       }
     },
     {
-      "label": "toArray()(Type[])",
+      "label": "toArray()((any|error)[])",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `Type[]`   \n- an array whose members are the members of `m`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- an array whose members are the members of `m`  \n  \n"
         }
       },
       "sortText": "D",
@@ -237,13 +237,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)(map<Type1>)",
+      "label": "map(function () func)(map<any|error>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<Type1>`   \n- new map containing result of applying function `func` to each member  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<any|error>`   \n- new map containing result of applying function `func` to each member  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config5.json
@@ -14,13 +14,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "reduce(function () func, any|error initial)(any|error)",
+      "label": "reduce(function () func, Type1 initial)(Type1)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `any|error` initial: initial value for the first argument of combining function `func`  \n  \n**Returns** `any|error`   \n- result of combining the members of `m` using `func`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `Type1` initial: initial value for the first argument of combining function `func`  \n  \n**Returns** `Type1`   \n- result of combining the members of `m` using `func`  \n  \n"
         }
       },
       "sortText": "D",
@@ -101,13 +101,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "remove(string k)(any|error)",
+      "label": "remove(string k)(Type)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- the member of `m` that had key `k`  \nThis removes the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type`   \n- the member of `m` that had key `k`  \nThis removes the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
         }
       },
       "sortText": "D",
@@ -120,13 +120,13 @@
       }
     },
     {
-      "label": "filter(function () func)(map<any|error>)",
+      "label": "filter(function () func)(map<Type>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<any|error>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<Type>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
         }
       },
       "sortText": "D",
@@ -139,13 +139,13 @@
       }
     },
     {
-      "label": "removeIfHasKey(string k)(any|error?)",
+      "label": "removeIfHasKey(string k)(Type?)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
         }
       },
       "sortText": "D",
@@ -158,13 +158,13 @@
       }
     },
     {
-      "label": "iterator()(object {public isolated function next() returns record {| any|error value; |}? ;})",
+      "label": "iterator()(object {public isolated function next() returns record {| Type value; |}? ;})",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| any|error value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| Type value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
         }
       },
       "sortText": "D",
@@ -173,13 +173,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "entries()(map<[string, any|error]>)",
+      "label": "entries()(map<[string, Type]>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, any|error]>`   \n- a new map of [key, member] pairs  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, Type]>`   \n- a new map of [key, member] pairs  \n  \n"
         }
       },
       "sortText": "D",
@@ -203,13 +203,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "get(string k)(any|error)",
+      "label": "get(string k)(Type)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- member with key `k`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type`   \n- member with key `k`  \n  \n"
         }
       },
       "sortText": "D",
@@ -222,13 +222,13 @@
       }
     },
     {
-      "label": "toArray()((any|error)[])",
+      "label": "toArray()(Type[])",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- an array whose members are the members of `m`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `Type[]`   \n- an array whose members are the members of `m`  \n  \n"
         }
       },
       "sortText": "D",
@@ -237,13 +237,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)(map<any|error>)",
+      "label": "map(function () func)(map<Type1>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<any|error>`   \n- new map containing result of applying function `func` to each member  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<Type1>`   \n- new map containing result of applying function `func` to each member  \n  \n"
         }
       },
       "sortText": "D",
@@ -275,13 +275,13 @@
       }
     },
     {
-      "label": "cloneReadOnly()(Cloneable & readonly)",
+      "label": "cloneReadOnly()(CloneableType & readonly)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable & readonly`   \n- immutable clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType & readonly`   \n- immutable clone of `v`  \n  \n"
         }
       },
       "sortText": "D",
@@ -335,13 +335,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "clone()(Cloneable)",
+      "label": "clone()(CloneableType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- clone of `v`  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config7.json
@@ -22,13 +22,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "reduce(function () func, Type1 initial)(Type1)",
+      "label": "reduce(function () func, any|error initial)(any|error)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `Type1` initial: initial value for the first argument of combining function `func`  \n  \n**Returns** `Type1`   \n- result of combining the members of `m` using `func`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `any|error` initial: initial value for the first argument of combining function `func`  \n  \n**Returns** `any|error`   \n- result of combining the members of `m` using `func`  \n  \n"
         }
       },
       "sortText": "D",
@@ -109,13 +109,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "remove(string k)(Type)",
+      "label": "remove(string k)(any|error)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type`   \n- the member of `m` that had key `k`  \nThis removes the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- the member of `m` that had key `k`  \nThis removes the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
         }
       },
       "sortText": "D",
@@ -128,13 +128,13 @@
       }
     },
     {
-      "label": "filter(function () func)(map<Type>)",
+      "label": "filter(function () func)(map<any|error>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<Type>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<any|error>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
         }
       },
       "sortText": "D",
@@ -147,13 +147,13 @@
       }
     },
     {
-      "label": "removeIfHasKey(string k)(Type?)",
+      "label": "removeIfHasKey(string k)(any|error?)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
         }
       },
       "sortText": "D",
@@ -166,13 +166,13 @@
       }
     },
     {
-      "label": "iterator()(object {public isolated function next() returns record {| Type value; |}? ;})",
+      "label": "iterator()(object {public isolated function next() returns record {| any|error value; |}? ;})",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| Type value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| any|error value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
         }
       },
       "sortText": "D",
@@ -181,13 +181,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "entries()(map<[string, Type]>)",
+      "label": "entries()(map<[string, any|error]>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, Type]>`   \n- a new map of [key, member] pairs  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, any|error]>`   \n- a new map of [key, member] pairs  \n  \n"
         }
       },
       "sortText": "D",
@@ -211,13 +211,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "get(string k)(Type)",
+      "label": "get(string k)(any|error)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type`   \n- member with key `k`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- member with key `k`  \n  \n"
         }
       },
       "sortText": "D",
@@ -230,13 +230,13 @@
       }
     },
     {
-      "label": "toArray()(Type[])",
+      "label": "toArray()((any|error)[])",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `Type[]`   \n- an array whose members are the members of `m`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- an array whose members are the members of `m`  \n  \n"
         }
       },
       "sortText": "D",
@@ -245,13 +245,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)(map<Type1>)",
+      "label": "map(function () func)(map<any|error>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<Type1>`   \n- new map containing result of applying function `func` to each member  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<any|error>`   \n- new map containing result of applying function `func` to each member  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config7.json
@@ -22,13 +22,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "reduce(function () func, any|error initial)(any|error)",
+      "label": "reduce(function () func, Type1 initial)(Type1)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `any|error` initial: initial value for the first argument of combining function `func`  \n  \n**Returns** `any|error`   \n- result of combining the members of `m` using `func`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `Type1` initial: initial value for the first argument of combining function `func`  \n  \n**Returns** `Type1`   \n- result of combining the members of `m` using `func`  \n  \n"
         }
       },
       "sortText": "D",
@@ -109,13 +109,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "remove(string k)(any|error)",
+      "label": "remove(string k)(Type)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- the member of `m` that had key `k`  \nThis removes the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type`   \n- the member of `m` that had key `k`  \nThis removes the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
         }
       },
       "sortText": "D",
@@ -128,13 +128,13 @@
       }
     },
     {
-      "label": "filter(function () func)(map<any|error>)",
+      "label": "filter(function () func)(map<Type>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<any|error>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<Type>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
         }
       },
       "sortText": "D",
@@ -147,13 +147,13 @@
       }
     },
     {
-      "label": "removeIfHasKey(string k)(any|error?)",
+      "label": "removeIfHasKey(string k)(Type?)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
         }
       },
       "sortText": "D",
@@ -166,13 +166,13 @@
       }
     },
     {
-      "label": "iterator()(object {public isolated function next() returns record {| any|error value; |}? ;})",
+      "label": "iterator()(object {public isolated function next() returns record {| Type value; |}? ;})",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| any|error value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| Type value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
         }
       },
       "sortText": "D",
@@ -181,13 +181,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "entries()(map<[string, any|error]>)",
+      "label": "entries()(map<[string, Type]>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, any|error]>`   \n- a new map of [key, member] pairs  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, Type]>`   \n- a new map of [key, member] pairs  \n  \n"
         }
       },
       "sortText": "D",
@@ -211,13 +211,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "get(string k)(any|error)",
+      "label": "get(string k)(Type)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- member with key `k`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type`   \n- member with key `k`  \n  \n"
         }
       },
       "sortText": "D",
@@ -230,13 +230,13 @@
       }
     },
     {
-      "label": "toArray()((any|error)[])",
+      "label": "toArray()(Type[])",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- an array whose members are the members of `m`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `Type[]`   \n- an array whose members are the members of `m`  \n  \n"
         }
       },
       "sortText": "D",
@@ -245,13 +245,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)(map<any|error>)",
+      "label": "map(function () func)(map<Type1>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<any|error>`   \n- new map containing result of applying function `func` to each member  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<Type1>`   \n- new map containing result of applying function `func` to each member  \n  \n"
         }
       },
       "sortText": "D",
@@ -283,13 +283,13 @@
       }
     },
     {
-      "label": "cloneReadOnly()(Cloneable & readonly)",
+      "label": "cloneReadOnly()(CloneableType & readonly)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable & readonly`   \n- immutable clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType & readonly`   \n- immutable clone of `v`  \n  \n"
         }
       },
       "sortText": "D",
@@ -343,13 +343,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "clone()(Cloneable)",
+      "label": "clone()(CloneableType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- clone of `v`  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config8.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config8.json
@@ -22,13 +22,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "reduce(function () func, Type1 initial)(Type1)",
+      "label": "reduce(function () func, any|error initial)(any|error)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `Type1` initial: initial value for the first argument of combining function `func`  \n  \n**Returns** `Type1`   \n- result of combining the members of `m` using `func`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `any|error` initial: initial value for the first argument of combining function `func`  \n  \n**Returns** `any|error`   \n- result of combining the members of `m` using `func`  \n  \n"
         }
       },
       "sortText": "D",
@@ -109,13 +109,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "remove(string k)(Type)",
+      "label": "remove(string k)(any|error)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type`   \n- the member of `m` that had key `k`  \nThis removes the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- the member of `m` that had key `k`  \nThis removes the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
         }
       },
       "sortText": "D",
@@ -128,13 +128,13 @@
       }
     },
     {
-      "label": "filter(function () func)(map<Type>)",
+      "label": "filter(function () func)(map<any|error>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<Type>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<any|error>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
         }
       },
       "sortText": "D",
@@ -147,13 +147,13 @@
       }
     },
     {
-      "label": "removeIfHasKey(string k)(Type?)",
+      "label": "removeIfHasKey(string k)(any|error?)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
         }
       },
       "sortText": "D",
@@ -166,13 +166,13 @@
       }
     },
     {
-      "label": "iterator()(object {public isolated function next() returns record {| Type value; |}? ;})",
+      "label": "iterator()(object {public isolated function next() returns record {| any|error value; |}? ;})",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| Type value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| any|error value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
         }
       },
       "sortText": "D",
@@ -181,13 +181,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "entries()(map<[string, Type]>)",
+      "label": "entries()(map<[string, any|error]>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, Type]>`   \n- a new map of [key, member] pairs  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, any|error]>`   \n- a new map of [key, member] pairs  \n  \n"
         }
       },
       "sortText": "D",
@@ -211,13 +211,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "get(string k)(Type)",
+      "label": "get(string k)(any|error)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type`   \n- member with key `k`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- member with key `k`  \n  \n"
         }
       },
       "sortText": "D",
@@ -230,13 +230,13 @@
       }
     },
     {
-      "label": "toArray()(Type[])",
+      "label": "toArray()((any|error)[])",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `Type[]`   \n- an array whose members are the members of `m`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- an array whose members are the members of `m`  \n  \n"
         }
       },
       "sortText": "D",
@@ -245,13 +245,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)(map<Type1>)",
+      "label": "map(function () func)(map<any|error>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<Type1>`   \n- new map containing result of applying function `func` to each member  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<any|error>`   \n- new map containing result of applying function `func` to each member  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config8.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config8.json
@@ -22,13 +22,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "reduce(function () func, any|error initial)(any|error)",
+      "label": "reduce(function () func, Type1 initial)(Type1)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `any|error` initial: initial value for the first argument of combining function `func`  \n  \n**Returns** `any|error`   \n- result of combining the members of `m` using `func`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `Type1` initial: initial value for the first argument of combining function `func`  \n  \n**Returns** `Type1`   \n- result of combining the members of `m` using `func`  \n  \n"
         }
       },
       "sortText": "D",
@@ -109,13 +109,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "remove(string k)(any|error)",
+      "label": "remove(string k)(Type)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- the member of `m` that had key `k`  \nThis removes the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type`   \n- the member of `m` that had key `k`  \nThis removes the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
         }
       },
       "sortText": "D",
@@ -128,13 +128,13 @@
       }
     },
     {
-      "label": "filter(function () func)(map<any|error>)",
+      "label": "filter(function () func)(map<Type>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<any|error>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<Type>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
         }
       },
       "sortText": "D",
@@ -147,13 +147,13 @@
       }
     },
     {
-      "label": "removeIfHasKey(string k)(any|error?)",
+      "label": "removeIfHasKey(string k)(Type?)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
         }
       },
       "sortText": "D",
@@ -166,13 +166,13 @@
       }
     },
     {
-      "label": "iterator()(object {public isolated function next() returns record {| any|error value; |}? ;})",
+      "label": "iterator()(object {public isolated function next() returns record {| Type value; |}? ;})",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| any|error value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| Type value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
         }
       },
       "sortText": "D",
@@ -181,13 +181,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "entries()(map<[string, any|error]>)",
+      "label": "entries()(map<[string, Type]>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, any|error]>`   \n- a new map of [key, member] pairs  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, Type]>`   \n- a new map of [key, member] pairs  \n  \n"
         }
       },
       "sortText": "D",
@@ -211,13 +211,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "get(string k)(any|error)",
+      "label": "get(string k)(Type)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- member with key `k`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type`   \n- member with key `k`  \n  \n"
         }
       },
       "sortText": "D",
@@ -230,13 +230,13 @@
       }
     },
     {
-      "label": "toArray()((any|error)[])",
+      "label": "toArray()(Type[])",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- an array whose members are the members of `m`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `Type[]`   \n- an array whose members are the members of `m`  \n  \n"
         }
       },
       "sortText": "D",
@@ -245,13 +245,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)(map<any|error>)",
+      "label": "map(function () func)(map<Type1>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<any|error>`   \n- new map containing result of applying function `func` to each member  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<Type1>`   \n- new map containing result of applying function `func` to each member  \n  \n"
         }
       },
       "sortText": "D",
@@ -283,13 +283,13 @@
       }
     },
     {
-      "label": "cloneReadOnly()(Cloneable & readonly)",
+      "label": "cloneReadOnly()(CloneableType & readonly)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable & readonly`   \n- immutable clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType & readonly`   \n- immutable clone of `v`  \n  \n"
         }
       },
       "sortText": "D",
@@ -343,13 +343,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "clone()(Cloneable)",
+      "label": "clone()(CloneableType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- clone of `v`  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config9.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config9.json
@@ -25,13 +25,13 @@
       }
     },
     {
-      "label": "cloneReadOnly()(Cloneable & readonly)",
+      "label": "cloneReadOnly()(CloneableType & readonly)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable & readonly`   \n- immutable clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType & readonly`   \n- immutable clone of `v`  \n  \n"
         }
       },
       "sortText": "D",
@@ -85,13 +85,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "clone()(Cloneable)",
+      "label": "clone()(CloneableType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- clone of `v`  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/foreach_stmt_ctx_config10.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/foreach_stmt_ctx_config10.json
@@ -425,13 +425,13 @@
       }
     },
     {
-      "label": "cloneReadOnly()(Cloneable & readonly)",
+      "label": "cloneReadOnly()(CloneableType & readonly)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable & readonly`   \n- immutable clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType & readonly`   \n- immutable clone of `v`  \n  \n"
         }
       },
       "sortText": "D",
@@ -523,13 +523,13 @@
       }
     },
     {
-      "label": "clone()(Cloneable)",
+      "label": "clone()(CloneableType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- clone of `v`  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/foreach_stmt_ctx_config11.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/foreach_stmt_ctx_config11.json
@@ -425,13 +425,13 @@
       }
     },
     {
-      "label": "cloneReadOnly()(Cloneable & readonly)",
+      "label": "cloneReadOnly()(CloneableType & readonly)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable & readonly`   \n- immutable clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType & readonly`   \n- immutable clone of `v`  \n  \n"
         }
       },
       "sortText": "D",
@@ -485,13 +485,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "clone()(Cloneable)",
+      "label": "clone()(CloneableType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- clone of `v`  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/foreach_stmt_ctx_config12.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/foreach_stmt_ctx_config12.json
@@ -425,13 +425,13 @@
       }
     },
     {
-      "label": "cloneReadOnly()(Cloneable & readonly)",
+      "label": "cloneReadOnly()(CloneableType & readonly)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable & readonly`   \n- immutable clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType & readonly`   \n- immutable clone of `v`  \n  \n"
         }
       },
       "sortText": "D",
@@ -485,13 +485,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "clone()(Cloneable)",
+      "label": "clone()(CloneableType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- clone of `v`  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/foreach_stmt_ctx_config13.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/foreach_stmt_ctx_config13.json
@@ -402,13 +402,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "fromJsonFloatString()(()|boolean|string|float|(JsonFloat)[]|map<JsonFloat>|error)",
+      "label": "fromJsonFloatString()(JsonFloat|error)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nParses a string in JSON format, using float to represent numbers.\nReturns an error if the string cannot be parsed.\n  \n  \n  \n**Returns** `()|boolean|string|float|(JsonFloat)[]|map<JsonFloat>|error`   \n- `str` parsed to JsonFloat or error  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nParses a string in JSON format, using float to represent numbers.\nReturns an error if the string cannot be parsed.\n  \n  \n  \n**Returns** `JsonFloat|error`   \n- `str` parsed to JsonFloat or error  \n  \n"
         }
       },
       "sortText": "D",
@@ -417,13 +417,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "fromJsonDecimalString()(()|boolean|string|decimal|(JsonDecimal)[]|map<JsonDecimal>|error)",
+      "label": "fromJsonDecimalString()(JsonDecimal|error)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nParses a string in JSON format, using decimal to represent numbers.\nReturns an error if the string cannot be parsed.\n  \n  \n  \n**Returns** `()|boolean|string|decimal|(JsonDecimal)[]|map<JsonDecimal>|error`   \n- `str` parsed to JsonDecimal or error  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nParses a string in JSON format, using decimal to represent numbers.\nReturns an error if the string cannot be parsed.\n  \n  \n  \n**Returns** `JsonDecimal|error`   \n- `str` parsed to JsonDecimal or error  \n  \n"
         }
       },
       "sortText": "D",
@@ -432,13 +432,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "cloneReadOnly()(Cloneable & readonly)",
+      "label": "cloneReadOnly()(CloneableType & readonly)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable & readonly`   \n- immutable clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType & readonly`   \n- immutable clone of `v`  \n  \n"
         }
       },
       "sortText": "D",
@@ -549,13 +549,13 @@
       }
     },
     {
-      "label": "clone()(Cloneable)",
+      "label": "clone()(CloneableType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- clone of `v`  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/foreach_stmt_ctx_config14.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/foreach_stmt_ctx_config14.json
@@ -425,13 +425,13 @@
       }
     },
     {
-      "label": "cloneReadOnly()(Cloneable & readonly)",
+      "label": "cloneReadOnly()(CloneableType & readonly)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable & readonly`   \n- immutable clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType & readonly`   \n- immutable clone of `v`  \n  \n"
         }
       },
       "sortText": "D",
@@ -485,13 +485,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "clone()(Cloneable)",
+      "label": "clone()(CloneableType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- clone of `v`  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/foreach_stmt_ctx_config15.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/foreach_stmt_ctx_config15.json
@@ -74,13 +74,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "reduce(function () func, Type1 initial)(Type1)",
+      "label": "reduce(function () func, any|error initial)(any|error)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `Type1` initial: initial value for the first argument of combining function `func`  \n  \n**Returns** `Type1`   \n- result of combining the members of `m` using `func`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `any|error` initial: initial value for the first argument of combining function `func`  \n  \n**Returns** `any|error`   \n- result of combining the members of `m` using `func`  \n  \n"
         }
       },
       "sortText": "D",
@@ -161,13 +161,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "remove(string k)(Type)",
+      "label": "remove(string k)(any|error)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type`   \n- the member of `m` that had key `k`  \nThis removes the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- the member of `m` that had key `k`  \nThis removes the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
         }
       },
       "sortText": "D",
@@ -180,13 +180,13 @@
       }
     },
     {
-      "label": "filter(function () func)(map<Type>)",
+      "label": "filter(function () func)(map<any|error>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<Type>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<any|error>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
         }
       },
       "sortText": "D",
@@ -199,13 +199,13 @@
       }
     },
     {
-      "label": "removeIfHasKey(string k)(Type?)",
+      "label": "removeIfHasKey(string k)(any|error?)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
         }
       },
       "sortText": "D",
@@ -218,13 +218,13 @@
       }
     },
     {
-      "label": "iterator()(object {public isolated function next() returns record {| Type value; |}? ;})",
+      "label": "iterator()(object {public isolated function next() returns record {| any|error value; |}? ;})",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| Type value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| any|error value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
         }
       },
       "sortText": "D",
@@ -233,13 +233,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "entries()(map<[string, Type]>)",
+      "label": "entries()(map<[string, any|error]>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, Type]>`   \n- a new map of [key, member] pairs  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, any|error]>`   \n- a new map of [key, member] pairs  \n  \n"
         }
       },
       "sortText": "D",
@@ -263,13 +263,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "get(string k)(Type)",
+      "label": "get(string k)(any|error)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type`   \n- member with key `k`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- member with key `k`  \n  \n"
         }
       },
       "sortText": "D",
@@ -282,13 +282,13 @@
       }
     },
     {
-      "label": "toArray()(Type[])",
+      "label": "toArray()((any|error)[])",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `Type[]`   \n- an array whose members are the members of `m`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- an array whose members are the members of `m`  \n  \n"
         }
       },
       "sortText": "D",
@@ -297,13 +297,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)(map<Type1>)",
+      "label": "map(function () func)(map<any|error>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<Type1>`   \n- new map containing result of applying function `func` to each member  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<any|error>`   \n- new map containing result of applying function `func` to each member  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/foreach_stmt_ctx_config15.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/foreach_stmt_ctx_config15.json
@@ -74,13 +74,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "reduce(function () func, any|error initial)(any|error)",
+      "label": "reduce(function () func, Type1 initial)(Type1)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `any|error` initial: initial value for the first argument of combining function `func`  \n  \n**Returns** `any|error`   \n- result of combining the members of `m` using `func`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `Type1` initial: initial value for the first argument of combining function `func`  \n  \n**Returns** `Type1`   \n- result of combining the members of `m` using `func`  \n  \n"
         }
       },
       "sortText": "D",
@@ -161,13 +161,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "remove(string k)(any|error)",
+      "label": "remove(string k)(Type)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- the member of `m` that had key `k`  \nThis removes the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type`   \n- the member of `m` that had key `k`  \nThis removes the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
         }
       },
       "sortText": "D",
@@ -180,13 +180,13 @@
       }
     },
     {
-      "label": "filter(function () func)(map<any|error>)",
+      "label": "filter(function () func)(map<Type>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<any|error>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<Type>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
         }
       },
       "sortText": "D",
@@ -199,13 +199,13 @@
       }
     },
     {
-      "label": "removeIfHasKey(string k)(any|error?)",
+      "label": "removeIfHasKey(string k)(Type?)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
         }
       },
       "sortText": "D",
@@ -218,13 +218,13 @@
       }
     },
     {
-      "label": "iterator()(object {public isolated function next() returns record {| any|error value; |}? ;})",
+      "label": "iterator()(object {public isolated function next() returns record {| Type value; |}? ;})",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| any|error value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| Type value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
         }
       },
       "sortText": "D",
@@ -233,13 +233,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "entries()(map<[string, any|error]>)",
+      "label": "entries()(map<[string, Type]>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, any|error]>`   \n- a new map of [key, member] pairs  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, Type]>`   \n- a new map of [key, member] pairs  \n  \n"
         }
       },
       "sortText": "D",
@@ -263,13 +263,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "get(string k)(any|error)",
+      "label": "get(string k)(Type)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- member with key `k`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type`   \n- member with key `k`  \n  \n"
         }
       },
       "sortText": "D",
@@ -282,13 +282,13 @@
       }
     },
     {
-      "label": "toArray()((any|error)[])",
+      "label": "toArray()(Type[])",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- an array whose members are the members of `m`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `Type[]`   \n- an array whose members are the members of `m`  \n  \n"
         }
       },
       "sortText": "D",
@@ -297,13 +297,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)(map<any|error>)",
+      "label": "map(function () func)(map<Type1>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<any|error>`   \n- new map containing result of applying function `func` to each member  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<Type1>`   \n- new map containing result of applying function `func` to each member  \n  \n"
         }
       },
       "sortText": "D",
@@ -335,13 +335,13 @@
       }
     },
     {
-      "label": "cloneReadOnly()(Cloneable & readonly)",
+      "label": "cloneReadOnly()(CloneableType & readonly)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable & readonly`   \n- immutable clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType & readonly`   \n- immutable clone of `v`  \n  \n"
         }
       },
       "sortText": "D",
@@ -433,13 +433,13 @@
       }
     },
     {
-      "label": "clone()(Cloneable)",
+      "label": "clone()(CloneableType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- clone of `v`  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/foreach_stmt_ctx_config16.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/foreach_stmt_ctx_config16.json
@@ -74,13 +74,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "reduce(function () func, Type1 initial)(Type1)",
+      "label": "reduce(function () func, any|error initial)(any|error)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `Type1` initial: initial value for the first argument of combining function `func`  \n  \n**Returns** `Type1`   \n- result of combining the members of `m` using `func`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `any|error` initial: initial value for the first argument of combining function `func`  \n  \n**Returns** `any|error`   \n- result of combining the members of `m` using `func`  \n  \n"
         }
       },
       "sortText": "D",
@@ -161,13 +161,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "remove(string k)(Type)",
+      "label": "remove(string k)(any|error)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type`   \n- the member of `m` that had key `k`  \nThis removes the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- the member of `m` that had key `k`  \nThis removes the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
         }
       },
       "sortText": "D",
@@ -180,13 +180,13 @@
       }
     },
     {
-      "label": "filter(function () func)(map<Type>)",
+      "label": "filter(function () func)(map<any|error>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<Type>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<any|error>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
         }
       },
       "sortText": "D",
@@ -199,13 +199,13 @@
       }
     },
     {
-      "label": "removeIfHasKey(string k)(Type?)",
+      "label": "removeIfHasKey(string k)(any|error?)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
         }
       },
       "sortText": "D",
@@ -218,13 +218,13 @@
       }
     },
     {
-      "label": "iterator()(object {public isolated function next() returns record {| Type value; |}? ;})",
+      "label": "iterator()(object {public isolated function next() returns record {| any|error value; |}? ;})",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| Type value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| any|error value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
         }
       },
       "sortText": "D",
@@ -233,13 +233,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "entries()(map<[string, Type]>)",
+      "label": "entries()(map<[string, any|error]>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, Type]>`   \n- a new map of [key, member] pairs  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, any|error]>`   \n- a new map of [key, member] pairs  \n  \n"
         }
       },
       "sortText": "D",
@@ -263,13 +263,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "get(string k)(Type)",
+      "label": "get(string k)(any|error)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type`   \n- member with key `k`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- member with key `k`  \n  \n"
         }
       },
       "sortText": "D",
@@ -282,13 +282,13 @@
       }
     },
     {
-      "label": "toArray()(Type[])",
+      "label": "toArray()((any|error)[])",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `Type[]`   \n- an array whose members are the members of `m`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- an array whose members are the members of `m`  \n  \n"
         }
       },
       "sortText": "D",
@@ -297,13 +297,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)(map<Type1>)",
+      "label": "map(function () func)(map<any|error>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<Type1>`   \n- new map containing result of applying function `func` to each member  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<any|error>`   \n- new map containing result of applying function `func` to each member  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/foreach_stmt_ctx_config16.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/foreach_stmt_ctx_config16.json
@@ -74,13 +74,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "reduce(function () func, any|error initial)(any|error)",
+      "label": "reduce(function () func, Type1 initial)(Type1)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `any|error` initial: initial value for the first argument of combining function `func`  \n  \n**Returns** `any|error`   \n- result of combining the members of `m` using `func`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `Type1` initial: initial value for the first argument of combining function `func`  \n  \n**Returns** `Type1`   \n- result of combining the members of `m` using `func`  \n  \n"
         }
       },
       "sortText": "D",
@@ -161,13 +161,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "remove(string k)(any|error)",
+      "label": "remove(string k)(Type)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- the member of `m` that had key `k`  \nThis removes the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type`   \n- the member of `m` that had key `k`  \nThis removes the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
         }
       },
       "sortText": "D",
@@ -180,13 +180,13 @@
       }
     },
     {
-      "label": "filter(function () func)(map<any|error>)",
+      "label": "filter(function () func)(map<Type>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<any|error>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<Type>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
         }
       },
       "sortText": "D",
@@ -199,13 +199,13 @@
       }
     },
     {
-      "label": "removeIfHasKey(string k)(any|error?)",
+      "label": "removeIfHasKey(string k)(Type?)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
         }
       },
       "sortText": "D",
@@ -218,13 +218,13 @@
       }
     },
     {
-      "label": "iterator()(object {public isolated function next() returns record {| any|error value; |}? ;})",
+      "label": "iterator()(object {public isolated function next() returns record {| Type value; |}? ;})",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| any|error value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| Type value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
         }
       },
       "sortText": "D",
@@ -233,13 +233,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "entries()(map<[string, any|error]>)",
+      "label": "entries()(map<[string, Type]>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, any|error]>`   \n- a new map of [key, member] pairs  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, Type]>`   \n- a new map of [key, member] pairs  \n  \n"
         }
       },
       "sortText": "D",
@@ -263,13 +263,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "get(string k)(any|error)",
+      "label": "get(string k)(Type)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- member with key `k`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `Type`   \n- member with key `k`  \n  \n"
         }
       },
       "sortText": "D",
@@ -282,13 +282,13 @@
       }
     },
     {
-      "label": "toArray()((any|error)[])",
+      "label": "toArray()(Type[])",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- an array whose members are the members of `m`  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `Type[]`   \n- an array whose members are the members of `m`  \n  \n"
         }
       },
       "sortText": "D",
@@ -297,13 +297,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)(map<any|error>)",
+      "label": "map(function () func)(map<Type1>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<any|error>`   \n- new map containing result of applying function `func` to each member  \n  \n"
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<Type1>`   \n- new map containing result of applying function `func` to each member  \n  \n"
         }
       },
       "sortText": "D",
@@ -335,13 +335,13 @@
       }
     },
     {
-      "label": "cloneReadOnly()(Cloneable & readonly)",
+      "label": "cloneReadOnly()(CloneableType & readonly)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable & readonly`   \n- immutable clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType & readonly`   \n- immutable clone of `v`  \n  \n"
         }
       },
       "sortText": "D",
@@ -433,13 +433,13 @@
       }
     },
     {
-      "label": "clone()(Cloneable)",
+      "label": "clone()(CloneableType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- clone of `v`  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/foreach_stmt_ctx_config17.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/foreach_stmt_ctx_config17.json
@@ -319,13 +319,13 @@
       }
     },
     {
-      "label": "cloneReadOnly()(Cloneable & readonly)",
+      "label": "cloneReadOnly()(CloneableType & readonly)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable & readonly`   \n- immutable clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType & readonly`   \n- immutable clone of `v`  \n  \n"
         }
       },
       "sortText": "D",
@@ -417,13 +417,13 @@
       }
     },
     {
-      "label": "clone()(Cloneable)",
+      "label": "clone()(CloneableType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- clone of `v`  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/foreach_stmt_ctx_config18.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/foreach_stmt_ctx_config18.json
@@ -232,13 +232,13 @@
       }
     },
     {
-      "label": "cloneReadOnly()(Cloneable & readonly)",
+      "label": "cloneReadOnly()(CloneableType & readonly)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable & readonly`   \n- immutable clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType & readonly`   \n- immutable clone of `v`  \n  \n"
         }
       },
       "sortText": "D",
@@ -292,13 +292,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "clone()(Cloneable)",
+      "label": "clone()(CloneableType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- clone of `v`  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/foreach_stmt_ctx_config20.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/foreach_stmt_ctx_config20.json
@@ -126,13 +126,13 @@
       }
     },
     {
-      "label": "iterator()(object {public isolated function next() returns record {| ItemType value; |}? ;})",
+      "label": "iterator()(object {public isolated function next() returns record {| xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text value; |}? ;})",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml:0.8.0_  \n  \nReturns an iterator over the xml items of `x`\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| ItemType value; |}? ;}`   \n- iterator object  \nEach item is represented by an xml singleton.  \n  \n"
+          "value": "**Package:** _ballerina/lang.xml:0.8.0_  \n  \nReturns an iterator over the xml items of `x`\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text value; |}? ;}`   \n- iterator object  \nEach item is represented by an xml singleton.  \n  \n"
         }
       },
       "sortText": "D",
@@ -156,13 +156,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "slice(int startIndex, int endIndex)(xml<ItemType>)",
+      "label": "slice(int startIndex, int endIndex)(xml<xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml:0.8.0_  \n  \nReturns a subsequence of an xml value.\n  \n**Params**  \n- `int` startIndex: start index, inclusive  \n- `int` endIndex: end index, exclusive(Defaultable)  \n  \n**Returns** `xml<ItemType>`   \n- a subsequence of `x` consisting of items with index >= startIndex and < endIndex  \n  \n"
+          "value": "**Package:** _ballerina/lang.xml:0.8.0_  \n  \nReturns a subsequence of an xml value.\n  \n**Params**  \n- `int` startIndex: start index, inclusive  \n- `int` endIndex: end index, exclusive(Defaultable)  \n  \n**Returns** `xml<xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text>`   \n- a subsequence of `x` consisting of items with index >= startIndex and < endIndex  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/foreach_stmt_ctx_config20.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/foreach_stmt_ctx_config20.json
@@ -126,13 +126,13 @@
       }
     },
     {
-      "label": "iterator()(object {public isolated function next() returns record {| xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text value; |}? ;})",
+      "label": "iterator()(object {public isolated function next() returns record {| ItemType value; |}? ;})",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml:0.8.0_  \n  \nReturns an iterator over the xml items of `x`\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text value; |}? ;}`   \n- iterator object  \nEach item is represented by an xml singleton.  \n  \n"
+          "value": "**Package:** _ballerina/lang.xml:0.8.0_  \n  \nReturns an iterator over the xml items of `x`\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| ItemType value; |}? ;}`   \n- iterator object  \nEach item is represented by an xml singleton.  \n  \n"
         }
       },
       "sortText": "D",
@@ -156,13 +156,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "slice(int startIndex, int endIndex)(xml<xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text>)",
+      "label": "slice(int startIndex, int endIndex)(xml<ItemType>)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml:0.8.0_  \n  \nReturns a subsequence of an xml value.\n  \n**Params**  \n- `int` startIndex: start index, inclusive  \n- `int` endIndex: end index, exclusive(Defaultable)  \n  \n**Returns** `xml<xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text>`   \n- a subsequence of `x` consisting of items with index >= startIndex and < endIndex  \n  \n"
+          "value": "**Package:** _ballerina/lang.xml:0.8.0_  \n  \nReturns a subsequence of an xml value.\n  \n**Params**  \n- `int` startIndex: start index, inclusive  \n- `int` endIndex: end index, exclusive(Defaultable)  \n  \n**Returns** `xml<ItemType>`   \n- a subsequence of `x` consisting of items with index >= startIndex and < endIndex  \n  \n"
         }
       },
       "sortText": "D",
@@ -300,13 +300,13 @@
       }
     },
     {
-      "label": "cloneReadOnly()(Cloneable & readonly)",
+      "label": "cloneReadOnly()(CloneableType & readonly)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable & readonly`   \n- immutable clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType & readonly`   \n- immutable clone of `v`  \n  \n"
         }
       },
       "sortText": "D",
@@ -360,13 +360,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "clone()(Cloneable)",
+      "label": "clone()(CloneableType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- clone of `v`  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/foreach_stmt_ctx_config21.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/foreach_stmt_ctx_config21.json
@@ -425,13 +425,13 @@
       }
     },
     {
-      "label": "cloneReadOnly()(Cloneable & readonly)",
+      "label": "cloneReadOnly()(CloneableType & readonly)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable & readonly`   \n- immutable clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType & readonly`   \n- immutable clone of `v`  \n  \n"
         }
       },
       "sortText": "D",
@@ -523,13 +523,13 @@
       }
     },
     {
-      "label": "clone()(Cloneable)",
+      "label": "clone()(CloneableType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- clone of `v`  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/foreach_stmt_ctx_config22.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/foreach_stmt_ctx_config22.json
@@ -425,13 +425,13 @@
       }
     },
     {
-      "label": "cloneReadOnly()(Cloneable & readonly)",
+      "label": "cloneReadOnly()(CloneableType & readonly)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable & readonly`   \n- immutable clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType & readonly`   \n- immutable clone of `v`  \n  \n"
         }
       },
       "sortText": "D",
@@ -485,13 +485,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "clone()(Cloneable)",
+      "label": "clone()(CloneableType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- clone of `v`  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/foreach_stmt_ctx_config23.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/foreach_stmt_ctx_config23.json
@@ -351,13 +351,13 @@
       }
     },
     {
-      "label": "cloneReadOnly()(Cloneable & readonly)",
+      "label": "cloneReadOnly()(CloneableType & readonly)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable & readonly`   \n- immutable clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType & readonly`   \n- immutable clone of `v`  \n  \n"
         }
       },
       "sortText": "D",
@@ -411,13 +411,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "clone()(Cloneable)",
+      "label": "clone()(CloneableType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- clone of `v`  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/foreach_stmt_ctx_config9.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/foreach_stmt_ctx_config9.json
@@ -425,13 +425,13 @@
       }
     },
     {
-      "label": "cloneReadOnly()(Cloneable & readonly)",
+      "label": "cloneReadOnly()(CloneableType & readonly)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable & readonly`   \n- immutable clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType & readonly`   \n- immutable clone of `v`  \n  \n"
         }
       },
       "sortText": "D",
@@ -523,13 +523,13 @@
       }
     },
     {
-      "label": "clone()(Cloneable)",
+      "label": "clone()(CloneableType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- clone of `v`  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/typeguard_stmt_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/typeguard_stmt_config1.json
@@ -29,13 +29,13 @@
       ]
     },
     {
-      "label": "cloneReadOnly()(Cloneable & readonly)",
+      "label": "cloneReadOnly()(CloneableType & readonly)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable & readonly`   \n- immutable clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType & readonly`   \n- immutable clone of `v`  \n  \n"
         }
       },
       "sortText": "D",
@@ -44,13 +44,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "clone()(Cloneable)",
+      "label": "clone()(CloneableType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- clone of `v`  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/typeguard_stmt_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/typeguard_stmt_config2.json
@@ -6,13 +6,13 @@
   "source": "statement_context/source/typeguard_stmt_source2.bal",
   "items": [
     {
-      "label": "cloneReadOnly()(Cloneable & readonly)",
+      "label": "cloneReadOnly()(CloneableType & readonly)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable & readonly`   \n- immutable clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType & readonly`   \n- immutable clone of `v`  \n  \n"
         }
       },
       "sortText": "D",
@@ -21,13 +21,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "clone()(Cloneable)",
+      "label": "clone()(CloneableType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- clone of `v`  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/typeguard_stmt_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/typeguard_stmt_config3.json
@@ -29,13 +29,13 @@
       ]
     },
     {
-      "label": "cloneReadOnly()(Cloneable & readonly)",
+      "label": "cloneReadOnly()(CloneableType & readonly)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable & readonly`   \n- immutable clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType & readonly`   \n- immutable clone of `v`  \n  \n"
         }
       },
       "sortText": "D",
@@ -44,13 +44,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "clone()(Cloneable)",
+      "label": "clone()(CloneableType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- clone of `v`  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/typeguard_stmt_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/typeguard_stmt_config4.json
@@ -48,13 +48,13 @@
       }
     },
     {
-      "label": "cloneReadOnly()(Cloneable & readonly)",
+      "label": "cloneReadOnly()(CloneableType & readonly)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable & readonly`   \n- immutable clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType & readonly`   \n- immutable clone of `v`  \n  \n"
         }
       },
       "sortText": "D",
@@ -146,13 +146,13 @@
       }
     },
     {
-      "label": "clone()(Cloneable)",
+      "label": "clone()(CloneableType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- clone of `v`  \n  \n"
         }
       },
       "sortText": "D",

--- a/language-server/modules/langserver-core/src/test/resources/extensions/document/syntaxTree/locate/locateModulePartNode.json
+++ b/language-server/modules/langserver-core/src/test/resources/extensions/document/syntaxTree/locate/locateModulePartNode.json
@@ -396,24 +396,7 @@
                       "signature":"int"
                     },
                     "symbol":{
-                      "name":"int",
-                      "typeKind":"typeReference",
-                      "moduleID":{
-                        "orgName":"ballerina",
-                        "moduleName":"lang.annotations",
-                        "version":"1.0.0"
-                      },
-                      "definition":{
-                        "readonly":false,
-                        "deprecated":false,
-                        "moduleID":{
-                          "orgName":"ballerina",
-                          "moduleName":"lang.annotations",
-                          "version":"1.0.0"
-                        },
-                        "kind":"TYPE_DEFINITION",
-                        "moduleQualifiedName":"annotations:int"
-                      },
+                      "typeKind":"int",
                       "kind":"TYPE",
                       "signature":"int"
                     },
@@ -731,24 +714,7 @@
                       "signature":"int"
                     },
                     "symbol":{
-                      "name":"int",
-                      "typeKind":"typeReference",
-                      "moduleID":{
-                        "orgName":"ballerina",
-                        "moduleName":"lang.annotations",
-                        "version":"1.0.0"
-                      },
-                      "definition":{
-                        "readonly":false,
-                        "deprecated":false,
-                        "moduleID":{
-                          "orgName":"ballerina",
-                          "moduleName":"lang.annotations",
-                          "version":"1.0.0"
-                        },
-                        "kind":"TYPE_DEFINITION",
-                        "moduleQualifiedName":"annotations:int"
-                      },
+                      "typeKind":"int",
                       "kind":"TYPE",
                       "signature":"int"
                     },

--- a/language-server/modules/langserver-core/src/test/resources/extensions/document/syntaxTree/locate/locateNodeList.json
+++ b/language-server/modules/langserver-core/src/test/resources/extensions/document/syntaxTree/locate/locateNodeList.json
@@ -396,24 +396,7 @@
                       "signature":"int"
                     },
                     "symbol":{
-                      "name":"int",
-                      "typeKind":"typeReference",
-                      "moduleID":{
-                        "orgName":"ballerina",
-                        "moduleName":"lang.annotations",
-                        "version":"1.0.0"
-                      },
-                      "definition":{
-                        "readonly":false,
-                        "deprecated":false,
-                        "moduleID":{
-                          "orgName":"ballerina",
-                          "moduleName":"lang.annotations",
-                          "version":"1.0.0"
-                        },
-                        "kind":"TYPE_DEFINITION",
-                        "moduleQualifiedName":"annotations:int"
-                      },
+                      "typeKind":"int",
                       "kind":"TYPE",
                       "signature":"int"
                     },
@@ -731,24 +714,7 @@
                       "signature":"int"
                     },
                     "symbol":{
-                      "name":"int",
-                      "typeKind":"typeReference",
-                      "moduleID":{
-                        "orgName":"ballerina",
-                        "moduleName":"lang.annotations",
-                        "version":"1.0.0"
-                      },
-                      "definition":{
-                        "readonly":false,
-                        "deprecated":false,
-                        "moduleID":{
-                          "orgName":"ballerina",
-                          "moduleName":"lang.annotations",
-                          "version":"1.0.0"
-                        },
-                        "kind":"TYPE_DEFINITION",
-                        "moduleQualifiedName":"annotations:int"
-                      },
+                      "typeKind":"int",
                       "kind":"TYPE",
                       "signature":"int"
                     },

--- a/language-server/modules/langserver-core/src/test/resources/hover/configs/hover_typeref1.json
+++ b/language-server/modules/langserver-core/src/test/resources/hover/configs/hover_typeref1.json
@@ -10,7 +10,7 @@
     "result": {
       "contents": {
         "kind": "markdown",
-        "value": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs.  \n  \n---  \n  \n### Fields  \n  \n`string` ***url*** : Target service url  \n  \n---  \n  \n### Methods  \n  \n+ `function (string path, string|xml<xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text>|json|byte[] message, string targetType) returns module1:Response`  \nThe `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.  \n"
+        "value": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs.  \n  \n---  \n  \n### Fields  \n  \n`string` ***url*** : Target service url  \n  \n---  \n  \n### Methods  \n  \n+ `function (string path, RequestMessage message, string targetType) returns module1:Response`  \nThe `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.  \n"
       }
     },
     "id": {

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
@@ -705,7 +705,7 @@ public class TypedescriptorTest {
                 {68, 4, READONLY},
                 {70, 4, ANY},
                 {71, 4, ANYDATA},
-//                {73, 4, TABLE},
+                {73, 4, TABLE},
                 {93, 4, STREAM},
 
         };

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
@@ -529,6 +529,7 @@ public class TypedescriptorTest {
         Symbol symbol = getSymbol(167, 6);
         TypeSymbol type = ((TypeDefinitionSymbol) symbol).typeDescriptor();
         assertEquals(type.typeKind(), INTERSECTION);
+        assertEquals(type.signature(), "Foo & readonly");
 
         List<TypeSymbol> members = ((IntersectionTypeSymbol) type).memberTypeDescriptors();
 
@@ -544,6 +545,7 @@ public class TypedescriptorTest {
         Symbol symbol = getSymbol(170, 25);
         TypeSymbol type = ((VariableSymbol) symbol).typeDescriptor();
         assertEquals(type.typeKind(), INTERSECTION);
+        assertEquals(type.signature(), "map<json> & readonly");
 
         List<TypeSymbol> members = ((IntersectionTypeSymbol) type).memberTypeDescriptors();
         assertEquals(members.get(0).typeKind(), MAP);

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
@@ -554,7 +554,17 @@ public class TypedescriptorTest {
     public void testIntersectionType3() {
         Symbol symbol = getSymbol(171, 16);
         TypeSymbol type = ((VariableSymbol) symbol).typeDescriptor();
-        assertEquals(type.typeKind(), INTERSECTION);
+
+        assertEquals(type.typeKind(), TYPE_REFERENCE);
+        assertEquals(type.getName().get(), "ReadonlyFoo");
+        assertEquals(((TypeReferenceTypeSymbol) type).typeDescriptor().typeKind(), INTERSECTION);
+
+        IntersectionTypeSymbol intrType = (IntersectionTypeSymbol) ((TypeReferenceTypeSymbol) type).typeDescriptor();
+        List<TypeSymbol> members = intrType.memberTypeDescriptors();
+
+        assertEquals(members.get(0).typeKind(), TYPE_REFERENCE);
+        assertEquals(members.get(0).getName().get(), "Foo");
+        assertEquals(members.get(1).typeKind(), READONLY);
     }
 
     @Test


### PR DESCRIPTION
## Purpose
This PR fixes the issue we had with `symbol()` always returning a type ref symbol when looking up a typedesc. 

- Case 1
```ballerina
<cursor>int foo = 10;
```
When calling `symbol()` for the above illustrated position, previously it returned a `TypeReferenceTypeSymbol` for `int` type. With this PR, it returns an instance of `IntTypeSymbol`.

- Case 2
```ballerina
type Foo int|float;

<cursor1>Foo <cursor2>foo = 10;
```
When calling `symbol()` for above illustrated positions, previously it returned the type symbol of the typedesc itself (in this case, a union). With this PR, both of the above cases will now return a type ref type symbol for `Foo`.

## Remarks
This modifies the behaviour of `symbol()` when it comes to type descs. Previously it used to return type ref for all typedescs. Now it returns the relevant typedesc symbol. 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
