### PR TITLE
[LS] Add foreach and typegurad  completion items  on nested field access

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/ForeachCompletionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/ForeachCompletionUtil.java
@@ -79,7 +79,8 @@ public class ForeachCompletionUtil {
         List<LSCompletionItem> completionItems = new ArrayList<>();
         if (!isInBlockContext(expr) || !ITERABLES.contains(CommonUtil.getRawType(typeSymbol).typeKind())
                 || !(expr.expression().kind() == SyntaxKind.SIMPLE_NAME_REFERENCE ||
-                expr.expression().kind() == SyntaxKind.FUNCTION_CALL)) {
+                expr.expression().kind() == SyntaxKind.FUNCTION_CALL ||
+                expr.expression().kind() == SyntaxKind.FIELD_ACCESS)) {
             return completionItems;
         }
         completionItems.addAll(getForEachCompletionItems(ctx, expr, typeSymbol));
@@ -110,11 +111,10 @@ public class ForeachCompletionUtil {
         textEdits.add(textEdit);
 
         String symbolName;
-        if (expr.expression().kind() == SyntaxKind.FUNCTION_CALL) {
-            symbolName = expr.expression().toSourceCode().trim();
-            //todo: Trim for arguments as well
-        } else {
+        if (expr.expression().kind() == SyntaxKind.SIMPLE_NAME_REFERENCE) {
             symbolName = ((SimpleNameReferenceNode) expr.expression()).name().text();
+        } else {
+            symbolName = expr.expression().toSourceCode().trim();
         }
 
         completionItems.add(new StaticCompletionItem(ctx,

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/TypeGuardCompletionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/TypeGuardCompletionUtil.java
@@ -65,12 +65,12 @@ public class TypeGuardCompletionUtil {
                                                               BallerinaCompletionContext ctx,
                                                               FieldAccessExpressionNode expr) {
         String symbolName;
-        if (expr.expression().kind() == SyntaxKind.FUNCTION_CALL) {
-            symbolName = expr.expression().toSourceCode().trim();
-            //todo: Trim for argument names as well
-        } else {
+        if (expr.expression().kind() == SyntaxKind.SIMPLE_NAME_REFERENCE) {
             symbolName = ((SimpleNameReferenceNode) expr.expression()).name().text();
+        } else {
+            symbolName = expr.expression().toSourceCode().trim();
         }
+
         List<TypeSymbol> members = new ArrayList<>(symbol.memberTypeDescriptors());
         String detail = "Destructure the variable " + symbolName + " with typeguard";
         String snippet = "";
@@ -107,22 +107,23 @@ public class TypeGuardCompletionUtil {
                                                                      FieldAccessExpressionNode expr,
                                                                      TypeSymbol typeSymbol) {
         List<LSCompletionItem> completionItems = new ArrayList<>();
-        if (TypeGuardCompletionUtil.isInFunctionBlockBodyContext(expr)
+        if (TypeGuardCompletionUtil.isInBlockContext(expr)
                 && typeSymbol.typeKind() == TypeDescKind.UNION
                 && (expr.expression().kind() == SyntaxKind.SIMPLE_NAME_REFERENCE ||
-                expr.expression().kind() == SyntaxKind.FUNCTION_CALL)) {
+                expr.expression().kind() == SyntaxKind.FUNCTION_CALL ||
+                expr.expression().kind() == SyntaxKind.FIELD_ACCESS)) {
             completionItems.add(getTypeGuardDestructedItem((UnionTypeSymbol) typeSymbol, ctx, expr));
         }
         return completionItems;
     }
 
     /**
-     * Check if the given node is within a FunctionBodyBlockNode context.
+     * Check if the given node is within a FunctionBodyNode or BlockStatementNode.
      *
      * @param node Expression node of which the context is checked
      * @return
      */
-    public static boolean isInFunctionBlockBodyContext(FieldAccessExpressionNode node) {
+    public static boolean isInBlockContext(FieldAccessExpressionNode node) {
         return node.parent() instanceof ExpressionStatementNode &&
                 (node.parent().parent() instanceof FunctionBodyNode ||
                         node.parent().parent() instanceof BlockStatementNode);

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config28.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config28.json
@@ -1,30 +1,30 @@
 {
   "position": {
-    "line": 3,
-    "character": 35
+    "line": 12,
+    "character": 26
   },
-  "source": "expression_context/source/field_access_ctx_source3.bal",
+  "source": "expression_context/source/field_access_ctx_source23.bal",
   "items": [
     {
       "label": "foreach",
       "kind": "Snippet",
       "detail": "foreach var item in expr",
       "documentation": {
-        "left": "foreach statement for iterable variable - functionWithReturn().testField"
+        "left": "foreach statement for iterable variable - self.routingTable"
       },
       "sortText": "Q",
-      "insertText": "foreach var item in functionWithReturn().testField {\n\t${1}\n}",
+      "insertText": "foreach NodeCredential item in self.routingTable {\n\t${1}\n}",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
           "range": {
             "start": {
-              "line": 3,
-              "character": 4
+              "line": 12,
+              "character": 8
             },
             "end": {
-              "line": 3,
-              "character": 35
+              "line": 12,
+              "character": 26
             }
           },
           "newText": ""
@@ -36,42 +36,26 @@
       "kind": "Snippet",
       "detail": "foreach int i in 0...expr",
       "documentation": {
-        "left": "foreach i statement for iterable variable - functionWithReturn().testField"
+        "left": "foreach i statement for iterable variable - self.routingTable"
       },
       "sortText": "Q",
-      "insertText": "foreach int i in ${1:0}...functionWithReturn().testField.length() {\n\t${2}\n}",
+      "insertText": "foreach int i in ${1:0}...self.routingTable.length() {\n\t${2}\n}",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
           "range": {
             "start": {
-              "line": 3,
-              "character": 4
+              "line": 12,
+              "character": 8
             },
             "end": {
-              "line": 3,
-              "character": 35
+              "line": 12,
+              "character": 26
             }
           },
           "newText": ""
         }
       ]
-    },
-    {
-      "label": "rec1Field1",
-      "kind": "Field",
-      "detail": "int",
-      "sortText": "A",
-      "insertText": "rec1Field1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "rec1Field2",
-      "kind": "Field",
-      "detail": "string",
-      "sortText": "A",
-      "insertText": "rec1Field2",
-      "insertTextFormat": "Snippet"
     },
     {
       "label": "reduce(function () func, any|error initial)(any|error)",
@@ -80,31 +64,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `any|error` initial: initial value for the first argument of combining function `func`  \n  \n**Returns** `any|error`   \n- result of combining the members of `m` using `func`  \n  \n"
+          "value": "**Package:** _ballerina/lang.array:1.1.0_  \n  \nCombines the members of an array using a combining function.\nThe combining function takes the combined value so far and a member of the array,\nand returns a new combined value.\n\n```\n# reduce([1, 2, 3], function (int total, int n) returns int { return total + n; }, 0)\n# ```  \n**Params**  \n- `function ()` func: combining function  \n- `any|error` initial: initial value for the first argument of combining parameter `func`  \n  \n**Returns** `any|error`   \n- result of combining the members of `arr` using `func`  \n  \nFor example  \nis the same as `sum(1, 2, 3)`.  \n  \n"
         }
       },
       "sortText": "D",
       "filterText": "reduce",
       "insertText": "reduce(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "hasKey(string k)(boolean)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nTests whether m has a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `boolean`   \n- true if m has a member with key `k`  \n  \n"
-        }
-      },
-      "sortText": "D",
-      "filterText": "hasKey",
-      "insertText": "hasKey(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
@@ -118,7 +83,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function to each member of a map.\nThe function `func` is applied to each member of `m`.\n  \n**Params**  \n- `function ()` func: a function to apply to each member"
+          "value": "**Package:** _ballerina/lang.array:1.1.0_  \n  \nApplies a function to each member of an array.\nThe parameter `func` is applied to each member of array `arr` in order.\n  \n**Params**  \n- `function ()` func: a function to apply to each member"
         }
       },
       "sortText": "D",
@@ -131,18 +96,18 @@
       }
     },
     {
-      "label": "keys()(string[])",
+      "label": "shift()(any|error)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the keys of map `m`.\n  \n  \n  \n**Returns** `string[]`   \n- a new list of all keys  \n  \n"
+          "value": "**Package:** _ballerina/lang.array:1.1.0_  \n  \nRemoves and returns first member of an array.\nThe array must not be empty.\n  \n  \n  \n**Returns** `any|error`   \n- the value that was the first member of the array  \n  \n"
         }
       },
       "sortText": "D",
