### PR TITLE
Fix dependently-typed functions with casts

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -589,6 +589,7 @@ public class Desugar extends BLangNodeVisitor {
         }
         // Since the expression of the requiredParam of both init functions refer to same object,
         // expression should be cloned.
+        expr.cloneAttempt++;
         BLangExpression expression = this.nodeCloner.clone(expr);
         if (expression.getKind() == NodeKind.ARROW_EXPR) {
             BLangIdentifier func = (BLangIdentifier) ((BLangArrowFunction) expression).functionName;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/NodeCloner.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/NodeCloner.java
@@ -1289,6 +1289,11 @@ public class NodeCloner extends BLangNodeVisitor {
 
         BLangTypeConversionExpr clone = new BLangTypeConversionExpr();
         source.cloneRef = clone;
+
+        // Forcefully clone the expression since it may clash with the clone of type cast expression type
+        // checking.
+        source.expr.cloneAttempt++;
+
         clone.expr = clone(source.expr);
         clone.typeNode = clone(source.typeNode);
         clone.targetType = source.targetType;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -4092,7 +4092,7 @@ public class TypeChecker extends BLangNodeVisitor {
         if (types.isTypeCastable(expr, exprType, targetType, this.env)) {
             // We reach this block only if the cast is valid, so we set the target type as the actual type.
             actualType = targetType;
-        } else if (exprType != symTable.semanticError) {
+        } else if (exprType != symTable.semanticError && exprType != symTable.noType) {
             dlog.error(conversionExpr.pos, DiagnosticErrorCode.INCOMPATIBLE_TYPES_CAST, exprType, targetType);
         }
         resultType = types.checkType(conversionExpr, actualType, this.expType);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -4048,37 +4048,66 @@ public class TypeChecker extends BLangNodeVisitor {
         // Annotation such as <@untainted [T]>, where T is not provided,
         // it's merely a annotation on contextually expected type.
         BLangExpression expr = conversionExpr.expr;
-        if (conversionExpr.typeNode == null && !conversionExpr.annAttachments.isEmpty()) {
-            resultType = checkExpr(expr, env, this.expType);
+        if (conversionExpr.typeNode == null) {
+            if (!conversionExpr.annAttachments.isEmpty()) {
+                resultType = checkExpr(expr, env, this.expType);
+            }
             return;
         }
 
-        BType targetType = symResolver.resolveTypeNode(conversionExpr.typeNode, env);
-
-        boolean requiresTypeInference = requireTypeInference(expr, false);
-        if (requiresTypeInference) {
-            targetType = getEffectiveReadOnlyType(conversionExpr.typeNode.pos, targetType);
-        }
+        BType targetType = getEffectiveReadOnlyType(conversionExpr.typeNode.pos,
+                                                    symResolver.resolveTypeNode(conversionExpr.typeNode, env));
 
         conversionExpr.targetType = targetType;
-        BType expType = requiresTypeInference ? targetType : symTable.noType;
-        BType sourceType = checkExpr(expr, env, expType);
 
-        if (types.isTypeCastable(expr, sourceType, targetType, this.env)) {
+        boolean prevNonErrorLoggingCheck = this.nonErrorLoggingCheck;
+        this.nonErrorLoggingCheck = true;
+        int prevErrorCount = this.dlog.errorCount();
+        this.dlog.resetErrorCount();
+        this.dlog.mute();
+
+        BLangExpression exprToCheck = expr;
+
+        if (!prevNonErrorLoggingCheck) {
+            expr.cloneAttempt++;
+            exprToCheck = nodeCloner.clone(expr);
+        }
+
+        BType exprCompatibleType = checkExpr(exprToCheck, env, targetType);
+
+        this.nonErrorLoggingCheck = prevNonErrorLoggingCheck;
+        int errorCount = this.dlog.errorCount();
+        this.dlog.setErrorCount(prevErrorCount);
+        if (!prevNonErrorLoggingCheck) {
+            this.dlog.unmute();
+        }
+
+        if ((errorCount == 0 && exprCompatibleType != symTable.semanticError) || requireTypeInference(expr, false)) {
+            checkExpr(expr, env, targetType);
+        } else {
+            checkExpr(expr, env, symTable.noType);
+        }
+
+        BType exprType = expr.type;
+        if (types.isTypeCastable(expr, exprType, targetType, this.env)) {
             // We reach this block only if the cast is valid, so we set the target type as the actual type.
             actualType = targetType;
-        } else {
-            dlog.error(conversionExpr.pos, DiagnosticErrorCode.INCOMPATIBLE_TYPES_CAST, sourceType, targetType);
+        } else if (exprType != symTable.semanticError) {
+            dlog.error(conversionExpr.pos, DiagnosticErrorCode.INCOMPATIBLE_TYPES_CAST, exprType, targetType);
         }
         resultType = types.checkType(conversionExpr, actualType, this.expType);
     }
 
     @Override
     public void visit(BLangLambdaFunction bLangLambdaFunction) {
-        bLangLambdaFunction.type = bLangLambdaFunction.function.symbol.type;
+        bLangLambdaFunction.type = bLangLambdaFunction.function.type;
         // creating a copy of the env to visit the lambda function later
         bLangLambdaFunction.capturedClosureEnv = env.createClone();
-        env.enclPkg.lambdaFunctions.add(bLangLambdaFunction);
+
+        if (!this.nonErrorLoggingCheck) {
+            env.enclPkg.lambdaFunctions.add(bLangLambdaFunction);
+        }
+
         resultType = types.checkType(bLangLambdaFunction, bLangLambdaFunction.type, expType);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/readonly/SelectivelyImmutableTypeBalaTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/readonly/SelectivelyImmutableTypeBalaTest.java
@@ -32,7 +32,6 @@ import static org.testng.Assert.assertEquals;
  *
  * @since 2.0.0
  */
-@Test(groups = { "brokenOnOldParser" })
 public class SelectivelyImmutableTypeBalaTest {
 
     private CompileResult result;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/InferredDependentlyTypeFunctionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/InferredDependentlyTypeFunctionTest.java
@@ -32,7 +32,7 @@ import static org.ballerinalang.test.BAssertUtil.validateError;
  *
  * @since 2.0.0
  */
-public class InferredDependentlyTypeFuncSignatureTest {
+public class InferredDependentlyTypeFunctionTest {
 
     private CompileResult result;
     private static final String INVALID_RETURN_TYPE_ERROR = "invalid return type: members of a dependently-typed " +
@@ -71,7 +71,8 @@ public class InferredDependentlyTypeFuncSignatureTest {
                 {"testBuiltInRefType"},
                 {"testParameterizedTypeInUnionWithNonParameterizedTypes"},
                 {"testUsageWithVarWithUserSpecifiedArg"},
-                {"testFunctionWithAnyFunctionParamType"}
+                {"testFunctionWithAnyFunctionParamType"},
+                {"testUsageWithCasts"}
         };
     }
 
@@ -184,6 +185,8 @@ public class InferredDependentlyTypeFuncSignatureTest {
                 "typedesc default", 180, 1);
         validateError(negativeResult, index++, "unknown type 't'", 180, 63);
         validateError(negativeResult, index++, "unknown type 'td'", 180, 65);
+        validateError(negativeResult, index++, "cannot infer type for parameter 'td'", 185, 44);
+        validateError(negativeResult, index++, "cannot infer type for parameter 'td'", 186, 52);
         Assert.assertEquals(index, negativeResult.getErrorCount());
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/json/BJSONValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/json/BJSONValueTest.java
@@ -524,7 +524,7 @@ public class BJSONValueTest {
     public void testDecimalArrayToJsonAssignment() {
         BValue[] returns = BRunUtil.invoke(compileResult, "testDecimalArrayToJsonAssignment");
         Assert.assertTrue(returns[0] instanceof BNewArray);
-        Assert.assertEquals(returns[0].stringValue(), "[1.3, 1.234, 4.1, 4.540000000000000035527136788005009]");
+        Assert.assertEquals(returns[0].stringValue(), "[1.3, 1.234, 4.1, 4.54]");
         Assert.assertTrue(returns[1] instanceof BDecimal);
         Assert.assertEquals(((BDecimal) returns[1]).decimalValue(), new BigDecimal("1.234", MathContext.DECIMAL128));
     }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/inferred_dependently_typed_func_signature.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/inferred_dependently_typed_func_signature.bal
@@ -365,6 +365,34 @@ function testFunctionWithAnyFunctionParamType() {
    assertSame(fn, x);
 }
 
+function testUsageWithCasts() {
+    int a = <int> getValue();
+    assert(150, a);
+
+    var b = <float> getValue();
+    assert(12.34, b);
+
+    any c = <decimal> getValue();
+    assert(23.45d, <anydata> c);
+
+    string|xml|float d = <string> getValue();
+    assert("Hello World!", d);
+
+    anydata e = <boolean> getValue();
+    assert(true, e);
+
+    anydata f = <[int, Person, boolean...]> getTupleWithRestDesc(int, Person);
+    assert(<[int, Person, boolean...]>[150, expPerson, true, true], f);
+
+    record {| stream<int> x; |} g = {x: (<int[]> [1, 2, 3]).toStream()};
+    var h = <object {}|record {| stream<int> x; |}|int> checkpanic getValueWithUnionReturnType(g);
+    assert(101, <int> h);
+
+    PersonObj i = new ("John", "Doe");
+    any|error j = <object {}|record {| stream<int> x; |}|string[]|error> getValueWithUnionReturnType(i);
+    assertSame(i, j);
+}
+
 // Interop functions
 function getValue(typedesc<int|float|decimal|string|boolean> td = <>) returns td = @java:Method {
     'class: "org.ballerinalang.nativeimpl.jvm.tests.VariableReturnType",

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/inferred_dependently_typed_func_signature_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/inferred_dependently_typed_func_signature_negative.bal
@@ -178,3 +178,10 @@ function (typedesc<boolean> td = <>) fn2 = bar;
 function (typedesc t, typedesc<boolean> td = <>) returns int|string fn3 = baz;
 
 function (typedesc t = <>, typedesc<boolean> td = <>) returns t|td fn4 = baz;
+
+type BooleanStream stream<boolean>;
+
+function testInvalidUsageWithCasts() {
+    var a = <function (function, boolean)> getFunctionWithAnyFunctionParamType(function (function x, int y) { });
+    BooleanStream|handle b = <BooleanStream> check funcReturningUnionWithBuiltInRefType(());
+}


### PR DESCRIPTION
## Purpose
$title.

Tried fixing the deviations with type cast expressions too, but ran into issues since `getTypeIntersection` doesn't cover all cases yet.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/30635

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
