### PR TITLE
Set position info to named arg exprs created in Unifier

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/Unifier.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/Unifier.java
@@ -651,7 +651,7 @@ public class Unifier implements BTypeVisitor<BType, BType> {
 
     private BLangNamedArgsExpression createTypedescExprNamedArg(BType expType, String name) {
         BLangTypedescExpr typedescExpr = (BLangTypedescExpr) TreeBuilder.createTypeAccessNode();
-        typedescExpr.pos = this.invocation.pos;
+        typedescExpr.pos = this.symbolTable.builtinPos;
         typedescExpr.resolvedType = expType;
         typedescExpr.type = new BTypedescType(expType, null);
 
@@ -660,6 +660,7 @@ public class Unifier implements BTypeVisitor<BType, BType> {
         identifierNode.value = name;
         namedArgsExpression.name = identifierNode;
         namedArgsExpression.expr = typedescExpr;
+        namedArgsExpression.pos = this.symbolTable.builtinPos;
         return namedArgsExpression;
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ExpressionTypeTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ExpressionTypeTest.java
@@ -361,6 +361,12 @@ public class ExpressionTypeTest {
         assertEquals(exprType.typeKind(), STRING);
     }
 
+    @Test
+    public void testFuncCallForDependentlyTypedSignatures() {
+        TypeSymbol exprType = getExprType(172, 12, 172, 35);
+        assertEquals(exprType.typeKind(), INT);
+    }
+
     private void assertType(int sLine, int sCol, int eLine, int eCol, TypeDescKind kind) {
         TypeSymbol type = getExprType(sLine, sCol, eLine, eCol);
         assertEquals(type.typeKind(), kind);

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/expressions_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/expressions_test.bal
@@ -168,6 +168,11 @@ function testExprsInDoAndOnFail() {
     }
 }
 
+function testDependentlyTypedSignatures() {
+    PersonObj p = new("John Doe");
+    int x = p.depFoo("bar", 10, 20);
+}
+
 // utils
 
 class PersonObj {
@@ -178,6 +183,8 @@ class PersonObj {
     }
 
     function getName() returns string => self.name;
+
+    function depFoo(string s, typedesc<anydata> td = <>, int... rest) returns td = external;
 }
 
 function foo() returns string|error => "foo";

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/inferred_dependently_typed_fn_signature_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/inferred_dependently_typed_fn_signature_test.bal
@@ -1,0 +1,21 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+function test() {
+    int x = foo("bar");
+}
+
+function foo(string s, typedesc<anydata> td = <>) returns td = external;


### PR DESCRIPTION
## Purpose
With this PR we set the position of the named args created in `Unifier` to the builtin position to avoid getting NPEs in the visitors used in the semantic API.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
