### PR TITLE
Refactor Hoverutil to filter private class fields and methods

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/HoverUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/HoverUtil.java
@@ -15,12 +15,16 @@
  */
 package org.ballerinalang.langserver.hover;
 
+import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.ClassFieldSymbol;
 import io.ballerina.compiler.api.symbols.ClassSymbol;
 import io.ballerina.compiler.api.symbols.Documentable;
 import io.ballerina.compiler.api.symbols.Documentation;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
 import io.ballerina.compiler.api.symbols.MethodSymbol;
+import io.ballerina.compiler.api.symbols.ModuleSymbol;
+import io.ballerina.compiler.api.symbols.ObjectFieldSymbol;
 import io.ballerina.compiler.api.symbols.ObjectTypeSymbol;
 import io.ballerina.compiler.api.symbols.ParameterSymbol;
 import io.ballerina.compiler.api.symbols.Qualifier;
@@ -32,6 +36,10 @@ import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.projects.Document;
+import io.ballerina.projects.Module;
+import io.ballerina.projects.ModuleId;
+import io.ballerina.projects.Package;
+import io.ballerina.projects.Project;
 import io.ballerina.tools.text.LinePosition;
 import org.ballerinalang.langserver.common.constants.ContextConstants;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
@@ -114,42 +122,50 @@ public class HoverUtil {
             hoverContent.add(documentation.description().get());
         }
 
