### PR TITLE
 Support transitive dependencies from local repo

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageResolution.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageResolution.java
@@ -150,7 +150,7 @@ public class PackageResolution {
         // Once we reach this section, all the direct dependencies have been resolved
         // Here we resolve all transitive dependencies
         // TODO Check for cycles
-        return depGraphBuilder.buildPackageDependencyGraph(rootPackageContext.descriptor(), packageResolver,
+        return depGraphBuilder.buildPackageDependencyGraph(rootPackageContext.manifest(), packageResolver,
                 packageCache, rootPackageContext.project());
     }
 
@@ -196,7 +196,8 @@ public class PackageResolution {
         return allModuleLoadRequests;
     }
 
-    PackageManifest.Dependency getVersionFromPackageManifest(PackageOrg requestedPkgOrg, PackageName requestedPkgName) {
+    PackageManifest.Dependency getDependencyFromPackageManifest(
+            PackageOrg requestedPkgOrg, PackageName requestedPkgName) {
         for (PackageManifest.Dependency dependency : rootPackageContext.manifest().dependencies()) {
             if (dependency.org().equals(requestedPkgOrg) && dependency.name().equals(requestedPkgName)) {
                 return dependency;
@@ -426,7 +427,7 @@ public class PackageResolution {
                     }
                 } else {
                     // Check whether this package is already defined in the package manifest, if so get the version
-                    PackageManifest.Dependency dependency = PackageResolution.this.getVersionFromPackageManifest(
+                    PackageManifest.Dependency dependency = PackageResolution.this.getDependencyFromPackageManifest(
                             packageOrg, possiblePkgName);
                     PackageVersion packageVersion = dependency != null ? dependency.version() : null;
                     String repository = dependency != null ? dependency.repository() : null;


### PR DESCRIPTION
## Purpose
> Support transitive dependencies from local repo
Fixes #30807

## Approach
> The transitive dependency has to be specified in the `Dependencies.toml`. 

## Samples
> A depends on B, B depends on C

**Dependencies.toml of B** should look like:
```
[[dependency]]
org = "foo"
name = "C"
version = "0.1.0"
repository = "local"
```
**Dependencies.toml of A** should look like:
```
[[dependency]]
org = "foo"
name = "B"
version = "0.1.0"
repository = "local"

[[dependency]]
org = "foo"
name = "C"
version = "0.1.0"
repository = "local"
```

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
