### PR TITLE
Improve method/remote method name collision diagnostic message

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
@@ -718,7 +718,9 @@ public enum DiagnosticErrorCode implements DiagnosticCode {
 
     UNIMPLEMENTED_REFERENCED_METHOD_IN_SERVICE_DECL("BCE4007",
             "unimplemented.referenced.method.in.service.declaration"),
-    UNIMPLEMENTED_REFERENCED_METHOD_IN_OBJECT_CTOR("BCE4008", "unimplemented.referenced.method.in.object.constructor")
+    UNIMPLEMENTED_REFERENCED_METHOD_IN_OBJECT_CTOR("BCE4008", "unimplemented.referenced.method.in.object.constructor"),
+
+    UNSUPPORTED_REMOTE_METHOD_NAME_IN_SCOPE("BCE4009", "unsupported.remote.method.name.in.scope")
             ;
 
     private String diagnosticId;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -208,7 +208,15 @@ public class SymbolResolver extends BLangNodeVisitor {
         }
 
         if (isRedeclaredSymbol(symbol, foundSym)) {
-            dlog.error(pos, DiagnosticErrorCode.REDECLARED_SYMBOL, symbol.name);
+
+            Name name = symbol.name;
+            if (Symbols.isRemote(symbol) && !Symbols.isRemote(foundSym)
+                || !Symbols.isRemote(symbol) && Symbols.isRemote(foundSym)) {
+                dlog.error(pos, DiagnosticErrorCode.UNSUPPORTED_REMOTE_METHOD_NAME_IN_SCOPE, name);
+                return false;
+            }
+
+            dlog.error(pos, DiagnosticErrorCode.REDECLARED_SYMBOL, name);
             return false;
         }
 

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1743,8 +1743,7 @@ error.optional.operand.precedes.operand=\
   of type ''{3}''
 
 error.unsupported.remote.method.name.in.scope=\
-  declaration of remote method ''{0}'' while non remote method with the same name exist in the object type is \
-  not supported
+  unsupported remote method name, ''{0}'' already exists as a method or field name in the object type
 
 # hints
 hint.unnecessary.condition=\

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1742,6 +1742,10 @@ error.optional.operand.precedes.operand=\
    'main' function optional operand parameter ''{0}'' of type ''{1}'' cannot precede operand parameter ''{2}'' \
   of type ''{3}''
 
+error.unsupported.remote.method.name.in.scope=\
+  declaration of remote method ''{0}'' while non remote method with the same name exist in the object type is \
+  not supported
+
 # hints
 hint.unnecessary.condition=\
   unnecessary condition: expression will always evaluate to ''true''

--- a/compiler/ballerina-lang/src/test/java/org/wso2/ballerinalang/compiler/diagnostic/BLangDiagnosticLogTest.java
+++ b/compiler/ballerina-lang/src/test/java/org/wso2/ballerinalang/compiler/diagnostic/BLangDiagnosticLogTest.java
@@ -90,6 +90,11 @@ public class BLangDiagnosticLogTest {
         assertDiagnosticEqual(diagnosticList.get(0), "Diagnostic Message", DiagnosticSeverity.WARNING, location);
     }
 
+    @Test
+    public void testDiagnosticHashCollusion() {
+        BLangDiagnosticLog dlog = (BLangDiagnosticLog) this.dlog;
+    }
+
     // helpers
     private PackageID createPackageID(String orgName, String name, String version) {
         return new PackageID(new Name(orgName), new Name(name), new Name(version));

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/endpoint/ClientObjectTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/endpoint/ClientObjectTest.java
@@ -125,6 +125,18 @@ public class ClientObjectTest {
                 " for remote method calls", 146, 5);
         BAssertUtil.validateError(compileResult, errIdx++, "invalid method call '->bar()': '->' can only be used" +
                 " with remote methods", 147, 5);
+        String doubleDeclMessage = "declaration of remote method '%s' " +
+                "while non remote method with the same name exist in the object type is not supported";
+        BAssertUtil.validateError(compileResult, errIdx++,
+                String.format(doubleDeclMessage, "DoubleMethod.a"), 155, 14);
+        BAssertUtil.validateError(compileResult, errIdx++,
+                String.format(doubleDeclMessage, "DoubleMethodOtherOrder.a"), 165, 21);
+        BAssertUtil.validateError(compileResult, errIdx++, "redeclared symbol 'DoubleRemoteMethod.a'", 175, 21);
+        BAssertUtil.validateError(compileResult, errIdx++,
+                String.format(doubleDeclMessage, "$anonType$_0.a"), 186, 18);
+        BAssertUtil.validateError(compileResult, errIdx++,
+                String.format(doubleDeclMessage, "$anonType$_1.a"), 196, 25);
+        BAssertUtil.validateError(compileResult, errIdx++, "redeclared symbol '$anonType$_2.a'", 206, 25);
         Assert.assertEquals(compileResult.getErrorCount(), errIdx);
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/endpoint/ClientObjectTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/endpoint/ClientObjectTest.java
@@ -125,8 +125,8 @@ public class ClientObjectTest {
                 " for remote method calls", 146, 5);
         BAssertUtil.validateError(compileResult, errIdx++, "invalid method call '->bar()': '->' can only be used" +
                 " with remote methods", 147, 5);
-        String doubleDeclMessage = "declaration of remote method '%s' " +
-                "while non remote method with the same name exist in the object type is not supported";
+        String doubleDeclMessage =
+                "unsupported remote method name, '%s' already exists as a method or field name in the object type";
         BAssertUtil.validateError(compileResult, errIdx++,
                 String.format(doubleDeclMessage, "DoubleMethod.a"), 155, 14);
         BAssertUtil.validateError(compileResult, errIdx++,

--- a/tests/jballerina-unit-test/src/test/resources/test-src/endpoint/new/remote_basic_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/endpoint/new/remote_basic_negative.bal
@@ -146,3 +146,65 @@ function testRemoteMethodCallAction() {
     cl.foo();
     cl->bar();
 }
+
+client class DoubleMethod {
+    remote function a() returns int {
+        return 0;
+    }
+
+    function a() returns int {
+        return 2;
+    }
+}
+
+client class DoubleMethodOtherOrder {
+    function a() returns int {
+        return 2;
+    }
+
+    remote function a() returns int {
+        return 0;
+    }
+}
+
+client class DoubleRemoteMethod {
+    remote function a() {
+
+    }
+
+    remote function a() {
+
+    }
+}
+
+function clientFunc() {
+    var x = client object {
+        remote function a() returns int {
+            return 0;
+        }
+
+        function a() returns int {
+            return 2;
+        }
+    };
+
+    var y = client object {
+        function a() returns int {
+            return 2;
+        }
+
+        remote function a() returns int {
+            return 0;
+        }
+    };
+
+    var z = client object {
+        remote function a() {
+
+        }
+
+        remote function a() {
+
+        }
+    };
+}


### PR DESCRIPTION
## Purpose
```ballerina
client class DoubleMethod {
    remote function a() returns int {
        return 0;
    }

    function a() returns int {
        return 2;
    }
}
```

Previous error:
```
redeclared symbol 'DoubleMethod.a'
```

Now:
```
declaration of remote method 'DoubleMethod.a' while non remote method with the same name exist in the object type is not supported
```
Fixes https://github.com/ballerina-platform/ballerina-lang/issues/30542

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