-      "filterText": "keys",
-      "insertText": "keys()",
+      "filterText": "shift",
+      "insertText": "shift()",
       "insertTextFormat": "Snippet"
     },
     {
@@ -152,7 +117,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns number of members of a map.\n  \n  \n  \n**Returns** `int`   \n- number of members in `m`  \n  \n"
+          "value": "**Package:** _ballerina/lang.array:1.1.0_  \n  \nReturns the number of members of an array.\n  \n  \n  \n**Returns** `int`   \n- number of members in `arr`  \n  \n"
         }
       },
       "sortText": "D",
@@ -161,13 +126,62 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "remove(string k)(any|error)",
+      "label": "sort(array:SortDirection direction, function ()? key)((any|error)[])",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- the member of `m` that had key `k`  \nThis removes the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
+          "value": "**Package:** _ballerina/lang.array:1.1.0_  \n  \nSorts an array.\nIf the member type of the array is not sorted, then the `key` function\nmust be specified.\nSorting works the same as with the `sort` clause of query expressions.\n  \n**Params**  \n- `array:SortDirection` direction: direction in which to sort(Defaultable)  \n- `function ()?` key: function that returns a key to use to sort the members(Defaultable)  \n  \n**Returns** `(any|error)[]`   \n- a new array consisting of the members of `arr` in sorted order  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "sort",
+      "insertText": "sort(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "reverse()((any|error)[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.array:1.1.0_  \n  \nReverses the order of the members of an array.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- `arr` with its members in reverse order  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "reverse",
+      "insertText": "reverse()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "toStream()(stream<any|error>)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.array:1.1.0_  \n  \nReturns a stream from the given array.\n  \n  \n  \n**Returns** `stream<any|error>`   \n- The stream representation of the array `arr`  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "toStream",
+      "insertText": "toStream()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "remove(int index)(any|error)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.array:1.1.0_  \n  \nRemoves a member of an array.\n  \n**Params**  \n- `int` index: index of member to be removed from `arr`  \n  \n**Returns** `any|error`   \n- the member of `arr` that was at `index`  \nThis removes the member of `arr` with index `index` and returns it.  \nIt panics if there is no such member.  \n  \n"
         }
       },
       "sortText": "D",
