### PR TITLE
[LS] Refactor FunctionCallExpressionNodeContext to provide sorted completion items in paramter context

### DIFF
--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/BallerinaCompletionContext.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/BallerinaCompletionContext.java
@@ -17,11 +17,13 @@
  */
 package org.ballerinalang.langserver.commons;
 
+import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.compiler.syntax.tree.NonTerminalNode;
 import io.ballerina.compiler.syntax.tree.Token;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Represents the Completion operation context.
@@ -71,4 +73,12 @@ public interface BallerinaCompletionContext extends CompletionContext {
      * @return {@link List} of nodes
      */
     List<Node> getResolverChain();
+
+    /**
+     * Get the ContextType for the node at cursor.
+     *
+     * @return {@link Optional<TypeSymbol>} Context TypeSymbol for node at cursor.
+     */
+    Optional<TypeSymbol> getContextType();
+
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -18,6 +18,7 @@ package org.ballerinalang.langserver.common.utils;
 import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.symbols.ArrayTypeSymbol;
 import io.ballerina.compiler.api.symbols.ClassSymbol;
+import io.ballerina.compiler.api.symbols.FunctionTypeSymbol;
 import io.ballerina.compiler.api.symbols.IntersectionTypeSymbol;
 import io.ballerina.compiler.api.symbols.ModuleSymbol;
 import io.ballerina.compiler.api.symbols.ObjectTypeSymbol;
@@ -32,10 +33,12 @@ import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
+import io.ballerina.compiler.syntax.tree.FunctionCallExpressionNode;
 import io.ballerina.compiler.syntax.tree.IdentifierToken;
 import io.ballerina.compiler.syntax.tree.ImportDeclarationNode;
 import io.ballerina.compiler.syntax.tree.ImportPrefixNode;
 import io.ballerina.compiler.syntax.tree.ModulePartNode;
+import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.compiler.syntax.tree.NonTerminalNode;
 import io.ballerina.compiler.syntax.tree.SeparatedNodeList;
 import io.ballerina.compiler.syntax.tree.SyntaxTree;
@@ -112,6 +115,7 @@ import static org.ballerinalang.langserver.common.utils.CommonKeys.SLASH_KEYWORD
  * Common utils to be reuse in language server implementation.
  */
 public class CommonUtil {
+
     private static final Path TEMP_DIR = Paths.get(System.getProperty("java.io.tmpdir"));
 
     public static final String MD_LINE_SEPARATOR = "  " + System.lineSeparator();
@@ -871,6 +875,7 @@ public class CommonUtil {
      * Node comparator to compare the nodes by position.
      */
     public static class BLangNodeComparator implements Comparator<BLangNode> {
+
         /**
          * {@inheritDoc}
          */
@@ -1095,11 +1100,12 @@ public class CommonUtil {
         String[] modNameComponents = modName.split("\\.");
         return modNameComponents[modNameComponents.length - 1];
     }
+
     /**
      * Get the validated symbol name against the visible symbols.
      * This method can be used to auto generate the symbol names without conflicting with the existing symbol names
      *
-     * @param context completion context
+     * @param context    completion context
      * @param symbolName raw symbol name to modify with the numbered suffix
      * @return {@link String} modified symbol name
      */
@@ -1134,7 +1140,7 @@ public class CommonUtil {
 
     /**
      * Escape a given value.
-     * 
+     *
      * @param value to be escape
      * @return {@link String}
      */
@@ -1173,5 +1179,47 @@ public class CommonUtil {
         } catch (ClassNotFoundException e) {
             return Collections.emptyList();
         }
+    }
+
+    /**
+     * Given the cursor position information, returns the expected ParameterSymbol
+     * information corresponding to the FunctionTypeSymbol instance.
+     *
+     * @param functionTypeSymbol Referenced FunctionTypeSymbol
+     * @param ctx                Positioned operation context information.
+     * @param node               Function call expression node.
+     * @return {@link Optional<ParameterSymbol>} Expected Parameter Symbol.
+     */
+    public static Optional<ParameterSymbol> resolveFunctionParameterSymbol(FunctionTypeSymbol functionTypeSymbol,
+                                                                           PositionedOperationContext ctx,
+                                                                           FunctionCallExpressionNode node) {
+        int cursorPosition = ctx.getCursorPositionInTree();
+        int argIndex = -1;
+        for (Node child : node.arguments()) {
+            if (child.textRange().endOffset() < cursorPosition) {
+                argIndex += 1;
+            }
+        }
+        Optional<List<ParameterSymbol>> params = functionTypeSymbol.params();
+        if (params.isEmpty() || params.get().size() < argIndex + 2) {
+            return Optional.empty();
+        }
+        return Optional.of(params.get().get(argIndex + 1));
+    }
+
+    /**
+     * Check if the cursor is positioned in a function call expression parameter context.
+     *
+     * @param ctx  PositionedOperationContext
+     * @param node FunctionCallExpressionNode
+     * @return {@link Boolean} whether the cursor is in parameter context.
+     */
+    public static Boolean isInFunctionCallParameterContext(PositionedOperationContext ctx,
+                                                           FunctionCallExpressionNode node) {
+        int cursorPosition = ctx.getCursorPositionInTree();
+        return (!node.openParenToken().isMissing())
+                && (node.openParenToken().textRange().endOffset() <= cursorPosition)
+                && (!node.closeParenToken().isMissing())
+                && (cursorPosition <= node.closeParenToken().textRange().startOffset());
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/FunctionCompletionItemBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/FunctionCompletionItemBuilder.java
@@ -84,6 +84,28 @@ public final class FunctionCompletionItemBuilder {
         return item;
     }
 
+    /**
+     * Creates and returns a completion item.
+     *
+     * @param functionSymbol BSymbol
+     * @param context        LS context
+     * @return {@link CompletionItem}
+     */
+    public static CompletionItem buildFunctionPointer(FunctionSymbol functionSymbol,
+                                                      BallerinaCompletionContext context) {
+        CompletionItem item = new CompletionItem();
+        setMeta(item, functionSymbol, context);
+        if (functionSymbol != null) {
+            // Override function signature
+            String funcName = functionSymbol.getName().get();
+            item.setInsertText(funcName);
+            item.setLabel(funcName);
+            item.setFilterText(funcName);
+            item.setKind(CompletionItemKind.Variable);
+        }
+        return item;
+    }
+
     public static CompletionItem build(ClassSymbol typeDesc, InitializerBuildMode mode,
                                        BallerinaCompletionContext ctx) {
         MethodSymbol initMethod = null;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FunctionCallExpressionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FunctionCallExpressionNodeContext.java
@@ -15,17 +15,28 @@
  */
 package org.ballerinalang.langserver.completions.providers.context;
 
+import io.ballerina.compiler.api.symbols.FunctionSymbol;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.SymbolKind;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.api.symbols.VariableSymbol;
 import io.ballerina.compiler.syntax.tree.FunctionCallExpressionNode;
 import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
 import io.ballerina.compiler.syntax.tree.Token;
 import org.ballerinalang.annotation.JavaSPIService;
+import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.common.utils.completion.QNameReferenceUtil;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
 import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
+import org.ballerinalang.langserver.completions.SymbolCompletionItem;
+import org.ballerinalang.langserver.completions.util.ContextTypeResolver;
+import org.ballerinalang.langserver.completions.util.SortingUtil;
+import org.eclipse.lsp4j.CompletionItemKind;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Completion Provider for {@link FunctionCallExpressionNode} context.
@@ -34,6 +45,7 @@ import java.util.List;
  */
 @JavaSPIService("org.ballerinalang.langserver.commons.completion.spi.BallerinaCompletionProvider")
 public class FunctionCallExpressionNodeContext extends BlockNodeContextProvider<FunctionCallExpressionNode> {
+
     public FunctionCallExpressionNodeContext() {
         super(FunctionCallExpressionNode.class);
     }
@@ -50,7 +62,7 @@ public class FunctionCallExpressionNodeContext extends BlockNodeContextProvider<
         completionItems.addAll(this.expressionCompletions(ctx));
         // TODO: implement the following
 //        completionItems.addAll(this.getNewExprCompletionItems(ctx, node));
-
+        this.sort(ctx, node, completionItems);
         return completionItems;
     }
 
@@ -61,5 +73,61 @@ public class FunctionCallExpressionNodeContext extends BlockNodeContextProvider<
         Token closeParen = node.closeParenToken();
 
         return cursor > openParen.textRange().startOffset() && cursor < closeParen.textRange().endOffset();
+    }
+
+    @Override
+    public void sort(BallerinaCompletionContext context,
+                     FunctionCallExpressionNode node,
+                     List<LSCompletionItem> completionItems) {
+
+        ContextTypeResolver contextTypeResolver = new ContextTypeResolver(context);
+        Optional<TypeSymbol> parameterSymbol = node.apply(contextTypeResolver);
+
+        if (parameterSymbol.isEmpty() || !CommonUtil.isInFunctionCallParameterContext(context, node)) {
+            super.sort(context, node, completionItems);
+            return;
+        }
+
+        completionItems.forEach(lsCompletionItem -> {
+            int rank;
+            CompletionItemKind completionItemKind = lsCompletionItem.getCompletionItem().getKind();
+            if (lsCompletionItem.getType() == LSCompletionItem.CompletionItemType.SYMBOL) {
+                Symbol symbol = ((SymbolCompletionItem) lsCompletionItem).getSymbol();
+                if (symbol == null) {
+                    rank = SortingUtil.toRank(lsCompletionItem, 2);
+                } else {
+                    switch (completionItemKind) {
+                        case Variable:
+                            if (symbol.kind() == SymbolKind.FUNCTION &&
+                                    ((FunctionSymbol) symbol).typeDescriptor()
+                                            .assignableTo(parameterSymbol.get())) {
+                                rank = 1;
+                            } else if (symbol.kind() != SymbolKind.FUNCTION &&
+                                    ((VariableSymbol) symbol).typeDescriptor()
+                                            .assignableTo(parameterSymbol.get())) {
+                                rank = 1;
+                            } else {
+                                rank = SortingUtil.toRank(lsCompletionItem, 2);
+                            }
+                            break;
+                        case Method:
+                        case Function:
+                            Optional<TypeSymbol> returnType =
+                                    ((FunctionSymbol) symbol).typeDescriptor().returnTypeDescriptor();
+                            if (returnType.isPresent() && returnType.get().assignableTo(parameterSymbol.get())) {
+                                rank = 2;
+                            } else {
+                                rank = SortingUtil.toRank(lsCompletionItem, 2);
+                            }
+                            break;
+                        default:
+                            rank = SortingUtil.toRank(lsCompletionItem, 2);
+                    }
+                }
+            } else {
+                rank = SortingUtil.toRank(lsCompletionItem, 2);
+            }
+            lsCompletionItem.getCompletionItem().setSortText(SortingUtil.genSortText(rank));
+        });
     }
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/anon_func_expr_ctx_config10.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/anon_func_expr_ctx_config10.json
@@ -612,6 +612,25 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "doTask",
+      "kind": "Variable",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _._  \n  \n  \n**Params**  \n- `int` a  \n- `int` c"
+        }
+      },
+      "sortText": "B",
+      "filterText": "doTask",
+      "insertText": "doTask",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
       "label": "doTask(int a, int c)",
       "kind": "Function",
       "detail": "Function",
@@ -631,6 +650,21 @@
       }
     },
     {
+      "label": "testFunction",
+      "kind": "Variable",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _._  \n  \n  \n"
+        }
+      },
+      "sortText": "B",
+      "filterText": "testFunction",
+      "insertText": "testFunction",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "testFunction()",
       "kind": "Function",
       "detail": "Function",
