### PR TITLE
Improve the indentation of object constructors when formatting

### DIFF
--- a/compiler/ballerina-parser/src/test/resources/expressions/object-constructor/object-constructor-with-annotations.bal
+++ b/compiler/ballerina-parser/src/test/resources/expressions/object-constructor/object-constructor-with-annotations.bal
@@ -1,6 +1,6 @@
 var objWithAnnotation = @deprecated object {
-                                        int n;
-                                        public function init() {
-                                            self.n = 1;
-                                        }
-                                    };
+    int n;
+    public function init() {
+        self.n = 1;
+    }
+};

--- a/compiler/ballerina-parser/src/test/resources/expressions/object-constructor/object-constructor-with-annotations.json
+++ b/compiler/ballerina-parser/src/test/resources/expressions/object-constructor/object-constructor-with-annotations.json
@@ -119,7 +119,7 @@
                       "leadingMinutiae": [
                         {
                           "kind": "WHITESPACE_MINUTIAE",
-                          "value": "                                        "
+                          "value": "    "
                         }
                       ],
                       "trailingMinutiae": [
@@ -157,7 +157,7 @@
                       "leadingMinutiae": [
                         {
                           "kind": "WHITESPACE_MINUTIAE",
-                          "value": "                                        "
+                          "value": "    "
                         }
                       ],
                       "trailingMinutiae": [
@@ -237,7 +237,7 @@
                                       "leadingMinutiae": [
                                         {
                                           "kind": "WHITESPACE_MINUTIAE",
-                                          "value": "                                            "
+                                          "value": "        "
                                         }
                                       ]
                                     }
@@ -299,7 +299,7 @@
                       "leadingMinutiae": [
                         {
                           "kind": "WHITESPACE_MINUTIAE",
-                          "value": "                                        "
+                          "value": "    "
                         }
                       ],
                       "trailingMinutiae": [
@@ -316,13 +316,7 @@
           ]
         },
         {
-          "kind": "CLOSE_BRACE_TOKEN",
-          "leadingMinutiae": [
-            {
-              "kind": "WHITESPACE_MINUTIAE",
-              "value": "                                    "
-            }
-          ]
+          "kind": "CLOSE_BRACE_TOKEN"
         }
       ]
     },

--- a/compiler/ballerina-parser/src/test/resources/expressions/object-constructor/object-constructor-with-basic-object-fields.bal
+++ b/compiler/ballerina-parser/src/test/resources/expressions/object-constructor/object-constructor-with-basic-object-fields.bal
@@ -1,6 +1,6 @@
 var objCreatedViaConstructor = object {
-                                   int n;
-                                   public function init() {
-                                       self.n = 1;
-                                   }
-                               };
+    int n;
+    public function init() {
+        self.n = 1;
+    }
+};

--- a/compiler/ballerina-parser/src/test/resources/expressions/object-constructor/object-constructor-with-basic-object-fields.json
+++ b/compiler/ballerina-parser/src/test/resources/expressions/object-constructor/object-constructor-with-basic-object-fields.json
@@ -95,7 +95,7 @@
                       "leadingMinutiae": [
                         {
                           "kind": "WHITESPACE_MINUTIAE",
-                          "value": "                                   "
+                          "value": "    "
                         }
                       ],
                       "trailingMinutiae": [
@@ -133,7 +133,7 @@
                       "leadingMinutiae": [
                         {
                           "kind": "WHITESPACE_MINUTIAE",
-                          "value": "                                   "
+                          "value": "    "
                         }
                       ],
                       "trailingMinutiae": [
@@ -213,7 +213,7 @@
                                       "leadingMinutiae": [
                                         {
                                           "kind": "WHITESPACE_MINUTIAE",
-                                          "value": "                                       "
+                                          "value": "        "
                                         }
                                       ]
                                     }
@@ -275,7 +275,7 @@
                       "leadingMinutiae": [
                         {
                           "kind": "WHITESPACE_MINUTIAE",
-                          "value": "                                   "
+                          "value": "    "
                         }
                       ],
                       "trailingMinutiae": [
@@ -292,13 +292,7 @@
           ]
         },
         {
-          "kind": "CLOSE_BRACE_TOKEN",
-          "leadingMinutiae": [
-            {
-              "kind": "WHITESPACE_MINUTIAE",
-              "value": "                               "
-            }
-          ]
+          "kind": "CLOSE_BRACE_TOKEN"
         }
       ]
     },

