### PR TITLE
[LS] Fix completions being shown within markdown documentation node

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MarkdownDocumentationNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MarkdownDocumentationNodeContext.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.langserver.completions.providers.context;
+
+import io.ballerina.compiler.syntax.tree.MarkdownDocumentationNode;
+import org.ballerinalang.annotation.JavaSPIService;
+import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
+import org.ballerinalang.langserver.commons.completion.LSCompletionException;
+import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
+import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Completion provider for {@link MarkdownDocumentationNode} context.
+ *
+ * @since 2.0.0
+ */
+@JavaSPIService("org.ballerinalang.langserver.commons.completion.spi.BallerinaCompletionProvider")
+public class MarkdownDocumentationNodeContext extends AbstractCompletionProvider<MarkdownDocumentationNode> {
+
+    public MarkdownDocumentationNodeContext() {
+        super(MarkdownDocumentationNode.class);
+    }
+
+    @Override
+    public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context,
+                                                 MarkdownDocumentationNode node) throws LSCompletionException {
+        // As of now, we are not showing any completions within documentation node
+        return Collections.emptyList();
+    }
+}

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/MarkdownDocumentationContextTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/MarkdownDocumentationContextTest.java
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.langserver.completion;
+
+import org.ballerinalang.langserver.commons.workspace.WorkspaceDocumentException;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+/**
+ * Markdown documentation node context tests.
+ *
+ * @since 2.0.0
+ */
+public class MarkdownDocumentationContextTest extends CompletionTest {
+
+    @Test(dataProvider = "completion-data-provider")
+    @Override
+    public void test(String config, String configPath) throws WorkspaceDocumentException, IOException {
+        super.test(config, configPath);
+    }
+
+    @DataProvider(name = "completion-data-provider")
+    @Override
+    public Object[][] dataProvider() {
+        return new Object[][]{
+                {"markdown_documentation_config1.json", getTestResourceDir()}
+        };
+    }
+
+    @Override
+    public String getTestResourceDir() {
+        return "markdown_documentation_context";
+    }
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/markdown_documentation_context/config/markdown_documentation_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/markdown_documentation_context/config/markdown_documentation_config1.json
@@ -1,0 +1,8 @@
+{
+  "position": {
+    "line": 0,
+    "character": 4
+  },
+  "source": "markdown_documentation_context/source/markdown_documentation_source1.bal",
+  "items": []
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/markdown_documentation_context/source/markdown_documentation_source1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/markdown_documentation_context/source/markdown_documentation_source1.bal
@@ -1,0 +1,4 @@
+# Description  
+public function function1() {
+    
+}


### PR DESCRIPTION
## Purpose
$subject

Fixes #30948
Fixes #30696

## Approach
Added a completion provider for markdown documentation. It returns an empty list as of now. In future, we may suggest documentation related keywords/parameters within that.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