@@ -644,6 +678,25 @@
       "filterText": "testFunction",
       "insertText": "testFunction()",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "lambda",
+      "kind": "Variable",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _._  \n  \n  \n**Params**  \n- `int` a  \n- `int` b  \n  \n**Returns** `int`   \n  \n"
+        }
+      },
+      "sortText": "B",
+      "filterText": "lambda",
+      "insertText": "lambda",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
     },
     {
       "label": "lambda(int a, int b)(int)",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/anon_func_expr_ctx_config8.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/anon_func_expr_ctx_config8.json
@@ -457,6 +457,25 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "doTask",
+      "kind": "Variable",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _._  \n  \n  \n**Params**  \n- `int` a  \n- `int` c"
+        }
+      },
+      "sortText": "B",
+      "filterText": "doTask",
+      "insertText": "doTask",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
       "label": "doTask(int a, int c)",
       "kind": "Function",
       "detail": "Function",
@@ -476,6 +495,21 @@
       }
     },
     {
+      "label": "testFunction",
+      "kind": "Variable",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _._  \n  \n  \n"
+        }
+      },
+      "sortText": "B",
+      "filterText": "testFunction",
+      "insertText": "testFunction",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "testFunction()",
       "kind": "Function",
       "detail": "Function",
@@ -489,6 +523,25 @@
       "filterText": "testFunction",
       "insertText": "testFunction()",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "lambda",
+      "kind": "Variable",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _._  \n  \n  \n**Params**  \n- `int` a  \n- `int` b  \n  \n**Returns** `int`   \n  \n"
+        }
+      },
+      "sortText": "B",
+      "filterText": "lambda",
+      "insertText": "lambda",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
     },
     {
       "label": "lambda(int a, int b)(int)",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/anon_func_expr_ctx_config9.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/anon_func_expr_ctx_config9.json
@@ -180,6 +180,21 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "function1",
+      "kind": "Variable",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \n  \n"
+        }
+      },
+      "sortText": "B",
+      "filterText": "function1",
+      "insertText": "function1",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "function1()",
       "kind": "Function",
       "detail": "Function",
@@ -192,6 +207,21 @@
       "sortText": "C",
       "filterText": "function1",
       "insertText": "function1()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "function2",
+      "kind": "Variable",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function2  \n"
+        }
+      },
+      "sortText": "B",
+      "filterText": "function2",
+      "insertText": "function2",
       "insertTextFormat": "Snippet"
     },
     {
@@ -210,6 +240,25 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "function3",
+      "kind": "Variable",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function3 with input parameters\n  \n**Params**  \n- `int` param1: param1 Parameter Description   \n- `int` param2: param2 Parameter Description  \n- `float[]` param3: param3 Parameter Description  \n  \n**Returns** `int`   \n- Return Value Description  \n  \n"
+        }
+      },
+      "sortText": "B",
+      "filterText": "function3",
+      "insertText": "function3",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
       "label": "function3(int param1, int param2, float... param3)(int)",
       "kind": "Function",
       "detail": "Function",
@@ -222,6 +271,25 @@
       "sortText": "C",
       "filterText": "function3",
       "insertText": "function3(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "function4",
+      "kind": "Variable",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function4 with input parameters\n  \n**Params**  \n- `int` param1: param1 Parameter Description   \n- `int` param2: param2 Parameter Description  \n- `string` param3: param3 Parameter Description(Defaultable)  \n- `float[]` param4: param4 Parameter Description"
+        }
+      },
+      "sortText": "B",
+      "filterText": "function4",
+      "insertText": "function4",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config1.json
@@ -9,6 +9,7 @@
       "label": "start",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "start ",
       "insertTextFormat": "Snippet"
     },
@@ -16,6 +17,7 @@
       "label": "wait",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "wait ",
       "insertTextFormat": "Snippet"
     },
@@ -23,6 +25,7 @@
       "label": "flush",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "flush ",
       "insertTextFormat": "Snippet"
     },
@@ -30,6 +33,7 @@
       "label": "from clause",
       "kind": "Snippet",
       "detail": "Snippet",
+      "sortText": "Q",
       "insertText": "from ${1:var} ${2:item} in ${3}",
       "insertTextFormat": "Snippet"
     },
@@ -37,14 +41,16 @@
       "label": "module1",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "P",
       "insertText": "module1",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "ballerina/lang.test",
+      "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
-      "insertText": "test",
+      "sortText": "Q",
+      "insertText": "runtime",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -58,7 +64,30 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.test;\n"
+          "newText": "import ballerina/lang.runtime;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "Q",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
         }
       ]
     },
@@ -66,6 +95,7 @@
       "label": "ballerina/lang.array",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "Q",
       "insertText": "array",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -88,6 +118,7 @@
       "label": "ballerina/jballerina.java",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "Q",
       "insertText": "java",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -107,10 +138,11 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
+      "label": "ballerina/lang.test",
       "kind": "Module",
       "detail": "Module",
-      "insertText": "value",
+      "sortText": "Q",
+      "insertText": "test",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -124,29 +156,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.value;\n"
-        }
-      ]
-    },
-    {
-      "label": "ballerina/lang.runtime",
-      "kind": "Module",
-      "detail": "Module",
-      "insertText": "runtime",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.runtime;\n"
+          "newText": "import ballerina/lang.test;\n"
         }
       ]
     },
@@ -154,6 +164,7 @@
       "label": "boolean",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "boolean",
       "insertTextFormat": "Snippet"
     },
@@ -161,6 +172,7 @@
       "label": "decimal",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "decimal",
       "insertTextFormat": "Snippet"
     },
@@ -168,6 +180,7 @@
       "label": "error",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "error",
       "insertTextFormat": "Snippet"
     },
@@ -175,6 +188,7 @@
       "label": "float",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "float",
       "insertTextFormat": "Snippet"
     },
@@ -182,6 +196,7 @@
       "label": "future",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "future",
       "insertTextFormat": "Snippet"
     },
@@ -189,6 +204,7 @@
       "label": "int",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "int",
       "insertTextFormat": "Snippet"
     },
@@ -196,6 +212,7 @@
       "label": "map",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "map",
       "insertTextFormat": "Snippet"
     },
@@ -203,6 +220,7 @@
       "label": "object",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "object",
       "insertTextFormat": "Snippet"
     },
@@ -210,6 +228,7 @@
       "label": "stream",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "stream",
       "insertTextFormat": "Snippet"
     },
@@ -217,6 +236,7 @@
       "label": "string",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "string",
       "insertTextFormat": "Snippet"
     },
@@ -224,6 +244,7 @@
       "label": "table",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "table",
       "insertTextFormat": "Snippet"
     },
@@ -231,6 +252,7 @@
       "label": "transaction",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "transaction",
       "insertTextFormat": "Snippet"
     },
@@ -238,6 +260,7 @@
       "label": "typedesc",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "typedesc",
       "insertTextFormat": "Snippet"
     },
@@ -245,6 +268,7 @@
       "label": "xml",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
     },
@@ -252,6 +276,7 @@
       "label": "service",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "service",
       "insertTextFormat": "Snippet"
     },
@@ -259,6 +284,7 @@
       "label": "new",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "new ",
       "insertTextFormat": "Snippet"
     },
@@ -266,6 +292,7 @@
       "label": "isolated",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "isolated ",
       "insertTextFormat": "Snippet"
     },
@@ -273,6 +300,7 @@
       "label": "transactional",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "transactional",
       "insertTextFormat": "Snippet"
     },
@@ -280,6 +308,7 @@
       "label": "function",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "function ",
       "insertTextFormat": "Snippet"
     },
@@ -287,6 +316,7 @@
       "label": "let",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "let",
       "insertTextFormat": "Snippet"
     },
@@ -294,6 +324,7 @@
       "label": "typeof",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "typeof ",
       "insertTextFormat": "Snippet"
     },
