### PR TITLE
Rename HTTP filters desugar class

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/DeclarativeAuthDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/DeclarativeAuthDesugar.java
@@ -65,7 +65,7 @@ import static org.ballerinalang.model.symbols.SymbolOrigin.VIRTUAL;
  *
  * @since 0.974.1
  */
-public class HttpFiltersDesugar {
+public class DeclarativeAuthDesugar {
 
     private final SymbolTable symTable;
     private final SymbolResolver symResolver;
@@ -76,20 +76,20 @@ public class HttpFiltersDesugar {
     private static final String WEBSOCKET_PACKAGE_NAME = "websocket";
     private static final String AUTHENTICATE_RESOURCE = "authenticateResource";
 
-    private static final CompilerContext.Key<HttpFiltersDesugar> HTTP_FILTERS_DESUGAR_KEY =
+    private static final CompilerContext.Key<DeclarativeAuthDesugar> DECLARATIVE_AUTH_DESUGAR_KEY =
             new CompilerContext.Key<>();
 
-    public static HttpFiltersDesugar getInstance(CompilerContext context) {
-        HttpFiltersDesugar desugar = context.get(HTTP_FILTERS_DESUGAR_KEY);
+    public static DeclarativeAuthDesugar getInstance(CompilerContext context) {
+        DeclarativeAuthDesugar desugar = context.get(DECLARATIVE_AUTH_DESUGAR_KEY);
         if (desugar == null) {
-            desugar = new HttpFiltersDesugar(context);
+            desugar = new DeclarativeAuthDesugar(context);
         }
 
         return desugar;
     }
 
-    private HttpFiltersDesugar(CompilerContext context) {
-        context.put(HTTP_FILTERS_DESUGAR_KEY, this);
+    private DeclarativeAuthDesugar(CompilerContext context) {
+        context.put(DECLARATIVE_AUTH_DESUGAR_KEY, this);
         this.symTable = SymbolTable.getInstance(context);
         this.symResolver = SymbolResolver.getInstance(context);
         this.names = Names.getInstance(context);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ServiceDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ServiceDesugar.java
@@ -78,7 +78,7 @@ public class ServiceDesugar {
     private final SymbolTable symTable;
     private final SymbolResolver symResolver;
     private final Names names;
-    private HttpFiltersDesugar httpFiltersDesugar;
+    private DeclarativeAuthDesugar declarativeAuthDesugar;
     private TransactionDesugar transactionDesugar;
     private final Types types;
 
@@ -96,7 +96,7 @@ public class ServiceDesugar {
         this.symTable = SymbolTable.getInstance(context);
         this.symResolver = SymbolResolver.getInstance(context);
         this.names = Names.getInstance(context);
-        this.httpFiltersDesugar = HttpFiltersDesugar.getInstance(context);
+        this.declarativeAuthDesugar = DeclarativeAuthDesugar.getInstance(context);
         this.transactionDesugar = TransactionDesugar.getInstance(context);
         this.types = Types.getInstance(context);
     }
@@ -299,6 +299,6 @@ public class ServiceDesugar {
                     .createBeginParticipantInvocation(functionNode.pos));
             ((BLangBlockFunctionBody) functionNode.body).stmts.add(0, stmt);
         }
-        httpFiltersDesugar.desugarFunction(functionNode, env, expressionTypes);
+        declarativeAuthDesugar.desugarFunction(functionNode, env, expressionTypes);
     }
 }


### PR DESCRIPTION
## Purpose
The $subject was done since this is not longer related to HTTP filters and it does only desugaring a particular method for services which is used for declarative auth design of stdlibs.

Related to: https://github.com/ballerina-platform/ballerina-standard-library/issues/584

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
