### PR TITLE
Fix decimal to int conversion for cloneWithType()

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeConverter.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeConverter.java
@@ -153,8 +153,8 @@ public class TypeConverter {
                 Double doubleValue = (Double) value;
                 return isFloatWithinIntRange(doubleValue) && TypeChecker.isByteLiteral(doubleValue.longValue());
             case TypeTags.DECIMAL_TAG:
-                return isDecimalWithinIntRange((BigDecimal) value)
-                        && TypeChecker.isByteLiteral(((BigDecimal) value).longValue());
+                return isDecimalWithinIntRange((DecimalValue) value)
+                        && TypeChecker.isByteLiteral(((DecimalValue) value).value().longValue());
             default:
                 return false;
         }
@@ -169,7 +169,7 @@ public class TypeConverter {
             case TypeTags.FLOAT_TAG:
                 return isFloatWithinIntRange((double) value);
             case TypeTags.DECIMAL_TAG:
-                return isDecimalWithinIntRange((BigDecimal) value);
+                return isDecimalWithinIntRange((DecimalValue) value);
             default:
                 return false;
         }
@@ -190,7 +190,7 @@ public class TypeConverter {
                 val = floatToInt((Double) value);
                 break;
             case TypeTags.DECIMAL_TAG:
-                if (!isDecimalWithinIntRange((BigDecimal) value)) {
+                if (!isDecimalWithinIntRange((DecimalValue) value)) {
                     return false;
                 }
                 val = ((BigDecimal) value).intValue();

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeConverter.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeConverter.java
@@ -46,7 +46,6 @@ import io.ballerina.runtime.internal.values.DecimalValue;
 import io.ballerina.runtime.internal.values.MapValue;
 import io.ballerina.runtime.internal.values.MapValueImpl;
 
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -193,7 +192,7 @@ public class TypeConverter {
                 if (!isDecimalWithinIntRange((DecimalValue) value)) {
                     return false;
                 }
-                val = ((BigDecimal) value).intValue();
+                val = ((DecimalValue) value).value().intValue();
                 break;
             default:
                 return false;

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/DecimalValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/DecimalValue.java
@@ -160,7 +160,7 @@ public class DecimalValue implements SimpleValue, BDecimal {
                 throw ErrorUtils.createNumericConversionError(POSITIVE_INF, PredefinedTypes.TYPE_INT);
         }
 
-        if (!isDecimalWithinIntRange(value)) {
+        if (!isDecimalWithinIntRange(this)) {
             throw ErrorUtils.createNumericConversionError(this.stringValue(null), PredefinedTypes.TYPE_DECIMAL,
                                                           PredefinedTypes.TYPE_INT);
         }
@@ -172,9 +172,10 @@ public class DecimalValue implements SimpleValue, BDecimal {
      * @param decimalValue value to be checked
      * @return true if the value is in int range
      */
-    public static boolean isDecimalWithinIntRange(BigDecimal decimalValue) {
-        return decimalValue.compareTo(RuntimeConstants.BINT_MAX_VALUE_BIG_DECIMAL_RANGE_MAX) < 0 &&
-               decimalValue.compareTo(RuntimeConstants.BINT_MIN_VALUE_BIG_DECIMAL_RANGE_MIN) > 0;
+    public static boolean isDecimalWithinIntRange(DecimalValue decimalValue) {
+        BigDecimal value = decimalValue.value;
+        return value.compareTo(RuntimeConstants.BINT_MAX_VALUE_BIG_DECIMAL_RANGE_MAX) < 0 &&
+               value.compareTo(RuntimeConstants.BINT_MIN_VALUE_BIG_DECIMAL_RANGE_MIN) > 0;
     }
 
     /**

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibValueTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibValueTest.java
@@ -328,6 +328,8 @@ public class LangLibValueTest {
                 { "testCloneWithTypeWithImmutableTypes" },
                 { "testCloneWithTypeDecimalToInt"},
                 {"testCloneWithTypeDecimalToIntNegative"},
+                { "testCloneWithTypeDecimalToByte"},
+                { "testCloneWithTypeDecimalToIntSubType"},
         };
     }
 

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibValueTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibValueTest.java
@@ -325,7 +325,8 @@ public class LangLibValueTest {
                 { "testCloneWithTypeNumeric7" },
                 { "testCloneWithTypeStringArray" },
                 { "testCloneWithTypeWithInferredArgument" },
-                { "testCloneWithTypeWithImmutableTypes" }
+                { "testCloneWithTypeWithImmutableTypes" },
+                { "testCloneWithTypeDecimalToInt"},
         };
     }
 

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibValueTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibValueTest.java
@@ -327,6 +327,7 @@ public class LangLibValueTest {
                 { "testCloneWithTypeWithInferredArgument" },
                 { "testCloneWithTypeWithImmutableTypes" },
                 { "testCloneWithTypeDecimalToInt"},
+                {"testCloneWithTypeDecimalToIntNegative"},
         };
     }
 

--- a/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
@@ -699,6 +699,8 @@ function testCloneWithTypeNumeric7() {
     assert(a2[2], <decimal> 3);
 }
 
+type ByteArray byte[];
+
 function testCloneWithTypeDecimalToInt() {
     decimal a = 12.3456;
     int|error result = a.cloneWithType(int);
@@ -714,6 +716,30 @@ function testCloneWithTypeDecimalToInt() {
     assert(a2[0], 1);
     assert(a2[1], 2);
     assert(a2[2], 3);
+}
+
+function testCloneWithTypeDecimalToByte() {
+    decimal a = 12.3456;
+    byte|error result = a.cloneWithType(byte);
+    assert(result is byte, true);
+    assert(checkpanic result, 12);
+
+    decimal[] a1 = [1.23, 2.34, 3.45];
+    byte[]|error a2e = a1.cloneWithType(ByteArray);
+    assert(a2e is byte[], true);
+
+    byte[] a2 = checkpanic a2e;
+    assert(a2.length(), a1.length());
+    assert(a2[0], 1);
+    assert(a2[1], 2);
+    assert(a2[2], 3);
+}
+
+function testCloneWithTypeDecimalToIntSubType() {
+    decimal a = 12.3456;
+    int:Signed32|error result = a.cloneWithType(int:Signed32);
+    assert(result is int:Signed32, true);
+    assert(checkpanic result, 12);
 }
 
 function testCloneWithTypeDecimalToIntNegative() {

--- a/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
@@ -716,6 +716,34 @@ function testCloneWithTypeDecimalToInt() {
     assert(a2[2], 3);
 }
 
+function testCloneWithTypeDecimalToIntNegative() {
+    decimal a = 9223372036854775807.5;
+    int|error result = a.cloneWithType(int);
+    checkDecimalToIntError(result);
+
+    decimal[] a1 = [9223372036854775807.5, -9223372036854775807.6];
+    int[]|error a2e = a1.cloneWithType(IntArray);
+    checkDecimalToIntError(a2e);
+
+    decimal a2 = 0.0 / 0;
+    int|error nan = a2.cloneWithType(int);
+    assert(nan is error, true);
+    error err = <error>nan;
+    var message = err.detail()["message"];
+    string messageString = message is error ? message.toString() : message.toString();
+    assert(err.message(), "{ballerina}NumberConversionError");
+    assert(messageString, "'decimal' value 'NaN' cannot be converted to 'int'");
+}
+
+function checkDecimalToIntError(any|error result) {
+    assert(result is error, true);
+    error err = <error>result;
+    var message = err.detail()["message"];
+    string messageString = message is error ? message.toString() : message.toString();
+    assert(err.message(), "{ballerina/lang.typedesc}ConversionError");
+    assert(messageString, "'decimal' value cannot be converted to 'int'");
+}
+
 type StringArray string[];
 function testCloneWithTypeStringArray() {
    string anArray = "[\"hello\", \"world\"]";

--- a/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
@@ -699,6 +699,23 @@ function testCloneWithTypeNumeric7() {
     assert(a2[2], <decimal> 3);
 }
 
+function testCloneWithTypeDecimalToInt() {
+    decimal a = 12.3456;
+    int|error result = a.cloneWithType(int);
+    assert(result is int, true);
+    assert(checkpanic result, 12);
+
+    decimal[] a1 = [1.23, 2.34, 3.45];
+    int[]|error a2e = a1.cloneWithType(IntArray);
+    assert(a2e is int[], true);
+
+    int[] a2 = checkpanic a2e;
+    assert(a2.length(), a1.length());
+    assert(a2[0], 1);
+    assert(a2[1], 2);
+    assert(a2[2], 3);
+}
+
 type StringArray string[];
 function testCloneWithTypeStringArray() {
    string anArray = "[\"hello\", \"world\"]";


### PR DESCRIPTION
## Purpose
$subject
Fixes #30291

## Approach
Fix incorrect class casting for `DecimalValue` to `BigDecimal`

## Samples
```ballerina
    decimal s = 2;
    int i = checkpanic s.cloneWithType(int);
```
## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