@@ -301,6 +332,7 @@
       "label": "trap",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "trap",
       "insertTextFormat": "Snippet"
     },
@@ -308,6 +340,7 @@
       "label": "error",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "error",
       "insertTextFormat": "Snippet"
     },
@@ -315,6 +348,7 @@
       "label": "client",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "client ",
       "insertTextFormat": "Snippet"
     },
@@ -322,6 +356,7 @@
       "label": "object",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "object ",
       "insertTextFormat": "Snippet"
     },
@@ -329,6 +364,7 @@
       "label": "true",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "true",
       "insertTextFormat": "Snippet"
     },
@@ -336,6 +372,7 @@
       "label": "false",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "false",
       "insertTextFormat": "Snippet"
     },
@@ -343,6 +380,7 @@
       "label": "check",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "check ",
       "insertTextFormat": "Snippet"
     },
@@ -350,6 +388,7 @@
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "checkpanic ",
       "insertTextFormat": "Snippet"
     },
@@ -357,6 +396,7 @@
       "label": "is",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "is",
       "insertTextFormat": "Snippet"
     },
@@ -364,6 +404,7 @@
       "label": "error constructor",
       "kind": "Snippet",
       "detail": "Snippet",
+      "sortText": "Q",
       "insertText": "error(\"${1}\")",
       "insertTextFormat": "Snippet"
     },
@@ -371,6 +412,7 @@
       "label": "object constructor",
       "kind": "Snippet",
       "detail": "Snippet",
+      "sortText": "Q",
       "insertText": "object {${1}};",
       "insertTextFormat": "Snippet"
     },
@@ -378,6 +420,7 @@
       "label": "base16",
       "kind": "Snippet",
       "detail": "Snippet",
+      "sortText": "Q",
       "insertText": "base16 `${1}`",
       "insertTextFormat": "Snippet"
     },
@@ -385,14 +428,8 @@
       "label": "base64",
       "kind": "Snippet",
       "detail": "Snippet",
+      "sortText": "Q",
       "insertText": "base64 `${1}`",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Thread",
-      "kind": "TypeParameter",
-      "detail": "Union",
-      "insertText": "Thread",
       "insertTextFormat": "Snippet"
     },
     {
@@ -405,32 +442,9 @@
           "value": "**Package:** _._  \n  \n  \n"
         }
       },
+      "sortText": "E",
       "filterText": "testFunction",
       "insertText": "testFunction()",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "valueA",
-      "kind": "Variable",
-      "detail": "int",
-      "insertText": "valueA",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "valueB",
-      "kind": "Variable",
-      "detail": "int",
-      "insertText": "valueB",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "StrandData",
-      "kind": "Struct",
-      "detail": "Record",
-      "documentation": {
-        "left": "Describes Strand execution details for the runtime.\n"
-      },
-      "insertText": "StrandData",
       "insertTextFormat": "Snippet"
     },
     {
@@ -443,6 +457,7 @@
           "value": "**Package:** _._  \n  \n  \n**Params**  \n- `int` a  \n- `int` b  \n  \n**Returns** `int`   \n  \n"
         }
       },
+      "sortText": "B",
       "filterText": "testFunctionWithParams",
       "insertText": "testFunctionWithParams(${1})",
       "insertTextFormat": "Snippet",
@@ -452,9 +467,45 @@
       }
     },
     {
+      "label": "StrandData",
+      "kind": "Struct",
+      "detail": "Record",
+      "documentation": {
+        "left": "Describes Strand execution details for the runtime.\n"
+      },
+      "sortText": "N",
+      "insertText": "StrandData",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Thread",
+      "kind": "TypeParameter",
+      "detail": "Union",
+      "sortText": "O",
+      "insertText": "Thread",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "valueB",
+      "kind": "Variable",
+      "detail": "int",
+      "sortText": "A",
+      "insertText": "valueB",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "valueA",
+      "kind": "Variable",
+      "detail": "int",
+      "sortText": "A",
+      "insertText": "valueA",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "readonly",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "readonly",
       "insertTextFormat": "Snippet"
     },
@@ -462,6 +513,7 @@
       "label": "handle",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "handle",
       "insertTextFormat": "Snippet"
     },
@@ -469,6 +521,7 @@
       "label": "never",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "never",
       "insertTextFormat": "Snippet"
     },
@@ -476,6 +529,7 @@
       "label": "json",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "json",
       "insertTextFormat": "Snippet"
     },
@@ -483,6 +537,7 @@
       "label": "anydata",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "anydata",
       "insertTextFormat": "Snippet"
     },
@@ -490,6 +545,7 @@
       "label": "any",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "any",
       "insertTextFormat": "Snippet"
     },
@@ -497,6 +553,7 @@
       "label": "byte",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config10.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config10.json
@@ -1,15 +1,15 @@
 {
   "position": {
-    "line": 6,
-    "character": 43
+    "line": 11,
+    "character": 36
   },
-  "source": "expression_context/source/anon_func_expr_ctx_source7.bal",
+  "source": "expression_context/source/function_call_expression_ctx_source10.bal",
   "items": [
     {
       "label": "start",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "start ",
       "insertTextFormat": "Snippet"
     },
@@ -17,7 +17,7 @@
       "label": "wait",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "wait ",
       "insertTextFormat": "Snippet"
     },
@@ -25,7 +25,7 @@
       "label": "flush",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "flush ",
       "insertTextFormat": "Snippet"
     },
@@ -33,16 +33,8 @@
       "label": "from clause",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "O",
+      "sortText": "Q",
       "insertText": "from ${1:var} ${2:item} in ${3}",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "module1",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "N",
-      "insertText": "module1",
       "insertTextFormat": "Snippet"
     },
     {
@@ -73,7 +65,7 @@
       "kind": "Module",
       "detail": "Module",
       "sortText": "Q",
-      "insertText": "value3",
+      "insertText": "value",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -87,7 +79,30 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.value as value3 ;\n"
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/module1",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "Q",
+      "insertText": "module1",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/module1;\n"
         }
       ]
     },
@@ -276,7 +291,7 @@
       "label": "service",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "service",
       "insertTextFormat": "Snippet"
     },
@@ -284,7 +299,7 @@
       "label": "new",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "new ",
       "insertTextFormat": "Snippet"
     },
@@ -292,7 +307,7 @@
       "label": "isolated",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "isolated ",
       "insertTextFormat": "Snippet"
     },
@@ -300,7 +315,7 @@
       "label": "transactional",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "transactional",
       "insertTextFormat": "Snippet"
     },
@@ -308,7 +323,7 @@
       "label": "function",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "function ",
       "insertTextFormat": "Snippet"
     },
@@ -316,7 +331,7 @@
       "label": "let",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "let",
       "insertTextFormat": "Snippet"
     },
@@ -324,7 +339,7 @@
       "label": "typeof",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "typeof ",
       "insertTextFormat": "Snippet"
     },
@@ -332,7 +347,7 @@
       "label": "trap",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "trap",
       "insertTextFormat": "Snippet"
     },
@@ -340,7 +355,7 @@
       "label": "error",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "error",
       "insertTextFormat": "Snippet"
     },
@@ -348,7 +363,7 @@
       "label": "client",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "client ",
       "insertTextFormat": "Snippet"
     },
@@ -356,7 +371,7 @@
       "label": "object",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "object ",
       "insertTextFormat": "Snippet"
     },
@@ -364,7 +379,7 @@
       "label": "true",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "true",
       "insertTextFormat": "Snippet"
     },
@@ -372,7 +387,7 @@
       "label": "false",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "false",
       "insertTextFormat": "Snippet"
     },
@@ -380,7 +395,7 @@
       "label": "check",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "check ",
       "insertTextFormat": "Snippet"
     },
@@ -388,7 +403,7 @@
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "checkpanic ",
       "insertTextFormat": "Snippet"
     },
@@ -396,7 +411,7 @@
       "label": "is",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "is",
       "insertTextFormat": "Snippet"
     },
@@ -404,7 +419,7 @@
       "label": "error constructor",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "O",
+      "sortText": "Q",
       "insertText": "error(\"${1}\")",
       "insertTextFormat": "Snippet"
     },
@@ -412,7 +427,7 @@
       "label": "object constructor",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "O",
+      "sortText": "Q",
       "insertText": "object {${1}};",
       "insertTextFormat": "Snippet"
     },
@@ -420,7 +435,7 @@
       "label": "base16",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "O",
+      "sortText": "Q",
       "insertText": "base16 `${1}`",
       "insertTextFormat": "Snippet"
     },
@@ -428,99 +443,23 @@
       "label": "base64",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "O",
+      "sortText": "Q",
       "insertText": "base64 `${1}`",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "value1",
-      "kind": "Variable",
-      "detail": "int",
-      "sortText": "B",
-      "insertText": "value1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "value2",
-      "kind": "Variable",
-      "detail": "int",
-      "sortText": "B",
-      "insertText": "value2",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "lambda",
-      "kind": "Variable",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `int`   \n  \n"
-        }
-      },
-      "sortText": "B",
-      "filterText": "lambda",
-      "insertText": "lambda",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "lambda()(int)",
+      "label": "addFunction(int num1, int num2)(int)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `int`   \n  \n"
-        }
-      },
-      "sortText": "C",
-      "filterText": "lambda",
-      "insertText": "lambda()",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "testFunction",
-      "kind": "Variable",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n"
+          "value": "**Package:** _._  \n  \n  \n**Params**  \n- `int` num1  \n- `int` num2  \n  \n**Returns** `int`   \n  \n"
         }
       },
       "sortText": "B",
