### PR TITLE
Add a new API for getting the unflattened member types of a union

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaUnionTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaUnionTypeSymbol.java
@@ -85,7 +85,8 @@ public class BallerinaUnionTypeSymbol extends AbstractTypeSymbol implements Unio
         return this.memberTypes;
     }
 
-    public List<TypeSymbol> originalMemberTypeDescriptors() {
+    @Override
+    public List<TypeSymbol> userSpecifiedMemberTypes() {
         if (this.originalMemberTypes == null) {
             List<TypeSymbol> members = new ArrayList<>();
 
@@ -141,7 +142,7 @@ public class BallerinaUnionTypeSymbol extends AbstractTypeSymbol implements Unio
             return "...";
         }
 
-        List<TypeSymbol> memberTypes = this.originalMemberTypeDescriptors();
+        List<TypeSymbol> memberTypes = this.userSpecifiedMemberTypes();
         if (containsTwoElements(memberTypes) && containsNil(memberTypes)) {
             TypeSymbol member1 = memberTypes.get(0);
             return member1.typeKind() == NIL ? getSignatureForIntersectionType(memberTypes.get(1)) + "?" :
@@ -158,7 +159,7 @@ public class BallerinaUnionTypeSymbol extends AbstractTypeSymbol implements Unio
     }
 
     private String getSignatureForFiniteType() {
-        List<TypeSymbol> memberTypes = this.memberTypeDescriptors();
+        List<TypeSymbol> memberTypes = this.userSpecifiedMemberTypes();
         StringJoiner joiner = new StringJoiner("|");
         for (TypeSymbol typeDescriptor : memberTypes) {
             joiner.add(typeDescriptor.signature());

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/UnionTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/UnionTypeSymbol.java
@@ -26,9 +26,17 @@ import java.util.List;
 public interface UnionTypeSymbol extends TypeSymbol {
 
     /**
-     * Get the member types.
+     * Gets the exact member types the user specified in the source code when writing the union.
      *
-     * @return {@link List} of member types
+     * @return {@link List} of user specified member types
+     */
+    List<TypeSymbol> userSpecifiedMemberTypes();
+
+    /**
+     * Gets the expanded set of member types. If there are any unions in the members, members of those unions are taken
+     * recursively.
+     *
+     * @return {@link List} of expanded member types
      */
     List<TypeSymbol> memberTypeDescriptors();
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
@@ -738,6 +738,66 @@ public class TypedescriptorTest {
         };
     }
 
+    @Test
+    public void testUserSpecifiedUnionMembers() {
+        Optional<Symbol> symbol = model.symbol(srcFile, from(229, 12));
+        TypeSymbol type = ((VariableSymbol) symbol.get()).typeDescriptor();
+
+        assertEquals(type.typeKind(), UNION);
+        assertEquals(type.signature(), "Colour?");
+
+        List<TypeSymbol> userSpecifiedMembers = ((UnionTypeSymbol) type).userSpecifiedMemberTypes();
+        assertEquals(userSpecifiedMembers.size(), 2);
+        assertEquals(userSpecifiedMembers.get(0).typeKind(), TYPE_REFERENCE);
+        assertEquals(userSpecifiedMembers.get(0).getName().get(), "Colour");
+        assertEquals(userSpecifiedMembers.get(1).typeKind(), NIL);
+
+        symbol = model.symbol(srcFile, from(230, 13));
+        type = ((VariableSymbol) symbol.get()).typeDescriptor();
+
+        assertEquals(type.typeKind(), TYPE_REFERENCE);
+        assertEquals(type.signature(), "FooUnion");
+
+        type = ((TypeReferenceTypeSymbol) type).typeDescriptor();
+        assertEquals(type.typeKind(), UNION);
+
+        userSpecifiedMembers = ((UnionTypeSymbol) type).userSpecifiedMemberTypes();
+        assertEquals(userSpecifiedMembers.get(0).typeKind(), TYPE_REFERENCE);
+        assertEquals(userSpecifiedMembers.get(0).getName().get(), "IntString");
+        assertEquals(userSpecifiedMembers.get(1).typeKind(), TYPE_REFERENCE);
+        assertEquals(userSpecifiedMembers.get(1).getName().get(), "FloatBoolean");
+    }
+
+    @Test
+    public void testFlattenedUnionMembers() {
+        Optional<Symbol> symbol = model.symbol(srcFile, from(229, 12));
+        TypeSymbol type = ((VariableSymbol) symbol.get()).typeDescriptor();
+
+        assertEquals(type.typeKind(), UNION);
+        assertEquals(type.signature(), "Colour?");
+
+        List<TypeSymbol> userSpecifiedMembers = ((UnionTypeSymbol) type).memberTypeDescriptors();
+        assertEquals(userSpecifiedMembers.size(), 4);
+        assertEquals(userSpecifiedMembers.get(0).typeKind(), SINGLETON);
+        assertEquals(userSpecifiedMembers.get(1).typeKind(), SINGLETON);
+        assertEquals(userSpecifiedMembers.get(2).typeKind(), SINGLETON);
+        assertEquals(userSpecifiedMembers.get(3).typeKind(), NIL);
+
+        symbol = model.symbol(srcFile, from(230, 13));
+        type = ((VariableSymbol) symbol.get()).typeDescriptor();
+
+        assertEquals(type.typeKind(), TYPE_REFERENCE);
+
+        type = ((TypeReferenceTypeSymbol) type).typeDescriptor();
+        assertEquals(type.typeKind(), UNION);
+
+        userSpecifiedMembers = ((UnionTypeSymbol) type).memberTypeDescriptors();
+        assertEquals(userSpecifiedMembers.get(0).typeKind(), INT);
+        assertEquals(userSpecifiedMembers.get(1).typeKind(), STRING);
+        assertEquals(userSpecifiedMembers.get(2).typeKind(), FLOAT);
+        assertEquals(userSpecifiedMembers.get(3).typeKind(), BOOLEAN);
+    }
+
     private Symbol getSymbol(int line, int column) {
         return model.symbol(srcFile, from(line, column)).get();
     }

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/typedesc_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/typedesc_test.bal
@@ -220,3 +220,13 @@ function testFunctionTypedesc() {
 function testParameterizedType1(typedesc<anydata> td) returns td = external;
 
 function testParameterizedType2(typedesc td = <>) returns error|td = external;
+
+type IntString int|string;
+type FloatBoolean float|boolean;
+
+type FooUnion IntString|FloatBoolean;
+
+function testUnions() {
+    Colour? clr = RED;
+    FooUnion fUnion = 10;
+}


### PR DESCRIPTION
## Purpose
This PR adds a new method to `UnionTypeSymbol` to get the member types as specified in the source code by the user.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
