### PR TITLE
Disable publish from local machines

### DIFF
--- a/.github/workflows/CI_publish_snapshots.yml
+++ b/.github/workflows/CI_publish_snapshots.yml
@@ -22,9 +22,8 @@ jobs:
 
             -   name: Build and Publish
                 env:
-                    packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
-                    packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
-                    isRelease: "true"
+                    publishUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
+                    publishPAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
                 run: |
                     ./gradlew clean build -x createJavadoc --scan publish --continue --rerun-tasks
                     ./gradlew createCodeCoverageReport

--- a/.github/workflows/CI_publish_snapshots.yml
+++ b/.github/workflows/CI_publish_snapshots.yml
@@ -24,6 +24,7 @@ jobs:
                 env:
                     packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
                     packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
+                    isRelease: "true"
                 run: |
                     ./gradlew clean build -x createJavadoc --scan publish --continue --rerun-tasks
                     ./gradlew createCodeCoverageReport

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -18,10 +18,9 @@ jobs:
         run: chmod +x gradlew
       - name: Publish artifact
         env:
-          packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
-          packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
+          publishUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
+          publishPAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
-          isRelease: "true"
         run: |
           git config user.name ${{ secrets.BALLERINA_BOT_USERNAME }}
           git config user.email ${{ secrets.BALLERINA_BOT_EMAIL }}

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -21,6 +21,7 @@ jobs:
           packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
           packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
+          isRelease: "true"
         run: |
           git config user.name ${{ secrets.BALLERINA_BOT_USERNAME }}
           git config user.email ${{ secrets.BALLERINA_BOT_EMAIL }}

--- a/.github/workflows/publish_timestamped_release.yml
+++ b/.github/workflows/publish_timestamped_release.yml
@@ -34,9 +34,8 @@ jobs:
 
       -   name: Build and Publish
           env:
-            packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
-            packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
-            isRelease: "true"
+            publishUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
+            publishPAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
           run: |
             ./gradlew clean build publish -x createJavadoc --scan --continue --rerun-tasks
             ./gradlew createCodeCoverageReport

--- a/.github/workflows/publish_timestamped_release.yml
+++ b/.github/workflows/publish_timestamped_release.yml
@@ -36,6 +36,7 @@ jobs:
           env:
             packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
             packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
+            isRelease: "true"
           run: |
             ./gradlew clean build publish -x createJavadoc --scan --continue --rerun-tasks
             ./gradlew createCodeCoverageReport

--- a/build.gradle
+++ b/build.gradle
@@ -33,14 +33,12 @@ subprojects {
             }
         }
         repositories {
-            if (System.getenv("isRelease") == "true") {
-                maven {
-                    name = "GitHubPackages"
-                    url = uri("https://maven.pkg.github.com/kaneeldias/ballerina-lang")
-                    credentials {
-                        username System.getenv("packageUser")
-                        password System.getenv("packagePAT")
-                    }
+            maven {
+                name = "GitHubPackages"
+                url = uri("https://maven.pkg.github.com/ballerina-platform/ballerina-lang")
+                credentials {
+                    username System.getenv("publishUser")
+                    password System.getenv("publishPAT")
                 }
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -33,12 +33,14 @@ subprojects {
             }
         }
         repositories {
-            maven {
-                name = "GitHubPackages"
-                url = uri("https://maven.pkg.github.com/ballerina-platform/ballerina-lang")
-                credentials {
-                    username System.getenv("packageUser")
-                    password System.getenv("packagePAT")
+            if (System.getenv("isRelease") == "true") {
+                maven {
+                    name = "GitHubPackages"
+                    url = uri("https://maven.pkg.github.com/kaneeldias/ballerina-lang")
+                    credentials {
+                        username System.getenv("packageUser")
+                        password System.getenv("packagePAT")
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Purpose
> Currently, it is possible for accounts with write committership access to publish packages. This changes the process so that only workflows should be able to publish.

Fixes #30166 

## Approach
> In the build.gradle file, before publishing, a check is made to ensure that the "isRelease" environment variable is set to "true". Publish will only occur if this is the case. Before the publish command is run in workflows, the above environment variable is set.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