@@ -180,13 +194,32 @@
       }
     },
     {
-      "label": "filter(function () func)(map<any|error>)",
+      "label": "push(any|error... vals)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<any|error>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
+          "value": "**Package:** _ballerina/lang.array:1.1.0_  \n  \nAdds values to the end of an array.\n  \n**Params**  \n- `(any|error)[]` vals: values to add to the end of the array"
+        }
+      },
+      "sortText": "D",
+      "filterText": "push",
+      "insertText": "push(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "filter(function () func)((any|error)[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.array:1.1.0_  \n  \nSelects the members from an array for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each member to test whether it should be selected  \n  \n**Returns** `(any|error)[]`   \n- new array only containing members of `arr` for which `func` evaluates to true  \n  \n"
         }
       },
       "sortText": "D",
@@ -199,18 +232,33 @@
       }
     },
     {
-      "label": "removeIfHasKey(string k)(any|error?)",
+      "label": "pop()(any|error)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
+          "value": "**Package:** _ballerina/lang.array:1.1.0_  \n  \nRemoves and returns the last member of an array.\nThe array must not be empty.\n  \n  \n  \n**Returns** `any|error`   \n- removed member  \n  \n"
         }
       },
       "sortText": "D",
-      "filterText": "removeIfHasKey",
-      "insertText": "removeIfHasKey(${1})",
+      "filterText": "pop",
+      "insertText": "pop()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "lastIndexOf(anydata val, int startIndex)(int?)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.array:1.1.0_  \n  \nReturns the index of last member of `arr` that is equal to `val` if there is one.\nReturns `()` if not found.\nEquality is tested using `==`.\n  \n**Params**  \n- `anydata` val: member to search for  \n- `int` startIndex: index to start searching backwards from(Defaultable)  \n  \n**Returns** `int?`   \n- index of the member if found, else `()`  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "lastIndexOf",
+      "insertText": "lastIndexOf(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
@@ -224,27 +272,12 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| any|error value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
+          "value": "**Package:** _ballerina/lang.array:1.1.0_  \n  \nReturns an iterator over an array.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| any|error value; |}? ;}`   \n- a new iterator object that will iterate over the members of `arr`.  \n  \n"
         }
       },
       "sortText": "D",
       "filterText": "iterator",
       "insertText": "iterator()",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "entries()(map<[string, any|error]>)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, any|error]>`   \n- a new map of [key, member] pairs  \n  \n"
