### PR TITLE
Improve --tests flag wildcard processing using regex

### DIFF
--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/util/TesterinaUtils.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/util/TesterinaUtils.java
@@ -35,6 +35,7 @@ import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 import static io.ballerina.runtime.api.constants.RuntimeConstants.BLANG_SRC_FILE_SUFFIX;
 import static io.ballerina.runtime.api.constants.RuntimeConstants.MODULE_INIT_CLASS_NAME;
@@ -228,23 +229,13 @@ public class TesterinaUtils {
                 String[] functionDetail = function.split(":");
                 try {
                     if (functionDetail[0].equals(suite.getPackageID())) {
-                        if (functionDetail[1].equals(TesterinaConstants.WILDCARD)) {
-                            handleWildCard(filteredList, suite.getTests());
-                        } else if (functionDetail[1].endsWith(TesterinaConstants.WILDCARD)) {
-                            handleEndingWithWildCard(filteredList, suite.getTests(), functionDetail[1]);
-                        } else {
-                            filteredList.add(functionDetail[1]);
-                        }
+                        handleWildCards(filteredList, suite.getTests(), functionDetail[1]);
                     }
                 } catch (IndexOutOfBoundsException e) {
-                    errStream.println("Error occured while executing tests. Test list cannot be empty");
+                    errStream.println("Error occurred while executing tests. Test list cannot be empty");
                 }
             } else {
-                if (function.endsWith(TesterinaConstants.WILDCARD)) {
-                    handleEndingWithWildCard(filteredList, suite.getTests(), function);
-                } else {
-                    filteredList.add(function);
-                }
+                handleWildCards(filteredList, suite.getTests(), function);
             }
         }
 
@@ -259,18 +250,15 @@ public class TesterinaUtils {
         return updatedTestList;
     }
 
-    private static void handleWildCard(List<String> filteredList, List<Test> suiteTests) {
-        for (Test test : suiteTests) {
-            filteredList.add(test.getTestName());
-        }
-    }
-
-    private static void handleEndingWithWildCard(List<String> filteredList, List<Test> suiteTests, String function) {
-        String fn = function.replace(TesterinaConstants.WILDCARD, "");
-        for (Test test : suiteTests) {
-            if (test.getTestName().startsWith(fn)) {
-                filteredList.add(test.getTestName());
+    private static void handleWildCards(List<String> filteredList, List<Test> suiteTests, String function) {
+        if (function.contains("*")) {
+            for (Test test: suiteTests) {
+                if (Pattern.matches(function.replace("*", ".*"), test.getTestName())) {
+                    filteredList.add(test.getTestName());
+                }
             }
+        } else {
+            filteredList.add(function);
         }
     }
 

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/util/TesterinaUtils.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/util/TesterinaUtils.java
@@ -251,9 +251,10 @@ public class TesterinaUtils {
     }
 
     private static void handleWildCards(List<String> filteredList, List<Test> suiteTests, String function) {
-        if (function.contains("*")) {
+        if (function.contains(TesterinaConstants.WILDCARD)) {
             for (Test test: suiteTests) {
-                if (Pattern.matches(function.replace("*", ".*"), test.getTestName())) {
+                if (Pattern.matches(function.replace(TesterinaConstants.WILDCARD, DOT + TesterinaConstants.WILDCARD),
+                        test.getTestName())) {
                     filteredList.add(test.getTestName());
                 }
             }

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/ModuleExecutionTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/ModuleExecutionTest.java
@@ -66,7 +66,33 @@ public class ModuleExecutionTest extends BaseTestCase {
     }
 
     @Test()
-    public void test_DefaultModule_WildCardTest() throws BallerinaTestException {
+    public void test_DefaultModule_StartWildCardTest() throws BallerinaTestException {
+        String msg1 = "1 passing";
+        String msg2 = "[pass] commonTest";
+        String[] args = new String[]{"--code-coverage", "--includes=*", "--tests", "moduleExecution:*Test"};
+        String output = balClient.runMainAndReadStdOut("test", args,
+                new HashMap<>(), projectPath, false);
+        if (!output.contains(msg1) || !output.contains(msg2)) {
+            throw new BallerinaTestException("Test failed due to default module wild card test failure.");
+        }
+    }
+
+    @Test()
+    public void test_DefaultModule_MiddleWildCardTest() throws BallerinaTestException {
+        String msg1 = "3 passing";
+        String msg2 = "[pass] main_test1";
+        String msg3 = "[pass] main_test2";
+        String msg4 = "[pass] main_test3";
+        String[] args = new String[]{"--code-coverage", "--includes=*", "--tests", "moduleExecution:*test*"};
+        String output = balClient.runMainAndReadStdOut("test", args,
+                new HashMap<>(), projectPath, false);
+        if (!output.contains(msg1) || !output.contains(msg2) || !output.contains(msg3) || !output.contains(msg4)) {
+            throw new BallerinaTestException("Test failed due to default module wild card test failure.");
+        }
+    }
+
+    @Test()
+    public void test_DefaultModule_EndWildCardTest() throws BallerinaTestException {
         String msg1 = "3 passing";
         String msg2 = "[pass] main_test1";
         String msg3 = "[pass] main_test2";


### PR DESCRIPTION
## Purpose
Improves --tests flag to handle wildcard at the beginning, middle and end of the function name. 

`bal test --tests *function1`
`bal test --tests Testfunction*`
`bal test --tests *function*`

This applies for module execution as well
Fixes #30967

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