-      "filterText": "testFunction",
-      "insertText": "testFunction",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "testFunction()",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n"
-        }
-      },
-      "sortText": "C",
-      "filterText": "testFunction",
-      "insertText": "testFunction()",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "doTask",
-      "kind": "Variable",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n**Params**  \n- `int` a  \n- `int` c"
-        }
-      },
-      "sortText": "B",
-      "filterText": "doTask",
-      "insertText": "doTask",
+      "filterText": "addFunction",
+      "insertText": "addFunction(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
@@ -528,18 +467,41 @@
       }
     },
     {
-      "label": "doTask(int a, int c)",
+      "label": "myString",
+      "kind": "Variable",
+      "detail": "string",
+      "sortText": "D",
+      "insertText": "myString",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "main()",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n**Params**  \n- `int` a  \n- `int` c"
+          "value": "**Package:** _._  \n  \n  \n"
         }
       },
-      "sortText": "C",
-      "filterText": "doTask",
-      "insertText": "doTask(${1})",
+      "sortText": "E",
+      "filterText": "main",
+      "insertText": "main()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "myFunc(int a, int b)(int)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _._  \n  \n  \n**Params**  \n- `int` a  \n- `int` b  \n  \n**Returns** `int`   \n  \n"
+        }
+      },
+      "sortText": "B",
+      "filterText": "myFunc",
+      "insertText": "myFunc(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
@@ -553,16 +515,59 @@
       "documentation": {
         "left": "Describes Strand execution details for the runtime.\n"
       },
-      "sortText": "L",
+      "sortText": "N",
       "insertText": "StrandData",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "process(function (int, int) returns int func, int num1, int num2)(int)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _._  \n  \n  \n**Params**  \n- `function (int, int) returns int` func  \n- `int` num1  \n- `int` num2  \n  \n**Returns** `int`   \n  \n"
+        }
+      },
+      "sortText": "B",
+      "filterText": "process",
+      "insertText": "process(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
     },
     {
       "label": "Thread",
       "kind": "TypeParameter",
       "detail": "Union",
-      "sortText": "M",
+      "sortText": "O",
       "insertText": "Thread",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "total",
+      "kind": "Variable",
+      "detail": "int",
+      "sortText": "A",
+      "insertText": "total",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "myInt2",
+      "kind": "Variable",
+      "detail": "int",
+      "sortText": "A",
+      "insertText": "myInt2",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "myInt1",
+      "kind": "Variable",
+      "detail": "int",
+      "sortText": "A",
+      "insertText": "myInt1",
       "insertTextFormat": "Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config11.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config11.json
@@ -1,15 +1,15 @@
 {
   "position": {
-    "line": 6,
-    "character": 43
+    "line": 13,
+    "character": 23
   },
-  "source": "expression_context/source/anon_func_expr_ctx_source7.bal",
+  "source": "expression_context/source/function_call_expression_ctx_source11.bal",
   "items": [
     {
       "label": "start",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "start ",
       "insertTextFormat": "Snippet"
     },
@@ -17,7 +17,7 @@
       "label": "wait",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "wait ",
       "insertTextFormat": "Snippet"
     },
@@ -25,7 +25,7 @@
       "label": "flush",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "flush ",
       "insertTextFormat": "Snippet"
     },
@@ -33,16 +33,8 @@
       "label": "from clause",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "O",
+      "sortText": "Q",
       "insertText": "from ${1:var} ${2:item} in ${3}",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "module1",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "N",
-      "insertText": "module1",
       "insertTextFormat": "Snippet"
     },
     {
@@ -73,7 +65,7 @@
       "kind": "Module",
       "detail": "Module",
       "sortText": "Q",
-      "insertText": "value3",
+      "insertText": "value",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -87,7 +79,30 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.value as value3 ;\n"
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/module1",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "Q",
+      "insertText": "module1",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/module1;\n"
         }
       ]
     },
@@ -276,7 +291,7 @@
       "label": "service",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "service",
       "insertTextFormat": "Snippet"
     },
@@ -284,7 +299,7 @@
       "label": "new",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "new ",
       "insertTextFormat": "Snippet"
     },
@@ -292,7 +307,7 @@
       "label": "isolated",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "isolated ",
       "insertTextFormat": "Snippet"
     },
@@ -300,7 +315,7 @@
       "label": "transactional",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "transactional",
       "insertTextFormat": "Snippet"
     },
@@ -308,7 +323,7 @@
       "label": "function",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "function ",
       "insertTextFormat": "Snippet"
     },
@@ -316,7 +331,7 @@
       "label": "let",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "let",
       "insertTextFormat": "Snippet"
     },
@@ -324,7 +339,7 @@
       "label": "typeof",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "typeof ",
       "insertTextFormat": "Snippet"
     },
@@ -332,7 +347,7 @@
       "label": "trap",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "trap",
       "insertTextFormat": "Snippet"
     },
@@ -340,7 +355,7 @@
       "label": "error",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "error",
       "insertTextFormat": "Snippet"
     },
@@ -348,7 +363,7 @@
       "label": "client",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "client ",
       "insertTextFormat": "Snippet"
     },
@@ -356,7 +371,7 @@
       "label": "object",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "object ",
       "insertTextFormat": "Snippet"
     },
@@ -364,7 +379,7 @@
       "label": "true",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "true",
       "insertTextFormat": "Snippet"
     },
@@ -372,7 +387,7 @@
       "label": "false",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "false",
       "insertTextFormat": "Snippet"
     },
@@ -380,7 +395,7 @@
       "label": "check",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "check ",
       "insertTextFormat": "Snippet"
     },
@@ -388,7 +403,7 @@
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "checkpanic ",
       "insertTextFormat": "Snippet"
     },
@@ -396,7 +411,7 @@
       "label": "is",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "is",
       "insertTextFormat": "Snippet"
     },
@@ -404,7 +419,7 @@
       "label": "error constructor",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "O",
+      "sortText": "Q",
       "insertText": "error(\"${1}\")",
       "insertTextFormat": "Snippet"
     },
@@ -412,7 +427,7 @@
       "label": "object constructor",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "O",
+      "sortText": "Q",
       "insertText": "object {${1}};",
       "insertTextFormat": "Snippet"
     },
@@ -420,7 +435,7 @@
       "label": "base16",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "O",
+      "sortText": "Q",
       "insertText": "base16 `${1}`",
       "insertTextFormat": "Snippet"
     },
@@ -428,118 +443,62 @@
       "label": "base64",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "O",
+      "sortText": "Q",
       "insertText": "base64 `${1}`",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "value1",
+      "label": "myString",
+      "kind": "Variable",
+      "detail": "string",
+      "sortText": "D",
+      "insertText": "myString",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "process4()(MyType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `MyType`   \n  \n"
+        }
+      },
+      "sortText": "B",
+      "filterText": "process4",
+      "insertText": "process4()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "myInt2",
       "kind": "Variable",
       "detail": "int",
-      "sortText": "B",
-      "insertText": "value1",
+      "sortText": "D",
+      "insertText": "myInt2",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "value2",
-      "kind": "Variable",
-      "detail": "int",
-      "sortText": "B",
-      "insertText": "value2",
+      "label": "Thread",
+      "kind": "TypeParameter",
+      "detail": "Union",
+      "sortText": "O",
+      "insertText": "Thread",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "lambda",
-      "kind": "Variable",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `int`   \n  \n"
-        }
-      },
-      "sortText": "B",
-      "filterText": "lambda",
-      "insertText": "lambda",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "lambda()(int)",
+      "label": "myFunc(MyType a)(int)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `int`   \n  \n"
+          "value": "**Package:** _._  \n  \n  \n**Params**  \n- `MyType` a  \n  \n**Returns** `int`   \n  \n"
         }
       },
-      "sortText": "C",
-      "filterText": "lambda",
-      "insertText": "lambda()",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "testFunction",
-      "kind": "Variable",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n"
-        }
-      },
-      "sortText": "B",
-      "filterText": "testFunction",
-      "insertText": "testFunction",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "testFunction()",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n"
-        }
-      },
-      "sortText": "C",
-      "filterText": "testFunction",
-      "insertText": "testFunction()",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "doTask",
-      "kind": "Variable",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n**Params**  \n- `int` a  \n- `int` c"
-        }
-      },
-      "sortText": "B",
-      "filterText": "doTask",
-      "insertText": "doTask",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "doTask(int a, int c)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n**Params**  \n- `int` a  \n- `int` c"
-        }
-      },
-      "sortText": "C",
-      "filterText": "doTask",
-      "insertText": "doTask(${1})",
+      "sortText": "E",
+      "filterText": "myFunc",
+      "insertText": "myFunc(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
@@ -553,16 +512,74 @@
       "documentation": {
         "left": "Describes Strand execution details for the runtime.\n"
       },
-      "sortText": "L",
+      "sortText": "N",
       "insertText": "StrandData",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "Thread",
-      "kind": "TypeParameter",
-      "detail": "Union",
-      "sortText": "M",
-      "insertText": "Thread",
+      "label": "total",
+      "kind": "Variable",
+      "detail": "int",
+      "sortText": "D",
+      "insertText": "total",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "main()",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _._  \n  \n  \n"
+        }
+      },
+      "sortText": "E",
+      "filterText": "main",
+      "insertText": "main()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "MyType",
+      "kind": "Struct",
+      "detail": "Record",
+      "sortText": "N",
+      "insertText": "MyType",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "addFunction(int num1, int num2)(int)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _._  \n  \n  \n**Params**  \n- `int` num1  \n- `int` num2  \n  \n**Returns** `int`   \n  \n"
+        }
+      },
+      "sortText": "E",
+      "filterText": "addFunction",
+      "insertText": "addFunction(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "var1",
+      "kind": "Variable",
+      "detail": "MyType",
+      "sortText": "A",
+      "insertText": "var1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "myInt1",
+      "kind": "Variable",
+      "detail": "int",
+      "sortText": "D",
+      "insertText": "myInt1",
       "insertTextFormat": "Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config2.json
