### PR TITLE
[LS]  Change AnnotationUtil to avoid empty mapping constructor for annotatons with optional fields

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/AnnotationUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/AnnotationUtil.java
@@ -198,22 +198,24 @@ public class AnnotationUtil {
             if (resultType.isPresent() && (resultType.get().typeKind() == TypeDescKind.RECORD
                     || resultType.get().typeKind() == TypeDescKind.MAP)) {
                 List<RecordFieldSymbol> requiredFields = new ArrayList<>();
-                annotationStart.append(" ").append(OPEN_BRACE_KEY).append(LINE_SEPARATOR);
                 if (resultType.get().typeKind() == TypeDescKind.RECORD) {
                     requiredFields.addAll(CommonUtil.getMandatoryRecordFields((RecordTypeSymbol) resultType.get()));
                 }
-                List<String> insertTexts = new ArrayList<>();
-                for (int i = 0; i < requiredFields.size(); i++) {
-                    RecordFieldSymbol field = requiredFields.get(i);
-                    String fieldInsertionText = "\t" +
-                            getRecordFieldCompletionInsertText(field, Collections.emptyList(), 1, i + 1);
-                    insertTexts.add(fieldInsertionText);
+                if (!requiredFields.isEmpty()) {
+                    annotationStart.append(" ").append(OPEN_BRACE_KEY).append(LINE_SEPARATOR);
+                    List<String> insertTexts = new ArrayList<>();
+                    for (int i = 0; i < requiredFields.size(); i++) {
+                        RecordFieldSymbol field = requiredFields.get(i);
+                        String fieldInsertionText = "\t" +
+                                getRecordFieldCompletionInsertText(field, Collections.emptyList(), 1, i + 1);
+                        insertTexts.add(fieldInsertionText);
+                    }
+                    annotationStart.append(String.join("," + LINE_SEPARATOR, insertTexts));
+                    if (requiredFields.isEmpty()) {
+                        annotationStart.append("\t").append("${1}");
+                    }
+                    annotationStart.append(LINE_SEPARATOR).append(CLOSE_BRACE_KEY);
                 }
-                annotationStart.append(String.join("," + LINE_SEPARATOR, insertTexts));
-                if (requiredFields.isEmpty()) {
-                    annotationStart.append("\t").append("${1}");
-                }
-                annotationStart.append(LINE_SEPARATOR).append(CLOSE_BRACE_KEY);
             }
         } else {
             annotationStart.append(annotationSymbol.getName().get());

--- a/language-server/modules/langserver-core/src/test/resources/completion/annotation_ctx/config/functionAnnotation7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/annotation_ctx/config/functionAnnotation7.json
@@ -1,24 +1,16 @@
 {
   "position": {
-    "line": 12,
-    "character": 13
+    "line": 6,
+    "character": 1
   },
-  "source": "annotation_ctx/source/startActionAnnotation2.bal",
+  "source": "annotation_ctx/source/functionAnnotation7.bal",
   "items": [
     {
-      "label": "module1",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "N",
-      "insertText": "module1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ballerina/lang.test",
+      "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
       "sortText": "Q",
-      "insertText": "test",
+      "insertText": "runtime",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -32,7 +24,53 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.test;\n"
+          "newText": "import ballerina/lang.runtime;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "Q",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/module1",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "Q",
+      "insertText": "module1",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/module1;\n"
         }
       ]
     },
@@ -83,11 +121,11 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
+      "label": "ballerina/lang.test",
       "kind": "Module",
       "detail": "Module",
       "sortText": "Q",
-      "insertText": "value",
+      "insertText": "test",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -101,30 +139,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.value;\n"
-        }
-      ]
-    },
-    {
-      "label": "ballerina/lang.runtime",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "Q",
-      "insertText": "runtime",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.runtime;\n"
+          "newText": "import ballerina/lang.test;\n"
         }
       ]
     },
@@ -241,29 +256,47 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "sourceWorkerAnnotation1",
+      "label": "deprecated",
       "kind": "Property",
       "detail": "Annotation",
       "sortText": "Q",
-      "insertText": "sourceWorkerAnnotation1 {\n\tfoo: \"${1}\"\n}",
+      "insertText": "deprecated",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": []
     },
     {
-      "label": "sourceWorkerAnnotation2",
+      "label": "AnnonType3",
       "kind": "Property",
       "detail": "Annotation",
       "sortText": "Q",
-      "insertText": "sourceWorkerAnnotation2",
+      "insertText": "AnnonType3 {\n\ti: ${1:0}\n}",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": []
     },
     {
-      "label": "strand",
+      "label": "AnnonType2",
       "kind": "Property",
       "detail": "Annotation",
       "sortText": "Q",
-      "insertText": "strand",
+      "insertText": "AnnonType2",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
+    },
+    {
+      "label": "AnnonType1",
+      "kind": "Property",
+      "detail": "Annotation",
+      "sortText": "Q",
+      "insertText": "AnnonType1 {\n\tm: \"${1}\"\n}",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
+    },
+    {
+      "label": "display",
+      "kind": "Property",
+      "detail": "Annotation",
+      "sortText": "Q",
+      "insertText": "display {\n\tlabel: \"${1}\"\n}",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": []
     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/annotation_ctx/config/startActionAnnotation1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/annotation_ctx/config/startActionAnnotation1.json
@@ -263,7 +263,7 @@
       "kind": "Property",
       "detail": "Annotation",
       "sortText": "Q",
-      "insertText": "strand {\n\t${1}\n}",
+      "insertText": "strand",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": []
     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/annotation_ctx/config/workerDeclAnnotation1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/annotation_ctx/config/workerDeclAnnotation1.json
@@ -263,7 +263,7 @@
       "kind": "Property",
       "detail": "Annotation",
       "sortText": "Q",
-      "insertText": "strand {\n\t${1}\n}",
+      "insertText": "strand",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": []
     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/annotation_ctx/config/workerDeclAnnotation2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/annotation_ctx/config/workerDeclAnnotation2.json
@@ -263,7 +263,7 @@
       "kind": "Property",
       "detail": "Annotation",
       "sortText": "Q",
-      "insertText": "strand {\n\t${1}\n}",
+      "insertText": "strand",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": []
     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/annotation_ctx/source/functionAnnotation7.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/annotation_ctx/source/functionAnnotation7.bal
@@ -1,0 +1,10 @@
+annotation record {| int i?; int j = 10; string m;|} AnnonType1 on function;
+
+annotation record {| int i?; int j = 10;|} AnnonType2 on function;
+
+annotation record {| int i;|} AnnonType3 on function;
+
+@
+function func() {
+
+}


### PR DESCRIPTION
## Purpose
$subject

![ezgif com-gif-maker(4)](https://user-images.githubusercontent.com/35211477/118018134-0b79a880-b375-11eb-96a7-f1835f77a087.gif)



Fixes #29355 

## Approach
Check if the required fields of the record symbol is empty before adding the constructor snippet.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
