### PR TITLE
Fix readonly-ness of slice of readonly arrays

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ArrayValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ArrayValueImpl.java
@@ -31,7 +31,6 @@ import io.ballerina.runtime.api.values.BValue;
 import io.ballerina.runtime.internal.CycleUtils;
 import io.ballerina.runtime.internal.TypeChecker;
 import io.ballerina.runtime.internal.types.BArrayType;
-import io.ballerina.runtime.internal.types.BIntersectionType;
 import io.ballerina.runtime.internal.util.exceptions.BLangExceptionHelper;
 import io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons;
 import io.ballerina.runtime.internal.util.exceptions.BallerinaException;
@@ -41,11 +40,9 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.StringJoiner;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static io.ballerina.runtime.api.constants.RuntimeConstants.ARRAY_LANG_LIB;
@@ -823,17 +820,6 @@ public class ArrayValueImpl extends AbstractArrayValue {
             case TypeTags.CHAR_STRING_TAG:
                 slicedArray = new ArrayValueImpl(new BString[slicedSize], false);
                 System.arraycopy(bStringValues, (int) startIndex, slicedArray.bStringValues, 0, slicedSize);
-                break;
-            case TypeTags.INTERSECTION_TAG:
-                List<Type> constituentTypes = ((BIntersectionType) this.elementType).getConstituentTypes();
-                List<Type> slicedArrayElementTypes = constituentTypes.stream()
-                                        .filter(arrayElementType -> arrayElementType.getTag() != TypeTags.READONLY_TAG)
-                                        .collect(Collectors.toList());
-                Type slicedArrayElementType = (slicedArrayElementTypes.size() != 1) ?
-                        ((BIntersectionType) slicedArrayElementTypes).getEffectiveType() :
-                        slicedArrayElementTypes.get(0);
-                slicedArray = new ArrayValueImpl(new Object[slicedSize], new BArrayType(slicedArrayElementType));
-                System.arraycopy(refValues, (int) startIndex, slicedArray.refValues, 0, slicedSize);
                 break;
             default:
                 slicedArray = new ArrayValueImpl(new Object[slicedSize], new BArrayType(this.elementType));

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ArrayValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ArrayValueImpl.java
@@ -31,6 +31,7 @@ import io.ballerina.runtime.api.values.BValue;
 import io.ballerina.runtime.internal.CycleUtils;
 import io.ballerina.runtime.internal.TypeChecker;
 import io.ballerina.runtime.internal.types.BArrayType;
+import io.ballerina.runtime.internal.types.BIntersectionType;
 import io.ballerina.runtime.internal.util.exceptions.BLangExceptionHelper;
 import io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons;
 import io.ballerina.runtime.internal.util.exceptions.BallerinaException;
@@ -822,6 +823,12 @@ public class ArrayValueImpl extends AbstractArrayValue {
                 System.arraycopy(bStringValues, (int) startIndex, slicedArray.bStringValues, 0, slicedSize);
                 break;
             default:
+                if (this.elementType.getTag() == TypeTags.INTERSECTION_TAG) {
+                    Type slicedArrayElementType = ((BIntersectionType) this.elementType).getConstituentTypes().get(0);
+                    slicedArray = new ArrayValueImpl(new Object[slicedSize], new BArrayType(slicedArrayElementType));
+                    System.arraycopy(refValues, (int) startIndex, slicedArray.refValues, 0, slicedSize);
+                    break;
+                }
                 slicedArray = new ArrayValueImpl(new Object[slicedSize], new BArrayType(this.elementType));
                 System.arraycopy(refValues, (int) startIndex, slicedArray.refValues, 0, slicedSize);
                 break;

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ArrayValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ArrayValueImpl.java
@@ -41,9 +41,11 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.StringJoiner;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static io.ballerina.runtime.api.constants.RuntimeConstants.ARRAY_LANG_LIB;
@@ -822,13 +824,18 @@ public class ArrayValueImpl extends AbstractArrayValue {
                 slicedArray = new ArrayValueImpl(new BString[slicedSize], false);
                 System.arraycopy(bStringValues, (int) startIndex, slicedArray.bStringValues, 0, slicedSize);
                 break;
+            case TypeTags.INTERSECTION_TAG:
+                List<Type> constituentTypes = ((BIntersectionType) this.elementType).getConstituentTypes();
+                List<Type> slicedArrayElementTypes = constituentTypes.stream()
+                                        .filter(arrayElementType -> arrayElementType.getTag() != TypeTags.READONLY_TAG)
+                                        .collect(Collectors.toList());
+                Type slicedArrayElementType = (slicedArrayElementTypes.size() != 1) ?
+                        ((BIntersectionType) slicedArrayElementTypes).getEffectiveType() :
+                        slicedArrayElementTypes.get(0);
+                slicedArray = new ArrayValueImpl(new Object[slicedSize], new BArrayType(slicedArrayElementType));
+                System.arraycopy(refValues, (int) startIndex, slicedArray.refValues, 0, slicedSize);
+                break;
             default:
-                if (this.elementType.getTag() == TypeTags.INTERSECTION_TAG) {
-                    Type slicedArrayElementType = ((BIntersectionType) this.elementType).getConstituentTypes().get(0);
-                    slicedArray = new ArrayValueImpl(new Object[slicedSize], new BArrayType(slicedArrayElementType));
-                    System.arraycopy(refValues, (int) startIndex, slicedArray.refValues, 0, slicedSize);
-                    break;
-                }
                 slicedArray = new ArrayValueImpl(new Object[slicedSize], new BArrayType(this.elementType));
                 System.arraycopy(refValues, (int) startIndex, slicedArray.refValues, 0, slicedSize);
                 break;

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ArrayValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ArrayValueImpl.java
@@ -801,24 +801,24 @@ public class ArrayValueImpl extends AbstractArrayValue {
             case TypeTags.UNSIGNED32_INT_TAG:
             case TypeTags.UNSIGNED16_INT_TAG:
             case TypeTags.UNSIGNED8_INT_TAG:
-                slicedArray = new ArrayValueImpl(new long[slicedSize], arrayType.isReadOnly());
+                slicedArray = new ArrayValueImpl(new long[slicedSize], false);
                 System.arraycopy(intValues, (int) startIndex, slicedArray.intValues, 0, slicedSize);
                 break;
             case TypeTags.BOOLEAN_TAG:
-                slicedArray = new ArrayValueImpl(new boolean[slicedSize], arrayType.isReadOnly());
+                slicedArray = new ArrayValueImpl(new boolean[slicedSize], false);
                 System.arraycopy(booleanValues, (int) startIndex, slicedArray.booleanValues, 0, slicedSize);
                 break;
             case TypeTags.BYTE_TAG:
-                slicedArray = new ArrayValueImpl(new byte[slicedSize], arrayType.isReadOnly());
+                slicedArray = new ArrayValueImpl(new byte[slicedSize], false);
                 System.arraycopy(byteValues, (int) startIndex, slicedArray.byteValues, 0, slicedSize);
                 break;
             case TypeTags.FLOAT_TAG:
-                slicedArray = new ArrayValueImpl(new double[slicedSize], arrayType.isReadOnly());
+                slicedArray = new ArrayValueImpl(new double[slicedSize], false);
                 System.arraycopy(floatValues, (int) startIndex, slicedArray.floatValues, 0, slicedSize);
                 break;
             case TypeTags.STRING_TAG:
             case TypeTags.CHAR_STRING_TAG:
-                slicedArray = new ArrayValueImpl(new BString[slicedSize], arrayType.isReadOnly());
+                slicedArray = new ArrayValueImpl(new BString[slicedSize], false);
                 System.arraycopy(bStringValues, (int) startIndex, slicedArray.bStringValues, 0, slicedSize);
                 break;
             default:

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibArrayTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibArrayTest.java
@@ -150,10 +150,16 @@ public class LangLibArrayTest {
                 {"testModificationAfterSliceOfReadonlyBooleanArray"},
                 {"testModificationAfterSliceOfReadonlyByteArray"},
                 {"testModificationAfterSliceOfReadonlyFloatArray"},
-                {"testModificationAfterSliceOfReadonlyRecordArray"},
-                {"testSliceOfIntersectionOfReadonlyRecordArray"},
-                {"testPushAfterSliceOfReadonlyMapArray"}
+                {"testSliceOfIntersectionOfReadonlyRecordArray"}
         };
+    }
+
+    @Test(expectedExceptions = BLangRuntimeException.class,
+            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.array}InherentTypeViolation " +
+                    "\\{\"message\":\"incompatible types: expected '\\(Employee & readonly\\)', found 'Employee'\"}.*")
+    public void testModificationAfterSliceOfReadonlyRecordArray() {
+        BRunUtil.invoke(compileResult, "testModificationAfterSliceOfReadonlyRecordArray");
+        Assert.fail();
     }
 
     @Test
@@ -187,6 +193,15 @@ public class LangLibArrayTest {
         assertEquals(arr.getInt(0), 4);
         assertEquals(arr.getInt(1), 5);
         assertEquals(arr.getInt(2), 88);
+    }
+
+    @Test(expectedExceptions = BLangRuntimeException.class,
+            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.array}InherentTypeViolation " +
+                    "\\{\"message\":\"incompatible types: expected '\\(map<string> & readonly\\)', " +
+                    "found 'map<string>'\"}.*")
+    public void testPushAfterSliceOfReadonlyMapArray() {
+        BRunUtil.invoke(compileResult, "testPushAfterSliceOfReadonlyMapArray");
+        Assert.fail();
     }
 
     @Test

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibArrayTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibArrayTest.java
@@ -151,6 +151,7 @@ public class LangLibArrayTest {
                 {"testModificationAfterSliceOfReadonlyByteArray"},
                 {"testModificationAfterSliceOfReadonlyFloatArray"},
                 {"testModificationAfterSliceOfReadonlyRecordArray"},
+                {"testSliceOfIntersectionOfReadonlyRecordArray"},
                 {"testPushAfterSliceOfReadonlyMapArray"}
         };
     }

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibArrayTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibArrayTest.java
@@ -145,11 +145,13 @@ public class LangLibArrayTest {
     @DataProvider(name = "testSliceOfReadonlyArrays")
     public Object[] testSliceOfReadonlyArrays() {
         return new Object[][]{
-                {"testSliceOfReadonlyIntArray"},
-                {"testSliceOfReadonlyStringArray"},
-                {"testSliceOfReadonlyBooleanArray"},
-                {"testSliceOfReadonlyByteArray"},
-                {"testSliceOfReadonlyFloatArray"}
+                {"testModificationAfterSliceOfReadonlyIntArray"},
+                {"testModificationAfterSliceOfReadonlyStringArray"},
+                {"testModificationAfterSliceOfReadonlyBooleanArray"},
+                {"testModificationAfterSliceOfReadonlyByteArray"},
+                {"testModificationAfterSliceOfReadonlyFloatArray"},
+                {"testModificationAfterSliceOfReadonlyRecordArray"},
+                {"testPushAfterSliceOfReadonlyMapArray"}
         };
     }
 

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibArrayTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibArrayTest.java
@@ -137,6 +137,20 @@ public class LangLibArrayTest {
         assertEquals(((BInteger) result.getRefValue(5)).intValue(), 2);
     }
 
+    @Test(dataProvider = "testSliceOfReadonlyArrays")
+    public void testSliceOfReadonlyArray(String funcName) {
+        BRunUtil.invoke(compileResult, funcName);
+    }
+
+    @DataProvider(name = "testSliceOfReadonlyArrays")
+    public Object[] testSliceOfReadonlyArrays() {
+        return new Object[][]{
+                {"testSliceOfReadonlyIntArray"},
+                {"testSliceOfReadonlyStringArray"},
+                {"testSliceOfReadonlyBooleanArray"}
+        };
+    }
+
     @Test
     public void testPushAfterSlice() {
         BValue[] returns = BRunUtil.invokeFunction(compileResult, "testPushAfterSlice");

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibArrayTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibArrayTest.java
@@ -147,7 +147,9 @@ public class LangLibArrayTest {
         return new Object[][]{
                 {"testSliceOfReadonlyIntArray"},
                 {"testSliceOfReadonlyStringArray"},
-                {"testSliceOfReadonlyBooleanArray"}
+                {"testSliceOfReadonlyBooleanArray"},
+                {"testSliceOfReadonlyByteArray"},
+                {"testSliceOfReadonlyFloatArray"}
         };
     }
 

--- a/langlib/langlib-test/src/test/resources/test-src/arraylib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/arraylib_test.bal
@@ -113,7 +113,6 @@ function testModificationAfterSliceOfReadonlyRecordArray() {
     readonly & Employee[] arr = [{name: "John Doe", age: 25, designation: "Software Engineer"}];
     Employee[] s = arr.slice(0);
     s[0] = {name: "Jane Doe", age: 27, designation: "UX Engineer"};
-    assertValueEquality([{name: "Jane Doe", age: 27, designation: "UX Engineer"}], s);
 }
 
 type Person2 record {
@@ -158,7 +157,6 @@ function testPushAfterSliceOfReadonlyMapArray() {
     readonly & map<string>[] arr = [{x: "a"}, {y: "b"}];
     map<string>[] r = arr.slice(1);
     r.push({z: "c"});
-    assertValueEquality([{y: "b"}, {z: "c"}], r);
 }
 
 function testSliceOnTupleWithRestDesc() {

--- a/langlib/langlib-test/src/test/resources/test-src/arraylib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/arraylib_test.bal
@@ -74,39 +74,46 @@ function testSlice() returns [float[], int, float[], int, float[], int] {
     return [r1, r1.length(), r2, r2.length(), r3, r3.length()];
 }
 
-function testSliceOfReadonlyIntArray() {
+function testModificationAfterSliceOfReadonlyIntArray() {
     readonly & int[] a = [1, 2, 3, 4, 5];
     int[] b = a.slice(2, 4);
     b[0] = 7;
     assertValueEquality([7, 4], b);
 }
 
-function testSliceOfReadonlyStringArray() {
+function testModificationAfterSliceOfReadonlyStringArray() {
     readonly & string[] roNames = ["x"];
     string[] rwNames = roNames.slice(0);
     rwNames[0] = "y";
     assertValueEquality(["y"], rwNames);
 }
 
-function testSliceOfReadonlyBooleanArray() {
+function testModificationAfterSliceOfReadonlyBooleanArray() {
     readonly & boolean[] a = [true, false, true, true];
     boolean[] b = a.slice(2);
     b[1] = false;
     assertValueEquality([true, false], b);
 }
 
-function testSliceOfReadonlyByteArray() {
+function testModificationAfterSliceOfReadonlyByteArray() {
     readonly & byte[] a = [1, 2, 3];
     byte[] b = a.slice(1);
     b[1] = 4;
     assertValueEquality([2, 4], b);
 }
 
-function testSliceOfReadonlyFloatArray() {
+function testModificationAfterSliceOfReadonlyFloatArray() {
     readonly & float[] f = [1.2, 3.4, 5, 7.3, 9.47];
     float[] g = f.slice(2, 4);
     g[2] = 6.78;
     assertValueEquality([5.0, 7.3, 6.78], g);
+}
+
+function testModificationAfterSliceOfReadonlyRecordArray() {
+    readonly & Employee[] arr = [{name: "John Doe", age: 25, designation: "Software Engineer"}];
+    Employee[] s = arr.slice(0);
+    s[0] = {name: "Jane Doe", age: 27, designation: "UX Engineer"};
+    assertValueEquality([{name: "Jane Doe", age: 27, designation: "UX Engineer"}], s);
 }
 
 function testPushAfterSlice() returns [int, int, float[]] {
@@ -125,6 +132,13 @@ function testPushAfterSliceFixed() returns [int, int, int[]] {
      s.push(88);
      int slp = s.length();
      return [sl, slp, s];
+}
+
+function testPushAfterSliceOfReadonlyMapArray() {
+    readonly & map<string>[] arr = [{x: "a"}, {y: "b"}];
+    map<string>[] r = arr.slice(1);
+    r.push({z: "c"});
+    assertValueEquality([{y: "b"}, {z: "c"}], r);
 }
 
 function testSliceOnTupleWithRestDesc() {

--- a/langlib/langlib-test/src/test/resources/test-src/arraylib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/arraylib_test.bal
@@ -116,6 +116,26 @@ function testModificationAfterSliceOfReadonlyRecordArray() {
     assertValueEquality([{name: "Jane Doe", age: 27, designation: "UX Engineer"}], s);
 }
 
+type Person2 record {
+    int id;
+    string name;
+    int age;
+};
+
+type Student2 record {
+    int id;
+    string name;
+    string school;
+    float average;
+};
+
+function testSliceOfIntersectionOfReadonlyRecordArray() {
+    readonly & (readonly & Person2 & Student2)[] ps = [{id: 16158, name: "Arun", age: 12, average: 89.9, school: "JHC"}];
+    (readonly & Person2 & Student2)[] s = ps.slice(0);
+    s[0] = {id: 175149, name: "Roy", age: 12, school: "RC", average: 84.9};
+    assertValueEquality([{id: 175149, name: "Roy", age: 12, school: "RC", average: 84.9}], s);
+}
+
 function testPushAfterSlice() returns [int, int, float[]] {
      float[] arr = [12.34, 23.45, 34.56, 45.67, 56.78];
      float[] s = arr.slice(1, 4);

--- a/langlib/langlib-test/src/test/resources/test-src/arraylib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/arraylib_test.bal
@@ -95,6 +95,20 @@ function testSliceOfReadonlyBooleanArray() {
     assertValueEquality([true, false], b);
 }
 
+function testSliceOfReadonlyByteArray() {
+    readonly & byte[] a = [1, 2, 3];
+    byte[] b = a.slice(1);
+    b[1] = 4;
+    assertValueEquality([2, 4], b);
+}
+
+function testSliceOfReadonlyFloatArray() {
+    readonly & float[] f = [1.2, 3.4, 5, 7.3, 9.47];
+    float[] g = f.slice(2, 4);
+    g[2] = 6.78;
+    assertValueEquality([5.0, 7.3, 6.78], g);
+}
+
 function testPushAfterSlice() returns [int, int, float[]] {
      float[] arr = [12.34, 23.45, 34.56, 45.67, 56.78];
      float[] s = arr.slice(1, 4);

--- a/langlib/langlib-test/src/test/resources/test-src/arraylib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/arraylib_test.bal
@@ -74,6 +74,27 @@ function testSlice() returns [float[], int, float[], int, float[], int] {
     return [r1, r1.length(), r2, r2.length(), r3, r3.length()];
 }
 
+function testSliceOfReadonlyIntArray() {
+    readonly & int[] a = [1, 2, 3, 4, 5];
+    int[] b = a.slice(2, 4);
+    b[0] = 7;
+    assertValueEquality([7, 4], b);
+}
+
+function testSliceOfReadonlyStringArray() {
+    readonly & string[] roNames = ["x"];
+    string[] rwNames = roNames.slice(0);
+    rwNames[0] = "y";
+    assertValueEquality(["y"], rwNames);
+}
+
+function testSliceOfReadonlyBooleanArray() {
+    readonly & boolean[] a = [true, false, true, true];
+    boolean[] b = a.slice(2);
+    b[1] = false;
+    assertValueEquality([true, false], b);
+}
+
 function testPushAfterSlice() returns [int, int, float[]] {
      float[] arr = [12.34, 23.45, 34.56, 45.67, 56.78];
      float[] s = arr.slice(1, 4);


### PR DESCRIPTION
## Purpose
> Slice of a readonly array should not needed to be a readonly array. This PR will fix the readonly-ness of the sliced arrays which are obtained from readonly arrays. 

Fixes #30353

## Approach

## Samples

## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
