### PR TITLE
[Debugger] Fix showing internal information of optional record fields

### DIFF
--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/variable/types/BRecord.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/variable/types/BRecord.java
@@ -35,6 +35,7 @@ import static org.ballerinalang.debugadapter.variable.VariableUtils.UNKNOWN_VALU
 public class BRecord extends NamedCompoundVariable {
 
     private static final String RECORD_FIELD_PATTERN_IDENTIFIER = "$value$";
+    private static final String GENERATED_RECORD_FIELD_IDENTIFIER = "$";
 
     public BRecord(SuspendedContext context, String name, Value value) {
         super(context, name, BVariableType.RECORD, value);
@@ -59,7 +60,8 @@ public class BRecord extends NamedCompoundVariable {
             Map<Field, Value> fieldValueMap = jvmValueRef.getValues(jvmValueRef.referenceType().allFields());
             Map<String, Value> recordFields = new LinkedHashMap<>();
             fieldValueMap.forEach((field, value) -> {
-                if (field.toString().contains(RECORD_FIELD_PATTERN_IDENTIFIER)) {
+                if (field.toString().contains(RECORD_FIELD_PATTERN_IDENTIFIER)
+                        && !field.name().contains(GENERATED_RECORD_FIELD_IDENTIFIER)) {
                     recordFields.put(field.name(), value);
                 }
             });

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/variables/VariableVisibilityTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/variables/VariableVisibilityTest.java
@@ -337,7 +337,8 @@ public class VariableVisibilityTest extends BaseTestCase {
 
         // record child variable visibility test (Student record)
         Map<String, Variable> studentRecordChildVariables =
-            debugTestRunner.fetchChildVariables(localVariables.get("recordVar"));
+                debugTestRunner.fetchChildVariables(localVariables.get("recordVar"));
+        Assert.assertEquals(studentRecordChildVariables.size(), 3);
         debugTestRunner.assertVariable(studentRecordChildVariables, "1st_name", "John Doe", "string");
         debugTestRunner.assertVariable(studentRecordChildVariables, "grades", "Grades", "record");
         debugTestRunner.assertVariable(studentRecordChildVariables, "Ȧɢέ_ /:@[`{~π", "20", "int");

--- a/tests/jballerina-debugger-integration-test/src/test/resources/project-based-tests/variable-tests/main.bal
+++ b/tests/jballerina-debugger-integration-test/src/test/resources/project-based-tests/variable-tests/main.bal
@@ -19,7 +19,7 @@ import ballerina/lang.'int;
 type '\ \/\:\@\[\`\{\~\u{03C0}_123_ƮέŞŢ_Student record {
     string '1st_name;
     int 'Ȧɢέ_\ \/\:\@\[\`\{\~\u{03C0};
-    Grades grades;
+    Grades grades?;
 };
 
 type Address record {|


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/ballerina-lang/issues/30593 - Debugger variables show $isPresent with defaultable fields of records.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
