### PR TITLE
Fix two issues with isolation analysis

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/IsolationAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/IsolationAnalyzer.java
@@ -2607,6 +2607,14 @@ public class IsolationAnalyzer extends BLangNodeVisitor {
                 return false;
             }
 
+            if (isCloneOrCloneReadOnlyInvocation(invocation)) {
+                return false;
+            }
+
+            if (!invokedOnSelf && invocation.type.tag == TypeTags.NIL) {
+                return !transferOut;
+            }
+
             return isInvalidTransfer(parentExpression, transferOut, invokedOnSelf);
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/IsolationAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/IsolationAnalyzer.java
@@ -2558,10 +2558,6 @@ public class IsolationAnalyzer extends BLangNodeVisitor {
                     BLangExpression varRef = ((BLangAssignment) parent).varRef;
 
                     if (varRef.getKind() != NodeKind.SIMPLE_VARIABLE_REF) {
-                        if (invokedOnSelf) {
-                            return !isIsolatedExpression(expression, false);
-                        }
-
                         // Will be validated for that expression.
                         return false;
                     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/isolation/IsolatedObjectTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/isolation/IsolatedObjectTest.java
@@ -234,6 +234,9 @@ public class IsolatedObjectTest {
         validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 666, 24);
         validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 667, 20);
         validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 673, 17);
+        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 686, 13);
+        validateError(result, i++, ERROR_INVALID_TRANSFER_OUT_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 687, 17);
+        validateError(result, i++, ERROR_INVALID_TRANSFER_OUT_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 688, 20);
         Assert.assertEquals(result.getErrorCount(), i);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/isolation/IsolatedObjectTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/isolation/IsolatedObjectTest.java
@@ -225,6 +225,15 @@ public class IsolatedObjectTest {
                 "'lock' statement", 592, 13);
         validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 614, 13);
         validateError(result, i++, ERROR_INVALID_TRANSFER_OUT_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 621, 13);
+        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 642, 13);
+        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 643, 13);
+        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 644, 24);
+        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 652, 17);
+        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 664, 13);
+        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 665, 13);
+        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 666, 24);
+        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 667, 20);
+        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 673, 17);
         Assert.assertEquals(result.getErrorCount(), i);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/isolation/IsolatedVariableTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/isolation/IsolatedVariableTest.java
@@ -118,6 +118,9 @@ public class IsolatedVariableTest {
         validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 307, 20);
         validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 308, 16);
         validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 314, 13);
+        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 323, 9);
+        validateError(result, i++, ERROR_INVALID_TRANSFER_OUT_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 324, 13);
+        validateError(result, i++, ERROR_INVALID_TRANSFER_OUT_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 325, 16);
         Assert.assertEquals(result.getErrorCount(), i);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/isolation/IsolatedVariableTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/isolation/IsolatedVariableTest.java
@@ -113,6 +113,11 @@ public class IsolatedVariableTest {
         validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 281, 22);
         validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 287, 22);
         validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 288, 39);
+        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 305, 9);
+        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 306, 9);
+        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 307, 20);
+        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 308, 16);
+        validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 314, 13);
         Assert.assertEquals(result.getErrorCount(), i);
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/isolated-objects/isolated_objects.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/isolated-objects/isolated_objects.bal
@@ -710,6 +710,27 @@ var isolatedObjectWithInvalidCopyInInMethodCall = isolated object {
     }
 };
 
+isolated class IsolatedClassAssigningProtectedFieldsToLocalVars {
+    private map<int> m = {};
+
+    isolated function baz() returns map<int>[] {
+        map<int>[] y = [];
+        map<int> z;
+        lock {
+            map<int>[] y2 = [self.m];
+            y2[0] = self.m;
+            y2.push(self.m);
+
+            map<int>[] y3 = y.clone();
+            y3[0] = self.m;
+
+            z = self.m.clone();
+
+            return y2.cloneReadOnly();
+        }
+    }
+}
+
 function assertTrue(any|error actual) {
     assertEquality(true, actual);
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/isolated-objects/isolated_objects_isolation_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/isolated-objects/isolated_objects_isolation_negative.bal
@@ -13,7 +13,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-
+import ballerina/lang.array;
 isolated class InvalidIsolatedClassWithNonPrivateMutableFields {
     int a;
     public map<int> b;
@@ -631,3 +631,46 @@ public isolated class IsolatedClassWithBoundMethodAccess {
     isolated function baz() {
     }
 }
+
+isolated class IsolatedClassWithInvalidCopyInInMethodCall {
+    private map<int> m = {};
+
+    isolated function baz() returns map<int>[] {
+        map<int>[] y = [];
+
+        lock {
+            y[0] = self.m;
+            y.push(self.m);
+            array:push(y, self.m);
+        }
+
+        return y;
+    }
+
+    function qux(map<int[]> y) {
+        lock {
+            _ = y.remove(self.m["a"].toString());
+        }
+    }
+}
+
+var isolatedObjectWithInvalidCopyInInMethodCall = isolated object {
+    private map<int> m = {};
+
+    isolated function baz() returns map<int>[] {
+        map<int>[] y = [];
+
+        lock {
+            y[0] = self.m;
+            y.push(self.m);
+            array:push(y, self.m);
+            return y;
+        }
+    }
+
+    function qux(map<int[]> y) {
+        lock {
+            _ = y.remove(self.m["a"].toString());
+        }
+    }
+};

--- a/tests/jballerina-unit-test/src/test/resources/test-src/isolated-objects/isolated_objects_isolation_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/isolated-objects/isolated_objects_isolation_negative.bal
@@ -674,3 +674,18 @@ var isolatedObjectWithInvalidCopyInInMethodCall = isolated object {
         }
     }
 };
