### PR TITLE
Add a parent to compiler plugin class loader

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/plugins/CompilerPlugins.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/plugins/CompilerPlugins.java
@@ -80,7 +80,8 @@ public class CompilerPlugins {
 
     private static ClassLoader createClassLoader(List<Path> jarDependencyPaths) {
         return AccessController.doPrivileged(
-                (PrivilegedAction<URLClassLoader>) () -> new URLClassLoader(getJarURLS(jarDependencyPaths))
+                (PrivilegedAction<URLClassLoader>) () -> new URLClassLoader(getJarURLS(jarDependencyPaths),
+                        CompilerPlugins.class.getClassLoader())
         );
     }
 


### PR DESCRIPTION
When ballerina compiler is used within the spring boot based lang
server, CNF exceptions were seeing while trying to compile an http
service. This is to fix the CNF.

## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues.

Fixes #<Issue Number>

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
