### PR TITLE
Introduce flag to pass supported coverage report formats

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/TestCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/TestCommand.java
@@ -41,6 +41,7 @@ import java.util.List;
 
 import static io.ballerina.cli.cmd.Constants.TEST_COMMAND;
 import static io.ballerina.runtime.api.constants.RuntimeConstants.SYSTEM_PROP_BAL_DEBUG;
+import static org.ballerinalang.test.runtime.util.TesterinaConstants.JACOCO_XML_FORMAT;
 
 /**
  * This class represents the "bal test" command.
@@ -109,6 +110,9 @@ public class TestCommand implements BLauncherCmd {
     @CommandLine.Option(names = "--jacoco-xml", description = "enable Jacoco XML generation")
     private boolean enableJacocoXML;
 
+    @CommandLine.Option(names = "--coverage-format", description = "list of supported coverage report formats")
+    private String coverageFormat;
+
     @CommandLine.Option(names = "--observability-included", description = "package observability in the executable.")
     private Boolean observabilityIncluded;
 
@@ -174,14 +178,30 @@ public class TestCommand implements BLauncherCmd {
             displayWarning = true;
         }
 
-        // Skip --includes flag if it is set without code coverage
-        if (!project.buildOptions().codeCoverage() && includes != null) {
-            this.outStream.println("warning: ignoring --includes flag since code coverage is not enabled");
-        }
-
-        // Skip --jacoco-xml flag if it is set without code coverage
-        if (!project.buildOptions().codeCoverage() && enableJacocoXML) {
-            this.outStream.println("warning: ignoring --jacoco-xml flag since code coverage is not enabled");
+        if (project.buildOptions().codeCoverage()) {
+            if (coverageFormat != null) {
+                if (!coverageFormat.equals(JACOCO_XML_FORMAT)) {
+                    String errMsg = "unsupported coverage report format '" + coverageFormat + "' found. Only '" +
+                            JACOCO_XML_FORMAT + "' format is supported.";
+                    CommandUtil.printError(this.errStream, errMsg, null, false);
+                    CommandUtil.exitError(this.exitWhenFinish);
+                    return;
+                }
+            }
+        } else {
+            // Skip --includes flag if it is set without code coverage
+            if (includes != null) {
+                this.outStream.println("warning: ignoring --includes flag since code coverage is not enabled");
+            }
+            // Skip --coverage-format flag if it is set without code coverage
+            if (coverageFormat != null) {
+                this.outStream.println("warning: ignoring --coverage-format flag since code coverage is not " +
+                        "enabled");
+            }
+            // Skip --jacoco-xml flag if it is set without code coverage
+            if (enableJacocoXML) {
+                this.outStream.println("warning: ignoring --jacoco-xml flag since code coverage is not enabled");
+            }
         }
 
         TaskExecutor taskExecutor = new TaskExecutor.TaskBuilder()
@@ -191,7 +211,7 @@ public class TestCommand implements BLauncherCmd {
 //                .addTask(new CopyResourcesTask(), listGroups) // merged with CreateJarTask
                 .addTask(new ListTestGroupsTask(outStream, displayWarning), !listGroups) // list available test groups
                 .addTask(new RunTestsTask(outStream, errStream, rerunTests, groupList, disableGroupList,
-                        testList, includes, enableJacocoXML), listGroups)
+                        testList, includes, enableJacocoXML, coverageFormat), listGroups)
                 .build();
 
         taskExecutor.executeTasks(project);

--- a/cli/ballerina-cli/src/main/resources/cli-help/ballerina-test.help
+++ b/cli/ballerina-cli/src/main/resources/cli-help/ballerina-test.help
@@ -70,8 +70,10 @@ OPTIONS
            This feature is not supported with single file executions.
 
        --test-report
-           Generates an HTML report containing test results. Defaults to 'true'
-           if code coverage is enabled.
+           Generates an HTML report containing test results.
+
+       --coverage-format
+            Generates a coverage report in specified format. Only the value 'xml' is allowed.
 
        --experimental
            Enable experimental language features.
@@ -111,6 +113,12 @@ EXAMPLES
         Run tests and generate a test report.
            $ bal test --test-report
 
-        Run tests with code coverage. This will generate a test report
-        with test statuses and code coverage information.
+        Run tests with code coverage.
            $ bal test --code-coverage
+
+        Run tests with code coverage and generate a test report
+        with test statuses and code coverage information.
+           $ bal test --test-report --code-coverage
+
+        Run tests with code coverage and generate a coverage report in the xml format.
+           $ bal test --test-report --code-coverage --coverage-format=xml

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/BuildCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/BuildCommandTest.java
@@ -637,4 +637,16 @@ public class BuildCommandTest extends BaseCommandTest {
             return FileVisitResult.CONTINUE;
         }
     }
+
+    @Test
+    public void testUnsupportedCoverageFormat() throws IOException {
+        Path projectPath = this.testResources.resolve("validProjectWithBuildOptions");
+        // Build project
+        BuildCommand buildCommand = new BuildCommand(
+                projectPath, printStream, printStream, false, true, null, null, true, false, "html");
+        new CommandLine(buildCommand).parse();
+        buildCommand.execute();
+        String buildLog = readOutput(true);
+        Assert.assertTrue(buildLog.contains("unsupported coverage report format 'html' found. Only 'xml' format is supported."));
+    }
 }

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/BuildCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/BuildCommandTest.java
@@ -365,7 +365,7 @@ public class BuildCommandTest extends BaseCommandTest {
         Path projectPath = this.testResources.resolve("validProjectWithBuildOptions");
         System.setProperty("user.dir", projectPath.toString());
         BuildCommand buildCommand = new BuildCommand(
-                projectPath, printStream, printStream, false, true, null, null, null, false);
+                projectPath, printStream, printStream, false, true, null, null, null, false, null);
         // non existing bal file
         new CommandLine(buildCommand).parse();
         buildCommand.execute();
@@ -389,7 +389,7 @@ public class BuildCommandTest extends BaseCommandTest {
         Path projectPath = this.testResources.resolve("validProjectWithBuildOptions");
         System.setProperty("user.dir", projectPath.toString());
         BuildCommand buildCommand = new BuildCommand(
-                projectPath, printStream, printStream, false, true, false, true, false, false);
+                projectPath, printStream, printStream, false, true, false, true, false, false, null);
         // non existing bal file
         new CommandLine(buildCommand).parse();
         try {
@@ -423,7 +423,7 @@ public class BuildCommandTest extends BaseCommandTest {
         Path projectPath = this.testResources.resolve("valid-bal-file").resolve("hello_world.bal");
         System.setProperty("user.dir", this.testResources.resolve("valid-bal-file").toString());
         BuildCommand buildCommand = new BuildCommand(
-                projectPath, printStream, printStream, false, true, null, null, null, false);
+                projectPath, printStream, printStream, false, true, null, null, null, false, null);
         // non existing bal file
         new CommandLine(buildCommand).parse();
         try {
@@ -448,7 +448,7 @@ public class BuildCommandTest extends BaseCommandTest {
         Path projectPath = this.testResources.resolve("valid-bal-file").resolve("hello_world.bal");
         System.setProperty("user.dir", this.testResources.resolve("valid-bal-file").toString());
         BuildCommand buildCommand = new BuildCommand(
-                projectPath, printStream, printStream, false, true, false, true, true, false);
+                projectPath, printStream, printStream, false, true, false, true, true, false, null);
         // non existing bal file
         new CommandLine(buildCommand).parse();
         try {

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/BuildCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/BuildCommandTest.java
@@ -647,6 +647,7 @@ public class BuildCommandTest extends BaseCommandTest {
         new CommandLine(buildCommand).parse();
         buildCommand.execute();
         String buildLog = readOutput(true);
-        Assert.assertTrue(buildLog.contains("unsupported coverage report format 'html' found. Only 'xml' format is supported."));
+        Assert.assertTrue(buildLog.contains("unsupported coverage report format 'html' found. Only 'xml' format is " +
+                "supported."));
     }
 }

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/TestCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/TestCommandTest.java
@@ -180,4 +180,16 @@ public class TestCommandTest extends BaseCommandTest {
             return FileVisitResult.CONTINUE;
         }
     }
+
+    @Test
+    public void testUnsupportedCoverageFormat() throws IOException {
+        Path projectPath = this.testResources.resolve("validProjectWithTests");
+        // Build project
+        BuildCommand buildCommand = new BuildCommand(
+                projectPath, printStream, printStream, false, true, null, null, true, false, "html");
+        new CommandLine(buildCommand).parse();
+        buildCommand.execute();
+        String buildLog = readOutput(true);
+        Assert.assertTrue(buildLog.contains("unsupported coverage report format 'html' found. Only 'xml' format is supported."));
+    }
 }

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/TestCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/TestCommandTest.java
@@ -190,6 +190,7 @@ public class TestCommandTest extends BaseCommandTest {
         new CommandLine(buildCommand).parse();
         buildCommand.execute();
         String buildLog = readOutput(true);
-        Assert.assertTrue(buildLog.contains("unsupported coverage report format 'html' found. Only 'xml' format is supported."));
+        Assert.assertTrue(buildLog.contains("unsupported coverage report format 'html' found. Only 'xml' format is " +
+                "supported."));
     }
 }

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/CoverageReport.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/CoverageReport.java
@@ -108,7 +108,8 @@ public class CoverageReport {
      * @param includesInCoverage boolean
      * @throws IOException
      */