--- a/compiler/ballerina-parser/src/test/resources/expressions/object-constructor/object-constructor-with-client-keyword.bal
+++ b/compiler/ballerina-parser/src/test/resources/expressions/object-constructor/object-constructor-with-client-keyword.bal
@@ -1,6 +1,6 @@
 var objWithAnnotation = @deprecated client object {
-                                               int n;
-                                               public function init() {
-                                                   self.n = 1;
-                                               }
-                                           };
+    int n;
+    public function init() {
+        self.n = 1;
+    }
+};

--- a/compiler/ballerina-parser/src/test/resources/expressions/object-constructor/object-constructor-with-client-keyword.json
+++ b/compiler/ballerina-parser/src/test/resources/expressions/object-constructor/object-constructor-with-client-keyword.json
@@ -129,7 +129,7 @@
                       "leadingMinutiae": [
                         {
                           "kind": "WHITESPACE_MINUTIAE",
-                          "value": "                                               "
+                          "value": "    "
                         }
                       ],
                       "trailingMinutiae": [
@@ -167,7 +167,7 @@
                       "leadingMinutiae": [
                         {
                           "kind": "WHITESPACE_MINUTIAE",
-                          "value": "                                               "
+                          "value": "    "
                         }
                       ],
                       "trailingMinutiae": [
@@ -247,7 +247,7 @@
                                       "leadingMinutiae": [
                                         {
                                           "kind": "WHITESPACE_MINUTIAE",
-                                          "value": "                                                   "
+                                          "value": "        "
                                         }
                                       ]
                                     }
@@ -309,7 +309,7 @@
                       "leadingMinutiae": [
                         {
                           "kind": "WHITESPACE_MINUTIAE",
-                          "value": "                                               "
+                          "value": "    "
                         }
                       ],
                       "trailingMinutiae": [
@@ -326,13 +326,7 @@
           ]
         },
         {
-          "kind": "CLOSE_BRACE_TOKEN",
-          "leadingMinutiae": [
-            {
-              "kind": "WHITESPACE_MINUTIAE",
-              "value": "                                           "
-            }
-          ]
+          "kind": "CLOSE_BRACE_TOKEN"
         }
       ]
     },

--- a/compiler/ballerina-parser/src/test/resources/expressions/object-constructor/object-constructor-with-type-reference.bal
+++ b/compiler/ballerina-parser/src/test/resources/expressions/object-constructor/object-constructor-with-type-reference.bal
@@ -1,7 +1,7 @@
 var objReferObject = object MO {
-                         int n;
-                         public function init() {
-                             self.n = 1;
-                             self.x = 2;
-                         }
-                     };
+    int n;
+    public function init() {
+        self.n = 1;
+        self.x = 2;
+    }
+};

--- a/compiler/ballerina-parser/src/test/resources/expressions/object-constructor/object-constructor-with-type-reference.json
+++ b/compiler/ballerina-parser/src/test/resources/expressions/object-constructor/object-constructor-with-type-reference.json
@@ -110,7 +110,7 @@
                       "leadingMinutiae": [
                         {
                           "kind": "WHITESPACE_MINUTIAE",
-                          "value": "                         "
+                          "value": "    "
                         }
                       ],
                       "trailingMinutiae": [
@@ -148,7 +148,7 @@
                       "leadingMinutiae": [
                         {
                           "kind": "WHITESPACE_MINUTIAE",
-                          "value": "                         "
+                          "value": "    "
                         }
                       ],
                       "trailingMinutiae": [
@@ -228,7 +228,7 @@
                                       "leadingMinutiae": [
                                         {
                                           "kind": "WHITESPACE_MINUTIAE",
-                                          "value": "                             "
+                                          "value": "        "
                                         }
                                       ]
                                     }
@@ -298,7 +298,7 @@
                                       "leadingMinutiae": [
                                         {
                                           "kind": "WHITESPACE_MINUTIAE",
-                                          "value": "                             "
+                                          "value": "        "
                                         }
                                       ]
                                     }
