### PR TITLE
Return Null as the Symbol of Wildcard Binding Pattern (`_`)

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
@@ -165,6 +165,11 @@ public class SymbolFactory {
                 return createPathParamSymbol((BVarSymbol) symbol, PathSegment.Kind.PATH_REST_PARAMETER);
             }
 
+            // If the symbol is a wildcard('_'), a variable symbol will not be created.
+            if (((BVarSymbol) symbol).isIgnorable) {
+                return null;
+            }
+
             // return the variable symbol
             return createVariableSymbol((BVarSymbol) symbol, name);
         }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
@@ -166,7 +166,7 @@ public class SymbolFactory {
             }
 
             // If the symbol is a wildcard('_'), a variable symbol will not be created.
-            if (((BVarSymbol) symbol).isIgnorable) {
+            if (((BVarSymbol) symbol).isWildcard) {
                 return null;
             }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -2122,8 +2122,11 @@ public class TypeChecker extends BLangNodeVisitor {
                 varRefExpr.type = this.symTable.semanticError;
                 dlog.error(varRefExpr.pos, DiagnosticErrorCode.UNDERSCORE_NOT_ALLOWED);
             }
-            varRefExpr.symbol = new BVarSymbol(0, varName, env.enclPkg.symbol.pkgID, varRefExpr.type, env.scope.owner,
-                                               varRefExpr.pos, VIRTUAL);
+
+            // If the variable name is a wildcard('_'), the symbol should be ignorable.
+            varRefExpr.symbol = new BVarSymbol(0, true, varName, env.enclPkg.symbol.pkgID, varRefExpr.type,
+                    env.scope.owner, varRefExpr.pos, VIRTUAL);
+
             resultType = varRefExpr.type;
             return;
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BVarSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BVarSymbol.java
@@ -38,6 +38,7 @@ public class BVarSymbol extends BSymbol implements VariableSymbol, Annotatable {
 
     private List<BAnnotationSymbol> annots;
     public boolean isDefaultable = false;
+    public boolean isIgnorable = false;
 
     // Only used for type-narrowing. Cache of the original symbol.
     public BVarSymbol originalSymbol;
@@ -51,6 +52,13 @@ public class BVarSymbol extends BSymbol implements VariableSymbol, Annotatable {
                       SymbolOrigin origin) {
         super(VARIABLE, flags, name, pkgID, type, owner, pos, origin);
         this.annots = new ArrayList<>();
+    }
+
+    public BVarSymbol(long flags, boolean isIgnorable, Name name, PackageID pkgID, BType type, BSymbol owner,
+                      Location pos,
+                      SymbolOrigin origin) {
+        this(flags, name, pkgID, type, owner, pos, origin);
+        this.isIgnorable = isIgnorable;
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BVarSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BVarSymbol.java
@@ -38,7 +38,7 @@ public class BVarSymbol extends BSymbol implements VariableSymbol, Annotatable {
 
     private List<BAnnotationSymbol> annots;
     public boolean isDefaultable = false;
-    public boolean isIgnorable = false;
+    public boolean isWildcard = false;
 
     // Only used for type-narrowing. Cache of the original symbol.
     public BVarSymbol originalSymbol;
@@ -58,7 +58,7 @@ public class BVarSymbol extends BSymbol implements VariableSymbol, Annotatable {
                       Location pos,
                       SymbolOrigin origin) {
         this(flags, name, pkgID, type, owner, pos, origin);
-        this.isIgnorable = isIgnorable;
+        this.isWildcard = isIgnorable;
     }
 
     @Override

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/BindingPatternTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/BindingPatternTest.java
@@ -86,8 +86,7 @@ public class BindingPatternTest {
     @Test
     public void testWildcardBindingPattern() {
         Optional<Symbol> symbol = model.symbol(srcFile, from(22, 4));
-        // TODO: Change if needed once https://github.com/ballerina-platform/ballerina-lang/issues/30000 is addressed
-        assertTrue(symbol.isPresent());
+        assertTrue(symbol.isEmpty());
 
         Optional<TypeSymbol> type = model.type(LineRange.from(srcFile.name(), from(22, 4), from(22, 5)));
         assertTrue(type.isPresent());

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolAtCursorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolAtCursorTest.java
@@ -101,6 +101,7 @@ public class SymbolAtCursorTest {
                 {93, 23, "v2"},
                 {93, 78, "v3"},
                 {102, 2, "v4"},
+                {112, 4, null},
         };
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol_at_cursor_basic_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol_at_cursor_basic_test.bal
@@ -108,3 +108,7 @@ const annotation map<string> v5 on source annotation;
 type Annot record {
     string val;
 };
+
+function testIgnoreSym() {
+    _ = 3.14;
+}


### PR DESCRIPTION
## Purpose
> The symbol of the wildcard binding pattern `_`  would set to be returning `null` in the semantic API symbol lookup. 

Fixes #30000

## Approach
> Maintain a flag in `BVarSymbol` to determine if it is ignorable. 

## Samples
> 

## Remarks
>

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
