### PR TITLE
Skip escape-character of method name in method-call-expressions

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/FieldAccessCompletionResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/FieldAccessCompletionResolver.java
@@ -49,6 +49,7 @@ import io.ballerina.projects.Module;
 import io.ballerina.projects.ModuleId;
 import io.ballerina.projects.Package;
 import io.ballerina.projects.Project;
+import io.ballerina.runtime.api.utils.IdentifierUtils;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.common.utils.SymbolUtil;
 import org.ballerinalang.langserver.common.utils.completion.QNameReferenceUtil;
@@ -71,6 +72,7 @@ import javax.annotation.Nonnull;
  * @since 2.0.0
  */
 public class FieldAccessCompletionResolver extends NodeTransformer<Optional<TypeSymbol>> {
+    private static final String IDENTIFIER_LITERAL_PREFIX = "'";
     private final PositionedOperationContext context;
     private final boolean optionalFieldAccess;
 
@@ -121,6 +123,9 @@ public class FieldAccessCompletionResolver extends NodeTransformer<Optional<Type
         Predicate<Symbol> predicate = symbol -> symbol.kind() == SymbolKind.METHOD
                 || symbol.kind() == SymbolKind.FUNCTION;
         String methodName = ((SimpleNameReferenceNode) nameRef).name().text();
+        if (methodName.startsWith(IDENTIFIER_LITERAL_PREFIX)) {
+            methodName = IdentifierUtils.unescapeUnicodeCodepoints(methodName.substring(1));
+        }
         List<Symbol> visibleEntries = this.getVisibleEntries(exprTypeSymbol.orElseThrow(), node.expression());
 
         FunctionSymbol symbol = (FunctionSymbol) this.getSymbolByName(visibleEntries, methodName, predicate);

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config28.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config28.json
@@ -1,0 +1,583 @@
+{
+  "position": {
+    "line": 1,
+    "character": 41
+  },
+  "source": "expression_context/source/field_access_ctx_source23.bal",
+  "items": [
+    {
+      "label": "getCodePoint(int index)(int)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.string:1.1.0_  \n  \nReturns the code point of a character in a string.\n  \n**Params**  \n- `int` index: an index in `str`  \n  \n**Returns** `int`   \n- the Unicode code point of the character at `index` in `str`  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "getCodePoint",
+      "insertText": "getCodePoint(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "toBytes()(byte[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.string:1.1.0_  \n  \nRepresents `str` as an array of bytes using UTF-8.\n  \n  \n  \n**Returns** `byte[]`   \n- UTF-8 byte array  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "toBytes",
+      "insertText": "toBytes()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "length()(int)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.string:1.1.0_  \n  \nReturns the length of the string.\n  \n  \n  \n**Returns** `int`   \n- the number of characters (code points) in `str`  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "length",
+      "insertText": "length()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "toCodePointInts()(int[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.string:1.1.0_  \n  \nConverts a string to an array of code points.\n  \n  \n  \n**Returns** `int[]`   \n- an array with a code point for each character of `str`  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "toCodePointInts",
+      "insertText": "toCodePointInts()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "includes(string substr, int startIndex)(boolean)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.string:1.1.0_  \n  \nTests whether a string includes another string.\n  \n**Params**  \n- `string` substr: the string to search for  \n- `int` startIndex: index to start searching from(Defaultable)  \n  \n**Returns** `boolean`   \n- `true` if there is an occurrence of `substr` in `str` at an index >= `startIndex`,  \nor `false` otherwise  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "includes",
+      "insertText": "includes(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "concat(string... strs)(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.string:1.1.0_  \n  \nConcatenates zero or more strings.\n  \n  \n  \n**Returns** `string`   \n- concatenation of all of the `strs`; empty string if `strs` is empty  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "concat",
+      "insertText": "concat(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "equalsIgnoreCaseAscii(string str2)(boolean)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.string:1.1.0_  \n  \nTests whether two strings are the same, ignoring the case of ASCII characters.\nA character in the range a-z is treated the same as the corresponding character in the range A-Z.\n  \n**Params**  \n- `string` str2: the second string to be compared  \n  \n**Returns** `boolean`   \n- true if `str1` is the same as `str2`, treating upper-case and lower-case  \nASCII letters as the same; false, otherwise  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "equalsIgnoreCaseAscii",
+      "insertText": "equalsIgnoreCaseAscii(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "toUpperAscii()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.string:1.1.0_  \n  \nConverts occurrences of a-z to A-Z.\nOther characters are left unchanged.\n  \n  \n  \n**Returns** `string`   \n- `str` with any occurrences of a-z converted to A-Z  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "toUpperAscii",
+      "insertText": "toUpperAscii()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "substring(int startIndex, int endIndex)(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.string:1.1.0_  \n  \nReturns a substring of a string.\n  \n**Params**  \n- `int` startIndex: the starting index, inclusive  \n- `int` endIndex: the ending index, exclusive(Defaultable)  \n  \n**Returns** `string`   \n- substring consisting of characters with index >= startIndex and < endIndex  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "substring",
+      "insertText": "substring(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "lastIndexOf(string substr, int startIndex)(int?)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.string:1.1.0_  \n  \nFinds the last occurrence of one string in another string.\n  \n**Params**  \n- `string` substr: the string to search for  \n- `int` startIndex: index to start searching backwards from(Defaultable)  \n  \n**Returns** `int?`   \n- index of the last occurrence of `substr` in `str` that is <= `startIndex`,  \nor `()` if there is no such occurrence  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "lastIndexOf",
+      "insertText": "lastIndexOf(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "iterator()(object {public isolated function next() returns record {| string value; |}? ;})",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.string:1.1.0_  \n  \nReturns an iterator over the string.\nThe iterator will yield the substrings of length 1 in order.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| string value; |}? ;}`   \n- a new iterator object  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "iterator",
+      "insertText": "iterator()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "trim()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.string:1.1.0_  \n  \nRemoves ASCII white space characters from the start and end of a string.\nThe ASCII white space characters are 0x9...0xD, 0x20.\n  \n  \n  \n**Returns** `string`   \n- `str` with leading or trailing ASCII white space characters removed  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "trim",
+      "insertText": "trim()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "endsWith(string substr)(boolean)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.string:1.1.0_  \n  \nTests whether a string ends with another string.\n  \n**Params**  \n- `string` substr: the ending string  \n  \n**Returns** `boolean`   \n- true if `str` ends with `substr`; false otherwise  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "endsWith",
+      "insertText": "endsWith(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "join(string... strs)(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.string:1.1.0_  \n  \nJoins zero or more strings together with a separator.\n  \n**Params**  \n- `string[]` strs: strings to be joined  \n  \n**Returns** `string`   \n- a string consisting of all of `strs` concatenated in order  \nwith `separator` in between them  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "join",
+      "insertText": "join(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "indexOf(string substr, int startIndex)(int?)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.string:1.1.0_  \n  \nFinds the first occurrence of one string in another string.\n  \n**Params**  \n- `string` substr: the string to search for  \n- `int` startIndex: index to start searching from(Defaultable)  \n  \n**Returns** `int?`   \n- index of the first occurrence of `substr` in `str` that is >= `startIndex`,  \nor `()` if there is no such occurrence  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "indexOf",
+      "insertText": "indexOf(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "codePointCompare(string str2)(int)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.string:1.1.0_  \n  \nLexicographically compares strings using their Unicode code points.\nThis orders strings in a consistent and well-defined way,\nbut the ordering will often not be consistent with cultural expectations\nfor sorted order.\n  \n**Params**  \n- `string` str2: the second string to be compared  \n  \n**Returns** `int`   \n- an int that is less than, equal to or greater than zero,  \naccording as `str1` is less than, equal to or greater than `str2`  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "codePointCompare",
+      "insertText": "codePointCompare(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "toLowerAscii()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.string:1.1.0_  \n  \nConverts occurrences of A-Z to a-z.\nOther characters are left unchanged.\n  \n  \n  \n**Returns** `string`   \n- `str` with any occurrences of A-Z converted to a-z  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "toLowerAscii",
+      "insertText": "toLowerAscii()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "startsWith(string substr)(boolean)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.string:1.1.0_  \n  \nTests whether a string starts with another string.\n  \n**Params**  \n- `string` substr: the starting string  \n  \n**Returns** `boolean`   \n- true if `str` starts with `substr`; false otherwise  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "startsWith",
+      "insertText": "startsWith(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "cloneWithType(typedesc<anydata> t)(t|error)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConstructs a value with a specified type by cloning another value.  \n**Params**  \n- `typedesc<anydata>` t: the type for the cloned to be constructed(Defaultable)  \n  \n**Returns** `t|error`   \n- a new value that belongs to type `t`, or an error if this cannot be done  \n  \nWhen `v` is a structural value, the inherent type of the value to be constructed  \ncomes from `t`. When `t` is a union, it must be possible to determine which  \nmember of the union to use for the inherent type by following the same rules  \nthat are used by list constructor expressions and mapping constructor expressions  \nwith the contextually expected type. If not, then an error is returned.  \nThe `cloneWithType` operation is recursively applied to each member of `v` using  \nthe type descriptor that the inherent type requires for that member.  \n  \nLike the Clone abstract operation, this does a deep copy, but differs in  \nthe following respects:  \n- the inherent type of any structural values constructed comes from the specified  \ntype descriptor rather than the value being constructed  \n- the read-only bit of values and fields comes from the specified type descriptor  \n- the graph structure of `v` is not preserved; the result will always be a tree;  \nan error will be returned if `v` has cycles  \n- immutable structural values are copied rather being returned as is; all  \nstructural values in the result will be mutable.  \n- numeric values can be converted using the NumericConvert abstract operation  \n- if a record type descriptor specifies default values, these will be used  \nto supply any missing members  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "cloneWithType",
+      "insertText": "cloneWithType(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "fromJsonString()(json|error)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nParses a string in JSON format and returns the the value that it represents.\nNumbers in the JSON string are converted into Ballerina values of type\ndecimal except in the following two cases:\nif the JSON number starts with `-` and is numerically equal to zero, then it is\nconverted into float value of `-0.0`;\notherwise, if the JSON number is syntactically an integer and is in the range representable\nby a Ballerina int, then it is converted into a Ballerina int.\nA JSON number is considered syntactically an integer if it contains neither\na decimal point nor an exponent.\n\nReturns an error if the string cannot be parsed.\n  \n  \n  \n**Returns** `json|error`   \n- `str` parsed to json or error  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "fromJsonString",
+      "insertText": "fromJsonString()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "fromBalString()(anydata|error)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nParses and evaluates a subset of Ballerina expression syntax.  \n  \n  \n**Returns** `anydata|error`   \n- the result of evaluating the parsed expression, or  \nan error if the string cannot be parsed  \nThe subset of Ballerina expression syntax supported is that produced  \nby toBalString when applied to an anydata value.  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "fromBalString",
+      "insertText": "fromBalString()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "fromJsonFloatString()(JsonFloat|error)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nParses a string in JSON format, using float to represent numbers.\nReturns an error if the string cannot be parsed.\n  \n  \n  \n**Returns** `JsonFloat|error`   \n- `str` parsed to JsonFloat or error  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "fromJsonFloatString",
+      "insertText": "fromJsonFloatString()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "fromJsonDecimalString()(JsonDecimal|error)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nParses a string in JSON format, using decimal to represent numbers.\nReturns an error if the string cannot be parsed.\n  \n  \n  \n**Returns** `JsonDecimal|error`   \n- `str` parsed to JsonDecimal or error  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "fromJsonDecimalString",
+      "insertText": "fromJsonDecimalString()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "cloneReadOnly()(CloneableType & readonly)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType & readonly`   \n- immutable clone of `v`  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "cloneReadOnly",
+      "insertText": "cloneReadOnly()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "toBalString()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value to a string that describes the value in Ballerina syntax.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nIf `v` is anydata and does not have cycles, then the result will  \nconform to the grammar for a Ballerina expression and when evaluated  \nwill result in a value that is == to v.  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the expression style.  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "toBalString",
+      "insertText": "toBalString()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "fromJsonStringWithType(typedesc<anydata> t)(t|error)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a string in JSON format to a user-specified type.\nThis is a combination of `fromJsonString` followed by\n`fromJsonWithType`.  \n**Params**  \n- `typedesc<anydata>` t: type to convert to(Defaultable)  \n  \n**Returns** `t|error`   \n- value belonging to type `t` or error if this cannot be done  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "fromJsonStringWithType",
+      "insertText": "fromJsonStringWithType(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "toJson()(json)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value of type `anydata` to `json`.\nThis does a deep copy of `v` converting values that do\nnot belong to json into values that do.\nA value of type `xml` is converted into a string as if\nby the `toString` function.\nA value of type `table` is converted into a list of\nmappings one for each row.\nThe inherent type of arrays in the return value will be\n`json[]` and of mappings will be `map<json>`.\nA new copy is made of all structural values, including\nimmutable values.\n  \n  \n  \n**Returns** `json`   \n- representation of `v` as value of type json  \nThis panics if `v` has cycles.  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "toJson",
+      "insertText": "toJson()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "isReadOnly()(boolean)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "isReadOnly",
+      "insertText": "isReadOnly()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "fromJsonWithType(typedesc<anydata> t)(t|error)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value of type json to a user-specified type.\nThis works the same as `cloneWithType`,\nexcept that it also does the inverse of the conversions done by `toJson`.\n  \n**Params**  \n- `typedesc<anydata>` t: type to convert to(Defaultable)  \n  \n**Returns** `t|error`   \n- value belonging to type `t` or error if this cannot be done  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "fromJsonWithType",
+      "insertText": "fromJsonWithType(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "mergeJson(json j2)(json|error)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nMerges two json values.\n  \n**Params**  \n- `json` j2: json value  \n  \n**Returns** `json|error`   \n- the merge of `j1` with `j2` or an error if the merge fails  \n  \nThe merge of `j1` with `j2` is defined as follows:  \n- if `j1` is `()`, then the result is `j2`  \n- if `j2` is `()`, then the result is `j1`  \n- if `j1` is a mapping and `j2` is a mapping, then for each entry [k, j] in j2,  \nset `j1[k]` to the merge of `j1[k]` with `j`  \n- if `j1[k]` is undefined, then set `j1[k]` to `j`  \n- if any merge fails, then the merge of `j1` with `j2` fails  \n- otherwise, the result is `j1`.  \n- otherwise, the merge fails  \nIf the merge fails, then `j1` is unchanged.  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "mergeJson",
+      "insertText": "mergeJson(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "clone()(CloneableType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- clone of `v`  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "clone",
+      "insertText": "clone()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ensureType(typedesc<any> t)(t|error)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nSafely casts a value to a type.\nThis casts a value to a type in the same way as a type cast expression,\nbut returns an error if the cast cannot be done, rather than panicking.  \n**Params**  \n- `typedesc<any>` t: a typedesc for the type to which to cast it\nreturn - `v` cast to the type described by `t`, or an error, if the cast cannot be done(Defaultable)  \n  \n**Returns** `t|error`   \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "ensureType",
+      "insertText": "ensureType(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "toString()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nPerforms a direct conversion of a value to a string.\nThe conversion is direct in the sense that when applied to a value that is already\na string it leaves the value unchanged.\n  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the direct style.  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "toString",
+      "insertText": "toString()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "toJsonString()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns the string that represents `v` in JSON format.\n`v` is first converted to `json` as if by the `toJson` function.\n  \n  \n  \n**Returns** `string`   \n- string representation of `v` converted to `json`  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "toJsonString",
+      "insertText": "toJsonString()",
+      "insertTextFormat": "Snippet"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/field_access_ctx_source23.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/field_access_ctx_source23.bal
@@ -1,0 +1,3 @@
+function main() {
+    string val = "value".'join("1", "2").
+}


### PR DESCRIPTION
## Purpose
$title

With this PR `'join` lang-lib method will be available as a completion
![Screenshot from 2021-05-25 15-35-30](https://user-images.githubusercontent.com/25485997/119480186-08b48580-bd6f-11eb-90aa-a76702f27bdc.png)


Fixes #30242 

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
