### PR TITLE
Handle int add, sub, mul overflow

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/ErrorUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/ErrorUtils.java
@@ -43,6 +43,7 @@ public class ErrorUtils {
     private static final BString ERROR_MESSAGE_FIELD = StringUtils.fromString("message");
     private static final BString ERROR_CAUSE_FIELD = StringUtils.fromString("cause");
     private static final BString NULL_REF_EXCEPTION = StringUtils.fromString("NullReferenceException");
+    private static final BString INT_RANGE_OVERFLOW_ERROR = StringUtils.fromString(" int range overflow");
 
     /**
      * Create balleria error using java exception for interop.
@@ -97,6 +98,10 @@ public class ErrorUtils {
 
     public static ErrorValue createCancelledFutureError() {
         return (ErrorValue) createError(BallerinaErrorReasons.FUTURE_CANCELLED);
+    }
+
+    public static BError createIntOverflowError() {
+        throw createError(BallerinaErrorReasons.NUMBER_OVERFLOW, INT_RANGE_OVERFLOW_ERROR);
     }
 
     public static BError createTypeCastError(Object sourceVal, Type targetType) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/MathUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/MathUtils.java
@@ -63,4 +63,28 @@ public class MathUtils {
             }
         }
     }
+
+    public static long addExact(long num1, long num2) {
+        try {
+            return Math.addExact(num1, num2);
+        } catch (ArithmeticException e) {
+            throw ErrorCreator.createError(BallerinaErrorReasons.NUMBER_OVERFLOW, INT_RANGE_OVERFLOW_ERROR);
+        }
+    }
+
+    public static long subtractExact(long num1, long num2) {
+        try {
+            return Math.subtractExact(num1, num2);
+        } catch (ArithmeticException e) {
+            throw ErrorCreator.createError(BallerinaErrorReasons.NUMBER_OVERFLOW, INT_RANGE_OVERFLOW_ERROR);
+        }
+    }
+
+    public static long multiplyExact(long num1, long num2) {
+        try {
+            return Math.multiplyExact(num1, num2);
+        } catch (ArithmeticException e) {
+            throw ErrorCreator.createError(BallerinaErrorReasons.NUMBER_OVERFLOW, INT_RANGE_OVERFLOW_ERROR);
+        }
+    }
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/MathUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/MathUtils.java
@@ -19,6 +19,7 @@ package io.ballerina.runtime.internal;
 
 import io.ballerina.runtime.api.creators.ErrorCreator;
 import io.ballerina.runtime.api.utils.StringUtils;
+import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.api.values.BString;
 import io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons;
 
@@ -33,8 +34,8 @@ public class MathUtils {
 
     private static final BString INT_RANGE_OVERFLOW_ERROR = StringUtils.fromString(" int range overflow");
 
-    private static void throwIntRangeOverflowError() {
-        throw ErrorCreator.createError(BallerinaErrorReasons.NUMBER_OVERFLOW, INT_RANGE_OVERFLOW_ERROR);
+    public static BError getIntOverflowError() {
+        return ErrorCreator.createError(BallerinaErrorReasons.NUMBER_OVERFLOW, INT_RANGE_OVERFLOW_ERROR);
     }
 
     public static long divide(long numerator, long denominator) {
@@ -42,7 +43,7 @@ public class MathUtils {
             if (numerator == Long.MIN_VALUE && denominator == -1) {
                 // a panic will occur on division by zero or overflow,
                 // which happens if the first operand is -2^63 and the second operand is -1
-                throwIntRangeOverflowError();
+                throw getIntOverflowError();
             }
             return numerator / denominator;
         } catch (ArithmeticException e) {
@@ -69,29 +70,26 @@ public class MathUtils {
     }
 
     public static long addExact(long num1, long num2) {
-        long result = num1 + num2;
-        // an overflow has happened on addition if the sign of the result is different from BOTH operands' sign
-        if (((num1 ^ result) & (num2 ^ result)) < 0) {
-            throwIntRangeOverflowError();
+        try {
+            return Math.addExact(num1, num2);
+        } catch (ArithmeticException e) {
+            throw getIntOverflowError();
         }
-        return result;
     }
 
     public static long subtractExact(long num1, long num2) {
-        long result = num1 - num2;
-        // an overflow has happened on subtraction when both operands have the same sign AND
-        // if the sign of the result is different from the first operand's sign
-        if (((num1 ^ num2) & (num1 ^ result)) < 0) {
-            throwIntRangeOverflowError();
+        try {
+            return Math.subtractExact(num1, num2);
+        } catch (ArithmeticException e) {
+            throw getIntOverflowError();
         }
-        return result;
     }
 
     public static long multiplyExact(long num1, long num2) {
-        long result = num1 * num2;
-        if ((num1 != 0 && result / num1 != num2) || (num2 != 0 && result / num2 != num1)) {
-            throwIntRangeOverflowError();
+        try {
+            return Math.multiplyExact(num1, num2);
+        } catch (ArithmeticException e) {
+            throw getIntOverflowError();
         }
-        return result;
     }
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/MathUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/MathUtils.java
@@ -65,26 +65,26 @@ public class MathUtils {
     }
 
     public static long addExact(long num1, long num2) {
-        try {
-            return Math.addExact(num1, num2);
-        } catch (ArithmeticException e) {
-            throw ErrorCreator.createError(BallerinaErrorReasons.NUMBER_OVERFLOW, INT_RANGE_OVERFLOW_ERROR);
+        long r = num1 + num2;
+        if (((num1 ^ r) & (num2 ^ r)) < 0) {
+            throw  ErrorCreator.createError(BallerinaErrorReasons.NUMBER_OVERFLOW, INT_RANGE_OVERFLOW_ERROR);
         }
+        return r;
     }
 
     public static long subtractExact(long num1, long num2) {
-        try {
-            return Math.subtractExact(num1, num2);
-        } catch (ArithmeticException e) {
-            throw ErrorCreator.createError(BallerinaErrorReasons.NUMBER_OVERFLOW, INT_RANGE_OVERFLOW_ERROR);
+        long r = num1 - num2;
+        if (((num1 ^ num2) & (num1 ^ r)) < 0) {
+            throw  ErrorCreator.createError(BallerinaErrorReasons.NUMBER_OVERFLOW, INT_RANGE_OVERFLOW_ERROR);
         }
+        return r;
     }
 
     public static long multiplyExact(long num1, long num2) {
-        try {
-            return Math.multiplyExact(num1, num2);
-        } catch (ArithmeticException e) {
-            throw ErrorCreator.createError(BallerinaErrorReasons.NUMBER_OVERFLOW, INT_RANGE_OVERFLOW_ERROR);
+        long r = num1 * num2;
+        if (num1 != 0 && r / num1 != num2) {
+            throw  ErrorCreator.createError(BallerinaErrorReasons.NUMBER_OVERFLOW, INT_RANGE_OVERFLOW_ERROR);
         }
+        return r;
     }
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/MathUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/MathUtils.java
@@ -19,7 +19,6 @@ package io.ballerina.runtime.internal;
 
 import io.ballerina.runtime.api.creators.ErrorCreator;
 import io.ballerina.runtime.api.utils.StringUtils;
-import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.api.values.BString;
 import io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons;
 
@@ -32,18 +31,12 @@ public class MathUtils {
 
     private static final BString DIVIDE_BY_ZERO_ERROR = StringUtils.fromString(" / by zero");
 
-    private static final BString INT_RANGE_OVERFLOW_ERROR = StringUtils.fromString(" int range overflow");
-
-    public static BError getIntOverflowError() {
-        return ErrorCreator.createError(BallerinaErrorReasons.NUMBER_OVERFLOW, INT_RANGE_OVERFLOW_ERROR);
-    }
-
     public static long divide(long numerator, long denominator) {
         try {
             if (numerator == Long.MIN_VALUE && denominator == -1) {
                 // a panic will occur on division by zero or overflow,
                 // which happens if the first operand is -2^63 and the second operand is -1
-                throw getIntOverflowError();
+                throw ErrorUtils.createIntOverflowError();
             }
             return numerator / denominator;
         } catch (ArithmeticException e) {
@@ -73,7 +66,7 @@ public class MathUtils {
         try {
             return Math.addExact(num1, num2);
         } catch (ArithmeticException e) {
-            throw getIntOverflowError();
+            throw ErrorUtils.createIntOverflowError();
         }
     }
 
@@ -81,7 +74,7 @@ public class MathUtils {
         try {
             return Math.subtractExact(num1, num2);
         } catch (ArithmeticException e) {
-            throw getIntOverflowError();
+            throw ErrorUtils.createIntOverflowError();
         }
     }
 
@@ -89,7 +82,7 @@ public class MathUtils {
         try {
             return Math.multiplyExact(num1, num2);
         } catch (ArithmeticException e) {
-            throw getIntOverflowError();
+            throw ErrorUtils.createIntOverflowError();
         }
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
@@ -102,17 +102,14 @@ import static org.objectweb.asm.Opcodes.ISTORE;
 import static org.objectweb.asm.Opcodes.IUSHR;
 import static org.objectweb.asm.Opcodes.IXOR;
 import static org.objectweb.asm.Opcodes.L2I;
-import static org.objectweb.asm.Opcodes.LADD;
 import static org.objectweb.asm.Opcodes.LAND;
 import static org.objectweb.asm.Opcodes.LCMP;
 import static org.objectweb.asm.Opcodes.LLOAD;
-import static org.objectweb.asm.Opcodes.LMUL;
 import static org.objectweb.asm.Opcodes.LNEG;
 import static org.objectweb.asm.Opcodes.LOR;
 import static org.objectweb.asm.Opcodes.LSHL;
 import static org.objectweb.asm.Opcodes.LSHR;
 import static org.objectweb.asm.Opcodes.LSTORE;
-import static org.objectweb.asm.Opcodes.LSUB;
 import static org.objectweb.asm.Opcodes.LUSHR;
 import static org.objectweb.asm.Opcodes.LXOR;
 import static org.objectweb.asm.Opcodes.NEW;
@@ -893,7 +890,7 @@ public class JvmInstructionGen {
         BType bType = binaryIns.lhsOp.variableDcl.type;
         this.generateBinaryRhsAndLhsLoad(binaryIns);
         if (TypeTags.isIntegerTypeTag(bType.tag)) {
-            this.mv.visitInsn(LADD);
+            this.mv.visitMethodInsn(INVOKESTATIC, MATH_UTILS, "addExact", "(JJ)J", false);
         } else if (bType.tag == TypeTags.BYTE) {
             this.mv.visitInsn(IADD);
         } else if (TypeTags.isStringTypeTag(bType.tag)) {
@@ -921,7 +918,7 @@ public class JvmInstructionGen {
         BType bType = binaryIns.lhsOp.variableDcl.type;
         this.generateBinaryRhsAndLhsLoad(binaryIns);
         if (TypeTags.isIntegerTypeTag(bType.tag)) {
-            this.mv.visitInsn(LSUB);
+            this.mv.visitMethodInsn(INVOKESTATIC, MATH_UTILS, "subtractExact", "(JJ)J", false);
         } else if (bType.tag == TypeTags.FLOAT) {
             this.mv.visitInsn(DSUB);
         } else if (bType.tag == TypeTags.DECIMAL) {
@@ -957,7 +954,7 @@ public class JvmInstructionGen {
         BType bType = binaryIns.lhsOp.variableDcl.type;
         this.generateBinaryRhsAndLhsLoad(binaryIns);
         if (TypeTags.isIntegerTypeTag(bType.tag)) {
-            this.mv.visitInsn(LMUL);
+            this.mv.visitMethodInsn(INVOKESTATIC, MATH_UTILS, "multiplyExact", "(JJ)J", false);
         } else if (bType.tag == TypeTags.FLOAT) {
             this.mv.visitInsn(DMUL);
         } else if (bType.tag == TypeTags.DECIMAL) {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/AddOperationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/AddOperationTest.java
@@ -20,6 +20,7 @@ import org.ballerinalang.core.model.values.BFloat;
 import org.ballerinalang.core.model.values.BInteger;
 import org.ballerinalang.core.model.values.BString;
 import org.ballerinalang.core.model.values.BValue;
+import org.ballerinalang.core.util.exceptions.BLangRuntimeException;
 import org.ballerinalang.test.BAssertUtil;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
@@ -45,14 +46,21 @@ public class AddOperationTest {
 
     @Test(description = "Test two int add expression")
     public void testIntAddExpr() {
-        BValue[] args = { new BInteger(100), new BInteger(200)};
+        BValue[] args = { new BInteger(2147483647), new BInteger(2147483646)};
 
         BValue[] returns = BRunUtil.invoke(result, "intAdd", args);
         Assert.assertEquals(returns.length, 1);
         Assert.assertSame(returns[0].getClass(), BInteger.class);
         long actual = ((BInteger) returns[0]).intValue();
-        long expected = 300;
+        long expected = 4294967293L;
         Assert.assertEquals(actual, expected);
+    }
+
+    @Test(description = "Test two int add overflow expression", expectedExceptions = BLangRuntimeException.class,
+            expectedExceptionsMessageRegExp = "error: \\{ballerina}NumberOverflow \\{\"message\":\" int range " +
+                    "overflow\"\\}.*")
+    public void testIntOverflowByAddition() {
+        BRunUtil.invoke(result, "overflowByAddition");
     }
 
     @Test(description = "Test two float add expression")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/DivisionOperationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/DivisionOperationTest.java
@@ -90,7 +90,7 @@ public class DivisionOperationTest {
                 "Result of the division operation is incorrect");
     }
 
-    @Test(description = "Test devide statement with errors")
+    @Test(description = "Test divide statement with errors")
     public void testDivideStmtNegativeCases() {
         Assert.assertEquals(resultNegative.getErrorCount(), 12);
         BAssertUtil.validateError(resultNegative, 0, "operator '/' not defined for 'json' and 'json'", 8, 10);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/ModOperationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/ModOperationTest.java
@@ -82,7 +82,7 @@ public class ModOperationTest {
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class,
-            expectedExceptionsMessageRegExp = "error: \\{ballerina\\}DivisionByZero \\{\"message\":\" / " +
+            expectedExceptionsMessageRegExp = "error: \\{ballerina}DivisionByZero \\{\"message\":\" / " +
                     "by zero\"\\}.*")
     public void testIntModZero() {
         BRunUtil.invoke(result, "intMod", new BValue[]{new BInteger(2000), new BInteger(0)});

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/ModOperationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/ModOperationTest.java
@@ -82,7 +82,7 @@ public class ModOperationTest {
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class,
-            expectedExceptionsMessageRegExp = "error: \\{ballerina}DivisionByZero \\{\"message\":\" / " +
+            expectedExceptionsMessageRegExp = "error: \\{ballerina\\}DivisionByZero \\{\"message\":\" / " +
                     "by zero\"\\}.*")
     public void testIntModZero() {
         BRunUtil.invoke(result, "intMod", new BValue[]{new BInteger(2000), new BInteger(0)});

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/MultiplyOperationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/MultiplyOperationTest.java
@@ -19,6 +19,7 @@ package org.ballerinalang.test.expressions.binaryoperations;
 import org.ballerinalang.core.model.values.BFloat;
 import org.ballerinalang.core.model.values.BInteger;
 import org.ballerinalang.core.model.values.BValue;
+import org.ballerinalang.core.util.exceptions.BLangRuntimeException;
 import org.ballerinalang.test.BAssertUtil;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
@@ -53,6 +54,13 @@ public class MultiplyOperationTest {
         long actual = ((BInteger) returns[0]).intValue();
         long expected = 5000;
         Assert.assertEquals(actual, expected);
+    }
+
+    @Test(description = "Test two int multiply overflow expression", expectedExceptions = BLangRuntimeException.class,
+            expectedExceptionsMessageRegExp = "error: \\{ballerina}NumberOverflow \\{\"message\":\" int range " +
+                    "overflow\"\\}.*")
+    public void testIntOverflowByMultiplication() {
+        BRunUtil.invoke(result, "overflowByMultiplication");
     }
 
     @Test(description = "Test two float multiply expression")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/MultiplyOperationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/MultiplyOperationTest.java
@@ -45,14 +45,14 @@ public class MultiplyOperationTest {
 
     @Test(description = "Test two int multiply expression")
     public void testIntMultiplyExpr() {
-        BValue[] args = { new BInteger(100), new BInteger(50) };
+        BValue[] args = { new BInteger(4611686018427387904L), new BInteger(-2L) };
         BValue[] returns = BRunUtil.invoke(result, "intMultiply", args);
 
         Assert.assertEquals(returns.length, 1);
         Assert.assertSame(returns[0].getClass(), BInteger.class);
 
         long actual = ((BInteger) returns[0]).intValue();
-        long expected = 5000;
+        long expected = -9223372036854775808L;
         Assert.assertEquals(actual, expected);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/SubtractOperationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/SubtractOperationTest.java
@@ -19,6 +19,7 @@ package org.ballerinalang.test.expressions.binaryoperations;
 import org.ballerinalang.core.model.values.BFloat;
 import org.ballerinalang.core.model.values.BInteger;
 import org.ballerinalang.core.model.values.BValue;
+import org.ballerinalang.core.util.exceptions.BLangRuntimeException;
 import org.ballerinalang.test.BAssertUtil;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
@@ -52,6 +53,13 @@ public class SubtractOperationTest {
         long actual = ((BInteger) returns[0]).intValue();
         long expected = -100;
         Assert.assertEquals(actual, expected);
+    }
+
+    @Test(description = "Test two int subtract overflow expression", expectedExceptions = BLangRuntimeException.class,
+            expectedExceptionsMessageRegExp = "error: \\{ballerina}NumberOverflow \\{\"message\":\" int range " +
+                    "overflow\"\\}.*")
+    public void testIntOverflowBySubtraction() {
+        BRunUtil.invoke(result, "overflowBySubtraction");
     }
 
     @Test(description = "Test two float subtract expression")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/SubtractOperationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/SubtractOperationTest.java
@@ -45,13 +45,13 @@ public class SubtractOperationTest {
 
     @Test(description = "Test two int subtract expression")
     public void testIntAddExpr() {
-        BValue[] args = { new BInteger(100), new BInteger(200)};
+        BValue[] args = { new BInteger(1234567891011L), new BInteger(9876543211110L)};
 
         BValue[]  returns = BRunUtil.invoke(result, "intSubtract", args);
         Assert.assertEquals(returns.length, 1);
         Assert.assertSame(returns[0].getClass(), BInteger.class);
         long actual = ((BInteger) returns[0]).intValue();
-        long expected = -100;
+        long expected = -8641975320099L;
         Assert.assertEquals(actual, expected);
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/add-operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/add-operation.bal
@@ -2,6 +2,12 @@ function intAdd(int a, int b) returns (int) {
     return a + b;
 }
 
+public function overflowByAddition() {
+ int val = 9223372036854775807;
+ int val1 = 1;
+ int k = val1 + val;
+}
+
 function floatAdd(float a, float b) returns (float) {
     return a + b;
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/add-operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/add-operation.bal
@@ -2,10 +2,10 @@ function intAdd(int a, int b) returns (int) {
     return a + b;
 }
 
-public function overflowByAddition() {
- int val = 9223372036854775807;
- int val1 = 1;
- int k = val1 + val;
+function overflowByAddition() {
+    int num1 = 9223372036854775807;
+    int num2 = 1;
+    int ans = num1 + num2;
 }
 
 function floatAdd(float a, float b) returns (float) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/multiply-operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/multiply-operation.bal
@@ -2,6 +2,12 @@ function intMultiply(int a, int b) returns (int) {
     return a * b;
 }
 
+public function overflowByMultiplication() {
+ int val = 9223372036854775807;
+ int val1 = -2;
+ int k = val1 * val;
+}
+
 function floatMultiply(float a, float b) returns (float) {
     return a * b;
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/multiply-operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/multiply-operation.bal
@@ -2,10 +2,10 @@ function intMultiply(int a, int b) returns (int) {
     return a * b;
 }
 
-public function overflowByMultiplication() {
- int val = 9223372036854775807;
- int val1 = -2;
- int k = val1 * val;
+function overflowByMultiplication() {
+    int num1 = -1;
+    int num2 = -9223372036854775808;
+    int ans = num1 * num2;
 }
 
 function floatMultiply(float a, float b) returns (float) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/subtract-operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/subtract-operation.bal
@@ -2,10 +2,10 @@ function intSubtract(int a, int b) returns (int) {
     return a - b;
 }
 
-public function overflowBySubtraction() {
- int val = -9223372036854775808;
- int val1 = 1;
- int k = val1 - val;
+function overflowBySubtraction() {
+    int num1 = -9223372036854775808;
+    int num2 = 1;
+    int ans = num1 - num2;
 }
 
 function floatSubtract(float a, float b) returns (float) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/subtract-operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/subtract-operation.bal
@@ -2,6 +2,12 @@ function intSubtract(int a, int b) returns (int) {
     return a - b;
 }
 
+public function overflowBySubtraction() {
+ int val = -9223372036854775808;
+ int val1 = 1;
+ int k = val1 - val;
+}
+
 function floatSubtract(float a, float b) returns (float) {
     return a - b;
 }


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues.

Previously int addition, subtraction, and multiplication overflowed
without giving a runtime error (panic). Now throws a panic and a 
message when int overflow happens. Added 3 unit tests for 
checking int addition, subtraction, and multiplication overflow.

Fixes #20799

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