@@ -360,7 +360,7 @@
                       "leadingMinutiae": [
                         {
                           "kind": "WHITESPACE_MINUTIAE",
-                          "value": "                         "
+                          "value": "    "
                         }
                       ],
                       "trailingMinutiae": [
@@ -377,13 +377,7 @@
           ]
         },
         {
-          "kind": "CLOSE_BRACE_TOKEN",
-          "leadingMinutiae": [
-            {
-              "kind": "WHITESPACE_MINUTIAE",
-              "value": "                     "
-            }
-          ]
+          "kind": "CLOSE_BRACE_TOKEN"
         }
       ]
     },

--- a/compiler/ballerina-parser/src/test/resources/expressions/object-constructor/object_constructor_assert_08.json
+++ b/compiler/ballerina-parser/src/test/resources/expressions/object-constructor/object_constructor_assert_08.json
@@ -91,7 +91,7 @@
                       "leadingMinutiae": [
                         {
                           "kind": "WHITESPACE_MINUTIAE",
-                          "value": "              "
+                          "value": "    "
                         }
                       ],
                       "trailingMinutiae": [
@@ -144,7 +144,7 @@
                       "leadingMinutiae": [
                         {
                           "kind": "WHITESPACE_MINUTIAE",
-                          "value": "              "
+                          "value": "    "
                         }
                       ],
                       "trailingMinutiae": [
@@ -196,7 +196,7 @@
                       "leadingMinutiae": [
                         {
                           "kind": "WHITESPACE_MINUTIAE",
-                          "value": "              "
+                          "value": "    "
                         }
                       ],
                       "trailingMinutiae": [
@@ -269,7 +269,7 @@
                   "leadingMinutiae": [
                     {
                       "kind": "WHITESPACE_MINUTIAE",
-                      "value": "              "
+                      "value": "    "
                     }
                   ],
                   "trailingMinutiae": [
@@ -325,13 +325,7 @@
           ]
         },
         {
-          "kind": "CLOSE_BRACE_TOKEN",
-          "leadingMinutiae": [
-            {
-              "kind": "WHITESPACE_MINUTIAE",
-              "value": "          "
-            }
-          ]
+          "kind": "CLOSE_BRACE_TOKEN"
         }
       ]
     },

--- a/compiler/ballerina-parser/src/test/resources/expressions/object-constructor/object_constructor_assert_10.json
+++ b/compiler/ballerina-parser/src/test/resources/expressions/object-constructor/object_constructor_assert_10.json
@@ -145,7 +145,7 @@
                                               "leadingMinutiae": [
                                                 {
                                                   "kind": "WHITESPACE_MINUTIAE",
-                                                  "value": "            "
+                                                  "value": "        "
                                                 }
                                               ],
                                               "trailingMinutiae": [
@@ -203,7 +203,7 @@
                                   "leadingMinutiae": [
                                     {
                                       "kind": "WHITESPACE_MINUTIAE",
-                                      "value": "        "
+                                      "value": "    "
                                     }
                                   ]
                                 }

--- a/compiler/ballerina-parser/src/test/resources/expressions/object-constructor/object_constructor_source_08.bal
+++ b/compiler/ballerina-parser/src/test/resources/expressions/object-constructor/object_constructor_source_08.bal
@@ -1,6 +1,6 @@
 var obj = object {
-              final T a;
-              final readonly b;
-              final int bar = 10;
-              public final string c;
-          };
+    final T a;
+    final readonly b;
+    final int bar = 10;
+    public final string c;
+};

