### PR TITLE
Fix required validation reset bug for table of arrays

### DIFF
--- a/misc/toml-parser/src/main/java/io/ballerina/toml/validator/SchemaValidator.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/validator/SchemaValidator.java
@@ -320,6 +320,6 @@ public class SchemaValidator extends TomlNodeVisitor {
         if (objectSchema.required() == null) {
             return new ArrayList<>();
         }
-        return objectSchema.required();
+        return new ArrayList<>(objectSchema.required());
     }
 }

--- a/misc/toml-parser/src/test/java/toml/parser/test/validator/TomlValidateTest.java
+++ b/misc/toml-parser/src/test/java/toml/parser/test/validator/TomlValidateTest.java
@@ -99,4 +99,20 @@ public class TomlValidateTest {
         Diagnostic diagnostic = toml.diagnostics().get(0);
         Assert.assertEquals(diagnostic.message(), "key 'field' not supported in schema 'C2C Spec'");
     }
+
+    @Test
+    public void testArrayTablesMultipleMissingEntry() throws IOException {
+        Path resourceDirectory = basePath.resolve("dependency-schema.json");
+        Path sampleInput = basePath.resolve("Dependencies.toml");
+
+        Toml toml = Toml.read(sampleInput, Schema.from(resourceDirectory));
+
+        List<Diagnostic> diagnostics = toml.diagnostics();
+        Assert.assertEquals(diagnostics.size(), 2);
+
+        Diagnostic diagnostic = diagnostics.get(0);
+        Diagnostic diagnostic1 = diagnostics.get(1);
+        Assert.assertEquals(diagnostic.message(), "'version' of the dependency is missing");
+        Assert.assertEquals(diagnostic1.message(), "'version' of the dependency is missing");
+    }
 }

--- a/misc/toml-parser/src/test/resources/validator/basic/Dependencies.toml
+++ b/misc/toml-parser/src/test/resources/validator/basic/Dependencies.toml
@@ -1,0 +1,9 @@
+[[dependency]]
+org = "wso2"
+name = "twitter"
+#version = "2.3.4"
+
+[[dependency]]
+org = "wso2"
+name = "github"
+#version = "1.2.3"

--- a/misc/toml-parser/src/test/resources/validator/basic/dependency-schema.json
+++ b/misc/toml-parser/src/test/resources/validator/basic/dependency-schema.json
@@ -1,0 +1,46 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Dependencies Toml Spec",
+    "description": "Schema for Dependencies Toml",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "dependency": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "org": {
+                        "type": "string",
+                        "pattern": "^[a-zA-Z0-9_]*$",
+                        "message" : {
+                            "pattern" : "invalid 'org' under [[dependency]]: 'org' can only contain alphanumerics, underscores and the maximum length is 256 characters"
+                        }
+                    },
+                    "name": {
+                        "type": "string",
+                        "pattern": "^[a-zA-Z0-9_.]*$",
+                        "message" : {
+                            "pattern" : "invalid 'name' under [[dependency]]: 'name' can only contain alphanumerics, underscores and periods and the maximum length is 256 characters"
+                        }
+                    },
+                    "version": {
+                        "type": "string",
+                        "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+                        "message": {
+                            "pattern": "invalid 'version' under [[dependency]]: 'version' should be compatible with semver"
+                        }
+                    },
+                    "repository": {
+                        "type": "string"
+                    }
+                },
+                "required": ["org", "name", "version"],
+                "message": {
+                    "required": "'${property}' of the dependency is missing"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Purpose
When there is an array type table in a toml file, the validations are only applied for the first element in the array. This is due to the removal logic in the toml validator. 

Resolves #30304

```ballerina 

[[dependency]]
org = "foo"
name = "winery"
#version = "0.1.0"

[[dependency]]
org = "bar"
name = "math"
#version = "0.1.0"

```

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
