### PR TITLE
Fix symbol kind not setting for error types loaded from bala projects

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BErrorTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BErrorTypeSymbol.java
@@ -19,6 +19,7 @@ package org.wso2.ballerinalang.compiler.semantics.model.symbols;
 
 import io.ballerina.tools.diagnostics.Location;
 import org.ballerinalang.model.elements.PackageID;
+import org.ballerinalang.model.symbols.SymbolKind;
 import org.ballerinalang.model.symbols.SymbolOrigin;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.util.Name;
@@ -34,6 +35,7 @@ public class BErrorTypeSymbol extends BTypeSymbol {
     public BErrorTypeSymbol(int symTag, long flags, Name name, PackageID pkgID, BType type, BSymbol owner,
                             Location pos, SymbolOrigin origin) {
         super(symTag, flags, name, pkgID, type, owner, pos, origin);
+        this.kind = SymbolKind.ERROR;
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/Symbols.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/Symbols.java
@@ -108,9 +108,7 @@ public class Symbols {
 
     public static BErrorTypeSymbol createErrorSymbol(long flags, Name name, PackageID pkgID, BType type, BSymbol owner,
                                                      Location pos, SymbolOrigin origin) {
-        BErrorTypeSymbol typeSymbol = new BErrorTypeSymbol(SymTag.ERROR, flags, name, pkgID, type, owner, pos, origin);
-        typeSymbol.kind = SymbolKind.ERROR;
-        return typeSymbol;
+        return new BErrorTypeSymbol(SymTag.ERROR, flags, name, pkgID, type, owner, pos, origin);
     }
 
     public static BAnnotationSymbol createAnnotationSymbol(long flags, Set<AttachPoint> points, Name name,

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/definition/DefinitionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/definition/DefinitionTest.java
@@ -124,6 +124,7 @@ public class DefinitionTest {
         log.info("Test textDocument/definition for Std Lib Cases");
         return new Object[][]{
                 {"defProject8.json", "project"},
+                {"def_error_config2.json", "project"}
         };
     }
 

--- a/language-server/modules/langserver-core/src/test/resources/definition/expected/project/def_error_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/definition/expected/project/def_error_config2.json
@@ -1,0 +1,24 @@
+{
+  "source": {
+    "file": "projectls/error_types.bal"
+  },
+  "position": {
+    "line": 23,
+    "character": 32
+  },
+  "result": [
+    {
+      "range": {
+        "start": {
+          "line": 17,
+          "character": 0
+        },
+        "end": {
+          "line": 17,
+          "character": 37
+        }
+      },
+      "uri": "repo/bala/ballerina/lang.error/1.0.0/any/modules/lang.error/retriable.bal"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/definition/sources/projectls/error_types.bal
+++ b/language-server/modules/langserver-core/src/test/resources/definition/sources/projectls/error_types.bal
@@ -19,3 +19,7 @@ public function f1() returns MyError? {
 public function f2() returns error? {
     return error lsmod1:Mod1Error("message");
 }
+
+function test1() returns error? {
+    error er = error error:Retriable("");
+}


### PR DESCRIPTION
## Purpose
$subject

And added a test case which covers a goto def scenario which was failing due to this.

Fixes #31066
Fixes #31005

## Approach
Updated the `BErrorTypeSymbol` constructor to set the symbol kind to `SymbolKind.ERROR`. And removed places (`BIRPackageSymbolEnter`) where it was being set manually.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
