### PR TITLE
Fix distinct error runtime is check

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -2550,8 +2550,12 @@ public class TypeChecker {
         unresolvedTypes.add(pair);
         BErrorType bErrorType = (BErrorType) sourceType;
 
+        if (!checkIsType(bErrorType.detailType, targetType.detailType, unresolvedTypes)) {
+            return false;
+        }
+
         if (targetType.typeIdSet == null) {
-            return checkIsType(bErrorType.detailType, targetType.detailType, unresolvedTypes);
+            return true;
         }
 
         BTypeIdSet sourceTypeIdSet = bErrorType.typeIdSet;
@@ -2569,9 +2573,13 @@ public class TypeChecker {
             return false;
         }
 
+        if (!checkIsLikeType(((ErrorValue) sourceValue).getDetails(), targetType.detailType, unresolvedValues,
+                allowNumericConversion)) {
+            return false;
+        }
+
         if (targetType.typeIdSet == null) {
-            return checkIsLikeType(((ErrorValue) sourceValue).getDetails(), targetType.detailType, unresolvedValues,
-                    allowNumericConversion);
+            return true;
         }
 
         BTypeIdSet sourceIdSet = ((BErrorType) sourceType).typeIdSet;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/intersection/IntersectionTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/intersection/IntersectionTypeTest.java
@@ -127,6 +127,11 @@ public class IntersectionTypeTest {
     }
 
     @Test
+    public void testDistinctErrorWithSameTypeIdsButDifferentTypes() {
+        BRunUtil.invoke(errorIntersectionResults, "testDistinctErrorWithSameTypeIdsButDifferentTypes");
+    }
+
+    @Test
     public void testErrorIntersectionNegative() {
         CompileResult result = BCompileUtil.compile("test-src/types/intersection/error_intersection_type_negative.bal");
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/intersection/error_intersection_type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/intersection/error_intersection_type.bal
@@ -177,6 +177,18 @@ function testAnonDistinctError() {
     }
 }
 
+type FreeError distinct error;
+
+type E1 distinct FreeError;
+
+type E2 FreeError & error<Detail>;
+
+public function testDistinctErrorWithSameTypeIdsButDifferentTypes() {
+    E1 x = error E1("");
+    // E1 and E2 have matching type-ids.
+    assertEquality(x is E2, false);
+}
+
 function assertEquality(any|error actual, any|error expected) {
     if expected is anydata && actual is anydata && expected == actual {
         return;


### PR DESCRIPTION
## Purpose
Take error intersections into consideration when `is type` is applied to distinct error types.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/30930

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
