### PR TITLE
Add an API for checking if an object type is compatible with `Listener`

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaClassSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaClassSymbol.java
@@ -62,6 +62,7 @@ public class BallerinaClassSymbol extends BallerinaSymbol implements ClassSymbol
     private final Documentation docAttachment;
     private MethodSymbol initMethod;
     private Map<String, ClassFieldSymbol> classFields;
+    private Boolean isListenerCompatible;
 
     protected BallerinaClassSymbol(CompilerContext context, String name, List<Qualifier> qualifiers,
                                    List<AnnotationSymbol> annots, ObjectTypeSymbol typeDescriptor,
@@ -127,6 +128,17 @@ public class BallerinaClassSymbol extends BallerinaSymbol implements ClassSymbol
     @Override
     public TypeDescKind typeKind() {
         return TypeDescKind.OBJECT;
+    }
+
+    @Override
+    public boolean isCompatibleListenerType() {
+        if (this.isListenerCompatible != null) {
+            return this.isListenerCompatible;
+        }
+
+        Types types = Types.getInstance(this.context);
+        this.isListenerCompatible = types.checkListenerCompatibility(this.getBType());
+        return this.isListenerCompatible;
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectTypeSymbol.java
@@ -25,6 +25,7 @@ import io.ballerina.compiler.api.symbols.ObjectTypeSymbol;
 import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
+import org.wso2.ballerinalang.compiler.semantics.analyzer.Types;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BAttachedFunction;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BObjectTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BResourceFunction;
@@ -57,6 +58,7 @@ public class BallerinaObjectTypeSymbol extends AbstractTypeSymbol implements Obj
     private Map<String, ObjectFieldSymbol> objectFields;
     private Map<String, MethodSymbol> methods;
     private List<TypeSymbol> typeInclusions;
+    private Boolean isListenerCompatible;
 
     public BallerinaObjectTypeSymbol(CompilerContext context, ModuleID moduleID, BObjectType objectType) {
         super(context, TypeDescKind.OBJECT, objectType);
@@ -145,6 +147,17 @@ public class BallerinaObjectTypeSymbol extends AbstractTypeSymbol implements Obj
         }
 
         return this.typeInclusions;
+    }
+
+    @Override
+    public boolean isCompatibleListenerType() {
+        if (this.isListenerCompatible != null) {
+            return this.isListenerCompatible;
+        }
+
+        Types types = Types.getInstance(this.context);
+        this.isListenerCompatible = types.checkListenerCompatibility(this.getBType());
+        return this.isListenerCompatible;
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/ObjectTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/ObjectTypeSymbol.java
@@ -50,4 +50,12 @@ public interface ObjectTypeSymbol extends TypeSymbol, Qualifiable {
      * @return The list of included object types
      */
     List<TypeSymbol> typeInclusions();
+
+    /**
+     * Checks whether this object type can be used in a listener declaraion. i.e., whether this object type is a subtype
+     * of the builtin `Listener` type.
+     *
+     * @return Returns true if this type is a subtype of `Listener`
+     */
+    boolean isCompatibleListenerType();
 }

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/service_with_multiple_listeners.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/service_with_multiple_listeners.bal
@@ -39,6 +39,7 @@ public class FooListener {
 }
 
 public class BarListener {
+    *Listener;
 
     public function 'start() returns error? {
     }
@@ -47,6 +48,44 @@ public class BarListener {
     }
 
     public function immediateStop() returns error? {
+    }
+
+    public function detach(service object {} s) returns error? {
+    }
+
+    public function attach(service object {} s, string[]? name = ()) returns error? {
+    }
+}
+
+public type Listener object {
+    public function 'start() returns error?;
+
+    public function gracefulStop() returns error?;
+
+    public function immediateStop() returns error?;
+
+    public function detach(service object {} s) returns error?;
+
+    public function attach(service object {} s, string[]? name = ()) returns error?;
+};
+
+public type IncompatibleListener object {
+    public function 'start() returns error?;
+
+    public function immediateStop() returns error?;
+
+    public function detach(service object {} s) returns error?;
+
+    public function attach(service object {} s, string[]? name = ()) returns error?;
+};
+
+
+public class IncompatibleListenerClass {
+
+    public function 'start() returns error? {
+    }
+
+    public function gracefulStop() returns error? {
     }
 
     public function detach(service object {} s) returns error? {


### PR DESCRIPTION
## Purpose
This PR introduces a new method to `ObjectTypeSymbol` for checking whether the object type can be used in a listener declaration context.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
