### PR TITLE
Add qualifier based filtering to field access completion resolver

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/HoverUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/HoverUtil.java
@@ -17,16 +17,15 @@ package org.ballerinalang.langserver.hover;
 
 import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SemanticModel;
-import io.ballerina.compiler.api.symbols.ClassFieldSymbol;
 import io.ballerina.compiler.api.symbols.ClassSymbol;
 import io.ballerina.compiler.api.symbols.Documentable;
 import io.ballerina.compiler.api.symbols.Documentation;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
 import io.ballerina.compiler.api.symbols.MethodSymbol;
 import io.ballerina.compiler.api.symbols.ModuleSymbol;
-import io.ballerina.compiler.api.symbols.ObjectFieldSymbol;
 import io.ballerina.compiler.api.symbols.ObjectTypeSymbol;
 import io.ballerina.compiler.api.symbols.ParameterSymbol;
+import io.ballerina.compiler.api.symbols.Qualifiable;
 import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.RecordTypeSymbol;
 import io.ballerina.compiler.api.symbols.ResourceMethodSymbol;
@@ -397,22 +396,12 @@ public class HoverUtil {
         boolean isPublic = false;
         boolean isRemote = false;
 
-        switch (symbol.kind()) {
-            case CLASS_FIELD:
-                isPublic = ((ClassFieldSymbol) symbol).qualifiers().contains(Qualifier.PUBLIC);
-                isPrivate = ((ClassFieldSymbol) symbol).qualifiers().contains(Qualifier.PRIVATE);
-                break;
-            case OBJECT_FIELD:
-                isPublic = ((ObjectFieldSymbol) symbol).qualifiers().contains(Qualifier.PUBLIC);
-                isPrivate = ((ObjectFieldSymbol) symbol).qualifiers().contains(Qualifier.PRIVATE);
-                break;
-            case RESOURCE_METHOD:
-                isResource = true;
-                break;
-            case METHOD:
-                isPublic = ((MethodSymbol) symbol).qualifiers().contains(Qualifier.PUBLIC);
-                isPrivate = ((MethodSymbol) symbol).qualifiers().contains(Qualifier.PRIVATE);
-                isRemote = ((MethodSymbol) symbol).qualifiers().contains(Qualifier.REMOTE);
+        if (symbol instanceof Qualifiable) {
+            Qualifiable qSymbol = (Qualifiable) symbol;
+            isPrivate = qSymbol.qualifiers().contains(Qualifier.PRIVATE);
+            isPublic = qSymbol.qualifiers().contains(Qualifier.PUBLIC);
+            isResource = qSymbol.qualifiers().contains(Qualifier.RESOURCE);
+            isRemote = qSymbol.qualifiers().contains(Qualifier.REMOTE);
         }
 
         if (isResource || isRemote || isPublic) {

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_conifg30.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_conifg30.json
@@ -1,0 +1,32 @@
+{
+  "position": {
+    "line": 3,
+    "character": 15
+  },
+  "source": "expression_context/source/projectls/defmodsource2.bal",
+  "items": [
+    {
+      "label": "PERSON_KW",
+      "kind": "Field",
+      "detail": "string",
+      "sortText": "A",
+      "insertText": "PERSON_KW",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getName()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _lstest/projectls.lsmod1:0.1.0_  \n  \n  \n  \n  \n**Return** `string`   \n  \n"
+        }
+      },
+      "sortText": "D",
+      "filterText": "getName",
+      "insertText": "getName()",
+      "insertTextFormat": "Snippet"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/projectls/defmodsource2.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/projectls/defmodsource2.bal
@@ -1,0 +1,5 @@
+import projectls.lsmod1;
+
+function testFunction(lsmod1:Mod1Class serviceObj) {
+    serviceObj.
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/projectls/modules/lsmod1/source1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/projectls/modules/lsmod1/source1.bal
@@ -4,3 +4,31 @@ function main() {
     mod4:TestClassEntity e = new();
     e.
 }
+
+public service class Mod1Class {
+
+    private string name;
+    private int age;
+    public final string PERSON_KW = "PERSON";
+
+    function init(string name, int age) {
+        self.name = name;
+        self.age = age;
+    }
+
+    public function getName() returns string {
+        return self.name;
+    }
+
+    resource function getName .() returns string {
+        return self.name;
+    }
+
+    remote function getAge() returns int {
+        return self.age;
+    }
+
+    private function incrementAge() {
+        self.age += 1;
+    }
+}


### PR DESCRIPTION
## Purpose
$subject to suggest only  visible methods, class fields and object fields based on qualifiers.

Fixes #31032 

## Samples
<img src="https://user-images.githubusercontent.com/35211477/121323338-5dd6c680-c92d-11eb-9a30-33f0602718a6.png" width=500/>

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