--- a/compiler/ballerina-parser/src/test/resources/expressions/object-constructor/object_constructor_source_10.bal
+++ b/compiler/ballerina-parser/src/test/resources/expressions/object-constructor/object_constructor_source_10.bal
@@ -1,5 +1,5 @@
 public function main() {
     foo(object {
-            int i = 1;
-        });
+        int i = 1;
+    });
 }

--- a/compiler/ballerina-parser/src/test/resources/expressions/object-constructor/service_object_constructor_assert_01.json
+++ b/compiler/ballerina-parser/src/test/resources/expressions/object-constructor/service_object_constructor_assert_01.json
@@ -182,7 +182,7 @@
                                   "leadingMinutiae": [
                                     {
                                       "kind": "WHITESPACE_MINUTIAE",
-                                      "value": "                        "
+                                      "value": "        "
                                     }
                                   ],
                                   "trailingMinutiae": [
@@ -225,7 +225,7 @@
                                 },
                                 {
                                   "kind": "WHITESPACE_MINUTIAE",
-                                  "value": "                        "
+                                  "value": "        "
                                 }
                               ],
                               "trailingMinutiae": [
@@ -297,7 +297,7 @@
                                                   "leadingMinutiae": [
                                                     {
                                                       "kind": "WHITESPACE_MINUTIAE",
-                                                      "value": "                            "
+                                                      "value": "            "
                                                     }
                                                   ],
                                                   "trailingMinutiae": [
@@ -362,7 +362,7 @@
                                   "leadingMinutiae": [
                                     {
                                       "kind": "WHITESPACE_MINUTIAE",
-                                      "value": "                        "
+                                      "value": "        "
                                     }
                                   ],
                                   "trailingMinutiae": [
@@ -383,7 +383,7 @@
                       "leadingMinutiae": [
                         {
                           "kind": "WHITESPACE_MINUTIAE",
-                          "value": "                    "
+                          "value": "    "
                         }
                       ]
                     }

--- a/compiler/ballerina-parser/src/test/resources/expressions/object-constructor/service_object_constructor_assert_02.json
+++ b/compiler/ballerina-parser/src/test/resources/expressions/object-constructor/service_object_constructor_assert_02.json
@@ -182,7 +182,7 @@
                                   "leadingMinutiae": [
                                     {
                                       "kind": "WHITESPACE_MINUTIAE",
-                                      "value": "                        "
+                                      "value": "        "
                                     }
                                   ],
                                   "trailingMinutiae": [
@@ -224,7 +224,7 @@
                                     },
                                     {
                                       "kind": "WHITESPACE_MINUTIAE",
-                                      "value": "                        "
+                                      "value": "        "
                                     }
                                   ],
                                   "trailingMinutiae": [
@@ -341,7 +341,7 @@
                                           "leadingMinutiae": [
                                             {
                                               "kind": "WHITESPACE_MINUTIAE",
-                                              "value": "                            "
+                                              "value": "            "
                                             }
                                           ],
                                           "trailingMinutiae": [
@@ -375,7 +375,7 @@
                                                       "leadingMinutiae": [
                                                         {
                                                           "kind": "WHITESPACE_MINUTIAE",
-                                                          "value": "                                "
+                                                          "value": "                "
                                                         }
                                                       ]
                                                     },
@@ -417,7 +417,7 @@
                                                       "leadingMinutiae": [
                                                         {
                                                           "kind": "WHITESPACE_MINUTIAE",
-                                                          "value": "                                "
+                                                          "value": "                "
                                                         }
                                                       ]
                                                     },
@@ -454,7 +454,7 @@
                                               "leadingMinutiae": [
                                                 {
                                                   "kind": "WHITESPACE_MINUTIAE",
-                                                  "value": "                            "
+                                                  "value": "            "
                                                 }
                                               ]
                                             }
