### PR TITLE
Fix Object mocking withArgs for Typedesc params

### DIFF
--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/mock/GenericMockObjectValue.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/mock/GenericMockObjectValue.java
@@ -27,6 +27,7 @@ import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
 import io.ballerina.runtime.internal.scheduling.Strand;
 import io.ballerina.runtime.internal.util.exceptions.BallerinaException;
+import io.ballerina.runtime.internal.values.TypedescValue;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -226,7 +227,7 @@ public class GenericMockObjectValue implements BObject {
         List<Object> newArgs = new ArrayList<>();
         int i = 0;
         while (i < args.length) {
-            if (args[i] != null) {
+            if (args[i] != null && !(args[i] instanceof TypedescValue)) {
                 newArgs.add(args[i]);
             }
             i += 2;

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/mock/GenericMockObjectValue.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/mock/GenericMockObjectValue.java
@@ -17,8 +17,10 @@
  */
 package org.ballerinalang.testerina.natives.mock;
 
+import io.ballerina.runtime.api.TypeTags;
 import io.ballerina.runtime.api.types.ObjectType;
 import io.ballerina.runtime.api.types.RecordType;
+import io.ballerina.runtime.api.utils.TypeUtils;
 import io.ballerina.runtime.api.values.BArray;
 import io.ballerina.runtime.api.values.BFuture;
 import io.ballerina.runtime.api.values.BLink;
@@ -27,7 +29,6 @@ import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
 import io.ballerina.runtime.internal.scheduling.Strand;
 import io.ballerina.runtime.internal.util.exceptions.BallerinaException;
-import io.ballerina.runtime.internal.values.TypedescValue;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -227,7 +228,7 @@ public class GenericMockObjectValue implements BObject {
         List<Object> newArgs = new ArrayList<>();
         int i = 0;
         while (i < args.length) {
-            if (args[i] != null && !(args[i] instanceof TypedescValue)) {
+            if (args[i] != null && (TypeUtils.getType(args[i]).getTag() != TypeTags.TYPEDESC_TAG)) {
                 newArgs.add(args[i]);
             }
             i += 2;


### PR DESCRIPTION
## Purpose
Fixes Object mocking with Args for dependently typed functions containing a `typedesc` in the parameter. 

Fixes #30691

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
