### PR TITLE
Relax restriction on having to access `self` within a lock statement of isolated objects even when safe

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
@@ -712,7 +712,7 @@ public enum DiagnosticErrorCode implements DiagnosticCode {
     INVALID_MAIN_OPTION_PARAMS_TYPE("BCE4002", "invalid.main.option.params.type"),
     WORKER_INTERACTION_AFTER_WAIT_ACTION("BCE4003", "invalid.worker.message.passing.after.wait.action"),
     OPTIONAL_OPERAND_PRECEDES_OPERAND("BCE4004", "optional.operand.precedes.operand"),
-    UNIMPLEMENTED_REFERENCED_METHOD_IN_SERVICE_DECL("BCE4004",
+    UNIMPLEMENTED_REFERENCED_METHOD_IN_SERVICE_DECL("BCE4005",
             "unimplemented.referenced.method.in.service.declaration"),
     UNIMPLEMENTED_REFERENCED_METHOD_IN_OBJECT_CTOR("BCE4006", "unimplemented.referenced.method.in.object.constructor"),
     UNSUPPORTED_REMOTE_METHOD_NAME_IN_SCOPE("BCE4007", "unsupported.remote.method.name.in.scope")

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
@@ -636,88 +636,86 @@ public enum DiagnosticErrorCode implements DiagnosticCode {
             "BCE3956", "invalid.non.private.mutable.field.in.isolated.object"),
     INVALID_MUTABLE_FIELD_ACCESS_IN_ISOLATED_OBJECT_OUTSIDE_LOCK(
             "BCE3957", "invalid.mutable.field.access.in.isolated.object.outside.lock"),
-    INVALID_REFERENCE_TO_SELF_IN_ISOLATED_OBJECT_OUTSIDE_LOCK(
-            "BCE3958", "invalid.reference.to.self.in.isolated.object.outside.lock"),
-    INVALID_NON_ISOLATED_EXPRESSION_AS_INITIAL_VALUE("BCE3959", "invalid.non.isolated.expression.as.initial.value"),
+    INVALID_NON_ISOLATED_EXPRESSION_AS_INITIAL_VALUE("BCE3958", "invalid.non.isolated.expression.as.initial.value"),
     INVALID_TRANSFER_OUT_OF_LOCK_WITH_RESTRICTED_VAR_USAGE(
-            "BCE3960", "invalid.transfer.out.of.lock.with.restricted.var.usage"),
+            "BCE3959", "invalid.transfer.out.of.lock.with.restricted.var.usage"),
     INVALID_TRANSFER_INTO_LOCK_WITH_RESTRICTED_VAR_USAGE(
-            "BCE3961", "invalid.transfer.into.lock.with.restricted.var.usage"),
+            "BCE3960", "invalid.transfer.into.lock.with.restricted.var.usage"),
     INVALID_NON_ISOLATED_INVOCATION_IN_LOCK_WITH_RESTRICTED_VAR_USAGE(
-            "BCE3962", "invalid.non.isolated.invocation.in.lock.with.restricted.var.usage"),
-    INVALID_ISOLATED_VARIABLE_ACCESS_OUTSIDE_LOCK("BCE3963", "invalid.isolated.variable.access.outside.lock"),
+            "BCE3961", "invalid.non.isolated.invocation.in.lock.with.restricted.var.usage"),
+    INVALID_ISOLATED_VARIABLE_ACCESS_OUTSIDE_LOCK("BCE3962", "invalid.isolated.variable.access.outside.lock"),
     INVALID_ASSIGNMENT_IN_LOCK_WITH_RESTRICTED_VAR_USAGE(
-            "BCE3964", "invalid.assignment.in.lock.with.restricted.var.usage"),
-    INVALID_USAGE_OF_MULTIPLE_RESTRICTED_VARS_IN_LOCK("BCE3965", "invalid.usage.of.multiple.restricted.vars.in.lock"),
+            "BCE3963", "invalid.assignment.in.lock.with.restricted.var.usage"),
+    INVALID_USAGE_OF_MULTIPLE_RESTRICTED_VARS_IN_LOCK("BCE3964", "invalid.usage.of.multiple.restricted.vars.in.lock"),
 
     INVALID_ISOLATED_QUALIFIER_ON_MODULE_NO_INIT_VAR_DECL(
-            "BCE3966", "invalid.isolated.qualifier.on.module.no.init.var.decl"),
+            "BCE3965", "invalid.isolated.qualifier.on.module.no.init.var.decl"),
     ONLY_A_SIMPLE_VARIABLE_CAN_BE_MARKED_AS_ISOLATED(
-            "BCE3967", "only.a.simple.variable.can.be.marked.as.isolated"),
+            "BCE3966", "only.a.simple.variable.can.be.marked.as.isolated"),
 
     // Configurable var related error codes
 
     CONFIGURABLE_VARIABLE_CANNOT_BE_DECLARED_WITH_VAR(
-            "BCE3968", "configurable.variable.cannot.be.declared.with.var"),
+            "BCE3967", "configurable.variable.cannot.be.declared.with.var"),
     CONFIGURABLE_VARIABLE_MUST_BE_ANYDATA(
-            "BCE3969", "configurable.variable.must.be.anydata"),
+            "BCE3968", "configurable.variable.must.be.anydata"),
     ONLY_SIMPLE_VARIABLES_ARE_ALLOWED_TO_BE_CONFIGURABLE(
-            "BCE3970", "only.simple.variables.are.allowed.to.be.configurable"),
+            "BCE3969", "only.simple.variables.are.allowed.to.be.configurable"),
     CONFIGURABLE_VARIABLE_CURRENTLY_NOT_SUPPORTED(
-            "BCE3971", "configurable.variable.currently.not.supported"),
+            "BCE3970", "configurable.variable.currently.not.supported"),
 
