### PR TITLE
Fix using type refs as the typedesc symbol for vars/fields referring to a function

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
@@ -248,7 +248,8 @@ public class SymbolFactory {
             builder.withAnnotation(createAnnotationSymbol(annAttachment.annotationSymbol));
         }
 
-        return builder.withTypeDescriptor((FunctionTypeSymbol) typesFactory.getTypeDescriptor(invokableSymbol.type))
+        return builder.withTypeDescriptor((FunctionTypeSymbol) typesFactory
+                .getTypeDescriptor(invokableSymbol.type, invokableSymbol.type.tsymbol, true))
                 .build();
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolAtCursorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolAtCursorTest.java
@@ -18,7 +18,10 @@
 package io.ballerina.semantic.api.test;
 
 import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.FunctionSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.SymbolKind;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.projects.Document;
 import io.ballerina.projects.Project;
 import io.ballerina.tools.text.LinePosition;
@@ -225,6 +228,29 @@ public class SymbolAtCursorTest {
                 {87, 13, "'new"},
                 {88, 4, "'new"},
                 {88, 9, "'anydata"}
+        };
+    }
+
+    @Test(dataProvider = "VarPosProvider")
+    public void testVarsWithFunctionType(int line, int col, String name) {
+        Project project = BCompileUtil.loadProject("test-src/regression-tests/field_with_function_type.bal");
+        SemanticModel model = getDefaultModulesSemanticModel(project);
+        Document srcFile = getDocumentForSingleSource(project);
+
+        Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, col));
+
+        assertTrue(symbol.isPresent());
+        assertEquals(symbol.get().kind(), SymbolKind.FUNCTION);
+        assertEquals(symbol.get().getName().get(), name);
+        assertEquals(((FunctionSymbol) symbol.get()).typeDescriptor().typeKind(), TypeDescKind.FUNCTION);
+    }
+
+    @DataProvider(name = "VarPosProvider")
+    public Object[][] getVarPos() {
+        return new Object[][]{
+                {19, 10, "union"},
+                {23, 10, "op"},
+                {27, 10, "op"}
         };
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/regression-tests/field_with_function_type.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/regression-tests/field_with_function_type.bal
@@ -1,0 +1,29 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+type BinOp function (int) returns string;
+
+type Foo readonly & record {|
+    BinOp union;
+|};
+
+type Bar object {
+    BinOp op;
+};
+
+function test() {
+    BinOp op = function (int n) returns string => n.toString();
+}


### PR DESCRIPTION
## Purpose
This fixes an issue we had with recent changes introduced for type ref type symbols. The issue was when we had a var/field of a function type and that function type had a type alias, the types factory would attempt to create a type ref symbol. With this PR, that behaviour is changed for the function symbol builder. Now the function symbol builder calls the types factory API explicitly stating not to get the type ref.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
