### PR TITLE
Add meta info regarding a variable's diagnostics to `VariableSymbol`

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaVariableSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaVariableSymbol.java
@@ -18,12 +18,14 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.symbols.AnnotationSymbol;
+import io.ballerina.compiler.api.symbols.DiagnosticState;
 import io.ballerina.compiler.api.symbols.Documentation;
 import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.VariableSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BVarSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.util.Flags;
@@ -75,6 +77,11 @@ public class BallerinaVariableSymbol extends BallerinaSymbol implements Variable
     @Override
     public TypeSymbol typeDescriptor() {
         return typeDescriptorImpl;
+    }
+
+    @Override
+    public DiagnosticState diagnosticState() {
+        return ((BVarSymbol) this.getInternalSymbol()).state;
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/DiagnosticState.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/DiagnosticState.java
@@ -34,12 +34,9 @@ public enum DiagnosticState {
      */
     REDECLARED,
     /**
-     * Indicates that the specified type of variable could not be resolved. i.e., specified type is not defined.
+     * Indicates that the specified type of variable could not be resolved (i.e., specified type is not defined) or that
+     * the compiler failed to determine the type of the variable using the context. This is applicable for variables
+     * declared using `var`.
      */
-    UNKNOWN_TYPE,
-    /**
-     * Indicates that the compiler failed to determine the type of the variable using the context. This is applicable
-     * for variables declared using `var`.
-     */
-    FAILED_TO_DETERMINE_TYPE
+    UNKNOWN_TYPE
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/DiagnosticState.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/DiagnosticState.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.compiler.api.symbols;
+
+/**
+ * This is used to represent the state of a variable symbol. In cases of compiler errors, sometimes a variable symbol's
+ * type may be set to compile error. In such cases, this will help to further narrow down the cause for it.
+ *
+ * @since 2.0.0
+ */
+public enum DiagnosticState {
+    /**
+     * Indicates that the variable symbol is semantically valid.
+     */
+    VALID,
+    /**
+     * Indicates that the symbol represents a redeclard symbol.
+     */
+    REDECLARED,
+    /**
+     * Indicates that the compiler failed to determine the type of the variable using the context. This is applicable
+     * for variables declared using `var`.
+     */
+    FAILED_TO_DETERMINE_TYPE
+}

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/DiagnosticState.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/DiagnosticState.java
@@ -34,6 +34,10 @@ public enum DiagnosticState {
      */
     REDECLARED,
     /**
+     * Indicates that the specified type of variable could not be resolved. i.e., specified type is not defined.
+     */
+    UNKNOWN_TYPE,
+    /**
      * Indicates that the compiler failed to determine the type of the variable using the context. This is applicable
      * for variables declared using `var`.
      */

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/DiagnosticState.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/DiagnosticState.java
@@ -30,7 +30,7 @@ public enum DiagnosticState {
      */
     VALID,
     /**
-     * Indicates that the symbol represents a redeclard symbol.
+     * Indicates that the symbol represents a redeclared symbol.
      */
     REDECLARED,
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/VariableSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/VariableSymbol.java
@@ -30,4 +30,12 @@ public interface VariableSymbol extends Symbol, Qualifiable, Deprecatable, Annot
      * @return {@link TypeSymbol} of the variable
      */
     TypeSymbol typeDescriptor();
+
+    /**
+     * Gets the diagnostic state of the variable. If the type of the variable is set as $CompilationError$, this will
+     * provide an additional bit of insight in to what type of error caused the type to be set as $CompilationError$.
+     *
+     * @return The state of the variable symbol
+     */
+    DiagnosticState diagnosticState();
 }

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/symbols/SymbolKind.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/symbols/SymbolKind.java
@@ -34,6 +34,7 @@ public enum SymbolKind {
     ANNOTATION,
     ANNOTATION_ATTRIBUTE,
     CONSTANT,
+    VARIABLE,
     PACKAGE_VARIABLE,
     TRANSFORMER,
     TYPE_DEF,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -1251,7 +1251,7 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
                 simpleVariable.symbol.type = rhsType;
 
                 if (simpleVariable.symbol.type == symTable.semanticError) {
-                    simpleVariable.symbol.state = DiagnosticState.FAILED_TO_DETERMINE_TYPE;
+                    simpleVariable.symbol.state = DiagnosticState.UNKNOWN_TYPE;
                 }
                 break;
             case TUPLE_VARIABLE:

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.ballerinalang.compiler.semantics.analyzer;
 
+import io.ballerina.compiler.api.symbols.DiagnosticState;
 import io.ballerina.tools.diagnostics.DiagnosticCode;
 import io.ballerina.tools.diagnostics.Location;
 import org.ballerinalang.compiler.CompilerPhase;
@@ -1248,6 +1249,10 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
                 // Set the type to the symbol. If the variable is a global variable, a symbol is already created in the
                 // symbol enter. If the variable is a local variable, the symbol will be created above.
                 simpleVariable.symbol.type = rhsType;
+
+                if (simpleVariable.symbol.type == symTable.semanticError) {
+                    simpleVariable.symbol.state = DiagnosticState.FAILED_TO_DETERMINE_TYPE;
+                }
                 break;
             case TUPLE_VARIABLE:
                 if (varRefExpr == null) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.ballerinalang.compiler.semantics.analyzer;
 
+import io.ballerina.compiler.api.symbols.DiagnosticState;
 import io.ballerina.tools.diagnostics.Location;
 import org.ballerinalang.compiler.CompilerOptionName;
 import org.ballerinalang.compiler.CompilerPhase;
@@ -3811,10 +3812,10 @@ public class SymbolEnter extends BLangNodeVisitor {
                 flagSet.contains(Flag.DEFAULTABLE_PARAM) || flagSet.contains(Flag.REST_PARAM) ||
                 flagSet.contains(Flag.INCLUDED);
 
-        if (considerAsMemberSymbol && !symResolver.checkForUniqueMemberSymbol(pos, env, varSymbol)) {
+        if (considerAsMemberSymbol && !symResolver.checkForUniqueMemberSymbol(pos, env, varSymbol) ||
+                !considerAsMemberSymbol && !symResolver.checkForUniqueSymbol(pos, env, varSymbol)) {
             varSymbol.type = symTable.semanticError;
-        } else if (!considerAsMemberSymbol && !symResolver.checkForUniqueSymbol(pos, env, varSymbol)) {
-            varSymbol.type = symTable.semanticError;
+            varSymbol.state = DiagnosticState.REDECLARED;
         }
 
         enclScope.define(varSymbol.name, varSymbol);
@@ -3824,6 +3825,7 @@ public class SymbolEnter extends BLangNodeVisitor {
     public void defineExistingVarSymbolInEnv(BVarSymbol varSymbol, SymbolEnv env) {
         if (!symResolver.checkForUniqueSymbol(env, varSymbol)) {
             varSymbol.type = symTable.semanticError;
+            varSymbol.state = DiagnosticState.REDECLARED;
         }
         env.scope.define(varSymbol.name, varSymbol);
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -1946,7 +1946,7 @@ public class SymbolEnter extends BLangNodeVisitor {
         if (varSymbol.type == symTable.semanticError && varSymbol.state == DiagnosticState.VALID) {
             varSymbol.state = DiagnosticState.UNKNOWN_TYPE;
         }
-        
+
         varSymbol.markdownDocumentation = getMarkdownDocAttachment(varNode.markdownDocumentationAttachment);
         varNode.symbol = varSymbol;
         if (varNode.symbol.type.tsymbol != null && Symbols.isFlagOn(varNode.symbol.type.tsymbol.flags, Flags.CLIENT)) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -1941,6 +1941,12 @@ public class SymbolEnter extends BLangNodeVisitor {
         if (isDeprecated(varNode.annAttachments)) {
             varSymbol.flags |= Flags.DEPRECATED;
         }
+
+        // Skip setting the state if there's a diagnostic already (e.g., redeclared symbol)
+        if (varSymbol.type == symTable.semanticError && varSymbol.state == DiagnosticState.VALID) {
+            varSymbol.state = DiagnosticState.UNKNOWN_TYPE;
+        }
+        
         varSymbol.markdownDocumentation = getMarkdownDocAttachment(varNode.markdownDocumentationAttachment);
         varNode.symbol = varSymbol;
         if (varNode.symbol.type.tsymbol != null && Symbols.isFlagOn(varNode.symbol.type.tsymbol.flags, Flags.CLIENT)) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -1616,7 +1616,7 @@ public class SymbolResolver extends BLangNodeVisitor {
                 } else {
                     List<ScopeEntry> scopeEntries = visibleEntries.get(name);
                     entryList.forEach(scopeEntry -> {
-                        if (!scopeEntries.contains(scopeEntry) && !(scopeEntry.symbol instanceof BVarSymbol)) {
+                        if (!scopeEntries.contains(scopeEntry)) {
                             scopeEntries.add(scopeEntry);
                         }
                     });

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -1616,7 +1616,7 @@ public class SymbolResolver extends BLangNodeVisitor {
                 } else {
                     List<ScopeEntry> scopeEntries = visibleEntries.get(name);
                     entryList.forEach(scopeEntry -> {
-                        if (!scopeEntries.contains(scopeEntry)) {
+                        if (!scopeEntries.contains(scopeEntry) && !isModuleLevelVar(scopeEntry.symbol)) {
                             scopeEntries.add(scopeEntry);
                         }
                     });
@@ -2133,6 +2133,10 @@ public class SymbolResolver extends BLangNodeVisitor {
         dlog.error(inferDefaultLocation,
                    DiagnosticErrorCode.CANNOT_USE_INFERRED_TYPEDESC_DEFAULT_WITH_UNREFERENCED_PARAM);
         return false;
+    }
+
+    private boolean isModuleLevelVar(BSymbol symbol) {
+        return symbol.getKind() == SymbolKind.VARIABLE && symbol.owner.getKind() == SymbolKind.PACKAGE;
     }
 
     private static class ParameterizedTypeInfo {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
@@ -949,7 +949,7 @@ public class TypeParamAnalyzer {
 
             BInvokableSymbol invokableSymbol = new BInvokableSymbol(expFunc.symbol.tag, expFunc.symbol.flags,
                                                                     expFunc.symbol.name, env.enclPkg.packageID,
-                                                                    matchType, env.scope.owner, expFunc.pos, VIRTUAL);
+                                                                    matchType, actObjectSymbol, expFunc.pos, VIRTUAL);
             invokableSymbol.retType = invokableSymbol.getType().retType;
             matchType.tsymbol = Symbols.createTypeSymbol(SymTag.FUNCTION_TYPE, invokableSymbol.flags, Names.EMPTY,
                                                          env.enclPkg.symbol.pkgID, invokableSymbol.type,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BInvokableSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BInvokableSymbol.java
@@ -21,6 +21,7 @@ import io.ballerina.tools.diagnostics.Location;
 import org.ballerinalang.compiler.BLangCompilerException;
 import org.ballerinalang.model.elements.PackageID;
 import org.ballerinalang.model.symbols.InvokableSymbol;
+import org.ballerinalang.model.symbols.SymbolKind;
 import org.ballerinalang.model.symbols.SymbolOrigin;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BInvokableType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
@@ -72,6 +73,7 @@ public class BInvokableSymbol extends BVarSymbol implements InvokableSymbol {
         this.annAttachments = new ArrayList<>();
         this.dependentGlobalVars = new HashSet<>();
         this.paramDefaultValTypes = new HashMap<>();
+        this.kind = SymbolKind.FUNCTION;
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BVarSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BVarSymbol.java
@@ -22,6 +22,7 @@ import io.ballerina.tools.diagnostics.Location;
 import org.ballerinalang.model.elements.PackageID;
 import org.ballerinalang.model.symbols.Annotatable;
 import org.ballerinalang.model.symbols.AnnotationSymbol;
+import org.ballerinalang.model.symbols.SymbolKind;
 import org.ballerinalang.model.symbols.SymbolOrigin;
 import org.ballerinalang.model.symbols.VariableSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
@@ -49,6 +50,7 @@ public class BVarSymbol extends BSymbol implements VariableSymbol, Annotatable {
                       SymbolOrigin origin) {
         super(VARIABLE, flags, name, pkgID, type, owner, pos, origin);
         this.annots = new ArrayList<>();
+        this.kind = SymbolKind.VARIABLE;
     }
 
     public BVarSymbol(long flags, boolean isIgnorable, Name name, PackageID pkgID, BType type, BSymbol owner,
@@ -73,5 +75,10 @@ public class BVarSymbol extends BSymbol implements VariableSymbol, Annotatable {
     @Override
     public Object getConstValue() {
         return null;
+    }
+
+    @Override
+    public SymbolKind getKind() {
+        return this.kind;
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BVarSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BVarSymbol.java
@@ -17,6 +17,7 @@
 */
 package org.wso2.ballerinalang.compiler.semantics.model.symbols;
 
+import io.ballerina.compiler.api.symbols.DiagnosticState;
 import io.ballerina.tools.diagnostics.Location;
 import org.ballerinalang.model.elements.PackageID;
 import org.ballerinalang.model.symbols.Annotatable;
@@ -39,6 +40,7 @@ public class BVarSymbol extends BSymbol implements VariableSymbol, Annotatable {
     private List<BAnnotationSymbol> annots;
     public boolean isDefaultable = false;
     public boolean isWildcard = false;
+    public DiagnosticState state = DiagnosticState.VALID;
 
     // Only used for type-narrowing. Cache of the original symbol.
     public BVarSymbol originalSymbol;
@@ -50,8 +52,7 @@ public class BVarSymbol extends BSymbol implements VariableSymbol, Annotatable {
     }
 
     public BVarSymbol(long flags, boolean isIgnorable, Name name, PackageID pkgID, BType type, BSymbol owner,
-                      Location pos,
-                      SymbolOrigin origin) {
+                      Location pos, SymbolOrigin origin) {
         this(flags, name, pkgID, type, owner, pos, origin);
         this.isWildcard = isIgnorable;
     }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolAtCursorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolAtCursorTest.java
@@ -279,12 +279,12 @@ public class SymbolAtCursorTest {
         return new Object[][]{
                 {17, 8, INT, DiagnosticState.VALID},
                 {20, 10, COMPILATION_ERROR, DiagnosticState.REDECLARED},
-                {23, 8, COMPILATION_ERROR, DiagnosticState.FAILED_TO_DETERMINE_TYPE},
-                {24, 8, COMPILATION_ERROR, DiagnosticState.FAILED_TO_DETERMINE_TYPE},
-                {25, 8, COMPILATION_ERROR, DiagnosticState.FAILED_TO_DETERMINE_TYPE},
+                {23, 8, COMPILATION_ERROR, DiagnosticState.UNKNOWN_TYPE},
+                {24, 8, COMPILATION_ERROR, DiagnosticState.UNKNOWN_TYPE},
+                {25, 8, COMPILATION_ERROR, DiagnosticState.UNKNOWN_TYPE},
                 {26, 11, TYPE_REFERENCE, DiagnosticState.VALID},
-                {27, 8, COMPILATION_ERROR, DiagnosticState.FAILED_TO_DETERMINE_TYPE},
-                {30, 8, COMPILATION_ERROR, DiagnosticState.FAILED_TO_DETERMINE_TYPE},
+                {27, 8, COMPILATION_ERROR, DiagnosticState.UNKNOWN_TYPE},
+                {30, 8, COMPILATION_ERROR, DiagnosticState.UNKNOWN_TYPE},
                 {33, 8, COMPILATION_ERROR, DiagnosticState.UNKNOWN_TYPE},
                 {35, 8, INT, DiagnosticState.VALID},
         };

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolAtCursorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolAtCursorTest.java
@@ -36,6 +36,7 @@ import java.util.Optional;
 import static io.ballerina.compiler.api.symbols.SymbolKind.VARIABLE;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.COMPILATION_ERROR;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.INT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.TYPE_REFERENCE;
 import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDefaultModulesSemanticModel;
 import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDocumentForSingleSource;
 import static org.testng.Assert.assertEquals;
@@ -259,30 +260,33 @@ public class SymbolAtCursorTest {
         };
     }
 
-    @Test(dataProvider = "SymWithErrorPosProvider")
-    public void testVarSymbolsWithCompileErrorType(int line, int col, TypeDescKind typeKind, DiagnosticState state) {
+    @Test(dataProvider = "SymWithDiagnosticStatePosProvider")
+    public void testVarSymbolsWithDiagnosticState(int line, int col, TypeDescKind typeKind, DiagnosticState state) {
         Project project = BCompileUtil.loadProject("test-src/var_symbols_with_error_type_test.bal");
         SemanticModel model = getDefaultModulesSemanticModel(project);
         Document srcFile = getDocumentForSingleSource(project);
 
         Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, col));
 
+        assertTrue(symbol.isPresent());
         assertEquals(symbol.get().kind(), VARIABLE);
         assertEquals(((VariableSymbol) symbol.get()).typeDescriptor().typeKind(), typeKind);
         assertEquals(((VariableSymbol) symbol.get()).diagnosticState(), state);
     }
 
-    @DataProvider(name = "SymWithErrorPosProvider")
-    public Object[][] getSymWithErrPos() {
+    @DataProvider(name = "SymWithDiagnosticStatePosProvider")
+    public Object[][] getSymWithDiagnosticStatePos() {
         return new Object[][]{
                 {17, 8, INT, DiagnosticState.VALID},
                 {20, 10, COMPILATION_ERROR, DiagnosticState.REDECLARED},
                 {23, 8, COMPILATION_ERROR, DiagnosticState.FAILED_TO_DETERMINE_TYPE},
                 {24, 8, COMPILATION_ERROR, DiagnosticState.FAILED_TO_DETERMINE_TYPE},
                 {25, 8, COMPILATION_ERROR, DiagnosticState.FAILED_TO_DETERMINE_TYPE},
+                {26, 11, TYPE_REFERENCE, DiagnosticState.VALID},
                 {27, 8, COMPILATION_ERROR, DiagnosticState.FAILED_TO_DETERMINE_TYPE},
                 {30, 8, COMPILATION_ERROR, DiagnosticState.FAILED_TO_DETERMINE_TYPE},
                 {33, 8, COMPILATION_ERROR, DiagnosticState.UNKNOWN_TYPE},
+                {35, 8, INT, DiagnosticState.VALID},
         };
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/errored_symbol_lookup_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/errored_symbol_lookup_test.bal
@@ -1,0 +1,26 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+boolean b = true;
+
+function test(int b) {
+    float b = 1.23;
+
+    if (true) {
+        decimal b = 3.4;
+
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/var_symbols_with_error_type_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/var_symbols_with_error_type_test.bal
@@ -1,0 +1,38 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+public function test() {
+    int a = 10;
+
+    // redeclared symbol
+    float a = 1.23;
+
+    // invalid RHS expr
+    var x = a + 3.14;
+    var p = foo();
+    var q = new;
+    Person person = new;
+    var r = person.foo();
+
+    // undefined symbol reference
+    var y = z;
+
+    // undefined type reference
+    Foo b;
+}
+
+class Person {
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/var_symbols_with_error_type_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/var_symbols_with_error_type_test.bal
@@ -32,7 +32,11 @@ public function test() {
 
     // undefined type reference
     Foo b;
+
+    abc d = 10;
 }
 
 class Person {
 }
+
+type abc int;


### PR DESCRIPTION
## Purpose
This PR adds a new method to `VariableSymbol` to retrieve a bit more fine grained info regarding a var symbol whose type is set to `$CompilationError$`. This allows for the user to distinguish between errored variables to some extent. e.g., filter out all the redeclared var symbols.

## Approach
- Introduce a new enum, `DiagnosticState`, to categorize the instances where `$CompilationError$` can be set to var symbols.
- The state is set to `VALID` by default, but then changed to the relevant code, at specific errors such as redeclared symbol.

## Remarks
This is a precursor to fixing #30081 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
