### PR TITLE
Add definition support to self reference in a class

### DIFF
--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/BallerinaCompletionContext.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/BallerinaCompletionContext.java
@@ -30,7 +30,7 @@ import java.util.Optional;
  *
  * @since 2.0.0
  */
-public interface BallerinaCompletionContext extends CompletionContext {
+public interface BallerinaCompletionContext extends CompletionContext, BallerinaEnclosedPositionContext {
 
     /**
      * Set the token at the completion's cursor position.
@@ -80,5 +80,4 @@ public interface BallerinaCompletionContext extends CompletionContext {
      * @return {@link Optional<TypeSymbol>} Context TypeSymbol for node at cursor.
      */
     Optional<TypeSymbol> getContextType();
-
 }

--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/BallerinaDefinitionContext.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/BallerinaDefinitionContext.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except
@@ -17,18 +17,10 @@
  */
 package org.ballerinalang.langserver.commons;
 
-import org.eclipse.lsp4j.CompletionCapabilities;
-
 /**
- * Represents the Completion operation context.
+ * Represents a Ballerina goto definition context.
  *
  * @since 2.0.0
  */
-public interface CompletionContext extends PositionedOperationContext {
-    /**
-     * Get the client capabilities.
-     *
-     * @return {@link CompletionCapabilities} client's completion capabilities
-     */
-    CompletionCapabilities getCapabilities();
+public interface BallerinaDefinitionContext extends PositionedOperationContext, BallerinaEnclosedPositionContext {
 }

--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/BallerinaEnclosedPositionContext.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/BallerinaEnclosedPositionContext.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except
@@ -17,18 +17,18 @@
  */
 package org.ballerinalang.langserver.commons;
 
-import org.eclipse.lsp4j.CompletionCapabilities;
+import io.ballerina.compiler.syntax.tree.ModuleMemberDeclarationNode;
+
+import java.util.Optional;
 
 /**
- * Represents the Completion operation context.
+ * Represents a Ballerina operation context where the cursor is enclosed within a module member.
  *
  * @since 2.0.0
  */
-public interface CompletionContext extends PositionedOperationContext {
+public interface BallerinaEnclosedPositionContext {
     /**
-     * Get the client capabilities.
-     *
-     * @return {@link CompletionCapabilities} client's completion capabilities
+     * Set the cursor position as an offset value according to the syntax tree.
      */
-    CompletionCapabilities getCapabilities();
+    Optional<ModuleMemberDeclarationNode> enclosedModuleMember();
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
@@ -29,6 +29,7 @@ import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.langserver.codelenses.CodeLensUtil;
 import org.ballerinalang.langserver.codelenses.LSCodeLensesProviderHolder;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
+import org.ballerinalang.langserver.commons.BallerinaDefinitionContext;
 import org.ballerinalang.langserver.commons.CodeActionContext;
 import org.ballerinalang.langserver.commons.CompletionContext;
 import org.ballerinalang.langserver.commons.DocumentServiceContext;
@@ -251,10 +252,11 @@ class BallerinaTextDocumentService implements TextDocumentService {
             (DefinitionParams params) {
         return CompletableFuture.supplyAsync(() -> {
             try {
-                DocumentServiceContext defContext = ContextBuilder.buildBaseContext(params.getTextDocument().getUri(),
+                BallerinaDefinitionContext defContext = ContextBuilder.buildDefinitionContext(
+                        params.getTextDocument().getUri(),
                         this.workspaceManager,
-                        LSContextOperation.TXT_DEFINITION,
-                        this.serverContext);
+                        this.serverContext,
+                        params.getPosition());
                 return Either.forLeft(DefinitionUtil.getDefinition(defContext, params.getPosition()));
             } catch (UserErrorException e) {
                 this.clientLogger.notifyUser("Goto Definition", e);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/BallerinaCompletionContextImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/BallerinaCompletionContextImpl.java
@@ -18,8 +18,10 @@
 package org.ballerinalang.langserver.contexts;
 
 import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.syntax.tree.ModuleMemberDeclarationNode;
 import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.compiler.syntax.tree.NonTerminalNode;
+import io.ballerina.compiler.syntax.tree.SyntaxTree;
 import io.ballerina.compiler.syntax.tree.Token;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
 import org.ballerinalang.langserver.commons.CompletionContext;
@@ -36,12 +38,13 @@ import java.util.Optional;
  * @since 2.0.0
  */
 public class BallerinaCompletionContextImpl extends CompletionContextImpl implements BallerinaCompletionContext {
-
     private final List<Node> resolverChain = new ArrayList<>();
     private Token tokenAtCursor;
     private NonTerminalNode nodeAtCursor;
-    private boolean isContextTypeFound = false;
+    private boolean contextTypeCaptured = false;
     private TypeSymbol contextType;
+    private boolean capturedEnclosingNode = false;
+    private ModuleMemberDeclarationNode enclosingNode = null;
 
     public BallerinaCompletionContextImpl(CompletionContext context, LanguageServerContext serverContext) {
         super(context.operation(),
@@ -90,29 +93,36 @@ public class BallerinaCompletionContextImpl extends CompletionContextImpl implem
 
     @Override
     public Optional<TypeSymbol> getContextType() {
-
-        if (this.isContextTypeFound) {
-            return Optional.ofNullable(this.contextType);
+        if (!this.contextTypeCaptured) {
+            this.contextTypeCaptured = true;
+            NonTerminalNode node = getNodeAtCursor();
+            do {
+                ContextTypeResolver contextTypeResolver = new ContextTypeResolver(this);
+                Optional<TypeSymbol> typeSymbol = node.apply(contextTypeResolver);
+                if (typeSymbol == null || typeSymbol.isEmpty()) {
+                    this.contextType = null;
+                } else {
+                    this.contextType = typeSymbol.get();
+                }
+                node = node.parent();
+            } while (this.contextType == null && node != null);
         }
-
-        this.isContextTypeFound = true;
-        if (this.getNodeAtCursor() == null) {
-            this.contextType = null;
-            return Optional.ofNullable(contextType);
-        }
-
-        NonTerminalNode node = getNodeAtCursor();
-        do {
-            ContextTypeResolver contextTypeResolver = new ContextTypeResolver(this);
-            Optional<TypeSymbol> typeSymbol = node.apply(contextTypeResolver);
-            if (typeSymbol == null || typeSymbol.isEmpty()) {
-                this.contextType = null;
-            } else {
-                this.contextType = typeSymbol.get();
-            }
-            node = node.parent();
-        } while (this.contextType == null && node != null);
 
         return Optional.ofNullable(this.contextType);
+    }
+
+    @Override
+    public Optional<ModuleMemberDeclarationNode> enclosedModuleMember() {
+        if (!this.capturedEnclosingNode) {
+            this.capturedEnclosingNode = true;
+            Optional<SyntaxTree> syntaxTree = this.currentSyntaxTree();
+            if (syntaxTree.isEmpty()) {
+                throw new RuntimeException("Cannot find a valid syntax tree");
+            }
+            this.enclosingNode = BallerinaContextUtils.getEnclosingModuleMember(syntaxTree.get(),
+                    this.getCursorPositionInTree()).orElse(null);
+        }
+        
+        return Optional.ofNullable(this.enclosingNode);
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/BallerinaContextUtils.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/BallerinaContextUtils.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.langserver.contexts;
+
+import io.ballerina.compiler.syntax.tree.ModuleMemberDeclarationNode;
+import io.ballerina.compiler.syntax.tree.ModulePartNode;
+import io.ballerina.compiler.syntax.tree.SyntaxTree;
+
+import java.util.Optional;
+
+/**
+ * Holds the utilities for ballerina context implementations.
+ * 
+ * @since 2.0.0
+ */
+public class BallerinaContextUtils {
+    private BallerinaContextUtils() {
+    }
+    
+    public static Optional<ModuleMemberDeclarationNode> getEnclosingModuleMember(SyntaxTree syntaxTree, int cursor) {
+        for (ModuleMemberDeclarationNode member : ((ModulePartNode) syntaxTree.rootNode()).members()) {
+            int startOffset = member.textRange().startOffset();
+            int endOffset = member.textRange().endOffset();
+            
+            if (cursor > startOffset && cursor < endOffset) {
+                return Optional.of(member);
+            }
+        }
+        
+        return Optional.empty();
+    }
+}

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/BallerinaDefinitionContextImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/BallerinaDefinitionContextImpl.java
@@ -1,0 +1,123 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.langserver.contexts;
+
+import io.ballerina.compiler.syntax.tree.ModuleMemberDeclarationNode;
+import io.ballerina.compiler.syntax.tree.SyntaxTree;
+import org.ballerinalang.langserver.LSContextOperation;
+import org.ballerinalang.langserver.commons.BallerinaDefinitionContext;
+import org.ballerinalang.langserver.commons.LSOperation;
+import org.ballerinalang.langserver.commons.LanguageServerContext;
+import org.ballerinalang.langserver.commons.workspace.WorkspaceManager;
+import org.eclipse.lsp4j.Position;
+
+import java.util.Optional;
+
+/**
+ * Implementation for the {@link BallerinaDefinitionContext}.
+ *
+ * @since 2.0.0
+ */
+public class BallerinaDefinitionContextImpl
+        extends AbstractDocumentServiceContext implements BallerinaDefinitionContext {
+    private boolean capturedEnclosingNode = false;
+    private ModuleMemberDeclarationNode enclosingNode = null;
+    private int cursorPosInTree = -1;
+    private final Position cursorPosition;
+
+    BallerinaDefinitionContextImpl(LSOperation operation,
+                                   String fileUri,
+                                   WorkspaceManager wsManager,
+                                   Position position,
+                                   LanguageServerContext serverContext) {
+        super(operation, fileUri, wsManager, serverContext);
+        this.cursorPosition = position;
+    }
+
+    @Override
+    public Optional<ModuleMemberDeclarationNode> enclosedModuleMember() {
+        if (!this.capturedEnclosingNode) {
+            this.capturedEnclosingNode = true;
+            Optional<SyntaxTree> syntaxTree = this.currentSyntaxTree();
+            if (syntaxTree.isEmpty()) {
+                throw new RuntimeException("Cannot find a valid syntax tree");
+            }
+            this.enclosingNode = BallerinaContextUtils.getEnclosingModuleMember(syntaxTree.get(),
+                    this.getCursorPositionInTree()).orElse(null);
+        }
+
+        return Optional.ofNullable(this.enclosingNode);
+    }
+
+    @Override
+    public void setCursorPositionInTree(int offset) {
+        if (this.cursorPosInTree > -1) {
+            throw new RuntimeException("Setting the cursor offset more than once is not allowed");
+        }
+        this.cursorPosInTree = offset;
+    }
+
+    @Override
+    public int getCursorPositionInTree() {
+        return this.cursorPosInTree;
+    }
+
+    @Override
+    public Position getCursorPosition() {
+        return this.cursorPosition;
+    }
+
+    /**
+     * Represents Language server completion context Builder.
+     *
+     * @since 2.0.0
+     */
+    protected static class DefinitionContextBuilder extends AbstractContextBuilder<DefinitionContextBuilder> {
+        private Position cursor;
+
+        /**
+         * Context Builder constructor.
+         */
+        public DefinitionContextBuilder(LanguageServerContext serverContext) {
+            super(LSContextOperation.TXT_DEFINITION, serverContext);
+        }
+
+        /**
+         * Setter for the position.
+         *
+         * @param position cursor position where the completion triggered
+         */
+        public DefinitionContextBuilder withCursorPosition(Position position) {
+            this.cursor = position;
+            return self();
+        }
+
+        public BallerinaDefinitionContext build() {
+            return new BallerinaDefinitionContextImpl(this.operation,
+                    this.fileUri,
+                    this.wsManager,
+                    this.cursor,
+                    this.serverContext);
+        }
+
+        @Override
+        public DefinitionContextBuilder self() {
+            return this;
+        }
+    }
+}

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/ContextBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/ContextBuilder.java
@@ -19,6 +19,7 @@ package org.ballerinalang.langserver.contexts;
 
 import org.ballerinalang.langserver.BallerinaLanguageServer;
 import org.ballerinalang.langserver.LSContextOperation;
+import org.ballerinalang.langserver.commons.BallerinaDefinitionContext;
 import org.ballerinalang.langserver.commons.CodeActionContext;
 import org.ballerinalang.langserver.commons.CompletionContext;
 import org.ballerinalang.langserver.commons.DocumentServiceContext;
@@ -203,6 +204,26 @@ public class ContextBuilder {
         return new FoldingRangeContextImpl.FoldingRangeContextBuilder(lineFoldingOnly, serverContext)
                 .withFileUri(uri)
                 .withWorkspaceManager(workspaceManager)
+                .build();
+    }
+
+    /**
+     * Build the goto definition context.
+     * 
+     * @param uri file URI
+     * @param workspaceManager workspace manager instance
+     * @param serverContext language server context
+     * @param position position where the definition operation invoked
+     * @return {@link BallerinaDefinitionContext}
+     */
+    public static BallerinaDefinitionContext buildDefinitionContext(String uri,
+                                                                    WorkspaceManager workspaceManager,
+                                                                    LanguageServerContext serverContext,
+                                                                    Position position) {
+        return new BallerinaDefinitionContextImpl.DefinitionContextBuilder(serverContext)
+                .withFileUri(uri)
+                .withWorkspaceManager(workspaceManager)
+                .withCursorPosition(position)
                 .build();
     }
 }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/definition/DefinitionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/definition/DefinitionTest.java
@@ -112,6 +112,8 @@ public class DefinitionTest {
                 {"defProject5.json", "project"},
                 {"defProject6.json", "project"},
                 {"defProject7.json", "project"},
+                {"defProject9.json", "project"},
+                {"defProject10.json", "project"},
         };
     }
 

--- a/language-server/modules/langserver-core/src/test/resources/definition/expected/project/defProject10.json
+++ b/language-server/modules/langserver-core/src/test/resources/definition/expected/project/defProject10.json
@@ -1,0 +1,24 @@
+{
+  "source": {
+    "file": "projectls/defmodsource4.bal"
+  },
+  "position": {
+    "line": 4,
+    "character": 22
+  },
+  "result": [
+    {
+      "range": {
+        "start": {
+          "line": 3,
+          "character": 11
+        },
+        "end": {
+          "line": 3,
+          "character": 15
+        }
+      },
+      "uri": "projectls/defmodsource4.bal"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/definition/expected/project/defProject9.json
+++ b/language-server/modules/langserver-core/src/test/resources/definition/expected/project/defProject9.json
@@ -1,0 +1,24 @@
+{
+  "source": {
+    "file": "projectls/defmodsource4.bal"
+  },
+  "position": {
+    "line": 10,
+    "character": 17
+  },
+  "result": [
+    {
+      "range": {
+        "start": {
+          "line": 7,
+          "character": 6
+        },
+        "end": {
+          "line": 7,
+          "character": 12
+        }
+      },
+      "uri": "projectls/defmodsource4.bal"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/definition/sources/projectls/defmodsource4.bal
+++ b/language-server/modules/langserver-core/src/test/resources/definition/sources/projectls/defmodsource4.bal
@@ -1,0 +1,13 @@
+import ballerina/module1;
+
+function testFunction() {
+    Person self = new();
+    int personAge = self.getAge();
+}
+
+class Person {
+    int age = 12;
+    function getAge() returns int {
+        return self.age;
+    }
+}


### PR DESCRIPTION
## Purpose
With this,
- Introduce a new utility API to the completion and definition contexts
- Add goto definition support for the self variable within a class.

Fixes #30427

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
