### PR TITLE
Prevent singleton type true from being return as type of an annotation symbol

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
@@ -53,6 +53,8 @@ import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.resourcepath.util.PathSegment;
 import org.ballerinalang.model.symbols.SymbolKind;
+import org.wso2.ballerinalang.compiler.semantics.analyzer.Types;
+import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BAnnotationSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BAttachedFunction;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BClassSymbol;
@@ -92,11 +94,15 @@ public class SymbolFactory {
 
     private final CompilerContext context;
     private final TypesFactory typesFactory;
+    private final Types types;
+    private final SymbolTable symTable;
 
     private SymbolFactory(CompilerContext context) {
         context.put(SYMBOL_FACTORY_KEY, this);
         this.context = context;
         this.typesFactory = TypesFactory.getInstance(context);
+        this.types = Types.getInstance(context);
+        this.symTable = SymbolTable.getInstance(context);
     }
 
     public static SymbolFactory getInstance(CompilerContext context) {
@@ -520,7 +526,10 @@ public class SymbolFactory {
         if ((symbol.flags & Flags.PUBLIC) == Flags.PUBLIC) {
             symbolBuilder.withQualifier(Qualifier.PUBLIC);
         }
-        if (symbol.attachedType != null && symbol.attachedType.getType() != null) {
+
+        // Skipping the compiler-generated singleton type `true`.
+        if (symbol.attachedType != null && symbol.attachedType.getType() != null
+                && !types.isAssignable(symbol.attachedType.getType(), this.symTable.trueType)) {
             symbolBuilder.withTypeDescriptor(typesFactory.getTypeDescriptor(symbol.attachedType.getType()));
         }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
@@ -339,6 +339,7 @@ class SymbolFinder extends BaseVisitor {
             return;
         }
 
+        lookupNodes(constant.annAttachments);
         lookupNode(constant.typeNode);
         lookupNode(constant.expr);
     }
@@ -1209,6 +1210,11 @@ class SymbolFinder extends BaseVisitor {
         }
 
         lookupNodes(classDefinition.annAttachments);
+
+        for (BLangSimpleVariable field : classDefinition.fields) {
+            lookupNodes(field.annAttachments);
+        }
+
         lookupNodes(classDefinition.fields);
         lookupNodes(classDefinition.referencedFields);
         lookupNode(classDefinition.initFunction);
@@ -1218,6 +1224,10 @@ class SymbolFinder extends BaseVisitor {
 
     @Override
     public void visit(BLangObjectTypeNode objectTypeNode) {
+        for (BLangSimpleVariable field : objectTypeNode.fields) {
+            lookupNodes(field.annAttachments);
+        }
+
         lookupNodes(objectTypeNode.fields);
         lookupNodes(objectTypeNode.functions);
         lookupNodes(objectTypeNode.typeRefs);
@@ -1225,6 +1235,10 @@ class SymbolFinder extends BaseVisitor {
 
     @Override
     public void visit(BLangRecordTypeNode recordTypeNode) {
+        for (BLangSimpleVariable field : recordTypeNode.fields) {
+            lookupNodes(field.annAttachments);
+        }
+
         lookupNodes(recordTypeNode.fields);
         lookupNodes(recordTypeNode.typeRefs);
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/TypesFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/TypesFactory.java
@@ -324,7 +324,7 @@ public class TypesFactory {
         throw new IllegalStateException("Invalid XML subtype type tag: " + internalType.tag);
     }
 
-    private static boolean isTypeReference(BType bType, BTypeSymbol tSymbol, boolean rawTypeOnly) {
+    private boolean isTypeReference(BType bType, BTypeSymbol tSymbol, boolean rawTypeOnly) {
         // Not considering type params as type refs for now because having it in the typedesc form will make more
         // sense for end users of the API consumers (e.g., VS Code plugin users). This probably can be removed once
         // https://github.com/ballerina-platform/ballerina-lang/issues/18150 is fixed.

--- a/compiler/ballerina-lang/src/test/java/org/wso2/ballerinalang/compiler/diagnostic/BLangDiagnosticLogTest.java
+++ b/compiler/ballerina-lang/src/test/java/org/wso2/ballerinalang/compiler/diagnostic/BLangDiagnosticLogTest.java
@@ -28,6 +28,7 @@ import io.ballerina.tools.diagnostics.DiagnosticFactory;
 import io.ballerina.tools.diagnostics.DiagnosticInfo;
 import io.ballerina.tools.diagnostics.DiagnosticSeverity;
 import io.ballerina.tools.diagnostics.Location;
+import org.ballerinalang.compiler.CompilerOptionName;
 import org.ballerinalang.model.TreeBuilder;
 import org.ballerinalang.model.elements.PackageID;
 import org.ballerinalang.util.diagnostic.DiagnosticLog;
@@ -37,6 +38,7 @@ import org.testng.annotations.Test;
 import org.wso2.ballerinalang.compiler.PackageCache;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
+import org.wso2.ballerinalang.compiler.util.CompilerOptions;
 import org.wso2.ballerinalang.compiler.util.Name;
 
 import java.util.List;
@@ -53,6 +55,8 @@ public class BLangDiagnosticLogTest {
     @BeforeClass
     public void setup() {
         context = new CompilerContext();
+        CompilerOptions options = CompilerOptions.getInstance(context);
+        options.put(CompilerOptionName.PROJECT_API_INITIATED_COMPILATION, String.valueOf(true));
         dlog = BLangDiagnosticLog.getInstance(context);
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/annotations_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/annotations_test.bal
@@ -112,6 +112,11 @@ enum Colour {
     BLUE
 }
 
+public type T2 object {
+    @v5 string name;
+};
+
+
 // util
 
 public class Listener {


### PR DESCRIPTION
## Purpose
This PR fixes a bug which caused the singleton type `true` to be returned as the type of an annotation when calling `typeDescriptor()` on an `AnnotationSymbol`.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
