### PR TITLE
Enable `testBallerinaTomlWithInvalidOrgNameVersion` on windows

### DIFF
--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/BallerinaTomlTests.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/BallerinaTomlTests.java
@@ -189,12 +189,6 @@ public class BallerinaTomlTests {
 
     @Test
     public void testBallerinaTomlWithInvalidOrgNameVersion() throws IOException {
-        // TODO: enable this after the alpha2-release
-        String os = System.getProperty("os.name").toLowerCase(Locale.getDefault());
-        if (os.contains("win")) {
-            throw new SkipException("Skipping tests on Windows");
-        }
-
         PackageManifest packageManifest = getPackageManifest(BAL_TOML_REPO.resolve("invalid-org-name-version.toml"));
         Assert.assertTrue(packageManifest.diagnostics().hasErrors());
         Assert.assertEquals(packageManifest.diagnostics().errors().size(), 3);
@@ -205,7 +199,15 @@ public class BallerinaTomlTests {
         Assert.assertEquals(firstDiagnostic.message(), "invalid 'name' under [package]: 'name' can only contain "
                 + "alphanumerics, underscores and periods and the maximum length is 256 characters");
         Assert.assertEquals(firstDiagnostic.location().lineRange().toString(), "(1:7,1:23)");
-        Assert.assertEquals(firstDiagnostic.location().textRange().toString(), "(17,33)");
+
+        String os = System.getProperty("os.name").toLowerCase(Locale.getDefault());
+        if (os.contains("win")) {
+            // text range including minutiae, if we get a node that includes newline minutiae,
+            // its text range will be different. i.e windows will have an extra 1 length due to \r\n.
+            Assert.assertEquals(firstDiagnostic.location().textRange().toString(), "(17,34)");
+        } else {
+            Assert.assertEquals(firstDiagnostic.location().textRange().toString(), "(17,33)");
+        }
 
         Assert.assertEquals(iterator.next().message(), "invalid 'org' under [package]: 'org' can only contain "
                 + "alphanumerics, underscores and the maximum length is 256 characters");

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/BallerinaTomlTests.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/BallerinaTomlTests.java
@@ -23,7 +23,6 @@ import io.ballerina.projects.providers.SemverDataProvider;
 import io.ballerina.projects.util.ProjectConstants;
 import io.ballerina.tools.diagnostics.Diagnostic;
 import org.testng.Assert;
-import org.testng.SkipException;
 import org.testng.annotations.Test;
 
 import java.io.IOException;


### PR DESCRIPTION

## Purpose
> Enable `testBallerinaTomlWithInvalidOrgNameVersion` on windows, by changing textRange value for windows platform.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/28753

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
