### PR TITLE
[LS] Fix documentation code actions to remove invalid sections

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/docs/DocAttachmentInfo.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/docs/DocAttachmentInfo.java
@@ -95,8 +95,18 @@ public class DocAttachmentInfo implements Documentation {
         if (!this.parameters.isEmpty()) {
             parameters.forEach((key, value) -> newParamsMap.put(key, other.parameterMap().getOrDefault(key, value)));
         }
-        String returnValueDescription = other.returnDescription().orElse(this.returnDesc);
-        String deprecatedDescription = other.deprecatedDescription().orElse(this.deprecatedDesc);
+
+        // Check if no return type present -> handles removal of return type descriptor
+        String returnValueDescription = null;
+        if (this.returnDesc != null) {
+            returnValueDescription = other.returnDescription().orElse(this.returnDesc);
+        }
+
+        // Check if deprecated description is present -> handles removal of deprecated description
+        String deprecatedDescription = null;
+        if (this.deprecatedDesc != null) {
+            deprecatedDescription = other.deprecatedDescription().orElse(this.deprecatedDesc);
+        }
 
         return new DocAttachmentInfo(description, newParamsMap, returnValueDescription, deprecatedDescription, 
                 docStart, padding);

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/command/AddDocumentationCommandExecTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/command/AddDocumentationCommandExecTest.java
@@ -66,6 +66,7 @@ public class AddDocumentationCommandExecTest extends AbstractCommandExecutionTes
                 {"document_already_documented_config1.json", "document_already_documented1.bal"},
                 {"document_already_documented_config2.json", "document_already_documented1.bal"},
                 {"document_already_documented_config3.json", "document_already_documented1.bal"},
+                {"document_already_documented_config4.json", "document_already_documented1.bal"},
         };
     }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/command/UpdateDocumentationExecutorTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/command/UpdateDocumentationExecutorTest.java
@@ -40,6 +40,7 @@ public class UpdateDocumentationExecutorTest extends AbstractCommandExecutionTes
         return new Object[][]{
                 {"updateDocumentationConfig1.json", "updateDocumentationSource1.bal"},
                 {"updateDocumentationConfig2.json", "updateDocumentationSource2.bal"},
+                {"updateDocumentationConfig3.json", "updateDocumentationSource3.bal"},
                 {"updateDocumentationWithDeprecatedConfig1.json", "updateDocumentationWithDeprecatedSource1.bal"},
                 {"updateDocumentationWithDeprecatedConfig2.json", "updateDocumentationWithDeprecatedSource2.bal"},
         };

--- a/language-server/modules/langserver-core/src/test/resources/command/add-documentation/config/document_already_documented_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/add-documentation/config/document_already_documented_config4.json
@@ -1,0 +1,40 @@
+{
+  "arguments": {
+    "node.range": {
+      "start": {
+        "line": 22,
+        "character": 0
+      },
+      "end": {
+        "line": 31,
+        "character": 1
+      }
+    }
+  },
+  "expected": {
+    "result": {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "range": {
+                  "start": {
+                    "line": 22,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 28,
+                    "character": 24
+                  }
+                },
+                "newText": "# Returns a value given some string\n#\n# + content - Parameter Description  \n# + round - Parameter Description\n# + return - Return Value Description"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "jsonrpc": "2.0"
+  }
+}

--- a/language-server/modules/langserver-core/src/test/resources/command/add-documentation/source/document_already_documented1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/command/add-documentation/source/document_already_documented1.bal
@@ -19,3 +19,14 @@ public class Encryptor {
         return "<encrypted>";
     }
 }
+
+# Returns a value given some string
+#
+# + content - Parameter Description
+# + round - Parameter Description
+# + return - Return Value Description
+# # Deprecated
+# Deprecated Description
+function getValue(string content, boolean round) returns float {
+    return 1.1;
+}

--- a/language-server/modules/langserver-core/src/test/resources/command/update-documentation/config/updateDocumentationConfig3.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/update-documentation/config/updateDocumentationConfig3.json
@@ -1,0 +1,40 @@
+{
+  "arguments": {
+    "node.range": {
+      "start": {
+        "line": 0,
+        "character": 0
+      },
+      "end": {
+        "line": 6,
+        "character": 1
+      }
+    }
+  },
+  "expected": {
+    "result": {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "range": {
+                  "start": {
+                    "line": 0,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 3,
+                    "character": 37
+                  }
+                },
+                "newText": "# Description\n#\n# + a - Parameter Description"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "jsonrpc": "2.0"
+  }
+}

--- a/language-server/modules/langserver-core/src/test/resources/command/update-documentation/source/updateDocumentationSource3.bal
+++ b/language-server/modules/langserver-core/src/test/resources/command/update-documentation/source/updateDocumentationSource3.bal
@@ -1,0 +1,7 @@
+# Description
+#
+# + a - Parameter Description
+# + return - Return Value Description
+function doSomething(int a) {
+    
+}


### PR DESCRIPTION
## Purpose
$subject

For example, if the documentation has a return description and the return descriptor has been removed from the function def, updating the documentation now reflects that.

Fixes #30941

## Approach
Updated `DocAttachmentInfo` class to neglect non-existing sections like return description and deprecated section

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
