### PR TITLE
Fix configurable records that refers other variables as default values

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -2062,6 +2062,9 @@ public class TypeChecker {
             case TypeTags.RECORD_TYPE_TAG:
                 return checkIsLikeRecordType(sourceValue, (BRecordType) targetType, unresolvedValues,
                         allowNumericConversion);
+            case TypeTags.TABLE_TAG:
+                return checkIsLikeTableType(sourceValue, (BTableType) targetType, unresolvedValues,
+                                            allowNumericConversion);
             case TypeTags.JSON_TAG:
                 return checkIsLikeJSONType(sourceValue, sourceType, (BJsonType) targetType, unresolvedValues,
                                            allowNumericConversion);
@@ -2496,6 +2499,27 @@ public class TypeChecker {
                 } else {
                     return false;
                 }
+            }
+        }
+        return true;
+    }
+
+    private static boolean checkIsLikeTableType(Object sourceValue, BTableType targetType,
+                                                List<TypeValuePair> unresolvedValues, boolean allowNumericConversion) {
+        if (!(sourceValue instanceof TableValueImpl)) {
+            return false;
+        }
+
+        TypeValuePair typeValuePair = new TypeValuePair(sourceValue, targetType);
+        if (unresolvedValues.contains(typeValuePair)) {
+            return true;
+        }
+
+        TableValueImpl tableValue = (TableValueImpl) sourceValue;
+        Object[] objects = tableValue.values().toArray();
+        for (Object object : objects) {
+            if (!checkIsLikeType(object, targetType.getConstrainedType(), allowNumericConversion)) {
+                return false;
             }
         }
         return true;

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeConverter.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeConverter.java
@@ -272,6 +272,11 @@ public class TypeConverter {
                     convertibleTypes.add(targetType);
                 }
                 break;
+            case TypeTags.INTERSECTION_TAG:
+                convertibleTypes
+                        .addAll(getConvertibleTypes(inputValue, ((BIntersectionType) targetType).getEffectiveType(),
+                                unresolvedValues));
+                break;
             default:
                 if (TypeChecker.checkIsLikeType(inputValue, targetType, true)) {
                     convertibleTypes.add(targetType);

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeConverter.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeConverter.java
@@ -267,6 +267,11 @@ public class TypeConverter {
                     convertibleTypes.add(matchingType);
                 }
                 break;
+            case TypeTags.MAP_TAG:
+                if (isConvertibleToMapType(inputValue, (BMapType) targetType, unresolvedValues)) {
+                    convertibleTypes.add(targetType);
+                }
+                break;
             default:
                 if (TypeChecker.checkIsLikeType(inputValue, targetType, true)) {
                     convertibleTypes.add(targetType);
@@ -388,6 +393,20 @@ public class TypeConverter {
                 return isConvertibleToTableType(((BIntersectionType) tableConstrainedType).getEffectiveType());
         }
         return false;
+    }
+
+    private static boolean isConvertibleToMapType(Object sourceValue, BMapType targetType,
+                                                  List<TypeValuePair> unresolvedValues) {
+        if (!(sourceValue instanceof MapValueImpl)) {
+            return false;
+        }
+
+        for (Object mapEntry : ((MapValueImpl) sourceValue).values()) {
+            if (getConvertibleTypes(mapEntry, targetType.getConstrainedType(), unresolvedValues).size() != 1) {
+                return false;
+            }
+        }
+        return true;
     }
 
     static long anyToInt(Object sourceVal, Supplier<BError> errorFunc) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/configurable/VariableKey.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/configurable/VariableKey.java
@@ -37,25 +37,32 @@ public class VariableKey {
     public final Type type;
     public final boolean isRequired;
     public final String location;
+    public final boolean hasDefaultField;
 
     public VariableKey(String org, String module, String version, String variable) {
-        this(new Module(org, module, version), variable, PredefinedTypes.TYPE_ANYDATA, null, false);
+        this(new Module(org, module, version), variable, PredefinedTypes.TYPE_ANYDATA, null, false, false);
     }
 
     public VariableKey(Module module, String variable) {
-        this(module, variable, PredefinedTypes.TYPE_ANYDATA, null, false);
+        this(module, variable, PredefinedTypes.TYPE_ANYDATA, null, false, false);
     }
 
     public VariableKey(Module module, String variable, Type type, boolean isRequired) {
-        this(module, variable, type, null, isRequired);
+        this(module, variable, type, null, isRequired, false);
     }
 
     public VariableKey(Module module, String variable, Type type, String location, boolean isRequired) {
+        this(module, variable, type, location, isRequired, false);
+    }
+
+    public VariableKey(Module module, String variable, Type type, String location, boolean isRequired,
+                       boolean hasDefaultField) {
         this.module = module;
         this.variable = variable;
         this.type = type;
         this.location = location;
         this.isRequired = isRequired;
+        this.hasDefaultField = hasDefaultField;
     }
 
     public boolean isRequired() {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/configurable/providers/toml/TomlProvider.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/configurable/providers/toml/TomlProvider.java
@@ -645,6 +645,10 @@ public class TomlProvider implements ConfigProvider {
             throw new ConfigException(CONFIG_INCOMPATIBLE_TYPE, getLineRange(tomlValue), variableName, arrayType,
                     getTomlTypeString(tomlValue));
         }
+        if (hasDefaultField && arrayType.getElementType().getTag() == TypeTags.INTERSECTION_TAG) {
+            elementType = getMutableType(elementType);
+            arrayType = TypeCreator.createArrayType(elementType);
+        }
         visitedNodes.add(tomlValue);
         List<TomlTableNode> tableNodeList = ((TomlTableArrayNode) tomlValue).children();
         int arraySize = tableNodeList.size();
@@ -652,9 +656,6 @@ public class TomlProvider implements ConfigProvider {
         for (int i = 0; i < arraySize; i++) {
             Object value = retrieveValue(tableNodeList.get(i), variableName, elementType, hasDefaultField);
             entries[i] = new ListInitialValueEntry.ExpressionEntry(value);
-        }
-        if (hasDefaultField && arrayType.getElementType().getTag() == TypeTags.INTERSECTION_TAG) {
-            return new ArrayValueImpl((ArrayType) getMutableType(arrayType), entries.length, entries);
         }
         return new ArrayValueImpl(arrayType, entries.length, entries);
     }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/util/exceptions/RuntimeErrors.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/util/exceptions/RuntimeErrors.java
@@ -93,7 +93,7 @@ public enum RuntimeErrors implements DiagnosticCode {
     CONFIG_TOML_REQUIRED_FILED_NOT_PROVIDED("config.toml.required.field.not.provided", "RUNTIME_0062"),
     CONFIG_TOML_TABLE_KEY_NOT_PROVIDED("config.toml.table.key.not.provided", "RUNTIME_0063"),
     CONFIG_TOML_INVALID_MODULE_STRUCTURE("config.toml.invalid.module.structure", "RUNTIME_0065"),
-    CONFIG_TOML_DEFAULT_FILED_NOT_SUPPORTED("config.toml.default.field.not.supported", "RUNTIME_0067"),
+    CONFIG_TOML_CONSTRAINT_TYPE_NOT_SUPPORTED("config.toml.constraint.type.not.supported", "RUNTIME_0066"),
     CONFIG_TOML_EMPTY_FILE("config.toml.empty.file", "RUNTIME_0068"),
     CONFIG_TOML_EMPTY_CONTENT("config.toml.empty.content", "RUNTIME_0069"),
     CONFIG_TOML_FILE_NOT_FOUND("config.toml.file.not.found", "RUNTIME_0070"),

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/util/exceptions/RuntimeErrors.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/util/exceptions/RuntimeErrors.java
@@ -94,6 +94,7 @@ public enum RuntimeErrors implements DiagnosticCode {
     CONFIG_TOML_TABLE_KEY_NOT_PROVIDED("config.toml.table.key.not.provided", "RUNTIME_0063"),
     CONFIG_TOML_INVALID_MODULE_STRUCTURE("config.toml.invalid.module.structure", "RUNTIME_0065"),
     CONFIG_TOML_CONSTRAINT_TYPE_NOT_SUPPORTED("config.toml.constraint.type.not.supported", "RUNTIME_0066"),
+    CONFIG_TOML_DEFAULT_FILED_NOT_SUPPORTED("config.toml.default.field.not.supported", "RUNTIME_0067"),
     CONFIG_TOML_EMPTY_FILE("config.toml.empty.file", "RUNTIME_0068"),
     CONFIG_TOML_EMPTY_CONTENT("config.toml.empty.content", "RUNTIME_0069"),
     CONFIG_TOML_FILE_NOT_FOUND("config.toml.file.not.found", "RUNTIME_0070"),

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TableValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TableValueImpl.java
@@ -21,6 +21,7 @@ import io.ballerina.runtime.api.TypeTags;
 import io.ballerina.runtime.api.creators.ErrorCreator;
 import io.ballerina.runtime.api.creators.ValueCreator;
 import io.ballerina.runtime.api.types.Field;
+import io.ballerina.runtime.api.types.IntersectionType;
 import io.ballerina.runtime.api.types.TableType;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.utils.StringUtils;
@@ -380,6 +381,8 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
             } else if (possibleTypes.size() > 1) {
                 return new BUnionType(new ArrayList<>(possibleTypes));
             }
+        } else if (constraintType.getTag() == TypeTags.INTERSECTION_TAG) {
+            return getTableConstraintField(((IntersectionType) constraintType).getEffectiveType(), fieldName);
         }
         //cannot reach here. constraint should be a subtype of map<any|error>
         return null;

--- a/bvm/ballerina-runtime/src/main/resources/MessagesBundle.properties
+++ b/bvm/ballerina-runtime/src/main/resources/MessagesBundle.properties
@@ -198,6 +198,8 @@ config.toml.table.key.not.provided = [{0}] value required for key ''{1}'' of typ
   ''{3}''
 config.toml.invalid.module.structure = [{0}] invalid toml structure found for module ''{1}''. Please provide the \
   module name as ''[{2}]''
+config.toml.default.field.not.supported = defaultable readonly record field ''{0}'' in configurable variable \
+''{1}'' is not supported
 config.toml.empty.file = an empty configuration file is found in path ''{0}''. Please provide values for \
 configurable variables
 config.toml.empty.content = [{0}] environment variable ''{1}'' contains an empty string. Please provide values for\

--- a/bvm/ballerina-runtime/src/main/resources/MessagesBundle.properties
+++ b/bvm/ballerina-runtime/src/main/resources/MessagesBundle.properties
@@ -198,8 +198,6 @@ config.toml.table.key.not.provided = [{0}] value required for key ''{1}'' of typ
   ''{3}''
 config.toml.invalid.module.structure = [{0}] invalid toml structure found for module ''{1}''. Please provide the \
   module name as ''[{2}]''
-config.toml.default.field.not.supported = [{0}] defaultable readonly record field ''{1}'' in configurable variable\
-''{2}'' is not supported
 config.toml.empty.file = an empty configuration file is found in path ''{0}''. Please provide values for \
 configurable variables
 config.toml.empty.content = [{0}] environment variable ''{1}'' contains an empty string. Please provide values for\

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/ConfigMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/ConfigMethodGen.java
@@ -32,6 +32,7 @@ import org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants;
 import org.wso2.ballerinalang.compiler.bir.codegen.JvmTypeGen;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
+import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.util.Flags;
 
 import java.util.List;
@@ -185,7 +186,12 @@ public class ConfigMethodGen {
                 } else {
                     mv.visitInsn(ICONST_0);
                 }
-                mv.visitMethodInsn(INVOKESPECIAL, VARIABLE_KEY, JVM_INIT_METHOD, String.format("(L%s;L%s;L%s;L%s;Z)V",
+                if (TypeTags.containsDefaultableRecordType(globalVar.type)) {
+                    mv.visitInsn(ICONST_1);
+                } else {
+                    mv.visitInsn(ICONST_0);
+                }
+                mv.visitMethodInsn(INVOKESPECIAL, VARIABLE_KEY, JVM_INIT_METHOD, String.format("(L%s;L%s;L%s;L%s;ZZ)V",
                         MODULE, STRING_VALUE, TYPE,  STRING_VALUE), false);
                 mv.visitVarInsn(ASTORE, varCount + 1);
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/TypeTags.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/TypeTags.java
@@ -165,9 +165,10 @@ public class TypeTags {
             case TypeTags.RECORD:
                 BRecordType recordType = (BRecordType) type;
                 for (Map.Entry<String, BField> field : recordType.fields.entrySet()) {
-                    long flags = field.getValue().symbol.flags;
+                    BField bField = field.getValue();
+                    long flags = bField.symbol.flags;
                     if (!SymbolFlags.isFlagOn(flags, SymbolFlags.OPTIONAL) && !SymbolFlags.isFlagOn(flags,
-                            SymbolFlags.REQUIRED)) {
+                            SymbolFlags.REQUIRED) || containsDefaultableRecordType(bField.type)) {
                         return true;
                     }
                 }

--- a/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/CloneWithType.java
+++ b/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/CloneWithType.java
@@ -27,6 +27,7 @@ import io.ballerina.runtime.api.types.Field;
 import io.ballerina.runtime.api.types.IntersectionType;
 import io.ballerina.runtime.api.types.MapType;
 import io.ballerina.runtime.api.types.RecordType;
+import io.ballerina.runtime.api.types.TableType;
 import io.ballerina.runtime.api.types.TupleType;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.types.TypedescType;
@@ -38,6 +39,7 @@ import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BMapInitialValueEntry;
 import io.ballerina.runtime.api.values.BRefValue;
 import io.ballerina.runtime.api.values.BString;
+import io.ballerina.runtime.api.values.BTable;
 import io.ballerina.runtime.api.values.BTypedesc;
 import io.ballerina.runtime.internal.TypeChecker;
 import io.ballerina.runtime.internal.TypeConverter;
@@ -151,6 +153,9 @@ public class CloneWithType {
             case TypeTags.TUPLE_TAG:
                 newValue = convertArray((BArray) value, targetType, unresolvedValues, t);
                 break;
+            case TypeTags.TABLE_TAG:
+                newValue = convertTable((BTable<?, ?>) value, targetType, unresolvedValues, t);
+                break;
             case TypeTags.XML_TAG:
             case TypeTags.XML_ELEMENT_TAG:
             case TypeTags.XML_COMMENT_TAG:
@@ -177,9 +182,8 @@ public class CloneWithType {
                 int count = 0;
                 for (Map.Entry<?, ?> entry : map.entrySet()) {
                     Object newValue = convert(entry.getValue(), constraintType, unresolvedValues, true, t);
-                    initialValues[count] = ValueCreator
+                    initialValues[count++] = ValueCreator
                             .createKeyFieldEntry(StringUtils.fromString(entry.getKey().toString()), newValue);
-                    count++;
                 }
                 return ValueCreator.createMapValue(targetType, initialValues);
             case TypeTags.RECORD_TYPE_TAG:
@@ -229,9 +233,8 @@ public class CloneWithType {
         int count = 0;
         for (Map.Entry<?, ?> entry : map.entrySet()) {
             Object newValue = convertRecordEntry(unresolvedValues, t, restFieldType, targetTypeField, entry);
-            initialValues[count] =
+            initialValues[count++] =
                     ValueCreator.createKeyFieldEntry(StringUtils.fromString(entry.getKey().toString()), newValue);
-            count++;
         }
         return (BMap<?, ?>) t.instantiate(Scheduler.getStrand(), initialValues);
     }
@@ -280,6 +283,29 @@ public class CloneWithType {
         }
         // should never reach here
         throw CloneUtils.createConversionError(array, targetType);
+    }
+
+    private static Object convertTable(BTable<?, ?> bTable, Type targetType, List<TypeValuePair> unresolvedValues,
+                                       BTypedesc t) {
+
+        TableType tableType = (TableType) targetType;
+        Object[] tableValues = new Object[bTable.size()];
+        int count = 0;
+        for (Object tableValue : bTable.values()) {
+            BMap<?, ?> bMap = (BMap<?, ?>) convert(tableValue, tableType.getConstrainedType(),
+                                                   unresolvedValues, t);
+            tableValues[count++] = bMap;
+        }
+        BArray data = ValueCreator
+                .createArrayValue(tableValues, TypeCreator.createArrayType(tableType.getConstrainedType()));
+        BArray fieldNames;
+        if (tableType.getFieldNames() != null) {
+            fieldNames = StringUtils.fromStringArray(tableType.getFieldNames());
+        } else {
+            fieldNames = ValueCreator.createArrayValue(new BString[]{});
+        }
+        return ValueCreator.createTableValue(tableType, data, fieldNames);
+
     }
 
     private static BError createConversionError(Object inputValue, Type targetType) {

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/configurables/ConfigurableTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/configurables/ConfigurableTest.java
@@ -245,10 +245,9 @@ public class ConfigurableTest extends BaseTest {
 
     @Test
     public void testInvalidDefaultableField() throws BallerinaTestException {
-        LogLeecher errorLog = new LogLeecher("error: [Config.toml:(1:1,3:17)] defaultable readonly record field " +
-                                                     "'name' in configurable variable'employees' is not supported",
-                                             ERROR);
-        LogLeecher errorLocationLog = new LogLeecher("\tat testOrg/main:0.1.0(main.bal:25)", ERROR);
+        LogLeecher errorLog = new LogLeecher("error: defaultable readonly record field 'country' in configurable " +
+                "variable 'person.address' is not supported", ERROR);
+        LogLeecher errorLocationLog = new LogLeecher("\tat testOrg/main:0.1.0(main.bal:32)", ERROR);
         bMainInstance.runMain("run", new String[]{"main"}, null, new String[]{},
                 new LogLeecher[]{errorLog, errorLocationLog}, testFileLocation + "/invalidDefaultable");
         errorLog.waitForText(5000);

--- a/tests/jballerina-integration-test/src/test/resources/configurables/configLibProject/modules/mod1/lib.bal
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/configLibProject/modules/mod1/lib.bal
@@ -62,3 +62,16 @@ public isolated function getNumber() returns int {
 isolated function getSymbol() returns string {
     return symbol3;
 }
+
+public type Person record {
+    string name;
+    Address address = {};
+};
+
+public type Address record {|
+    Country country = {};
+|};
+
+public type Country record {
+    string name = "LK";
+};

--- a/tests/jballerina-integration-test/src/test/resources/configurables/configLibProject/modules/mod1/lib.bal
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/configLibProject/modules/mod1/lib.bal
@@ -37,12 +37,12 @@ public enum HttpVersion {
 public type IntMap map<int>;
 public type ManagerMap map<Manager>;
 
-configurable int num4 = ?;
-configurable string word5 = ?;
+configurable int num4 = 8;
+configurable string word5 = "word";
 
 final string symbol1 = "!";
-configurable string symbol2 = ?;
-configurable string symbol3 = ?;
+configurable string symbol2 = "a";
+configurable string symbol3 = "a";
 
 public type Symbols record {|
     string symbol1 = symbol1;
@@ -75,3 +75,32 @@ public type Address record {|
 public type Country record {
     string name = "LK";
 };
+
+const DEFAULT_PROVIDER = "choreo";
+
+public type MetricsConfig record {|
+    boolean enabled = enabled;
+    string reporter = DEFAULT_PROVIDER;
+|} & readonly;
+
+public type TracingConfig record {|
+    boolean enabled = enabled;
+    string provider = DEFAULT_PROVIDER;
+|} & readonly;
+
+// Enables both metrics and tracing
+configurable boolean enabled = false;
+configurable MetricsConfig metrics = {};
+configurable TracingConfig tracing = {};
+
+public function getMetrics() returns MetricsConfig {
+    return metrics;
+}
+
+public function getTracing() returns TracingConfig {
+    return tracing;
+}
+
+public function getEnabled() returns boolean {
+    return enabled;
+}

--- a/tests/jballerina-integration-test/src/test/resources/configurables/configLibProject/modules/mod1/lib.bal
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/configLibProject/modules/mod1/lib.bal
@@ -36,3 +36,29 @@ public enum HttpVersion {
 
 public type IntMap map<int>;
 public type ManagerMap map<Manager>;
+
+configurable int num4 = ?;
+configurable string word5 = ?;
+
+final string symbol1 = "!";
+configurable string symbol2 = ?;
+configurable string symbol3 = ?;
+
+public type Symbols record {|
+    string symbol1 = symbol1;
+    string symbol2 = symbol2;
+    string symbol3 = getSymbol();
+    string symbol4;
+|};
+
+public isolated function getWord() returns string {
+    return word5;
+}
+
+public isolated function getNumber() returns int {
+    return num4;
+}
+
+isolated function getSymbol() returns string {
+    return symbol3;
+}

--- a/tests/jballerina-integration-test/src/test/resources/configurables/configStructuredTypesProject/Config.toml
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/configStructuredTypesProject/Config.toml
@@ -128,17 +128,17 @@ id = 12
 address.city="London"
 address.country.name="UK"
 
-[[personArray1]]
-name = "waruna"
-id = 700
-address.city="Abu Dhabi"
-address.country.name="UAE"
+# [[personArray1]]
+# name = "waruna"
+# id = 700
+# address.city="Abu Dhabi"
+# address.country.name="UAE"
 
-[[personArray1]]
-name = "manu"
-id = 701
-address.city="Mumbai"
-address.country.name="India"
+# [[personArray1]]
+# name = "manu"
+# id = 701
+# address.city="Mumbai"
+# address.country.name="India"
 
 [[personArray2]]
 name = "gabilan"
@@ -284,17 +284,17 @@ id = 122
 address.city="Mumbai"
 address.country.name="India"
 
-[[configStructuredTypes.mod2.personArray1]]
-name = "manu"
-id = 800
-address.city="New York"
-address.country.name="USA"
+# [[configStructuredTypes.mod2.personArray1]]
+# name = "manu"
+# id = 800
+# address.city="New York"
+# address.country.name="USA"
 
-[[configStructuredTypes.mod2.personArray1]]
-name = "hinduja"
-id = 801
-address.city="London"
-address.country.name="UK"
+# [[configStructuredTypes.mod2.personArray1]]
+# name = "hinduja"
+# id = 801
+# address.city="London"
+# address.country.name="UK"
 
 [[configStructuredTypes.mod2.personArray2]]
 name = "riyafa"

--- a/tests/jballerina-integration-test/src/test/resources/configurables/configStructuredTypesProject/Config.toml
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/configStructuredTypesProject/Config.toml
@@ -882,6 +882,13 @@ num4 = 4
 word5 = "word 5"
 symbol2 = "@"
 symbol3 = "#"
+enabled = true
+
+[testOrg.configLib.mod1.metrics]
+enabled = false
+
+[testOrg.configLib.mod1.tracing]
+provider = "wso2"
 
 [configStructuredTypes.mod3]
 word2 = "word 2"

--- a/tests/jballerina-integration-test/src/test/resources/configurables/configStructuredTypesProject/Config.toml
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/configStructuredTypesProject/Config.toml
@@ -871,3 +871,140 @@ m1.id = 66
 m1.name = "John"
 m2.id = 77
 m2.name = "Jim"
+
+[configStructuredTypes.mod1]
+num2 = 2
+num3 = 3
+word4 = "word 4"
+
+[testOrg.configLib.mod1]
+num4 = 4
+word5 = "word 5"
+symbol2 = "@"
+symbol3 = "#"
+
+[configStructuredTypes.mod3]
+word2 = "word 2"
+
+[configStructuredTypes.mod3.words]
+word6 = "word 6"
+
+[configStructuredTypes.mod3.numbers]
+num5 = 5
+
+[configStructuredTypes.mod3.symbols]
+symbol4 = "$"
+
+[[configStructuredTypes.mod3.wordArr]]
+word6 = "word 7"
+
+[[configStructuredTypes.mod3.wordArr]]
+word1 = "word 10"
+word2 = "word 20"
+word3 = "word 30"
+word4 = "word 40"
+word5 = "word 50"
+word6 = "word 60"
+
+[[configStructuredTypes.mod3.numberArr]]
+num5 = 6
+
+[[configStructuredTypes.mod3.numberArr]]
+num1 = 10
+num2 = 20
+num3 = 30
+num4 = 40
+num5 = 50
+
+[[configStructuredTypes.mod3.symbolArr]]
+symbol4 = "%"
+
+[[configStructuredTypes.mod3.symbolArr]]
+symbol1 = "^"
+symbol2 = "&"
+symbol3 = "*"
+symbol4 = "-"
+
+[[configStructuredTypes.mod3.wordTable]]
+word6 = "word 7"
+
+[[configStructuredTypes.mod3.wordTable]]
+word1 = "word 10"
+word2 = "word 20"
+word3 = "word 30"
+word4 = "word 40"
+word5 = "word 50"
+word6 = "word 60"
+
+[[configStructuredTypes.mod3.numberTable]]
+num5 = 6
+
+[[configStructuredTypes.mod3.numberTable]]
+num1 = 10
+num2 = 20
+num3 = 30
+num4 = 40
+num5 = 50
+
+[[configStructuredTypes.mod3.symbolTable]]
+symbol4 = "%"
+
+[[configStructuredTypes.mod3.symbolTable]]
+symbol1 = "^"
+symbol2 = "&"
+symbol3 = "*"
+symbol4 = "-"
+
+[configStructuredTypes.mod3.wordMap]
+entry1.word6 = "word 6"
+entry2.word1 = "word 11"
+entry2.word2 = "word 22"
+entry2.word3 = "word 33"
+entry2.word4 = "word 44"
+entry2.word5 = "word 55"
+entry2.word6 = "word 66"
+
+[configStructuredTypes.mod3.numberMap]
+entry1.num5 = 55
+entry2.num1 = 11
+entry2.num2 = 22
+entry2.num3 = 33
+entry2.num4 = 44
+entry2.num5 = 55
+
+[configStructuredTypes.mod3.symbolMap]
+entry1.symbol4 = "="
+entry2.symbol1 = "+"
+entry2.symbol2 = "|"
+entry2.symbol3 = "}"
+entry2.symbol4 = "?"
+
+[[configStructuredTypes.mod3.wordTableMap.map1]]
+word6 = "word 7"
+
+[[configStructuredTypes.mod3.wordTableMap.map2]]
+word1 = "word 10"
+word2 = "word 20"
+word3 = "word 30"
+word4 = "word 40"
+word5 = "word 50"
+word6 = "word 60"
+
+[[configStructuredTypes.mod3.numberTableMap.map1]]
+num5 = 6
+
+[[configStructuredTypes.mod3.numberTableMap.map2]]
+num1 = 10
+num2 = 20
+num3 = 30
+num4 = 40
+num5 = 50
+
+[[configStructuredTypes.mod3.symbolTableMap.map1]]
+symbol4 = "%"
+
+[[configStructuredTypes.mod3.symbolTableMap.map2]]
+symbol1 = "^"
+symbol2 = "&"
+symbol3 = "*"
+symbol4 = "-"

--- a/tests/jballerina-integration-test/src/test/resources/configurables/configStructuredTypesProject/configStructuredTypes/main.bal
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/configStructuredTypesProject/configStructuredTypes/main.bal
@@ -155,7 +155,7 @@ public function main() {
     testComplexRecords();
     testMaps();
     mod2:testMaps();
-    mod3:testRecords();
+    mod3:testRecordsReferringConfigVariables();
     print("Tests passed");
 }
 

--- a/tests/jballerina-integration-test/src/test/resources/configurables/configStructuredTypesProject/configStructuredTypes/main.bal
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/configStructuredTypesProject/configStructuredTypes/main.bal
@@ -82,7 +82,8 @@ configurable readonly & record {
 } person3 = ?;
 configurable table<mod1:Person> & readonly personTable = ?;
 configurable mod1:Person[] & readonly personArray = ?;
-configurable (mod1:Person & readonly)[] & readonly personArray1 = ?;
+// Need to enable this after fixing #31161
+// configurable (mod1:Person & readonly)[] & readonly personArray1 = ?;
 
 configurable Lecturer & readonly lecturer = ?;
 configurable Lawyer lawyer = ?;
@@ -226,15 +227,15 @@ public function testTables() {
 }
 
 public function testArrays() {
-    test:assertEquals(personArray.toString(), "[{\"address\":{\"city\":\"New York\",\"country\":" +
-    "{\"name\":\"USA\"}},\"name\":\"manu\",\"id\":11},{\"address\":{\"city\":\"London\",\"country\":" +
-    "{\"name\":\"UK\"}},\"name\":\"hinduja\",\"id\":12}]");
-    test:assertEquals(personArray1.toString(), "[{\"address\":{\"city\":\"Abu Dhabi\",\"country\":" +
-    "{\"name\":\"UAE\"}}"+",\"name\":\"waruna\",\"id\":700},{\"address\":{\"city\":\"Mumbai\"," +
-    "\"country\":{\"name\":\"India\"}},\"name\":\"manu\",\"id\":701}]");
-    test:assertEquals(personArray2.toString(), "[{\"address\":{\"city\":\"Abu Dhabi\",\"country\":" +
-    "{\"name\":\"UAE\"}},\"name\":\"gabilan\",\"id\":900},{\"address\":{\"city\":\"Mumbai\"," +
-    "\"country\":{\"name\":\"India\"}},\"name\":\"hinduja\",\"id\":901}]");
+    test:assertEquals(personArray.toString(), "[{\"name\":\"manu\",\"id\":11,\"address\":{\"city\":\"New York\"," +
+    "\"country\":{\"name\":\"USA\"}}},{\"name\":\"hinduja\",\"id\":12,\"address\":{\"city\":\"London\"," +
+    "\"country\":{\"name\":\"UK\"}}}]");
+    // test:assertEquals(personArray1.toString(), "[{\"address\":{\"city\":\"Abu Dhabi\",\"country\":" +
+    // "{\"name\":\"UAE\"}}"+",\"name\":\"waruna\",\"id\":700},{\"address\":{\"city\":\"Mumbai\"," +
+    // "\"country\":{\"name\":\"India\"}},\"name\":\"manu\",\"id\":701}]");
+    test:assertEquals(personArray2.toString(), "[{\"name\":\"gabilan\",\"id\":900,\"address\":{\"city\":\"Abu Dhabi\"," +
+    "\"country\":{\"name\":\"UAE\"}}},{\"name\":\"hinduja\",\"id\":901,\"address\":{\"city\":\"Mumbai\"," +
+    "\"country\":{\"name\":\"India\"}}}]");
 }
 
 public function testMaps() {

--- a/tests/jballerina-integration-test/src/test/resources/configurables/configStructuredTypesProject/configStructuredTypes/main.bal
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/configStructuredTypesProject/configStructuredTypes/main.bal
@@ -18,6 +18,7 @@
 import configStructuredTypes.mod1;
 import ballerina/jballerina.java;
 import configStructuredTypes.mod2;
+import configStructuredTypes.mod3;
 import testOrg/configLib.mod1 as configLib;
 import ballerina/test;
 
@@ -153,6 +154,7 @@ public function main() {
     testComplexRecords();
     testMaps();
     mod2:testMaps();
+    mod3:testRecords();
     print("Tests passed");
 }
 
@@ -275,25 +277,25 @@ public function testMaps() {
     test:assertEquals(readonlyManagerMap.toString(), "{\"m1\":{\"name\":\"manu\",\"id\":333},\"m2\":{\"name\":" +
     "\"riyafa\",\"id\":444}}");
 
-    testMapIterator(user, 3);
-    testMapIterator(numbers, 4);
-    testMapIterator(fractions, 3);
-    testMapIterator(bits, 2);
-    testMapIterator(numberSet, 3);
-    testMapIterator(stringSet, 3);
-    testMapIterator(engineerMap, 3);
-    testMapIterator(lecturerMap, 2);
-    testMapIterator(readonlyEngineerMap, 3);
-    testMapIterator(readonlyLecturerMap, 2);
-    testMapIterator(subjects, 3);
-    testMapIterator(departments, 3);
-    testMapIterator(intMap, 3);
-    testMapIterator(libIntMap, 3);
-    testMapIterator(managerMap, 2);
-    testMapIterator(readonlyManagerMap, 2);
+    mod3:testMapIterator(user, 3);
+    mod3:testMapIterator(numbers, 4);
+    mod3:testMapIterator(fractions, 3);
+    mod3:testMapIterator(bits, 2);
+    mod3:testMapIterator(numberSet, 3);
+    mod3:testMapIterator(stringSet, 3);
+    mod3:testMapIterator(engineerMap, 3);
+    mod3:testMapIterator(lecturerMap, 2);
+    mod3:testMapIterator(readonlyEngineerMap, 3);
+    mod3:testMapIterator(readonlyLecturerMap, 2);
+    mod3:testMapIterator(subjects, 3);
+    mod3:testMapIterator(departments, 3);
+    mod3:testMapIterator(intMap, 3);
+    mod3:testMapIterator(libIntMap, 3);
+    mod3:testMapIterator(managerMap, 2);
+    mod3:testMapIterator(readonlyManagerMap, 2);
     // These lines should be enabled after fixing #30566
-    // testMapIterator(studentMap, 3);
-    // testMapIterator(readonlyStudentMap, 3);
+    // mod3:testMapIterator(studentMap, 3);
+    // mod3:testMapIterator(readonlyStudentMap, 3);
 
     testArrayOfMaps();
     testTableOfMaps();
@@ -339,31 +341,15 @@ public function testTableOfMaps() {
     "\"m2\":{\"name\":\"Jill\",\"id\":88}},{\"m1\":{\"name\":\"John\",\"id\":66}," +
     "\"m2\":{\"name\":\"Jim\",\"id\":77}}]");
 
-    testTableIterator(stringMapTable);
-    testTableIterator(readonlyTable);
-    testTableIterator(stringMapArrTable);
-    testTableIterator(engineerMapTable);
-    testTableIterator(readonlyEngineerMapTable);
-    testTableIterator(studentMapTable);
-    testTableIterator(readonlyStudentMapTable);
-    testTableIterator(managerMapTable);
-    testTableIterator(readonlyManagerMapTable);
-}
-
-function testTableIterator(table<map<anydata>> tab) {
-    int count = 0;
-    foreach var entry in tab {
-        count += 1;
-    }
-    test:assertEquals(count, 2);
-}
-
-function testMapIterator(map<anydata> testMap, int length) {
-    int count = 0;
-    foreach var entry in testMap {
-        count += 1;
-    }
-    test:assertEquals(count, length);
+    mod3:testTableIterator(stringMapTable);
+    mod3:testTableIterator(readonlyTable);
+    mod3:testTableIterator(stringMapArrTable);
+    mod3:testTableIterator(engineerMapTable);
+    mod3:testTableIterator(readonlyEngineerMapTable);
+    mod3:testTableIterator(studentMapTable);
+    mod3:testTableIterator(readonlyStudentMapTable);
+    mod3:testTableIterator(managerMapTable);
+    mod3:testTableIterator(readonlyManagerMapTable);
 }
 
 function print(string value) {

--- a/tests/jballerina-integration-test/src/test/resources/configurables/configStructuredTypesProject/configStructuredTypes/modules/mod1/mod1.bal
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/configStructuredTypesProject/configStructuredTypes/modules/mod1/mod1.bal
@@ -14,6 +14,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import testOrg/configLib.mod1 as configLib;
+
 public type Student record {
     string name = "";
     int id = 444;
@@ -71,3 +73,25 @@ public type Place record {|
 
 public type IntMap map<int>;
 public type StudentMap map<Student>;
+
+configurable int num3 = ?;
+configurable string word4 = ?;
+
+final int num1 = 1;
+configurable int num2 = ?;
+
+public type Numbers record {|
+    int num1 = num1;
+    int num2 = num2;
+    int num3 = getNumber();
+    int num4 = configLib:getNumber();
+    int num5;
+|};
+
+public isolated function getWord() returns string {
+    return word4;
+}
+
+public isolated function getNumber() returns int {
+    return num3;
+}

--- a/tests/jballerina-integration-test/src/test/resources/configurables/configStructuredTypesProject/configStructuredTypes/modules/mod1/mod1.bal
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/configStructuredTypesProject/configStructuredTypes/modules/mod1/mod1.bal
@@ -31,19 +31,18 @@ public type Officer record {|
     readonly int id = 0;
 |};
 
-
-public type Person readonly & record {
-     string name;
-     int id;
-     Address address;
+public type Person record {
+    string name;
+    int id;
+    Address address;
 };
 
-public type Address  record {
+public type Address record {
     string city;
-    County country = {};
+    Country country = {};
 };
 
-public type County  record {
+public type Country record {
     string name = "SL";
 };
 

--- a/tests/jballerina-integration-test/src/test/resources/configurables/configStructuredTypesProject/configStructuredTypes/modules/mod2/mod2.bal
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/configStructuredTypesProject/configStructuredTypes/modules/mod2/mod2.bal
@@ -53,7 +53,7 @@ configurable table<mod1:Employee & readonly> & readonly employeeTable1 = ?;
 configurable mod1:Person person = ?;
 configurable table<mod1:Person> & readonly personTable = ?;
 configurable mod1:Person[] & readonly personArray = ?;
-configurable (mod1:Person & readonly)[] & readonly personArray1 = ?;
+// configurable (mod1:Person & readonly)[] & readonly personArray1 = ?;
 configurable mod1:PersonArray[] & readonly personArray2 = ?;
 
 // Maps
@@ -140,15 +140,15 @@ public function testTables() {
 }
 
 public function testArrays() {
-    test:assertEquals(personArray.toString(), "[{\"address\":{\"city\":\"Abu Dhabi\",\"country\":{\"name\":\"UAE\"}}," +
-        "\"name\":\"waruna\",\"id\":111},{\"address\":{\"city\":\"Mumbai\",\"country\":{\"name\":\"India\"}}," +
-        "\"name\":\"manu\",\"id\":122}]");
-    test:assertEquals(personArray1.toString(), "[{\"address\":{\"city\":\"New York\",\"country\":{\"name\":\"USA\"}}," +
-        "\"name\":\"manu\",\"id\":800},{\"address\":{\"city\":\"London\",\"country\":{\"name\":\"UK\"}}," +
-        "\"name\":\"hinduja\",\"id\":801}]");
-    test:assertEquals(personArray2.toString(), "[{\"address\":{\"city\":\"New York\",\"country\":{\"name\":\"USA\"}}," +
-        "\"name\":\"riyafa\",\"id\":1000},{\"address\":{\"city\":\"London\",\"country\":{\"name\":\"UK\"}}," +
-        "\"name\":\"waruna\",\"id\":1001}]");
+    test:assertEquals(personArray.toString(), "[{\"name\":\"waruna\",\"id\":111,\"address\":{\"city\":\"Abu Dhabi\"," +
+    "\"country\":{\"name\":\"UAE\"}}},{\"name\":\"manu\",\"id\":122,\"address\":{\"city\":\"Mumbai\"," +
+    "\"country\":{\"name\":\"India\"}}}]");
+    // test:assertEquals(personArray1.toString(), "[{\"address\":{\"city\":\"New York\",\"country\":{\"name\":\"USA\"}}," +
+    //     "\"name\":\"manu\",\"id\":800},{\"address\":{\"city\":\"London\",\"country\":{\"name\":\"UK\"}}," +
+    //     "\"name\":\"hinduja\",\"id\":801}]");
+    test:assertEquals(personArray2.toString(), "[{\"name\":\"riyafa\",\"id\":1000,\"address\":{\"city\":\"New York\"," +
+    "\"country\":{\"name\":\"USA\"}}},{\"name\":\"waruna\",\"id\":1001,\"address\":{\"city\":\"London\"," +
+    "\"country\":{\"name\":\"UK\"}}}]");
 }
 
 public function testMaps() {

--- a/tests/jballerina-integration-test/src/test/resources/configurables/configStructuredTypesProject/configStructuredTypes/modules/mod3/mod3.bal
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/configStructuredTypesProject/configStructuredTypes/modules/mod3/mod3.bal
@@ -56,42 +56,42 @@ configurable map<table<Words>> wordTableMap = ?;
 configurable map<table<mod1:Numbers>> numberTableMap = ?;
 configurable map<table<configLib:Symbols>> symbolTableMap = ?;
 
-public function testRecords() {
-    test:assertEquals(words.toString(), "{\"word1\":\"word 1\",\"word2\":\"word 2\",\"word3\":\"word 3\","+
+function testRecords() {
+    test:assertEquals(words.toString(), "{\"word1\":\"word 1\",\"word2\":\"word 2\",\"word3\":\"word 3\"," + 
     "\"word4\":\"word 4\",\"word5\":\"word 5\",\"word6\":\"word 6\"}");
-    test:assertEquals(wordArr.toString(), "[{\"word1\":\"word 1\",\"word2\":\"word 2\",\"word3\":\"word 3\"," +
-    "\"word4\":\"word 4\",\"word5\":\"word 5\",\"word6\":\"word 7\"},{\"word1\":\"word 10\",\"word2\":\"word 20\"," +
+    test:assertEquals(wordArr.toString(), "[{\"word1\":\"word 1\",\"word2\":\"word 2\",\"word3\":\"word 3\"," + 
+    "\"word4\":\"word 4\",\"word5\":\"word 5\",\"word6\":\"word 7\"},{\"word1\":\"word 10\",\"word2\":\"word 20\"," + 
     "\"word3\":\"word 30\",\"word4\":\"word 40\",\"word5\":\"word 50\",\"word6\":\"word 60\"}]");
-    test:assertEquals(wordTable.toString(), "[{\"word1\":\"word 1\",\"word2\":\"word 2\",\"word3\":\"word 3\"," +
-    "\"word4\":\"word 4\",\"word5\":\"word 5\",\"word6\":\"word 7\"},{\"word1\":\"word 10\",\"word2\":\"word 20\"," +
+    test:assertEquals(wordTable.toString(), "[{\"word1\":\"word 1\",\"word2\":\"word 2\",\"word3\":\"word 3\"," + 
+    "\"word4\":\"word 4\",\"word5\":\"word 5\",\"word6\":\"word 7\"},{\"word1\":\"word 10\",\"word2\":\"word 20\"," + 
     "\"word3\":\"word 30\",\"word4\":\"word 40\",\"word5\":\"word 50\",\"word6\":\"word 60\"}]");
-    test:assertEquals(wordMap.toString(), "{\"entry1\":{\"word1\":\"word 1\",\"word2\":\"word 2\"," +
-    "\"word3\":\"word 3\",\"word4\":\"word 4\",\"word5\":\"word 5\",\"word6\":\"word 6\"}," +
-    "\"entry2\":{\"word1\":\"word 11\",\"word2\":\"word 22\",\"word3\":\"word 33\",\"word4\":\"word 44\"," +
+    test:assertEquals(wordMap.toString(), "{\"entry1\":{\"word1\":\"word 1\",\"word2\":\"word 2\"," + 
+    "\"word3\":\"word 3\",\"word4\":\"word 4\",\"word5\":\"word 5\",\"word6\":\"word 6\"}," + 
+    "\"entry2\":{\"word1\":\"word 11\",\"word2\":\"word 22\",\"word3\":\"word 33\",\"word4\":\"word 44\"," + 
     "\"word5\":\"word 55\",\"word6\":\"word 66\"}}");
-    test:assertEquals(wordTableMap.toString(), "{\"map1\":[{\"word1\":\"word 1\",\"word2\":\"word 2\"," +
-    "\"word3\":\"word 3\",\"word4\":\"word 4\",\"word5\":\"word 5\",\"word6\":\"word 7\"}]," +
-    "\"map2\":[{\"word1\":\"word 10\",\"word2\":\"word 20\",\"word3\":\"word 30\",\"word4\":\"word 40\"," +
+    test:assertEquals(wordTableMap.toString(), "{\"map1\":[{\"word1\":\"word 1\",\"word2\":\"word 2\"," + 
+    "\"word3\":\"word 3\",\"word4\":\"word 4\",\"word5\":\"word 5\",\"word6\":\"word 7\"}]," + 
+    "\"map2\":[{\"word1\":\"word 10\",\"word2\":\"word 20\",\"word3\":\"word 30\",\"word4\":\"word 40\"," + 
     "\"word5\":\"word 50\",\"word6\":\"word 60\"}]}");
 
     test:assertEquals(numbers.toString(), "{\"num1\":1,\"num2\":2,\"num3\":3,\"num4\":4,\"num5\":5}");
-    test:assertEquals(numberArr.toString(), "[{\"num1\":1,\"num2\":2,\"num3\":3,\"num4\":4,\"num5\":6}," +
+    test:assertEquals(numberArr.toString(), "[{\"num1\":1,\"num2\":2,\"num3\":3,\"num4\":4,\"num5\":6}," + 
     "{\"num1\":10,\"num2\":20,\"num3\":30,\"num4\":40,\"num5\":50}]");
-    test:assertEquals(numberTable.toString(), "[{\"num1\":1,\"num2\":2,\"num3\":3,\"num4\":4,\"num5\":6}," +
+    test:assertEquals(numberTable.toString(), "[{\"num1\":1,\"num2\":2,\"num3\":3,\"num4\":4,\"num5\":6}," + 
     "{\"num1\":10,\"num2\":20,\"num3\":30,\"num4\":40,\"num5\":50}]");
-    test:assertEquals(numberMap.toString(), "{\"entry1\":{\"num1\":1,\"num2\":2,\"num3\":3,\"num4\":4," +
+    test:assertEquals(numberMap.toString(), "{\"entry1\":{\"num1\":1,\"num2\":2,\"num3\":3,\"num4\":4," + 
     "\"num5\":55},\"entry2\":{\"num1\":11,\"num2\":22,\"num3\":33,\"num4\":44,\"num5\":55}}");
-    test:assertEquals(numberTableMap.toString(), "{\"map1\":[{\"num1\":1,\"num2\":2,\"num3\":3,\"num4\":4," +
+    test:assertEquals(numberTableMap.toString(), "{\"map1\":[{\"num1\":1,\"num2\":2,\"num3\":3,\"num4\":4," + 
     "\"num5\":6}],\"map2\":[{\"num1\":10,\"num2\":20,\"num3\":30,\"num4\":40,\"num5\":50}]}");
 
     test:assertEquals(symbols.toString(), "{\"symbol1\":\"!\",\"symbol2\":\"@\",\"symbol3\":\"#\",\"symbol4\":\"$\"}");
-    test:assertEquals(symbolArr.toString(), "[{\"symbol1\":\"!\",\"symbol2\":\"@\",\"symbol3\":\"#\"," +
+    test:assertEquals(symbolArr.toString(), "[{\"symbol1\":\"!\",\"symbol2\":\"@\",\"symbol3\":\"#\"," + 
     "\"symbol4\":\"%\"},{\"symbol1\":\"^\",\"symbol2\":\"&\",\"symbol3\":\"*\",\"symbol4\":\"-\"}]");
-    test:assertEquals(symbolTable.toString(), "[{\"symbol1\":\"!\",\"symbol2\":\"@\",\"symbol3\":\"#\"," +
+    test:assertEquals(symbolTable.toString(), "[{\"symbol1\":\"!\",\"symbol2\":\"@\",\"symbol3\":\"#\"," + 
     "\"symbol4\":\"%\"},{\"symbol1\":\"^\",\"symbol2\":\"&\",\"symbol3\":\"*\",\"symbol4\":\"-\"}]");
-    test:assertEquals(symbolMap.toString(), "{\"entry1\":{\"symbol1\":\"!\",\"symbol2\":\"@\",\"symbol3\":\"#\"," +
+    test:assertEquals(symbolMap.toString(), "{\"entry1\":{\"symbol1\":\"!\",\"symbol2\":\"@\",\"symbol3\":\"#\"," + 
     "\"symbol4\":\"=\"},\"entry2\":{\"symbol1\":\"+\",\"symbol2\":\"|\",\"symbol3\":\"}\",\"symbol4\":\"?\"}}");
-    test:assertEquals(symbolTableMap.toString(), "{\"map1\":[{\"symbol1\":\"!\",\"symbol2\":\"@\",\"symbol3\":\"#\"," +
+    test:assertEquals(symbolTableMap.toString(), "{\"map1\":[{\"symbol1\":\"!\",\"symbol2\":\"@\",\"symbol3\":\"#\"," + 
     "\"symbol4\":\"%\"}],\"map2\":[{\"symbol1\":\"^\",\"symbol2\":\"&\",\"symbol3\":\"*\",\"symbol4\":\"-\"}]}");
 
     testTableIterator(wordTable);
@@ -124,4 +124,11 @@ public function testMapIterator(map<anydata> testMap, int length) {
         count += 1;
     }
     test:assertEquals(count, length);
+}
+
+public function testRecordsReferringConfigVariables() {
+    testRecords();
+    test:assertTrue(configLib:getEnabled());
+    test:assertEquals(configLib:getMetrics().toString(), "{\"enabled\":false,\"reporter\":\"choreo\"}");
+    test:assertEquals(configLib:getTracing().toString(), "{\"enabled\":true,\"provider\":\"wso2\"}");
 }

--- a/tests/jballerina-integration-test/src/test/resources/configurables/configStructuredTypesProject/configStructuredTypes/modules/mod3/mod3.bal
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/configStructuredTypesProject/configStructuredTypes/modules/mod3/mod3.bal
@@ -57,23 +57,42 @@ configurable map<table<mod1:Numbers>> numberTableMap = ?;
 configurable map<table<configLib:Symbols>> symbolTableMap = ?;
 
 public function testRecords() {
-    test:assertEquals(words.toString(), "");
-    test:assertEquals(wordArr.toString(), "");
-    test:assertEquals(wordTable.toString(), "");
-    test:assertEquals(wordMap.toString(), "");
-    test:assertEquals(wordTableMap.toString(), "");
+    test:assertEquals(words.toString(), "{\"word1\":\"word 1\",\"word2\":\"word 2\",\"word3\":\"word 3\","+
+    "\"word4\":\"word 4\",\"word5\":\"word 5\",\"word6\":\"word 6\"}");
+    test:assertEquals(wordArr.toString(), "[{\"word1\":\"word 1\",\"word2\":\"word 2\",\"word3\":\"word 3\"," +
+    "\"word4\":\"word 4\",\"word5\":\"word 5\",\"word6\":\"word 7\"},{\"word1\":\"word 10\",\"word2\":\"word 20\"," +
+    "\"word3\":\"word 30\",\"word4\":\"word 40\",\"word5\":\"word 50\",\"word6\":\"word 60\"}]");
+    test:assertEquals(wordTable.toString(), "[{\"word1\":\"word 1\",\"word2\":\"word 2\",\"word3\":\"word 3\"," +
+    "\"word4\":\"word 4\",\"word5\":\"word 5\",\"word6\":\"word 7\"},{\"word1\":\"word 10\",\"word2\":\"word 20\"," +
+    "\"word3\":\"word 30\",\"word4\":\"word 40\",\"word5\":\"word 50\",\"word6\":\"word 60\"}]");
+    test:assertEquals(wordMap.toString(), "{\"entry1\":{\"word1\":\"word 1\",\"word2\":\"word 2\"," +
+    "\"word3\":\"word 3\",\"word4\":\"word 4\",\"word5\":\"word 5\",\"word6\":\"word 6\"}," +
+    "\"entry2\":{\"word1\":\"word 11\",\"word2\":\"word 22\",\"word3\":\"word 33\",\"word4\":\"word 44\"," +
+    "\"word5\":\"word 55\",\"word6\":\"word 66\"}}");
+    test:assertEquals(wordTableMap.toString(), "{\"map1\":[{\"word1\":\"word 1\",\"word2\":\"word 2\"," +
+    "\"word3\":\"word 3\",\"word4\":\"word 4\",\"word5\":\"word 5\",\"word6\":\"word 7\"}]," +
+    "\"map2\":[{\"word1\":\"word 10\",\"word2\":\"word 20\",\"word3\":\"word 30\",\"word4\":\"word 40\"," +
+    "\"word5\":\"word 50\",\"word6\":\"word 60\"}]}");
 
-    test:assertEquals(numbers.toString(), "");
-    test:assertEquals(numberArr.toString(), "");
-    test:assertEquals(numberTable.toString(), "");
-    test:assertEquals(numberMap.toString(), "");
-    test:assertEquals(numberTableMap.toString(), "");
+    test:assertEquals(numbers.toString(), "{\"num1\":1,\"num2\":2,\"num3\":3,\"num4\":4,\"num5\":5}");
+    test:assertEquals(numberArr.toString(), "[{\"num1\":1,\"num2\":2,\"num3\":3,\"num4\":4,\"num5\":6}," +
+    "{\"num1\":10,\"num2\":20,\"num3\":30,\"num4\":40,\"num5\":50}]");
+    test:assertEquals(numberTable.toString(), "[{\"num1\":1,\"num2\":2,\"num3\":3,\"num4\":4,\"num5\":6}," +
+    "{\"num1\":10,\"num2\":20,\"num3\":30,\"num4\":40,\"num5\":50}]");
+    test:assertEquals(numberMap.toString(), "{\"entry1\":{\"num1\":1,\"num2\":2,\"num3\":3,\"num4\":4," +
+    "\"num5\":55},\"entry2\":{\"num1\":11,\"num2\":22,\"num3\":33,\"num4\":44,\"num5\":55}}");
+    test:assertEquals(numberTableMap.toString(), "{\"map1\":[{\"num1\":1,\"num2\":2,\"num3\":3,\"num4\":4," +
+    "\"num5\":6}],\"map2\":[{\"num1\":10,\"num2\":20,\"num3\":30,\"num4\":40,\"num5\":50}]}");
 
-    test:assertEquals(symbols.toString(), "");
-    test:assertEquals(symbols.toString(), "");
-    test:assertEquals(symbolTable.toString(), "");
-    test:assertEquals(symbolMap.toString(), "");
-    test:assertEquals(symbolTableMap.toString(), "");
+    test:assertEquals(symbols.toString(), "{\"symbol1\":\"!\",\"symbol2\":\"@\",\"symbol3\":\"#\",\"symbol4\":\"$\"}");
+    test:assertEquals(symbolArr.toString(), "[{\"symbol1\":\"!\",\"symbol2\":\"@\",\"symbol3\":\"#\"," +
+    "\"symbol4\":\"%\"},{\"symbol1\":\"^\",\"symbol2\":\"&\",\"symbol3\":\"*\",\"symbol4\":\"-\"}]");
+    test:assertEquals(symbolTable.toString(), "[{\"symbol1\":\"!\",\"symbol2\":\"@\",\"symbol3\":\"#\"," +
+    "\"symbol4\":\"%\"},{\"symbol1\":\"^\",\"symbol2\":\"&\",\"symbol3\":\"*\",\"symbol4\":\"-\"}]");
+    test:assertEquals(symbolMap.toString(), "{\"entry1\":{\"symbol1\":\"!\",\"symbol2\":\"@\",\"symbol3\":\"#\"," +
+    "\"symbol4\":\"=\"},\"entry2\":{\"symbol1\":\"+\",\"symbol2\":\"|\",\"symbol3\":\"}\",\"symbol4\":\"?\"}}");
+    test:assertEquals(symbolTableMap.toString(), "{\"map1\":[{\"symbol1\":\"!\",\"symbol2\":\"@\",\"symbol3\":\"#\"," +
+    "\"symbol4\":\"%\"}],\"map2\":[{\"symbol1\":\"^\",\"symbol2\":\"&\",\"symbol3\":\"*\",\"symbol4\":\"-\"}]}");
 
     testTableIterator(wordTable);
     testTableIterator(numberTable);

--- a/tests/jballerina-integration-test/src/test/resources/configurables/configStructuredTypesProject/configStructuredTypes/modules/mod3/mod3.bal
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/configStructuredTypesProject/configStructuredTypes/modules/mod3/mod3.bal
@@ -1,0 +1,108 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import configStructuredTypes.mod1;
+import testOrg/configLib.mod1 as configLib;
+import ballerina/test;
+
+final string word1 = "word 1";
+
+configurable string word2 = ?;
+
+type Words record {|
+    string word1 = word1;
+    string word2 = word2;
+    string word3 = getWord();
+    string word4 = mod1:getWord();
+    string word5 = configLib:getWord();
+    string word6;
+|};
+
+// Defaultable records
+configurable Words words = ?;
+configurable mod1:Numbers numbers = ?;
+configurable configLib:Symbols symbols = ?;
+
+// Array of defaultable records
+configurable Words[] wordArr = ?;
+configurable mod1:Numbers[] numberArr = ?;
+configurable configLib:Symbols[] symbolArr = ?;
+
+// Defaultable record tables
+configurable table<Words> wordTable = ?;
+configurable table<mod1:Numbers> numberTable = ?;
+configurable table<configLib:Symbols> symbolTable = ?;
+
+// Map of defaultable records
+configurable map<Words> wordMap = ?;
+configurable map<mod1:Numbers> numberMap = ?;
+configurable map<configLib:Symbols> symbolMap = ?;
+
+// Map of table with defaultable records
+configurable map<table<Words>> wordTableMap = ?;
+configurable map<table<mod1:Numbers>> numberTableMap = ?;
+configurable map<table<configLib:Symbols>> symbolTableMap = ?;
+
+public function testRecords() {
+    test:assertEquals(words.toString(), "");
+    test:assertEquals(wordArr.toString(), "");
+    test:assertEquals(wordTable.toString(), "");
+    test:assertEquals(wordMap.toString(), "");
+    test:assertEquals(wordTableMap.toString(), "");
+
+    test:assertEquals(numbers.toString(), "");
+    test:assertEquals(numberArr.toString(), "");
+    test:assertEquals(numberTable.toString(), "");
+    test:assertEquals(numberMap.toString(), "");
+    test:assertEquals(numberTableMap.toString(), "");
+
+    test:assertEquals(symbols.toString(), "");
+    test:assertEquals(symbols.toString(), "");
+    test:assertEquals(symbolTable.toString(), "");
+    test:assertEquals(symbolMap.toString(), "");
+    test:assertEquals(symbolTableMap.toString(), "");
+
+    testTableIterator(wordTable);
+    testTableIterator(numberTable);
+    testTableIterator(symbolTable);
+
+    testMapIterator(wordMap, 2);
+    testMapIterator(numberMap, 2);
+    testMapIterator(symbolMap, 2);
+    testMapIterator(wordTableMap, 2);
+    testMapIterator(numberTableMap, 2);
+    testMapIterator(symbolTableMap, 2);
+}
+
+isolated function getWord() returns string {
+    return "word 3";
+}
+
+public function testTableIterator(table<map<anydata>> tab) {
+    int count = 0;
+    foreach var entry in tab {
+        count += 1;
+    }
+    test:assertEquals(count, 2);
+}
+
+public function testMapIterator(map<anydata> testMap, int length) {
+    int count = 0;
+    foreach var entry in testMap {
+        count += 1;
+    }
+    test:assertEquals(count, length);
+}

--- a/tests/jballerina-integration-test/src/test/resources/configurables/configUnionTypesProject/Config.toml
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/configUnionTypesProject/Config.toml
@@ -15,9 +15,3 @@ countryCodes = ["Sri Lanka", "United States"]
 httpVersion = "HTTP_1_1"
 [configUnionTypes.mod2.country]
 countryCode = "Sri Lanka"
-
-[testOrg.configLib.mod1]
-num4 = 4
-word5 = "word 5"
-symbol2 = "@"
-symbol3 = "#"

--- a/tests/jballerina-integration-test/src/test/resources/configurables/configUnionTypesProject/Config.toml
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/configUnionTypesProject/Config.toml
@@ -15,3 +15,9 @@ countryCodes = ["Sri Lanka", "United States"]
 httpVersion = "HTTP_1_1"
 [configUnionTypes.mod2.country]
 countryCode = "Sri Lanka"
+
+[testOrg.configLib.mod1]
+num4 = 4
+word5 = "word 5"
+symbol2 = "@"
+symbol3 = "#"

--- a/tests/jballerina-integration-test/src/test/resources/configurables/invalidDefaultable/Config.toml
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/invalidDefaultable/Config.toml
@@ -1,3 +1,5 @@
-[[main.employees]]
+[[person]]
+name = "Jane Doe"
 id = 222
-salary = 34000.0
+address.city = "Colombo"
+address.country.name = "LK"

--- a/tests/jballerina-integration-test/src/test/resources/configurables/invalidDefaultable/main/main.bal
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/invalidDefaultable/main/main.bal
@@ -14,15 +14,22 @@
 // specific language governing permissions and limitations
 // under the License.
 
-type Employee record {|
-    readonly int id;
-    readonly string name = "Default";
-    readonly float salary?;
-|};
+type Person record {
+    string name;
+    int id;
+    Address address;
+};
 
-type EmployeeTable table<Employee> key(id) & readonly;
+type Address record {
+    string city;
+    readonly Country country = {};
+};
 
-configurable EmployeeTable employees = ?;
+type Country record {
+    string name = "SL";
+};
+
+configurable table<Person> key(id) person = ?;
 
 public function main() {
     // do nothing


### PR DESCRIPTION
## Purpose
$subject
Fixes #28966 

## Approach
using `cloneWithType()` call to create record values at module init, instead of creating values at `configInit`.

## Samples
```ballerina
final string number = "123456";

type Person record {|
    string name;
    string phone = number;
|};

configurable Person person = ?;
```
## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [x] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
