### PR TITLE
Remove file name from the module name in the CallStackElement record

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/constants/RuntimeConstants.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/constants/RuntimeConstants.java
@@ -33,6 +33,7 @@ public class RuntimeConstants {
 
     public static final String MAIN_FUNCTION_NAME = "main";
     public static final String MODULE_INIT_CLASS_NAME = "$_init";
+    public static final String FILE_NAME_PERIOD_SEPARATOR = "$$$";
 
     // Configs
     public static final String BALLERINA_ARGS_INIT_PREFIX = "--";

--- a/langlib/jballerina.java/src/main/ballerina/stackFrameImpl.bal
+++ b/langlib/jballerina.java/src/main/ballerina/stackFrameImpl.bal
@@ -23,7 +23,7 @@
 public readonly class StackFrameImpl {
 
     public string callableName;
-    public string moduleName;
+    public string? moduleName;
     public string fileName;
     public int lineNumber;
 
@@ -31,39 +31,19 @@ public readonly class StackFrameImpl {
     #
     # + return - A stack frame as string
     public function toString() returns string {
-        return "callableName: " + self.callableName + " " + "moduleName: " + self.moduleName +
-                " " + "fileName: " + self.fileName + " " + "lineNumber: " + getStringValue(self.lineNumber);
+        if (self.moduleName is string) {
+            return "callableName: " + self.callableName + " " + "moduleName: " + <string> self.moduleName +
+                            " " + "fileName: " + self.fileName + " " + "lineNumber: " + getStringValue(self.lineNumber);
+        } else {
+            return "callableName: " + self.callableName + " " +
+                            " " + "fileName: " + self.fileName + " " + "lineNumber: " + getStringValue(self.lineNumber);
+        }
+
     }
 
-    public function init(string callableName, string moduleName, string fileName, int lineNumber) {
+    public function init(string callableName, string fileName, int lineNumber, string? moduleName) {
         self.callableName = callableName;
         self.moduleName = moduleName;
-        self.fileName = fileName;
-        self.lineNumber = lineNumber;
-    }
-}
-
-# Implementation for the `runtime.StackFrame`.
-#
-# + callableName - Callable name
-# + fileName - File name
-# + lineNumber - Line number
-public readonly class StackFrameImplForSingleBalFile {
-
-    public string callableName;
-    public string fileName;
-    public int lineNumber;
-
-    # Returns a string representing for the `StackFrame`
-    #
-    # + return - A stack frame as string
-    public function toString() returns string {
-        return "callableName: " + self.callableName + " " + "fileName: " + self.fileName +
-                        " " + "lineNumber: " + getStringValue(self.lineNumber);
-    }
-
-    public function init(string callableName, string fileName, int lineNumber) {
-        self.callableName = callableName;
         self.fileName = fileName;
         self.lineNumber = lineNumber;
     }

--- a/langlib/jballerina.java/src/main/ballerina/stackFrameImpl.bal
+++ b/langlib/jballerina.java/src/main/ballerina/stackFrameImpl.bal
@@ -42,3 +42,29 @@ public readonly class StackFrameImpl {
         self.lineNumber = lineNumber;
     }
 }
+
+# Implementation for the `runtime.StackFrame`.
+#
+# + callableName - Callable name
+# + fileName - File name
+# + lineNumber - Line number
+public readonly class StackFrameImplForSingleBalFile {
+
+    public string callableName;
+    public string fileName;
+    public int lineNumber;
+
+    # Returns a string representing for the `StackFrame`
+    #
+    # + return - A stack frame as string
+    public function toString() returns string {
+        return "callableName: " + self.callableName + " " + "fileName: " + self.fileName +
+                        " " + "lineNumber: " + getStringValue(self.lineNumber);
+    }
+
+    public function init(string callableName, string fileName, int lineNumber) {
+        self.callableName = callableName;
+        self.fileName = fileName;
+        self.lineNumber = lineNumber;
+    }
+}

--- a/langlib/jballerina.java/src/main/ballerina/stackFrameImpl.bal
+++ b/langlib/jballerina.java/src/main/ballerina/stackFrameImpl.bal
@@ -31,8 +31,9 @@ public readonly class StackFrameImpl {
     #
     # + return - A stack frame as string
     public function toString() returns string {
-        if (self.moduleName is string) {
-            return "callableName: " + self.callableName + " " + "moduleName: " + <string> self.moduleName +
+        var moduleName = self.moduleName;
+        if (moduleName is string) {
+            return "callableName: " + self.callableName + " " + "moduleName: " + moduleName +
                             " " + "fileName: " + self.fileName + " " + "lineNumber: " + getStringValue(self.lineNumber);
         } else {
             return "callableName: " + self.callableName + " " +

--- a/langlib/lang.error/src/main/ballerina/error.bal
+++ b/langlib/lang.error/src/main/ballerina/error.bal
@@ -67,7 +67,7 @@ public isolated function detail(error<DetailType> e) returns DetailType = @java:
 # + lineNumber - Line number
 public type CallStackElement record {|
     string callableName;
-    string moduleName;
+    string moduleName?;
     string fileName;
     int lineNumber;
 |};

--- a/langlib/lang.error/src/main/java/org/ballerinalang/langlib/error/StackTrace.java
+++ b/langlib/lang.error/src/main/java/org/ballerinalang/langlib/error/StackTrace.java
@@ -25,6 +25,7 @@ import io.ballerina.runtime.api.creators.ValueCreator;
 import io.ballerina.runtime.api.types.MethodType;
 import io.ballerina.runtime.api.types.ObjectType;
 import io.ballerina.runtime.api.types.Type;
+import io.ballerina.runtime.api.utils.IdentifierUtils;
 import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.values.BArray;
 import io.ballerina.runtime.api.values.BError;
@@ -41,6 +42,8 @@ import java.util.Map;
 
 import static io.ballerina.runtime.api.constants.RuntimeConstants.BALLERINA_LANG_ERROR_PKG_ID;
 import static io.ballerina.runtime.api.constants.RuntimeConstants.BLANG_SRC_FILE_SUFFIX;
+import static io.ballerina.runtime.api.constants.RuntimeConstants.DOT;
+import static io.ballerina.runtime.api.constants.RuntimeConstants.FILE_NAME_PERIOD_SEPARATOR;
 import static io.ballerina.runtime.api.values.BError.CALL_STACK_ELEMENT;
 
 /**
@@ -79,7 +82,7 @@ public class StackTrace {
 
     static BMap<BString, Object> getStackFrame(StackTraceElement stackTraceElement) {
         String methodName = stackTraceElement.getMethodName();
-        String moduleName = stackTraceElement.getClassName();
+        String moduleName = IdentifierUtils.decodeIdentifier(stackTraceElement.getClassName());
         String fileName = stackTraceElement.getFileName();
         int lineNumber = stackTraceElement.getLineNumber();
 
@@ -96,6 +99,7 @@ public class StackTrace {
 
     private static String getModuleName(String moduleName, String fileName) {
         fileName = fileName.replace(BLANG_SRC_FILE_SUFFIX, "");
+        moduleName = moduleName.replace(FILE_NAME_PERIOD_SEPARATOR, DOT);
         int index = moduleName.lastIndexOf("." + fileName);
         if (index != -1) {
             moduleName = moduleName.substring(0, index);
@@ -104,7 +108,9 @@ public class StackTrace {
     }
 
     private static boolean isSingleBalFile(String moduleName, String fileName) {
-        return moduleName.equals(fileName.replace(BLANG_SRC_FILE_SUFFIX, "")) ? true : false;
+        moduleName = moduleName.replace(FILE_NAME_PERIOD_SEPARATOR, DOT);
+        fileName = fileName.replace(BLANG_SRC_FILE_SUFFIX, "");
+        return moduleName.equals(fileName) ? true : false;
     }
 
     /**

--- a/langlib/lang.runtime/src/main/ballerina/runtime.bal
+++ b/langlib/lang.runtime/src/main/ballerina/runtime.bal
@@ -33,7 +33,7 @@ public type DynamicListener object {
 # + lineNumber - Line number
 type CallStackElement record {|
     string callableName;
-    string moduleName;
+    string moduleName?;
     string fileName;
     int lineNumber;
 |};
@@ -84,13 +84,8 @@ public isolated function getStackTrace() returns StackFrame[] {
     int i = 0;
     CallStackElement[] callStackElements = externGetStackTrace();
     lang_array:forEach(callStackElements, function (CallStackElement callStackElement) {
-        if (callStackElement["moduleName"] is string) {
-            stackFrame[i] = new java:StackFrameImpl(callStackElement.callableName, callStackElement.moduleName,
-            callStackElement.fileName, callStackElement.lineNumber);
-        } else {
-            stackFrame[i] = new java:StackFrameImplForSingleBalFile(callStackElement.callableName,
-            callStackElement.fileName, callStackElement.lineNumber);
-        }
+            stackFrame[i] = new java:StackFrameImpl(callStackElement.callableName,
+            callStackElement.fileName, callStackElement.lineNumber, callStackElement?.moduleName);
         i += 1;
     });
     return stackFrame;

--- a/langlib/lang.runtime/src/main/ballerina/runtime.bal
+++ b/langlib/lang.runtime/src/main/ballerina/runtime.bal
@@ -84,10 +84,15 @@ public isolated function getStackTrace() returns StackFrame[] {
     int i = 0;
     CallStackElement[] callStackElements = externGetStackTrace();
     lang_array:forEach(callStackElements, function (CallStackElement callStackElement) {
-                                stackFrame[i] = new java:StackFrameImpl(callStackElement.callableName,
-                                callStackElement.moduleName, callStackElement.fileName, callStackElement.lineNumber);
-                                i += 1;
-                            });
+        if (callStackElement["moduleName"] is string) {
+            stackFrame[i] = new java:StackFrameImpl(callStackElement.callableName, callStackElement.moduleName,
+            callStackElement.fileName, callStackElement.lineNumber);
+        } else {
+            stackFrame[i] = new java:StackFrameImplForSingleBalFile(callStackElement.callableName,
+            callStackElement.fileName, callStackElement.lineNumber);
+        }
+        i += 1;
+    });
     return stackFrame;
 }
 

--- a/langlib/lang.runtime/src/main/java/org/ballerinalang/langlib/runtime/GetStackTrace.java
+++ b/langlib/lang.runtime/src/main/java/org/ballerinalang/langlib/runtime/GetStackTrace.java
@@ -22,12 +22,18 @@ import io.ballerina.runtime.api.creators.ErrorCreator;
 import io.ballerina.runtime.api.creators.TypeCreator;
 import io.ballerina.runtime.api.creators.ValueCreator;
 import io.ballerina.runtime.api.types.Type;
+import io.ballerina.runtime.api.utils.IdentifierUtils;
 import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.values.BArray;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BString;
 
 import java.util.List;
+
+import static io.ballerina.runtime.api.constants.RuntimeConstants.BLANG_SRC_FILE_SUFFIX;
+import static io.ballerina.runtime.api.constants.RuntimeConstants.DOT;
+import static io.ballerina.runtime.api.constants.RuntimeConstants.EMPTY;
+import static io.ballerina.runtime.api.constants.RuntimeConstants.FILE_NAME_PERIOD_SEPARATOR;
 
 /**
  * Native implementation for get error's call stack.
@@ -55,9 +61,20 @@ public class GetStackTrace {
     private static Object[] getStackFrame(StackTraceElement stackTraceElement) {
         Object[] values = new Object[4];
         values[0] = stackTraceElement.getMethodName();
-        values[1] = stackTraceElement.getClassName();
         values[2] = stackTraceElement.getFileName();
         values[3] = stackTraceElement.getLineNumber();
+
+        String moduleName = IdentifierUtils.decodeIdentifier(stackTraceElement.getClassName())
+                .replace(FILE_NAME_PERIOD_SEPARATOR, DOT);
+        String fileName = stackTraceElement.getFileName().replace(BLANG_SRC_FILE_SUFFIX, EMPTY);
+        if (!moduleName.equals(fileName)) {
+            int index = moduleName.lastIndexOf(DOT + fileName);
+            if (index != -1) {
+                values[1] = moduleName.substring(0, index);
+            } else {
+                values[1] = moduleName;
+            }
+        }
         return values;
     }
 }

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibErrorTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibErrorTest.java
@@ -78,16 +78,16 @@ public class LangLibErrorTest {
         BValue[] returns = BRunUtil.invoke(compileResult, "getErrorStackTrace");
         assertEquals(returns[0].getType().getTag(), TypeTags.OBJECT_TYPE_TAG);
         BRefType<?>[] callStacks = ((BValueArray) ((BMap) returns[0]).get("callStack")).getValues();
-        assertEquals(callStacks[0].stringValue(), "{callableName:\"getError\", moduleName:\"errorlib_test\", " +
+        assertEquals(callStacks[0].stringValue(), "{callableName:\"getError\", " +
                 "fileName:\"errorlib_test.bal\", lineNumber:45}");
-        assertEquals(callStacks[1].stringValue(), "{callableName:\"stack2\", moduleName:\"errorlib_test\", " +
+        assertEquals(callStacks[1].stringValue(), "{callableName:\"stack2\", " +
                 "fileName:\"errorlib_test.bal\", lineNumber:88}");
-        assertEquals(callStacks[2].stringValue(), "{callableName:\"stack1\", moduleName:\"errorlib_test\", " +
+        assertEquals(callStacks[2].stringValue(), "{callableName:\"stack1\", " +
                 "fileName:\"errorlib_test.bal\", lineNumber:84}");
-        assertEquals(callStacks[3].stringValue(), "{callableName:\"stack0\", moduleName:\"errorlib_test\", " +
+        assertEquals(callStacks[3].stringValue(), "{callableName:\"stack0\", " +
                 "fileName:\"errorlib_test.bal\", lineNumber:80}");
         assertEquals(callStacks[4].stringValue(), "{callableName:\"getErrorStackTrace\", " +
-                "moduleName:\"errorlib_test\", fileName:\"errorlib_test.bal\", lineNumber:92}");
+                "fileName:\"errorlib_test.bal\", lineNumber:92}");
     }
 
     @Test

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibRuntimeTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibRuntimeTest.java
@@ -41,17 +41,17 @@ public class LangLibRuntimeTest {
 
     @Test
     public void testGetStackTrace() {
-        BRunUtil.invoke(compileResult, "getCallStackTest");
+        BValue[] returns = BRunUtil.invoke(compileResult, "getCallStackTest");
+        assertEquals(returns[0].toString(), "{callableName:\"externGetStackTrace\", " +
+                "moduleName:\"ballerina.lang.runtime.0_0_1\", fileName:\"runtime.bal\", lineNumber:95}");
+        assertEquals(returns[1].toString(), "{callableName:\"getStackTrace\", " +
+                "moduleName:\"ballerina.lang.runtime.0_0_1\", fileName:\"runtime.bal\", lineNumber:85}");
+        assertEquals(returns[2].toString(), "{callableName:\"getCallStackTest\", moduleName:(), " +
+                "fileName:\"runtimelib_test.bal\", lineNumber:21}");
     }
 
     @Test
     public void testGetStackTraceToString() {
-        BValue[] returns = BRunUtil.invoke(compileResult, "getCallStackTest");
-        assertEquals(returns[0].toString(), "{callableName:\"externGetStackTrace\", " +
-                "moduleName:\"ballerina.lang.runtime.0_0_1\", fileName:\"runtime.bal\", lineNumber:100}");
-        assertEquals(returns[1].toString(), "{callableName:\"getStackTrace\", " +
-                "moduleName:\"ballerina.lang.runtime.0_0_1\", fileName:\"runtime.bal\", lineNumber:85}");
-        assertEquals(returns[2].toString(), "{callableName:\"getCallStackTest\", " +
-                "fileName:\"runtimelib_test.bal\", lineNumber:20}");
+        BRunUtil.invoke(compileResult, "getCallStacktoStringTest");
     }
 }

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibRuntimeTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibRuntimeTest.java
@@ -18,17 +18,16 @@
 
 package org.ballerinalang.langlib.test;
 
-import org.ballerinalang.core.model.values.BValue;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.assertEquals;
-
 /**
  * Test cases for runtime.
+ *
+ * @since 2.0.0
  */
 public class LangLibRuntimeTest {
 
@@ -37,17 +36,6 @@ public class LangLibRuntimeTest {
     @BeforeClass
     public void setup() {
         compileResult = BCompileUtil.compile("test-src/runtimelib_test.bal");
-    }
-
-    @Test
-    public void testGetStackTrace() {
-        BValue[] returns = BRunUtil.invoke(compileResult, "getCallStackTest");
-        assertEquals(returns[0].toString(), "{callableName:\"externGetStackTrace\", " +
-                "moduleName:\"ballerina.lang.runtime.0_0_1\", fileName:\"runtime.bal\", lineNumber:95}");
-        assertEquals(returns[1].toString(), "{callableName:\"getStackTrace\", " +
-                "moduleName:\"ballerina.lang.runtime.0_0_1\", fileName:\"runtime.bal\", lineNumber:85}");
-        assertEquals(returns[2].toString(), "{callableName:\"getCallStackTest\", moduleName:(), " +
-                "fileName:\"runtimelib_test.bal\", lineNumber:21}");
     }
 
     @Test

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibRuntimeTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibRuntimeTest.java
@@ -43,21 +43,21 @@ public class LangLibRuntimeTest {
     public void testGetStackTrace() {
         BValue[] returns = BRunUtil.invoke(compileResult, "getCallStackTest");
         assertEquals(returns[0].stringValue(), "{callableName:\"externGetStackTrace\"," +
-                " moduleName:\"ballerina.lang$0046runtime.0_0_1.runtime\", fileName:\"runtime.bal\", lineNumber:95}");
+                " moduleName:\"ballerina.lang.runtime.0_0_1\", fileName:\"runtime.bal\", lineNumber:100}");
         assertEquals(returns[1].stringValue(), "{callableName:\"getStackTrace\", " +
-                "moduleName:\"ballerina.lang$0046runtime.0_0_1.runtime\", fileName:\"runtime.bal\", lineNumber:85}");
+                "moduleName:\"ballerina.lang.runtime.0_0_1\", fileName:\"runtime.bal\", lineNumber:85}");
         assertEquals(returns[2].stringValue(), "{callableName:\"getCallStackTest\", " +
-                "moduleName:\"runtimelib_test\", fileName:\"runtimelib_test.bal\", lineNumber:20}");
+                "fileName:\"runtimelib_test.bal\", lineNumber:20}");
     }
 
     @Test
     public void testGetStackTraceToString() {
         BValue[] returns = BRunUtil.invoke(compileResult, "getCallStackTest");
         assertEquals(returns[0].toString(), "{callableName:\"externGetStackTrace\", " +
-                "moduleName:\"ballerina.lang$0046runtime.0_0_1.runtime\", fileName:\"runtime.bal\", lineNumber:95}");
+                "moduleName:\"ballerina.lang.runtime.0_0_1\", fileName:\"runtime.bal\", lineNumber:100}");
         assertEquals(returns[1].toString(), "{callableName:\"getStackTrace\", " +
-                "moduleName:\"ballerina.lang$0046runtime.0_0_1.runtime\", fileName:\"runtime.bal\", lineNumber:85}");
+                "moduleName:\"ballerina.lang.runtime.0_0_1\", fileName:\"runtime.bal\", lineNumber:85}");
         assertEquals(returns[2].toString(), "{callableName:\"getCallStackTest\", " +
-                "moduleName:\"runtimelib_test\", fileName:\"runtimelib_test.bal\", lineNumber:20}");
+                "fileName:\"runtimelib_test.bal\", lineNumber:20}");
     }
 }

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibRuntimeTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibRuntimeTest.java
@@ -41,13 +41,7 @@ public class LangLibRuntimeTest {
 
     @Test
     public void testGetStackTrace() {
-        BValue[] returns = BRunUtil.invoke(compileResult, "getCallStackTest");
-        assertEquals(returns[0].stringValue(), "{callableName:\"externGetStackTrace\"," +
-                " moduleName:\"ballerina.lang.runtime.0_0_1\", fileName:\"runtime.bal\", lineNumber:100}");
-        assertEquals(returns[1].stringValue(), "{callableName:\"getStackTrace\", " +
-                "moduleName:\"ballerina.lang.runtime.0_0_1\", fileName:\"runtime.bal\", lineNumber:85}");
-        assertEquals(returns[2].stringValue(), "{callableName:\"getCallStackTest\", " +
-                "fileName:\"runtimelib_test.bal\", lineNumber:20}");
+        BRunUtil.invoke(compileResult, "getCallStackTest");
     }
 
     @Test

--- a/langlib/langlib-test/src/test/resources/test-src/runtimelib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/runtimelib_test.bal
@@ -14,19 +14,18 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/lang.runtime as runtime;
 import ballerina/jballerina.java;
-
-function getCallStackTest() returns runtime:StackFrame[] {
-    return runtime:getStackTrace();
-}
+import ballerina/lang.runtime as runtime;
 
 function getCallStacktoStringTest() {
     runtime:StackFrame[] stackFrames = runtime:getStackTrace();
     assertEquality(stackFrames.length(), 3);
-    assertEquality("callableName: externGetStackTrace moduleName: ballerina.lang.runtime.0_0_1 fileName: runtime.bal lineNumber: 95", stackFrames[0].toString());
-    assertEquality("callableName: getStackTrace moduleName: ballerina.lang.runtime.0_0_1 fileName: runtime.bal lineNumber: 85", stackFrames[1].toString());
-    assertEquality("callableName: getCallStacktoStringTest  fileName: runtimelib_test.bal lineNumber: 25", stackFrames[2].toString());
+    assertEquality("callableName: externGetStackTrace moduleName: ballerina.lang.runtime.0_0_1 fileName: runtime.bal " +
+                    "lineNumber: 95", stackFrames[0].toString());
+    assertEquality("callableName: getStackTrace moduleName: ballerina.lang.runtime.0_0_1 fileName: runtime.bal " +
+                    "lineNumber: 85", stackFrames[1].toString());
+    assertEquality("callableName: getCallStacktoStringTest  fileName: runtimelib_test.bal lineNumber: 21",
+                    stackFrames[2].toString());
 
     java:StackFrameImpl stackFrame1 = <java:StackFrameImpl> stackFrames[1];
     string callableName = stackFrame1.callableName;
@@ -48,7 +47,7 @@ function getCallStacktoStringTest() {
     assertEquality("getCallStacktoStringTest", callableName);
     assertEquality((), moduleName);
     assertEquality("runtimelib_test.bal", fileName);
-    assertEquality(25, lineNumber);
+    assertEquality(21, lineNumber);
 }
 
 function assertEquality(any|error expected, any|error actual) {

--- a/langlib/langlib-test/src/test/resources/test-src/runtimelib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/runtimelib_test.bal
@@ -17,42 +17,38 @@
 import ballerina/lang.runtime as runtime;
 import ballerina/jballerina.java;
 
-function getCallStackTest() {
+function getCallStackTest() returns runtime:StackFrame[] {
+    return runtime:getStackTrace();
+}
+
+function getCallStacktoStringTest() {
     runtime:StackFrame[] stackFrames = runtime:getStackTrace();
     assertEquality(stackFrames.length(), 3);
-    assertEquality(stackFrames[0].toString(), "callableName: externGetStackTrace moduleName: ballerina.lang.runtime.0_0_1 fileName: runtime.bal lineNumber: 95");
-    assertEquality(stackFrames[1].toString(), "callableName: getStackTrace moduleName: ballerina.lang.runtime.0_0_1 fileName: runtime.bal lineNumber: 85");
-    assertEquality(stackFrames[2].toString(), "callableName: getCallStackTest  fileName: runtimelib_test.bal lineNumber: 21");
+    assertEquality("callableName: externGetStackTrace moduleName: ballerina.lang.runtime.0_0_1 fileName: runtime.bal lineNumber: 95", stackFrames[0].toString());
+    assertEquality("callableName: getStackTrace moduleName: ballerina.lang.runtime.0_0_1 fileName: runtime.bal lineNumber: 85", stackFrames[1].toString());
+    assertEquality("callableName: getCallStacktoStringTest  fileName: runtimelib_test.bal lineNumber: 25", stackFrames[2].toString());
 
     java:StackFrameImpl stackFrame1 = <java:StackFrameImpl> stackFrames[1];
     string callableName = stackFrame1.callableName;
     string? moduleName = stackFrame1.moduleName;
     string fileName = stackFrame1.fileName;
     int lineNumber = stackFrame1.lineNumber;
-    assertEquality(callableName, "getStackTrace");
-    assertEquality(moduleName, "ballerina.lang.runtime.0_0_1");
-    assertEquality(fileName, "runtime.bal");
-    assertEquality(lineNumber, 85);
+
+    assertEquality("getStackTrace", callableName);
+    assertEquality("ballerina.lang.runtime.0_0_1", moduleName);
+    assertEquality("runtime.bal", fileName);
+    assertEquality(85, lineNumber);
 
     java:StackFrameImpl stackFrame2 = <java:StackFrameImpl> stackFrames[2];
     callableName = stackFrame2.callableName;
     moduleName = stackFrame2.moduleName;
     fileName = stackFrame2.fileName;
     lineNumber = stackFrame2.lineNumber;
-    assertEquality(callableName, "getCallStackTest");
-    assertEquality(moduleName, ());
-    assertEquality(fileName, "runtimelib_test.bal");
-    assertEquality(lineNumber, 21);
-}
 
-function getCallStacktoStringTest() returns string[] {
-    runtime:StackFrame[] stackFrames = runtime:getStackTrace();
-    string[] output = [];
-    foreach runtime:StackFrame stackFrame in stackFrames {
-        output.push(stackFrame.toString());
-    }
-    return output;
-
+    assertEquality("getCallStacktoStringTest", callableName);
+    assertEquality((), moduleName);
+    assertEquality("runtimelib_test.bal", fileName);
+    assertEquality(25, lineNumber);
 }
 
 function assertEquality(any|error expected, any|error actual) {

--- a/langlib/langlib-test/src/test/resources/test-src/runtimelib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/runtimelib_test.bal
@@ -15,9 +15,34 @@
 // under the License.
 
 import ballerina/lang.runtime as runtime;
+import ballerina/jballerina.java;
 
-function getCallStackTest() returns runtime:StackFrame[] {
-    return runtime:getStackTrace();
+function getCallStackTest() {
+    runtime:StackFrame[] stackFrames = runtime:getStackTrace();
+    assertEquality(stackFrames.length(), 3);
+    assertEquality(stackFrames[0].toString(), "callableName: externGetStackTrace moduleName: ballerina.lang.runtime.0_0_1 fileName: runtime.bal lineNumber: 95");
+    assertEquality(stackFrames[1].toString(), "callableName: getStackTrace moduleName: ballerina.lang.runtime.0_0_1 fileName: runtime.bal lineNumber: 85");
+    assertEquality(stackFrames[2].toString(), "callableName: getCallStackTest  fileName: runtimelib_test.bal lineNumber: 21");
+
+    java:StackFrameImpl stackFrame1 = <java:StackFrameImpl> stackFrames[1];
+    string callableName = stackFrame1.callableName;
+    string? moduleName = stackFrame1.moduleName;
+    string fileName = stackFrame1.fileName;
+    int lineNumber = stackFrame1.lineNumber;
+    assertEquality(callableName, "getStackTrace");
+    assertEquality(moduleName, "ballerina.lang.runtime.0_0_1");
+    assertEquality(fileName, "runtime.bal");
+    assertEquality(lineNumber, 85);
+
+    java:StackFrameImpl stackFrame2 = <java:StackFrameImpl> stackFrames[2];
+    callableName = stackFrame2.callableName;
+    moduleName = stackFrame2.moduleName;
+    fileName = stackFrame2.fileName;
+    lineNumber = stackFrame2.lineNumber;
+    assertEquality(callableName, "getCallStackTest");
+    assertEquality(moduleName, ());
+    assertEquality(fileName, "runtimelib_test.bal");
+    assertEquality(lineNumber, 21);
 }
 
 function getCallStacktoStringTest() returns string[] {
@@ -28,4 +53,18 @@ function getCallStacktoStringTest() returns string[] {
     }
     return output;
 
+}
+
+function assertEquality(any|error expected, any|error actual) {
+    if expected is anydata && actual is anydata && expected == actual {
+        return;
+    }
+
+    if expected === actual {
+        return;
+    }
+
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
+    panic error(string `expected '${expectedValAsString}', found '${actualValAsString}'`);
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorStackTraceTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorStackTraceTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.test.error;
+
+import org.ballerinalang.test.BCompileUtil;
+import org.ballerinalang.test.BRunUtil;
+import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class ErrorStackTraceTest {
+
+    private CompileResult compileResult;
+
+    @BeforeClass
+    public void setup() {
+        compileResult = BCompileUtil.compile("test-src/error/stacktrace-project");
+    }
+
+    @Test
+    public void testStackTraceElements() {
+        BRunUtil.invoke(compileResult, "testStackTraceElements");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
+    }
+
+}

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorStackTraceTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorStackTraceTest.java
@@ -24,6 +24,11 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+/**
+ * Test case for Error StackTrace.
+ *
+ * @since 2.0
+ */
 public class ErrorStackTraceTest {
 
     private CompileResult compileResult;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorStackTraceTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorStackTraceTest.java
@@ -27,7 +27,7 @@ import org.testng.annotations.Test;
 /**
  * Test case for Error StackTrace.
  *
- * @since 2.0
+ * @since 2.0.0
  */
 public class ErrorStackTraceTest {
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
@@ -368,9 +368,9 @@ public class ErrorTest {
     @Test
     public void testStackOverFlow() {
         BValue[] result = BRunUtil.invoke(errorTestResult, "testStackOverFlow");
-        String expected1 = "{callableName:\"bar\", moduleName:\"error_test\", fileName:\"error_test.bal\", " +
+        String expected1 = "{callableName:\"bar\", fileName:\"error_test.bal\", " +
                 "lineNumber:408}";
-        String expected2 = "{callableName:\"bar2\", moduleName:\"error_test\", fileName:\"error_test.bal\", " +
+        String expected2 = "{callableName:\"bar2\", fileName:\"error_test.bal\", " +
                 "lineNumber:412}";
         String resultStack = ((BValueArray) result[0]).getRefValue(0).toString();
         Assert.assertTrue(resultStack.equals(expected1) || resultStack.equals(expected2), "Received unexpected " +

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/RuntimeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/RuntimeTest.java
@@ -53,14 +53,14 @@ public class RuntimeTest {
         BValue[] returns = BRunUtil.invoke(errorResult, "testGetCallStack");
         Assert.assertEquals(returns.length, 5);
         Assert.assertEquals(returns[0].stringValue(), "{callableName:\"externGetStackTrace\", moduleName:\"ballerina" +
-                ".lang.runtime.0_0_1\", fileName:\"runtime.bal\", lineNumber:100}");
+                ".lang.runtime.0_0_1\", fileName:\"runtime.bal\", lineNumber:95}");
         Assert.assertEquals(returns[1].stringValue(), "{callableName:\"getStackTrace\", moduleName:\"ballerina" +
                 ".lang.runtime.0_0_1\", fileName:\"runtime.bal\", lineNumber:85}");
-        Assert.assertEquals(returns[2].stringValue(), "{callableName:\"level2Function\", " +
+        Assert.assertEquals(returns[2].stringValue(), "{callableName:\"level2Function\", moduleName:(), " +
                 "fileName:\"runtime-error.bal\", lineNumber:12}");
-        Assert.assertEquals(returns[3].stringValue(), "{callableName:\"level1Function\", " +
+        Assert.assertEquals(returns[3].stringValue(), "{callableName:\"level1Function\", moduleName:(), " +
                 "fileName:\"runtime-error.bal\", lineNumber:8}");
-        Assert.assertEquals(returns[4].stringValue(), "{callableName:\"testGetCallStack\", " +
+        Assert.assertEquals(returns[4].stringValue(), "{callableName:\"testGetCallStack\", moduleName:(), " +
                 "fileName:\"runtime-error.bal\", lineNumber:4}");
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/RuntimeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/RuntimeTest.java
@@ -68,12 +68,12 @@ public class RuntimeTest {
     public void testErrorCallStack() {
         BValue[] returns = BRunUtil.invoke(errorResult, "testErrorCallStack");
         Assert.assertEquals(returns.length, 3);
-        Assert.assertEquals(returns[0].stringValue(), "{callableName:\"level2Error\", moduleName:\"runtime-error\", " +
+        Assert.assertEquals(returns[0].stringValue(), "{callableName:\"level2Error\", " +
                 "fileName:\"runtime-error.bal\", lineNumber:30}");
-        Assert.assertEquals(returns[1].stringValue(), "{callableName:\"level1Error\", moduleName:\"runtime-error\", " +
+        Assert.assertEquals(returns[1].stringValue(), "{callableName:\"level1Error\", " +
                 "fileName:\"runtime-error.bal\", lineNumber:25}");
         Assert.assertEquals(returns[2].stringValue(), "{callableName:\"testErrorCallStack\", " +
-                "moduleName:\"runtime-error\", fileName:\"runtime-error.bal\", lineNumber:16}");
+                "fileName:\"runtime-error.bal\", lineNumber:16}");
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/RuntimeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/RuntimeTest.java
@@ -53,15 +53,15 @@ public class RuntimeTest {
         BValue[] returns = BRunUtil.invoke(errorResult, "testGetCallStack");
         Assert.assertEquals(returns.length, 5);
         Assert.assertEquals(returns[0].stringValue(), "{callableName:\"externGetStackTrace\", moduleName:\"ballerina" +
-                ".lang$0046runtime.0_0_1.runtime\", fileName:\"runtime.bal\", lineNumber:95}");
+                ".lang.runtime.0_0_1\", fileName:\"runtime.bal\", lineNumber:100}");
         Assert.assertEquals(returns[1].stringValue(), "{callableName:\"getStackTrace\", moduleName:\"ballerina" +
-                ".lang$0046runtime.0_0_1.runtime\", fileName:\"runtime.bal\", lineNumber:85}");
+                ".lang.runtime.0_0_1\", fileName:\"runtime.bal\", lineNumber:85}");
         Assert.assertEquals(returns[2].stringValue(), "{callableName:\"level2Function\", " +
-                "moduleName:\"runtime-error\", fileName:\"runtime-error.bal\", lineNumber:12}");
+                "fileName:\"runtime-error.bal\", lineNumber:12}");
         Assert.assertEquals(returns[3].stringValue(), "{callableName:\"level1Function\", " +
-                "moduleName:\"runtime-error\", fileName:\"runtime-error.bal\", lineNumber:8}");
+                "fileName:\"runtime-error.bal\", lineNumber:8}");
         Assert.assertEquals(returns[4].stringValue(), "{callableName:\"testGetCallStack\", " +
-                "moduleName:\"runtime-error\", fileName:\"runtime-error.bal\", lineNumber:4}");
+                "fileName:\"runtime-error.bal\", lineNumber:4}");
     }
 
     @Test

--- a/tests/jballerina-unit-test/src/test/resources/test-src/error/stacktrace-project/Ballerina.toml
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/error/stacktrace-project/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "test_org"
+name = "stacktrace_project"
+version= "0.1.0"

--- a/tests/jballerina-unit-test/src/test/resources/test-src/error/stacktrace-project/main.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/error/stacktrace-project/main.bal
@@ -1,0 +1,20 @@
+import stacktrace_project.stacktrace as stacktrace;
+
+public function testStackTraceElements() {
+    any st = stacktrace:getStackTrace();
+    assertEquality("[{\"callableName\":\"getStackTrace\",\"moduleName\":\"test_org.stacktrace_project.stacktrace.0_1_0\",\"fileName\":\"stacktrace.bal\",\"lineNumber\":2},{\"callableName\":\"testStackTraceElements\",\"moduleName\":\"test_org.stacktrace_project.0_1_0\",\"fileName\":\"main.bal\",\"lineNumber\":4}]", st.toString());
+}
+
+function assertEquality(any|error expected, any|error actual) {
+    if expected is anydata && actual is anydata && expected == actual {
+        return;
+    }
+
+    if expected === actual {
+        return;
+    }
+
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
+    panic error(string `expected '${expectedValAsString}', found '${actualValAsString}'`);
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/error/stacktrace-project/main.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/error/stacktrace-project/main.bal
@@ -1,8 +1,22 @@
 import stacktrace_project.stacktrace as stacktrace;
 
 public function testStackTraceElements() {
-    any st = stacktrace:getStackTrace();
-    assertEquality("[{\"callableName\":\"getStackTrace\",\"moduleName\":\"test_org.stacktrace_project.stacktrace.0_1_0\",\"fileName\":\"stacktrace.bal\",\"lineNumber\":2},{\"callableName\":\"testStackTraceElements\",\"moduleName\":\"test_org.stacktrace_project.0_1_0\",\"fileName\":\"main.bal\",\"lineNumber\":4}]", st.toString());
+    error:CallStackElement[] callStackElements = stacktrace:getStackTrace();
+
+    assertEquality(callStackElements.length(), 2);
+    assertEquality(callStackElements[0].toString(), "{\"callableName\":\"getStackTrace\",\"moduleName\":\"test_org.stacktrace_project.stacktrace.0_1_0\",\"fileName\":\"stacktrace.bal\",\"lineNumber\":2}");
+    assertEquality(callStackElements[1].toString(), "{\"callableName\":\"testStackTraceElements\",\"moduleName\":\"test_org.stacktrace_project.0_1_0\",\"fileName\":\"main.bal\",\"lineNumber\":4}");
+
+    error:CallStackElement callStackElement = callStackElements[0];
+    string callableName = callStackElement["callableName"];
+    string? moduleName = callStackElement["moduleName"];
+    string fileName = callStackElement["fileName"];
+    int lineNumber = callStackElement["lineNumber"];
+
+    assertEquality(callableName, "getStackTrace");
+    assertEquality(moduleName, "test_org.stacktrace_project.stacktrace.0_1_0");
+    assertEquality(fileName, "stacktrace.bal");
+    assertEquality(lineNumber, 2);
 }
 
 function assertEquality(any|error expected, any|error actual) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/error/stacktrace-project/main.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/error/stacktrace-project/main.bal
@@ -1,11 +1,29 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import stacktrace_project.stacktrace as stacktrace;
 
 public function testStackTraceElements() {
     error:CallStackElement[] callStackElements = stacktrace:getStackTrace();
 
     assertEquality(callStackElements.length(), 2);
-    assertEquality(callStackElements[0].toString(), "{\"callableName\":\"getStackTrace\",\"moduleName\":\"test_org.stacktrace_project.stacktrace.0_1_0\",\"fileName\":\"stacktrace.bal\",\"lineNumber\":2}");
-    assertEquality(callStackElements[1].toString(), "{\"callableName\":\"testStackTraceElements\",\"moduleName\":\"test_org.stacktrace_project.0_1_0\",\"fileName\":\"main.bal\",\"lineNumber\":4}");
+    assertEquality(callStackElements[0].toString(), "{\"callableName\":\"getStackTrace\",\"moduleName\":" +
+                "\"test_org.stacktrace_project.stacktrace.0_1_0\",\"fileName\":\"stacktrace.bal\",\"lineNumber\":18}");
+    assertEquality(callStackElements[1].toString(), "{\"callableName\":\"testStackTraceElements\",\"moduleName\":" +
+                "\"test_org.stacktrace_project.0_1_0\",\"fileName\":\"main.bal\",\"lineNumber\":20}");
 
     error:CallStackElement callStackElement = callStackElements[0];
     string callableName = callStackElement["callableName"];
@@ -16,10 +34,10 @@ public function testStackTraceElements() {
     assertEquality(callableName, "getStackTrace");
     assertEquality(moduleName, "test_org.stacktrace_project.stacktrace.0_1_0");
     assertEquality(fileName, "stacktrace.bal");
-    assertEquality(lineNumber, 2);
+    assertEquality(lineNumber, 18);
 }
 
-function assertEquality(any|error expected, any|error actual) {
+function assertEquality(any|error actual, any|error expected) {
     if expected is anydata && actual is anydata && expected == actual {
         return;
     }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/error/stacktrace-project/modules/stacktrace/stacktrace.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/error/stacktrace-project/modules/stacktrace/stacktrace.bal
@@ -1,0 +1,4 @@
+public function getStackTrace() returns any {
+    error e = error("error!");
+    return e.stackTrace().callStack;
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/error/stacktrace-project/modules/stacktrace/stacktrace.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/error/stacktrace-project/modules/stacktrace/stacktrace.bal
@@ -1,4 +1,4 @@
-public function getStackTrace() returns any {
+public function getStackTrace() returns error:CallStackElement[] {
     error e = error("error!");
     return e.stackTrace().callStack;
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/error/stacktrace-project/modules/stacktrace/stacktrace.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/error/stacktrace-project/modules/stacktrace/stacktrace.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 public function getStackTrace() returns error:CallStackElement[] {
     error e = error("error!");
     return e.stackTrace().callStack;


### PR DESCRIPTION
## Purpose
> To remove the file name from the module name in the `CallStackElement` record and skip `module name` field for single `.bal` files. 

For a single bal file `foo.bal`
```
import ballerina/io;

public function main() {
    error e = error("error!");
    io:println(e.stackTrace().callStack);
} 
```
will print
```
[{"callableName":"main","fileName":"foo.bal","lineNumber":4}]
```

Fixes #30293
Fixes #28837 

## Approach

## Samples

## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