-    REMOTE_FUNCTION_IN_NON_NETWORK_OBJECT("BCE3972", "remote.function.in.non.network.object"),
-    UNSUPPORTED_PATH_PARAM_TYPE("BCE3973", "unsupported.path.param.type"),
-    UNSUPPORTED_REST_PATH_PARAM_TYPE("BCE3974", "unsupported.rest.path.param.type"),
-    OBJECT_TYPE_DEF_DOES_NOT_ALLOW_RESOURCE_FUNC_DECL("BCE3975",
+    REMOTE_FUNCTION_IN_NON_NETWORK_OBJECT("BCE3971", "remote.function.in.non.network.object"),
+    UNSUPPORTED_PATH_PARAM_TYPE("BCE3972", "unsupported.path.param.type"),
+    UNSUPPORTED_REST_PATH_PARAM_TYPE("BCE3973", "unsupported.rest.path.param.type"),
+    OBJECT_TYPE_DEF_DOES_NOT_ALLOW_RESOURCE_FUNC_DECL("BCE3974",
             "unsupported.resource.function.declaration.in.object.type"),
-    SERVICE_ABSOLUTE_PATH_OR_LITERAL_IS_REQUIRED_BY_LISTENER("BCE3976",
+    SERVICE_ABSOLUTE_PATH_OR_LITERAL_IS_REQUIRED_BY_LISTENER("BCE3975",
             "service.absolute.path.or.literal.required.by.listener"),
-    SERVICE_PATH_LITERAL_IS_NOT_SUPPORTED_BY_LISTENER("BCE3977", "service.path.literal.is.not.supported.by.listener"),
-    SERVICE_ABSOLUTE_PATH_IS_NOT_SUPPORTED_BY_LISTENER("BCE3978", "service.absolute.path.is.not.supported.by.listener"),
-    SERVICE_LITERAL_REQUIRED_BY_LISTENER("BCE3979", "service.path.literal.required.by.listener"),
-    SERVICE_ABSOLUTE_PATH_REQUIRED_BY_LISTENER("BCE3980", "service.absolute.path.required.by.listener"),
-    SERVICE_TYPE_IS_NOT_SUPPORTED_BY_LISTENER("BCE3981", "service.type.is.not.supported.by.listener"),
+    SERVICE_PATH_LITERAL_IS_NOT_SUPPORTED_BY_LISTENER("BCE3976", "service.path.literal.is.not.supported.by.listener"),
+    SERVICE_ABSOLUTE_PATH_IS_NOT_SUPPORTED_BY_LISTENER("BCE3977", "service.absolute.path.is.not.supported.by.listener"),
+    SERVICE_LITERAL_REQUIRED_BY_LISTENER("BCE3978", "service.path.literal.required.by.listener"),
+    SERVICE_ABSOLUTE_PATH_REQUIRED_BY_LISTENER("BCE3979", "service.absolute.path.required.by.listener"),
+    SERVICE_TYPE_IS_NOT_SUPPORTED_BY_LISTENER("BCE3980", "service.type.is.not.supported.by.listener"),
 
     INVALID_READ_ONLY_CLASS_INCLUSION_IN_OBJECT_TYPE_DESCRIPTOR(
-            "BCE3982", "invalid.read.only.class.inclusion.in.object.type.descriptor"),
-    INVALID_INCLUSION_WITH_MISMATCHED_QUALIFIERS("BCE3983", "invalid.inclusion.with.mismatched.qualifiers"),
-    INVALID_REFERENCE_WITH_MISMATCHED_QUALIFIERS("BCE3984", "invalid.reference.with.mismatched.qualifiers"),
+            "BCE3981", "invalid.read.only.class.inclusion.in.object.type.descriptor"),
+    INVALID_INCLUSION_WITH_MISMATCHED_QUALIFIERS("BCE3982", "invalid.inclusion.with.mismatched.qualifiers"),
+    INVALID_REFERENCE_WITH_MISMATCHED_QUALIFIERS("BCE3983", "invalid.reference.with.mismatched.qualifiers"),
     INVALID_READ_ONLY_TYPEDESC_INCLUSION_IN_OBJECT_TYPEDESC(
-            "BCE3985", "invalid.read.only.typedesc.inclusion.in.object.typedesc"),
+            "BCE3984", "invalid.read.only.typedesc.inclusion.in.object.typedesc"),
     INVALID_READ_ONLY_TYPEDESC_INCLUSION_IN_NON_READ_ONLY_CLASS(
-            "BCE3986", "invalid.read.only.typedesc.inclusion.in.non.read.only.class"),
+            "BCE3985", "invalid.read.only.typedesc.inclusion.in.non.read.only.class"),
     INVALID_READ_ONLY_CLASS_INCLUSION_IN_NON_READ_ONLY_CLASS(
-            "BCE3987", "invalid.read.only.class.inclusion.in.non.read.only.class"),
+            "BCE3986", "invalid.read.only.class.inclusion.in.non.read.only.class"),
     INVALID_FIELD_IN_OBJECT_CONSTUCTOR_EXPR_WITH_READONLY_REFERENCE(
-            "BCE3988", "invalid.field.in.object.constructor.expr.with.readonly.reference"),
+            "BCE3987", "invalid.field.in.object.constructor.expr.with.readonly.reference"),
     MISMATCHED_VISIBILITY_QUALIFIERS_IN_OBJECT_FIELD(
-            "BCE3989", "mismatched.visibility.qualifiers.in.object.field"),
+            "BCE3988", "mismatched.visibility.qualifiers.in.object.field"),
 
