### PR TITLE
Improve xml navigation type checking by using xml subtyping

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -420,7 +420,7 @@ public class TypeChecker extends BLangNodeVisitor {
         // check for undeclared namespaces.
         checkXMLNamespacePrefixes(xmlElementAccess.filters);
         checkExpr(xmlElementAccess.expr, env, symTable.xmlType);
-        resultType = new BXMLType(symTable.xmlElementType, null);
+        resultType = types.checkType(xmlElementAccess, symTable.xmlElementSeqType, expType);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -432,18 +432,21 @@ public class TypeChecker extends BLangNodeVisitor {
         if (xmlNavigation.childIndex != null) {
             checkExpr(xmlNavigation.childIndex, env, symTable.intType);
         }
-        BType actualType = checkExpr(xmlNavigation.expr, env, symTable.xmlType);
+        BType exprType = checkExpr(xmlNavigation.expr, env, symTable.xmlType);
 
-        if (actualType.tag == TypeTags.UNION) {
+        if (exprType.tag == TypeTags.UNION) {
             dlog.error(xmlNavigation.pos, DiagnosticErrorCode.TYPE_DOES_NOT_SUPPORT_XML_NAVIGATION_ACCESS,
                     xmlNavigation.expr.type);
         }
+
+        BType actualType = xmlNavigation.navAccessType == XMLNavigationAccess.NavAccessType.CHILDREN
+                ? symTable.xmlType : symTable.xmlElementSeqType;
 
         types.checkType(xmlNavigation, actualType, expType);
         if (xmlNavigation.navAccessType == XMLNavigationAccess.NavAccessType.CHILDREN) {
             resultType = symTable.xmlType;
         } else {
-            resultType = new BXMLType(symTable.xmlElementType, null);
+            resultType = symTable.xmlElementSeqType;
         }
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
@@ -165,6 +165,7 @@ public class SymbolTable {
     public final BXMLSubType xmlCommentType = new BXMLSubType(TypeTags.XML_COMMENT, Names.XML_COMMENT);
     public final BXMLSubType xmlTextType = new BXMLSubType(TypeTags.XML_TEXT, Names.XML_TEXT, Flags.READONLY);
     public final BType xmlNeverType = new BXMLType(neverType,  null);
+    public final BType xmlElementSeqType = new BXMLType(xmlElementType, null);
 
     public final BType xmlType = new BXMLType(BUnionType.create(null, xmlElementType, xmlCommentType,
             xmlPIType, xmlTextType),  null);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLAccessTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLAccessTest.java
@@ -211,7 +211,17 @@ public class XMLAccessTest {
                 "<object xmlns=\"http://www.force.com/2009/06/asyncapi/dataload\">Account</object>");
     }
 
-    @Test(groups = { "disableOnOldParser" })
+    @Test
+    public void testXMLNavigationExpressionWithXMLSubtypeOnLHS() {
+        BRunUtil.invoke(navigation, "testXMLNavigationExpressionWithXMLSubtypeOnLHS");
+    }
+
+    @Test
+    public void testXMLNavigationDescendantsStepWithXMLSubtypeOnLHS() {
+        BRunUtil.invoke(navigation, "testXMLNavigationDescendantsStepWithXMLSubtypeOnLHS");
+    }
+
+    @Test
     public void testInvalidXMLAccessWithIndex() {
         int i = 0;
         BAssertUtil.validateError(negativeResult, i++, "invalid expr in assignment lhs", 4, 10);
@@ -243,7 +253,7 @@ public class XMLAccessTest {
     }
 
     @Test
-    public void testXMLNavExpressionMethodInvocationNegative() {
+    public void testXMLNavExpressionNegative() {
         String methodInvocMessage = "method invocations are not yet supported within XML navigation expressions, " +
                 "use a grouping expression (parenthesis) " +
                 "if you intend to invoke the method on the result of the navigation expression.";
@@ -260,6 +270,17 @@ public class XMLAccessTest {
         BAssertUtil.validateError(navigationNegative, i++, navIndexingMessage, 8, 14);
         BAssertUtil.validateError(navigationNegative, i++, navIndexingMessage, 9, 14);
         Assert.assertEquals(navigationNegative.getErrorCount(), i);
+    }
+
+    @Test
+    public void testXMLNavExpressionTypeCheckNegative() {
+        CompileResult compile = BCompileUtil.compile("test-src/types/xml/xml-nav-access-type-check-negative.bal");
+        int i = 0;
+        BAssertUtil.validateError(compile, i++,
+                "incompatible types: expected 'xml<xml:Comment>', found 'xml<xml:Element>'", 19, 27);
+        BAssertUtil.validateError(compile, i++,
+                "incompatible types: expected 'xml<xml:Comment>', found 'xml<xml:Element>'", 20, 27);
+        Assert.assertEquals(compile.getErrorCount(), i);
     }
 
     @Test void testXMLFilterExpressionsNegative() {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLAccessTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLAccessTest.java
@@ -280,6 +280,8 @@ public class XMLAccessTest {
                 "incompatible types: expected 'xml<xml:Comment>', found 'xml<xml:Element>'", 19, 27);
         BAssertUtil.validateError(compile, i++,
                 "incompatible types: expected 'xml<xml:Comment>', found 'xml<xml:Element>'", 20, 27);
+        BAssertUtil.validateError(compile, i++,
+                "incompatible types: expected 'xml<xml:Comment>', found 'xml<xml:Element>'", 21, 28);
         Assert.assertEquals(compile.getErrorCount(), i);
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-nav-access-type-check-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-nav-access-type-check-negative.bal
@@ -18,4 +18,5 @@ function stepTypeCheckingNegative() {
     xml x1 = xml `<root><child attr="attr-val"></child></root>`;
     xml<xml:Comment> x9 = x1/<child>;
     xml<xml:Comment> xx = x1/**/<child>;
+    xml<xml:Comment> xx1 = x1/*.<child>;
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-nav-access-type-check-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-nav-access-type-check-negative.bal
@@ -1,0 +1,21 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+function stepTypeCheckingNegative() {
+    xml x1 = xml `<root><child attr="attr-val"></child></root>`;
+    xml<xml:Comment> x9 = x1/<child>;
+    xml<xml:Comment> xx = x1/**/<child>;
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-navigation-access.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-navigation-access.bal
@@ -128,3 +128,23 @@ function testXMLNavigationExpressionWithQuotedIdentifiers() returns [xml, xml] {
 
     return [x/<'object>, x/<ns0:'object>];
 }
+
+function testXMLNavigationExpressionWithXMLSubtypeOnLHS() {
+        xml val = xml `<foo><bar>0</bar><baz>1</baz><bar>2</bar></foo>`;
+        xml<xml:Element> xmlResult = val/<bar>;
+        string s = xmlResult.toString();
+        if (s == "<bar>0</bar><bar>2</bar>") {
+            return;
+        }
+        panic error("Assertion error, expected: `<bar>0</bar><bar>2</bar>`, found: " + s);
+}
+
+function testXMLNavigationDescendantsStepWithXMLSubtypeOnLHS() {
+        xml val = xml `<foo><bar>0</bar><baz>1</baz><bar>2</bar></foo>`;
+        xml<xml:Element> xmlResult = val/**/<baz>;
+        string s = xmlResult.toString();
+        if (s == "<baz>1</baz>") {
+            return;
+        }
+        panic error("Assertion error, expected: `<baz>1</baz>`, found: " + s);
+}


### PR DESCRIPTION
## Purpose
Allow below:
```ballerina
xml<xml:Element> x = x1/<child>;
xml<xml:Element> y = x1/**/<child>;
```

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/30336

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