@@ -9,6 +9,7 @@
       "label": "start",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "start ",
       "insertTextFormat": "Snippet"
     },
@@ -16,6 +17,7 @@
       "label": "wait",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "wait ",
       "insertTextFormat": "Snippet"
     },
@@ -23,6 +25,7 @@
       "label": "flush",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "flush ",
       "insertTextFormat": "Snippet"
     },
@@ -30,6 +33,7 @@
       "label": "from clause",
       "kind": "Snippet",
       "detail": "Snippet",
+      "sortText": "Q",
       "insertText": "from ${1:var} ${2:item} in ${3}",
       "insertTextFormat": "Snippet"
     },
@@ -37,14 +41,16 @@
       "label": "module1",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "P",
       "insertText": "module1",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "ballerina/lang.test",
+      "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
-      "insertText": "test",
+      "sortText": "Q",
+      "insertText": "runtime",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -58,7 +64,30 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.test;\n"
+          "newText": "import ballerina/lang.runtime;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "Q",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
         }
       ]
     },
@@ -66,6 +95,7 @@
       "label": "ballerina/lang.array",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "Q",
       "insertText": "array",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -88,6 +118,7 @@
       "label": "ballerina/jballerina.java",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "Q",
       "insertText": "java",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -107,10 +138,11 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
+      "label": "ballerina/lang.test",
       "kind": "Module",
       "detail": "Module",
-      "insertText": "value",
+      "sortText": "Q",
+      "insertText": "test",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -124,29 +156,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.value;\n"
-        }
-      ]
-    },
-    {
-      "label": "ballerina/lang.runtime",
-      "kind": "Module",
-      "detail": "Module",
-      "insertText": "runtime",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.runtime;\n"
+          "newText": "import ballerina/lang.test;\n"
         }
       ]
     },
@@ -154,6 +164,7 @@
       "label": "boolean",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "boolean",
       "insertTextFormat": "Snippet"
     },
@@ -161,6 +172,7 @@
       "label": "decimal",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "decimal",
       "insertTextFormat": "Snippet"
     },
@@ -168,6 +180,7 @@
       "label": "error",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "error",
       "insertTextFormat": "Snippet"
     },
@@ -175,6 +188,7 @@
       "label": "float",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "float",
       "insertTextFormat": "Snippet"
     },
@@ -182,6 +196,7 @@
       "label": "future",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "future",
       "insertTextFormat": "Snippet"
     },
@@ -189,6 +204,7 @@
       "label": "int",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "int",
       "insertTextFormat": "Snippet"
     },
@@ -196,6 +212,7 @@
       "label": "map",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "map",
       "insertTextFormat": "Snippet"
     },
@@ -203,6 +220,7 @@
       "label": "object",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "object",
       "insertTextFormat": "Snippet"
     },
@@ -210,6 +228,7 @@
       "label": "stream",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "stream",
       "insertTextFormat": "Snippet"
     },
@@ -217,6 +236,7 @@
       "label": "string",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "string",
       "insertTextFormat": "Snippet"
     },
@@ -224,6 +244,7 @@
       "label": "table",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "table",
       "insertTextFormat": "Snippet"
     },
@@ -231,6 +252,7 @@
       "label": "transaction",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "transaction",
       "insertTextFormat": "Snippet"
     },
@@ -238,6 +260,7 @@
       "label": "typedesc",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "typedesc",
       "insertTextFormat": "Snippet"
     },
@@ -245,6 +268,7 @@
       "label": "xml",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
     },
@@ -252,6 +276,7 @@
       "label": "service",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "service",
       "insertTextFormat": "Snippet"
     },
@@ -259,6 +284,7 @@
       "label": "new",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "new ",
       "insertTextFormat": "Snippet"
     },
@@ -266,6 +292,7 @@
       "label": "isolated",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "isolated ",
       "insertTextFormat": "Snippet"
     },
@@ -273,6 +300,7 @@
       "label": "transactional",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "transactional",
       "insertTextFormat": "Snippet"
     },
@@ -280,6 +308,7 @@
       "label": "function",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "function ",
       "insertTextFormat": "Snippet"
     },
@@ -287,6 +316,7 @@
       "label": "let",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "let",
       "insertTextFormat": "Snippet"
     },
@@ -294,6 +324,7 @@
       "label": "typeof",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "typeof ",
       "insertTextFormat": "Snippet"
     },
@@ -301,6 +332,7 @@
       "label": "trap",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "trap",
       "insertTextFormat": "Snippet"
     },
@@ -308,6 +340,7 @@
       "label": "error",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "error",
       "insertTextFormat": "Snippet"
     },
@@ -315,6 +348,7 @@
       "label": "client",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "client ",
       "insertTextFormat": "Snippet"
     },
@@ -322,6 +356,7 @@
       "label": "object",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "object ",
       "insertTextFormat": "Snippet"
     },
@@ -329,6 +364,7 @@
       "label": "true",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "true",
       "insertTextFormat": "Snippet"
     },
@@ -336,6 +372,7 @@
       "label": "false",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "false",
       "insertTextFormat": "Snippet"
     },
@@ -343,6 +380,7 @@
       "label": "check",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "check ",
       "insertTextFormat": "Snippet"
     },
@@ -350,6 +388,7 @@
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "checkpanic ",
       "insertTextFormat": "Snippet"
     },
@@ -357,6 +396,7 @@
       "label": "is",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "is",
       "insertTextFormat": "Snippet"
     },
@@ -364,6 +404,7 @@
       "label": "error constructor",
       "kind": "Snippet",
       "detail": "Snippet",
+      "sortText": "Q",
       "insertText": "error(\"${1}\")",
       "insertTextFormat": "Snippet"
     },
@@ -371,6 +412,7 @@
       "label": "object constructor",
       "kind": "Snippet",
       "detail": "Snippet",
+      "sortText": "Q",
       "insertText": "object {${1}};",
       "insertTextFormat": "Snippet"
     },
@@ -378,6 +420,7 @@
       "label": "base16",
       "kind": "Snippet",
       "detail": "Snippet",
+      "sortText": "Q",
       "insertText": "base16 `${1}`",
       "insertTextFormat": "Snippet"
     },
@@ -385,14 +428,8 @@
       "label": "base64",
       "kind": "Snippet",
       "detail": "Snippet",
+      "sortText": "Q",
       "insertText": "base64 `${1}`",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Thread",
-      "kind": "TypeParameter",
-      "detail": "Union",
-      "insertText": "Thread",
       "insertTextFormat": "Snippet"
     },
     {
@@ -405,32 +442,9 @@
           "value": "**Package:** _._  \n  \n  \n"
         }
       },
+      "sortText": "E",
       "filterText": "testFunction",
       "insertText": "testFunction()",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "valueA",
-      "kind": "Variable",
-      "detail": "int",
-      "insertText": "valueA",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "valueB",
-      "kind": "Variable",
-      "detail": "int",
-      "insertText": "valueB",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "StrandData",
-      "kind": "Struct",
-      "detail": "Record",
-      "documentation": {
-        "left": "Describes Strand execution details for the runtime.\n"
-      },
-      "insertText": "StrandData",
       "insertTextFormat": "Snippet"
     },
     {
@@ -443,6 +457,7 @@
           "value": "**Package:** _._  \n  \n  \n**Params**  \n- `int` a  \n- `int` b  \n  \n**Returns** `int`   \n  \n"
         }
       },
+      "sortText": "B",
       "filterText": "testFunctionWithParams",
       "insertText": "testFunctionWithParams(${1})",
       "insertTextFormat": "Snippet",
@@ -452,9 +467,45 @@
       }
     },
     {
+      "label": "StrandData",
+      "kind": "Struct",
+      "detail": "Record",
+      "documentation": {
+        "left": "Describes Strand execution details for the runtime.\n"
+      },
+      "sortText": "N",
+      "insertText": "StrandData",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Thread",
+      "kind": "TypeParameter",
+      "detail": "Union",
+      "sortText": "O",
+      "insertText": "Thread",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "valueB",
+      "kind": "Variable",
+      "detail": "int",
+      "sortText": "A",
+      "insertText": "valueB",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "valueA",
+      "kind": "Variable",
+      "detail": "int",
+      "sortText": "A",
+      "insertText": "valueA",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "readonly",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "readonly",
       "insertTextFormat": "Snippet"
     },
@@ -462,6 +513,7 @@
       "label": "handle",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "handle",
       "insertTextFormat": "Snippet"
     },
@@ -469,6 +521,7 @@
       "label": "never",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "never",
       "insertTextFormat": "Snippet"
     },
@@ -476,6 +529,7 @@
       "label": "json",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "json",
       "insertTextFormat": "Snippet"
     },
@@ -483,6 +537,7 @@
       "label": "anydata",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "anydata",
       "insertTextFormat": "Snippet"
     },
@@ -490,6 +545,7 @@
       "label": "any",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "any",
       "insertTextFormat": "Snippet"
     },
@@ -497,6 +553,7 @@
       "label": "byte",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config3.json
@@ -9,6 +9,7 @@
       "label": "start",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "start ",
       "insertTextFormat": "Snippet"
     },
@@ -16,6 +17,7 @@
       "label": "wait",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "wait ",
       "insertTextFormat": "Snippet"
     },
@@ -23,6 +25,7 @@
       "label": "flush",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "flush ",
       "insertTextFormat": "Snippet"
     },
@@ -30,6 +33,7 @@
       "label": "from clause",
       "kind": "Snippet",
       "detail": "Snippet",
+      "sortText": "Q",
       "insertText": "from ${1:var} ${2:item} in ${3}",
       "insertTextFormat": "Snippet"
     },
