### PR TITLE
Fix NPE

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/BuildCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/BuildCommand.java
@@ -167,9 +167,6 @@ public class BuildCommand implements BLauncherCmd {
     @CommandLine.Option(names = "--cloud", description = "Enable cloud artifact generation")
     private String cloud;
 
-    @CommandLine.Option(names = "--taint-check", description = "perform taint flow analysis")
-    private Boolean taintCheck;
-
     @CommandLine.Option(names = "--includes", hidden = true,
             description = "hidden option for code coverage to include all classes")
     private String includes;
@@ -314,7 +311,6 @@ public class BuildCommand implements BLauncherCmd {
                 .testReport(testReport)
                 .observabilityIncluded(observabilityIncluded)
                 .cloud(cloud)
-                .taintCheck(taintCheck)
                 .dumpBir(dumpBIR)
                 .dumpBirFile(dumpBIRFile)
                 .listConflictedClasses(listConflictedClasses)
@@ -342,7 +338,7 @@ public class BuildCommand implements BLauncherCmd {
 
     @Override
     public void printUsage(StringBuilder out) {
-        out.append("  bal build [-o <output>] [--offline] [--skip-tests] [--taint-check]\\n\" +\n" +
+        out.append("  bal build [-o <output>] [--offline] [--skip-tests]\\n\" +\n" +
                 "            \"                    [<ballerina-file | package-path>]");
     }
 

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/RunCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/RunCommand.java
@@ -80,10 +80,7 @@ public class RunCommand implements BLauncherCmd {
             "when run is used with a source file or a module.")
     private Boolean observabilityIncluded;
 
-    @CommandLine.Option(names = "--taint-check", description = "perform taint flow analysis")
-    private Boolean taintCheck;
-
-    private static final String runCmd = "bal run [--experimental] [--offline] [--taint-check]\n" +
+    private static final String runCmd = "bal run [--experimental] [--offline]\n" +
             "                  [<executable-jar | ballerina-file | package-path>] [-- program-args...]";
 
     public RunCommand() {
@@ -201,7 +198,6 @@ public class RunCommand implements BLauncherCmd {
                 .skipTests(true)
                 .testReport(false)
                 .observabilityIncluded(observabilityIncluded)
-                .taintCheck(taintCheck)
                 .build();
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BuildOptionsBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BuildOptionsBuilder.java
@@ -83,11 +83,6 @@ public class BuildOptionsBuilder {
         return this;
     }
 
-    public BuildOptionsBuilder taintCheck(Boolean value) {
-        compilationOptionsBuilder.taintCheck(value);
-        return this;
-    }
-
     public BuildOptions build() {
         CompilationOptions compilationOptions = compilationOptionsBuilder.build();
         return new BuildOptions(testReport, codeCoverage, compilationOptions);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/CompilationOptions.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/CompilationOptions.java
@@ -32,12 +32,11 @@ class CompilationOptions {
     private Boolean dumpBir;
     private String dumpBirFile;
     private String cloud;
-    private Boolean taintCheck;
     private Boolean listConflictedClasses;
 
     public CompilationOptions(Boolean skipTests, Boolean offlineBuild, Boolean experimental,
                               Boolean observabilityIncluded, Boolean dumpBir, String dumpBirFile,
-                              String cloud, Boolean taintCheck, Boolean listConflictedClasses) {
+                              String cloud, Boolean listConflictedClasses) {
         this.skipTests = skipTests;
         this.offlineBuild = offlineBuild;
         this.experimental = experimental;
@@ -45,7 +44,6 @@ class CompilationOptions {
         this.dumpBir = dumpBir;
         this.dumpBirFile = dumpBirFile;
         this.cloud = cloud;
-        this.taintCheck = taintCheck;
         this.listConflictedClasses = listConflictedClasses;
     }
 
@@ -77,10 +75,6 @@ class CompilationOptions {
         return cloud;
     }
 
-    public boolean getTaintCheck() {
-        return toBooleanDefaultIfNull(taintCheck);
-    }
-
     public boolean listConflictedClasses() {
         return toBooleanDefaultIfNull(listConflictedClasses);
     }
@@ -104,8 +98,6 @@ class CompilationOptions {
         this.dumpBir = Objects.requireNonNullElseGet(theirOptions.dumpBir, () -> toBooleanDefaultIfNull(this.dumpBir));
         this.cloud = Objects.requireNonNullElse(theirOptions.cloud, toStringDefaultIfNull(this.cloud));
         this.dumpBirFile = theirOptions.dumpBirFile;
-        this.taintCheck = Objects.requireNonNullElseGet(theirOptions.taintCheck,
-                () -> toBooleanDefaultIfNull(this.taintCheck));
         this.listConflictedClasses = Objects.requireNonNullElseGet(
                 theirOptions.listConflictedClasses, () -> toBooleanDefaultIfNull(this.listConflictedClasses));
         return this;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/CompilationOptionsBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/CompilationOptionsBuilder.java
@@ -32,7 +32,6 @@ class CompilationOptionsBuilder {
     private Boolean dumpBir;
     private String dumpBirFile;
     private String cloud;
-    private Boolean taintCheck;
     private Boolean listConflictedClasses;
 
     public CompilationOptionsBuilder() {
@@ -73,11 +72,6 @@ class CompilationOptionsBuilder {
         return this;
     }
 
-    public CompilationOptionsBuilder taintCheck(Boolean value) {
-        taintCheck = value;
-        return this;
-    }
-
     public CompilationOptionsBuilder listConflictedClasses(Boolean value) {
         listConflictedClasses = value;
         return this;
@@ -85,6 +79,6 @@ class CompilationOptionsBuilder {
 
     public CompilationOptions build() {
         return new CompilationOptions(skipTests, buildOffline, experimental, observabilityIncluded, dumpBir,
-                dumpBirFile, cloud, taintCheck, listConflictedClasses);
+                dumpBirFile, cloud, listConflictedClasses);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageCompilation.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageCompilation.java
@@ -44,7 +44,6 @@ import static org.ballerinalang.compiler.CompilerOptionName.EXPERIMENTAL_FEATURE
 import static org.ballerinalang.compiler.CompilerOptionName.OBSERVABILITY_INCLUDED;
 import static org.ballerinalang.compiler.CompilerOptionName.OFFLINE;
 import static org.ballerinalang.compiler.CompilerOptionName.SKIP_TESTS;
-import static org.ballerinalang.compiler.CompilerOptionName.TAINT_CHECK;
 
 /**
  * Compilation at package level by resolving all the dependencies.
@@ -87,7 +86,6 @@ public class PackageCompilation {
         options.put(DUMP_BIR, Boolean.toString(compilationOptions.dumpBir()));
         options.put(DUMP_BIR_FILE, compilationOptions.getBirDumpFile());
         options.put(CLOUD, compilationOptions.getCloud());
-        options.put(TAINT_CHECK, Boolean.toString(compilationOptions.getTaintCheck()));
     }
 
     static PackageCompilation from(PackageContext rootPackageContext) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/CompilerPhaseRunner.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/CompilerPhaseRunner.java
@@ -133,11 +133,6 @@ public class CompilerPhaseRunner {
         }
 
         documentationAnalyze(pkgNode);
-        if (this.stopCompilation(pkgNode, CompilerPhase.TAINT_ANALYZE)) {
-            return;
-        }
-
-        taintAnalyze(pkgNode);
         if (this.stopCompilation(pkgNode, CompilerPhase.CONSTANT_PROPAGATION)) {
             return;
         }
@@ -187,8 +182,6 @@ public class CompilerPhaseRunner {
         if (this.stopCompilation(pkgNode, CompilerPhase.TAINT_ANALYZE)) {
             return;
         }
-
-        taintAnalyze(pkgNode);
     }
 
     public void performLangLibBirGenPhases(BLangPackage pkgNode) {
@@ -231,10 +224,6 @@ public class CompilerPhaseRunner {
 
     private BLangPackage isolationAnalyze(BLangPackage pkgNode) {
         return this.isolationAnalyzer.analyze(pkgNode);
-    }
-
-    private BLangPackage taintAnalyze(BLangPackage pkgNode) {
-        return this.taintAnalyzer.analyze(pkgNode);
     }
 
     private BLangPackage propagateConstants(BLangPackage pkgNode) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ManifestBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ManifestBuilder.java
@@ -416,8 +416,6 @@ public class ManifestBuilder {
         if (topLevelNode != null) {
             cloud = getStringFromTomlTableNode(topLevelNode);
         }
-        boolean taintCheck =
-                getBooleanFromBuildOptionsTableNode(tableNode, CompilerOptionName.TAINT_CHECK.toString());
         boolean listConflictedClasses =
                 getBooleanFromBuildOptionsTableNode(tableNode, CompilerOptionName.LIST_CONFLICTED_CLASSES.toString());
 
@@ -428,7 +426,6 @@ public class ManifestBuilder {
                 .testReport(testReport)
                 .codeCoverage(codeCoverage)
                 .cloud(cloud)
-                .taintCheck(taintCheck)
                 .listConflictedClasses(listConflictedClasses)
                 .build();
     }

--- a/compiler/ballerina-lang/src/main/java/module-info.java
+++ b/compiler/ballerina-lang/src/main/java/module-info.java
@@ -75,5 +75,5 @@ module io.ballerina.lang {
     exports io.ballerina.projects.plugins;
     exports io.ballerina.projects.internal.model; // TODO Remove this exports
     exports io.ballerina.projects.internal.environment; // TODO Remove these exports
-    exports io.ballerina.projects.internal to org.wso2.ballerinalang.compiler.semantics.model.symbols, io.ballerina.cli;
+    exports io.ballerina.projects.internal to io.ballerina.cli;
 }

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/compiler/CompilerOptionName.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/compiler/CompilerOptionName.java
@@ -62,8 +62,6 @@ public enum CompilerOptionName {
 
     EXPERIMENTAL_FEATURES_ENABLED("experimentalFeaturesEnabled"),
 
-    TAINT_CHECK("taintCheck"),
-
     LIST_CONFLICTED_CLASSES("listConflictedClasses"),
 
     /**

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -4175,6 +4175,10 @@ public class CodeAnalyzer extends BLangNodeVisitor {
     }
 
     private BType getErrorTypes(BType bType) {
+        if (bType == null) {
+            return symTable.semanticError;
+        }
+
         BType errorType = symTable.semanticError;
 
         int tag = bType.tag;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TaintAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TaintAnalyzer.java
@@ -1128,7 +1128,8 @@ public class TaintAnalyzer extends BLangNodeVisitor {
         if (varRefExpr.symbol == null) {
             Name varName = names.fromIdNode(varRefExpr.variableName);
             if (varName != Names.IGNORE) {
-                if (varRefExpr.pkgSymbol.tag == SymTag.XMLNS) {
+                // Check xml namespace reference such as ns0:foo, where nso is a xml namespace prefix
+                if (varRefExpr.pkgSymbol != null && varRefExpr.pkgSymbol.tag == SymTag.XMLNS) {
                     getCurrentAnalysisState().taintedStatus = varRefExpr.pkgSymbol.tainted ?
                             TaintedStatus.TAINTED : TaintedStatus.UNTAINTED;
                     return;
@@ -1252,9 +1253,11 @@ public class TaintAnalyzer extends BLangNodeVisitor {
     }
 
     private boolean isExternalLangLibFunction(BLangInvocation invocationExpr) {
-        return invocationExpr.symbol.pkgID.orgName.value.equals("ballerina")
-                && invocationExpr.symbol.pkgID.name.value.startsWith("lang.")
-                && Symbols.isNative(invocationExpr.symbol);
+        BSymbol symbol = invocationExpr.symbol;
+        return symbol != null
+                && symbol.pkgID.orgName.value.equals("ballerina")
+                && symbol.pkgID.name.value.startsWith("lang.")
+                && Symbols.isNative(symbol);
     }
 
     private int receiverIfAttachedFunction(BLangInvocation invocationExpr) {

--- a/langlib/lang.annotations/src/main/ballerina/annotations.bal
+++ b/langlib/lang.annotations/src/main/ballerina/annotations.bal
@@ -21,10 +21,16 @@ public type 'anydata ()|boolean|int|float|decimal|string|xml|'anydata[]|map<'any
 public type 'json ()|boolean|int|float|decimal|string|'json[]|map<'json>;
 
 # Denote that the return value is tainted.
+# # Deprecated
+# @tainted annotation is deprecated as taint checking phase is disabled in `Swan Lake beta`
+@deprecated
 public const annotation tainted on parameter, return, source listener, source var, source type;
 
 # Denote that the return value is untainted, parameter expect untainted value, type cast mark value untainted,
 # denote a listener as producing untainted arguments to service resource params.
+# # Deprecated
+# @tainted annotation is deprecated as taint checking pahse is disabled in `Swan Lake beta`
+@deprecated
 public const annotation untainted on return, parameter, source type, source listener;
 
 # Denotes annotated type is a parametric type.

--- a/langlib/lang.annotations/src/main/ballerina/annotations.bal
+++ b/langlib/lang.annotations/src/main/ballerina/annotations.bal
@@ -21,16 +21,10 @@ public type 'anydata ()|boolean|int|float|decimal|string|xml|'anydata[]|map<'any
 public type 'json ()|boolean|int|float|decimal|string|'json[]|map<'json>;
 
 # Denote that the return value is tainted.
-# # Deprecated
-# @tainted annotation is deprecated as taint checking phase is disabled in `Swan Lake beta`
-@deprecated
 public const annotation tainted on parameter, return, source listener, source var, source type;
 
 # Denote that the return value is untainted, parameter expect untainted value, type cast mark value untainted,
 # denote a listener as producing untainted arguments to service resource params.
-# # Deprecated
-# @tainted annotation is deprecated as taint checking pahse is disabled in `Swan Lake beta`
-@deprecated
 public const annotation untainted on return, parameter, source type, source listener;
 
 # Denotes annotated type is a parametric type.

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/BCompileUtil.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/BCompileUtil.java
@@ -65,7 +65,7 @@ public class BCompileUtil {
         Path projectPath = Paths.get(sourceRoot.toString(), sourceFileName);
 
         BuildOptionsBuilder buildOptionsBuilder = new BuildOptionsBuilder();
-        return ProjectLoader.loadProject(projectPath, buildOptionsBuilder.taintCheck(Boolean.TRUE).build());
+        return ProjectLoader.loadProject(projectPath, buildOptionsBuilder.build());
     }
 
     public static CompileResult compile(String sourceFilePath) {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/builtinoperations/CloneOperationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/builtinoperations/CloneOperationTest.java
@@ -315,7 +315,7 @@ public class CloneOperationTest {
         Assert.assertTrue(results[1] != results[2] && results[0] != results[1] && results[0] != results[2]);
     }
 
-    @Test
+    @Test(enabled = false)
     public void testCloneNegative() {
         Assert.assertEquals(negativeResult.getErrorCount(), 1);
         BAssertUtil.validateError(negativeResult, 0, "too many arguments in call to 'clone()'", 19, 13);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/conversion/NativeConversionNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/conversion/NativeConversionNegativeTest.java
@@ -90,7 +90,7 @@ public class NativeConversionNegativeTest {
         Assert.assertEquals(errorMsg, "'TX[]' value cannot be converted to 'json'");
     }
 
-    @Test(description = "Test passing tainted value with convert")
+    @Test(enabled = false, description = "Test passing tainted value with convert")
     public void testTaintedValue() {
         Assert.assertEquals(taintCheckResult.getErrorCount(), 1);
         BAssertUtil.validateError(taintCheckResult, 0, "tainted value passed to untainted " +

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/mappingconstructor/MappingConstructorExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/mappingconstructor/MappingConstructorExprTest.java
@@ -111,7 +111,7 @@ public class MappingConstructorExprTest {
         validateError(result, 3, "invalid usage of map literal: duplicate key 'i'", 27, 42);
     }
 
-    @Test
+    @Test(enabled = false)
     public void testVarNameFieldTaintAnalysisNegative() {
         CompileResult result = BCompileUtil.compile(
                 "test-src/expressions/mappingconstructor/var_name_field_taint_analysis_negative.bal");
@@ -214,7 +214,7 @@ public class MappingConstructorExprTest {
         validateError(result, 0, "expression is not a constant expression", 19, 47);
     }
 
-    @Test
+    @Test(enabled = false)
     public void testSpreadOpFieldTaintAnalysisNegative() {
         CompileResult result = BCompileUtil.compile(
                 "test-src/expressions/mappingconstructor/spread_op_field_taint_analysis_negative.bal");

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/functions/ExprBodiedFunctionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/functions/ExprBodiedFunctionTest.java
@@ -70,7 +70,7 @@ public class ExprBodiedFunctionTest {
         Assert.assertEquals(result.getErrorCount(), index);
     }
 
-    @Test
+    @Test(enabled = false)
     public void testTaintChecking() {
         CompileResult result = BCompileUtil.compile("test-src/functions/expr_bodied_functions_taint.bal");
         int index = 0;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/vardeclr/ModuleErrorVariableTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/vardeclr/ModuleErrorVariableTest.java
@@ -85,7 +85,7 @@ public class ModuleErrorVariableTest {
         assertEquals(compileResultNegetive.getErrorCount(), index);
     }
 
-    @Test
+    @Test(enabled = false)
     public void testTaintAnalysisWithModuleLevelErrorVar() {
         CompileResult compileResult = BCompileUtil.compile(
                 "test-src/statements/vardeclr/module_error_var_decl_taint_analysis_negetive.bal");

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/vardeclr/ModuleRecordVariableTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/vardeclr/ModuleRecordVariableTest.java
@@ -86,7 +86,7 @@ public class ModuleRecordVariableTest {
         assertEquals(compileResultNegetive.getErrorCount(), index);
     }
 
-    @Test
+    @Test(enabled = false)
     public void testTaintAnalysisWithModuleLevelRecordVar() {
         CompileResult compileResult = BCompileUtil.compile(
                 "test-src/statements/vardeclr/module_record_var_decl_taint_analysis_negetive.bal");

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/vardeclr/ModuleTupleVariableTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/vardeclr/ModuleTupleVariableTest.java
@@ -85,7 +85,7 @@ public class ModuleTupleVariableTest {
         assertEquals(compileResultNegative.getErrorCount(), index);
     }
 
-    @Test
+    @Test(enabled = false)
     public void testTaintAnalysisWithModuleLevelTupleVar() {
         CompileResult compileResult = BCompileUtil.compile(
                 "test-src/statements/vardeclr/module_tuple_var_decl_taint_analysis_negetive.bal");

--- a/tests/jballerina-unit-test/src/test/resources/testng.xml
+++ b/tests/jballerina-unit-test/src/test/resources/testng.xml
@@ -113,7 +113,6 @@
 
             <package name="org.ballerinalang.test.strand.*"/>
             <package name="org.ballerinalang.test.structs.*"/>
-            <package name="org.ballerinalang.test.taintchecking.*"/>
             <package name="org.ballerinalang.test.testerina.*"/>
             <package name="org.ballerinalang.test.typedefs.*"/>
 


### PR DESCRIPTION
## Purpose
Disable taint-checking phase from running. 
Before this PR, we had disabled taint-error emitting with a flag, however the taint-checking phase used to run for all the compilations to generate taint-tables.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/30729

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