-        }
-      },
-      "sortText": "D",
-      "filterText": "entries",
-      "insertText": "entries()",
       "insertTextFormat": "Snippet"
     },
     {
@@ -254,7 +287,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves all members of a map.\nThis panics if any member cannot be removed.\n  \n"
+          "value": "**Package:** _ballerina/lang.array:1.1.0_  \n  \nRemoves all members of an array.  \n"
         }
       },
       "sortText": "D",
@@ -263,18 +296,18 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "get(string k)(any|error)",
+      "label": "setLength(int length)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- member with key `k`  \n  \n"
+          "value": "**Package:** _ballerina/lang.array:1.1.0_  \n  \nChanges the length of an array.\n  \n**Params**  \n- `int` length: new length\n`setLength(arr, 0)` is equivalent to `removeAll(arr)`."
         }
       },
       "sortText": "D",
-      "filterText": "get",
-      "insertText": "get(${1})",
+      "filterText": "setLength",
+      "insertText": "setLength(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
@@ -282,33 +315,90 @@
       }
     },
     {
-      "label": "toArray()((any|error)[])",
+      "label": "slice(int startIndex, int endIndex)((any|error)[])",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- an array whose members are the members of `m`  \n  \n"
+          "value": "**Package:** _ballerina/lang.array:1.1.0_  \n  \nReturns a subarray starting from `startIndex` (inclusive) to `endIndex` (exclusive).\n  \n**Params**  \n- `int` startIndex: index of first member to include in the slice  \n- `int` endIndex: index of first member not to include in the slice(Defaultable)  \n  \n**Returns** `(any|error)[]`   \n- array slice within specified range  \n  \n"
         }
       },
       "sortText": "D",
