### PR TITLE
Allow accessing immutable parameters of the enclosing function in anonymous isolated functions

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/IsolationAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/IsolationAnalyzer.java
@@ -1168,11 +1168,13 @@ public class IsolationAnalyzer extends BLangNodeVisitor {
             return;
         }
 
-        if (Symbols.isFlagOn(symbol.flags, Flags.CONSTANT)) {
+        long flags = symbol.flags;
+        if (Symbols.isFlagOn(flags, Flags.CONSTANT)) {
             return;
         }
 
-        if (Symbols.isFlagOn(symbol.flags, Flags.FINAL) && types.isSubTypeOfReadOnlyOrIsolatedObjectUnion(accessType)) {
+        if ((Symbols.isFlagOn(flags, Flags.FINAL) || Symbols.isFlagOn(flags, Flags.FUNCTION_FINAL)) &&
+                types.isSubTypeOfReadOnlyOrIsolatedObjectUnion(accessType)) {
             return;
         }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/isolation/IsolationAnalysisTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/isolation/IsolationAnalysisTest.java
@@ -101,6 +101,14 @@ public class IsolationAnalysisTest {
     }
 
     @Test
+    public void testAnonIsolatedFuncAccessingImplicitlyFinalVars() {
+        CompileResult result = BCompileUtil.compile(
+                "test-src/isolation-analysis/implicitly_final_var_access_in_anon_isolated_functions.bal");
+        Assert.assertEquals(result.getErrorCount(), 0);
+        Assert.assertEquals(result.getWarnCount(), 0);
+    }
+
+    @Test
     public void testIsolatedFunctionsSemanticNegative() {
         CompileResult result =
                 BCompileUtil.compile("test-src/isolation-analysis/isolation_analysis_semantic_negative.bal");
@@ -197,6 +205,19 @@ public class IsolationAnalysisTest {
         validateError(result, i++, INVALID_MUTABLE_STORAGE_ACCESS_ERROR, 271, 14);
         validateError(result, i++, INVALID_MUTABLE_STORAGE_ACCESS_ERROR, 272, 14);
         validateError(result, i++, INVALID_MUTABLE_STORAGE_ACCESS_ERROR, 273, 14);
+        validateError(result, i++, INVALID_MUTABLE_STORAGE_ACCESS_ERROR, 277, 52);
+        validateError(result, i++, INVALID_MUTABLE_STORAGE_ACCESS_ERROR, 282, 10);
+        validateError(result, i++, INVALID_MUTABLE_STORAGE_ACCESS_ERROR, 282, 20);
+        validateError(result, i++, INVALID_MUTABLE_STORAGE_ACCESS_ERROR, 283, 17);
+        validateError(result, i++, INVALID_MUTABLE_STORAGE_ACCESS_ERROR, 287, 85);
+        validateError(result, i++, INVALID_MUTABLE_STORAGE_ACCESS_ERROR, 290, 7);
+        validateError(result, i++, INVALID_MUTABLE_STORAGE_ACCESS_ERROR, 291, 14);
+        validateError(result, i++, INVALID_MUTABLE_STORAGE_ACCESS_ERROR, 299, 20);
+        validateError(result, i++, INVALID_MUTABLE_STORAGE_ACCESS_ERROR, 300, 20);
+        validateError(result, i++, INVALID_MUTABLE_STORAGE_ACCESS_ERROR, 305, 51);
+        validateError(result, i++, INVALID_MUTABLE_STORAGE_ACCESS_ERROR, 308, 54);
+        validateError(result, i++, INVALID_MUTABLE_STORAGE_ACCESS_ERROR, 311, 70);
+        validateError(result, i++, INVALID_MUTABLE_STORAGE_ACCESS_ERROR, 313, 76);
         Assert.assertEquals(result.getErrorCount(), i - 2);
         Assert.assertEquals(result.getDiagnostics().length, i);
     }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/isolation-analysis/implicitly_final_var_access_in_anon_isolated_functions.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/isolation-analysis/implicitly_final_var_access_in_anon_isolated_functions.bal
@@ -1,0 +1,52 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+public function testAnonIsolatedFuncAccessingImplicitlyFinalVars(int i) {
+   var fn1 = isolated function () returns int => i;
+
+   int[] x = [];
+   foreach var j in x {
+      var fn2 = isolated function () returns int {
+         return j + i;
+      };
+   }
+
+   var fn3 = let int k = 1 + i in isolated function () returns int => k;
+
+   var fn4 = let int k = 1 + i in isolated function (int l) returns int {
+      return k + l;
+   };
+
+   // https://github.com/ballerina-platform/ballerina-lang/issues/30987
+   // (isolated function () returns int)[] fn5 =
+   //    from var m in x
+   //    where m > 10
+   //    let int n = m + 1
+   //    select isolated function () returns int => m + n;
+
+
+   isolated function () returns int fn6 = () => i;
+
+   foreach var j in x {
+      isolated function () returns int fn7 = () => j;
+   }
+
+   isolated function () returns int fn8 = let int k = 1 + i in () => k;
+
+   isolated function (int) returns int fn9 = let int k = 1 + i in (l) => k + l;
+
+   isolated function (int[]) returns int[] fn10 = let int[] k = [i] in (l) => l;
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/isolation-analysis/isolation_analysis_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/isolation-analysis/isolation_analysis_negative.bal
@@ -272,3 +272,43 @@ isolated function testInvalidMutableServiceAccess() {
     any x2 = ser2;
     any x3 = ser3;
 }
+
+function testAnonIsolatedFuncAccessingImplicitlyFinalVarsNegative(int[] i) {
+   var fn1 = isolated function () returns int[] => i;
+
+   int[][] x = [];
+   foreach var j in x {
+      var fn2 = isolated function () returns int[] {
+         j.push(...i);
+         return j;
+      };
+   }
+
+   var fn3 = let int[] k = [i.length(), 1] in isolated function () returns int[] => k;
+
+   var fn4 = let int[] k = i in isolated function (int[] l) returns int[] {
+      k.push(...l);
+      return k;
+   };
+
+   (isolated function () returns int[])[] fn5 =
+      from var m in x
+      where m.length() > 10
+      let int[] n = []
+      select isolated function () returns int[] {
+         int[] y = m;
+         y.push(...n);
+         return y;
+      };
+
+
+   isolated function () returns int[] fn6 = () => i;
+
+   foreach var j in x {
+      isolated function () returns int[] fn7 = () => j;
+   }
+
+   isolated function () returns int[] fn8 = let int[] k = i in () => k;
+
+   isolated function (int[]) returns int[] fn9 = let int[] k = i in (l) => k;
+}


### PR DESCRIPTION
## Purpose
$title.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/30902

This PR also adds tests for accessing other implicitly-final variables.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