-    MULTIPLE_RECEIVE_ACTION_NOT_YET_SUPPORTED("BCE3990", "multiple.receive.action.not.yet.supported"),
+    MULTIPLE_RECEIVE_ACTION_NOT_YET_SUPPORTED("BCE3989", "multiple.receive.action.not.yet.supported"),
 
-    INVALID_READONLY_FIELD_TYPE("BCE3991", "invalid.readonly.field.type"),
+    INVALID_READONLY_FIELD_TYPE("BCE3990", "invalid.readonly.field.type"),
 
-    CONTINUE_NOT_ALLOWED("BCE3992", "continue.not.allowed"),
-    BREAK_NOT_ALLOWED("BCE3993", "break.not.allowed"),
-    TYPE_DOES_NOT_SUPPORT_XML_NAVIGATION_ACCESS("BCE3994", "type.does.not.support.xml.navigation.access"),
-    XML_FUNCTION_DOES_NOT_SUPPORT_ARGUMENT_TYPE("BCE3995", "xml.function.does.not.support.argument.type"),
+    CONTINUE_NOT_ALLOWED("BCE3991", "continue.not.allowed"),
+    BREAK_NOT_ALLOWED("BCE3992", "break.not.allowed"),
+    TYPE_DOES_NOT_SUPPORT_XML_NAVIGATION_ACCESS("BCE3993", "type.does.not.support.xml.navigation.access"),
+    XML_FUNCTION_DOES_NOT_SUPPORT_ARGUMENT_TYPE("BCE3994", "xml.function.does.not.support.argument.type"),
 