@@ -478,7 +478,7 @@
                                   "leadingMinutiae": [
                                     {
                                       "kind": "WHITESPACE_MINUTIAE",
-                                      "value": "                        "
+                                      "value": "        "
                                     }
                                   ],
                                   "trailingMinutiae": [
@@ -499,7 +499,7 @@
                       "leadingMinutiae": [
                         {
                           "kind": "WHITESPACE_MINUTIAE",
-                          "value": "                    "
+                          "value": "    "
                         }
                       ]
                     }

--- a/compiler/ballerina-parser/src/test/resources/expressions/object-constructor/service_object_constructor_source_01.bal
+++ b/compiler/ballerina-parser/src/test/resources/expressions/object-constructor/service_object_constructor_source_01.bal
@@ -1,9 +1,9 @@
 public function foo() {
     int a = service object {
-                        Person person;
+        Person person;
 
-                        function foo() {
-                            int b = m;
-                        }
-                    };
+        function foo() {
+            int b = m;
+        }
+    };
 }

--- a/compiler/ballerina-parser/src/test/resources/expressions/object-constructor/service_object_constructor_source_02.bal
+++ b/compiler/ballerina-parser/src/test/resources/expressions/object-constructor/service_object_constructor_source_02.bal
@@ -1,12 +1,12 @@
 public function foo() {
     int a = service object {
-                        Person person;
+        Person person;
 
-                        resource function get person() returns Person {
-                            return {
-                                firstName: "Lochana",
-                                lastName: "Jayawickrama"
-                            };
-                        }
-                    };
+        resource function get person() returns Person {
+            return {
+                firstName: "Lochana",
+                lastName: "Jayawickrama"
+            };
+        }
+    };
 }

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
@@ -2328,12 +2328,6 @@ public class FormattingTreeModifier extends TreeModifier {
             fieldTrailingWS++;
         }
 
-        int prevIndentation = env.currentIndentation;
-
-        // Set indentation for braces.
-        int fieldIndentation = env.lineLength - objectKeyword.text().length() - 1;
-        setIndentation(fieldIndentation);
-
         TypeDescriptorNode typeReference = formatNode(objectConstructorExpressionNode.typeReference().orElse(null),
                 1, 0);
         Token openBraceToken = formatToken(objectConstructorExpressionNode.openBraceToken(), 0, fieldTrailingNL);
@@ -2343,7 +2337,6 @@ public class FormattingTreeModifier extends TreeModifier {
         unindent();
         Token closeBraceToken = formatToken(objectConstructorExpressionNode.closeBraceToken(),
                 env.trailingWS, env.trailingNL);
-        setIndentation(prevIndentation);  // Revert indentation for braces
 
         return objectConstructorExpressionNode.modify()
                 .withAnnotations(annotations)

--- a/misc/formatter/modules/formatter-core/src/test/resources/misc/blocks/assert/blocks_2.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/misc/blocks/assert/blocks_2.bal
@@ -24,24 +24,24 @@ public type Address object {
 
 function foo() {
     Address adr = object {
-                      public string city;
-                      public string country;
-                  };
+        public string city;
+        public string country;
+    };
 
     Address adr = object {public string city; public string country;};
 
     Address adr = object {
-                      public string city;
-                      public string country;
-                  };
+        public string city;
+        public string country;
+    };
 
     Address adr = object {
-                      public string city;
-                      public string country;
-                  };
+        public string city;
+        public string country;
+    };
 
     Address adr = object {
-                      public string city;
-                      public string country;
-                  };
+        public string city;
+        public string country;
+    };
 }

--- a/misc/formatter/modules/formatter-core/src/test/resources/types/behavioural/assert/object_type_1.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/types/behavioural/assert/object_type_1.bal
@@ -4,7 +4,7 @@ type Obj object {
 
 function bar() {
     var o = object {
-                function foo() {
-                }
-            };
+        function foo() {
+        }
+    };
 }


### PR DESCRIPTION
## Purpose
Currently, the formatted object constructors have a tendency to be indented to the right side, since the object constructor body is indented starting from the object keyword.

However, this seems like a waste of space utilization, and therefore, this right alignment is removed through this PR. Please refer the test cases in this PR for a better understanding of the change.

Fixes #27247

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
