### PR TITLE
Add recordtype descriptor completion item to error type paramater context

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/TypeParameterNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/TypeParameterNodeContext.java
@@ -31,11 +31,13 @@ import org.ballerinalang.langserver.common.utils.completion.QNameReferenceUtil;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
 import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
+import org.ballerinalang.langserver.completions.SnippetCompletionItem;
 import org.ballerinalang.langserver.completions.TypeCompletionItem;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
 import org.ballerinalang.langserver.completions.util.Snippet;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -121,6 +123,9 @@ public class TypeParameterNodeContext extends AbstractCompletionProvider<TypePar
                     predicate);
             completionItems.addAll(this.getCompletionItemList(mappingTypes, context));
         } else {
+            completionItems.addAll(
+                    Arrays.asList(new SnippetCompletionItem(context, Snippet.DEF_RECORD_TYPE_DESC.get()),
+                    new SnippetCompletionItem(context, Snippet.DEF_CLOSED_RECORD_TYPE_DESC.get())));
             List<Symbol> visibleSymbols = context.visibleSymbols(context.getCursorPosition());
             mappingTypes = visibleSymbols.stream().filter(predicate).collect(Collectors.toList());
             completionItems.addAll(this.getCompletionItemList(mappingTypes, context));

--- a/language-server/modules/langserver-core/src/test/resources/completion/typedesc_context/config/error_typedesc1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/typedesc_context/config/error_typedesc1.json
@@ -6,6 +6,22 @@
   "source": "typedesc_context/source/error_typedesc1.bal",
   "items": [
     {
+      "label": "record {}",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "O",
+      "insertText": "record {${1}}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "record {||}",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "O",
+      "insertText": "record {|${1}|}",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "TestMap3",
       "kind": "TypeParameter",
       "detail": "Map",

--- a/language-server/modules/langserver-core/src/test/resources/completion/typedesc_context/config/error_typedesc2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/typedesc_context/config/error_typedesc2.json
@@ -6,6 +6,22 @@
   "source": "typedesc_context/source/error_typedesc2.bal",
   "items": [
     {
+      "label": "record {}",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "O",
+      "insertText": "record {${1}}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "record {||}",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "O",
+      "insertText": "record {|${1}|}",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "TestMap3",
       "kind": "TypeParameter",
       "detail": "Map",

--- a/language-server/modules/langserver-core/src/test/resources/completion/typedesc_context/config/error_typedesc5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/typedesc_context/config/error_typedesc5.json
@@ -6,6 +6,22 @@
   "source": "typedesc_context/source/error_typedesc5.bal",
   "items": [
     {
+      "label": "record {}",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "O",
+      "insertText": "record {${1}}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "record {||}",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "O",
+      "insertText": "record {|${1}|}",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "TestRecord1",
       "kind": "Struct",
       "detail": "Record",


### PR DESCRIPTION
## Purpose
$Subject

<img src = "https://user-images.githubusercontent.com/35211477/117749542-96508b00-b22f-11eb-966d-1b1e39469b37.png" width=400 />

Fixes #30398 

## Approach
Add record type descriptor static completion item to `TypeParameterNodeContext`.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
