### PR TITLE
Fix incorrect results with maps and arrays of int and string subtypes

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/TypeTags.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/TypeTags.java
@@ -24,35 +24,37 @@ package io.ballerina.runtime.api;
  */
 public class TypeTags {
 
-    // Value types
     public static final int INT_TAG = 1;
     public static final int BYTE_TAG = INT_TAG + 1;
     public static final int FLOAT_TAG = BYTE_TAG + 1;
     public static final int DECIMAL_TAG = FLOAT_TAG + 1;
     public static final int STRING_TAG = DECIMAL_TAG + 1;
     public static final int BOOLEAN_TAG = STRING_TAG + 1;
+    public static final int JSON_TAG = BOOLEAN_TAG + 1;
+    public static final int XML_TAG = JSON_TAG + 1;
+    public static final int TABLE_TAG = XML_TAG + 1;
+    public static final int NULL_TAG = TABLE_TAG + 1;
 
-    // Subtypes of value types (int and string)
-    public static final int SIGNED32_INT_TAG = BOOLEAN_TAG + 1;
+    // subtypes
+    public static final int SIGNED32_INT_TAG = NULL_TAG + 1;
     public static final int SIGNED16_INT_TAG = SIGNED32_INT_TAG + 1;
     public static final int SIGNED8_INT_TAG = SIGNED16_INT_TAG + 1;
     public static final int UNSIGNED32_INT_TAG = SIGNED8_INT_TAG + 1;
     public static final int UNSIGNED16_INT_TAG = UNSIGNED32_INT_TAG + 1;
     public static final int UNSIGNED8_INT_TAG = UNSIGNED16_INT_TAG + 1;
     public static final int CHAR_STRING_TAG = UNSIGNED8_INT_TAG + 1;
+    public static final int XML_ELEMENT_TAG = CHAR_STRING_TAG + 1;
+    public static final int XML_PI_TAG = XML_ELEMENT_TAG + 1;
+    public static final int XML_COMMENT_TAG = XML_PI_TAG + 1;
+    public static final int XML_TEXT_TAG = XML_COMMENT_TAG + 1;
+    public static final int NEVER_TAG = XML_TEXT_TAG + 1;
 
-    // branded types
-    public static final int JSON_TAG = CHAR_STRING_TAG + 1;
-    public static final int XML_TAG = JSON_TAG + 1;
-    public static final int TABLE_TAG = XML_TAG + 1;
-    public static final int NULL_TAG = TABLE_TAG + 1;
-    public static final int ANYDATA_TAG = NULL_TAG + 1;
+    public static final int ANYDATA_TAG = NEVER_TAG + 1;
     public static final int RECORD_TYPE_TAG = ANYDATA_TAG + 1;
     public static final int TYPEDESC_TAG = RECORD_TYPE_TAG + 1;
     public static final int STREAM_TAG = TYPEDESC_TAG + 1;
     public static final int MAP_TAG = STREAM_TAG + 1;
     public static final int INVOKABLE_TAG = MAP_TAG + 1;
-
     public static final int ANY_TAG = INVOKABLE_TAG + 1;
     public static final int ENDPOINT_TAG = ANY_TAG + 1;
     public static final int SERVICE_TAG = ENDPOINT_TAG + 1;
@@ -78,14 +80,7 @@ public class TypeTags {
     public static final int HANDLE_TAG = FUNCTION_POINTER_TAG + 1;
     public static final int READONLY_TAG = HANDLE_TAG + 1;
 
-    // Subtypes of Xml and ()
-    public static final int XML_ELEMENT_TAG = READONLY_TAG + 1;
-    public static final int XML_PI_TAG = XML_ELEMENT_TAG + 1;
-    public static final int XML_COMMENT_TAG = XML_PI_TAG + 1;
-    public static final int XML_TEXT_TAG = XML_COMMENT_TAG + 1;
-    public static final int NEVER_TAG = XML_TEXT_TAG + 1;
-
-    public static final int PARAMETERIZED_TYPE_TAG = NEVER_TAG + 1;
+    public static final int PARAMETERIZED_TYPE_TAG = READONLY_TAG + 1;
 
     public static boolean isIntegerTypeTag(int tag) {
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/TypeTags.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/TypeTags.java
@@ -23,13 +23,26 @@ package io.ballerina.runtime.api;
  * @since 0.995.0
  */
 public class TypeTags {
+
+    // Value types
     public static final int INT_TAG = 1;
     public static final int BYTE_TAG = INT_TAG + 1;
     public static final int FLOAT_TAG = BYTE_TAG + 1;
     public static final int DECIMAL_TAG = FLOAT_TAG + 1;
     public static final int STRING_TAG = DECIMAL_TAG + 1;
     public static final int BOOLEAN_TAG = STRING_TAG + 1;
-    public static final int JSON_TAG = BOOLEAN_TAG + 1;
+
+    // Subtypes of value types (int and string)
+    public static final int SIGNED32_INT_TAG = BOOLEAN_TAG + 1;
+    public static final int SIGNED16_INT_TAG = SIGNED32_INT_TAG + 1;
+    public static final int SIGNED8_INT_TAG = SIGNED16_INT_TAG + 1;
+    public static final int UNSIGNED32_INT_TAG = SIGNED8_INT_TAG + 1;
+    public static final int UNSIGNED16_INT_TAG = UNSIGNED32_INT_TAG + 1;
+    public static final int UNSIGNED8_INT_TAG = UNSIGNED16_INT_TAG + 1;
+    public static final int CHAR_STRING_TAG = UNSIGNED8_INT_TAG + 1;
+
+    // branded types
+    public static final int JSON_TAG = CHAR_STRING_TAG + 1;
     public static final int XML_TAG = JSON_TAG + 1;
     public static final int TABLE_TAG = XML_TAG + 1;
     public static final int NULL_TAG = TABLE_TAG + 1;
@@ -39,6 +52,7 @@ public class TypeTags {
     public static final int STREAM_TAG = TYPEDESC_TAG + 1;
     public static final int MAP_TAG = STREAM_TAG + 1;
     public static final int INVOKABLE_TAG = MAP_TAG + 1;
+
     public static final int ANY_TAG = INVOKABLE_TAG + 1;
     public static final int ENDPOINT_TAG = ANY_TAG + 1;
     public static final int SERVICE_TAG = ENDPOINT_TAG + 1;
@@ -64,15 +78,8 @@ public class TypeTags {
     public static final int HANDLE_TAG = FUNCTION_POINTER_TAG + 1;
     public static final int READONLY_TAG = HANDLE_TAG + 1;
 
-    // Subtypes
-    public static final int SIGNED32_INT_TAG = READONLY_TAG + 1;
-    public static final int SIGNED16_INT_TAG = SIGNED32_INT_TAG + 1;
-    public static final int SIGNED8_INT_TAG = SIGNED16_INT_TAG + 1;
-    public static final int UNSIGNED32_INT_TAG = SIGNED8_INT_TAG + 1;
-    public static final int UNSIGNED16_INT_TAG = UNSIGNED32_INT_TAG + 1;
-    public static final int UNSIGNED8_INT_TAG = UNSIGNED16_INT_TAG + 1;
-    public static final int CHAR_STRING_TAG = UNSIGNED8_INT_TAG + 1;
-    public static final int XML_ELEMENT_TAG = CHAR_STRING_TAG + 1;
+    // Subtypes of Xml and ()
+    public static final int XML_ELEMENT_TAG = READONLY_TAG + 1;
     public static final int XML_PI_TAG = XML_ELEMENT_TAG + 1;
     public static final int XML_COMMENT_TAG = XML_PI_TAG + 1;
     public static final int XML_TEXT_TAG = XML_COMMENT_TAG + 1;

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/TypeTags.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/TypeTags.java
@@ -30,20 +30,23 @@ public class TypeTags {
     public static final int DECIMAL_TAG = FLOAT_TAG + 1;
     public static final int STRING_TAG = DECIMAL_TAG + 1;
     public static final int BOOLEAN_TAG = STRING_TAG + 1;
-    public static final int JSON_TAG = BOOLEAN_TAG + 1;
-    public static final int XML_TAG = JSON_TAG + 1;
-    public static final int TABLE_TAG = XML_TAG + 1;
-    public static final int NULL_TAG = TABLE_TAG + 1;
 
-    // subtypes
-    public static final int SIGNED32_INT_TAG = NULL_TAG + 1;
+    // subtypes of int & string
+    public static final int SIGNED32_INT_TAG = BOOLEAN_TAG + 1;
     public static final int SIGNED16_INT_TAG = SIGNED32_INT_TAG + 1;
     public static final int SIGNED8_INT_TAG = SIGNED16_INT_TAG + 1;
     public static final int UNSIGNED32_INT_TAG = SIGNED8_INT_TAG + 1;
     public static final int UNSIGNED16_INT_TAG = UNSIGNED32_INT_TAG + 1;
     public static final int UNSIGNED8_INT_TAG = UNSIGNED16_INT_TAG + 1;
     public static final int CHAR_STRING_TAG = UNSIGNED8_INT_TAG + 1;
-    public static final int XML_ELEMENT_TAG = CHAR_STRING_TAG + 1;
+
+    public static final int JSON_TAG = CHAR_STRING_TAG + 1;
+    public static final int XML_TAG = JSON_TAG + 1;
+    public static final int TABLE_TAG = XML_TAG + 1;
+    public static final int NULL_TAG = TABLE_TAG + 1;
+
+    // subtypes of Xml & ()
+    public static final int XML_ELEMENT_TAG = NULL_TAG + 1;
     public static final int XML_PI_TAG = XML_ELEMENT_TAG + 1;
     public static final int XML_COMMENT_TAG = XML_PI_TAG + 1;
     public static final int XML_TEXT_TAG = XML_COMMENT_TAG + 1;

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -2864,11 +2864,11 @@ public class TypeChecker {
         if (type == null) {
             return true;
         }
-        if (type.getTag() < TypeTags.CHAR_STRING_TAG) {
+        if (type.getTag() < TypeTags.RECORD_TYPE_TAG &&
+                !(type.getTag() == TypeTags.CHAR_STRING_TAG || type.getTag() == TypeTags.NEVER_TAG)) {
             return true;
         }
         switch (type.getTag()) {
-            case TypeTags.ANYDATA_TAG:
             case TypeTags.STREAM_TAG:
             case TypeTags.MAP_TAG:
             case TypeTags.ANY_TAG:

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -1913,8 +1913,8 @@ public class TypeChecker {
 
     private static boolean isMutable(Object value, Type sourceType) {
         // All the value types are immutable
-        if (value == null || sourceType.getTag() < TypeTags.JSON_TAG || TypeTags.isIntegerTypeTag(sourceType.getTag())
-                || sourceType.getTag() == TypeTags.FINITE_TYPE_TAG || TypeTags.isStringTypeTag(sourceType.getTag())) {
+        if (value == null || sourceType.getTag() < TypeTags.JSON_TAG ||
+                sourceType.getTag() == TypeTags.FINITE_TYPE_TAG) {
             return false;
         }
 
@@ -2584,7 +2584,7 @@ public class TypeChecker {
     }
 
     private static boolean isSimpleBasicType(Type type) {
-        return type.getTag() < TypeTags.JSON_TAG || TypeTags.isIntegerTypeTag(type.getTag());
+        return type.getTag() < TypeTags.JSON_TAG;
     }
 
     private static boolean isHandleType(Type type) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -2864,10 +2864,11 @@ public class TypeChecker {
         if (type == null) {
             return true;
         }
-        if (type.getTag() < TypeTags.RECORD_TYPE_TAG || TypeTags.isIntegerTypeTag(type.getTag())) {
+        if (type.getTag() < TypeTags.CHAR_STRING_TAG) {
             return true;
         }
         switch (type.getTag()) {
+            case TypeTags.ANYDATA_TAG:
             case TypeTags.STREAM_TAG:
             case TypeTags.MAP_TAG:
             case TypeTags.ANY_TAG:

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BType.java
@@ -158,8 +158,7 @@ public abstract class BType implements Type {
     }
 
     public boolean isAnydata() {
-        return this.getTag() <= TypeTags.ANYDATA_TAG ||
-                (this.getTag() >= TypeTags.SIGNED32_INT_TAG && this.getTag() <= TypeTags.NEVER_TAG);
+        return this.getTag() <= TypeTags.ANYDATA_TAG;
     }
 
     public boolean isPureType() {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BType.java
@@ -158,7 +158,8 @@ public abstract class BType implements Type {
     }
 
     public boolean isAnydata() {
-        return this.getTag() <= TypeTags.ANYDATA_TAG;
+        return this.getTag() <= TypeTags.ANYDATA_TAG ||
+                (this.getTag() >= TypeTags.SIGNED32_INT_TAG && this.getTag() <= TypeTags.NEVER_TAG);
     }
 
     public boolean isPureType() {

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibXMLTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibXMLTest.java
@@ -316,6 +316,11 @@ public class LangLibXMLTest {
     }
 
     @Test
+    public void testXmlSubtypeFillerValue() {
+        BRunUtil.invoke(compileResult, "testXmlSubtypeFillerValue");
+    }
+
+    @Test
     public void testNegativeCases() {
         negativeResult = BCompileUtil.compile("test-src/xmllib_test_negative.bal");
         int i = 0;

--- a/langlib/langlib-test/src/test/resources/test-src/xmllib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/xmllib_test.bal
@@ -777,6 +777,20 @@ function testData() {
     assertEquals(concat.data(), "EnidBlytonhello>abc<");
 }
 
+function testXmlSubtypeFillerValue() {
+    'xml:Text x1 = 'xml:createText("text 1");
+    'xml:Text x2 = 'xml:createText("text 2");
+    'xml:Text x3 = 'xml:createText("text 3");
+
+    'xml:Text[] x = [x1, x2];
+    insertListValue(x, 3, x3);
+    assertEquals(x.toString(), "[`text 1`,`text 2`,``,`text 3`]");
+}
+
+function insertListValue('xml:Text[] list, int pos, 'xml:Text value) {
+    list[pos] = value;
+}
+
 function testXmlGetContentOverACommentSequence() {
     xml a = xml `<elem><!--Hello--></elem>`;
     xml c = a/*;

--- a/langlib/langlib-test/src/test/resources/test-src/xmllib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/xmllib_test.bal
@@ -778,11 +778,11 @@ function testData() {
 }
 
 function testXmlSubtypeFillerValue() {
-    'xml:Text x1 = 'xml:createText("text 1");
-    'xml:Text x2 = 'xml:createText("text 2");
-    'xml:Text x3 = 'xml:createText("text 3");
+    xml:Text x1 = xml:createText("text 1");
+    xml:Text x2 = xml:createText("text 2");
+    xml:Text x3 = xml:createText("text 3");
 
-    'xml:Text[] x = [x1, x2];
+    xml:Text[] x = [x1, x2];
     insertListValue(x, 3, x3);
     assertEquals(x.toString(), "[`text 1`,`text 2`,``,`text 3`]");
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/anydata/AnydataTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/anydata/AnydataTest.java
@@ -300,4 +300,9 @@ public class AnydataTest {
     public void testRuntimeIsAnydata() {
         BRunUtil.invokeFunction(result, "testRuntimeIsAnydata");
     }
+
+    @Test
+    public void testSubtypeOfBasicTypesIsAnydata() {
+        BRunUtil.invokeFunction(result, "testSubtypeOfBasicTypesIsAnydata");
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/anydata/AnydataTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/anydata/AnydataTest.java
@@ -33,6 +33,7 @@ import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -301,8 +302,19 @@ public class AnydataTest {
         BRunUtil.invokeFunction(result, "testRuntimeIsAnydata");
     }
 
-    @Test
-    public void testSubtypeOfBasicTypesIsAnydata() {
-        BRunUtil.invokeFunction(result, "testSubtypeOfBasicTypesIsAnydata");
+    @Test(dataProvider = "subtypeOfBasicTypesIsAnydata")
+    public void testSubtypeOfBasicTypesIsAnydata(String function) {
+        BRunUtil.invokeFunction(result, function);
+    }
+
+    @DataProvider(name = "subtypeOfBasicTypesIsAnydata")
+    public Object[][] subtypeOfBasicTypesIsAnydata() {
+        return new Object[][]{
+                {"testMapOfCharIsAnydata"},
+                {"testCharArrayIsAnydata"},
+                {"testMapOfIntSubtypeIsAnydata"},
+                {"testArrayOfIntSubtypeIsAnydata"},
+                {"testMapOfNeverTypeIsAnydata"}
+        };
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/anydata/anydata_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/anydata/anydata_test.bal
@@ -900,6 +900,29 @@ function testRuntimeIsAnydata() {
     assertTrue(h2 is anydata);
 }
 
+function testSubtypeOfBasicTypesIsAnydata() {
+
+    map<string:Char> x1 = {};
+    any a1 = x1;
+    assertTrue(a1 is anydata);
+
+    string:Char[] x2 = ["a", "b"];
+    any a2 = x2;
+    assertTrue(a2 is anydata);
+
+    map<int:Signed32> x3 = {};
+    any a3 = x3;
+    assertTrue(a3 is anydata);
+
+    int:Signed32[] x4 = [];
+    any a4 = x4;
+    assertTrue(a4 is anydata);
+
+    map<never> x5 = {};
+    any a5 = x5;
+    assertTrue(a5 is anydata);
+}
+
 function assertTrue(any|error actual) {
     assertEquality(true, actual);
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/anydata/anydata_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/anydata/anydata_test.bal
@@ -900,24 +900,31 @@ function testRuntimeIsAnydata() {
     assertTrue(h2 is anydata);
 }
 
-function testSubtypeOfBasicTypesIsAnydata() {
-
+function testMapOfCharIsAnydata() {
     map<string:Char> x1 = {};
     any a1 = x1;
     assertTrue(a1 is anydata);
+}
 
+function testCharArrayIsAnydata() {
     string:Char[] x2 = ["a", "b"];
     any a2 = x2;
     assertTrue(a2 is anydata);
+}
 
+function testMapOfIntSubtypeIsAnydata() {
     map<int:Signed32> x3 = {};
     any a3 = x3;
     assertTrue(a3 is anydata);
+}
 
+function testArrayOfIntSubtypeIsAnydata() {
     int:Signed32[] x4 = [];
     any a4 = x4;
     assertTrue(a4 is anydata);
+}
 
+function testMapOfNeverTypeIsAnydata() {
     map<never> x5 = {};
     any a5 = x5;
     assertTrue(a5 is anydata);


### PR DESCRIPTION
## Purpose
> This PR will 
fix the incorrect results occurred for type test expression with maps and arrays of int and string sub types.
include the built-in subtypes of `xml` to the `io.ballerina.runtime.TypeChecker#hasFillerValue` check. 

Fixes 
#30264
#30524
## Approach

## Samples

## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
