### PR TITLE
Remove duplication of runtime error logs

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/util/RuntimeUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/util/RuntimeUtils.java
@@ -15,11 +15,12 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
+
 package io.ballerina.runtime.internal.util;
 
 import io.ballerina.runtime.api.TypeTags;
-import io.ballerina.runtime.api.constants.RuntimeConstants;
 import io.ballerina.runtime.api.types.Type;
+import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.internal.TypeConverter;
 import io.ballerina.runtime.internal.diagnostics.RuntimeDiagnosticLog;
 import io.ballerina.runtime.internal.types.BArrayType;
@@ -28,12 +29,9 @@ import io.ballerina.runtime.internal.values.ArrayValueImpl;
 import io.ballerina.runtime.internal.values.ErrorValue;
 
 import java.io.PrintStream;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.Optional;
 import java.util.logging.ConsoleHandler;
 import java.util.logging.Level;
-import java.util.logging.LogManager;
 import java.util.logging.Logger;
 
 import static io.ballerina.runtime.api.constants.RuntimeConstants.BBYTE_MAX_VALUE;
@@ -48,13 +46,10 @@ import static io.ballerina.runtime.api.constants.RuntimeConstants.BBYTE_MIN_VALU
 public class RuntimeUtils {
 
     private static final String CRASH_LOGGER = "b7a.log.crash";
-    private static final String DEFAULT_CRASH_LOG_FILE = "ballerina-internal.log";
-    private static PrintStream errStream = System.err;
+    private static final PrintStream errStream = System.err;
     public static final String USER_DIR = System.getProperty("user.dir");
     public static final String TEMP_DIR = System.getProperty("java.io.tmpdir");
-    private static Logger crashLogger = Logger.getLogger(CRASH_LOGGER);
-
-    private static final PrintStream stderr = System.err;
+    private static final Logger crashLogger = Logger.getLogger(CRASH_LOGGER);
     private static ConsoleHandler handler;
 
     /**
@@ -78,7 +73,7 @@ public class RuntimeUtils {
         // TODO: need to add parsing logic for ref values for both var args and other args as well.
         switch (type.getTag()) {
             case TypeTags.STRING_TAG:
-                array.add(array.size(), value);
+                array.add(array.size(), StringUtils.fromString(value));
                 break;
             case TypeTags.INT_TAG:
                 array.add(array.size(), (long) TypeConverter.convertValues(type, value));
@@ -115,7 +110,6 @@ public class RuntimeUtils {
         String name;
         boolean hasDefaultable;
         Type type;
-        int index = -1;
 
         public ParamInfo(boolean hasDefaultable, String name, Type type) {
             this.name = name;
@@ -198,19 +192,6 @@ public class RuntimeUtils {
             }
         }
         crashLogger.log(Level.SEVERE, throwable.getMessage(), throwable);
-    }
-
-    private static String initBRELogHandler() {
-        String fileName = LogManager.getLogManager().getProperty(RuntimeConstants.DEFAULT_LOG_FILE_HANDLER_PATTERN);
-        if (fileName == null || fileName.trim().isEmpty()) {
-            fileName = DEFAULT_CRASH_LOG_FILE;
-        }
-
-        if (Files.isWritable(Paths.get(USER_DIR))) {
-            return Paths.get(USER_DIR, fileName).toString();
-        } else {
-            return Paths.get(TEMP_DIR, fileName).toString();
-        }
     }
 
     private RuntimeUtils() {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
@@ -250,7 +250,8 @@ public class JvmConstants {
             "io/ballerina/runtime/internal/util/exceptions/BLangRuntimeException";
     public static final String THROWABLE = "java/lang/Throwable";
     public static final String STACK_OVERFLOW_ERROR = "java/lang/StackOverflowError";
-    public static final String HANDLE_THROWABLE_METHOD = "handleRuntimeErrorsAndExit";
+    public static final String HANDLE_THROWABLE_METHOD = "handleBErrorAndExit";
+    public static final String HANDLE_ALL_THROWABLE_METHOD = "handleAllRuntimeErrorsAndExit";
     public static final String HANDLE_RETURNED_ERROR_METHOD = "handleRuntimeReturnValues";
     public static final String UNSUPPORTED_OPERATION_EXCEPTION = "java/lang/UnsupportedOperationException";
     public static final String HANDLE_STOP_PANIC_METHOD = "handleRuntimeErrors";

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/MainMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/MainMethodGen.java
@@ -143,7 +143,7 @@ public class MainMethodGen {
         mv.visitLabel(tryCatchEnd);
         mv.visitInsn(RETURN);
         mv.visitLabel(tryCatchHandle);
-        mv.visitMethodInsn(INVOKESTATIC, JvmConstants.RUNTIME_UTILS, JvmConstants.HANDLE_THROWABLE_METHOD,
+        mv.visitMethodInsn(INVOKESTATIC, JvmConstants.RUNTIME_UTILS, JvmConstants.HANDLE_ALL_THROWABLE_METHOD,
                            String.format("(L%s;)V", JvmConstants.THROWABLE), false);
         mv.visitInsn(RETURN);
         mv.visitMaxs(0, 0);

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/BRunUtil.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/BRunUtil.java
@@ -15,6 +15,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.ballerinalang.test;
 
 import io.ballerina.projects.JarResolver;
@@ -1311,7 +1312,7 @@ public class BRunUtil {
         return invoke(compileResult, function, functionName, new BValue[0], new Class<?>[0]);
     }
 
-    public static String runMain(CompileResult compileResult, String[] args) {
+    public static String runMain(CompileResult compileResult, String... args) {
         ExitDetails exitDetails = run(compileResult, args);
         if (exitDetails.exitCode != 0) {
             throw new RuntimeException(exitDetails.errorOutput);
@@ -1319,7 +1320,7 @@ public class BRunUtil {
         return exitDetails.consoleOutput;
     }
 
-    public static ExitDetails run(CompileResult compileResult, String[] args) {
+    public static ExitDetails run(CompileResult compileResult, String... args) {
         PackageManifest packageManifest = compileResult.packageManifest();
         String initClassName = JarResolver.getQualifiedClassName(packageManifest.org().toString(),
                 packageManifest.name().toString(),
@@ -1457,5 +1458,8 @@ public class BRunUtil {
             this.consoleOutput = consoleOutput;
             this.errorOutput = errorOutput;
         }
+    }
+
+    private BRunUtil() {
     }
 }

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/logging/BadSadTests.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/logging/BadSadTests.java
@@ -65,12 +65,11 @@ public class BadSadTests extends BaseTest {
     }
 
     @Test
-    public void testBadSadInRun() throws BallerinaTestException, IOException {
+    public void testBadSadInRun() throws BallerinaTestException {
         BMainInstance bMainInstance = new BMainInstance(balServer);
         String output = bMainInstance.runMainAndReadStdOut("run", new String[] {}, new HashMap<>(),
                 Paths.get("src/test/resources/logging/projects-for-badsad-tests/runCmdBadSad")
                         .toAbsolutePath().toString(), true);
-        Assert.assertTrue(output.contains("ballerina: Oh no, something really went wrong."));
 
         String expected = "java.lang.ClassCastException: class io.ballerina.runtime.internal.values.ErrorValue cannot" +
                 " be cast to class io.ballerina.runtime.internal.values.ArrayValue " +
@@ -84,7 +83,7 @@ public class BadSadTests extends BaseTest {
     }
 
     @Test
-    public void testBadSadInTest() throws BallerinaTestException, IOException {
+    public void testBadSadInTest() throws BallerinaTestException {
         BMainInstance bMainInstance = new BMainInstance(balServer);
         String output = bMainInstance.runMainAndReadStdOut("build", new String[] {}, new HashMap<>(),
                 Paths.get("src/test/resources/logging/projects-for-badsad-tests/runCmdBadSad")

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/run/BalRunFunctionPositiveTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/run/BalRunFunctionPositiveTestCase.java
@@ -15,6 +15,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.ballerinalang.test.run;
 
 import org.ballerinalang.test.BaseTest;
@@ -23,7 +24,7 @@ import org.ballerinalang.test.context.BallerinaTestException;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import java.io.File;
+import java.nio.file.Paths;
 
 /**
  * This class tests invoking a main function in a bal file via the Ballerina Run Command and the data binding
@@ -31,31 +32,25 @@ import java.io.File;
  */
 public class BalRunFunctionPositiveTestCase extends BaseTest {
 
-    private static final int LOG_LEECHER_TIMEOUT = 10000;
-
-    @Test(enabled = false)
+    @Test
     public void testNoArg() throws BallerinaTestException {
-        BMainInstance bMainInstance = new BMainInstance(balServer);
-        String output = bMainInstance.runMainAndReadStdOut("run", new String[] { "test_main_with_no_params.bal" },
-                                                           (new File("src" + File.separator + "test" + File.separator
-                                                                             + "resources" + File.separator + "run" +
-                                                                             File.separator + "file"))
-                                                                   .getAbsolutePath());
-        Assert.assertTrue(output.endsWith("1"));
+        executeTest(new String[]{"test_main_with_no_params.bal"}, "1");
     }
 
-    @Test(enabled = false)
+    @Test
     public void testMultipleParam() throws BallerinaTestException {
+        String[] args = new String[]{
+                "test_main_with_multiple_typed_params.bal", "--", "1000", "1.0", "Hello Ballerina",
+                "just", "the", "rest", "--name=Em"};
+        executeTest(args,
+                    "integer: 1000, float: 1.0, string: Hello Ballerina, Employee Name Field: Em, string rest args: " +
+                            "just the rest ");
+    }
+
+    private void executeTest(String[] args, String expected) throws BallerinaTestException {
         BMainInstance bMainInstance = new BMainInstance(balServer);
-        String[] args = new String[] {
-                "test_main_with_multiple_typed_params.bal", "1000", "1.0", "Hello Ballerina", "255", "true",
-                "{ \"name\": \"Maryam\" }", "<book>Harry Potter</book>", "{ \"name\": \"Em\" }", "just", "the", "rest"
-        };
-        String balFile = (new File("src" + File.separator + "test" + File.separator + "resources" + File.separator +
-                                           "run" + File.separator + "file")).getAbsolutePath();
-        String output = bMainInstance.runMainAndReadStdOut("run", args, balFile);
-        Assert.assertTrue(output.endsWith("integer: 1000, float: 1.0, string: Hello Ballerina, byte: 255, boolean: " +
-                                          "true, JSON Name Field: Maryam, XML Element Name: book, Employee Name " +
-                                          "Field: Em, string rest args: just the rest "));
+        String output = bMainInstance.runMainAndReadStdOut("run", args, Paths
+                .get("src", "test", "resources", "run", "file").toString());
+        Assert.assertTrue(output.endsWith(expected));
     }
 }

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/run/BasicJavaJarRunTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/run/BasicJavaJarRunTestCase.java
@@ -15,6 +15,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.ballerinalang.test.run;
 
 import org.ballerinalang.test.BaseTest;
@@ -23,42 +24,32 @@ import org.ballerinalang.test.context.BallerinaTestException;
 import org.ballerinalang.test.context.LogLeecher;
 import org.testng.annotations.Test;
 
-import java.io.File;
+import java.nio.file.Paths;
 
 /**
- * This class tests build a bal file and execute the jar via the java jar Command and the test the basic data
- * binding functionality.
+ * This class tests build a bal file and execute the jar via the java jar Command and the test the basic data binding
+ * functionality.
  */
 public class BasicJavaJarRunTestCase extends BaseTest {
 
-    private static final int LOG_LEECHER_TIMEOUT = 10000;
-
-    @Test(enabled = false)
+    @Test
     public void testNoArg() throws BallerinaTestException {
-        BMainInstance ballerinaClient = new BMainInstance(balServer);
-        String serverResponse = "1";
-        String balFile = (new File("src" + File.separator + "test" + File.separator + "resources" + File.separator +
-                                           "run" + File.separator + "file" + File.separator +
-                                           "test_main_with_no_params.bal")).getAbsolutePath();
-        LogLeecher clientLeecher = new LogLeecher(serverResponse);
-        ballerinaClient.runMain(balFile, new LogLeecher[] { clientLeecher });
-        clientLeecher.waitForText(LOG_LEECHER_TIMEOUT);
+        executeTest("1", "test_main_with_no_params.bal");
     }
 
-    @Test(enabled = false)
+    @Test
     public void testMultipleParam() throws BallerinaTestException {
+        executeTest(
+                "integer: 1000, float: 1.0, string: Hello Ballerina, Employee Name Field: Em, string rest args: just " +
+                        "the rest ", "test_main_with_multiple_typed_params.bal", "1000", "1.0", "Hello Ballerina",
+                "just", "the", "rest", "--name=Em");
+    }
+
+    private void executeTest(String serverResponse, String fileName, String... args) throws BallerinaTestException {
         BMainInstance ballerinaClient = new BMainInstance(balServer);
-        String serverResponse = "integer: 1000, float: 1.0, string: Hello Ballerina, byte: 255, boolean: true, JSON "
-                + "Name Field: Maryam, XML Element Name: book, Employee Name Field: Em, string rest args: just the "
-                + "rest";
-        String balFile = (new File("src" + File.separator + "test" + File.separator + "resources" + File.separator +
-                                           "run" + File.separator + "file" + File.separator +
-                                           "test_main_with_multiple_typed_params.bal")).getAbsolutePath();
+        String balFile = Paths.get("src", "test", "resources", "run", "file", fileName).toAbsolutePath().toString();
         LogLeecher clientLeecher = new LogLeecher(serverResponse);
-        ballerinaClient.runMain(balFile, null, new String[] {
-                "1000", "1.0", "Hello Ballerina", "255", "true", "{ " + "\"name\": \"Maryam\" }", "<book>Harry "
-                + "Potter</book>", "{ \"name\": \"Em\" }", "just", "the", "rest"
-        }, new LogLeecher[] { clientLeecher });
-        clientLeecher.waitForText(20000);
+        ballerinaClient.runMain(balFile, null, args, new LogLeecher[]{clientLeecher});
+        clientLeecher.waitForText(10000);
     }
 }

--- a/tests/jballerina-integration-test/src/test/resources/run/file/main_error_panic.bal
+++ b/tests/jballerina-integration-test/src/test/resources/run/file/main_error_panic.bal
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 //
 // WSO2 Inc. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
@@ -14,24 +14,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/jballerina.java;
-
 public function main() {
-    print("1");
+    panic error("Returning an error");
 }
-
-function print(string str) {
-    printVal(system_out(), java:fromString(str));
-}
-
-function system_out() returns handle = @java:FieldGet {
-    name: "out",
-    'class: "java.lang.System"
-} external;
-
-function printVal(handle receiver, handle arg0) = @java:Method {
-    name: "print",
-    'class: "java.io.PrintStream",
-    paramTypes: ["java.lang.String"]
-} external;
-

--- a/tests/jballerina-integration-test/src/test/resources/run/file/main_error_return.bal
+++ b/tests/jballerina-integration-test/src/test/resources/run/file/main_error_return.bal
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 //
 // WSO2 Inc. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
@@ -14,24 +14,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/jballerina.java;
-
-public function main() {
-    print("1");
+public function main() returns error? {
+    return error("Returning an error");
 }
-
-function print(string str) {
-    printVal(system_out(), java:fromString(str));
-}
-
-function system_out() returns handle = @java:FieldGet {
-    name: "out",
-    'class: "java.lang.System"
-} external;
-
-function printVal(handle receiver, handle arg0) = @java:Method {
-    name: "print",
-    'class: "java.io.PrintStream",
-    paramTypes: ["java.lang.String"]
-} external;
-

--- a/tests/jballerina-integration-test/src/test/resources/run/file/test_main_with_multiple_typed_params.bal
+++ b/tests/jballerina-integration-test/src/test/resources/run/file/test_main_with_multiple_typed_params.bal
@@ -13,23 +13,35 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-import ballerina/io;
-import ballerina/lang.'xml as xmllib;
 
-public function main(int i, float f, string s, byte b, boolean bool, json j, xml x, Employee e, string... args) {
+import ballerina/jballerina.java;
+
+public function main(int i, float f, string s, *Employee e, string... args) {
     string restArgs = "";
     foreach var str in args {
         restArgs += str + " ";
     }
 
-    xmllib:Element elem = <xmllib:Element> x;
-
-    io:print("integer: " + i.toString() + ", float: " + f.toString() + ", string: " + s + ", byte: " +
-            b.toString() + ", boolean: " + bool.toString() + ", JSON Name Field: " +
-            j.name.toString() + ", XML Element Name: " + elem.getName() + ", Employee Name Field: " + e.name +
-            ", string rest args: " + restArgs);
+    print("integer: " + i.toString() + ", float: " + f.toString() + ", string: " + s + ", Employee Name Field: " +
+        e.name + ", string rest args: " + restArgs);
 }
 
 public type Employee record {
     string name = "";
 };
+
+function print(string str) {
+    printVal(system_out(), java:fromString(str));
+}
+
+function system_out() returns handle = @java:FieldGet {
+    name: "out",
+    'class: "java.lang.System"
+} external;
+
+function printVal(handle receiver, handle arg0) = @java:Method {
+    name: "print",
+    'class: "java.io.PrintStream",
+    paramTypes: ["java.lang.String"]
+} external;
+

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/ErrorTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/ErrorTest.java
@@ -82,7 +82,6 @@ public class ErrorTest {
             CompileResult compileResult = BCompileUtil.compile("test-src/jvm/runtime-oom-error.bal");
             BRunUtil.runMain(compileResult, new String[]{});
         } catch (Throwable e) {
-            Assert.assertTrue(e.getMessage().contains("ballerina: Oh no, something really went wrong."));
             return;
         }
         Assert.fail("runtime out of memory errors are not handled");

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayTest.java
@@ -36,6 +36,7 @@ import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.ballerinalang.compiler.util.BArrayState;
 
@@ -210,39 +211,16 @@ public class ArrayTest {
         Assert.assertEquals(value.intValue(), 4);
     }
 
-    @Test
-    public void createAbstractObjectEmptyArray() {
-        BRunUtil.invokeFunction(compileResult, "createAbstractObjectEmptyArray");
+    @Test(dataProvider = "functionNamesProvider")
+    public void testInvokeFunctions(String funcName) {
+        BRunUtil.invokeFunction(compileResult, funcName);
     }
 
-    @Test
-    public void testObjectDynamicArrayFilling() {
-        BRunUtil.invokeFunction(compileResult, "testObjectDynamicArrayFilling");
-    }
-
-    @Test
-    public void testMultidimensionalArrayString() {
-        BRunUtil.invokeFunction(compileResult, "testMultidimensionalArrayString");
-    }
-
-    @Test
-    public void testArrayMapString() {
-        BRunUtil.invokeFunction(compileResult, "testArrayMapString");
-    }
-
-    @Test
-    public void testArrayUnionType() {
-        BRunUtil.invokeFunction(compileResult, "testArrayUnionType");
-    }
-
-    @Test
-    public void testArrayTupleType() {
-        BRunUtil.invokeFunction(compileResult, "testArrayTupleType");
-    }
-
-    @Test
-    public void testUpdatingJsonTupleViaArrayTypedVar() {
-        BRunUtil.invokeFunction(compileResult, "testUpdatingJsonTupleViaArrayTypedVar");
+    @DataProvider(name = "functionNamesProvider")
+    public Object[] getFunctionNames() {
+        return new String[]{"createAbstractObjectEmptyArray", "testObjectDynamicArrayFilling",
+                "testMultidimensionalArrayString", "testArrayMapString", "testArrayUnionType", "testArrayTupleType",
+                "testUpdatingJsonTupleViaArrayTypedVar", "testVarArgsArray"};
     }
 
     @Test

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array-test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array-test.bal
@@ -1,3 +1,31 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+
+function testVarArgsArray() {
+    validateVarArgs("val0", "val1", "val2");
+}
+
+function validateVarArgs(string... arr) {
+    test:assertEquals(arr[0], "val0");
+    test:assertEquals(arr[1], "val1");
+    test:assertEquals(arr[2], "val2");
+}
+
 function testFloatArrayLength(float[] arg) returns [int, int]{
     float[] defined;
     defined = [10.1, 11.1];
@@ -205,43 +233,27 @@ const TYPEDESC_ARRAY = "typedesc int[][2]";
 function testMultidimensionalArrayString() {
     int[][2] arr = [];
     typedesc<any> t = typeof arr;
-    assertEquality(TYPEDESC_ARRAY, t.toString());
+    test:assertEquals(TYPEDESC_ARRAY, t.toString());
 
 }
 
 function testArrayMapString() {
     map<Foo>[2][] arr = [];
     typedesc<any> t = typeof arr;
-    assertEquality("typedesc map<Foo>[2][]", t.toString());
+    test:assertEquals("typedesc map<Foo>[2][]", t.toString());
 
 }
 
 function testArrayUnionType() {
     (int|string[4][3])[][2][4] arr = [];
     typedesc<any> t = typeof arr;
-    assertEquality("typedesc (int|string[4][3])[][2][4]", t.toString());
+    test:assertEquals("typedesc (int|string[4][3])[][2][4]", t.toString());
 }
 
 function testArrayTupleType() {
     [string[2],int,float[3][4]][][] arr = [];
     typedesc<any> t = typeof arr;
-    assertEquality("typedesc [string[2],int,float[3][4]][][]", t.toString());
-}
-
-const ASSERTION_ERROR_REASON = "AssertionError";
-
-function assertEquality(any|error expected, any|error actual) {
-    if expected is anydata && actual is anydata && expected == actual {
-        return;
-    }
-    if expected === actual {
-        return;
-    }
-
-    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
-    string actualValAsString = actual is error ? actual.toString() : actual.toString();
-    panic error(ASSERTION_ERROR_REASON,
-                message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
+    test:assertEquals("typedesc [string[2],int,float[3][4]][][]", t.toString());
 }
 
 function testUpdatingJsonTupleViaArrayTypedVar() {


### PR DESCRIPTION
## Purpose
> The runtime errors were logged twice. Once in the scheduler and again during exit. Both are printed in the ballerina-internal.log. 

## Approach
> This removes the duplication and prints the log only once.

## Samples
> N/A

## Remarks
> N/A

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