@@ -37,14 +41,16 @@
       "label": "module1",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "P",
       "insertText": "module1",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "ballerina/lang.test",
+      "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
-      "insertText": "test",
+      "sortText": "Q",
+      "insertText": "runtime",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -58,7 +64,30 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.test;\n"
+          "newText": "import ballerina/lang.runtime;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "Q",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
         }
       ]
     },
@@ -66,6 +95,7 @@
       "label": "ballerina/lang.array",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "Q",
       "insertText": "array",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -88,6 +118,7 @@
       "label": "ballerina/jballerina.java",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "Q",
       "insertText": "java",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -107,10 +138,11 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
+      "label": "ballerina/lang.test",
       "kind": "Module",
       "detail": "Module",
-      "insertText": "value",
+      "sortText": "Q",
+      "insertText": "test",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -124,29 +156,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.value;\n"
-        }
-      ]
-    },
-    {
-      "label": "ballerina/lang.runtime",
-      "kind": "Module",
-      "detail": "Module",
-      "insertText": "runtime",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.runtime;\n"
+          "newText": "import ballerina/lang.test;\n"
         }
       ]
     },
@@ -154,6 +164,7 @@
       "label": "boolean",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "boolean",
       "insertTextFormat": "Snippet"
     },
@@ -161,6 +172,7 @@
       "label": "decimal",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "decimal",
       "insertTextFormat": "Snippet"
     },
@@ -168,6 +180,7 @@
       "label": "error",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "error",
       "insertTextFormat": "Snippet"
     },
@@ -175,6 +188,7 @@
       "label": "float",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "float",
       "insertTextFormat": "Snippet"
     },
@@ -182,6 +196,7 @@
       "label": "future",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "future",
       "insertTextFormat": "Snippet"
     },
@@ -189,6 +204,7 @@
       "label": "int",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "int",
       "insertTextFormat": "Snippet"
     },
@@ -196,6 +212,7 @@
       "label": "map",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "map",
       "insertTextFormat": "Snippet"
     },
@@ -203,6 +220,7 @@
       "label": "object",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "object",
       "insertTextFormat": "Snippet"
     },
@@ -210,6 +228,7 @@
       "label": "stream",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "stream",
       "insertTextFormat": "Snippet"
     },
@@ -217,6 +236,7 @@
       "label": "string",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "string",
       "insertTextFormat": "Snippet"
     },
@@ -224,6 +244,7 @@
       "label": "table",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "table",
       "insertTextFormat": "Snippet"
     },
@@ -231,6 +252,7 @@
       "label": "transaction",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "transaction",
       "insertTextFormat": "Snippet"
     },
@@ -238,6 +260,7 @@
       "label": "typedesc",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "typedesc",
       "insertTextFormat": "Snippet"
     },
@@ -245,6 +268,7 @@
       "label": "xml",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
     },
@@ -252,6 +276,7 @@
       "label": "service",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "service",
       "insertTextFormat": "Snippet"
     },
@@ -259,6 +284,7 @@
       "label": "new",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "new ",
       "insertTextFormat": "Snippet"
     },
@@ -266,6 +292,7 @@
       "label": "isolated",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "isolated ",
       "insertTextFormat": "Snippet"
     },
@@ -273,6 +300,7 @@
       "label": "transactional",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "transactional",
       "insertTextFormat": "Snippet"
     },
@@ -280,6 +308,7 @@
       "label": "function",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "function ",
       "insertTextFormat": "Snippet"
     },
@@ -287,6 +316,7 @@
       "label": "let",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "let",
       "insertTextFormat": "Snippet"
     },
@@ -294,6 +324,7 @@
       "label": "typeof",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "typeof ",
       "insertTextFormat": "Snippet"
     },
@@ -301,6 +332,7 @@
       "label": "trap",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "trap",
       "insertTextFormat": "Snippet"
     },
@@ -308,6 +340,7 @@
       "label": "error",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "error",
       "insertTextFormat": "Snippet"
     },
@@ -315,6 +348,7 @@
       "label": "client",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "client ",
       "insertTextFormat": "Snippet"
     },
@@ -322,6 +356,7 @@
       "label": "object",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "object ",
       "insertTextFormat": "Snippet"
     },
@@ -329,6 +364,7 @@
       "label": "true",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "true",
       "insertTextFormat": "Snippet"
     },
@@ -336,6 +372,7 @@
       "label": "false",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "false",
       "insertTextFormat": "Snippet"
     },
@@ -343,6 +380,7 @@
       "label": "check",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "check ",
       "insertTextFormat": "Snippet"
     },
@@ -350,6 +388,7 @@
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "checkpanic ",
       "insertTextFormat": "Snippet"
     },
@@ -357,6 +396,7 @@
       "label": "is",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "is",
       "insertTextFormat": "Snippet"
     },
@@ -364,6 +404,7 @@
       "label": "error constructor",
       "kind": "Snippet",
       "detail": "Snippet",
+      "sortText": "Q",
       "insertText": "error(\"${1}\")",
       "insertTextFormat": "Snippet"
     },
@@ -371,6 +412,7 @@
       "label": "object constructor",
       "kind": "Snippet",
       "detail": "Snippet",
+      "sortText": "Q",
       "insertText": "object {${1}};",
       "insertTextFormat": "Snippet"
     },
@@ -378,6 +420,7 @@
       "label": "base16",
       "kind": "Snippet",
       "detail": "Snippet",
+      "sortText": "Q",
       "insertText": "base16 `${1}`",
       "insertTextFormat": "Snippet"
     },
@@ -385,14 +428,8 @@
       "label": "base64",
       "kind": "Snippet",
       "detail": "Snippet",
+      "sortText": "Q",
       "insertText": "base64 `${1}`",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Thread",
-      "kind": "TypeParameter",
-      "detail": "Union",
-      "insertText": "Thread",
       "insertTextFormat": "Snippet"
     },
     {
@@ -405,32 +442,9 @@
           "value": "**Package:** _._  \n  \n  \n"
         }
       },
+      "sortText": "E",
       "filterText": "testFunction",
       "insertText": "testFunction()",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "valueA",
-      "kind": "Variable",
-      "detail": "int",
-      "insertText": "valueA",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "valueB",
-      "kind": "Variable",
-      "detail": "int",
-      "insertText": "valueB",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "StrandData",
-      "kind": "Struct",
-      "detail": "Record",
-      "documentation": {
-        "left": "Describes Strand execution details for the runtime.\n"
-      },
-      "insertText": "StrandData",
       "insertTextFormat": "Snippet"
     },
     {
@@ -443,6 +457,7 @@
           "value": "**Package:** _._  \n  \n  \n**Params**  \n- `int` a  \n- `int` b  \n  \n**Returns** `int`   \n  \n"
         }
       },
+      "sortText": "B",
       "filterText": "testFunctionWithParams",
       "insertText": "testFunctionWithParams(${1})",
       "insertTextFormat": "Snippet",
@@ -452,9 +467,45 @@
       }
     },
     {
+      "label": "StrandData",
+      "kind": "Struct",
+      "detail": "Record",
+      "documentation": {
+        "left": "Describes Strand execution details for the runtime.\n"
+      },
+      "sortText": "N",
+      "insertText": "StrandData",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Thread",
+      "kind": "TypeParameter",
+      "detail": "Union",
+      "sortText": "O",
+      "insertText": "Thread",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "valueB",
+      "kind": "Variable",
+      "detail": "int",
+      "sortText": "A",
+      "insertText": "valueB",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "valueA",
+      "kind": "Variable",
+      "detail": "int",
+      "sortText": "A",
+      "insertText": "valueA",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "readonly",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "readonly",
       "insertTextFormat": "Snippet"
     },
@@ -462,6 +513,7 @@
       "label": "handle",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "handle",
       "insertTextFormat": "Snippet"
     },
@@ -469,6 +521,7 @@
       "label": "never",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "never",
       "insertTextFormat": "Snippet"
     },
@@ -476,6 +529,7 @@
       "label": "json",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "json",
       "insertTextFormat": "Snippet"
     },
@@ -483,6 +537,7 @@
       "label": "anydata",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "anydata",
       "insertTextFormat": "Snippet"
     },
@@ -490,6 +545,7 @@
       "label": "any",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "any",
       "insertTextFormat": "Snippet"
     },
@@ -497,6 +553,7 @@
       "label": "byte",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config4.json
@@ -9,6 +9,7 @@
       "label": "start",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "start ",
       "insertTextFormat": "Snippet"
     },
@@ -16,6 +17,7 @@
       "label": "wait",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "wait ",
       "insertTextFormat": "Snippet"
     },
@@ -23,6 +25,7 @@
       "label": "flush",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "flush ",
       "insertTextFormat": "Snippet"
     },
@@ -30,6 +33,7 @@
       "label": "from clause",
       "kind": "Snippet",
       "detail": "Snippet",
+      "sortText": "Q",
       "insertText": "from ${1:var} ${2:item} in ${3}",
       "insertTextFormat": "Snippet"
     },
@@ -37,14 +41,16 @@
       "label": "module1",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "P",
       "insertText": "module1",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "ballerina/lang.test",
+      "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
-      "insertText": "test",
+      "sortText": "Q",
+      "insertText": "runtime",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -58,7 +64,30 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.test;\n"
+          "newText": "import ballerina/lang.runtime;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "Q",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
         }
       ]
     },
@@ -66,6 +95,7 @@
       "label": "ballerina/lang.array",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "Q",
       "insertText": "array",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -88,6 +118,7 @@
       "label": "ballerina/jballerina.java",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "Q",
       "insertText": "java",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -107,10 +138,11 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
+      "label": "ballerina/lang.test",
       "kind": "Module",
       "detail": "Module",
