### PR TITLE
Introduce flag to enable jacoco coverage XML report

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/BuildCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/BuildCommand.java
@@ -255,7 +255,7 @@ public class BuildCommand implements BLauncherCmd {
         }
 
         // Skip --jacoco-xml flag if it is set without code coverage
-        if (!project.buildOptions().codeCoverage() && enableJacocoXML == true) {
+        if (!project.buildOptions().codeCoverage() && enableJacocoXML) {
             this.outStream.println("warning: ignoring --jacoco-xml flag since code coverage is not enabled");
         }
 

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/TestCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/TestCommand.java
@@ -183,7 +183,7 @@ public class TestCommand implements BLauncherCmd {
         }
 
         // Skip --jacoco-xml flag if it is set without code coverage
-        if (!project.buildOptions().codeCoverage() && enableJacocoXML == true) {
+        if (!project.buildOptions().codeCoverage() && enableJacocoXML) {
             this.outStream.println("warning: ignoring --jacoco-xml flag since code coverage is not enabled");
         }
 

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/TestCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/TestCommand.java
@@ -106,6 +106,9 @@ public class TestCommand implements BLauncherCmd {
     @CommandLine.Option(names = "--code-coverage", description = "enable code coverage")
     private Boolean coverage;
 
+    @CommandLine.Option(names = "--jacoco-xml", description = "enable Jacoco XML generation")
+    private boolean enableJacocoXML;
+
     @CommandLine.Option(names = "--observability-included", description = "package observability in the executable.")
     private Boolean observabilityIncluded;
 
@@ -179,6 +182,11 @@ public class TestCommand implements BLauncherCmd {
             this.outStream.println("warning: ignoring --includes flag since code coverage is not enabled");
         }
 
+        // Skip --jacoco-xml flag if it is set without code coverage
+        if (!project.buildOptions().codeCoverage() && enableJacocoXML == true) {
+            this.outStream.println("warning: ignoring --jacoco-xml flag since code coverage is not enabled");
+        }
+
         TaskExecutor taskExecutor = new TaskExecutor.TaskBuilder()
                 .addTask(new CleanTargetDirTask(), isSingleFile)   // clean the target directory(projects only)
                 .addTask(new ResolveMavenDependenciesTask(outStream)) // resolve maven dependencies in Ballerina.toml
@@ -186,7 +194,7 @@ public class TestCommand implements BLauncherCmd {
 //                .addTask(new CopyResourcesTask(), listGroups) // merged with CreateJarTask
                 .addTask(new ListTestGroupsTask(outStream, displayWarning), !listGroups) // list available test groups
                 .addTask(new RunTestsTask(outStream, errStream, rerunTests, groupList, disableGroupList,
-                        testList, includes), listGroups)
+                        testList, includes, enableJacocoXML), listGroups)
                 .build();
 
         taskExecutor.executeTasks(project);

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
@@ -99,19 +99,22 @@ public class RunTestsTask implements Task {
     private List<String> disableGroupList;
     private boolean report;
     private boolean coverage;
+    private boolean enableJacocoXML;
     private boolean isSingleTestExecution;
     private boolean isRerunTestExecution;
     private List<String> singleExecTests;
     TestReport testReport;
 
-    public RunTestsTask(PrintStream out, PrintStream err, String includes) {
+    public RunTestsTask(PrintStream out, PrintStream err, String includes, boolean enableJacocoXML) {
         this.out = out;
         this.err = err;
         this.includesInCoverage = includes;
+        this.enableJacocoXML = enableJacocoXML;
     }
 
     public RunTestsTask(PrintStream out, PrintStream err, boolean rerunTests, List<String> groupList,
-                        List<String> disableGroupList, List<String> testList, String includes) {
+                        List<String> disableGroupList, List<String> testList, String includes,
+                        boolean enableJacocoXML) {
         this.out = out;
         this.err = err;
         this.isSingleTestExecution = false;
@@ -133,6 +136,7 @@ public class RunTestsTask implements Task {
             singleExecTests = testList;
         }
         this.includesInCoverage = includes;
+        this.enableJacocoXML = enableJacocoXML;
     }
 
     @Override
@@ -274,7 +278,7 @@ public class RunTestsTask implements Task {
             CoverageReport coverageReport = new CoverageReport(module, moduleCoverageMap,
                     packageNativeClassCoverageList, packageBalClassCoverageList, packageSourceCoverageList,
                     packageExecData, packageSessionInfo);
-            coverageReport.generateReport(jBallerinaBackend, this.includesInCoverage);
+            coverageReport.generateReport(jBallerinaBackend, this.includesInCoverage, enableJacocoXML);
         }
         // Traverse coverage map and add module wise coverage to test report
         for (Map.Entry mapElement : moduleCoverageMap.entrySet()) {
@@ -282,9 +286,11 @@ public class RunTestsTask implements Task {
             ModuleCoverage moduleCoverage = (ModuleCoverage) mapElement.getValue();
             testReport.addCoverage(moduleName, moduleCoverage);
         }
-        // Generate coverage XML report
-        CodeCoverageUtils.createXMLReport(project, packageExecData, packageNativeClassCoverageList,
-                packageBalClassCoverageList, packageSourceCoverageList, packageSessionInfo);
+        if (enableJacocoXML) {
+            // Generate coverage XML report
+            CodeCoverageUtils.createXMLReport(project, packageExecData, packageNativeClassCoverageList,
+                    packageBalClassCoverageList, packageSourceCoverageList, packageSessionInfo);
+        }
     }
 
     private void filterTestGroups() {

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/BuildCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/BuildCommandTest.java
@@ -365,7 +365,7 @@ public class BuildCommandTest extends BaseCommandTest {
         Path projectPath = this.testResources.resolve("validProjectWithBuildOptions");
         System.setProperty("user.dir", projectPath.toString());
         BuildCommand buildCommand = new BuildCommand(
-                projectPath, printStream, printStream, false, true, null, null, null, null);
+                projectPath, printStream, printStream, false, true, null, null, null, false);
         // non existing bal file
         new CommandLine(buildCommand).parse();
         buildCommand.execute();
@@ -423,7 +423,7 @@ public class BuildCommandTest extends BaseCommandTest {
         Path projectPath = this.testResources.resolve("valid-bal-file").resolve("hello_world.bal");
         System.setProperty("user.dir", this.testResources.resolve("valid-bal-file").toString());
         BuildCommand buildCommand = new BuildCommand(
-                projectPath, printStream, printStream, false, true, null, null, null, null);
+                projectPath, printStream, printStream, false, true, null, null, null, false);
         // non existing bal file
         new CommandLine(buildCommand).parse();
         try {
@@ -448,7 +448,7 @@ public class BuildCommandTest extends BaseCommandTest {
         Path projectPath = this.testResources.resolve("valid-bal-file").resolve("hello_world.bal");
         System.setProperty("user.dir", this.testResources.resolve("valid-bal-file").toString());
         BuildCommand buildCommand = new BuildCommand(
-                projectPath, printStream, printStream, false, true, false, true, true, true);
+                projectPath, printStream, printStream, false, true, false, true, true, false);
         // non existing bal file
         new CommandLine(buildCommand).parse();
         try {

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/BuildCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/BuildCommandTest.java
@@ -365,7 +365,7 @@ public class BuildCommandTest extends BaseCommandTest {
         Path projectPath = this.testResources.resolve("validProjectWithBuildOptions");
         System.setProperty("user.dir", projectPath.toString());
         BuildCommand buildCommand = new BuildCommand(
-                projectPath, printStream, printStream, false, true, null, null, null);
+                projectPath, printStream, printStream, false, true, null, null, null, null);
         // non existing bal file
         new CommandLine(buildCommand).parse();
         buildCommand.execute();
@@ -389,7 +389,7 @@ public class BuildCommandTest extends BaseCommandTest {
         Path projectPath = this.testResources.resolve("validProjectWithBuildOptions");
         System.setProperty("user.dir", projectPath.toString());
         BuildCommand buildCommand = new BuildCommand(
-                projectPath, printStream, printStream, false, true, false, true, false);
+                projectPath, printStream, printStream, false, true, false, true, false, false);
         // non existing bal file
         new CommandLine(buildCommand).parse();
         try {
@@ -423,7 +423,7 @@ public class BuildCommandTest extends BaseCommandTest {
         Path projectPath = this.testResources.resolve("valid-bal-file").resolve("hello_world.bal");
         System.setProperty("user.dir", this.testResources.resolve("valid-bal-file").toString());
         BuildCommand buildCommand = new BuildCommand(
-                projectPath, printStream, printStream, false, true, null, null, null);
+                projectPath, printStream, printStream, false, true, null, null, null, null);
         // non existing bal file
         new CommandLine(buildCommand).parse();
         try {
@@ -448,7 +448,7 @@ public class BuildCommandTest extends BaseCommandTest {
         Path projectPath = this.testResources.resolve("valid-bal-file").resolve("hello_world.bal");
         System.setProperty("user.dir", this.testResources.resolve("valid-bal-file").toString());
         BuildCommand buildCommand = new BuildCommand(
-                projectPath, printStream, printStream, false, true, false, true, true);
+                projectPath, printStream, printStream, false, true, false, true, true, true);
         // non existing bal file
         new CommandLine(buildCommand).parse();
         try {

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/CoverageReport.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/CoverageReport.java
@@ -108,7 +108,8 @@ public class CoverageReport {
      * @param includesInCoverage boolean
      * @throws IOException
      */
-    public void generateReport(JBallerinaBackend jBallerinaBackend, String includesInCoverage) throws IOException {
+    public void generateReport(JBallerinaBackend jBallerinaBackend, String includesInCoverage, boolean enableJacocoXML)
+            throws IOException {
         String orgName = this.module.packageInstance().packageOrg().toString();
         String packageName = this.module.packageInstance().packageName().toString();
 
@@ -124,15 +125,17 @@ public class CoverageReport {
         }
         if (!filteredPathList.isEmpty()) {
             CoverageBuilder coverageBuilder = generateTesterinaCoverageReport(orgName, packageName, filteredPathList);
-            // Add additional dependency jars for Jacoco Coverage XML if included
-            if (includesInCoverage != null) {
-                List<Path> dependencyPathList = getDependenciesForJacocoXML(jBallerinaBackend);
-                addCompiledSources(dependencyPathList, orgName, packageName, includesInCoverage);
-                execFileLoader.load(executionDataFile.toFile());
-                final CoverageBuilder xmlCoverageBuilder = analyzeStructure();
-                updatePackageLevelCoverage(xmlCoverageBuilder);
-            } else {
-                updatePackageLevelCoverage(coverageBuilder);
+            if (enableJacocoXML) {
+                // Add additional dependency jars for Jacoco Coverage XML if included
+                if (includesInCoverage != null) {
+                    List<Path> dependencyPathList = getDependenciesForJacocoXML(jBallerinaBackend);
+                    addCompiledSources(dependencyPathList, orgName, packageName, includesInCoverage);
+                    execFileLoader.load(executionDataFile.toFile());
+                    final CoverageBuilder xmlCoverageBuilder = analyzeStructure();
+                    updatePackageLevelCoverage(xmlCoverageBuilder);
+                } else {
+                    updatePackageLevelCoverage(coverageBuilder);
+                }
             }
             CodeCoverageUtils.deleteDirectory(coverageDir.resolve(BIN_DIR).toFile());
         } else {

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/CodeCoverageReportTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/CodeCoverageReportTest.java
@@ -67,8 +67,8 @@ public class CodeCoverageReportTest extends BaseTestCase {
         projectPath = projectBasedTestsPath.resolve(singleModuleTestRoot).toString();
         coverageXMLPath = projectBasedTestsPath.resolve(singleModuleTestRoot).resolve("target").resolve("report")
                 .resolve("codecov").resolve("coverage-report.xml");
-        balClient.runMain("test", new String[]{"--code-coverage"}, null, new String[]{},
-                new LogLeecher[]{}, projectPath);
+        balClient.runMain("test", new String[]{"--code-coverage", "--jacoco-xml"}, null,
+                new String[]{}, new LogLeecher[]{}, projectPath);
         Path reportRoot = projectBasedTestsPath.resolve(singleModuleTestRoot).resolve("target").
                 resolve("report").resolve("codecov");
         if (!reportRoot.toFile().exists()) {
@@ -90,8 +90,8 @@ public class CodeCoverageReportTest extends BaseTestCase {
         projectPath = projectBasedTestsPath.resolve(multiModuleTestRoot).toString();
         coverageXMLPath = projectBasedTestsPath.resolve(multiModuleTestRoot).resolve("target").resolve("report")
                 .resolve("foo").resolve("coverage-report.xml");
-        balClient.runMain("test", new String[]{"--code-coverage"}, null, new String[]{},
-                new LogLeecher[]{}, projectPath);
+        balClient.runMain("test", new String[]{"--code-coverage", "--jacoco-xml"}, null,
+                new String[]{}, new LogLeecher[]{}, projectPath);
         Path reportRoot = projectBasedTestsPath.resolve(multiModuleTestRoot).resolve("target").
                 resolve("report").resolve("foo");
         if (!reportRoot.toFile().exists()) {
@@ -114,8 +114,8 @@ public class CodeCoverageReportTest extends BaseTestCase {
     @Test
     public void normalizedCoverageClassTest() throws BallerinaTestException {
         projectPath = projectBasedTestsPath.resolve(multiModuleTestRoot).toString();
-        balClient.runMain("test", new String[]{"--code-coverage"}, null, new String[]{},
-                new LogLeecher[]{}, projectPath);
+        balClient.runMain("test", new String[]{"--code-coverage", "--jacoco-xml"}, null,
+                new String[]{}, new LogLeecher[]{}, projectPath);
         Path reportRoot = projectBasedTestsPath.resolve(multiModuleTestRoot).resolve("target").
                 resolve("report").resolve("foo");
         if (!reportRoot.toFile().exists()) {

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/TestReportTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/TestReportTest.java
@@ -66,6 +66,17 @@ public class TestReportTest extends BaseTestCase {
     }
 
     @Test ()
+    public void testWarningForJacocoXMLFlag() throws BallerinaTestException {
+        String msg = "warning: ignoring --jacoco-xml flag since code coverage is not enabled";
+        String[] args = new String[]{"--jacoco-xml"};
+        String output = balClient.runMainAndReadStdOut("test", args,
+                new HashMap<>(), projectPath, false);
+        if (!output.contains(msg)) {
+            Assert.fail("Test failed due to jacoco-xml flag validation failure.");
+        }
+    }
+
+    @Test ()
     public void testWithCoverage() throws BallerinaTestException, IOException {
         runCommand(true);
         validateStatuses();


### PR DESCRIPTION
## Purpose
Introduce flag to enable jacoco coverage XML report.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/30381

## Approach
A test command with the flag looks like follows. By default, the coverage report format will be json. If the '--jacoco-xml' flag is present it will also create the jacoo XML for the project.

`bal test --code-coverage --jacoco-xml`

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
