### PR TITLE
Fix intersection computation with intersection types

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -4090,6 +4090,9 @@ public class Types {
     }
 
     private BType getIntersection(IntersectionContext intersectionContext, BType lhsType, SymbolEnv env, BType type) {
+        lhsType = getEffectiveTypeForIntersection(lhsType);
+        type = getEffectiveTypeForIntersection(type);
+
         if (intersectionContext.preferNonGenerativeIntersection) {
             if (isAssignable(type, lhsType)) {
                 return type;
@@ -4217,6 +4220,18 @@ public class Types {
             return type;
         }
         return null;
+    }
+
+    private BType getEffectiveTypeForIntersection(BType type) {
+        if (type.tag != TypeTags.INTERSECTION) {
+            return type;
+        }
+
+        BType effectiveType = ((BIntersectionType) type).effectiveType;
+
+        // Don't return a cyclic type as the effective type due to
+        // https://github.com/ballerina-platform/ballerina-lang/issues/30681.
+        return effectiveType.tag == TypeTags.UNION && ((BUnionType) effectiveType).isCyclic ? type : effectiveType;
     }
 
     private boolean isAnydataOrJson(BType type) {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/TypeGuardTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/TypeGuardTest.java
@@ -210,6 +210,12 @@ public class TypeGuardTest {
                 "'map<int>'", 480, 30);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'boolean[]', found '" +
                 "(string|boolean)[]'", 484, 23);
+        BAssertUtil.validateError(negativeResult, i++, "invalid operation: type '(Bar & readonly)' does not support " +
+                "optional field access for field 't'", 498, 17);
+        BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'boolean', found '(record {| " +
+                "string s; |} & readonly)?'", 499, 21);
+        BAssertUtil.validateError(negativeResult, i++, "invalid operation: type '(Bar & readonly)' does not support " +
+                "field access for non-required field 'baz'", 500, 50);
         Assert.assertEquals(negativeResult.getErrorCount(), i);
     }
 
@@ -699,6 +705,11 @@ public class TypeGuardTest {
     @Test
     public void testJsonIntersection() {
         BRunUtil.invoke(result, "testJsonIntersection");
+    }
+
+    @Test
+    public void testIntersectionWithIntersectionType() {
+        BRunUtil.invoke(result, "testIntersectionWithIntersectionType");
     }
 
     @Test

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/ifelse/type-guard-semantics-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/ifelse/type-guard-semantics-negative.bal
@@ -484,3 +484,19 @@ function jsonIntersectionNegative(json j) {
         boolean[] a = j;
     }
 }
+
+public type Bar record {|
+    record {|
+        string s;
+    |} baz?;
+|};
+
+function testIntersectionWithIntersectionTypeNegative() {
+    Bar? & readonly bar = ();
+
+    if bar is Bar {
+        var t = bar?.t;
+        boolean x = bar?.baz;
+        (record {| string s; |} & readonly)? y = bar.baz;
+    }
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/ifelse/type-guard.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/ifelse/type-guard.bal
@@ -1509,6 +1509,26 @@ function testJsonIntersection() {
     assertEquality(4, jsonIntersection(<int[]> [1, 2, 3, 4]));
 }
 
+public type Qux record {|
+    record {|
+        string s;
+    |} baz?;
+|};
+
+function intersectionWithIntersectionType(Qux? & readonly bar) returns string {
+    if bar is Qux {
+        record {| string s; |}? y = bar?.baz;
+        return y?.s ?: "Qux without baz";
+    }
+    return "nil";
+}
+
+function testIntersectionWithIntersectionType() {
+    assertEquality("nil", intersectionWithIntersectionType(()));
+    assertEquality("Qux without baz", intersectionWithIntersectionType({}));
+    assertEquality("hello world", intersectionWithIntersectionType({baz: {s: "hello world"}}));
+}
+
 function assertEquality(anydata expected, anydata actual) {
     if expected == actual {
         return;


### PR DESCRIPTION
## Purpose
$title.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/30680

## Remarks
- The sample in https://github.com/ballerina-platform/ballerina-lang/issues/30142 which previously failed at the backend now results in a compilation error with these changes. We need to improve the intersection computation to propagate attributes (read-onlyness, size if fixed, etc.) from the original type.

```ballerina
public function main() {
    int[] & readonly x = [1, 2, 3];
    anydata & readonly y = x;

    if y is int[] {
        int[] & readonly z = y; // incompatible types: expected 'int[] & readonly', found 'int[]'
    }
}
```

- Also came across #30681 - The intersection computation logic has not been updated for cyclic types. 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
