### PR TITLE
Fix build from outside of project with maven dependency

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/ResolveMavenDependenciesTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/ResolveMavenDependenciesTask.java
@@ -26,7 +26,6 @@ import org.ballerinalang.maven.MavenResolver;
 import org.ballerinalang.maven.Utils;
 import org.ballerinalang.maven.exceptions.MavenResolverException;
 
-import java.io.File;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.List;
@@ -60,8 +59,7 @@ public class ResolveMavenDependenciesTask implements Task {
             return;
         }
 
-        String targetRepo = project.sourceRoot().toString() + File.separator + "target" + File.separator
-                + "platform-libs";
+        String targetRepo = project.sourceRoot().resolve("target").resolve("platform-libs").toAbsolutePath().toString();
         MavenResolver resolver = new MavenResolver(targetRepo);
 
         for (Map<String, Object> repository : platformRepositories) {


### PR DESCRIPTION
## Purpose
> Building a project from an outside directory fails for projects with maven dependencies.
This PR fixes this issue.

Ballerina.toml
```toml
[[platform.java11.dependency]]
artifactId = "mysql-connector-java"
version = "8.0.21"
groupId = "mysql"
```
Error
```
Generating executable
error: error while creating the executable jar file for package: mysql_bbe_project
```

Linked PRs: https://github.com/ballerina-platform/ballerina-lang/pull/30850

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
