### PR TITLE
[LS] Add record construtor completion item to annotation definition context

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/AnnotationDeclarationNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/AnnotationDeclarationNodeContext.java
@@ -71,6 +71,8 @@ public class AnnotationDeclarationNodeContext extends AbstractCompletionProvider
                         .collect(Collectors.toList());
                 completionItemList.addAll(this.getCompletionItemList(filteredSymbols, context));
                 completionItemList.addAll(this.getModuleCompletionItems(context));
+                completionItemList.add(new SnippetCompletionItem(context, Snippet.DEF_RECORD_TYPE_DESC.get()));
+                completionItemList.add(new SnippetCompletionItem(context, Snippet.DEF_CLOSED_RECORD_TYPE_DESC.get()));
             }
         } else if (this.onSuggestOnKeyword(context, node)) {
             completionItemList.add(new SnippetCompletionItem(context, Snippet.KW_ON.get()));

--- a/language-server/modules/langserver-core/src/test/resources/completion/annotation_decl/config/config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/annotation_decl/config/config1.json
@@ -274,6 +274,22 @@
       "sortText": "Q",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "record {}",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "O",
+      "insertText": "record {${1}}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "record {||}",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "O",
+      "insertText": "record {|${1}|}",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/annotation_decl/config/config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/annotation_decl/config/config2.json
@@ -274,6 +274,22 @@
       "sortText": "Q",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "record {}",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "O",
+      "insertText": "record {${1}}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "record {||}",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "O",
+      "insertText": "record {|${1}|}",
+      "insertTextFormat": "Snippet"
     }
   ]
 }


### PR DESCRIPTION
## Purpose
$subject

Fixes #30528 

## Samples

<img src="https://user-images.githubusercontent.com/35211477/118401822-cc08d000-b684-11eb-83b8-0ae3220e0f44.png" width=600/>


## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
