### PR TITLE
Fix wrong position being set for retry spec inside BLangNodeTransformer

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
@@ -3958,7 +3958,12 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
 
         if (retryStatementNode.arguments().isPresent()) {
             ParenthesizedArgList arg = retryStatementNode.arguments().get();
-            retrySpec.pos = getPosition(arg);
+            // If type param is present, retry spec spans from type param to args
+            if (retryStatementNode.typeParameter().isPresent()) {
+                retrySpec.pos = getPosition(retryStatementNode.typeParameter().get(), arg);
+            } else {
+                retrySpec.pos = getPosition(arg);
+            }
             for (Node argNode : arg.arguments()) {
                 retrySpec.argExprs.add(createExpression(argNode));
             }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/definition/DefinitionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/definition/DefinitionTest.java
@@ -124,7 +124,8 @@ public class DefinitionTest {
         log.info("Test textDocument/definition for Std Lib Cases");
         return new Object[][]{
                 {"defProject8.json", "project"},
-                {"def_error_config2.json", "project"}
+                {"def_error_config2.json", "project"},
+                {"def_retry_spec_config1.json", "project"}
         };
     }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/references/ReferencesTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/references/ReferencesTest.java
@@ -88,7 +88,8 @@ public class ReferencesTest {
                 {"ref_record_types_config1.json"},
                 // TODO type Err error; user defined types from other modules are not detected due to their parent
                 //  being set to lang.annotations.
-                {"ref_package_alias_config1.json"}
+                {"ref_package_alias_config1.json"},
+                {"ref_retry_spec_config1.json"},
         };
     }
 

--- a/language-server/modules/langserver-core/src/test/resources/definition/expected/project/def_retry_spec_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/definition/expected/project/def_retry_spec_config1.json
@@ -1,0 +1,24 @@
+{
+  "source": {
+    "file": "projectls/transactions.bal"
+  },
+  "position": {
+    "line": 1,
+    "character": 23
+  },
+  "result": [
+    {
+      "range": {
+        "start": {
+          "line": 26,
+          "character": 0
+        },
+        "end": {
+          "line": 39,
+          "character": 1
+        }
+      },
+      "uri": "repo/bala/ballerina/lang.error/1.0.0/any/modules/lang.error/retriable.bal"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/definition/sources/projectls/transactions.bal
+++ b/language-server/modules/langserver-core/src/test/resources/definition/sources/projectls/transactions.bal
@@ -1,0 +1,5 @@
+function demo() returns error? {
+    retry<error:DefaultRetryManager>(3) transaction {
+        check commit;
+    }
+}

--- a/language-server/modules/langserver-core/src/test/resources/references/expected/ref_retry_spec_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/references/expected/ref_retry_spec_config1.json
@@ -1,0 +1,37 @@
+{
+  "source": {
+    "file": "projectls/transactions.bal"
+  },
+  "position": {
+    "line": 3,
+    "character": 22
+  },
+  "result": [
+    {
+      "uri": "projectls/transactions.bal",
+      "range": {
+        "start": {
+          "line": 1,
+          "character": 24
+        },
+        "end": {
+          "line": 1,
+          "character": 43
+        }
+      }
+    },
+    {
+      "uri": "projectls/transactions.bal",
+      "range": {
+        "start": {
+          "line": 3,
+          "character": 16
+        },
+        "end": {
+          "line": 3,
+          "character": 35
+        }
+      }
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/references/sources/projectls/transactions.bal
+++ b/language-server/modules/langserver-core/src/test/resources/references/sources/projectls/transactions.bal
@@ -1,0 +1,7 @@
+function demo() returns error? {
+    var manager = error:DefaultRetryManager;
+    
+    retry<error:DefaultRetryManager>(3) transaction {
+        check commit;
+    }
+}


### PR DESCRIPTION
## Purpose
Position set for retry statement is wrong. Update with correct logic inside BLangNodeTransformer.

Fixes #30866

## Approach
See description

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