-    INTERSECTION_NOT_ALLOWED_WITH_TYPE("BCE3996", "intersection.not.allowed.with.type"),
-    ASYNC_SEND_NOT_YET_SUPPORTED_AS_EXPRESSION("BCE3997", "async.send.action.not.yet.supported.as.expression"),
-    UNUSED_VARIABLE_WITH_INFERRED_TYPE_INCLUDING_ERROR("BCE3998", "unused.variable.with.inferred.type.including.error"),
-    INVALID_ITERABLE_OBJECT_TYPE("BCE3999", "invalid.iterable.type"),
-    INVALID_ITERABLE_COMPLETION_TYPE_IN_FOREACH_NEXT_FUNCTION("BCE4000",
+    INTERSECTION_NOT_ALLOWED_WITH_TYPE("BCE3995", "intersection.not.allowed.with.type"),
+    ASYNC_SEND_NOT_YET_SUPPORTED_AS_EXPRESSION("BCE3996", "async.send.action.not.yet.supported.as.expression"),
+    UNUSED_VARIABLE_WITH_INFERRED_TYPE_INCLUDING_ERROR("BCE3997", "unused.variable.with.inferred.type.including.error"),
+    INVALID_ITERABLE_OBJECT_TYPE("BCE3998", "invalid.iterable.type"),
+    INVALID_ITERABLE_COMPLETION_TYPE_IN_FOREACH_NEXT_FUNCTION("BCE3999",
             "invalid.iterable.completion.type.in.foreach.next.function"),
-    SAME_ARRAY_TYPE_AS_MAIN_PARAMETER("BCE4001", "same.array.type.as.main.param"),
-    VARIABLE_AND_ARRAY_TYPE_AS_MAIN_PARAM("BCE4002", "variable.and.array.type.as.main.param"),
-    INVALID_MAIN_OPTION_PARAMS_TYPE("BCE4003", "invalid.main.option.params.type"),
-    WORKER_INTERACTION_AFTER_WAIT_ACTION("BCE4005", "invalid.worker.message.passing.after.wait.action"),
-    OPTIONAL_OPERAND_PRECEDES_OPERAND("BCE4006", "optional.operand.precedes.operand"),
-    UNIMPLEMENTED_REFERENCED_METHOD_IN_SERVICE_DECL("BCE4007",
+    SAME_ARRAY_TYPE_AS_MAIN_PARAMETER("BCE4000", "same.array.type.as.main.param"),
+    VARIABLE_AND_ARRAY_TYPE_AS_MAIN_PARAM("BCE4001", "variable.and.array.type.as.main.param"),
+    INVALID_MAIN_OPTION_PARAMS_TYPE("BCE4002", "invalid.main.option.params.type"),
+    WORKER_INTERACTION_AFTER_WAIT_ACTION("BCE4003", "invalid.worker.message.passing.after.wait.action"),
+    OPTIONAL_OPERAND_PRECEDES_OPERAND("BCE4004", "optional.operand.precedes.operand"),
+    UNIMPLEMENTED_REFERENCED_METHOD_IN_SERVICE_DECL("BCE4004",
             "unimplemented.referenced.method.in.service.declaration"),
-    UNIMPLEMENTED_REFERENCED_METHOD_IN_OBJECT_CTOR("BCE4008", "unimplemented.referenced.method.in.object.constructor"),
-    UNSUPPORTED_REMOTE_METHOD_NAME_IN_SCOPE("BCE4009", "unsupported.remote.method.name.in.scope")
+    UNIMPLEMENTED_REFERENCED_METHOD_IN_OBJECT_CTOR("BCE4006", "unimplemented.referenced.method.in.object.constructor"),
+    UNSUPPORTED_REMOTE_METHOD_NAME_IN_SCOPE("BCE4007", "unsupported.remote.method.name.in.scope")
     ;
 
     private String diagnosticId;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/IsolationAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/IsolationAnalyzer.java
@@ -1118,8 +1118,6 @@ public class IsolationAnalyzer extends BLangNodeVisitor {
             } else if (!varRefExpr.isLValue && parent != null && isInvalidTransfer(varRefExpr, true)) {
                 exprInfo.copyOutVarRefs.add(varRefExpr);
             }
-        } else if (isMethodCallOnSelfInIsolatedObject(varRefExpr, parent)) {
-            dlog.error(varRefExpr.pos, DiagnosticErrorCode.INVALID_REFERENCE_TO_SELF_IN_ISOLATED_OBJECT_OUTSIDE_LOCK);
         }
 
         boolean inIsolatedFunction = isInIsolatedFunction(enclInvokable);
@@ -1201,12 +1199,6 @@ public class IsolationAnalyzer extends BLangNodeVisitor {
         if (inLockStatement) {
             addToAccessedRestrictedVars(copyInLockInfoStack.peek().accessedRestrictedVars,
                                         (BLangSimpleVarRef) fieldAccessExpr.expr);
-            return;
-        }
-
-        if (((BObjectType) env.enclInvokable.symbol.owner.type).fields.get(fieldAccessExpr.field.value) == null) {
-            dlog.error(fieldAccessExpr.pos,
-                       DiagnosticErrorCode.INVALID_REFERENCE_TO_SELF_IN_ISOLATED_OBJECT_OUTSIDE_LOCK);
             return;
         }
 
@@ -2256,7 +2248,7 @@ public class IsolationAnalyzer extends BLangNodeVisitor {
 
         if (field == null) {
             // Bound method access.
-            return true;
+            return false;
         }
 
         return isExpectedToBeAPrivateField(field.symbol, field.type);

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1643,9 +1643,6 @@ error.invalid.non.private.mutable.field.in.isolated.object=\
 error.invalid.mutable.field.access.in.isolated.object.outside.lock=\
   invalid access of a mutable field of an ''isolated'' object outside a ''lock'' statement
 
-error.invalid.reference.to.self.in.isolated.object.outside.lock=\
-  invalid reference to ''self'' outside a ''lock'' statement in an ''isolated'' object
-
 error.invalid.non.isolated.expression.as.initial.value=\
   invalid initial value expression: expected an isolated expression
 

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/BallerinaTomlTests.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/BallerinaTomlTests.java
@@ -203,7 +203,7 @@ public class BallerinaTomlTests {
         if (os.contains("win")) {
             // text range including minutiae, if we get a node that includes newline minutiae,
             // its text range will be different. i.e windows will have an extra 1 length due to \r\n.
-            Assert.assertEquals(firstDiagnostic.location().textRange().toString(), "(17,34)");
+            Assert.assertEquals(firstDiagnostic.location().textRange().toString(), "(18,34)");
         } else {
             Assert.assertEquals(firstDiagnostic.location().textRange().toString(), "(17,33)");
         }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/isolation/IsolatedObjectTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/isolation/IsolatedObjectTest.java
@@ -142,95 +142,89 @@ public class IsolatedObjectTest {
         validateError(result, i++, "invalid non-private mutable field in an 'isolated' object", 334, 5);
         validateError(result, i++, "invalid non-private mutable field in an 'isolated' object", 335, 5);
         validateError(result, i++, "invalid non-private mutable field in an 'isolated' object", 339, 5);
-        validateError(result, i++, "invalid reference to 'self' outside a 'lock' statement in an 'isolated' object",
-                      347, 13);
-        validateError(result, i++, "invalid reference to 'self' outside a 'lock' statement in an 'isolated' object",
-                      348, 9);
-        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 374, 40);
-        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 386, 27);
-        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 388, 27);
-        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 389, 22);
-        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 390, 33);
-        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 393, 31);
-        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 396, 35);
-        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 404, 35);
-        validateError(result, i++, ERROR_INVALID_ASSIGNMENT_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 430, 14);
-        validateError(result, i++, ERROR_INVALID_ASSIGNMENT_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 430, 17);
-        validateError(result, i++, ERROR_INVALID_ASSIGNMENT_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 431, 14);
-        validateError(result, i++, ERROR_INVALID_ASSIGNMENT_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 431, 18);
-        validateError(result, i++, ERROR_INVALID_TRANSFER_OUT_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 431, 33);
-        validateError(result, i++, ERROR_INVALID_ASSIGNMENT_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 441, 14);
-        validateError(result, i++, ERROR_INVALID_ASSIGNMENT_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 441, 17);
-        validateError(result, i++, ERROR_INVALID_TRANSFER_OUT_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 441, 25);
-        validateError(result, i++, ERROR_INVALID_ASSIGNMENT_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 442, 14);
-        validateError(result, i++, ERROR_INVALID_ASSIGNMENT_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 442, 17);
-        validateError(result, i++, ERROR_EXPECTED_AN_ISOLATED_EXPRESSION, 456, 18);
-        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 461, 36);
-        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 461, 42);
-        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 461, 45);
-        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 462, 38);
-        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 462, 59);
-        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 463, 49);
-        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 463, 71);
-        validateError(result, i++, ERROR_INVALID_ACCESS_OF_MUTABLE_STORAGE_IN_ISOLATED_FUNC, 468, 35);
-        validateError(result, i++, ERROR_INVALID_ACCESS_OF_MUTABLE_STORAGE_IN_ISOLATED_FUNC, 471, 36);
-        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 471, 36);
-        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 471, 42);
-        validateError(result, i++, ERROR_INVALID_ACCESS_OF_MUTABLE_STORAGE_IN_ISOLATED_FUNC, 471, 59);
-        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 471, 59);
-        validateError(result, i++, ERROR_INVALID_ACCESS_OF_MUTABLE_STORAGE_IN_ISOLATED_FUNC, 471, 112);
-        validateError(result, i++, ERROR_INVALID_ACCESS_OF_MUTABLE_STORAGE_IN_ISOLATED_FUNC, 471, 115);
-        validateError(result, i++, "invalid non-private mutable field in an 'isolated' object", 477, 5);
-        validateError(result, i++, "invalid non-private mutable field in an 'isolated' object", 478, 5);
-        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 493, 40);
-        validateError(result, i++, "invalid non-private mutable field in an 'isolated' object", 505, 6);
-        validateError(result, i++, "invalid non-private mutable field in an 'isolated' object", 516, 5);
+        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 356, 40);
+        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 368, 27);
+        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 370, 27);
+        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 371, 22);
+        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 372, 33);
+        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 375, 31);
+        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 378, 35);
+        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 386, 35);
+        validateError(result, i++, ERROR_INVALID_ASSIGNMENT_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 412, 14);
+        validateError(result, i++, ERROR_INVALID_ASSIGNMENT_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 412, 17);
+        validateError(result, i++, ERROR_INVALID_ASSIGNMENT_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 413, 14);
+        validateError(result, i++, ERROR_INVALID_ASSIGNMENT_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 413, 18);
+        validateError(result, i++, ERROR_INVALID_TRANSFER_OUT_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 413, 33);
+        validateError(result, i++, ERROR_INVALID_ASSIGNMENT_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 423, 14);
+        validateError(result, i++, ERROR_INVALID_ASSIGNMENT_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 423, 17);
+        validateError(result, i++, ERROR_INVALID_TRANSFER_OUT_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 423, 25);
+        validateError(result, i++, ERROR_INVALID_ASSIGNMENT_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 424, 14);
+        validateError(result, i++, ERROR_INVALID_ASSIGNMENT_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 424, 17);
+        validateError(result, i++, ERROR_EXPECTED_AN_ISOLATED_EXPRESSION, 438, 18);
+        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 443, 36);
+        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 443, 42);
+        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 443, 45);
+        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 444, 38);
+        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 444, 59);
+        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 445, 49);
+        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 445, 71);
+        validateError(result, i++, ERROR_INVALID_ACCESS_OF_MUTABLE_STORAGE_IN_ISOLATED_FUNC, 450, 35);
+        validateError(result, i++, ERROR_INVALID_ACCESS_OF_MUTABLE_STORAGE_IN_ISOLATED_FUNC, 453, 36);
+        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 453, 36);
+        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 453, 42);
+        validateError(result, i++, ERROR_INVALID_ACCESS_OF_MUTABLE_STORAGE_IN_ISOLATED_FUNC, 453, 59);
+        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 453, 59);
+        validateError(result, i++, ERROR_INVALID_ACCESS_OF_MUTABLE_STORAGE_IN_ISOLATED_FUNC, 453, 112);
+        validateError(result, i++, ERROR_INVALID_ACCESS_OF_MUTABLE_STORAGE_IN_ISOLATED_FUNC, 453, 115);
+        validateError(result, i++, "invalid non-private mutable field in an 'isolated' object", 459, 5);
+        validateError(result, i++, "invalid non-private mutable field in an 'isolated' object", 460, 5);
+        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 475, 40);
+        validateError(result, i++, "invalid non-private mutable field in an 'isolated' object", 487, 6);
+        validateError(result, i++, "invalid non-private mutable field in an 'isolated' object", 498, 5);
         validateError(result, i++, "invalid access of a mutable field of an 'isolated' object outside a 'lock' " +
-                "statement", 519, 9);
+                "statement", 501, 9);
         validateError(result, i++, "invalid access of a mutable field of an 'isolated' object outside a 'lock' " +
-                "statement", 523, 9);
+                "statement", 505, 9);
         validateError(result, i++, "invalid access of a mutable field of an 'isolated' object outside a 'lock' " +
-                "statement", 527, 9);
-        validateError(result, i++, ERROR_INVALID_ACCESS_OF_MUTABLE_STORAGE_IN_ISOLATED_FUNC, 531, 9);
-        validateError(result, i++, ERROR_INVALID_ACCESS_OF_MUTABLE_STORAGE_IN_ISOLATED_FUNC, 535, 9);
+                "statement", 509, 9);
+        validateError(result, i++, ERROR_INVALID_ACCESS_OF_MUTABLE_STORAGE_IN_ISOLATED_FUNC, 513, 9);
+        validateError(result, i++, ERROR_INVALID_ACCESS_OF_MUTABLE_STORAGE_IN_ISOLATED_FUNC, 517, 9);
         validateError(result, i++, "cannot access more than one variable for which usage is restricted in a single " +
-                "'lock' statement", 540, 13);
+                "'lock' statement", 522, 13);
         validateError(result, i++, "cannot access more than one variable for which usage is restricted in a single " +
-                "'lock' statement", 541, 13);
-        validateError(result, i++, "invalid non-private mutable field in an 'isolated' object", 547, 5);
+                "'lock' statement", 523, 13);
+        validateError(result, i++, "invalid non-private mutable field in an 'isolated' object", 529, 5);
         validateError(result, i++, "invalid access of a mutable field of an 'isolated' object outside a 'lock' " +
-                "statement", 550, 9);
+                "statement", 532, 9);
         validateError(result, i++, "invalid access of a mutable field of an 'isolated' object outside a 'lock' " +
-                "statement", 554, 9);
+                "statement", 536, 9);
         validateError(result, i++, "invalid access of a mutable field of an 'isolated' object outside a 'lock' " +
-                "statement", 558, 9);
-        validateError(result, i++, ERROR_INVALID_ACCESS_OF_MUTABLE_STORAGE_IN_ISOLATED_FUNC, 562, 9);
-        validateError(result, i++, ERROR_INVALID_ACCESS_OF_MUTABLE_STORAGE_IN_ISOLATED_FUNC, 566, 9);
+                "statement", 540, 9);
+        validateError(result, i++, ERROR_INVALID_ACCESS_OF_MUTABLE_STORAGE_IN_ISOLATED_FUNC, 544, 9);
+        validateError(result, i++, ERROR_INVALID_ACCESS_OF_MUTABLE_STORAGE_IN_ISOLATED_FUNC, 548, 9);
         validateError(result, i++, "cannot access more than one variable for which usage is restricted in a single " +
-                "'lock' statement", 571, 13);
+                "'lock' statement", 553, 13);
         validateError(result, i++, "cannot access more than one variable for which usage is restricted in a single " +
-                "'lock' statement", 572, 13);
-        validateError(result, i++, "invalid non-private mutable field in an 'isolated' object", 578, 5);
+                "'lock' statement", 554, 13);
+        validateError(result, i++, "invalid non-private mutable field in an 'isolated' object", 560, 5);
         validateError(result, i++, "invalid access of a mutable field of an 'isolated' object outside a 'lock' " +
-                "statement", 581, 9);
+                "statement", 563, 9);
         validateError(result, i++, "invalid access of a mutable field of an 'isolated' object outside a 'lock' " +
-                "statement", 585, 9);
+                "statement", 567, 9);
         validateError(result, i++, "invalid access of a mutable field of an 'isolated' object outside a 'lock' " +
-                "statement", 589, 9);
-        validateError(result, i++, ERROR_INVALID_ACCESS_OF_MUTABLE_STORAGE_IN_ISOLATED_FUNC, 593, 9);
-        validateError(result, i++, ERROR_INVALID_ACCESS_OF_MUTABLE_STORAGE_IN_ISOLATED_FUNC, 597, 9);
+                "statement", 571, 9);
+        validateError(result, i++, ERROR_INVALID_ACCESS_OF_MUTABLE_STORAGE_IN_ISOLATED_FUNC, 575, 9);
+        validateError(result, i++, ERROR_INVALID_ACCESS_OF_MUTABLE_STORAGE_IN_ISOLATED_FUNC, 579, 9);
         validateError(result, i++, "cannot access more than one variable for which usage is restricted in a single " +
-                "'lock' statement", 602, 13);
+                "'lock' statement", 584, 13);
         validateError(result, i++, "cannot access more than one variable for which usage is restricted in a single " +
-                "'lock' statement", 603, 13);
+                "'lock' statement", 585, 13);
         validateError(result, i++, "cannot access more than one variable for which usage is restricted in a single " +
-                "'lock' statement", 609, 13);
+                "'lock' statement", 591, 13);
         validateError(result, i++, "cannot access more than one variable for which usage is restricted in a single " +
-                "'lock' statement", 610, 13);
-        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 632, 13);
-        validateError(result, i++, ERROR_INVALID_TRANSFER_OUT_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 639, 13);
-        validateError(result, i++, "invalid reference to 'self' outside a 'lock' statement in an 'isolated' object",
-                646, 35);
+                "'lock' statement", 592, 13);
+        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 614, 13);
+        validateError(result, i++, ERROR_INVALID_TRANSFER_OUT_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 621, 13);
         Assert.assertEquals(result.getErrorCount(), i);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/isolation/IsolationAnalysisTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/isolation/IsolationAnalysisTest.java
