### PR TITLE
Add actionkw completions to return context of expr-bodied function

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ExpressionFunctionBodyNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ExpressionFunctionBodyNodeContext.java
@@ -50,10 +50,11 @@ public class ExpressionFunctionBodyNodeContext extends AbstractCompletionProvide
             List<Symbol> expressionContextEntries = QNameReferenceUtil.getExpressionContextEntries(ctx, qNameRef);
             completionItems.addAll(this.getCompletionItemList(expressionContextEntries, ctx));
         } else {
+            completionItems.addAll(this.actionKWCompletions(ctx));
             completionItems.addAll(this.expressionCompletions(ctx));
         }
         this.sort(ctx, node, completionItems);
-        
+
         return completionItems;
     }
 

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/anon_func_expr_ctx_config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/anon_func_expr_ctx_config7.json
@@ -6,6 +6,38 @@
   "source": "expression_context/source/anon_func_expr_ctx_source7.bal",
   "items": [
     {
+      "label": "start",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "P",
+      "insertText": "start ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "wait",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "P",
+      "insertText": "wait ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "flush",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "P",
+      "insertText": "flush ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "from clause",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "O",
+      "insertText": "from ${1:var} ${2:item} in ${3}",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "module1",
       "kind": "Module",
       "detail": "Module",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/anon_func_expr_ctx_config8.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/anon_func_expr_ctx_config8.json
@@ -6,6 +6,38 @@
   "source": "expression_context/source/anon_func_expr_ctx_source8.bal",
   "items": [
     {
+      "label": "start",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "P",
+      "insertText": "start ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "wait",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "P",
+      "insertText": "wait ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "flush",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "P",
+      "insertText": "flush ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "from clause",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "O",
+      "insertText": "from ${1:var} ${2:item} in ${3}",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "module1",
       "kind": "Module",
       "detail": "Module",


### PR DESCRIPTION
## Purpose
$subject
In order to provide the same completion items as the return context in a normal block bodied function.

Fixes #30393 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
