### PR TITLE
Add a temporary fix for the stackoverflow issue caused by cyclic dependencies

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticWarningCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticWarningCode.java
@@ -55,6 +55,7 @@ public enum DiagnosticWarningCode implements DiagnosticCode {
     FUNCTION_CAN_BE_MARKED_ISOLATED("BCE20300", "function.can.be.marked.isolated"),
 
     COMPILER_PLUGIN_ERROR("BCE20400", "compiler.plugin.crashed"),
+    COMPILER_PLUGIN_FAILURE("BCE20401", "compiler.plugin.failed"),
     ;
 
     private String diagnosticId;

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -83,6 +83,9 @@ warning.non.module.qualified.error.reason=\
 warning.compiler.plugin.crashed=\
   compiler plugin crashed
 
+warning.compiler.plugin.failed=\
+  compiler plugin ''{0}'' failed
+
 # -------------------------
 # Compiler error messages
 # -------------------------


### PR DESCRIPTION
## Purpose
This is a temporary fix for #29695 and #30756 to stop the compiler from crashing. Once the data mapper plugin is migrated need to get rid of this fix. If the compiler crashes due to an issue in a plugin, this will give the following sort of warning:
```
WARNING [:(0:0,0:0)] compiler plugin 'org.ballerinax.datamapper.DataMapperPlugin' failed
```

## Remarks
*Only to be merged if any issue comes up with the migration of the Data Mapper plugin*

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