-      "insertText": "value",
+      "sortText": "Q",
+      "insertText": "test",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -124,29 +156,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.value;\n"
-        }
-      ]
-    },
-    {
-      "label": "ballerina/lang.runtime",
-      "kind": "Module",
-      "detail": "Module",
-      "insertText": "runtime",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.runtime;\n"
+          "newText": "import ballerina/lang.test;\n"
         }
       ]
     },
@@ -154,6 +164,7 @@
       "label": "boolean",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "boolean",
       "insertTextFormat": "Snippet"
     },
@@ -161,6 +172,7 @@
       "label": "decimal",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "decimal",
       "insertTextFormat": "Snippet"
     },
@@ -168,6 +180,7 @@
       "label": "error",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "error",
       "insertTextFormat": "Snippet"
     },
@@ -175,6 +188,7 @@
       "label": "float",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "float",
       "insertTextFormat": "Snippet"
     },
@@ -182,6 +196,7 @@
       "label": "future",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "future",
       "insertTextFormat": "Snippet"
     },
@@ -189,6 +204,7 @@
       "label": "int",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "int",
       "insertTextFormat": "Snippet"
     },
@@ -196,6 +212,7 @@
       "label": "map",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "map",
       "insertTextFormat": "Snippet"
     },
@@ -203,6 +220,7 @@
       "label": "object",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "object",
       "insertTextFormat": "Snippet"
     },
@@ -210,6 +228,7 @@
       "label": "stream",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "stream",
       "insertTextFormat": "Snippet"
     },
@@ -217,6 +236,7 @@
       "label": "string",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "string",
       "insertTextFormat": "Snippet"
     },
@@ -224,6 +244,7 @@
       "label": "table",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "table",
       "insertTextFormat": "Snippet"
     },
@@ -231,6 +252,7 @@
       "label": "transaction",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "transaction",
       "insertTextFormat": "Snippet"
     },
@@ -238,6 +260,7 @@
       "label": "typedesc",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "typedesc",
       "insertTextFormat": "Snippet"
     },
@@ -245,6 +268,7 @@
       "label": "xml",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
     },
@@ -252,6 +276,7 @@
       "label": "service",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "service",
       "insertTextFormat": "Snippet"
     },
@@ -259,6 +284,7 @@
       "label": "new",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "new ",
       "insertTextFormat": "Snippet"
     },
@@ -266,6 +292,7 @@
       "label": "isolated",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "isolated ",
       "insertTextFormat": "Snippet"
     },
@@ -273,6 +300,7 @@
       "label": "transactional",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "transactional",
       "insertTextFormat": "Snippet"
     },
@@ -280,6 +308,7 @@
       "label": "function",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "function ",
       "insertTextFormat": "Snippet"
     },
@@ -287,6 +316,7 @@
       "label": "let",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "let",
       "insertTextFormat": "Snippet"
     },
@@ -294,6 +324,7 @@
       "label": "typeof",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "typeof ",
       "insertTextFormat": "Snippet"
     },
@@ -301,6 +332,7 @@
       "label": "trap",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "trap",
       "insertTextFormat": "Snippet"
     },
@@ -308,6 +340,7 @@
       "label": "error",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "error",
       "insertTextFormat": "Snippet"
     },
@@ -315,6 +348,7 @@
       "label": "client",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "client ",
       "insertTextFormat": "Snippet"
     },
@@ -322,6 +356,7 @@
       "label": "object",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "object ",
       "insertTextFormat": "Snippet"
     },
@@ -329,6 +364,7 @@
       "label": "true",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "true",
       "insertTextFormat": "Snippet"
     },
@@ -336,6 +372,7 @@
       "label": "false",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "false",
       "insertTextFormat": "Snippet"
     },
@@ -343,6 +380,7 @@
       "label": "check",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "check ",
       "insertTextFormat": "Snippet"
     },
@@ -350,6 +388,7 @@
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "checkpanic ",
       "insertTextFormat": "Snippet"
     },
@@ -357,6 +396,7 @@
       "label": "is",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "R",
       "insertText": "is",
       "insertTextFormat": "Snippet"
     },
@@ -364,6 +404,7 @@
       "label": "error constructor",
       "kind": "Snippet",
       "detail": "Snippet",
+      "sortText": "Q",
       "insertText": "error(\"${1}\")",
       "insertTextFormat": "Snippet"
     },
@@ -371,6 +412,7 @@
       "label": "object constructor",
       "kind": "Snippet",
       "detail": "Snippet",
+      "sortText": "Q",
       "insertText": "object {${1}};",
       "insertTextFormat": "Snippet"
     },
@@ -378,6 +420,7 @@
       "label": "base16",
       "kind": "Snippet",
       "detail": "Snippet",
+      "sortText": "Q",
       "insertText": "base16 `${1}`",
       "insertTextFormat": "Snippet"
     },
@@ -385,14 +428,8 @@
       "label": "base64",
       "kind": "Snippet",
       "detail": "Snippet",
+      "sortText": "Q",
       "insertText": "base64 `${1}`",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Thread",
-      "kind": "TypeParameter",
-      "detail": "Union",
-      "insertText": "Thread",
       "insertTextFormat": "Snippet"
     },
     {
@@ -405,32 +442,9 @@
           "value": "**Package:** _._  \n  \n  \n"
         }
       },
+      "sortText": "E",
       "filterText": "testFunction",
       "insertText": "testFunction()",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "valueA",
-      "kind": "Variable",
-      "detail": "int",
-      "insertText": "valueA",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "valueB",
-      "kind": "Variable",
-      "detail": "int",
-      "insertText": "valueB",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "StrandData",
-      "kind": "Struct",
-      "detail": "Record",
-      "documentation": {
-        "left": "Describes Strand execution details for the runtime.\n"
-      },
-      "insertText": "StrandData",
       "insertTextFormat": "Snippet"
     },
     {
@@ -443,6 +457,7 @@
           "value": "**Package:** _._  \n  \n  \n**Params**  \n- `int` a  \n- `int` b  \n  \n**Returns** `int`   \n  \n"
         }
       },
+      "sortText": "B",
       "filterText": "testFunctionWithParams",
       "insertText": "testFunctionWithParams(${1})",
       "insertTextFormat": "Snippet",
@@ -452,9 +467,45 @@
       }
     },
     {
+      "label": "StrandData",
+      "kind": "Struct",
+      "detail": "Record",
+      "documentation": {
+        "left": "Describes Strand execution details for the runtime.\n"
+      },
+      "sortText": "N",
+      "insertText": "StrandData",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Thread",
+      "kind": "TypeParameter",
+      "detail": "Union",
+      "sortText": "O",
+      "insertText": "Thread",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "valueB",
+      "kind": "Variable",
+      "detail": "int",
+      "sortText": "A",
+      "insertText": "valueB",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "valueA",
+      "kind": "Variable",
+      "detail": "int",
+      "sortText": "A",
+      "insertText": "valueA",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "readonly",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "readonly",
       "insertTextFormat": "Snippet"
     },
@@ -462,6 +513,7 @@
       "label": "handle",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "handle",
       "insertTextFormat": "Snippet"
     },
@@ -469,6 +521,7 @@
       "label": "never",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "never",
       "insertTextFormat": "Snippet"
     },
@@ -476,6 +529,7 @@
       "label": "json",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "json",
       "insertTextFormat": "Snippet"
     },
@@ -483,6 +537,7 @@
       "label": "anydata",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "anydata",
       "insertTextFormat": "Snippet"
     },
@@ -490,6 +545,7 @@
       "label": "any",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "any",
       "insertTextFormat": "Snippet"
     },
@@ -497,6 +553,7 @@
       "label": "byte",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "Q",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config9.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config9.json
@@ -1,15 +1,15 @@
 {
   "position": {
-    "line": 6,
-    "character": 43
+    "line": 18,
+    "character": 24
   },
-  "source": "expression_context/source/anon_func_expr_ctx_source7.bal",
+  "source": "expression_context/source/function_call_expression_ctx_source9.bal",
   "items": [
     {
       "label": "start",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "start ",
       "insertTextFormat": "Snippet"
     },
@@ -17,7 +17,7 @@
       "label": "wait",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "wait ",
       "insertTextFormat": "Snippet"
     },
@@ -25,7 +25,7 @@
       "label": "flush",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "flush ",
       "insertTextFormat": "Snippet"
     },
@@ -33,16 +33,8 @@
       "label": "from clause",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "O",
+      "sortText": "Q",
       "insertText": "from ${1:var} ${2:item} in ${3}",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "module1",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "N",
-      "insertText": "module1",
       "insertTextFormat": "Snippet"
     },
     {
@@ -73,7 +65,7 @@
       "kind": "Module",
       "detail": "Module",
       "sortText": "Q",
-      "insertText": "value3",
+      "insertText": "value",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -87,7 +79,30 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.value as value3 ;\n"
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/module1",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "Q",
+      "insertText": "module1",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/module1;\n"
         }
       ]
     },
@@ -276,7 +291,7 @@
       "label": "service",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "service",
       "insertTextFormat": "Snippet"
     },
@@ -284,7 +299,7 @@
       "label": "new",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "new ",
       "insertTextFormat": "Snippet"
     },
@@ -292,7 +307,7 @@
       "label": "isolated",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "isolated ",
       "insertTextFormat": "Snippet"
     },
@@ -300,7 +315,7 @@
       "label": "transactional",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "transactional",
       "insertTextFormat": "Snippet"
     },
@@ -308,7 +323,7 @@
       "label": "function",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "function ",
       "insertTextFormat": "Snippet"
     },
@@ -316,7 +331,7 @@
       "label": "let",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "let",
       "insertTextFormat": "Snippet"
     },
@@ -324,7 +339,7 @@
       "label": "typeof",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "typeof ",
       "insertTextFormat": "Snippet"
     },
