### PR TITLE
Fix Value equality checks produce incorrect results at runtime for numeric values of different basic types

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -2600,25 +2600,15 @@ public class TypeChecker {
             case TypeTags.BOOLEAN_TAG:
                 return lhsValue.equals(rhsValue);
             case TypeTags.INT_TAG:
-                if (rhsValTypeTag <= TypeTags.FLOAT_TAG) {
-                    return lhsValue.equals(((Number) rhsValue).longValue());
+                if (rhsValTypeTag != TypeTags.BYTE_TAG && rhsValTypeTag != TypeTags.INT_TAG) {
+                    return false;
                 }
-
-                if (rhsValTypeTag == TypeTags.DECIMAL_TAG) {
-                    return DecimalValue.valueOf((long) lhsValue).equals(rhsValue);
-                }
-
-                return false;
+                return lhsValue.equals(((Number) rhsValue).longValue());
             case TypeTags.BYTE_TAG:
-                if (rhsValTypeTag <= TypeTags.FLOAT_TAG) {
-                    return ((Number) lhsValue).byteValue() == ((Number) rhsValue).byteValue();
+                if (rhsValTypeTag != TypeTags.BYTE_TAG && rhsValTypeTag != TypeTags.INT_TAG) {
+                    return false;
                 }
-
-                if (rhsValTypeTag == TypeTags.DECIMAL_TAG) {
-                    return DecimalValue.valueOf((int) lhsValue).equals(rhsValue);
-                }
-
-                return false;
+                return ((Number) lhsValue).byteValue() == ((Number) rhsValue).byteValue();
             case TypeTags.XML_TAG:
             case TypeTags.XML_ELEMENT_TAG:
             case TypeTags.XML_COMMENT_TAG:

--- a/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
@@ -1500,6 +1500,7 @@ function testEnsureTypeFunction3() returns int|error {
 
 function testEnsureType() {
     decimal h = 178.5;
+    decimal d = 24.0;
     float h1 = 178.5;
     decimal w = 72.5;
     json name = "Chiran";
@@ -1510,7 +1511,7 @@ function testEnsureType() {
     assert(<int>(checkpanic testEnsureTypeWithInt2()), 178);
     assert(<int>(checkpanic testEnsureTypeWithInt3()), 0);
     assert(<decimal>(checkpanic testEnsureTypeWithDecimal()), h);
-    assert(<decimal>(checkpanic testEnsureTypeWithDecimal2()), 24);
+    assert(<decimal>(checkpanic testEnsureTypeWithDecimal2()), d);
     assert(<()>(checkpanic testEnsureTypeWithNil()), ());
     assert( <string>(checkpanic testEnsureTypeWithString()), "Chiran");
     assert(<float>(checkpanic testEnsureTypeWithFloat()), w1);

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/BRunUtil.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/BRunUtil.java
@@ -381,6 +381,7 @@ public class BRunUtil {
                     break;
                 case TypeTags.UNION_TAG:
                 case TypeTags.ANY_TAG:
+                case TypeTags.ANYDATA_TAG:
                 case TypeTags.FINITE_TYPE_TAG:
                 case TypeTags.JSON_TAG:
                     typeClazz = Object.class;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/EqualAndNotEqualOperationsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/EqualAndNotEqualOperationsTest.java
@@ -19,6 +19,7 @@ package org.ballerinalang.test.expressions.binaryoperations;
 import org.ballerinalang.core.model.util.JsonParser;
 import org.ballerinalang.core.model.values.BBoolean;
 import org.ballerinalang.core.model.values.BByte;
+import org.ballerinalang.core.model.values.BDecimal;
 import org.ballerinalang.core.model.values.BFloat;
 import org.ballerinalang.core.model.values.BInteger;
 import org.ballerinalang.core.model.values.BMap;
@@ -162,6 +163,22 @@ public class EqualAndNotEqualOperationsTest {
         Assert.assertSame(returns[0].getClass(), BBoolean.class);
         Assert.assertFalse(((BBoolean) returns[0]).booleanValue(), "Expected value to be identified as not equal to " +
                 "nil");
+    }
+
+    @Test(description = "Test equals/unequals operation with equal any values", dataProvider = "anyDataValues")
+    public void checkAnyDataEqualityPositive(BValue a, BValue b) {
+        BValue[] returns = BRunUtil.invoke(result, "checkAnyDataEqualityPositive", new BValue[]{a, b});
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertSame(returns[0].getClass(), BBoolean.class);
+        Assert.assertTrue(((BBoolean) returns[0]).booleanValue(), "Expected values to be identified as equal");
+    }
+
+    @Test(description = "Test equals/unequals operation with not equal any values", dataProvider = "nonAnyDataValues")
+    public void checkAnyDataEqualityNegative(BValue a, BValue b) {
+        BValue[] returns = BRunUtil.invoke(result, "checkAnyDataEqualityNegative", new BValue[]{a, b});
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertSame(returns[0].getClass(), BBoolean.class);
+        Assert.assertFalse(((BBoolean) returns[0]).booleanValue(), "Expected values to be identified as not equal");
     }
 
     @Test(description = "Test equals/unequals operation with two equal open records")
@@ -980,6 +997,30 @@ public class EqualAndNotEqualOperationsTest {
                 {new BFloat(5.0)},
                 {new BString("Hi from Ballerina!")},
                 {new BMap<String, BInteger>()}
+        };
+    }
+
+    @DataProvider(name = "anyDataValues")
+    public Object[][] anydataValues() {
+        return new Object[][]{
+                {new BInteger(10), new BInteger(10)},
+                {new BInteger(10), new BByte(10)},
+                {new BByte(5), new BByte(5)},
+                {new BByte(24), new BInteger(24)}
+        };
+    }
+
+    @DataProvider(name = "nonAnyDataValues")
+    public Object[][] nonAnyDataValues() {
+        return new Object[][]{
+                {new BInteger(10), new BInteger(12)},
+                {new BInteger(10), new BByte(12)},
+                {new BInteger(10), new BFloat(10)},
+                {new BInteger(10), new BDecimal("10")},
+                {new BByte(16), new BByte(8)},
+                {new BByte(8), new BInteger(4)},
+                {new BByte(10), new BFloat(10)},
+                {new BByte(10), new BDecimal("10")}
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/object/object_override_includes.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/object/object_override_includes.bal
@@ -69,7 +69,7 @@ public function testObjectOverrideInterfaceWithInterface() {
 
 public function testObjectWithOverriddenFieldsAndMethods() {
     foo:ManagingDirector p = new foo:ManagingDirector(20, "John");
-    assertEquality(2000000, p.getBonus(1, 1));
+    assertEquality(2000000.0, p.getBonus(1, 1));
     assertEquality("Hello Director, John", p.getName());
 }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/equal_and_not_equal_operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/equal_and_not_equal_operation.bal
@@ -101,6 +101,14 @@ function checkEqualityToNilNegative(any a) returns boolean {
     return (a == ()) || !(a != ());
 }
 
+function checkAnyDataEqualityPositive(anydata a, anydata b) returns boolean {
+    return (a == b) && !(a != b);
+}
+
+function checkAnyDataEqualityNegative(anydata a, anydata b) returns boolean {
+    return (a == b) || !(a != b);
+}
+
 type ErrorDetail record {
     string message?;
     error cause?;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/imports/PredeclaredImportsTestProject/predeclared-modules.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/imports/PredeclaredImportsTestProject/predeclared-modules.bal
@@ -73,12 +73,13 @@ function testPredeclaredModules() {
 
 function testPredeclaredModules2() {
     decimal d1 = 10.5;
+    decimal d2 = 10.0;
     assertEquality(15, testMax(10, 15));
     assertEquality(10, testMin(10, 15));
     assertEquality(20, testMax1(15, 20));
     assertEquality(15, testMin1(15, 20));
     assertEquality(d1, testSum1(5, 5.5));
-    assertEquality(10, testOneArgMax(10));
+    assertEquality(d2, testOneArgMax(10));
     assertEquality(d1, testSum2(5, 5.5));
     assertEquality(false, testStartsWith());
     assertEquality("Hello from Ballerina",testStringConcat());

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/sealed_array.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/sealed_array.bal
@@ -319,7 +319,7 @@ function createNullableNonHomogeneousUnionAutoFillArray() {
     unionArray[2] = 4.0;
     assertArrayValuePanic((), unionArray, 0);
     assertArrayValuePanic((), unionArray, 1);
-    assertArrayValuePanic(4, unionArray, 2);
+    assertArrayValuePanic(4.0, unionArray, 2);
     assertArrayLengthPanic(3, unionArray);
 }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/tuples/tuple_basic_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/tuples/tuple_basic_test.bal
@@ -320,7 +320,7 @@ function testTupleDeclaredWithVar3() {
     assertEquality(321, c1[1]);
     assertEquality(32.56, c1[2]);
     assertEquality(100.4, c1[3]);
-    assertEquality(5, c1[4]);
+    assertEquality(5.0, c1[4]);
     assertEquality("Anne", c1[5]);
 
     var [a2, ...b2] = getData3();


### PR DESCRIPTION
## Purpose

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/30135
## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
