### PR TITLE
Improve the formatting of empty records and inline records

### DIFF
--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
@@ -538,10 +538,10 @@ public class FormattingTreeModifier extends TreeModifier {
             fieldTrailingWS++;
         }
 
-        Token bodyStartDelimiter = formatToken(recordTypeDesc.bodyStartDelimiter(), fieldTrailingWS, fieldTrailingNL);
+        Token bodyStartDelimiter = formatToken(recordTypeDesc.bodyStartDelimiter(), 0, fieldTrailingNL);
         indent(); // Set indentation for record fields
         NodeList<Node> fields = formatNodeList(recordTypeDesc.fields(), fieldTrailingWS, fieldTrailingNL,
-                fieldTrailingWS, fieldTrailingNL);
+                0, fieldTrailingNL);
         RecordRestDescriptorNode recordRestDescriptor =
                 formatNode(recordTypeDesc.recordRestDescriptor().orElse(null), fieldTrailingWS, fieldTrailingNL);
         unindent(); // Revert indentation for record fields

--- a/misc/formatter/modules/formatter-core/src/test/resources/expressions/range/assert/range_expression_2.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/expressions/range/assert/range_expression_2.bal
@@ -1,7 +1,7 @@
 public function foo() {
     object {
         public function __iterator() returns object {
-            public isolated function next() returns record {| int value; |}?;
+            public isolated function next() returns record {|int value;|}?;
         };
     } iterableObj = 25 ..< 28;
 }

--- a/misc/formatter/modules/formatter-core/src/test/resources/types/behavioural/assert/streams_type_1.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/types/behavioural/assert/streams_type_1.bal
@@ -5,7 +5,7 @@ import ballerina/io;
 class OddNumberGenerator {
     int i = 1;
 
-    public isolated function next() returns record {| int value; |}|error? {
+    public isolated function next() returns record {|int value;|}|error? {
         self.i += 2;
         return {value: self.i};
     }
@@ -17,7 +17,7 @@ public function main() {
     //Creating a stream passing an OddNumberGenerator class to the stream constructor
     var oddNumberStream = new stream<int, error>(oddGen);
 
-    record {| int value; |}|error? oddNumber = oddNumberStream.next();
+    record {|int value;|}|error? oddNumber = oddNumberStream.next();
 
     if (oddNumber is ResultValue) {
         io:println("Retrieved odd number: ", oddNumber.value);
@@ -56,7 +56,7 @@ public function main() {
 
     io:println("Calls next method manually and get the next iteration value: ");
     //Calls the `next()` operation to retrieve the data from the stream.
-    record {| Student value; |}|error? student = studentStream2.next();
+    record {|Student value;|}|error? student = studentStream2.next();
     if (student is StudentValue) {
         io:println(student.value);
     }
@@ -78,7 +78,7 @@ public function main() {
     var iterator = studentStream3.iterator();
 
     //Calls the `next()` operation on the iterator to retrieve the next data from the stream.
-    record {| Student value; |}|error? nextStudent = iterator.next();
+    record {|Student value;|}|error? nextStudent = iterator.next();
     if (nextStudent is StudentValue) {
         io:println(nextStudent.value);
     }

--- a/misc/formatter/modules/formatter-core/src/test/resources/types/structured/assert/record_type_1.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/types/structured/assert/record_type_1.bal
@@ -12,7 +12,7 @@ type Grades record {|
     int...;
 |};
 
-function testRecords() returns record {ib}[] {
+function testRecords() returns record {}[] {
     record {||}[] recArr = [r1, r2, r3, r4];
     record {int a;}[] recArr;
     Person p = {name: "john", age: 20};

--- a/misc/formatter/modules/formatter-core/src/test/resources/types/structured/assert/record_type_1.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/types/structured/assert/record_type_1.bal
@@ -11,3 +11,10 @@ type Grades record {|
     int maths;
     int...;
 |};
+
+function testRecords() returns record {ib}[] {
+    record {||}[] recArr = [r1, r2, r3, r4];
+    record {int a;}[] recArr;
+    Person p = {name: "john", age: 20};
+    return recArr;
+}

--- a/misc/formatter/modules/formatter-core/src/test/resources/types/structured/source/record_type_1.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/types/structured/source/record_type_1.bal
@@ -6,3 +6,11 @@
     type Grades    record  {|
        int maths;  int...;
     |};
+
+
+function testRecords() returns record {}[] {
+    record {||}[] recArr = [r1, r2, r3, r4];
+    record {int a;}[] recArr;
+    Person p = {name: "john", age: 20};
+    return recArr;
+}


### PR DESCRIPTION
## Purpose
* Remove the space in between the start delimiter and the end delimiter in empty records.

**Previous:**
```bal
function test() returns record { } { // notice the space in between the start delimiter and the end delimiter of the empty record
}
```
**New:**
```bal
function test() returns record {} { // the space in between the start delimiter and the end delimiter of the empty record is removed
}
```
* Remove the space after the start delimiter and the space before the end delimiter in inline records.

**Previous:**
```bal
function test() {
    record { int a; } x; // notice the space after the start delimiter and the space before the end delimiter of the inline record
}
```
**New:**
```bal
function test() {
    record {int a;} x; // the space after the start delimiter and the space before the end delimiter of the inline record are removed
}
```

Fixes #29535

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
