### PR TITLE
Filter out minutiae from syntaxTreeNode API

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/BallerinaDocumentServiceImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/BallerinaDocumentServiceImpl.java
@@ -24,6 +24,7 @@ import io.ballerina.projects.Project;
 import io.ballerina.projects.ProjectKind;
 import io.ballerina.syntaxapicallsgen.SyntaxApiCallsGen;
 import io.ballerina.syntaxapicallsgen.config.SyntaxApiCallsGenConfig;
+import io.ballerina.tools.text.LinePosition;
 import org.ballerinalang.diagramutil.DiagramUtil;
 import org.ballerinalang.langserver.LSClientLogger;
 import org.ballerinalang.langserver.LSContextOperation;
@@ -36,6 +37,7 @@ import org.ballerinalang.langserver.diagnostic.DiagnosticsHelper;
 import org.ballerinalang.langserver.extensions.ballerina.packages.BallerinaPackageService;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.PublishDiagnosticsParams;
+import org.eclipse.lsp4j.Range;
 
 import java.nio.file.Path;
 import java.util.Collections;
@@ -50,6 +52,8 @@ import java.util.stream.Collectors;
  * @since 0.981.2
  */
 public class BallerinaDocumentServiceImpl implements BallerinaDocumentService {
+    protected static final String MINUTIAE = "WHITESPACE_MINUTIAE";
+
     private final WorkspaceManager workspaceManager;
     private final LSClientLogger clientLogger;
     private final LanguageServerContext serverContext;
@@ -337,7 +341,17 @@ public class BallerinaDocumentServiceImpl implements BallerinaDocumentService {
                 }
                 SyntaxTree syntaxTree = this.workspaceManager.syntaxTree(filePath.get()).orElseThrow();
                 NonTerminalNode currentNode = CommonUtil.findNode(params.getRange(), syntaxTree);
-                syntaxTreeNodeResponse.setKind(currentNode.kind().name());
+                LinePosition startLine = currentNode.lineRange().startLine();
+                LinePosition endLine = currentNode.lineRange().endLine();
+                Range cursor = params.getRange();
+                if ((startLine.line() < cursor.getStart().getLine() || startLine.line() == cursor.getStart().getLine()
+                        && startLine.offset() < cursor.getStart().getCharacter()) &&
+                        (endLine.line() > cursor.getEnd().getLine() || endLine.line() == cursor.getEnd().getLine()
+                                && endLine.offset() > cursor.getEnd().getCharacter())) {
+                    syntaxTreeNodeResponse.setKind(currentNode.kind().name());
+                } else {
+                    syntaxTreeNodeResponse.setKind(MINUTIAE);
+                }
             } catch (Throwable e) {
                 String msg = "Operation 'ballerinaDocument/syntaxTreeNode' failed!";
                 this.clientLogger.logError(DocumentContext.DC_SYNTAX_TREE_NODE, msg, e, params.getDocumentIdentifier(),

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/stnode/SyntaxTreeNodeTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/stnode/SyntaxTreeNodeTest.java
@@ -37,6 +37,7 @@ public class SyntaxTreeNodeTest {
 
     private static final JsonParser JSON_PARSER = new JsonParser();
     private static final String STRING_LITERAL = "STRING_LITERAL";
+    private static final String MINUTIAE = "WHITESPACE_MINUTIAE";
 
     private Path resource;
     private Endpoint serviceEndpoint;
@@ -67,7 +68,8 @@ public class SyntaxTreeNodeTest {
     @DataProvider(name = "stnode-data-provider")
     public Object[][] getDataProvider() {
         return new Object[][]{
-                {0, 0, "IMPORT_DECLARATION"},
+                {0, 0, MINUTIAE},
+                {0, 1, "IMPORT_DECLARATION"},
                 {2, 25, STRING_LITERAL},
                 {4, 20, "FUNCTION_DEFINITION"},
                 {5, 30, STRING_LITERAL},
@@ -81,7 +83,9 @@ public class SyntaxTreeNodeTest {
                 {12, 5, "RECORD_TYPE_DESC"},
                 {8, 3, "PARAMETERIZED_TYPE_DESC"},
                 {2, 5, "CONST_DECLARATION"},
-                {18, 45, "RETURN_TYPE_DESCRIPTOR"}
+                {18, 45, "RETURN_TYPE_DESCRIPTOR"},
+                {9, 40, MINUTIAE},
+                {19, 42, MINUTIAE}
         };
     }
 }

--- a/language-server/modules/langserver-core/src/test/resources/stnode/stnode_test.bal
+++ b/language-server/modules/langserver-core/src/test/resources/stnode/stnode_test.bal
@@ -17,6 +17,6 @@ record {|
 service /hello on new http:Listener(9093) {
 
     resource function get satyHello() returns string {
-        return "This is inside resource.";
+        return "This is inside resource." ;
     }
 }


### PR DESCRIPTION
## Purpose
Filter out minutiae from syntaxTreeNode API to avoid having incorrect positioning for string split feature in VSCode plugin.

Fix https://github.com/wso2/ballerina-plugin-vscode/issues/58

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