@@ -146,13 +146,9 @@ public class IsolationAnalysisTest {
         validateError(result, i++, INVALID_MUTABLE_STORAGE_ACCESS_ERROR, 101, 22);
         validateError(result, i++, INVALID_MUTABLE_STORAGE_ACCESS_ERROR, 105, 25);
         validateError(result, i++, INVALID_MUTABLE_STORAGE_ACCESS_ERROR, 124, 17);
-        validateError(result, i++, "invalid reference to 'self' outside a 'lock' statement in an 'isolated' object",
-                      128, 9);
         validateError(result, i++, INVALID_MUTABLE_STORAGE_ACCESS_ERROR, 129, 28);
         validateError(result, i++, INVALID_MUTABLE_STORAGE_ACCESS_ERROR, 133, 17);
         validateError(result, i++, INVALID_MUTABLE_STORAGE_ACCESS_ERROR, 139, 17);
-        validateError(result, i++, "invalid reference to 'self' outside a 'lock' statement in an 'isolated' object",
-                      143, 9);
         validateError(result, i++, INVALID_MUTABLE_STORAGE_ACCESS_ERROR, 144, 28);
         validateError(result, i++, INVALID_MUTABLE_STORAGE_ACCESS_ERROR, 148, 17);
         validateError(result, i++, INVALID_MUTABLE_STORAGE_ACCESS_ERROR, 155, 20);

--- a/tests/jballerina-unit-test/src/test/resources/test-src/isolated-objects/isolated_objects.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/isolated-objects/isolated_objects.bal
@@ -630,6 +630,38 @@ isolated class IsolatedClassWithBoundMethodAccess {
     }
 }
 
