### PR TITLE
Add moudle level enum completions for record field type desc context

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/RecordTypeDescriptorNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/RecordTypeDescriptorNodeContext.java
@@ -64,7 +64,8 @@ public class RecordTypeDescriptorNodeContext extends AbstractCompletionProvider<
 
         if (this.onQualifiedNameIdentifier(context, nodeAtCursor)) {
             Predicate<Symbol> predicate =
-                    symbol -> symbol.kind() == SymbolKind.TYPE_DEFINITION || symbol.kind() == SymbolKind.CLASS;
+                    symbol -> symbol.kind() == SymbolKind.TYPE_DEFINITION || symbol.kind() == SymbolKind.CLASS
+                            || symbol.kind() == SymbolKind.ENUM;
             List<Symbol> types = QNameReferenceUtil.getModuleContent(context,
                     (QualifiedNameReferenceNode) nodeAtCursor, predicate);
             completionItems.addAll(this.getCompletionItemList(types, context));

--- a/language-server/modules/langserver-core/src/test/resources/completion/record_type_desc/config/config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/record_type_desc/config/config3.json
@@ -92,6 +92,14 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "TestEnum1",
+      "kind": "Enum",
+      "detail": "enum",
+      "sortText": "I",
+      "insertText": "TestEnum1",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "TestClass1",
       "kind": "Interface",
       "detail": "Class",

--- a/language-server/modules/langserver-core/src/test/resources/completion/record_type_desc/config/config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/record_type_desc/config/config4.json
@@ -92,6 +92,14 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "TestEnum1",
+      "kind": "Enum",
+      "detail": "enum",
+      "sortText": "I",
+      "insertText": "TestEnum1",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "TestClass1",
       "kind": "Interface",
       "detail": "Class",


### PR DESCRIPTION
## Purpose
$subject

Fixes #30839 

## Approach
Refactor the symbol filtering predicate

## Samples
![fix](https://user-images.githubusercontent.com/35211477/120185331-ac9aa700-c22f-11eb-89e5-398a9f3d6354.png)


## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