@@ -332,7 +347,7 @@
       "label": "trap",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "trap",
       "insertTextFormat": "Snippet"
     },
@@ -340,7 +355,7 @@
       "label": "error",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "error",
       "insertTextFormat": "Snippet"
     },
@@ -348,7 +363,7 @@
       "label": "client",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "client ",
       "insertTextFormat": "Snippet"
     },
@@ -356,7 +371,7 @@
       "label": "object",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "object ",
       "insertTextFormat": "Snippet"
     },
@@ -364,7 +379,7 @@
       "label": "true",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "true",
       "insertTextFormat": "Snippet"
     },
@@ -372,7 +387,7 @@
       "label": "false",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "false",
       "insertTextFormat": "Snippet"
     },
@@ -380,7 +395,7 @@
       "label": "check",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "check ",
       "insertTextFormat": "Snippet"
     },
@@ -388,7 +403,7 @@
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "checkpanic ",
       "insertTextFormat": "Snippet"
     },
@@ -396,7 +411,7 @@
       "label": "is",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "P",
+      "sortText": "R",
       "insertText": "is",
       "insertTextFormat": "Snippet"
     },
@@ -404,7 +419,7 @@
       "label": "error constructor",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "O",
+      "sortText": "Q",
       "insertText": "error(\"${1}\")",
       "insertTextFormat": "Snippet"
     },
@@ -412,7 +427,7 @@
       "label": "object constructor",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "O",
+      "sortText": "Q",
       "insertText": "object {${1}};",
       "insertTextFormat": "Snippet"
     },
@@ -420,7 +435,7 @@
       "label": "base16",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "O",
+      "sortText": "Q",
       "insertText": "base16 `${1}`",
       "insertTextFormat": "Snippet"
     },
@@ -428,99 +443,23 @@
       "label": "base64",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "O",
+      "sortText": "Q",
       "insertText": "base64 `${1}`",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "value1",
-      "kind": "Variable",
-      "detail": "int",
-      "sortText": "B",
-      "insertText": "value1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "value2",
-      "kind": "Variable",
-      "detail": "int",
-      "sortText": "B",
-      "insertText": "value2",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "lambda",
+      "label": "addFunction",
       "kind": "Variable",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `int`   \n  \n"
+          "value": "**Package:** _._  \n  \n  \n**Params**  \n- `int` num1  \n- `int` num2  \n  \n**Returns** `int`   \n  \n"
         }
       },
-      "sortText": "B",
-      "filterText": "lambda",
-      "insertText": "lambda",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "lambda()(int)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `int`   \n  \n"
-        }
-      },
-      "sortText": "C",
-      "filterText": "lambda",
-      "insertText": "lambda()",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "testFunction",
-      "kind": "Variable",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n"
-        }
-      },
-      "sortText": "B",
-      "filterText": "testFunction",
-      "insertText": "testFunction",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "testFunction()",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n"
-        }
-      },
-      "sortText": "C",
-      "filterText": "testFunction",
-      "insertText": "testFunction()",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "doTask",
-      "kind": "Variable",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n**Params**  \n- `int` a  \n- `int` c"
-        }
-      },
-      "sortText": "B",
-      "filterText": "doTask",
-      "insertText": "doTask",
+      "sortText": "A",
+      "filterText": "addFunction",
+      "insertText": "addFunction",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
@@ -528,18 +467,94 @@
       }
     },
     {
-      "label": "doTask(int a, int c)",
+      "label": "addFunction(int num1, int num2)(int)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n**Params**  \n- `int` a  \n- `int` c"
+          "value": "**Package:** _._  \n  \n  \n**Params**  \n- `int` num1  \n- `int` num2  \n  \n**Returns** `int`   \n  \n"
         }
       },
-      "sortText": "C",
-      "filterText": "doTask",
-      "insertText": "doTask(${1})",
+      "sortText": "E",
+      "filterText": "addFunction",
+      "insertText": "addFunction(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "Thread",
+      "kind": "TypeParameter",
+      "detail": "Union",
+      "sortText": "O",
+      "insertText": "Thread",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getFunction",
+      "kind": "Variable",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `function (int, int) returns int`   \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "getFunction",
+      "insertText": "getFunction",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getFunction()(function (int, int) returns int)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `function (int, int) returns int`   \n  \n"
+        }
+      },
+      "sortText": "B",
+      "filterText": "getFunction",
+      "insertText": "getFunction()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "process",
+      "kind": "Variable",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _._  \n  \n  \n**Params**  \n- `function (int, int) returns int` func  \n- `int` num1  \n- `int` num2  \n  \n**Returns** `int`   \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "process",
+      "insertText": "process",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "process(function (int, int) returns int func, int num1, int num2)(int)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _._  \n  \n  \n**Params**  \n- `function (int, int) returns int` func  \n- `int` num1  \n- `int` num2  \n  \n**Returns** `int`   \n  \n"
+        }
+      },
+      "sortText": "E",
+      "filterText": "process",
+      "insertText": "process(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
@@ -553,16 +568,100 @@
       "documentation": {
         "left": "Describes Strand execution details for the runtime.\n"
       },
-      "sortText": "L",
+      "sortText": "N",
       "insertText": "StrandData",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "Thread",
-      "kind": "TypeParameter",
-      "detail": "Union",
-      "sortText": "M",
-      "insertText": "Thread",
+      "label": "subtractFunction",
+      "kind": "Variable",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _._  \n  \n  \n**Params**  \n- `int` a  \n- `int` b  \n  \n**Returns** `int`   \n  \n"
+        }
+      },
+      "sortText": "A",
+      "filterText": "subtractFunction",
+      "insertText": "subtractFunction",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "subtractFunction(int a, int b)(int)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _._  \n  \n  \n**Params**  \n- `int` a  \n- `int` b  \n  \n**Returns** `int`   \n  \n"
+        }
+      },
+      "sortText": "E",
+      "filterText": "subtractFunction",
+      "insertText": "subtractFunction(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "main",
+      "kind": "Variable",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _._  \n  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "main",
+      "insertText": "main",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "main()",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _._  \n  \n  \n"
+        }
+      },
+      "sortText": "E",
+      "filterText": "main",
+      "insertText": "main()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "total",
+      "kind": "Variable",
+      "detail": "int",
+      "sortText": "D",
+      "insertText": "total",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "myInt1",
+      "kind": "Variable",
+      "detail": "int",
+      "sortText": "D",
+      "insertText": "myInt1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "myInt2",
+      "kind": "Variable",
+      "detail": "int",
+      "sortText": "D",
+      "insertText": "myInt2",
       "insertTextFormat": "Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/function_call_expression_ctx_source10.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/function_call_expression_ctx_source10.bal
@@ -1,0 +1,17 @@
+function process(function (int, int) returns int func, int num1, int num2) returns int{
+    return func(num1,num2);
+}
+
+public function main() {
+    var addFunction = function (int num1, int num2) returns int {
+                return num1 + num2;
+            };
+    int myInt1 = 1;
+    int myInt2 = 2;
+    string myString = "hello";
+    int total = process(addFunction,);
+}
+
+function myFunc(int a, int b) returns int {
+    return a+b;
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/function_call_expression_ctx_source11.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/function_call_expression_ctx_source11.bal
@@ -1,0 +1,32 @@
+public function main() {
+    var addFunction = function (int num1, int num2) returns int {
+                return num1 + num2;
+            };
+    int myInt1 = 1;
+    int myInt2 = 2;
+    string myString = "hello";
+
+    MyType var1 = {
+            a:10,
+            b:5
+        };
+
+    int total = myFunc();
+}
+
+function myFunc(MyType a) returns int {
+    return 10;
+}
+
+public function process4() returns MyType {
+    MyType a = {
+        a:10,
+        b:5
+    };
+    return a;
+}
+
+type MyType record {|
+    int a;
+    int b;
+|};

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/function_call_expression_ctx_source9.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/function_call_expression_ctx_source9.bal
@@ -1,0 +1,20 @@
+function process(function (int, int) returns int func, int num1, int num2) returns int{
+    return func(num1,num2);
+}
+
+public function subtractFunction(int a, int b) returns int {
+    return a-b;
+}
+
+public function getFunction() returns function(int,int) returns int {
+    return subtractFunction;
+}
+
+public function main() {
+    var addFunction = function (int num1, int num2) returns int {
+                return num1 + num2;
+            };
+    int myInt1 = 1;
+    int myInt2 = 2;
+    int total = process();
+}


### PR DESCRIPTION
## Purpose
**1. Fix function pointer not rendering issue**

  >Solution: Provide function pointer completion item in addition to the function completion item when the context type of the node at cursor is FUNCTION

Sample: 

<img src="https://user-images.githubusercontent.com/35211477/118304250-1151c400-b504-11eb-9cad-33e44b405e5b.gif"  width=600>


**2. Refactor `FunctionCallExpressionNodeContext` to provide sorted completion items  when the cursor is positioned within the parameter (argument) context.**

> With this change the completion items for the parameter context  of a function call expression is sorted in the following precedence depending on the assignability as an argument. 
>   
>   1. Variable symbols with assignable TypeDescriptor ( Function pointers are also considered variables)
>   2. Function symbols with assignable TypeDescriptor
>   3. Other symbols - Default Sorting precedence

Consider the following samples

Sample 1

<img src="https://user-images.githubusercontent.com/35211477/118302030-5cb6a300-b501-11eb-9f12-380cd676e4ad.png"  width=500/>

Sample 2

<img src="https://user-images.githubusercontent.com/35211477/118304852-d4d29800-b504-11eb-92f2-65b02401c6b9.png"  width=500/>


Fixes #30078, #29748, #30529 

## Approach
Filter out visible symbols based on expected parameter type descriptor.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
