### PR TITLE
Fix type checking for type cast in constructor member when the contextually-expected type is a union

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -4168,14 +4168,8 @@ public class TypeChecker extends BLangNodeVisitor {
         this.dlog.resetErrorCount();
         this.dlog.mute();
 
-        BLangExpression exprToCheck = expr;
-
-        if (!prevNonErrorLoggingCheck) {
-            expr.cloneAttempt++;
-            exprToCheck = nodeCloner.clone(expr);
-        }
-
-        BType exprCompatibleType = checkExpr(exprToCheck, env, targetType);
+        expr.cloneAttempt++;
+        BType exprCompatibleType = checkExpr(nodeCloner.clone(expr), env, targetType);
 
         this.nonErrorLoggingCheck = prevNonErrorLoggingCheck;
         int errorCount = this.dlog.errorCount();

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExpressionsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExpressionsTest.java
@@ -188,6 +188,11 @@ public class TypeCastExpressionsTest {
         BRunUtil.invoke(result, "testMutableJsonMappingToExclusiveRecordNegative");
     }
 
+    @Test
+    public void testTypeCastInConstructorMemberWithUnionCET() {
+        BRunUtil.invoke(result, "testTypeCastInConstructorMemberWithUnionCET");
+    }
+
     @Test(expectedExceptions = BLangRuntimeException.class,
             expectedExceptionsMessageRegExp = ".*incompatible types: 'string' cannot be cast to 'int'.*")
     public void testStringAsInvalidBasicType() {
@@ -291,6 +296,14 @@ public class TypeCastExpressionsTest {
                 , 13);
         validateError(resultNegative, errIndex++, "incompatible types: '(json|error)' cannot be cast to 'string'", 69,
                 13);
+        validateError(resultNegative, errIndex++, "incompatible types: '(string[]|int)' cannot be cast to 'byte[]'",
+                78, 32);
+        validateError(resultNegative, errIndex++, "incompatible mapping constructor expression for type '(record {| " +
+                        "byte[] a; anydata...; |}|record {| string a; anydata...; |})'", 79, 47);
+        validateError(resultNegative, errIndex++, "incompatible types: '(string[]|int)' cannot be cast to 'byte[]'",
+                79, 51);
+        validateError(resultNegative, errIndex++, "incompatible mapping constructor expression for type '(record {| " +
+                "string[] a; anydata...; |}|record {| string a; anydata...; |})'", 82, 49);
         Assert.assertEquals(resultNegative.getErrorCount(), errIndex);
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typecast/type_cast_expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typecast/type_cast_expr.bal
@@ -864,6 +864,34 @@ function testMutableJsonMappingToExclusiveRecordNegative() {
     assertEquality("incompatible types: 'map<json>' cannot be cast to 'Bar'", err.detail()["message"]);
 }
 
+function testTypeCastInConstructorMemberWithUnionCET() {
+    any[]|error v1 = [];
+    var fn1 = function () {
+        record {byte[] a;} x = {a: <byte[]> checkpanic v1};
+    };
+    assertErrorForTypeCastFailure(trap fn1());
+
+    var fn2 = function () {
+        record {byte[] a;}|int x = {a: <byte[]> checkpanic v1};
+    };
+    assertErrorForTypeCastFailure(trap fn2());
+
+    any[]|error v2 = <byte[]> [1, 2];
+
+    record {byte[] a;} x = {a: <byte[]> checkpanic v2};
+    assertEquality(<byte[]> [1, 2], x.a);
+
+    record {byte[] a;}|int y = {a: <byte[]> checkpanic v2};
+    assertEquality(<byte[]> [1, 2], (<record {byte[] a;}> y).a);
+}
+
+function assertErrorForTypeCastFailure(error? res) {
+    assertEquality(true, res is error);
+    error err1 = <error> res;
+    assertEquality("{ballerina}TypeCastError", err1.message());
+    assertEquality("incompatible types: 'any[]' cannot be cast to 'byte[]'", err1.detail()["message"]);
+}
+
 // Util functions
 
 const ASSERTION_ERROR_REASON = "AssertionError";

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typecast/type_cast_expr_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typecast/type_cast_expr_negative.bal
@@ -72,3 +72,12 @@ function testCastWithErrorType() {
 function foo() returns int|error {
     return 1;
 }
+
+function testTypeCastInConstructorMemberWithUnionCETNegative() {
+    string[]|int val1 = [];
+    record {byte[] a;} a = {a: <byte[]> val1};
+    record {byte[] a;}|record {string a;} b = {a: <byte[]> val1};
+
+    any[]|error val2 = [];
+    record {string[] a;}|record {string a;} c = {a: <byte[]> checkpanic val2};
+}


### PR DESCRIPTION
## Purpose
$title.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/30951

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
