### PR TITLE
[LS] Fix create var code action for function return types

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionUtil.java
@@ -298,9 +298,17 @@ public class CodeActionUtil {
         } else if (typeDescriptor.typeKind() == TypeDescKind.ARRAY) {
             // Handle ambiguous array element types eg. record[], json[], map[]
             ArrayTypeSymbol arrayTypeSymbol = (ArrayTypeSymbol) typeDescriptor;
-            boolean isUnion = arrayTypeSymbol.memberTypeDescriptor().typeKind() == TypeDescKind.UNION;
-            return getPossibleTypes(arrayTypeSymbol.memberTypeDescriptor(), importEdits, context)
-                    .stream().map(m -> isUnion ? "(" + m + ")[]" : m + "[]")
+            return getPossibleTypes(arrayTypeSymbol.memberTypeDescriptor(), importEdits, context).stream()
+                    .map(m -> {
+                        switch (arrayTypeSymbol.memberTypeDescriptor().typeKind()) {
+                            case UNION:
+                            case FUNCTION:
+                                return "(" + m + ")[]";
+
+                            default:
+                                return m + "[]";
+                        }
+                    })
                     .collect(Collectors.toList());
         } else {
             types.add(FunctionGenerator.generateTypeDefinition(importsAcceptor, typeDescriptor, context));

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/CreateVariableTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/CreateVariableTest.java
@@ -98,6 +98,10 @@ public class CreateVariableTest extends AbstractCodeActionTest {
                 {"createVariableWithUnionType.json", "createVariableWithUnionType.bal"},
                 {"createVariableWithIntersectionType.json", "createVariableWithIntersectionType.bal"},
                 {"createVariableWithIntersectionType2.json", "createVariableWithIntersectionType.bal"},
+                
+                // Create variables of function/invocable type
+                {"createVariableWithFunctionType1.json", "createVariableWithFunctionType1.bal"},
+                {"createVariableWithFunctionType2.json", "createVariableWithFunctionType1.bal"},
         };
     }
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithFunctionType1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithFunctionType1.json
@@ -1,0 +1,24 @@
+{
+  "line": 2,
+  "character": 5,
+  "expected": [
+    {
+      "title": "Create variable",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 2,
+              "character": 4
+            },
+            "end": {
+              "line": 2,
+              "character": 4
+            }
+          },
+          "newText": "(function () returns int)[] funcResult = "
+        }
+      ]
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithFunctionType2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithFunctionType2.json
@@ -1,0 +1,24 @@
+{
+  "line": 4,
+  "character": 6,
+  "expected": [
+    {
+      "title": "Create variable",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 4,
+              "character": 4
+            },
+            "end": {
+              "line": 4,
+              "character": 4
+            }
+          },
+          "newText": "(function () returns ())[] functionResult = "
+        }
+      ]
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/source/createVariableWithFunctionType1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/source/createVariableWithFunctionType1.bal
@@ -1,0 +1,12 @@
+
+public function main() {
+    func();
+
+    getFunction();
+}
+
+function func() returns (function () returns int)[] => [() => 1];
+
+function getFunction() returns function()[] {
+
+}


### PR DESCRIPTION
## Purpose
$subject

Fixes #30988

## Approach
Updated `CommonUtil`'s `getPossibleTypes()` method to check if the array member type is function and act upon.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
