### PR TITLE
Fix repeated options not throwing an error

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/cli/Option.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/cli/Option.java
@@ -116,11 +116,15 @@ public class Option {
         if (fieldType.getTag() == TypeTags.ARRAY_TAG) {
             handleArrayParameter(optionName, val, (ArrayType) fieldType);
         } else {
-            if (recordKeysFound.contains(optionName)) {
-                throw ErrorCreator.createError(
-                        StringUtils.fromString("The option '" + optionName + "' cannot be repeated"));
-            }
+            validateRepeatingOptions(optionName);
             recordVal.put(optionName, CliUtil.getBValueWithUnionValue(fieldType, val, optionName.getValue()));
+        }
+    }
+
+    private void validateRepeatingOptions(BString optionName) {
+        if (recordKeysFound.contains(optionName)) {
+            throw ErrorCreator.createError(
+                    StringUtils.fromString("The option '" + optionName + "' cannot be repeated"));
         }
     }
 
@@ -134,6 +138,7 @@ public class Option {
     private boolean handleBooleanTrue(BString paramName) {
         Type fieldType = recordType.getFields().get(paramName.getValue()).getFieldType();
         if (isABoolean(fieldType)) {
+            validateRepeatingOptions(paramName);
             recordVal.put(paramName, true);
             return true;
         } else if (fieldType.getTag() == TypeTags.ARRAY_TAG) {
@@ -214,6 +219,7 @@ public class Option {
             handleArrayParameter(paramName, val, (ArrayType) fieldType);
             return;
         }
+        validateRepeatingOptions(paramName);
         recordVal.put(paramName, CliUtil.getBValueWithUnionValue(fieldType, val, paramName.getValue()));
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/cli/OptionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/cli/OptionTest.java
@@ -32,7 +32,7 @@ public class OptionTest {
         CompileResult compileResult = BCompileUtil.compile("test-src/cli/option_all.bal");
         String[] args =
                 {"--name", "Riyafa=Riyafa", "--good", "--score", "100", "--height", "5.5", "--energy", "10e99",
-                        "--ratings", "5", "--ratings", "3", "--friends", "--friends", "--good"};
+                        "--ratings", "5", "--ratings", "3", "--friends", "--friends"};
         BRunUtil.runMain(compileResult, args);
     }
 
@@ -41,7 +41,7 @@ public class OptionTest {
         CompileResult compileResult = BCompileUtil.compile("test-src/cli/option_all.bal");
         String[] args =
                 {"--name=Riyafa=Riyafa", "--good", "--score=100", "--height=5.5", "--energy=10e99",
-                        "--ratings=5", "--ratings=3", "--friends", "--friends", "--good"};
+                        "--ratings=5", "--ratings=3", "--friends", "--friends"};
         BRunUtil.runMain(compileResult, args);
     }
 


### PR DESCRIPTION

## Purpose
> The following issues are fixed in this PR:
- Repeated boolean options not throwing an error
- Repeated named options not throwing an error

Moreover this PR refactors some of the test cases and adds a few more.

## Approach
> Fix issues
## Samples
> N/A

## Remarks
> Continuation of https://github.com/ballerina-platform/ballerina-lang/pull/30217

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
