### PR TITLE
Add support for looking up types of expressions in do statement and on-fail clause

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/NodeFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/NodeFinder.java
@@ -66,6 +66,7 @@ import org.wso2.ballerinalang.compiler.tree.clauses.BLangLimitClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangMatchClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangOnClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangOnConflictClause;
+import org.wso2.ballerinalang.compiler.tree.clauses.BLangOnFailClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangOrderByClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangOrderKey;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangSelectClause;
@@ -142,6 +143,7 @@ import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangVarBindingPattern
 import org.wso2.ballerinalang.compiler.tree.statements.BLangAssignment;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangBlockStmt;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangCompoundAssignment;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangDo;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangErrorDestructure;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangErrorVariableDef;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangExpressionStmt;
@@ -1323,6 +1325,18 @@ class NodeFinder extends BaseVisitor {
     public void visit(BLangListBindingPattern listBindingPattern) {
         lookupNodes(listBindingPattern.bindingPatterns);
         lookupNode(listBindingPattern.restBindingPattern);
+    }
+
+    @Override
+    public void visit(BLangDo doNode) {
+        lookupNode(doNode.body);
+        lookupNode(doNode.onFailClause);
+    }
+
+    @Override
+    public void visit(BLangOnFailClause onFailClause) {
+        lookupNode((BLangNode) onFailClause.variableDefinitionNode);
+        lookupNode(onFailClause.body);
     }
 
     private boolean setEnclosingNode(BLangNode node, Location pos) {

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ExpressionTypeTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ExpressionTypeTest.java
@@ -351,6 +351,16 @@ public class ExpressionTypeTest {
         assertType(118, 15, 118, 16, RECORD);
     }
 
+    @Test
+    public void testTypeWithinDoAndOnFailClause() {
+        TypeSymbol exprType = getExprType(164, 16, 164, 23);
+        assertEquals(exprType.typeKind(), TYPE_REFERENCE);
+        assertEquals(exprType.getName().get(), "Foo");
+
+        exprType = getExprType(166, 12, 166, 42);
+        assertEquals(exprType.typeKind(), STRING);
+    }
+
     private void assertType(int sLine, int sCol, int eLine, int eCol, TypeDescKind kind) {
         TypeSymbol type = getExprType(sLine, sCol, eLine, eCol);
         assertEquals(type.typeKind(), kind);

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/expressions_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/expressions_test.bal
@@ -160,6 +160,14 @@ function nilableIntersection1() returns (int[] & readonly)? => ();
 
 function nilableIntersection2() returns ()|(int[] & readonly) => [1, 2];
 
+function testExprsInDoAndOnFail() {
+    do {
+        Foo f = {i: 10};
+    } on fail error e {
+        _ = testParameterizedType1(string);
+    }
+}
+
 // utils
 
 class PersonObj {


### PR DESCRIPTION
## Purpose
This PR implements `visit()` methods for do statement and on-fail clause in `NodeFinder`, enabling using `type()` to check the types of expressions within the aforementioned statement/clause.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