-    public void generateReport(JBallerinaBackend jBallerinaBackend, String includesInCoverage, boolean enableJacocoXML)
+    public void generateReport(JBallerinaBackend jBallerinaBackend, String includesInCoverage, boolean enableJacocoXML,
+                               String reportFormat)
             throws IOException {
         String orgName = this.module.packageInstance().packageOrg().toString();
         String packageName = this.module.packageInstance().packageName().toString();
@@ -125,7 +126,8 @@ public class CoverageReport {
         }
         if (!filteredPathList.isEmpty()) {
             CoverageBuilder coverageBuilder = generateTesterinaCoverageReport(orgName, packageName, filteredPathList);
-            if (enableJacocoXML) {
+            if (CodeCoverageUtils.isRequestedReportFormat(reportFormat, TesterinaConstants.JACOCO_XML_FORMAT) ||
+                    enableJacocoXML) {
                 // Add additional dependency jars for Jacoco Coverage XML if included
                 if (includesInCoverage != null) {
                     List<Path> dependencyPathList = getDependenciesForJacocoXML(jBallerinaBackend);

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/util/CodeCoverageUtils.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/util/CodeCoverageUtils.java
@@ -72,6 +72,21 @@ public class CodeCoverageUtils {
     private static final PrintStream errStream = System.err;
 
     /**
+     * Checks if a given code coverage report format was requested by user.
+     *
+     * @param coverageReportFormat
+     * @param format
+     * @return
+     */
+    public static boolean isRequestedReportFormat(String coverageReportFormat, String format) {
+        boolean isRequested = false;
+        if (coverageReportFormat != null) {
+            isRequested = coverageReportFormat.equals(format);
+        }
+        return isRequested;
+    }
+
+    /**
      * Util method to extract required class files for code coverage analysis.
      *
      * @param source      path of testable jar

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/util/TesterinaConstants.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/util/TesterinaConstants.java
@@ -67,4 +67,5 @@ public class TesterinaConstants {
     public static final String BLANG_SRC_FILE_EXT = "bal";
     public static final String BLANG_SRC_FILE_SUFFIX = "." + BLANG_SRC_FILE_EXT;
 
+    public static final String JACOCO_XML_FORMAT = "xml";
 }

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/CodeCoverageReportTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/CodeCoverageReportTest.java
@@ -67,7 +67,7 @@ public class CodeCoverageReportTest extends BaseTestCase {
         projectPath = projectBasedTestsPath.resolve(singleModuleTestRoot).toString();
         coverageXMLPath = projectBasedTestsPath.resolve(singleModuleTestRoot).resolve("target").resolve("report")
                 .resolve("codecov").resolve("coverage-report.xml");
-        balClient.runMain("test", new String[]{"--code-coverage", "--jacoco-xml"}, null,
+        balClient.runMain("test", new String[]{"--code-coverage", "--coverage-format=xml"}, null,
                 new String[]{}, new LogLeecher[]{}, projectPath);
         Path reportRoot = projectBasedTestsPath.resolve(singleModuleTestRoot).resolve("target").
                 resolve("report").resolve("codecov");
@@ -90,7 +90,7 @@ public class CodeCoverageReportTest extends BaseTestCase {
         projectPath = projectBasedTestsPath.resolve(multiModuleTestRoot).toString();
         coverageXMLPath = projectBasedTestsPath.resolve(multiModuleTestRoot).resolve("target").resolve("report")
                 .resolve("foo").resolve("coverage-report.xml");
-        balClient.runMain("test", new String[]{"--code-coverage", "--jacoco-xml"}, null,
+        balClient.runMain("test", new String[]{"--code-coverage", "--coverage-format=xml"}, null,
                 new String[]{}, new LogLeecher[]{}, projectPath);
         Path reportRoot = projectBasedTestsPath.resolve(multiModuleTestRoot).resolve("target").
                 resolve("report").resolve("foo");
@@ -114,7 +114,7 @@ public class CodeCoverageReportTest extends BaseTestCase {
     @Test
     public void normalizedCoverageClassTest() throws BallerinaTestException {
         projectPath = projectBasedTestsPath.resolve(multiModuleTestRoot).toString();
-        balClient.runMain("test", new String[]{"--code-coverage", "--jacoco-xml"}, null,
+        balClient.runMain("test", new String[]{"--code-coverage", "--coverage-format=xml"}, null,
                 new String[]{}, new LogLeecher[]{}, projectPath);
         Path reportRoot = projectBasedTestsPath.resolve(multiModuleTestRoot).resolve("target").
                 resolve("report").resolve("foo");

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/TestReportTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/TestReportTest.java
@@ -62,7 +62,7 @@ public class TestReportTest extends BaseTestCase {
     @Test()
     public void testWarningForReportTools() throws BallerinaTestException, IOException {
         String msg = "warning: Could not find the required HTML report tools for code coverage";
-        String[] args = mergeCoverageArgs(new String[]{});
+        String[] args = mergeCoverageArgs(new String[]{"--test-report"});
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
         if (!output.contains(msg)) {

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/TestReportTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/TestReportTest.java
@@ -71,13 +71,13 @@ public class TestReportTest extends BaseTestCase {
     }
 
     @Test ()
-    public void testWarningForJacocoXMLFlag() throws BallerinaTestException {
-        String msg = "warning: ignoring --jacoco-xml flag since code coverage is not enabled";
-        String[] args = new String[]{"--jacoco-xml"};
+    public void testWarningForCoverageFormatFlag() throws BallerinaTestException {
+        String msg = "warning: ignoring --coverage-format flag since code coverage is not enabled";
+        String[] args = new String[]{"--coverage-format=xml"};
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
         if (!output.contains(msg)) {
-            Assert.fail("Test failed due to jacoco-xml flag validation failure.");
+            Assert.fail("Test failed due to coverage-format flag validation failure.");
         }
     }
 


### PR DESCRIPTION
## Purpose
Introduce flag to pass supported coverage report formats
Fixes #30381

## Approach

Following is the expected behaviour when the test-report, code-coverage, coverage-format flags are being used.

```bal test --test-report``` : Generates testerina html report without code coverage and also dumps test_results.json

```bal test --code-coverage``` : Only dumps test_results.json

```bal test --test-report --code-coverage``` : Generates the testerina html report with code coverage and dumps test_results.json

```bal test --code-coverage --coverage-format=xml```: Generates the jacoco xml report and dumps test_results.json

```bal test --test-report --code-coverage --coverage-format=xml```: Generates the jacoco xml report, testerina html report and dumps test_results.json

The coverage-format flag only supports 'xml' at the moment.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