+
+isolated class IsolatedClassWithInvalidCopyOut2 {
+    private map<int> m = {};
+
+    isolated function baz() returns map<int>[] {
+        map<int>[] y = [];
+        map<int> z;
+        lock {
+            map<int>[] y2 = [];
+            y[0] = self.m;
+            z = self.m;
+            return y2;
+        }
+    }
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/isolated-variables/isolated_variables.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/isolated-variables/isolated_variables.bal
@@ -164,3 +164,14 @@ function copyInInMethodCall2(map<int[]> y) {
         _ = y.clone().remove(isolatedModuleLevelMap["a"].toString());
     }
 }
+
+function copyOutAccessingIsolatedVar() returns map<int>[] {
+     map<int>[] y = [];
+     map<int> z;
+     lock {
+         map<int>[] y2 = [];
+         y2[0] = isolatedModuleLevelMap;
+         z = isolatedModuleLevelMap.cloneReadOnly();
+         return y2.clone();
+     }
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/isolated-variables/isolated_variables.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/isolated-variables/isolated_variables.bal
@@ -14,6 +14,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/lang.array;
+
 int[] a = getIntArray();
 
 isolated int[][] b = [a.cloneReadOnly(), getIntArray()];
@@ -139,4 +141,26 @@ function testValidTransferInAsArgInLockAccessingIsolatedVar(int[] n) {
 
 isolated function update(int[][] x, int[] y) {
     x.push(y);
+}
+
+isolated map<int> isolatedModuleLevelMap = {};
+
+isolated function copyInInMethodCall1() returns map<int>[] {
+    map<int>[] y = [];
+
+    lock {
+        map<int>[] y2 = y.clone();
+        y2[0] = isolatedModuleLevelMap;
+        y.clone().push(isolatedModuleLevelMap);
+        array:push(y.clone(), isolatedModuleLevelMap);
+        array:push(y2, isolatedModuleLevelMap);
+    }
+
+    return y;
+}
+
+function copyInInMethodCall2(map<int[]> y) {
+    lock {
+        _ = y.clone().remove(isolatedModuleLevelMap["a"].toString());
+    }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/isolated-variables/isolated_variables_isolation_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/isolated-variables/isolated_variables_isolation_negative.bal
@@ -13,9 +13,9 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+import ballerina/lang.array;
 
 int[] a = getIntArray();
-
 isolated int[][] b = [a, getIntArray()];
 
 isolated record {
@@ -295,3 +295,22 @@ class NonIsolatedClass {
 }
 
 isolated function getMemberUsingSelf(NonIsolatedClass cl) returns int[] => cl.getMemberInternal();
+
+isolated map<int> isolatedModuleLevelMap = {};
+
+isolated function invalidCopyInInMethodCall1() returns map<int>[] {
+    map<int>[] y = [];
+
+    lock {
+        y[0] = isolatedModuleLevelMap;
+        y.push(isolatedModuleLevelMap);
+        array:push(y, isolatedModuleLevelMap);
+        return y;
+    }
+}
+
+function invalidCopyInInMethodCall2(map<int[]> y) {
+    lock {
+        _ = y.remove(isolatedModuleLevelMap["a"].toString());
+    }
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/isolated-variables/isolated_variables_isolation_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/isolated-variables/isolated_variables_isolation_negative.bal
@@ -314,3 +314,14 @@ function invalidCopyInInMethodCall2(map<int[]> y) {
         _ = y.remove(isolatedModuleLevelMap["a"].toString());
     }
 }
+
+function invalidCopyOutAccessingIsolatedVar() returns map<int>[] {
+    map<int>[] y = [];
+    map<int> z;
+    lock {
+        map<int>[] y2 = [];
+        y[0] = isolatedModuleLevelMap;
+        z = isolatedModuleLevelMap;
+        return y2;
+    }
+}


### PR DESCRIPTION
## Purpose
Fix the following issues.

Fixes #30720 - No error for method call expression when the method is called on an expression that is an invalid transfer in
Fixes #30726 - Valid assignment to a local variable in a lock statement that accesses a protected variable is disallowed

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
