### PR TITLE
Add an overloaded version of `visibleSymbols()` 

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/SemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/SemanticModel.java
@@ -17,6 +17,7 @@
  */
 package io.ballerina.compiler.api;
 
+import io.ballerina.compiler.api.symbols.DiagnosticState;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.syntax.tree.Node;
@@ -44,6 +45,17 @@ public interface SemanticModel {
      * @return {@link List} of visible symbols in the given location
      */
     List<Symbol> visibleSymbols(Document sourceFile, LinePosition position);
+
+    /**
+     * Lookup the visible symbols at the given location. This additionally takes a list of diagnostic states. These are
+     * used to determine whether to include variable symbols with varying diagnostic states.
+     *
+     * @param sourceFile The source file document in which to look up the position
+     * @param position   text position in the source
+     * @param states     The allowed states of in-scope variable symbols
+     * @return {@link List} of visible symbols in the given location
+     */
+    List<Symbol> visibleSymbols(Document sourceFile, LinePosition position, DiagnosticState... states);
 
     /**
      * Lookup the symbol at the given location.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
@@ -21,6 +21,7 @@ import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.impl.symbols.AbstractTypeSymbol;
 import io.ballerina.compiler.api.impl.symbols.BallerinaSymbol;
 import io.ballerina.compiler.api.impl.symbols.TypesFactory;
+import io.ballerina.compiler.api.symbols.DiagnosticState;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.syntax.tree.Node;
@@ -38,6 +39,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BPackageSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BTypeSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BVarSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.tree.BLangCompilationUnit;
 import org.wso2.ballerinalang.compiler.tree.BLangNode;
@@ -366,7 +368,7 @@ public class BallerinaSemanticModel implements SemanticModel {
                                       Scope.ScopeEntry scopeEntry,
                                       Location cursorPos,
                                       Name name) {
-        if (scopeEntry == null || scopeEntry.symbol == null) {
+        if (scopeEntry == null || scopeEntry.symbol == null || isRedeclaredSymbol(scopeEntry.symbol)) {
             return;
         }
 
@@ -384,5 +386,9 @@ public class BallerinaSemanticModel implements SemanticModel {
 
     private boolean isServiceDeclSymbol(BSymbol symbol) {
         return symbol.kind == SymbolKind.SERVICE;
+    }
+
+    private boolean isRedeclaredSymbol(BSymbol symbol) {
+        return symbol instanceof BVarSymbol && ((BVarSymbol) symbol).state == DiagnosticState.REDECLARED;
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
@@ -50,6 +50,7 @@ import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.util.Flags;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -91,7 +92,12 @@ public class BallerinaSemanticModel implements SemanticModel {
      */
     @Override
     public List<Symbol> visibleSymbols(Document srcFile, LinePosition linePosition) {
-        BLangCompilationUnit compilationUnit = getCompilationUnit(srcFile);
+        return visibleSymbols(srcFile, linePosition, DiagnosticState.VALID, DiagnosticState.UNKNOWN_TYPE);
+    }
+
+    @Override
+    public List<Symbol> visibleSymbols(Document sourceFile, LinePosition position, DiagnosticState... states) {
+        BLangCompilationUnit compilationUnit = getCompilationUnit(sourceFile);
         BPackageSymbol moduleSymbol = getModuleSymbol(compilationUnit);
         SymbolTable symbolTable = SymbolTable.getInstance(this.compilerContext);
         SymbolEnv pkgEnv = symbolTable.pkgEnvMap.get(moduleSymbol);
@@ -99,19 +105,20 @@ public class BallerinaSemanticModel implements SemanticModel {
 
         SymbolResolver symbolResolver = SymbolResolver.getInstance(this.compilerContext);
         Map<Name, List<Scope.ScopeEntry>> scopeSymbols =
-                symbolResolver.getAllVisibleInScopeSymbols(envResolver.lookUp(compilationUnit, linePosition));
+                symbolResolver.getAllVisibleInScopeSymbols(envResolver.lookUp(compilationUnit, position));
 
         Location cursorPos = new BLangDiagnosticLocation(compilationUnit.name,
-                                                         linePosition.line(), linePosition.line(),
-                                                         linePosition.offset(), linePosition.offset());
+                                                         position.line(), position.line(),
+                                                         position.offset(), position.offset());
 
+        Set<DiagnosticState> statesSet = new HashSet<>(Arrays.asList(states));
         Set<Symbol> compiledSymbols = new HashSet<>();
         for (Map.Entry<Name, List<Scope.ScopeEntry>> entry : scopeSymbols.entrySet()) {
             Name name = entry.getKey();
             List<Scope.ScopeEntry> scopeEntries = entry.getValue();
 
             for (Scope.ScopeEntry scopeEntry : scopeEntries) {
-                addToCompiledSymbols(compiledSymbols, scopeEntry, cursorPos, name);
+                addToCompiledSymbols(compiledSymbols, scopeEntry, cursorPos, name, statesSet);
             }
         }
 
@@ -364,11 +371,9 @@ public class BallerinaSemanticModel implements SemanticModel {
                 startOffset >= specifiedStartOffset && startOffset <= specifiedEndOffset;
     }
 
-    private void addToCompiledSymbols(Set<Symbol> compiledSymbols,
-                                      Scope.ScopeEntry scopeEntry,
-                                      Location cursorPos,
-                                      Name name) {
-        if (scopeEntry == null || scopeEntry.symbol == null || isRedeclaredSymbol(scopeEntry.symbol)) {
+    private void addToCompiledSymbols(Set<Symbol> compiledSymbols, Scope.ScopeEntry scopeEntry, Location cursorPos,
+                                      Name name, Set<DiagnosticState> states) {
+        if (scopeEntry == null || scopeEntry.symbol == null || isFilteredVarSymbol(scopeEntry.symbol, states)) {
             return;
         }
 
@@ -381,14 +386,14 @@ public class BallerinaSemanticModel implements SemanticModel {
             }
             compiledSymbols.add(compiledSymbol);
         }
-        addToCompiledSymbols(compiledSymbols, scopeEntry.next, cursorPos, name);
+        addToCompiledSymbols(compiledSymbols, scopeEntry.next, cursorPos, name, states);
     }
 
     private boolean isServiceDeclSymbol(BSymbol symbol) {
         return symbol.kind == SymbolKind.SERVICE;
     }
 
-    private boolean isRedeclaredSymbol(BSymbol symbol) {
-        return symbol instanceof BVarSymbol && ((BVarSymbol) symbol).state == DiagnosticState.REDECLARED;
+    private boolean isFilteredVarSymbol(BSymbol symbol, Set<DiagnosticState> states) {
+        return symbol instanceof BVarSymbol && !states.contains(((BVarSymbol) symbol).state);
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolLookupTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolLookupTest.java
@@ -267,40 +267,40 @@ public class SymbolLookupTest {
         ModuleID moduleID = new BallerinaModuleID(pkg.packageID);
 
         Map<String, Symbol> symbolsForWhere = getSymbolsInFile(model, srcFile, 22, 21, moduleID);
-        assertList(symbolsForWhere, Arrays.asList("test", "arr1", "arr2", "i", "j", "res1"));
+        assertList(symbolsForWhere, Arrays.asList("test", "arr1", "arr2", "i", "j", "res1", "Person"));
 
         Map<String, Symbol> symbolsForSelect = getSymbolsInFile(model, srcFile, 28, 21, moduleID);
         assertList(symbolsForSelect, Arrays.asList("intVal", "test", "res1", "stringVal", "res2", "i", "j", "arr2",
-                "arr1"));
+                "arr1", "Person"));
 
         Map<String, Symbol> symbolsForQueryAct = getSymbolsInFile(model, srcFile, 31, 20, moduleID);
-        assertList(symbolsForQueryAct, Arrays.asList("ii", "test", "res1", "res3", "res2", "arr2", "arr1"));
+        assertList(symbolsForQueryAct, Arrays.asList("ii", "test", "res1", "res3", "res2", "arr2", "arr1", "Person"));
 
         Map<String, Symbol> symbolsForJoinLHS = getSymbolsInFile(model, srcFile, 36, 20, moduleID);
-        assertList(symbolsForJoinLHS, Arrays.asList("test", "res1", "res3", "res2", "i", "arr2", "arr1"));
+        assertList(symbolsForJoinLHS, Arrays.asList("test", "res1", "res3", "res2", "i", "arr2", "arr1", "Person"));
  
         Map<String, Symbol> symbolsForJoinRHS = getSymbolsInFile(model, srcFile, 36, 28, moduleID);
-        assertList(symbolsForJoinRHS, Arrays.asList("test", "res1", "res3", "res2", "j", "arr2", "arr1"));
+        assertList(symbolsForJoinRHS, Arrays.asList("test", "res1", "res3", "res2", "j", "arr2", "arr1", "Person"));
 
         Map<String, Symbol> symbolsForOrderBy = getSymbolsInFile(model, srcFile, 44, 25, moduleID);
         assertList(symbolsForOrderBy, Arrays.asList("res5", "p", "res4", "p1", "p2", "personList", "test", "res1",
-                "res3", "res2", "arr2", "arr1"));
+                "res3", "res2", "arr2", "arr1", "Person"));
 
         Map<String, Symbol> symbolsForNestedFrom1 = getSymbolsInFile(model, srcFile, 48, 42, moduleID);
         assertList(symbolsForNestedFrom1, Arrays.asList("res5", "res4", "p1", "p2", "personList", "res6", "test",
-                "res1", "res3", "res2", "k", "arr2", "arr1"));
+                "res1", "res3", "res2", "k", "arr2", "arr1", "Person"));
  
         Map<String, Symbol> symbolsForNestedFrom2 = getSymbolsInFile(model, srcFile, 49, 23, moduleID);
         assertList(symbolsForNestedFrom2, Arrays.asList("res5", "res4", "p1", "p2", "personList", "res6", "test",
-                "res1", "res3", "res2", "i", "arr2", "arr1"));
+                "res1", "res3", "res2", "i", "arr2", "arr1", "Person"));
  
         Map<String, Symbol> symbolsForNestedFrom3 = getSymbolsInFile(model, srcFile, 53, 58, moduleID);
         assertList(symbolsForNestedFrom3, Arrays.asList("res5", "res4", "p1", "res7", "p2", "personList", "res6",
-                "test", "res1", "res3", "res2", "m", "arr2", "arr1"));
+                "test", "res1", "res3", "res2", "m", "arr2", "arr1", "Person"));
 
         Map<String, Symbol> symbolsForNestedFrom4 = getSymbolsInFile(model, srcFile, 53, 64, moduleID);
         assertList(symbolsForNestedFrom4, Arrays.asList("res5", "ii", "res4", "p1", "p2", "personList", "res6",
-                "test", "res1", "res3", "res2", "arr2", "arr1"));
+                "test", "res1", "res3", "res2", "arr2", "arr1", "Person"));
     }
 
     @Test

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/errored_symbol_lookup_test_2.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/errored_symbol_lookup_test_2.bal
@@ -1,0 +1,28 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+boolean b = true;
+
+function test(int b) {
+    float b = 1.23;
+
+    if (true) {
+        decimal b = 3.4;
+        Person p = {};
+        var x = 10 + 2.3;
+
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol_lookup_in_query.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol_lookup_in_query.bal
@@ -53,3 +53,9 @@ function test() {
                                        select k)
                 join int jj in (from int m in arr2 select m) on
 }
+
+type Person record {|
+    string firstName;
+    string lastName;
+    int age;
+|};


### PR DESCRIPTION
## Purpose
This PR adds an overloaded version of `visibleSymbols()` which accepts a vararg of diagnostic states. This basically allows the user to tell the Semantic API which var symbols should be dropped when returning the list of visible symbols.

Fixes #30081 

## Remarks
This PR leaves the original `visibleSymbols()` method's behaviour intact.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
