### PR TITLE
Remove duplication of runtime error logs

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/util/RuntimeUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/util/RuntimeUtils.java
@@ -125,19 +125,28 @@ public class RuntimeUtils {
         }
     }
 
-    public static void handleRuntimeErrorsAndExit(Throwable throwable) {
-        handleRuntimeErrors(throwable);
+    public static void handleBErrorAndExit(Throwable throwable) {
+        if (throwable instanceof ErrorValue) {
+            printToConsole((ErrorValue) throwable);
+        }
         Runtime.getRuntime().exit(1);
     }
 
-    public static void handleRuntimeErrors(Throwable throwable) {
+    public static void handleAllRuntimeErrorsAndExit(Throwable throwable) {
+        handleAllRuntimeErrors(throwable);
+        Runtime.getRuntime().exit(1);
+    }
+
+    public static void handleAllRuntimeErrors(Throwable throwable) {
         if (throwable instanceof ErrorValue) {
-            errStream.println("error: " + ((ErrorValue) throwable).getPrintableStackTrace());
+            printToConsole((ErrorValue) throwable);
         } else {
-            // These errors are unhandled errors in JVM, hence logging them to bre log.
-            errStream.println(RuntimeConstants.INTERNAL_ERROR_MESSAGE);
             logBadSad(throwable);
         }
+    }
+
+    private static void printToConsole(ErrorValue throwable) {
+        errStream.println("error: " + throwable.getPrintableStackTrace());
     }
 
     public static void handleRuntimeReturnValues(Object returnValue) {

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/TestCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/TestCommandTest.java
@@ -61,7 +61,7 @@ public class TestCommandTest extends BaseCommandTest {
     }
 
     @Test(description = "Test a valid ballerina file")
-    public void testTestBalFile() throws IOException {
+    public void testTestBalFile() {
         Path validBalFilePath = this.testResources.resolve("valid-test-bal-file").resolve("sample_tests.bal");
 
         System.setProperty("user.dir", this.testResources.resolve("valid-test-bal-file").toString());
@@ -125,7 +125,7 @@ public class TestCommandTest extends BaseCommandTest {
     }
 
     @Test(description = "Build a valid ballerina project")
-    public void testBuildMultiModuleProject() throws IOException {
+    public void testBuildMultiModuleProject() {
         Path projectPath = this.testResources.resolve("validMultiModuleProjectWithTests");
         System.setProperty("user.dir", projectPath.toString());
         TestCommand testCommand = new TestCommand(projectPath, printStream, printStream, false);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
@@ -249,7 +249,8 @@ public class JvmConstants {
             "io/ballerina/runtime/internal/util/exceptions/BLangRuntimeException";
     public static final String THROWABLE = "java/lang/Throwable";
     public static final String STACK_OVERFLOW_ERROR = "java/lang/StackOverflowError";
-    public static final String HANDLE_THROWABLE_METHOD = "handleRuntimeErrorsAndExit";
+    public static final String HANDLE_THROWABLE_METHOD = "handleBErrorAndExit";
+    public static final String HANDLE_ALL_THROWABLE_METHOD = "handleAllRuntimeErrorsAndExit";
     public static final String HANDLE_RETURNED_ERROR_METHOD = "handleRuntimeReturnValues";
     public static final String UNSUPPORTED_OPERATION_EXCEPTION = "java/lang/UnsupportedOperationException";
     public static final String HANDLE_STOP_PANIC_METHOD = "handleRuntimeErrors";

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/MainMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/MainMethodGen.java
@@ -143,7 +143,7 @@ public class MainMethodGen {
         mv.visitLabel(tryCatchEnd);
         mv.visitInsn(RETURN);
         mv.visitLabel(tryCatchHandle);
-        mv.visitMethodInsn(INVOKESTATIC, JvmConstants.RUNTIME_UTILS, JvmConstants.HANDLE_THROWABLE_METHOD,
+        mv.visitMethodInsn(INVOKESTATIC, JvmConstants.RUNTIME_UTILS, JvmConstants.HANDLE_ALL_THROWABLE_METHOD,
                            String.format("(L%s;)V", JvmConstants.THROWABLE), false);
         mv.visitInsn(RETURN);
         mv.visitMaxs(0, 0);
@@ -352,7 +352,7 @@ public class MainMethodGen {
         mv.visitFieldInsn(GETFIELD, JvmConstants.FUTURE_VALUE, "result", String.format("L%s;", JvmConstants.OBJECT));
 
         mv.visitMethodInsn(INVOKESTATIC, JvmConstants.RUNTIME_UTILS, JvmConstants.HANDLE_RETURNED_ERROR_METHOD,
-                           String.format("(L%s;)V", JvmConstants.OBJECT), false);
+                           String.format("(L%s;)V", OBJECT), false);
     }
 
     private void genSubmitToScheduler(String initClass, MethodVisitor mv, String lambdaName,

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/logging/BadSadTests.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/logging/BadSadTests.java
@@ -70,7 +70,6 @@ public class BadSadTests extends BaseTest {
         String output = bMainInstance.runMainAndReadStdOut("run", new String[] {}, new HashMap<>(),
                 Paths.get("src/test/resources/logging/projects-for-badsad-tests/runCmdBadSad")
                         .toAbsolutePath().toString(), true);
-        Assert.assertTrue(output.contains("ballerina: Oh no, something really went wrong."));
 
         String expected = "java.lang.ClassCastException: class io.ballerina.runtime.internal.values.ErrorValue cannot" +
                 " be cast to class io.ballerina.runtime.internal.values.ArrayValue " +

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/ErrorTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/ErrorTest.java
@@ -82,7 +82,6 @@ public class ErrorTest {
             CompileResult compileResult = BCompileUtil.compile("test-src/jvm/runtime-oom-error.bal");
             BRunUtil.runMain(compileResult, new String[]{});
         } catch (Throwable e) {
-            Assert.assertTrue(e.getMessage().contains("ballerina: Oh no, something really went wrong."));
             return;
         }
         Assert.fail("runtime out of memory errors are not handled");


### PR DESCRIPTION
## Purpose
> The runtime errors were logged twice. Once in the scheduler and again during exit. Both are printed in the ballerina-internal.log. 

Fixes #<Issue Number>

## Approach
> This removes the duplication and prints the log only once.

## Samples
> N/A

## Remarks
> https://github.com/ballerina-platform/ballerina-lang/pull/31098

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