+isolated class IsolatedClassReferringSelfOutsideLock {
+    final int a = 1;
+    private int[] b = [];
+
+    function foo() {
+        f1(self);
+        self.baz();
+    }
+
+    isolated function baz() {
+        f2(1, self);
+    }
+}
+
+function f1(IsolatedClassReferringSelfOutsideLock x) {
+
+}
+
+isolated function f2(int i, IsolatedClassReferringSelfOutsideLock x) {
+
+}
+
+public isolated class IsolatedClassWithBoundMethodAccessOutsideLock {
+
+    public isolated function bar() {
+        isolated function () fn = self.baz;
+    }
+
+    isolated function baz() {
+    }
+}
+
 function assertTrue(any|error actual) {
     assertEquality(true, actual);
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/isolated-objects/isolated_objects_isolation_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/isolated-objects/isolated_objects_isolation_negative.bal
@@ -339,24 +339,6 @@ isolated class InvalidIsolatedClassWithNonInvalidObjectFields {
     final object {} c = object {}; // should be an `isolated object`
 }
 
-isolated class InvalidIsolatedClassReferringSelfOutsideLock {
-    final int a = 1;
-    private int[] b = [];
-
-    function foo() {
-        bar(self);
-        self.baz();
-    }
-
-    function baz() {
-
-    }
-}
-
-function bar(InvalidIsolatedClassReferringSelfOutsideLock x) {
-
-}
-
 isolated class IsolatedClass {
     function nonIsolatedFunc() returns int => 1;
 }


### PR DESCRIPTION
## Purpose
$title.

Fixes #<Issue Number>

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
