### PR TITLE
Fix potential concurrency issue

### DIFF
--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/future/FutureNegativeTests.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/future/FutureNegativeTests.java
@@ -17,6 +17,8 @@
 
 package org.ballerinalang.test.types.future;
 
+import org.ballerinalang.core.model.values.BMap;
+import org.ballerinalang.core.model.values.BValue;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
@@ -25,6 +27,9 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+
+import java.util.HashSet;
+import java.util.Set;
 
 import static org.ballerinalang.test.BAssertUtil.validateError;
 
@@ -67,6 +72,21 @@ public class FutureNegativeTests {
     @Test(dataProvider = "multipleWait")
     public void testFutureNegatives(String functionName) {
         BRunUtil.invoke(result, functionName);
+    }
+
+    @Test
+    public void testStrand() {
+        CompileResult compileResult = BCompileUtil.compile("test-src/types/future/strand_error.bal");
+        BValue[] result = BRunUtil.invoke(compileResult, "testStrand");
+        var mapResult = (BMap<String, BMap<String, BValue>>) result[0];
+        Set<String> set = new HashSet<>();
+        set.add(mapResult.get("f1").get("f0").stringValue());
+        set.add(mapResult.get("f1").get("f00").stringValue());
+        set.add(mapResult.get("f2").get("f0").stringValue());
+        set.add(mapResult.get("f2").get("f00").stringValue());
+        Assert.assertEquals(set.size(), 2);
+        Assert.assertTrue(set.contains("3"));
+        Assert.assertTrue(set.contains("multiple waits on the same future is not allowed {}"));
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/future/strand_error.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/future/strand_error.bal
@@ -1,0 +1,50 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+type first record {
+    int|error f0 = 1;
+    int|error f00 = 2;
+};
+
+public type secondRec record {
+    first|error f1;
+    first|error f2;
+};
+
+public function testStrand() returns secondRec {
+    future<int|error> f0 = start add(1, 2);
+    future<int|error> f00 = start add(1, 2);
+    future<first> f1 = @strand{thread:"any"} start concat(f0, f00);
+    future<first> f2 = @strand{thread:"any"} start concat(f0, f00);
+    secondRec result = wait {f1, f2};
+    return result;
+}
+
+function add(int i, int j) returns int {
+    int k = i + j;
+    int l = 0;
+    while (l < 9999999) {
+        l = l + 1;
+    }
+    return k;
+}
+
+function concat(future<int|error> f0, future<int|error> f00) returns first {
+    first result = wait {f0, f00};
+    return result;
+}
+
+


### PR DESCRIPTION
## Purpose
A potential concurrency issue in returning an error for multiple waits on a future has been fixed. This can occur because the doneCount in the previous implementation of the handleWaitMultiple doesn't reflect the the waiting of the future in multiple different strands/threads.

Resolve https://github.com/ballerina-platform/ballerina-lang/issues/30621

## Approach
> Use the `nativeData` in the map to fix this

## Samples
> N/A

## Remarks
> N/A

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
