### PR TITLE
Fix IndexOutOfBoundsException in LS

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/directory/BuildProject.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/directory/BuildProject.java
@@ -138,7 +138,7 @@ public class BuildProject extends Project {
                 String moduleDirName;
                 if (moduleId.moduleName().contains(DOT)) {
                     moduleDirName = moduleId.moduleName()
-                            .split(this.currentPackage().packageName().toString() + DOT)[1];
+                            .split(this.currentPackage().packageName().toString() + "\\.")[1];
                 } else {
                     moduleDirName = Optional.of(this.sourceRoot.getFileName()).get().toString();
                 }

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProject.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProject.java
@@ -1218,6 +1218,38 @@ public class TestBuildProject {
                 .contains("unknown type 'PersonalDetails'"));
     }
 
+    /**
+     * Test DocumentId of a document which it's module name contains package name.
+     * Package name: winery
+     * Module name: winery1
+     */
+    @Test
+    public void testDocumentIdWhichModuleContainsPackageName() {
+        Path projectPath = RESOURCE_DIRECTORY.resolve("projectForDocumentIdTest");
+
+        // 1) Initialize the project instance
+        BuildProject project = null;
+        try {
+            project = BuildProject.load(projectPath);
+        } catch (Exception e) {
+            Assert.fail(e.getMessage());
+        }
+        // 2) Load current package
+        Package currentPackage = project.currentPackage();
+
+        // 3) Compile the package
+        PackageCompilation compilation = currentPackage.getCompilation();
+        Assert.assertFalse(compilation.diagnosticResult().hasErrors());
+
+        // Inputs from langserver
+        Path filePath = RESOURCE_DIRECTORY.resolve("projectForDocumentIdTest").resolve("modules").resolve("winery1")
+                .resolve("winery1.bal").toAbsolutePath();
+
+        // Load the project from document filepath
+        Project buildProject = ProjectLoader.loadProject(filePath);
+        buildProject.documentId(filePath); // get the document ID
+    }
+
     @AfterClass (alwaysRun = true)
     public void reset() {
         Path projectPath = RESOURCE_DIRECTORY.resolve("project_no_permission");

--- a/project-api/project-api-test/src/test/resources/projectForDocumentIdTest/Ballerina.toml
+++ b/project-api/project-api-test/src/test/resources/projectForDocumentIdTest/Ballerina.toml
@@ -1,0 +1,10 @@
+[package]
+org = "sameera"
+name = "winery"
+version = "0.1.0"
+
+[build-options]
+b7aConfigFile="/tmp/ballerina.conf"
+experimental=true
+observabilityIncluded=true
+skipTests=true

--- a/project-api/project-api-test/src/test/resources/projectForDocumentIdTest/main.bal
+++ b/project-api/project-api-test/src/test/resources/projectForDocumentIdTest/main.bal
@@ -1,0 +1,3 @@
+
+public function main() {
+}


### PR DESCRIPTION


## Purpose
> IndexOutOfBoundsException is thrown in LS  when a `.bal` file of a submodule is opened. The issue was at `BuildProject` where `moduleId` is split using the regex `packageName() + "."`. Here, the result of split is an empty array. Since `.` is a special character and it should be escaped. Hence, escaping the `.` in this PR. 

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/30452
## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
