### PR TITLE
Optimize TypeChecker for union with error

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
@@ -44,6 +44,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BArrayType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BIntersectionType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BObjectType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BUnionType;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.util.Flags;
 
@@ -91,6 +92,7 @@ import static org.objectweb.asm.Opcodes.IF_ICMPLT;
 import static org.objectweb.asm.Opcodes.IF_ICMPNE;
 import static org.objectweb.asm.Opcodes.ILOAD;
 import static org.objectweb.asm.Opcodes.INEG;
+import static org.objectweb.asm.Opcodes.INSTANCEOF;
 import static org.objectweb.asm.Opcodes.INVOKEINTERFACE;
 import static org.objectweb.asm.Opcodes.INVOKESPECIAL;
 import static org.objectweb.asm.Opcodes.INVOKESTATIC;
@@ -1398,7 +1400,6 @@ public class JvmInstructionGen {
     }
 
     void generateArrayValueLoad(BIRNonTerminator.FieldAccess inst) {
-
         this.loadVar(inst.rhsOp.variableDcl);
         this.mv.visitTypeInsn(CHECKCAST, ARRAY_VALUE);
         this.loadVar(inst.keyOp.variableDcl);
@@ -1520,15 +1521,61 @@ public class JvmInstructionGen {
     }
 
     void generateTypeTestIns(BIRNonTerminator.TypeTest typeTestIns) {
-        // load source value
-        this.loadVar(typeTestIns.rhsOp.variableDcl);
-
-        // load targetType
-        jvmTypeGen.loadType(this.mv, typeTestIns.type);
+        var sourceValue = typeTestIns.rhsOp.variableDcl;
+        BType targetType = typeTestIns.type;
+        if (canOptimizeType(sourceValue, targetType)) {
+            handleErrorUnionType(typeTestIns);
+            return;
+        }
+        this.loadVar(sourceValue);
+        jvmTypeGen.loadType(this.mv, targetType);
 
         this.mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "checkIsType",
                                 String.format("(L%s;L%s;)Z", OBJECT, TYPE), false);
         this.storeToVar(typeTestIns.lhsOp.variableDcl);
+    }
+
+    private void handleErrorUnionType(BIRNonTerminator.TypeTest typeTestIns) {
+        loadVar(typeTestIns.rhsOp.variableDcl);
+        mv.visitTypeInsn(INSTANCEOF, BERROR);
+        if (typeTestIns.type.tag != TypeTags.ERROR) {
+            generateNegateBoolean();
+        }
+        storeToVar(typeTestIns.lhsOp.variableDcl);
+    }
+
+    private boolean canOptimizeType(BIRNode.BIRVariableDcl rhsVar, BType type) {
+        BType rhsType = rhsVar.type;
+        if (rhsType.tag != TypeTags.UNION) {
+            return false;
+        }
+        var unionMemberTypes = ((BUnionType) rhsType).getMemberTypes();
+        if (unionMemberTypes.size() != 2) {
+            return false;
+        }
+        BType errorType = null;
+        BType otherType = null;
+        boolean foundError = false;
+        for (BType bType : unionMemberTypes) {
+            if (bType.tag == TypeTags.ERROR) {
+                errorType = bType;
+                foundError = true;
+            } else {
+                otherType = bType;
+            }
+        }
+        return foundError && (type.equals(errorType) || type.equals(otherType));
+    }
+
+    private void generateNegateBoolean() {
+        Label ifLabel = new Label();
+        mv.visitJumpInsn(IFNE, ifLabel);
+        mv.visitInsn(ICONST_1);
+        Label gotoLabel = new Label();
+        mv.visitJumpInsn(GOTO, gotoLabel);
+        mv.visitLabel(ifLabel);
+        mv.visitInsn(ICONST_0);
+        mv.visitLabel(gotoLabel);
     }
 
     void generateIsLikeIns(BIRNonTerminator.IsLike isLike) {
@@ -1751,8 +1798,6 @@ public class JvmInstructionGen {
         this.mv.visitMethodInsn(INVOKEVIRTUAL, XML_VALUE, "getAttribute",
                                 String.format("(L%s;)L%s;", B_XML_QNAME, STRING_VALUE), false);
 
-        // store in the target reg
-        BType targetType = xmlAttrStoreIns.lhsOp.variableDcl.type;
         this.storeToVar(xmlAttrStoreIns.lhsOp.variableDcl);
     }
 
@@ -1790,8 +1835,6 @@ public class JvmInstructionGen {
                     String.format("(I)L%s;", XML_VALUE), false);
         }
 
-        // store in the target reg
-        BType targetType = xmlLoadIns.lhsOp.variableDcl.type;
         this.storeToVar(xmlLoadIns.lhsOp.variableDcl);
     }
 
@@ -1845,7 +1888,7 @@ public class JvmInstructionGen {
     void generateNewTypedescIns(BIRNonTerminator.NewTypeDesc newTypeDesc) {
         List<BIROperand> closureVars = newTypeDesc.closureVars;
         BType type = newTypeDesc.type;
-        if (type.tag == TypeTags.RECORD && closureVars.size() == 0 && type.tsymbol != null) {
+        if (type.tag == TypeTags.RECORD && closureVars.isEmpty() && type.tsymbol != null) {
             PackageID packageID = type.tsymbol.pkgID;
             String typeOwner = JvmCodeGenUtil.getPackageName(packageID) + MODULE_INIT_CLASS_NAME;
             String fieldName = jvmTypeGen.getTypedescFieldName(toNameString(type));


### PR DESCRIPTION
## Purpose
Resolve https://github.com/ballerina-platform/ballerina-lang/issues/30185

## Approach
> When there's a union of error and another value, the type checking only happens for the error. This is because union with error is a common use case. This eliminate call to the TypeChecker.checkIsType method which is costly.
## Samples
> N/A

## Remarks
> N/A

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
