### PR TITLE
Change Warning for testerina list-flags

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/TestCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/TestCommand.java
@@ -170,9 +170,9 @@ public class TestCommand implements BLauncherCmd {
             System.setProperty(SYSTEM_PROP_BAL_DEBUG, this.debugPort);
         }
         //Display warning if any other options are provided with list-groups flag.
-        boolean displayWarning = false;
-        if (listGroups && (rerunTests || groupList != null || disableGroupList != null || testList != null)) {
-            displayWarning = true;
+        if (listGroups && (rerunTests || coverage || testReport || groupList != null || disableGroupList != null
+                || testList != null)) {
+            this.outStream.println("\nWarning: Other flags are skipped when list-groups flag is provided.\n");
         }
 
         if (project.buildOptions().codeCoverage()) {
@@ -202,7 +202,7 @@ public class TestCommand implements BLauncherCmd {
                 .addTask(new ResolveMavenDependenciesTask(outStream)) // resolve maven dependencies in Ballerina.toml
                 .addTask(new CompileTask(outStream, errStream)) // compile the modules
 //                .addTask(new CopyResourcesTask(), listGroups) // merged with CreateJarTask
-                .addTask(new ListTestGroupsTask(outStream, displayWarning), !listGroups) // list available test groups
+                .addTask(new ListTestGroupsTask(outStream), !listGroups) // list available test groups
                 .addTask(new RunTestsTask(outStream, errStream, rerunTests, groupList, disableGroupList,
                         testList, includes, coverageFormat), listGroups)
                 .build();

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/TestCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/TestCommand.java
@@ -143,6 +143,7 @@ public class TestCommand implements BLauncherCmd {
                         "and continuing the test run...");
             }
             coverage = false;
+            testReport = false;
         }
         BuildOptions buildOptions = constructBuildOptions();
         boolean isSingleFile = false;

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/ListTestGroupsTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/ListTestGroupsTask.java
@@ -40,11 +40,9 @@ import java.util.stream.Collectors;
 public class ListTestGroupsTask implements Task {
 
     private final PrintStream out;
-    private boolean displayWarning;
 
-    public ListTestGroupsTask(PrintStream out, boolean displayWarning) {
+    public ListTestGroupsTask(PrintStream out) {
         this.out = out;
-        this.displayWarning = displayWarning;
     }
 
     @Override
@@ -53,9 +51,6 @@ public class ListTestGroupsTask implements Task {
             Module module = project.currentPackage().module(moduleId);
             TestProcessor testProcessor = new TestProcessor();
             Optional<TestSuite> suite = testProcessor.testSuite(module);
-            if (displayWarning) {
-                out.println("\nWarning: Other flags are skipped when list-groups flag is provided.\n");
-            }
             if (!project.currentPackage().packageOrg().anonymous()) {
                 out.println();
                 out.println("\t" + module.moduleName().toString());


### PR DESCRIPTION
## Purpose
Change point at which the warning is printed so as to not display it multiple times during execution

The warning now shows up before the `Compiling source` portion of the logs on the terminal

```
Warning: Other flags are skipped when list-groups flag is provided.

Compiling source
        wso2/moduleExecution:0.0.0

        moduleExecution
        Following groups are available : 
        [g1]

        moduleExecution.Module1
        Following groups are available : 
        [g2, g1]
```
        
 Also added the other flags to be covered by the filter

Fixes #30963

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
