### PR TITLE
Avoid creating types unnecessarily during type param analysis

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
@@ -19,6 +19,7 @@ package org.wso2.ballerinalang.compiler.semantics.analyzer;
 
 import io.ballerina.tools.diagnostics.Location;
 import org.ballerinalang.model.Name;
+import org.ballerinalang.model.types.SelectivelyImmutableReferenceType;
 import org.ballerinalang.util.diagnostic.DiagnosticErrorCode;
 import org.wso2.ballerinalang.compiler.diagnostic.BLangDiagnosticLog;
 import org.wso2.ballerinalang.compiler.parser.BLangAnonymousModelHelper;
@@ -680,25 +681,53 @@ public class TypeParamAnalyzer {
         switch (expType.tag) {
             case TypeTags.ARRAY:
                 BType elementType = ((BArrayType) expType).eType;
-                return new BArrayType(getMatchingBoundType(elementType, env, resolvedTypes));
+                BType matchingBoundElementType = getMatchingBoundType(elementType, env, resolvedTypes);
+                if (matchingBoundElementType == elementType) {
+                    return expType;
+                }
+                return new BArrayType(matchingBoundElementType);
             case TypeTags.MAP:
                 BType constraint = ((BMapType) expType).constraint;
-                return new BMapType(TypeTags.MAP, getMatchingBoundType(constraint, env, resolvedTypes),
-                        symTable.mapType.tsymbol);
+                BType matchingBoundMapConstraintType = getMatchingBoundType(constraint, env, resolvedTypes);
+                if (matchingBoundMapConstraintType == constraint) {
+                    return expType;
+                }
+                return new BMapType(TypeTags.MAP, matchingBoundMapConstraintType, symTable.mapType.tsymbol);
             case TypeTags.STREAM:
-                BType constraintType = getMatchingBoundType(((BStreamType) expType).constraint, env, resolvedTypes);
-                BType completionType = getMatchingBoundType(((BStreamType) expType).completionType, env, resolvedTypes);
+                BStreamType expStreamType = (BStreamType) expType;
+                BType expStreamConstraint = expStreamType.constraint;
+                BType expStreamCompletionType = expStreamType.completionType;
+                BType constraintType = getMatchingBoundType(expStreamConstraint, env, resolvedTypes);
+                BType completionType = getMatchingBoundType(expStreamCompletionType, env, resolvedTypes);
                 if (completionType.tag == TypeTags.NONE) {
                     //setting nil type the completion type if not resolved
                     completionType = symTable.nilType;
                 }
+
+                if (expStreamConstraint == constraintType && expStreamCompletionType == completionType) {
+                    return expStreamType;
+                }
+
                 return new BStreamType(TypeTags.STREAM, constraintType, completionType, symTable.streamType.tsymbol);
             case TypeTags.TABLE:
-                BType tableConstraint = getMatchingBoundType(((BTableType) expType).constraint, env, resolvedTypes);
+                BTableType expTableType = (BTableType) expType;
+                BType expTableConstraint = expTableType.constraint;
+                BType tableConstraint = getMatchingBoundType(expTableConstraint, env, resolvedTypes);
+                boolean differentTypes = expTableConstraint != tableConstraint;
+
+                BType expTableKeyTypeConstraint = expTableType.keyTypeConstraint;
+                BType keyTypeConstraint = null;
+                if (expTableKeyTypeConstraint != null) {
+                    keyTypeConstraint = getMatchingBoundType(expTableKeyTypeConstraint, env, resolvedTypes);
+                    differentTypes = differentTypes || expTableKeyTypeConstraint != keyTypeConstraint;
+                }
+
+                if (!differentTypes) {
+                    return expTableType;
+                }
+
                 BTableType tableType = new BTableType(TypeTags.TABLE, tableConstraint, symTable.tableType.tsymbol);
-                if (((BTableType) expType).keyTypeConstraint != null) {
-                    BType keyTypeConstraint = getMatchingBoundType(((BTableType) expType).keyTypeConstraint, env,
-                            resolvedTypes);
+                if (expTableKeyTypeConstraint != null) {
                     tableType.keyTypeConstraint = keyTypeConstraint;
                 }
                 return tableType;
@@ -716,8 +745,12 @@ public class TypeParamAnalyzer {
                 return getMatchingErrorBoundType((BErrorType) expType, env, resolvedTypes);
             case TypeTags.TYPEDESC:
                 constraint = ((BTypedescType) expType).constraint;
-                return new BTypedescType(getMatchingBoundType(constraint, env, resolvedTypes),
-                        symTable.typeDesc.tsymbol);
+                BType matchingBoundType = getMatchingBoundType(constraint, env, resolvedTypes);
+                if (matchingBoundType == constraint) {
+                    return expType;
+                }
+
+                return new BTypedescType(matchingBoundType, symTable.typeDesc.tsymbol);
             case TypeTags.INTERSECTION:
                 return getMatchingReadonlyIntersectionBoundType((BIntersectionType) expType, env, resolvedTypes);
             default:
@@ -727,7 +760,7 @@ public class TypeParamAnalyzer {
 
     private BType getMatchingReadonlyIntersectionBoundType(BIntersectionType intersectionType, SymbolEnv env,
                                                            HashSet<BType> resolvedTypes) {
-
+        boolean hasDifferentType = false;
         Set<BType> constituentTypes = intersectionType.getConstituentTypes();
 
         LinkedHashSet<BType> boundTypes = new LinkedHashSet<>(constituentTypes.size());
@@ -735,27 +768,72 @@ public class TypeParamAnalyzer {
             if (type == symTable.readonlyType) {
                 continue;
             }
-            boundTypes.add(getMatchingBoundType(type, env, resolvedTypes));
+            BType matchingBoundType = getMatchingBoundType(type, env, resolvedTypes);
+            boundTypes.add(matchingBoundType);
+
+            if (!hasDifferentType && type != matchingBoundType) {
+                hasDifferentType = true;
+            }
         }
 
-        BUnionType boundUnion = BUnionType.create(null, boundTypes);
+        if (!hasDifferentType) {
+            return intersectionType;
+        }
+
+        SelectivelyImmutableReferenceType nonReadOnlyType;
+
+        if (boundTypes.size() == 1) {
+            BType type = boundTypes.iterator().next();
+            if (types.isInherentlyImmutableType(type) || Symbols.isFlagOn(type.flags, Flags.READONLY)) {
+                return type;
+            }
+
+            if (!types.isSelectivelyImmutableType(type)) {
+                return symTable.semanticError;
+            }
+
+            nonReadOnlyType = (SelectivelyImmutableReferenceType) type;
+        } else {
+            nonReadOnlyType = BUnionType.create(null, boundTypes);
+        }
+
         BIntersectionType boundIntersectionType =
                 ImmutableTypeCloner.getImmutableIntersectionType(intersectionType.tsymbol.pos, types,
-                        boundUnion, env, symTable, anonymousModelHelper, names,
+                        nonReadOnlyType, env, symTable, anonymousModelHelper, names,
                         new HashSet<>());
 
         return boundIntersectionType.effectiveType;
     }
 
     private BTupleType getMatchingTupleBoundType(BTupleType expType, SymbolEnv env, HashSet<BType> resolvedTypes) {
-
+        boolean hasDifferentType = false;
         List<BType> tupleTypes = new ArrayList<>();
-        expType.tupleTypes.forEach(type -> tupleTypes.add(getMatchingBoundType(type, env, resolvedTypes)));
+        for (BType type : expType.tupleTypes) {
+            BType matchingBoundType = getMatchingBoundType(type, env, resolvedTypes);
+            if (!hasDifferentType && type != matchingBoundType) {
+                hasDifferentType = true;
+            }
+
+            tupleTypes.add(matchingBoundType);
+        }
+
+        BType restType = expType.restType;
+        if (restType != null) {
+            BType matchingBoundRestType = getMatchingBoundType(restType, env, resolvedTypes);
+            if (!hasDifferentType && restType != matchingBoundRestType) {
+                hasDifferentType = true;
+            }
+        }
+
+        if (!hasDifferentType) {
+            return expType;
+        }
+
         return new BTupleType(tupleTypes);
     }
 
     private BRecordType getMatchingRecordBoundType(BRecordType expType, SymbolEnv env, HashSet<BType> resolvedTypes) {
-
+        boolean hasDifferentType = false;
         BRecordTypeSymbol expTSymbol = (BRecordTypeSymbol) expType.tsymbol;
         BRecordTypeSymbol recordSymbol = Symbols.createRecordSymbol(expTSymbol.flags, expTSymbol.name,
                                                                     expTSymbol.pkgID, null,
@@ -768,10 +846,14 @@ public class TypeParamAnalyzer {
 
         LinkedHashMap<String, BField> fields = new LinkedHashMap<>();
         for (BField expField : expType.fields.values()) {
+            BType type = expField.type;
+            BType matchingBoundType = getMatchingBoundType(type, env, resolvedTypes);
+            if (!hasDifferentType && type != matchingBoundType) {
+                hasDifferentType = true;
+            }
             BField field = new BField(expField.name, expField.pos,
                                       new BVarSymbol(0, expField.name, env.enclPkg.packageID,
-                                                     getMatchingBoundType(expField.type, env, resolvedTypes),
-                                                     env.scope.owner, expField.pos, VIRTUAL));
+                                              matchingBoundType, env.scope.owner, expField.pos, VIRTUAL));
             fields.put(field.name.value, field);
             recordSymbol.scope.define(expField.name, field.symbol);
         }
@@ -779,28 +861,53 @@ public class TypeParamAnalyzer {
         BRecordType bRecordType = new BRecordType(recordSymbol);
         bRecordType.fields = fields;
         recordSymbol.type = bRecordType;
+        bRecordType.flags = expType.flags;
 
         if (expType.sealed) {
             bRecordType.sealed = true;
         }
-        bRecordType.restFieldType = getMatchingBoundType(expType.restFieldType, env, resolvedTypes);
+        BType restFieldType = expType.restFieldType;
+        bRecordType.restFieldType = getMatchingBoundType(restFieldType, env, resolvedTypes);
+        if (!hasDifferentType && restFieldType != bRecordType.restFieldType) {
+            hasDifferentType = true;
+        }
+
+        if (!hasDifferentType) {
+            return expType;
+        }
 
         return bRecordType;
     }
 
     private BInvokableType getMatchingFunctionBoundType(BInvokableType expType, SymbolEnv env,
                                                         HashSet<BType> resolvedTypes) {
+        boolean hasDifferentType = false;
+        List<BType> paramTypes = new ArrayList<>();
+        for (BType type : expType.paramTypes) {
+            BType matchingBoundType = getMatchingBoundType(type, env, resolvedTypes);
+            if (!hasDifferentType && type != matchingBoundType) {
+                hasDifferentType = true;
+            }
+            paramTypes.add(matchingBoundType);
+        }
 
-        List<BType> paramTypes = expType.paramTypes.stream()
-                .map(type -> getMatchingBoundType(type, env, resolvedTypes))
-                .collect(Collectors.toList());
         BType restType = expType.restType;
         var flags = expType.flags;
         BInvokableTypeSymbol invokableTypeSymbol = Symbols.createInvokableTypeSymbol(SymTag.FUNCTION_TYPE, flags,
                 env.enclPkg.symbol.pkgID, expType, env.scope.owner, expType.tsymbol.pos, VIRTUAL);
 
+        BType retType = expType.retType;
+        BType matchingBoundType = getMatchingBoundType(retType, env, resolvedTypes);
+        if (!hasDifferentType && retType != matchingBoundType) {
+            hasDifferentType = true;
+        }
+
+        if (!hasDifferentType) {
+            return expType;
+        }
+
         BInvokableType invokableType = new BInvokableType(paramTypes, restType,
-                getMatchingBoundType(expType.retType, env, resolvedTypes), invokableTypeSymbol);
+                matchingBoundType, invokableTypeSymbol);
 
         invokableTypeSymbol.returnType = invokableType.retType;
 
@@ -814,7 +921,7 @@ public class TypeParamAnalyzer {
     }
 
     private BType getMatchingObjectBoundType(BObjectType expType, SymbolEnv env, HashSet<BType> resolvedTypes) {
-
+        boolean hasDifferentType = false;
         BObjectTypeSymbol actObjectSymbol = Symbols.createObjectSymbol(expType.tsymbol.flags,
                                                                        expType.tsymbol.name, expType.tsymbol.pkgID,
                                                                        null, expType.tsymbol.scope.owner,
@@ -827,16 +934,26 @@ public class TypeParamAnalyzer {
         actObjectSymbol.scope = new Scope(actObjectSymbol);
 
         for (BField expField : expType.fields.values()) {
+            BType type = expField.type;
+            BType matchingBoundType = getMatchingBoundType(type, env, resolvedTypes);
+            if (!hasDifferentType && matchingBoundType != type) {
+                hasDifferentType = true;
+            }
+
             BField field = new BField(expField.name, expField.pos,
                                       new BVarSymbol(expField.symbol.flags, expField.name, env.enclPkg.packageID,
-                                                     getMatchingBoundType(expField.type, env, resolvedTypes),
-                                                     env.scope.owner, expField.pos, VIRTUAL));
+                                              matchingBoundType, env.scope.owner, expField.pos, VIRTUAL));
             objectType.fields.put(field.name.value, field);
             objectType.tsymbol.scope.define(expField.name, field.symbol);
         }
 
         for (BAttachedFunction expFunc : ((BObjectTypeSymbol) expType.tsymbol).attachedFuncs) {
-            BInvokableType matchType = getMatchingFunctionBoundType(expFunc.type, env, resolvedTypes);
+            BInvokableType type = expFunc.type;
+            BInvokableType matchType = getMatchingFunctionBoundType(type, env, resolvedTypes);
+            if (!hasDifferentType && type != matchType) {
+                hasDifferentType = true;
+            }
+
             BInvokableSymbol invokableSymbol = new BInvokableSymbol(expFunc.symbol.tag, expFunc.symbol.flags,
                                                                     expFunc.symbol.name, env.enclPkg.packageID,
                                                                     matchType, env.scope.owner, expFunc.pos, VIRTUAL);
@@ -848,6 +965,10 @@ public class TypeParamAnalyzer {
             String funcName = Symbols.getAttachedFuncSymbolName(actObjectSymbol.type.tsymbol.name.value,
                     expFunc.funcName.value);
             actObjectSymbol.scope.define(names.fromString(funcName), invokableSymbol);
+        }
+
+        if (!hasDifferentType) {
+            return expType;
         }
 
         return objectType;
@@ -865,14 +986,23 @@ public class TypeParamAnalyzer {
     }
 
     private BType getMatchingOptionalBoundType(BUnionType expType, SymbolEnv env, HashSet<BType> resolvedTypes) {
+        boolean hasDifferentType = false;
         LinkedHashSet<BType> members = new LinkedHashSet<>();
-        expType.getMemberTypes()
-                .forEach(type -> {
-                    final BType boundType = getMatchingBoundType(type, env, resolvedTypes);
-                    if (boundType != symTable.noType) {
-                        members.add(boundType);
-                    }
-                });
+        for (BType type : expType.getMemberTypes()) {
+            final BType boundType = getMatchingBoundType(type, env, resolvedTypes);
+            if (boundType != symTable.noType) {
+                members.add(boundType);
+            }
+
+            if (!hasDifferentType && type != boundType) {
+                hasDifferentType = true;
+            }
+        }
+
+        if (!hasDifferentType) {
+            return expType;
+        }
+
         return BUnionType.create(null, members);
     }
 
@@ -881,7 +1011,13 @@ public class TypeParamAnalyzer {
         if (expType == symTable.errorType) {
             return expType;
         }
-        BType detailType = getMatchingBoundType(expType.detailType, env, resolvedTypes);
+        BType expDetailType = expType.detailType;
+        BType detailType = getMatchingBoundType(expDetailType, env, resolvedTypes);
+
+        if (expDetailType == detailType) {
+            return expType;
+        }
+
         BErrorTypeSymbol typeSymbol = new BErrorTypeSymbol(SymTag.ERROR,
                                                            symTable.errorType.tsymbol.flags,
                                                            symTable.errorType.tsymbol.name,

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibArrayTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibArrayTest.java
@@ -480,8 +480,7 @@ public class LangLibArrayTest {
         BAssertUtil.validateError(negativeResult, errorIndex++,
                 "invalid member type of the array/tuple to sort: 'map<string>?[]' is not an ordered type", 171, 47);
         BAssertUtil.validateError(negativeResult, errorIndex++,
-                "incompatible types: expected '(boolean|int|float|decimal|string|" +
-                        "ballerina/lang.array:1.1.0:OrderedType[])?', found 'any'", 174, 60);
+                "incompatible types: expected 'ballerina/lang.array:1.1.0:OrderedType', found 'any'", 174, 60);
         BAssertUtil.validateError(negativeResult, errorIndex++,
                 "invalid member type of the array/tuple to sort: '(string|int)[]' is not an ordered type", 178, 34);
         BAssertUtil.validateError(negativeResult, errorIndex++,

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/TypeParamTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/TypeParamTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
@@ -118,5 +119,21 @@ public class TypeParamTest {
         BRunUtil.invoke(result, "testIntFloatSimpleArrayMapUnion");
         BRunUtil.invoke(result, "testUnionOfRecordTypes");
         BRunUtil.invoke(result, "testUnionOfSimpleTupleTypes");
+    }
+
+    @Test(description = "Tests for type param resolution with non variable reference expressions. Tests that no " +
+            "unnecessary types are created.", dataProvider = "testFileNames")
+    public void testTypeParamResolutionWithExpression(String fileName) {
+        CompileResult result = BCompileUtil.compile(fileName);
+        BRunUtil.invoke(result, "testTypeParamResolutionWithExpression");
+    }
+
+    @DataProvider(name = "testFileNames")
+    public Object[] testFileNames() {
+        return new Object[]{
+                "test-src/type-param/type_param_resolution_with_exprs_one.bal",
+                "test-src/type-param/type_param_resolution_with_exprs_two.bal",
+                "test-src/type-param/type_param_resolution_with_exprs_three.bal"
+        };
     }
 }

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/TypeParamTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/TypeParamTest.java
@@ -133,7 +133,8 @@ public class TypeParamTest {
         return new Object[]{
                 "test-src/type-param/type_param_resolution_with_exprs_one.bal",
                 "test-src/type-param/type_param_resolution_with_exprs_two.bal",
-                "test-src/type-param/type_param_resolution_with_exprs_three.bal"
+                "test-src/type-param/type_param_resolution_with_exprs_three.bal",
+                "test-src/type-param/type_param_resolution_with_exprs_four.bal"
         };
     }
 }

--- a/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_resolution_with_exprs_four.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_resolution_with_exprs_four.bal
@@ -1,0 +1,73 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+type Map readonly & map<int>;
+
+function test() returns error? {
+    Map[] a = [];
+    a.push(check getMap());
+
+    stream<int>[] b = [];
+    b.push(check  getStream());
+
+    table<record {| int i; |}>[] c = [];
+    c.push(check getTableOne());
+
+    (table<record {| readonly int i; int j; |}> key (i))[] d = [];
+    d.push(check getTableTwo());
+
+    typedesc<anydata>[] e = [];
+    e.push(check getTypedesc());
+
+    [int, string...][] f = [];
+    f.push(check getTuple());
+
+    function ()[] g = [];
+    g.push(getFunction());
+
+    error<Detail>[] h = [];
+    h.push(getError());
+}
+
+function getMap() returns Map|error => {};
+
+function getStream() returns stream<int, ()>|error => (<int[]> [1, 2]).toStream();
+
+function getTableOne() returns error|table<record {| int i; |}> => table [{i: 1}, {i: 2}];
+
+function getTableTwo() returns (table<record {| readonly int i; int j; |}> key (i))|error => table [{i: 1, j: 101}, {i: 2, j: 202}];
+
+function getTypedesc() returns error|typedesc<int> => int;
+
+function getTuple() returns [int, string...]|error => [1, "hello"];
+
+function getFunction() returns function () => function () {};
+
+type Detail record {|
+    int code;
+|};
+
+function getError() returns error<Detail> => error("error!", code = 123);
+
+function testTypeParamResolutionWithExpression() {
+    error? res = test();
+
+    if res is () {
+        return;
+    }
+
+    panic error("expected nil, found '" + (<error> res).toString() + "'");
+}

--- a/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_resolution_with_exprs_one.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_resolution_with_exprs_one.bal
@@ -1,0 +1,40 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+type Foo readonly & record {| |};
+
+public readonly class Bar {
+    Foo[] arr = [];
+}
+
+function parse() returns error? {
+    Bar[] s = [];
+    s.push(check parseBar());
+}
+
+function parseBar() returns Bar|error => error("error!");
+
+function testTypeParamResolutionWithExpression() {
+    assertEquality(true, parse() is error);
+}
+
+function assertEquality(any expected, any actual) {
+    if expected is anydata && actual is anydata && expected == actual {
+        return;
+    }
+
+    panic error("expected '" + expected.toString() + "', found '" + actual.toString() + "'");
+}

--- a/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_resolution_with_exprs_three.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_resolution_with_exprs_three.bal
@@ -1,0 +1,53 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+type Foo readonly & record {| int i; |};
+
+public readonly class Bar {
+    Foo[] arr = [];
+}
+
+public class Baz {
+    Foo[] arr = [];
+}
+
+function parse() returns error? {
+    Bar[] s = [];
+    s.push(check parseBar());
+}
+
+function parse2() returns error? {
+    (Baz & readonly)[] s = [];
+    s.push(check parseBaz());
+}
+
+function parseBar() returns Bar|error => new;
+
+function parseBaz() returns (Baz & readonly)|error => error("error!");
+
+function testTypeParamResolutionWithExpression() {
+    assertEquality(0, (checkpanic parseBar()).arr.length());
+    assertEquality(true, parse() is ());
+    assertEquality(true, parse2() is error);
+}
+
+function assertEquality(any expected, any actual) {
+    if expected is anydata && actual is anydata && expected == actual {
+        return;
+    }
+
+    panic error("expected '" + expected.toString() + "', found '" + actual.toString() + "'");
+}

--- a/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_resolution_with_exprs_two.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_resolution_with_exprs_two.bal
@@ -1,0 +1,50 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+type Foo readonly & record {| int i; |};
+
+final Foo f1 = {i: 100};
+final Foo f2 = {i: 200};
+
+public readonly class Bar {
+    Foo[] arr = [f1, f2];
+}
+
+function func() returns Bar[]|error {
+    Bar[] s = [];
+    s.push(check getBar());
+    return s;
+}
+
+function getBar() returns Bar|error => new;
+
+function testTypeParamResolutionWithExpression() {
+    Bar[] arr = checkpanic func();
+    assertEquality(1, arr.length());
+
+    Bar bar = arr[0];
+    Foo[] fooArr = bar.arr;
+    assertEquality(2, fooArr.length());
+    assertEquality(<Foo[]> [f1, f2], fooArr);
+}
+
+function assertEquality(any expected, any actual) {
+    if expected is anydata && actual is anydata && expected == actual {
+        return;
+    }
+
+    panic error("expected '" + expected.toString() + "', found '" + actual.toString() + "'");
+}


### PR DESCRIPTION
## Purpose
We seem to have been creating new types for structure types even when their member types don't contain type params. 

Although the type param analyzer doesn't add type definitions, when these new types are used in places where type definitions may get added (like in intersection types), they result in in > 1 type definition with the same name, causing code gen to fail.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/30265
Fixes https://github.com/ballerina-platform/ballerina-lang/issues/30116
Fixes https://github.com/ballerina-platform/ballerina-lang/issues/30208

## Approach
The changes introduced in this PR will check if the type of any of the members is different, before adding a new type.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
