### PR TITLE
Update default observability extensions to choreo

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/ObserveUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/ObserveUtils.java
@@ -83,9 +83,9 @@ public class ObserveUtils {
 
         metricsEnabled = readConfig(metricsEnabledKey, enabledKey, false);
         metricsProvider = readConfig(metricsProviderKey, null, StringUtils.fromString("default"));
-        metricsReporter = readConfig(metricsReporterKey, providerKey, StringUtils.fromString("prometheus"));
+        metricsReporter = readConfig(metricsReporterKey, providerKey, StringUtils.fromString("choreo"));
         tracingEnabled = readConfig(tracingEnabledKey, enabledKey, false);
-        tracingProvider = readConfig(tracingProviderKey, providerKey, StringUtils.fromString("jaeger"));
+        tracingProvider = readConfig(tracingProviderKey, providerKey, StringUtils.fromString("choreo"));
         enabled = metricsEnabled || tracingEnabled;
     }
 

--- a/observelib/observe/src/main/ballerina/commons.bal
+++ b/observelib/observe/src/main/ballerina/commons.bal
@@ -20,9 +20,9 @@ import ballerina/jballerina.java;
 final configurable boolean enabled = false;
 final configurable string provider = "";
 final configurable boolean metricsEnabled = false;
-final configurable string metricsReporter = "prometheus";
+final configurable string metricsReporter = "choreo";
 final configurable boolean tracingEnabled = false;
-final configurable string tracingProvider = "jaeger";
+final configurable string tracingProvider = "choreo";
 
 function init() {
     externInitializeModule();


### PR DESCRIPTION
## Purpose
With this PR, the default observability extensions of Prometheus (Metrics-reporter ) and Jaeger  (Tracing provider) will be updated to choreo



## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
