### PR TITLE
Add support to use noop Observability extensions

### DIFF
--- a/observelib/observe-internal/src/main/java/org/ballerinalang/observe/NativeFunctions.java
+++ b/observelib/observe-internal/src/main/java/org/ballerinalang/observe/NativeFunctions.java
@@ -42,15 +42,19 @@ public class NativeFunctions {
     public static BError enableMetrics(BString providerName) {
         // Loading the proper Metrics Provider
         MetricProvider selectedProvider = null;
-        for (MetricProvider providerFactory : ServiceLoader.load(MetricProvider.class)) {
-            if (providerName.getValue().equalsIgnoreCase(providerFactory.getName())) {
-                selectedProvider = providerFactory;
-                break;
-            }
-        }
-        if (selectedProvider == null) {
-            errStream.println("error: metrics provider " + providerName + " not found");
+        if (NoOpMetricProvider.NAME.equalsIgnoreCase(providerName.getValue())) {
             selectedProvider = new NoOpMetricProvider();
+        } else {
+            for (MetricProvider providerFactory : ServiceLoader.load(MetricProvider.class)) {
+                if (providerName.getValue().equalsIgnoreCase(providerFactory.getName())) {
+                    selectedProvider = providerFactory;
+                    break;
+                }
+            }
+            if (selectedProvider == null) {
+                errStream.println("error: metrics provider " + providerName + " not found");
+                selectedProvider = new NoOpMetricProvider();
+            }
         }
 
         try {
@@ -66,14 +70,18 @@ public class NativeFunctions {
     public static BError enableTracing(BString providerName) {
         // Loading the proper tracing Provider
         TracerProvider selectedProvider = null;
-        for (TracerProvider providerFactory : ServiceLoader.load(TracerProvider.class)) {
-            if (providerName.getValue().equalsIgnoreCase(providerFactory.getName())) {
-                selectedProvider = providerFactory;
-            }
-        }
-        if (selectedProvider == null) {
-            errStream.println("error: tracer provider " + providerName + " not found");
+        if (NoOpTracerProvider.NAME.equalsIgnoreCase(providerName.getValue())) {
             selectedProvider = new NoOpTracerProvider();
+        } else {
+            for (TracerProvider providerFactory : ServiceLoader.load(TracerProvider.class)) {
+                if (providerName.getValue().equalsIgnoreCase(providerFactory.getName())) {
+                    selectedProvider = providerFactory;
+                }
+            }
+            if (selectedProvider == null) {
+                errStream.println("error: tracer provider " + providerName + " not found");
+                selectedProvider = new NoOpTracerProvider();
+            }
         }
 
         try {

--- a/observelib/observe-internal/src/main/java/org/ballerinalang/observe/noop/NoOpMetricProvider.java
+++ b/observelib/observe-internal/src/main/java/org/ballerinalang/observe/noop/NoOpMetricProvider.java
@@ -30,10 +30,11 @@ import java.util.function.ToDoubleFunction;
  * Provide No-Op implementations of metrics.
  */
 public class NoOpMetricProvider implements MetricProvider {
+    public static final String NAME = "noop";
 
     @Override
     public String getName() {
-        return "NoOp";
+        return NAME;
     }
 
     @Override

--- a/observelib/observe-internal/src/main/java/org/ballerinalang/observe/noop/NoOpTracerProvider.java
+++ b/observelib/observe-internal/src/main/java/org/ballerinalang/observe/noop/NoOpTracerProvider.java
@@ -25,11 +25,13 @@ import io.opentelemetry.context.propagation.ContextPropagators;
  * Implementation of No-Op {@link TracerProvider}.
  */
 public class NoOpTracerProvider implements TracerProvider {
+    public static final String NAME = "noop";
+
     private Tracer instance;
 
     @Override
     public String getName() {
-        return "noop";
+        return NAME;
     }
 
     @Override


### PR DESCRIPTION
## Purpose
> Add support to use noop Observability extensions.

## Approach
> Currently Observability falls back to noop extension when Observability fails to find the correct extension. However, noop extension can be specified as the extension to be used. With this change, the users will be able to use noop directly without any errors being printed in the stderr.