### PR TITLE
Add a parent to compiler plugin class loader

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/plugins/CompilerPlugins.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/plugins/CompilerPlugins.java
@@ -80,7 +80,8 @@ public class CompilerPlugins {
 
     private static ClassLoader createClassLoader(List<Path> jarDependencyPaths) {
         return AccessController.doPrivileged(
-                (PrivilegedAction<URLClassLoader>) () -> new URLClassLoader(getJarURLS(jarDependencyPaths))
+                (PrivilegedAction<URLClassLoader>) () -> new URLClassLoader(getJarURLS(jarDependencyPaths),
+                        CompilerPlugins.class.getClassLoader())
         );
     }
 


### PR DESCRIPTION
When ballerina compiler is used within the spring boot based lang
server, CNF exceptions were seeing while trying to compile an http
service. This is to fix the CNF.