-      "filterText": "toArray",
-      "insertText": "toArray()",
-      "insertTextFormat": "Snippet"
+      "filterText": "slice",
+      "insertText": "slice(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
     },
     {
-      "label": "map(function () func)(map<any|error>)",
+      "label": "enumerate()([int, any|error][])",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<any|error>`   \n- new map containing result of applying function `func` to each member  \n  \n"
+          "value": "**Package:** _ballerina/lang.array:1.1.0_  \n  \nReturns a new array consisting of index and member pairs.\n  \n  \n  \n**Returns** `[int, any|error][]`   \n- array of index, member pairs  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "enumerate",
+      "insertText": "enumerate()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "unshift(any|error... vals)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.array:1.1.0_  \n  \nAdds values to the start of an array.\nThe values newly added to the array will be in the same order\nas they are in `vals`.\n  \n**Params**  \n- `(any|error)[]` vals: values to add to the start of the array"
+        }
+      },
+      "sortText": "D",
+      "filterText": "unshift",
+      "insertText": "unshift(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "map(function () func)((any|error)[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.array:1.1.0_  \n  \nApplies a function to each member of an array and returns an array of the results.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `(any|error)[]`   \n- new array containing result of applying `func` to each member of `arr` in order  \n  \n"
         }
       },
       "sortText": "D",
       "filterText": "map",
       "insertText": "map(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "indexOf(anydata val, int startIndex)(int?)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.array:1.1.0_  \n  \nReturns the index of first member of `arr` that is equal to `val` if there is one.\nReturns `()` if not found.\nEquality is tested using `==`.\n  \n**Params**  \n- `anydata` val: member to search for  \n- `int` startIndex: index to start the search from(Defaultable)  \n  \n**Returns** `int?`   \n- index of the member if found, else `()`  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "indexOf",
+      "insertText": "indexOf(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
@@ -393,6 +483,44 @@
       "filterText": "isReadOnly",
       "insertText": "isReadOnly()",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "fromJsonWithType(typedesc<anydata> t)(t|error)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value of type json to a user-specified type.\nThis works the same as `cloneWithType`,\nexcept that it also does the inverse of the conversions done by `toJson`.\n  \n**Params**  \n- `typedesc<anydata>` t: type to convert to(Defaultable)  \n  \n**Returns** `t|error`   \n- value belonging to type `t` or error if this cannot be done  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "fromJsonWithType",
+      "insertText": "fromJsonWithType(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "mergeJson(json j2)(json|error)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nMerges two json values.\n  \n**Params**  \n- `json` j2: json value  \n  \n**Returns** `json|error`   \n- the merge of `j1` with `j2` or an error if the merge fails  \n  \nThe merge of `j1` with `j2` is defined as follows:  \n- if `j1` is `()`, then the result is `j2`  \n- if `j2` is `()`, then the result is `j1`  \n- if `j1` is a mapping and `j2` is a mapping, then for each entry [k, j] in j2,  \nset `j1[k]` to the merge of `j1[k]` with `j`  \n- if `j1[k]` is undefined, then set `j1[k]` to `j`  \n- if any merge fails, then the merge of `j1` with `j2` fails  \n- otherwise, the result is `j1`.  \n- otherwise, the merge fails  \nIf the merge fails, then `j1` is unchanged.  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "mergeJson",
+      "insertText": "mergeJson(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
     },
     {
       "label": "clone()(CloneableType)",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config29.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config29.json
@@ -1,0 +1,81 @@
+{
+  "position": {
+    "line": 13,
+    "character": 22
+  },
+  "source": "expression_context/source/field_access_ctx_source24.bal",
+  "items": [
+    {
+      "label": "typeguard",
+      "kind": "Snippet",
+      "detail": "Destructure the variable self.response with typeguard",
+      "sortText": "Q",
+      "insertText": "if self.response is int {\n\t${1}\n} else {\n\t${2}\n}",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 13,
+              "character": 8
+            },
+            "end": {
+              "line": 13,
+              "character": 22
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": "cloneReadOnly()(CloneableType & readonly)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType & readonly`   \n- immutable clone of `v`  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "cloneReadOnly",
+      "insertText": "cloneReadOnly()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "clone()(CloneableType)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- clone of `v`  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "clone",
+      "insertText": "clone()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ensureType(typedesc<any> t)(t|error)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nSafely casts a value to a type.\nThis casts a value to a type in the same way as a type cast expression,\nbut returns an error if the cast cannot be done, rather than panicking.  \n**Params**  \n- `typedesc<any>` t: a typedesc for the type to which to cast it\nreturn - `v` cast to the type described by `t`, or an error, if the cast cannot be done(Defaultable)  \n  \n**Returns** `t|error`   \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "ensureType",
+      "insertText": "ensureType(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/field_access_ctx_source23.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/field_access_ctx_source23.bal
@@ -1,0 +1,15 @@
+
+type NodeCredential record {|
+    string ip;
+    int port;
+    string username;
+    string[] alias;
+|};
+
+class Node {
+    private NodeCredential[] routingTable = [];
+
+    function addNeighbor(NodeCredential credential) {
+        self.routingTable.
+    }
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/field_access_ctx_source24.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/field_access_ctx_source24.bal
@@ -1,0 +1,16 @@
+
+type NodeCredential record {|
+    string ip;
+    int port;
+    string username;
+    string[] alias;
+|};
+
+class Node {
+    private NodeCredential[] routingTable = [];
+    private int|error response;
+
+    function addNeighbor(NodeCredential credential) {
+        self.response.
+    }
+}


### PR DESCRIPTION
## Purpose
$subject

Fixes #30829 

## Samples

#### foreach statement

![ezgif com-gif-maker(1)](https://user-images.githubusercontent.com/35211477/120175497-e960a100-c223-11eb-8d3d-5cdc1e6f14fb.gif)

#### typeguard statement

![ezgif com-gif-maker](https://user-images.githubusercontent.com/35211477/120175516-ed8cbe80-c223-11eb-98c4-0e7e82e259ae.gif)



## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