-        Map<String, String> paramsMap = documentation.parameterMap();
-        if (!paramsMap.isEmpty()) {
-            List<String> params = new ArrayList<>();
-            params.add(header(3, ContextConstants.FIELD_TITLE) + CommonUtil.MD_LINE_SEPARATOR);
+        Optional<Package> currentPackage = context.workspace()
+                .project(context.filePath()).map(Project::currentPackage);
+        Optional<Module> currentModule = context.currentModule();
 
-            params.addAll(classSymbol.fieldDescriptors().entrySet().stream()
-                    .filter(fieldEntry -> paramsMap.containsKey(fieldEntry.getKey())
-                            && !fieldEntry.getValue().qualifiers().contains(Qualifier.PRIVATE)).map(fieldEntry -> {
-                        String desc = paramsMap.get(fieldEntry.getKey());
-                        String modifiedTypeName =
-                                CommonUtil.getModifiedTypeName(context, fieldEntry.getValue().typeDescriptor());
-                        return quotedString(modifiedTypeName) + " " + italicString(boldString(fieldEntry.getKey()))
-                                + " : " + desc;
-                    }).collect(Collectors.toList()));
-            if (params.size() > 1) {
-                hoverContent.add(String.join(CommonUtil.MD_LINE_SEPARATOR, params));
+        if (currentModule.isPresent() && currentPackage.isPresent()) {
+            Map<String, String> paramsMap = documentation.parameterMap();
+            if (!paramsMap.isEmpty()) {
+                List<String> params = new ArrayList<>();
+                params.add(header(3, ContextConstants.FIELD_TITLE) + CommonUtil.MD_LINE_SEPARATOR);
+
+                params.addAll(classSymbol.fieldDescriptors().entrySet().stream()
+                        .filter(fieldEntry -> withValidAccessModifiers(
+                                fieldEntry.getValue(), currentPackage.get(), currentModule.get().moduleId(), context))
+                        .map(fieldEntry -> {
+                            String desc = paramsMap.get(fieldEntry.getKey());
+                            String modifiedTypeName =
+                                    CommonUtil.getModifiedTypeName(context, fieldEntry.getValue().typeDescriptor());
+                            return quotedString(modifiedTypeName) + " " + italicString(boldString(fieldEntry.getKey()))
+                                    + " : " + desc;
+                        }).collect(Collectors.toList()));
+                if (params.size() > 1) {
+                    hoverContent.add(String.join(CommonUtil.MD_LINE_SEPARATOR, params));
+                }
             }
-        }
 
-        List<String> methods = new ArrayList<>();
-        classSymbol.methods().entrySet().stream()
-                .filter(methodEntry -> !methodEntry.getValue().qualifiers().contains(Qualifier.PRIVATE))
-                .collect(Collectors.toList()).forEach(methodEntry -> {
-            StringBuilder methodInfo = new StringBuilder();
-            Optional<Documentation> methodDoc = methodEntry.getValue().documentation();
-            methodInfo.append(quotedString(CommonUtil.getModifiedTypeName(context,
-                    methodEntry.getValue().typeDescriptor())));
-            if (methodDoc.isPresent() && methodDoc.get().description().isPresent()) {
-                methodInfo.append(CommonUtil.MD_LINE_SEPARATOR).append(methodDoc.get().description().get());
+            List<String> methods = new ArrayList<>();
+            classSymbol.methods().entrySet().stream()
+                    .filter(methodSymbol -> withValidAccessModifiers(methodSymbol.getValue(),
+                            currentPackage.get(), currentModule.get().moduleId(), context))
+                    .collect(Collectors.toList()).forEach(methodEntry -> {
+                StringBuilder methodInfo = new StringBuilder();
+                Optional<Documentation> methodDoc = methodEntry.getValue().documentation();
+                methodInfo.append(quotedString(CommonUtil.getModifiedTypeName(context,
+                        methodEntry.getValue().typeDescriptor())));
+                if (methodDoc.isPresent() && methodDoc.get().description().isPresent()) {
+                    methodInfo.append(CommonUtil.MD_LINE_SEPARATOR).append(methodDoc.get().description().get());
+                }
+                methods.add(bulletItem(methodInfo.toString()));
+            });
+
+            if (!methods.isEmpty()) {
+                methods.add(0, header(3, ContextConstants.METHOD_TITLE) + CommonUtil.MD_LINE_SEPARATOR);
+                hoverContent.add(String.join(CommonUtil.MD_LINE_SEPARATOR, methods));
             }
-            methods.add(bulletItem(methodInfo.toString()));
-        });
-
-        if (!methods.isEmpty()) {
-            methods.add(0, header(3, ContextConstants.METHOD_TITLE) + CommonUtil.MD_LINE_SEPARATOR);
-            hoverContent.add(String.join(CommonUtil.MD_LINE_SEPARATOR, methods));
         }
 
         Hover hover = new Hover();
@@ -357,5 +373,54 @@ public class HoverUtil {
 
     private static String header(int level, String header) {
         return String.join("", Collections.nCopies(level, "#")) + " " + header;
+    }
+
+    /**
+     * Check if a given symbol has valid access modifiers to be visible with in the give context.
+     *
+     * @param symbol         Symbol.
+     * @param currentPackage Current Package.
+     * @param currentModule  Current Module.
+     * @return {@link Boolean} Whether the symbol is visible in the current context.
+     */
+    private static Boolean withValidAccessModifiers(Symbol symbol, Package currentPackage,
+                                                    ModuleId currentModule, HoverContext context) {
+        Optional<Project> project = context.workspace().project(context.filePath());
+        Optional<ModuleSymbol> typeSymbolModule = symbol.getModule();
+
+        if (project.isEmpty() || typeSymbolModule.isEmpty()) {
+            return false;
+        }
+
+        boolean isResource = false;
+        boolean isPrivate = false;
+        boolean isPublic = false;
+        boolean isRemote = false;
+
+        switch (symbol.kind()) {
+            case CLASS_FIELD:
+                isPublic = ((ClassFieldSymbol) symbol).qualifiers().contains(Qualifier.PUBLIC);
+                isPrivate = ((ClassFieldSymbol) symbol).qualifiers().contains(Qualifier.PRIVATE);
+                break;
+            case OBJECT_FIELD:
+                isPublic = ((ObjectFieldSymbol) symbol).qualifiers().contains(Qualifier.PUBLIC);
+                isPrivate = ((ObjectFieldSymbol) symbol).qualifiers().contains(Qualifier.PRIVATE);
+                break;
+            case RESOURCE_METHOD:
+                isResource = true;
+                break;
+            case METHOD:
+                isPublic = ((MethodSymbol) symbol).qualifiers().contains(Qualifier.PUBLIC);
+                isPrivate = ((MethodSymbol) symbol).qualifiers().contains(Qualifier.PRIVATE);
+                isRemote = ((MethodSymbol) symbol).qualifiers().contains(Qualifier.REMOTE);
+        }
+
+        if (isResource || isRemote || isPublic) {
+            return true;
+        }
+
+        ModuleID objModuleId = typeSymbolModule.get().id();
+        return (!isPrivate && objModuleId.moduleName().equals(currentModule.moduleName())
+                && objModuleId.orgName().equals(currentPackage.packageOrg().value()));
     }
 }

--- a/language-server/modules/langserver-core/src/test/resources/hover/configs/hover_classdef3.json
+++ b/language-server/modules/langserver-core/src/test/resources/hover/configs/hover_classdef3.json
@@ -1,0 +1,21 @@
+{
+  "source": {
+    "file": "projectls/defmodsource3.bal"
+  },
+  "position": {
+    "line": 2,
+    "character": 33
+  },
+  "expected": {
+    "result": {
+      "contents": {
+        "kind": "markdown",
+        "value": "Mod3\n  \n  \n---  \n  \n### Fields  \n  \n`string` ***PERSON_KW*** : PERSON Keyword  \n  \n---  \n  \n### Methods  \n  \n+ `function () returns string`  \nGet name of the person  \n"
+      }
+    },
+    "id": {
+      "left": "324"
+    },
+    "jsonrpc": "2.0"
+  }
+}

--- a/language-server/modules/langserver-core/src/test/resources/hover/source/projectls/defmodsource3.bal
+++ b/language-server/modules/langserver-core/src/test/resources/hover/source/projectls/defmodsource3.bal
@@ -1,0 +1,5 @@
+import projectls.lsmod3;
+
+function myFunction(lsmod3:Mod3Class obj1) {
+
+}

--- a/language-server/modules/langserver-core/src/test/resources/hover/source/projectls/modules/lsmod3/source1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/hover/source/projectls/modules/lsmod3/source1.bal
@@ -11,3 +11,29 @@ public type Mod3Record1 record {
     int field1;
     module1:TestRecord1 field2;
 };
+
+# Mod3
+#
+# + name - Name
+# + age - Age
+# + PERSON_KW - PERSON Keyword
+public class Mod3Class {
+    private string name;
+    private int age;
+    public final string PERSON_KW = "PERSON";
+
+    function init(string name, int age) {
+        self.name = name;
+        self.age = age;
+    }
+
+    # Get name of the person
+    # + return - String
+    function getName() returns string{
+        return self.name;
+    }
+
+    private function incrementAge() {
+        self.age += 1;
+    }
+}

--- a/language-server/modules/langserver-core/src/test/resources/hover/source/projectls/modules/lsmod3/source1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/hover/source/projectls/modules/lsmod3/source1.bal
@@ -29,7 +29,13 @@ public class Mod3Class {
 
     # Get name of the person
     # + return - String
-    function getName() returns string{
+    public function getName() returns string{
+        return self.name;
+    }
+
+    # Get name of the person
+    # + return - String
+    function getName2() returns string{
         return self.name;
     }
 


### PR DESCRIPTION
## Purpose
$subject so that internal fields and methods are not shown

Fixes #30832 

## Samples
<img src="https://user-images.githubusercontent.com/35211477/121182531-cddb4300-c880-11eb-9770-90e21258908f.png" width=500/>

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
