### PR TITLE
Encapsulate type field in BLangNode

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
@@ -225,7 +225,7 @@ public class BallerinaSemanticModel implements SemanticModel {
             return Optional.empty();
         }
 
-        return Optional.ofNullable(typesFactory.getTypeDescriptor(node.type));
+        return Optional.ofNullable(typesFactory.getTypeDescriptor(node.getBType()));
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/EnvironmentResolver.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/EnvironmentResolver.java
@@ -353,7 +353,7 @@ public class EnvironmentResolver extends BLangNodeVisitor {
     @Override
     public void visit(BLangSimpleVariableDef varDefNode) {
         boolean isFuture = varDefNode.getVariable().expr != null
-                && varDefNode.getVariable().expr.type instanceof BFutureType;
+                && varDefNode.getVariable().expr.getBType() instanceof BFutureType;
         if (isFuture) {
             return;
         }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
@@ -1127,7 +1127,7 @@ class SymbolFinder extends BaseVisitor {
 
     @Override
     public void visit(BLangValueType valueType) {
-        this.symbolAtCursor = valueType.type.tsymbol;
+        this.symbolAtCursor = valueType.getBType().tsymbol;
     }
 
     @Override
@@ -1137,7 +1137,7 @@ class SymbolFinder extends BaseVisitor {
 
     @Override
     public void visit(BLangBuiltInRefTypeNode builtInRefType) {
-        this.symbolAtCursor = builtInRefType.type.tsymbol;
+        this.symbolAtCursor = builtInRefType.getBType().tsymbol;
     }
 
     @Override
@@ -1145,7 +1145,7 @@ class SymbolFinder extends BaseVisitor {
         lookupNode(constrainedType.constraint);
 
         if (this.symbolAtCursor == null) {
-            this.symbolAtCursor = ((BLangNode) constrainedType).type.tsymbol;
+            this.symbolAtCursor = ((BLangNode) constrainedType).getBType().tsymbol;
         }
     }
 
@@ -1155,7 +1155,7 @@ class SymbolFinder extends BaseVisitor {
         lookupNode(streamType.error);
 
         if (symbolAtCursor == null) {
-            this.symbolAtCursor = streamType.type.type.tsymbol;
+            this.symbolAtCursor = streamType.type.getBType().tsymbol;
         }
     }
 
@@ -1166,7 +1166,7 @@ class SymbolFinder extends BaseVisitor {
         lookupNode(tableType.tableKeyTypeConstraint);
 
         if (this.symbolAtCursor == null) {
-            this.symbolAtCursor = tableType.type.type.tsymbol;
+            this.symbolAtCursor = tableType.type.getBType().tsymbol;
         }
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSingletonTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSingletonTypeSymbol.java
@@ -44,7 +44,8 @@ public class BallerinaSingletonTypeSymbol extends AbstractTypeSymbol implements 
         super(context, TypeDescKind.SINGLETON, bType);
 
         // Special case handling for `()` since in BLangLiteral, `null` is used to represent nil.
-        if (shape instanceof BLangLiteral && ((BLangLiteral) shape).value == null && shape.type.tag == TypeTags.NIL) {
+        if (shape instanceof BLangLiteral && ((BLangLiteral) shape).value == null
+                && shape.getBType().tag == TypeTags.NIL) {
             this.typeName = "()";
         } else {
             this.typeName = shape.toString();
@@ -56,7 +57,7 @@ public class BallerinaSingletonTypeSymbol extends AbstractTypeSymbol implements 
         if (this.langLibFunctions == null) {
             LangLibrary langLibrary = LangLibrary.getInstance(this.context);
             BFiniteType internalType = (BFiniteType) this.getBType();
-            BType valueType = internalType.getValueSpace().iterator().next().type;
+            BType valueType = internalType.getValueSpace().iterator().next().getBType();
             List<FunctionSymbol> functions = langLibrary.getMethods(valueType.getKind());
             this.langLibFunctions = filterLangLibMethods(functions, valueType);
         }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaUnionTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaUnionTypeSymbol.java
@@ -75,7 +75,7 @@ public class BallerinaUnionTypeSymbol extends AbstractTypeSymbol implements Unio
             } else {
                 for (BLangExpression value : ((BFiniteType) this.getBType()).getValueSpace()) {
                     ModuleID moduleID = getModule().isPresent() ? getModule().get().id() : null;
-                    members.add(new BallerinaSingletonTypeSymbol(this.context, moduleID, value, value.type));
+                    members.add(new BallerinaSingletonTypeSymbol(this.context, moduleID, value, value.getBType()));
                 }
             }
 
@@ -99,7 +99,7 @@ public class BallerinaUnionTypeSymbol extends AbstractTypeSymbol implements Unio
             } else {
                 for (BLangExpression value : ((BFiniteType) this.getBType()).getValueSpace()) {
                     ModuleID moduleID = getModule().isPresent() ? getModule().get().id() : null;
-                    members.add(new BallerinaSingletonTypeSymbol(this.context, moduleID, value, value.type));
+                    members.add(new BallerinaSingletonTypeSymbol(this.context, moduleID, value, value.getBType()));
                 }
             }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
@@ -1638,7 +1638,7 @@ public class BIRPackageSymbolEnter {
                 throw new UnsupportedOperationException("finite type value is not supported for type: " + valueType);
         }
 
-        litExpr.type = valueType;
+        litExpr.setBType(valueType);
 
         finiteType.addValue(litExpr);
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -439,7 +439,7 @@ public class BIRGen extends BLangNodeVisitor {
                 astTypeDefinition.typeNode.getKind() == NodeKind.OBJECT_TYPE) {
             BLangStructureTypeNode typeNode = (BLangStructureTypeNode) astTypeDefinition.typeNode;
             for (BLangType typeRef : typeNode.typeRefs) {
-                typeDef.referencedTypes.add(typeRef.type);
+                typeDef.referencedTypes.add(typeRef.getBType());
             }
         }
 
@@ -483,7 +483,7 @@ public class BIRGen extends BLangNodeVisitor {
     }
 
     private BType getDefinedType(BLangTypeDefinition astTypeDefinition) {
-        BType nodeType = astTypeDefinition.typeNode.type;
+        BType nodeType = astTypeDefinition.typeNode.getBType();
         // Consider: type DE distinct E;
         // For distinct types, the type defined by typeDefStmt (DE) is different from type used to define it (E).
         if (nodeType.tag == TypeTags.ERROR) {
@@ -499,7 +499,7 @@ public class BIRGen extends BLangNodeVisitor {
                 classDefinition.symbol.flags,
                 classDefinition.symbol.isLabel,
                 false,
-                classDefinition.type,
+                                                          classDefinition.getBType(),
                 new ArrayList<>(),
                 classDefinition.symbol.origin.toBIROrigin());
         typeDefs.put(classDefinition.symbol, typeDef);
@@ -509,7 +509,7 @@ public class BIRGen extends BLangNodeVisitor {
         typeDef.setMarkdownDocAttachment(classDefinition.symbol.markdownDocumentation);
 
         for (BLangType typeRef : classDefinition.typeRefs) {
-            typeDef.referencedTypes.add(typeRef.type);
+            typeDef.referencedTypes.add(typeRef.getBType());
         }
 
         populateBIRAnnotAttachments(classDefinition.annAttachments, typeDef.annotAttachments, this.env);
@@ -603,7 +603,7 @@ public class BIRGen extends BLangNodeVisitor {
         BInvokableType type = astFunc.symbol.getType();
 
         boolean isTypeAttachedFunction = astFunc.flagSet.contains(Flag.ATTACHED) &&
-                !typeDefs.containsKey(astFunc.receiver.type.tsymbol);
+                !typeDefs.containsKey(astFunc.receiver.getBType().tsymbol);
 
         Name workerName = names.fromIdNode(astFunc.defaultWorkerName);
 
@@ -621,9 +621,9 @@ public class BIRGen extends BLangNodeVisitor {
         }
         this.currentScope = new BirScope(0, null);
         if (astFunc.receiver != null) {
-            BIRFunctionParameter birVarDcl = new BIRFunctionParameter(astFunc.pos, astFunc.receiver.type,
-                    this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.ARG,
-                    astFunc.receiver.name.value, false);
+            BIRFunctionParameter birVarDcl = new BIRFunctionParameter(astFunc.pos, astFunc.receiver.getBType(),
+                                                                      this.env.nextLocalVarId(names), VarScope.FUNCTION,
+                                                                      VarKind.ARG, astFunc.receiver.name.value, false);
             this.env.symbolVarMap.put(astFunc.receiver.symbol, birVarDcl);
         }
 
@@ -654,8 +654,8 @@ public class BIRGen extends BLangNodeVisitor {
 
         birFunc.argsCount = astFunc.requiredParams.size()
                 + (astFunc.restParam != null ? 1 : 0) + astFunc.paramClosureMap.size();
-        if (astFunc.flagSet.contains(Flag.ATTACHED) && typeDefs.containsKey(astFunc.receiver.type.tsymbol)) {
-            typeDefs.get(astFunc.receiver.type.tsymbol).attachedFuncs.add(birFunc);
+        if (astFunc.flagSet.contains(Flag.ATTACHED) && typeDefs.containsKey(astFunc.receiver.getBType().tsymbol)) {
+            typeDefs.get(astFunc.receiver.getBType().tsymbol).attachedFuncs.add(birFunc);
         } else {
             this.env.enclPkg.functions.add(birFunc);
         }
@@ -893,7 +893,7 @@ public class BIRGen extends BLangNodeVisitor {
             BIRAnnotationValue annotationValue = createAnnotationValue(keyValuePair.valueExpr);
             annotValueEntryMap.put(entryKey, annotationValue);
         }
-        return new BIRNode.BIRAnnotationRecordValue(recordLiteral.type, annotValueEntryMap);
+        return new BIRNode.BIRAnnotationRecordValue(recordLiteral.getBType(), annotValueEntryMap);
     }
 
     private BIRNode.BIRAnnotationRecordValue createAnnotationRecordValue(BLangStatementExpression stmtExpr) {
@@ -907,7 +907,7 @@ public class BIRGen extends BLangNodeVisitor {
                     (String) ((BLangLiteral) ((BLangIndexBasedAccess) assignmentStmt.varRef).indexExpr).value,
                     createAnnotationValue(assignmentStmt.expr));
         }
-        return new BIRNode.BIRAnnotationRecordValue(stmtExpr.type, annotValueEntryMap);
+        return new BIRNode.BIRAnnotationRecordValue(stmtExpr.getBType(), annotValueEntryMap);
     }
 
 
@@ -916,11 +916,11 @@ public class BIRGen extends BLangNodeVisitor {
         for (int exprIndex = 0; exprIndex < arrayLiteral.exprs.size(); exprIndex++) {
             annotValues[exprIndex] = createAnnotationValue(arrayLiteral.exprs.get(exprIndex));
         }
-        return new BIRNode.BIRAnnotationArrayValue(arrayLiteral.type, annotValues);
+        return new BIRNode.BIRAnnotationArrayValue(arrayLiteral.getBType(), annotValues);
     }
 
     private BIRNode.BIRAnnotationLiteralValue createAnnotationLiteralValue(BLangLiteral literalValue) {
-        return new BIRNode.BIRAnnotationLiteralValue(literalValue.type, literalValue.value);
+        return new BIRNode.BIRAnnotationLiteralValue(literalValue.getBType(), literalValue.value);
     }
 
     @Override
@@ -942,8 +942,9 @@ public class BIRGen extends BLangNodeVisitor {
     @Override
     public void visit(BLangLambdaFunction lambdaExpr) {
         //fpload instruction
-        BIRVariableDcl tempVarLambda = new BIRVariableDcl(lambdaExpr.pos, lambdaExpr.type,
-                this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.TEMP, null);
+        BIRVariableDcl tempVarLambda = new BIRVariableDcl(lambdaExpr.pos, lambdaExpr.getBType(),
+                                                          this.env.nextLocalVarId(names), VarScope.FUNCTION,
+                                                          VarKind.TEMP, null);
         this.env.enclFunc.localVars.add(tempVarLambda);
         BIROperand lhsOp = new BIROperand(tempVarLambda);
         Name funcName = getFuncName(lambdaExpr.function.symbol);
@@ -965,9 +966,9 @@ public class BIRGen extends BLangNodeVisitor {
         }
         setScopeAndEmit(
                 new BIRNonTerminator.FPLoad(lambdaExpr.pos, lambdaExpr.function.symbol.pkgID, funcName, lhsOp, params,
-                        getClosureMapOperands(lambdaExpr), lambdaExpr.type,
-                        lambdaExpr.function.symbol.strandName,
-                        lambdaExpr.function.symbol.schedulerPolicy));
+                                            getClosureMapOperands(lambdaExpr), lambdaExpr.getBType(),
+                                            lambdaExpr.function.symbol.strandName,
+                                            lambdaExpr.function.symbol.schedulerPolicy));
         this.env.targetOperand = lhsOp;
     }
 
@@ -1242,7 +1243,7 @@ public class BIRGen extends BLangNodeVisitor {
         addToTrapStack(thenBB);
         String channel = workerReceive.workerIdentifier.value + "->" + env.enclFunc.workerName.value;
 
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(workerReceive.type, this.env.nextLocalVarId(names),
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(workerReceive.getBType(), this.env.nextLocalVarId(names),
                                                        VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand lhsOp = new BIROperand(tempVarDcl);
@@ -1312,7 +1313,7 @@ public class BIRGen extends BLangNodeVisitor {
             i++;
         }
 
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(flushExpr.type, this.env.nextLocalVarId(names),
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(flushExpr.getBType(), this.env.nextLocalVarId(names),
                                                        VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand lhsOp = new BIROperand(tempVarDcl);
@@ -1335,8 +1336,8 @@ public class BIRGen extends BLangNodeVisitor {
             exprList.add(this.env.targetOperand);
         });
 
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(waitExpr.type, this.env.nextLocalVarId(names),
-                VarScope.FUNCTION, VarKind.TEMP);
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(waitExpr.getBType(), this.env.nextLocalVarId(names),
+                                                       VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand lhsOp = new BIROperand(tempVarDcl);
         this.env.targetOperand = lhsOp;
@@ -1349,8 +1350,9 @@ public class BIRGen extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangErrorConstructorExpr errorConstructorExpr) {
-        BIRVariableDcl tempVarError = new BIRVariableDcl(errorConstructorExpr.type,
-                this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.TEMP);
+        BIRVariableDcl tempVarError = new BIRVariableDcl(errorConstructorExpr.getBType(),
+                                                         this.env.nextLocalVarId(names), VarScope.FUNCTION,
+                                                         VarKind.TEMP);
 
         this.env.enclFunc.localVars.add(tempVarError);
         BIROperand lhsOp = new BIROperand(tempVarError);
@@ -1366,8 +1368,9 @@ public class BIRGen extends BLangNodeVisitor {
         errorConstructorExpr.errorDetail.accept(this);
         BIROperand detailsOp = this.env.targetOperand;
 
-        BIRNonTerminator.NewError newError = new BIRNonTerminator.NewError(errorConstructorExpr.pos,
-                errorConstructorExpr.type, lhsOp, messageOp, causeOp, detailsOp);
+        BIRNonTerminator.NewError newError =
+                new BIRNonTerminator.NewError(errorConstructorExpr.pos, errorConstructorExpr.getBType(), lhsOp,
+                                              messageOp, causeOp, detailsOp);
         setScopeAndEmit(newError);
         this.env.targetOperand = lhsOp;
     }
@@ -1390,7 +1393,7 @@ public class BIRGen extends BLangNodeVisitor {
                 args.add(new BIRArgument(ArgumentState.PROVIDED, this.env.targetOperand.variableDcl));
             } else {
                 BIRVariableDcl birVariableDcl =
-                        new BIRVariableDcl(requiredArg.type, new Name("_"), VarScope.FUNCTION, VarKind.ARG);
+                        new BIRVariableDcl(requiredArg.getBType(), new Name("_"), VarScope.FUNCTION, VarKind.ARG);
                 birVariableDcl.ignoreVariable = true;
                 args.add(new BIRArgument(ArgumentState.NOT_PROVIDED, birVariableDcl));
             }
@@ -1409,8 +1412,8 @@ public class BIRGen extends BLangNodeVisitor {
         }
 
         // Create a temporary variable to store the return operation result.
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(invocationExpr.type, this.env.nextLocalVarId(names),
-                VarScope.FUNCTION, VarKind.TEMP);
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(invocationExpr.getBType(), this.env.nextLocalVarId(names),
+                                                       VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand lhsOp = new BIROperand(tempVarDcl);
         this.env.targetOperand = lhsOp;
@@ -1619,28 +1622,28 @@ public class BIRGen extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangIgnoreExpr ignoreExpr) {
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(ignoreExpr.type,
-                this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.TEMP);
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(ignoreExpr.getBType(),
+                                                       this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
     }
 
     @Override
     public void visit(BLangLiteral astLiteralExpr) {
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(astLiteralExpr.type,
-                this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.TEMP);
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(astLiteralExpr.getBType(),
+                                                       this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand toVarRef = new BIROperand(tempVarDcl);
         setScopeAndEmit(new BIRNonTerminator.ConstantLoad(astLiteralExpr.pos,
-                astLiteralExpr.value, astLiteralExpr.type, toVarRef));
+                                                          astLiteralExpr.value, astLiteralExpr.getBType(), toVarRef));
         this.env.targetOperand = toVarRef;
     }
 
     @Override
     public void visit(BLangMapLiteral astMapLiteralExpr) {
-        visitTypedesc(astMapLiteralExpr.pos, astMapLiteralExpr.type, Collections.emptyList());
+        visitTypedesc(astMapLiteralExpr.pos, astMapLiteralExpr.getBType(), Collections.emptyList());
         BIRVariableDcl tempVarDcl =
-                new BIRVariableDcl(astMapLiteralExpr.type, this.env.nextLocalVarId(names),
-                                                       VarScope.FUNCTION, VarKind.TEMP);
+                new BIRVariableDcl(astMapLiteralExpr.getBType(), this.env.nextLocalVarId(names),
+                                   VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand toVarRef = new BIROperand(tempVarDcl);
 
@@ -1651,8 +1654,8 @@ public class BIRGen extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangTypeConversionExpr astTypeConversionExpr) {
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(astTypeConversionExpr.type,
-                this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.TEMP);
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(astTypeConversionExpr.getBType(),
+                                                       this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand toVarRef = new BIROperand(tempVarDcl);
 
@@ -1668,10 +1671,10 @@ public class BIRGen extends BLangNodeVisitor {
     @Override
     public void visit(BLangStructLiteral astStructLiteralExpr) {
         List<BIROperand> varDcls = mapToVarDcls(astStructLiteralExpr.enclMapSymbols);
-        visitTypedesc(astStructLiteralExpr.pos, astStructLiteralExpr.type, varDcls);
+        visitTypedesc(astStructLiteralExpr.pos, astStructLiteralExpr.getBType(), varDcls);
 
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(astStructLiteralExpr.type,
-                this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.TEMP);
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(astStructLiteralExpr.getBType(),
+                                                       this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand toVarRef = new BIROperand(tempVarDcl);
 
@@ -1704,19 +1707,19 @@ public class BIRGen extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangTypeInit connectorInitExpr) {
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(connectorInitExpr.type, this.env.nextLocalVarId(names),
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(connectorInitExpr.getBType(), this.env.nextLocalVarId(names),
                                                        VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand toVarRef = new BIROperand(tempVarDcl);
 
-        BTypeSymbol objectTypeSymbol = getObjectTypeSymbol(connectorInitExpr.type);
+        BTypeSymbol objectTypeSymbol = getObjectTypeSymbol(connectorInitExpr.getBType());
         BIRNonTerminator.NewInstance instruction;
         if (isInSamePackage(objectTypeSymbol, env.enclPkg.packageID)) {
             BIRTypeDefinition def = typeDefs.get(objectTypeSymbol);
             instruction = new BIRNonTerminator.NewInstance(connectorInitExpr.pos, def, toVarRef);
         } else {
-            BType objectType = connectorInitExpr.type.tag != TypeTags.UNION ? connectorInitExpr.type :
-                    ((BUnionType) connectorInitExpr.type).getMemberTypes().stream()
+            BType objectType = connectorInitExpr.getBType().tag != TypeTags.UNION ? connectorInitExpr.getBType() :
+                    ((BUnionType) connectorInitExpr.getBType()).getMemberTypes().stream()
                             .filter(bType -> bType.tag != TypeTags.ERROR)
                             .findFirst()
                             .get();
@@ -1774,8 +1777,8 @@ public class BIRGen extends BLangNodeVisitor {
                             keyRegIndex, rhsOp, astMapAccessExpr.isStoreOnCreation));
             return;
         }
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(astMapAccessExpr.type, this.env.nextLocalVarId(names),
-                VarScope.FUNCTION, VarKind.TEMP);
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(astMapAccessExpr.getBType(), this.env.nextLocalVarId(names),
+                                                       VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand tempVarRef = new BIROperand(tempVarDcl);
 
@@ -1802,8 +1805,8 @@ public class BIRGen extends BLangNodeVisitor {
                     varRefRegIndex, keyRegIndex, rhsOp));
             return;
         }
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(astTableAccessExpr.type, this.env.nextLocalVarId(names),
-                VarScope.FUNCTION, VarKind.TEMP);
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(astTableAccessExpr.getBType(), this.env.nextLocalVarId(names),
+                                                       VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand tempVarRef = new BIROperand(tempVarDcl);
 
@@ -1820,7 +1823,7 @@ public class BIRGen extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangJSONAccessExpr astJSONFieldAccessExpr) {
-        if (astJSONFieldAccessExpr.indexExpr.type.tag == TypeTags.INT) {
+        if (astJSONFieldAccessExpr.indexExpr.getBType().tag == TypeTags.INT) {
             generateArrayAccess(astJSONFieldAccessExpr);
             return;
         }
@@ -1836,7 +1839,7 @@ public class BIRGen extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangStringAccessExpr stringAccessExpr) {
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(stringAccessExpr.type, this.env.nextLocalVarId(names),
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(stringAccessExpr.getBType(), this.env.nextLocalVarId(names),
                                                        VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand tempVarRef = new BIROperand(tempVarDcl);
@@ -1872,7 +1875,8 @@ public class BIRGen extends BLangNodeVisitor {
         isLikeExpr.expr.accept(this);
         BIROperand exprIndex = this.env.targetOperand;
 
-        setScopeAndEmit(new BIRNonTerminator.IsLike(isLikeExpr.pos, isLikeExpr.typeNode.type, toVarRef, exprIndex));
+        setScopeAndEmit(new BIRNonTerminator.IsLike(isLikeExpr.pos, isLikeExpr.typeNode.getBType(), toVarRef,
+                                                    exprIndex));
 
         this.env.targetOperand = toVarRef;
     }
@@ -1888,7 +1892,7 @@ public class BIRGen extends BLangNodeVisitor {
         BIROperand exprIndex = this.env.targetOperand;
 
         setScopeAndEmit(
-                new BIRNonTerminator.TypeTest(typeTestExpr.pos, typeTestExpr.typeNode.type, toVarRef, exprIndex));
+                new BIRNonTerminator.TypeTest(typeTestExpr.pos, typeTestExpr.typeNode.getBType(), toVarRef, exprIndex));
 
         this.env.targetOperand = toVarRef;
     }
@@ -1939,8 +1943,9 @@ public class BIRGen extends BLangNodeVisitor {
                 setScopeAndEmit(new Move(astPackageVarRefExpr.pos, this.env.targetOperand, varRef));
             }
         } else {
-            BIRVariableDcl tempVarDcl = new BIRVariableDcl(astPackageVarRefExpr.type, this.env.nextLocalVarId(names),
-                    VarScope.FUNCTION, VarKind.TEMP);
+            BIRVariableDcl tempVarDcl = new BIRVariableDcl(astPackageVarRefExpr.getBType(),
+                                                           this.env.nextLocalVarId(names), VarScope.FUNCTION,
+                                                           VarKind.TEMP);
             this.env.enclFunc.localVars.add(tempVarDcl);
             BIROperand tempVarRef = new BIROperand(tempVarDcl);
             BIROperand fromVarRef = new BIROperand(getVarRef(astPackageVarRefExpr));
@@ -1971,15 +1976,15 @@ public class BIRGen extends BLangNodeVisitor {
         BIROperand rhsOp2 = this.env.targetOperand;
 
         // Create a temporary variable to store the binary operation result.
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(astBinaryExpr.type,
-                this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.TEMP);
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(astBinaryExpr.getBType(),
+                                                       this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand lhsOp = new BIROperand(tempVarDcl);
         this.env.targetOperand = lhsOp;
 
         // Create binary instruction
         BinaryOp binaryIns = new BinaryOp(astBinaryExpr.pos, getBinaryInstructionKind(astBinaryExpr.opKind),
-                astBinaryExpr.type, lhsOp, rhsOp1, rhsOp2);
+                                          astBinaryExpr.getBType(), lhsOp, rhsOp1, rhsOp2);
         setScopeAndEmit(binaryIns);
     }
 
@@ -1989,8 +1994,8 @@ public class BIRGen extends BLangNodeVisitor {
         BIROperand rhsOp = this.env.targetOperand;
 
         // Create a temporary variable to store the unary operation result.
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(unaryExpr.type,
-                this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.TEMP);
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(unaryExpr.getBType(),
+                                                       this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand lhsOp = new BIROperand(tempVarDcl);
 
@@ -2036,11 +2041,11 @@ public class BIRGen extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangWaitForAllExpr.BLangWaitLiteral waitLiteral) {
-        visitTypedesc(waitLiteral.pos, waitLiteral.type, Collections.emptyList());
+        visitTypedesc(waitLiteral.pos, waitLiteral.getBType(), Collections.emptyList());
         BIRBasicBlock thenBB = new BIRBasicBlock(this.env.nextBBId(names));
         addToTrapStack(thenBB);
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(waitLiteral.type,
-                this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.TEMP);
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(waitLiteral.getBType(),
+                                                       this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand toVarRef = new BIROperand(tempVarDcl);
         setScopeAndEmit(new BIRNonTerminator.NewStructure(waitLiteral.pos, toVarRef, this.env.targetOperand));
@@ -2103,8 +2108,8 @@ public class BIRGen extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangXMLElementLiteral xmlElementLiteral) {
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(xmlElementLiteral.type, this.env.nextLocalVarId(names),
-                VarScope.FUNCTION, VarKind.TEMP);
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(xmlElementLiteral.getBType(), this.env.nextLocalVarId(names),
+                                                       VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand toVarRef = new BIROperand(tempVarDcl);
 
@@ -2124,7 +2129,8 @@ public class BIRGen extends BLangNodeVisitor {
         BIRNonTerminator.NewXMLElement newXMLElement =
                 new BIRNonTerminator.NewXMLElement(xmlElementLiteral.pos, toVarRef, startTagNameIndex,
                                                    defaultNsURIVarRef,
-                                                   Symbols.isFlagOn(xmlElementLiteral.type.flags, Flags.READONLY));
+                                                   Symbols.isFlagOn(xmlElementLiteral.getBType().flags,
+                                                                    Flags.READONLY));
         setScopeAndEmit(newXMLElement);
 
         // Populate the XML by adding namespace declarations, attributes and children
@@ -2147,8 +2153,8 @@ public class BIRGen extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangXMLSequenceLiteral xmlSequenceLiteral) {
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(xmlSequenceLiteral.type, this.env.nextLocalVarId(names),
-                VarScope.FUNCTION, VarKind.TEMP);
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(xmlSequenceLiteral.getBType(), this.env.nextLocalVarId(names),
+                                                       VarScope.FUNCTION, VarKind.TEMP);
 
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand toVarRef = new BIROperand(tempVarDcl);
@@ -2163,8 +2169,8 @@ public class BIRGen extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangXMLTextLiteral xmlTextLiteral) {
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(xmlTextLiteral.type, this.env.nextLocalVarId(names),
-                VarScope.FUNCTION, VarKind.TEMP);
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(xmlTextLiteral.getBType(), this.env.nextLocalVarId(names),
+                                                       VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand toVarRef = new BIROperand(tempVarDcl);
 
@@ -2179,8 +2185,8 @@ public class BIRGen extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangXMLCommentLiteral xmlCommentLiteral) {
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(xmlCommentLiteral.type, this.env.nextLocalVarId(names),
-                VarScope.FUNCTION, VarKind.TEMP);
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(xmlCommentLiteral.getBType(), this.env.nextLocalVarId(names),
+                                                       VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand toVarRef = new BIROperand(tempVarDcl);
 
@@ -2189,15 +2195,16 @@ public class BIRGen extends BLangNodeVisitor {
 
         BIRNonTerminator.NewXMLComment newXMLComment =
                 new BIRNonTerminator.NewXMLComment(xmlCommentLiteral.pos, toVarRef, xmlCommentIndex,
-                                                   Symbols.isFlagOn(xmlCommentLiteral.type.flags, Flags.READONLY));
+                                                   Symbols.isFlagOn(xmlCommentLiteral.getBType().flags,
+                                                                    Flags.READONLY));
         setScopeAndEmit(newXMLComment);
         this.env.targetOperand = toVarRef;
     }
 
     @Override
     public void visit(BLangXMLProcInsLiteral xmlProcInsLiteral) {
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(xmlProcInsLiteral.type, this.env.nextLocalVarId(names),
-                VarScope.FUNCTION, VarKind.TEMP);
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(xmlProcInsLiteral.getBType(), this.env.nextLocalVarId(names),
+                                                       VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand toVarRef = new BIROperand(tempVarDcl);
 
@@ -2209,7 +2216,8 @@ public class BIRGen extends BLangNodeVisitor {
 
         BIRNonTerminator.NewXMLProcIns newXMLProcIns =
                 new BIRNonTerminator.NewXMLProcIns(xmlProcInsLiteral.pos, toVarRef, dataIndex, targetIndex,
-                                                   Symbols.isFlagOn(xmlProcInsLiteral.type.flags, Flags.READONLY));
+                                                   Symbols.isFlagOn(xmlProcInsLiteral.getBType().flags,
+                                                                    Flags.READONLY));
         setScopeAndEmit(newXMLProcIns);
         this.env.targetOperand = toVarRef;
     }
@@ -2269,7 +2277,8 @@ public class BIRGen extends BLangNodeVisitor {
     @Override
     public void visit(BLangTypedescExpr accessExpr) {
         BIRVariableDcl tempVarDcl =
-                new BIRVariableDcl(accessExpr.type, this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.TEMP);
+                new BIRVariableDcl(accessExpr.getBType(), this.env.nextLocalVarId(names), VarScope.FUNCTION,
+                                   VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand toVarRef = new BIROperand(tempVarDcl);
         setScopeAndEmit(new BIRNonTerminator.NewTypeDesc(accessExpr.pos, toVarRef, accessExpr.resolvedType,
@@ -2279,23 +2288,23 @@ public class BIRGen extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangTableConstructorExpr tableConstructorExpr) {
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(tableConstructorExpr.type, this.env.nextLocalVarId(names),
-                VarScope.FUNCTION, VarKind.TEMP);
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(tableConstructorExpr.getBType(), this.env.nextLocalVarId(names),
+                                                       VarScope.FUNCTION, VarKind.TEMP);
 
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand toVarRef = new BIROperand(tempVarDcl);
 
         BLangArrayLiteral keySpecifierLiteral = new BLangArrayLiteral();
         keySpecifierLiteral.pos = tableConstructorExpr.pos;
-        keySpecifierLiteral.type = symTable.stringArrayType;
+        keySpecifierLiteral.setBType(symTable.stringArrayType);
         keySpecifierLiteral.exprs = new ArrayList<>();
-        BTableType type = (BTableType) tableConstructorExpr.type;
+        BTableType type = (BTableType) tableConstructorExpr.getBType();
 
         if (type.fieldNameList != null) {
             type.fieldNameList.forEach(col -> {
                 BLangLiteral colLiteral = new BLangLiteral();
                 colLiteral.pos = tableConstructorExpr.pos;
-                colLiteral.type = symTable.stringType;
+                colLiteral.setBType(symTable.stringType);
                 colLiteral.value = col;
                 keySpecifierLiteral.exprs.add(colLiteral);
             });
@@ -2306,14 +2315,14 @@ public class BIRGen extends BLangNodeVisitor {
 
         BLangArrayLiteral dataLiteral = new BLangArrayLiteral();
         dataLiteral.pos = tableConstructorExpr.pos;
-        dataLiteral.type = new BArrayType(((BTableType) tableConstructorExpr.type).constraint);
+        dataLiteral.setBType(new BArrayType(((BTableType) tableConstructorExpr.getBType()).constraint));
         dataLiteral.exprs = new ArrayList<>(tableConstructorExpr.recordLiteralList);
         dataLiteral.accept(this);
         BIROperand dataOp = this.env.targetOperand;
 
         setScopeAndEmit(
-                new BIRNonTerminator.NewTable(tableConstructorExpr.pos, tableConstructorExpr.type, toVarRef, keyColOp,
-                        dataOp));
+                new BIRNonTerminator.NewTable(tableConstructorExpr.pos, tableConstructorExpr.getBType(), toVarRef,
+                                              keyColOp, dataOp));
 
         this.env.targetOperand = toVarRef;
     }
@@ -2514,24 +2523,24 @@ public class BIRGen extends BLangNodeVisitor {
 
     private void generateListConstructorExpr(BLangListConstructorExpr listConstructorExpr) {
         // Emit create array instruction
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(listConstructorExpr.type, this.env.nextLocalVarId(names),
-                VarScope.FUNCTION, VarKind.TEMP);
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(listConstructorExpr.getBType(), this.env.nextLocalVarId(names),
+                                                       VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand toVarRef = new BIROperand(tempVarDcl);
 
         long size = -1L;
         List<BLangExpression> exprs = listConstructorExpr.exprs;
-        if (listConstructorExpr.type.tag == TypeTags.ARRAY &&
-                ((BArrayType) listConstructorExpr.type).state != BArrayState.OPEN) {
-            size = ((BArrayType) listConstructorExpr.type).size;
-        } else if (listConstructorExpr.type.tag == TypeTags.TUPLE) {
+        if (listConstructorExpr.getBType().tag == TypeTags.ARRAY &&
+                ((BArrayType) listConstructorExpr.getBType()).state != BArrayState.OPEN) {
+            size = ((BArrayType) listConstructorExpr.getBType()).size;
+        } else if (listConstructorExpr.getBType().tag == TypeTags.TUPLE) {
             size = exprs.size();
         }
 
         BLangLiteral literal = new BLangLiteral();
         literal.pos = listConstructorExpr.pos;
         literal.value = size;
-        literal.type = symTable.intType;
+        literal.setBType(symTable.intType);
         literal.accept(this);
         BIROperand sizeOp = this.env.targetOperand;
 
@@ -2543,8 +2552,8 @@ public class BIRGen extends BLangNodeVisitor {
         }
 
         setScopeAndEmit(
-                new BIRNonTerminator.NewArray(listConstructorExpr.pos, listConstructorExpr.type, toVarRef, sizeOp,
-                        valueOperands));
+                new BIRNonTerminator.NewArray(listConstructorExpr.pos, listConstructorExpr.getBType(), toVarRef, sizeOp,
+                                              valueOperands));
         this.env.targetOperand = toVarRef;
     }
 
@@ -2565,8 +2574,8 @@ public class BIRGen extends BLangNodeVisitor {
                     varRefRegIndex, keyRegIndex, rhsOp));
             return;
         }
-        BIRVariableDcl tempVarDcl = new BIRVariableDcl(astArrayAccessExpr.type, this.env.nextLocalVarId(names),
-                VarScope.FUNCTION, VarKind.TEMP);
+        BIRVariableDcl tempVarDcl = new BIRVariableDcl(astArrayAccessExpr.getBType(), this.env.nextLocalVarId(names),
+                                                       VarScope.FUNCTION, VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarDcl);
         BIROperand tempVarRef = new BIROperand(tempVarDcl);
 
@@ -2582,7 +2591,7 @@ public class BIRGen extends BLangNodeVisitor {
         boolean variableStore = this.varAssignment;
         this.varAssignment = false;
         InstructionKind insKind;
-        BType astAccessExprExprType = astIndexBasedAccessExpr.expr.type;
+        BType astAccessExprExprType = astIndexBasedAccessExpr.expr.getBType();
         if (variableStore) {
             BIROperand rhsOp = this.env.targetOperand;
 
@@ -2607,8 +2616,9 @@ public class BIRGen extends BLangNodeVisitor {
                     new BIRNonTerminator.FieldAccess(astIndexBasedAccessExpr.pos, insKind, varRefRegIndex, keyRegIndex,
                             rhsOp, astIndexBasedAccessExpr.isStoreOnCreation));
         } else {
-            BIRVariableDcl tempVarDcl = new BIRVariableDcl(astIndexBasedAccessExpr.type, this.env.nextLocalVarId(names),
-                    VarScope.FUNCTION, VarKind.TEMP);
+            BIRVariableDcl tempVarDcl = new BIRVariableDcl(astIndexBasedAccessExpr.getBType(),
+                                                           this.env.nextLocalVarId(names),
+                                                           VarScope.FUNCTION, VarKind.TEMP);
             this.env.enclFunc.localVars.add(tempVarDcl);
             BIROperand tempVarRef = new BIROperand(tempVarDcl);
 
@@ -2658,9 +2668,9 @@ public class BIRGen extends BLangNodeVisitor {
         prefixLiteral.value = value;
 
         if (value == null) {
-            prefixLiteral.type = symTable.nilType;
+            prefixLiteral.setBType(symTable.nilType);
         } else {
-            prefixLiteral.type = symTable.stringType;
+            prefixLiteral.setBType(symTable.stringType);
         }
 
         prefixLiteral.accept(this);
@@ -2719,7 +2729,7 @@ public class BIRGen extends BLangNodeVisitor {
         // Add namespaces decelerations visible to this element.
         xmlElementLiteral.namespacesInScope.forEach((name, symbol) -> {
             BLangXMLQName nsQName = new BLangXMLQName(name.getValue(), XMLConstants.XMLNS_ATTRIBUTE);
-            nsQName.type = symTable.stringType;
+            nsQName.setBType(symTable.stringType);
             nsQName.accept(this);
             BIROperand nsQNameIndex = this.env.targetOperand;
             BIROperand nsURIIndex = generateNamespaceRef(symbol, xmlElementLiteral.pos);
@@ -2764,7 +2774,7 @@ public class BIRGen extends BLangNodeVisitor {
             setScopeAndEmit(new BIRNonTerminator.XMLAccess(xmlAccessExpr.pos, InstructionKind.XML_LOAD_ALL, tempVarRef,
                     varRefRegIndex));
             return;
-        } else if (xmlAccessExpr.indexExpr.type.tag == TypeTags.STRING) {
+        } else if (xmlAccessExpr.indexExpr.getBType().tag == TypeTags.STRING) {
             insKind = InstructionKind.XML_LOAD;
         } else {
             insKind = InstructionKind.XML_SEQ_LOAD;
@@ -2777,7 +2787,8 @@ public class BIRGen extends BLangNodeVisitor {
     private void generateFPVarRef(BLangExpression fpVarRef, BInvokableSymbol funcSymbol) {
         // fpload instruction
         BIRVariableDcl tempVarLambda =
-                new BIRVariableDcl(fpVarRef.type, this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.TEMP);
+                new BIRVariableDcl(fpVarRef.getBType(), this.env.nextLocalVarId(names), VarScope.FUNCTION,
+                                   VarKind.TEMP);
         this.env.enclFunc.localVars.add(tempVarLambda);
         BIROperand lhsOp = new BIROperand(tempVarLambda);
         Name funcName = getFuncName(funcSymbol);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTypeGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTypeGen.java
@@ -2123,7 +2123,7 @@ public class JvmTypeGen {
 
         for (BLangExpression valueTypePair : finiteType.getValueSpace()) {
             Object value = ((BLangLiteral) valueTypePair).value;
-            BType valueType = valueTypePair.type;
+            BType valueType = valueTypePair.getBType();
             mv.visitInsn(DUP);
 
             JvmCodeGenUtil.loadConstantValue(valueType, value, mv, stringConstantsGen);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JMethodResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JMethodResolver.java
@@ -449,7 +449,7 @@ class JMethodResolver {
                     Set<BLangExpression> valueSpace = ((BFiniteType) bType).getValueSpace();
                     for (Iterator<BLangExpression> iterator = valueSpace.iterator(); iterator.hasNext(); ) {
                         BLangExpression value = iterator.next();
-                        if (!isValidParamBType(jType, value.type, isLastParam, restParamExist)) {
+                        if (!isValidParamBType(jType, value.getBType(), isLastParam, restParamExist)) {
                             return false;
                         }
                     }
@@ -606,7 +606,7 @@ class JMethodResolver {
 
                     Set<BLangExpression> valueSpace = ((BFiniteType) bType).getValueSpace();
                     for (BLangExpression value : valueSpace) {
-                        if (isValidReturnBType(jType, value.type, jMethodRequest, visitedSet)) {
+                        if (isValidReturnBType(jType, value.getBType(), jMethodRequest, visitedSet)) {
                             return true;
                         }
                     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRTypeWriter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRTypeWriter.java
@@ -177,8 +177,8 @@ public class BIRTypeWriter implements TypeVisitor {
                 throw new AssertionError(
                         "Type serialization is not implemented for finite type with value: " + valueLiteral.getKind());
             }
-            writeTypeCpIndex(valueLiteral.type);
-            writeValue(((BLangLiteral) valueLiteral).value, valueLiteral.type);
+            writeTypeCpIndex(valueLiteral.getBType());
+            writeValue(((BLangLiteral) valueLiteral).value, valueLiteral.getBType());
         }
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ASTBuilderUtil.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ASTBuilderUtil.java
@@ -151,7 +151,7 @@ public class ASTBuilderUtil {
     }
 
     static void defineVariable(BLangSimpleVariable variable, BSymbol targetSymbol, Names names) {
-        variable.symbol = new BVarSymbol(0, names.fromIdNode(variable.name), targetSymbol.pkgID, variable.type,
+        variable.symbol = new BVarSymbol(0, names.fromIdNode(variable.name), targetSymbol.pkgID, variable.getBType(),
                                          targetSymbol, variable.pos, VIRTUAL);
         targetSymbol.scope.define(variable.symbol.name, variable.symbol);
     }
@@ -162,14 +162,14 @@ public class ASTBuilderUtil {
 
     static BLangExpression wrapToConversionExpr(BType sourceType, BLangExpression exprToWrap,
                                                 SymbolTable symTable, Types types) {
-        if (types.isSameType(sourceType, exprToWrap.type) || !isValueType(exprToWrap.type)) {
+        if (types.isSameType(sourceType, exprToWrap.getBType()) || !isValueType(exprToWrap.getBType())) {
             // No conversion needed.
             return exprToWrap;
         }
         BLangTypeConversionExpr castExpr = (BLangTypeConversionExpr) TreeBuilder.createTypeConversionNode();
         castExpr.expr = exprToWrap;
-        castExpr.type = symTable.anyType;
-        castExpr.targetType = castExpr.type;
+        castExpr.setBType(symTable.anyType);
+        castExpr.targetType = castExpr.getBType();
         return castExpr;
     }
 
@@ -195,14 +195,14 @@ public class ASTBuilderUtil {
                 return null;
             }
         };
-        bLangType.type = type;
+        bLangType.setBType(type);
         return bLangType;
     }
 
     static BLangUserDefinedType createUserDefineTypeNode(String typeName, BType type, Location pos) {
         BLangUserDefinedType userDefinedType = (BLangUserDefinedType) TreeBuilder.createUserDefinedTypeNode();
         userDefinedType.typeName = (BLangIdentifier) createIdentifier(typeName);
-        userDefinedType.type = type;
+        userDefinedType.setBType(type);
         userDefinedType.pos = pos;
         userDefinedType.pkgAlias = (BLangIdentifier) createIdentifier("");
         return userDefinedType;
@@ -383,7 +383,7 @@ public class ASTBuilderUtil {
         final BLangUnaryExpr unaryExpr = (BLangUnaryExpr) TreeBuilder.createUnaryExpressionNode();
         unaryExpr.pos = pos;
         unaryExpr.expr = expr;
-        unaryExpr.type = type;
+        unaryExpr.setBType(type);
         unaryExpr.operator = kind;
         unaryExpr.opSymbol = symbol;
         return unaryExpr;
@@ -392,7 +392,7 @@ public class ASTBuilderUtil {
     static BLangTypedescExpr createTypedescExpr(Location pos, BType type, BType resolvedType) {
         final BLangTypedescExpr typeofExpr = (BLangTypedescExpr) TreeBuilder.createTypeAccessNode();
         typeofExpr.pos = pos;
-        typeofExpr.type = type;
+        typeofExpr.setBType(type);
         typeofExpr.resolvedType = resolvedType;
         return typeofExpr;
     }
@@ -404,19 +404,19 @@ public class ASTBuilderUtil {
         arrayAccess.pos = location;
         arrayAccess.expr = createVariableRef(location, varSymbol);
         arrayAccess.indexExpr = indexExpr;
-        arrayAccess.type = type;
+        arrayAccess.setBType(type);
         return arrayAccess;
     }
 
     static BLangExpression generateConversionExpr(BLangExpression varRef, BType target, SymbolResolver symResolver) {
-        if (varRef.type.tag == target.tag || varRef.type.tag > TypeTags.BOOLEAN) {
+        if (varRef.getBType().tag == target.tag || varRef.getBType().tag > TypeTags.BOOLEAN) {
             return varRef;
         }
         // Box value using cast expression.
         final BLangTypeConversionExpr conversion = (BLangTypeConversionExpr) TreeBuilder.createTypeConversionNode();
         conversion.pos = varRef.pos;
         conversion.expr = varRef;
-        conversion.type = target;
+        conversion.setBType(target);
         conversion.targetType = target;
         return conversion;
     }
@@ -455,7 +455,7 @@ public class ASTBuilderUtil {
                 .addAll(generateArgExprs(pos, restArgs, Lists.of(invokableSymbol.restParam), symResolver));
 
         invokeLambda.symbol = invokableSymbol;
-        invokeLambda.type = ((BInvokableType) invokableSymbol.type).retType;
+        invokeLambda.setBType(((BInvokableType) invokableSymbol.type).retType);
         return invokeLambda;
     }
 
@@ -487,7 +487,7 @@ public class ASTBuilderUtil {
                 .addAll(generateArgExprs(pos, restArgs, Lists.of(invokableSymbol.restParam), symResolver));
 
         invokeLambda.symbol = invokableSymbol;
-        invokeLambda.type = ((BInvokableType) invokableSymbol.type).retType;
+        invokeLambda.setBType(((BInvokableType) invokableSymbol.type).retType);
         return invokeLambda;
     }
 
@@ -502,7 +502,7 @@ public class ASTBuilderUtil {
         varRef.pos = pos;
         varRef.variableName = createIdentifier(pos, varSymbol.name.value);
         varRef.symbol = varSymbol;
-        varRef.type = varSymbol.type;
+        varRef.setBType(varSymbol.type);
         return varRef;
     }
 
@@ -514,7 +514,7 @@ public class ASTBuilderUtil {
         final BLangSimpleVariable varNode = (BLangSimpleVariable) TreeBuilder.createSimpleVariableNode();
         varNode.pos = pos;
         varNode.name = createIdentifier(pos, name);
-        varNode.type = type;
+        varNode.setBType(type);
         varNode.expr = expr;
         varNode.symbol = varSymbol;
         return varNode;
@@ -560,7 +560,7 @@ public class ASTBuilderUtil {
         final BLangCheckedExpr checkExpr = (BLangCheckedExpr) TreeBuilder.createCheckExpressionNode();
         checkExpr.pos = pos;
         checkExpr.expr = expr;
-        checkExpr.type = returnType;
+        checkExpr.setBType(returnType);
         checkExpr.equivalentErrorTypeList = new ArrayList<>();
         return checkExpr;
     }
@@ -570,7 +570,7 @@ public class ASTBuilderUtil {
         final BLangCheckPanickedExpr checkExpr = (BLangCheckPanickedExpr) TreeBuilder.createCheckPanicExpressionNode();
         checkExpr.pos = location;
         checkExpr.expr = expr;
-        checkExpr.type = returnType;
+        checkExpr.setBType(returnType);
         checkExpr.equivalentErrorTypeList = new ArrayList<>();
         return checkExpr;
     }
@@ -585,7 +585,7 @@ public class ASTBuilderUtil {
         binaryExpr.pos = pos;
         binaryExpr.lhsExpr = lhsExpr;
         binaryExpr.rhsExpr = rhsExpr;
-        binaryExpr.type = type;
+        binaryExpr.setBType(type);
         binaryExpr.opKind = opKind;
         binaryExpr.opSymbol = symbol;
         return binaryExpr;
@@ -601,7 +601,7 @@ public class ASTBuilderUtil {
         assignableExpr.pos = pos;
         assignableExpr.lhsExpr = lhsExpr;
         assignableExpr.targetType = targetType;
-        assignableExpr.type = type;
+        assignableExpr.setBType(type);
         assignableExpr.opSymbol = new BOperatorSymbol(names.fromString(assignableExpr.opKind.value()),
                                                       null, targetType, null, opSymPos, VIRTUAL);
         return assignableExpr;
@@ -613,7 +613,7 @@ public class ASTBuilderUtil {
         isLikeExpr.pos = pos;
         isLikeExpr.expr = expr;
         isLikeExpr.typeNode = typeNode;
-        isLikeExpr.type = retType;
+        isLikeExpr.setBType(retType);
         return isLikeExpr;
     }
 
@@ -621,7 +621,7 @@ public class ASTBuilderUtil {
         final BLangLiteral literal = (BLangLiteral) TreeBuilder.createLiteralExpression();
         literal.pos = pos;
         literal.value = value;
-        literal.type = type;
+        literal.setBType(type);
         return literal;
     }
 
@@ -629,14 +629,14 @@ public class ASTBuilderUtil {
         final BLangConstRef constRef = (BLangConstRef) TreeBuilder.createConstLiteralNode();
         constRef.pos = pos;
         constRef.value = value;
-        constRef.type = type;
+        constRef.setBType(type);
         return constRef;
     }
 
     static BLangRecordLiteral createEmptyRecordLiteral(Location pos, BType type) {
         final BLangRecordLiteral recordLiteralNode = (BLangRecordLiteral) TreeBuilder.createRecordLiteralNode();
         recordLiteralNode.pos = pos;
-        recordLiteralNode.type = type;
+        recordLiteralNode.setBType(type);
         return recordLiteralNode;
     }
 
@@ -654,7 +654,7 @@ public class ASTBuilderUtil {
         final BLangListConstructorExpr.BLangArrayLiteral arrayLiteralNode =
                 (BLangListConstructorExpr.BLangArrayLiteral) TreeBuilder.createArrayLiteralExpressionNode();
         arrayLiteralNode.pos = location;
-        arrayLiteralNode.type = type;
+        arrayLiteralNode.setBType(type);
         arrayLiteralNode.exprs = new ArrayList<>();
         return arrayLiteralNode;
     }
@@ -671,7 +671,7 @@ public class ASTBuilderUtil {
         final BLangListConstructorExpr listConstructorExpr =
                 (BLangListConstructorExpr) TreeBuilder.createListConstructorExpressionNode();
         listConstructorExpr.pos = pos;
-        listConstructorExpr.type = type;
+        listConstructorExpr.setBType(type);
         listConstructorExpr.exprs = new ArrayList<>();
         listConstructorExpr.internal = true;
         return listConstructorExpr;
@@ -680,12 +680,12 @@ public class ASTBuilderUtil {
     static BLangTypeInit createEmptyTypeInit(Location pos, BType type) {
         BLangTypeInit objectInitNode = (BLangTypeInit) TreeBuilder.createInitNode();
         objectInitNode.pos = pos;
-        objectInitNode.type = type;
+        objectInitNode.setBType(type);
         objectInitNode.internal = true;
 
         BLangInvocation invocationNode = (BLangInvocation) TreeBuilder.createInvocationNode();
         invocationNode.symbol = ((BObjectTypeSymbol) type.tsymbol).generatedInitializerFunc.symbol;
-        invocationNode.type = type;
+        invocationNode.setBType(type);
         invocationNode.pos = pos;
         invocationNode.internal = true;
 
@@ -763,7 +763,7 @@ public class ASTBuilderUtil {
         BLangValueType typeNode = (BLangValueType) TreeBuilder.createValueTypeNode();
         typeNode.pos = pos;
         typeNode.typeKind = TypeKind.UNION;
-        typeNode.type = symTable.errorOrNilType;
+        typeNode.setBType(symTable.errorOrNilType);
         return createInitFunction(pos, name, suffix, typeNode);
     }
 
@@ -788,7 +788,7 @@ public class ASTBuilderUtil {
                 .createServiceConstructorNode();
         constExpr.pos = service.pos;
         constExpr.serviceNode = service;
-        constExpr.type = service.symbol.type;
+        constExpr.setBType(service.symbol.type);
         return constExpr;
     }
 
@@ -797,7 +797,7 @@ public class ASTBuilderUtil {
         receiver.pos = pos;
         IdentifierNode identifier = createIdentifier(pos, Names.SELF.getValue());
         receiver.setName(identifier);
-        receiver.type = type;
+        receiver.setBType(type);
         return receiver;
     }
 
@@ -924,7 +924,7 @@ public class ASTBuilderUtil {
         xmlTextLiteral.concatExpr = concatExpr;
         xmlTextLiteral.pos = pos;
         xmlTextLiteral.parent = parent;
-        xmlTextLiteral.type = type;
+        xmlTextLiteral.setBType(type);
         return xmlTextLiteral;
     }
 
@@ -942,7 +942,7 @@ public class ASTBuilderUtil {
         ternaryExpr.elseExpr = elseExpr;
         ternaryExpr.thenExpr = thenExpr;
         ternaryExpr.expr = expr;
-        ternaryExpr.type = type;
+        ternaryExpr.setBType(type);
         return ternaryExpr;
     }
 
@@ -951,13 +951,13 @@ public class ASTBuilderUtil {
         BLangIndexBasedAccess memberAccessExpr = (BLangIndexBasedAccess) TreeBuilder.createIndexBasedAccessNode();
         memberAccessExpr.expr = expr;
         memberAccessExpr.indexExpr = indexExpr;
-        memberAccessExpr.type = type;
+        memberAccessExpr.setBType(type);
         return memberAccessExpr;
     }
 
     public static BLangExpression createIgnoreExprNode(BType type) {
         BLangExpression ignoreExpr = (BLangExpression) TreeBuilder.createIgnoreExprNode();
-        ignoreExpr.type = type;
+        ignoreExpr.setBType(type);
         return ignoreExpr;
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/AnnotationDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/AnnotationDesugar.java
@@ -172,7 +172,7 @@ public class AnnotationDesugar {
             SymbolEnv classEnv = SymbolEnv.createClassEnv(classDefinition, initFunction.symbol.scope, env);
             BLangLambdaFunction lambdaFunction = defineAnnotations(classDefinition, pkgNode, classEnv, pkgID, owner);
             if (lambdaFunction != null) {
-                BType type = classDefinition.type;
+                BType type = classDefinition.getBType();
                 if (Symbols.isFlagOn(type.flags, Flags.OBJECT_CTOR)) {
                     // Add the lambda/invocation in a temporary block.
                     BLangBlockStmt target = (BLangBlockStmt) TreeBuilder.createBlockNode();
@@ -279,9 +279,9 @@ public class AnnotationDesugar {
                 String identifier = function.attachedFunction ? function.symbol.name.value : function.name.value;
 
                 int index;
-                if (function.attachedFunction && ((function.receiver.type.flags & Flags.SERVICE) == Flags.SERVICE)) {
+                if (function.attachedFunction && Symbols.isFlagOn(function.receiver.getBType().flags, Flags.SERVICE)) {
                     addLambdaToGlobalAnnotMap(identifier, lambdaFunction, target);
-                    index = calculateIndex(initFnBody.stmts, function.receiver.type.tsymbol);
+                    index = calculateIndex(initFnBody.stmts, function.receiver.getBType().tsymbol);
                 } else {
                     addInvocationToGlobalAnnotMap(identifier, lambdaFunction, target);
                     index = initFnBody.stmts.size();
@@ -495,7 +495,7 @@ public class AnnotationDesugar {
         BSymbol annTypeSymbol = symResolver.lookupSymbolInMainSpace(pkgEnv, names.fromString(DEFAULTABLE_REC));
         if (annTypeSymbol instanceof BStructureTypeSymbol) {
             bStructSymbol = (BStructureTypeSymbol) annTypeSymbol;
-            literalNode.type = bStructSymbol.type;
+            literalNode.setBType(bStructSymbol.type);
         }
 
         //Add Root Descriptor
@@ -505,24 +505,24 @@ public class AnnotationDesugar {
 
         BLangLiteral keyLiteral = (BLangLiteral) TreeBuilder.createLiteralExpression();
         keyLiteral.value = ARG_NAMES;
-        keyLiteral.type = symTable.stringType;
+        keyLiteral.setBType(symTable.stringType);
 
         BLangListConstructorExpr.BLangArrayLiteral valueLiteral = (BLangListConstructorExpr.BLangArrayLiteral)
                 TreeBuilder.createArrayLiteralExpressionNode();
-        valueLiteral.type = new BArrayType(symTable.stringType);
+        valueLiteral.setBType(new BArrayType(symTable.stringType));
         valueLiteral.pos = pos;
 
         for (BVarSymbol varSymbol : mainFunc.symbol.getParameters()) {
             BLangLiteral str = (BLangLiteral) TreeBuilder.createLiteralExpression();
             str.value = varSymbol.name.value;
-            str.type = symTable.stringType;
+            str.setBType(symTable.stringType);
             valueLiteral.exprs.add(str);
         }
 
         if (mainFunc.symbol.restParam != null) {
             BLangLiteral str = (BLangLiteral) TreeBuilder.createLiteralExpression();
             str.value = mainFunc.symbol.restParam.name.value;
-            str.type = symTable.stringType;
+            str.setBType(symTable.stringType);
             valueLiteral.exprs.add(str);
         }
         descriptorKeyValue.key = new BLangRecordLiteral.BLangRecordKey(keyLiteral);
@@ -539,7 +539,7 @@ public class AnnotationDesugar {
     private BLangFunction defineFunction(Location pos, PackageID pkgID, BSymbol owner) {
         String funcName = ANNOT_FUNC + UNDERSCORE + annotFuncCount++;
         BLangFunction function = ASTBuilderUtil.createFunction(pos, funcName);
-        function.type = new BInvokableType(Collections.emptyList(), symTable.mapType, null);
+        function.setBType(new BInvokableType(Collections.emptyList(), symTable.mapType, null));
 
         BLangBuiltInRefTypeNode anyMapType = (BLangBuiltInRefTypeNode) TreeBuilder.createBuiltInReferenceTypeNode();
         anyMapType.typeKind = TypeKind.MAP;
@@ -554,17 +554,17 @@ public class AnnotationDesugar {
         constrainedType.pos = pos;
 
         function.returnTypeNode = anyMapType;
-        function.returnTypeNode.type = symTable.mapType;
+        function.returnTypeNode.setBType(symTable.mapType);
 
         function.body = ASTBuilderUtil.createBlockFunctionBody(pos, new ArrayList<>());
 
         BInvokableSymbol functionSymbol = new BInvokableSymbol(SymTag.INVOKABLE, Flags.asMask(function.flagSet),
-                                                               new Name(funcName), pkgID, function.type, owner,
+                                                               new Name(funcName), pkgID, function.getBType(), owner,
                                                                function.name.pos, VIRTUAL);
         functionSymbol.bodyExist = true;
         functionSymbol.kind = SymbolKind.FUNCTION;
 
-        functionSymbol.retType = function.returnTypeNode.type;
+        functionSymbol.retType = function.returnTypeNode.getBType();
         functionSymbol.scope = new Scope(functionSymbol);
         function.symbol = functionSymbol;
         return function;
@@ -671,16 +671,16 @@ public class AnnotationDesugar {
     private BInvokableSymbol createInvokableSymbol(BLangFunction function, PackageID pkgID, BSymbol owner) {
         BInvokableSymbol functionSymbol = Symbols.createFunctionSymbol(Flags.asMask(function.flagSet),
                                                                        new Name(function.name.value),
-                                                                       pkgID, function.type, owner, true, function.pos,
-                                                                       VIRTUAL);
-        functionSymbol.retType = function.returnTypeNode.type;
+                                                                       pkgID, function.getBType(), owner, true,
+                                                                       function.pos, VIRTUAL);
+        functionSymbol.retType = function.returnTypeNode.getBType();
         functionSymbol.params = function.requiredParams.stream()
                 .map(param -> param.symbol)
                 .collect(Collectors.toList());
         functionSymbol.scope = new Scope(functionSymbol);
         functionSymbol.restParam = function.restParam != null ? function.restParam.symbol : null;
         functionSymbol.type = new BInvokableType(Collections.emptyList(),
-                function.restParam != null ? function.restParam.type : null,
+                function.restParam != null ? function.restParam.getBType() : null,
                 new BMapType(TypeTags.MAP, symTable.anyType, null),
                 null);
         function.symbol = functionSymbol;
@@ -771,7 +771,7 @@ public class AnnotationDesugar {
         indexAccessNode.indexExpr = ASTBuilderUtil.createLiteral(targetPos, symTable.stringType,
                 StringEscapeUtils.unescapeJava(identifier));
         indexAccessNode.expr = ASTBuilderUtil.createVariableRef(targetPos, mapVar.symbol);
-        indexAccessNode.type = ((BMapType) mapVar.type).constraint;
+        indexAccessNode.setBType(((BMapType) mapVar.getBType()).constraint);
         assignmentStmt.varRef = indexAccessNode;
     }
 
@@ -793,7 +793,7 @@ public class AnnotationDesugar {
 
     private BLangInvocation getInvocation(BLangLambdaFunction lambdaFunction) {
         BLangInvocation funcInvocation = (BLangInvocation) TreeBuilder.createInvocationNode();
-        funcInvocation.type = symTable.mapType;
+        funcInvocation.setBType(symTable.mapType);
         funcInvocation.expr = null;
         BInvokableSymbol lambdaSymbol = lambdaFunction.function.symbol;
         funcInvocation.symbol = lambdaSymbol;
@@ -825,7 +825,7 @@ public class AnnotationDesugar {
             NodeKind kind = expr.getKind();
 
             if ((kind == NodeKind.TYPE_INIT_EXPR || kind == NodeKind.OBJECT_CTOR_EXPRESSION) &&
-                    expr.type.tsymbol == symbol) {
+                    expr.getBType().tsymbol == symbol) {
                 return i;
             }
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureDesugar.java
@@ -278,7 +278,7 @@ public class ClosureDesugar extends BLangNodeVisitor {
             if (funcNode.mapSymbol == null) {
                 createFunctionMap(funcNode, funcEnv);
             }
-            addToFunctionMap(funcNode, funcEnv, position, receiver.symbol, receiver.type);
+            addToFunctionMap(funcNode, funcEnv, position, receiver.symbol, receiver.getBType());
         }
 
         funcNode.body = rewrite(funcNode.body, funcEnv);
@@ -369,11 +369,11 @@ public class ClosureDesugar extends BLangNodeVisitor {
         BLangSimpleVarRef.BLangLocalVarRef localVarRef = new BLangSimpleVarRef.BLangLocalVarRef(paramSymbol);
         // Added the flag so it will not be desugared again.
         localVarRef.closureDesugared = true;
-        localVarRef.type = type;
+        localVarRef.setBType(type);
         BLangIndexBasedAccess accessExpr = ASTBuilderUtil.createIndexBasesAccessExpr(funcNode.pos, type,
                 funcNode.mapSymbol, ASTBuilderUtil.createLiteral(funcNode.pos, symTable.stringType,
                         paramSymbol.name.value));
-        accessExpr.type = ((BMapType) funcNode.mapSymbol.type).constraint;
+        accessExpr.setBType(((BMapType) funcNode.mapSymbol.type).constraint);
         accessExpr.isLValue = true;
         BLangAssignment stmt = desugar.rewrite(ASTBuilderUtil.createAssignmentStmt(funcNode.pos, accessExpr,
                 localVarRef), symbolEnv);
@@ -443,11 +443,11 @@ public class ClosureDesugar extends BLangNodeVisitor {
 
         // Add the variable to the created map.
         BLangIndexBasedAccess accessExpr =
-                ASTBuilderUtil.createIndexBasesAccessExpr(varDefNode.pos, varDefNode.type, mapSymbol,
+                ASTBuilderUtil.createIndexBasesAccessExpr(varDefNode.pos, varDefNode.getBType(), mapSymbol,
                                                           ASTBuilderUtil
                                                                   .createLiteral(varDefNode.pos, symTable.stringType,
                                                                                  varDefNode.var.name.value));
-        accessExpr.type = ((BMapType) mapSymbol.type).constraint;
+        accessExpr.setBType(((BMapType) mapSymbol.type).constraint);
         accessExpr.isLValue = true;
         // Written to: 'map["x"] = 8'.
         return ASTBuilderUtil.createAssignmentStmt(varDefNode.pos, accessExpr, varDefNode.var.expr);
@@ -595,10 +595,10 @@ public class ClosureDesugar extends BLangNodeVisitor {
     public void visit(BLangAssignment assignNode) {
         assignNode.varRef = rewriteExpr(assignNode.varRef);
         if (assignNode.expr.impConversionExpr != null) {
-            types.setImplicitCastExpr(assignNode.expr.impConversionExpr, assignNode.expr.impConversionExpr.type,
-                    assignNode.varRef.type);
+            types.setImplicitCastExpr(assignNode.expr.impConversionExpr, assignNode.expr.impConversionExpr.getBType(),
+                                      assignNode.varRef.getBType());
         } else {
-            types.setImplicitCastExpr(assignNode.expr, assignNode.expr.type, assignNode.varRef.type);
+            types.setImplicitCastExpr(assignNode.expr, assignNode.expr.getBType(), assignNode.varRef.getBType());
         }
         assignNode.expr = rewriteExpr(assignNode.expr);
         result = assignNode;
@@ -1170,8 +1170,9 @@ public class ClosureDesugar extends BLangNodeVisitor {
         // Create the index based access expression.
         BLangLiteral indexExpr = ASTBuilderUtil.createLiteral(varRefExpr.pos, symTable.stringType,
                 varRefExpr.varSymbol.name.value);
-        BLangIndexBasedAccess accessExpr = ASTBuilderUtil.createIndexBasesAccessExpr(varRefExpr.pos, varRefExpr.type,
-                mapSymbol, indexExpr);
+        BLangIndexBasedAccess accessExpr = ASTBuilderUtil.createIndexBasesAccessExpr(varRefExpr.pos,
+                                                                                     varRefExpr.getBType(),
+                                                                                     mapSymbol, indexExpr);
         result = rewriteExpr(accessExpr);
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ConstantPropagation.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ConstantPropagation.java
@@ -1113,11 +1113,11 @@ public class ConstantPropagation extends BLangNodeVisitor {
                             TreeBuilder.createTypeConversionNode();
                     implConversionExpr.expr = constRef;
                     implConversionExpr.pos = varRefExpr.impConversionExpr.pos;
-                    implConversionExpr.type = varRefExpr.impConversionExpr.type;
+                    implConversionExpr.setBType(varRefExpr.impConversionExpr.getBType());
                     implConversionExpr.targetType = varRefExpr.impConversionExpr.targetType;
                     constRef.impConversionExpr = implConversionExpr;
                 } else {
-                    types.setImplicitCastExpr(constRef, constRef.type, varRefExpr.type);
+                    types.setImplicitCastExpr(constRef, constRef.getBType(), varRefExpr.getBType());
                 }
                 result = constRef;
                 return;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/DeclarativeAuthDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/DeclarativeAuthDesugar.java
@@ -177,7 +177,7 @@ public class DeclarativeAuthDesugar {
         statements.add(0, result);
 
         BVarSymbol resultSymbol = new BVarSymbol(0, names.fromIdNode(result.var.name), env.enclPkg.packageID,
-                                                 result.var.type, resourceNode.symbol, pos, VIRTUAL);
+                                                 result.var.getBType(), resourceNode.symbol, pos, VIRTUAL);
         resourceNode.symbol.scope.define(resultSymbol.name, resultSymbol);
         result.var.symbol = resultSymbol;
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -548,7 +548,7 @@ public class Desugar extends BLangNodeVisitor {
         addRestParamsToGeneratedInitFunction(initFunction, generatedInitFunc, generatedInitializerFunc);
 
         generatedInitFunc.returnTypeNode = initFunction.returnTypeNode;
-        generatedInitializerFunc.symbol.retType = generatedInitFunc.returnTypeNode.type;
+        generatedInitializerFunc.symbol.retType = generatedInitFunc.returnTypeNode.getBType();
 
         ((BInvokableType) generatedInitFunc.symbol.type).paramTypes = initializerFunc.type.paramTypes;
         ((BInvokableType) generatedInitFunc.symbol.type).retType = initializerFunc.type.retType;
@@ -567,13 +567,14 @@ public class Desugar extends BLangNodeVisitor {
         for (BLangSimpleVariable requiredParameter : initFunction.requiredParams) {
             BLangSimpleVariable var =
                     ASTBuilderUtil.createVariable(initFunction.pos,
-                                                  requiredParameter.name.getValue(), requiredParameter.type,
+                                                  requiredParameter.name.getValue(), requiredParameter.getBType(),
                                                   createRequiredParamExpr(requiredParameter.expr),
                                                   new BVarSymbol(Flags.asMask(requiredParameter.flagSet),
                                                                  names.fromString(requiredParameter.name.getValue()),
                                                                  requiredParameter.symbol.pkgID,
-                                                                 requiredParameter.type, requiredParameter.symbol.owner,
-                                                                 initFunction.pos, VIRTUAL));
+                                                                 requiredParameter.getBType(),
+                                                                 requiredParameter.symbol.owner, initFunction.pos,
+                                                                 VIRTUAL));
             generatedInitFunc.requiredParams.add(var);
             generatedInitializerFunc.symbol.params.add(var.symbol);
         }
@@ -607,9 +608,9 @@ public class Desugar extends BLangNodeVisitor {
         BLangSimpleVariable restParam = initFunction.restParam;
         generatedInitFunc.restParam =
                 ASTBuilderUtil.createVariable(initFunction.pos,
-                                              restParam.name.getValue(), restParam.type, null,
+                                              restParam.name.getValue(), restParam.getBType(), null,
                                               new BVarSymbol(0, names.fromString(restParam.name.getValue()),
-                                                             restParam.symbol.pkgID, restParam.type,
+                                                             restParam.symbol.pkgID, restParam.getBType(),
                                                              restParam.symbol.owner, restParam.pos, VIRTUAL));
         generatedInitializerFunc.symbol.restParam = generatedInitFunc.restParam.symbol;
     }
@@ -671,7 +672,7 @@ public class Desugar extends BLangNodeVisitor {
         pkgAlias.setValue(pkgNode.packageID.name.value);
         userDefInitInvocation.pkgAlias = pkgAlias;
 
-        userDefInitInvocation.type = userDefInit.returnTypeNode.type;
+        userDefInitInvocation.setBType(userDefInit.returnTypeNode.getBType());
         userDefInitInvocation.requiredArgs = Collections.emptyList();
 
         BLangReturn returnStmt = (BLangReturn) TreeBuilder.createReturnNode();
@@ -687,8 +688,9 @@ public class Desugar extends BLangNodeVisitor {
      * @param env           Symbol environment
      */
     private void createInvokableSymbol(BLangFunction bLangFunction, SymbolEnv env) {
-        BType returnType = bLangFunction.returnTypeNode.type == null ?
-                symResolver.resolveTypeNode(bLangFunction.returnTypeNode, env) : bLangFunction.returnTypeNode.type;
+        BType returnType = bLangFunction.returnTypeNode.getBType() == null ?
+                symResolver.resolveTypeNode(bLangFunction.returnTypeNode, env) :
+                bLangFunction.returnTypeNode.getBType();
         BInvokableType invokableType = new BInvokableType(new ArrayList<>(), getRestType(bLangFunction),
                                                           returnType, null);
         BInvokableSymbol functionSymbol = Symbols.createFunctionSymbol(Flags.asMask(bLangFunction.flagSet),
@@ -764,7 +766,8 @@ public class Desugar extends BLangNodeVisitor {
                                                                                pkgNode.initFunction.symbol.scope, env));
                 BLangInvocation frozenConstValExpr =
                         createLangLibInvocationNode(
-                                "cloneReadOnly", constant.expr, new ArrayList<>(), constant.expr.type, constant.pos);
+                                "cloneReadOnly", constant.expr, new ArrayList<>(), constant.expr.getBType(),
+                                constant.pos);
                 BLangAssignment constInit =
                         ASTBuilderUtil.createAssignmentStmt(constant.pos, constVarRef, frozenConstValExpr);
                 initFnBody.stmts.add(constInit);
@@ -857,7 +860,7 @@ public class Desugar extends BLangNodeVisitor {
         // Then make it an expression-statement, since we need it to be an expression
         BLangSimpleVarRef resultVarRef = ASTBuilderUtil.createVariableRef(configurableVar.pos, configurableVar.symbol);
         BLangStatementExpression stmtExpr = createStatementExpression(ifElse, resultVarRef);
-        stmtExpr.type = configurableVar.type;
+        stmtExpr.setBType(configurableVar.getBType());
 
         return rewriteExpr(stmtExpr);
     }
@@ -930,9 +933,9 @@ public class Desugar extends BLangNodeVisitor {
 
                     // Module init should fail if listener is a error value.
                     if (Symbols.isFlagOn(globalVarFlags, Flags.LISTENER)
-                            && types.containsErrorType(globalVar.expr.type)) {
+                            && types.containsErrorType(globalVar.expr.getBType())) {
                         globalVar.expr = ASTBuilderUtil.createCheckExpr(globalVar.expr.pos, globalVar.expr,
-                                globalVar.type);
+                                                                        globalVar.getBType());
                     }
 
                     addToInitFunction(simpleGlobalVar, initFnBody);
@@ -1081,8 +1084,8 @@ public class Desugar extends BLangNodeVisitor {
             BLangRestArgsExpression bLangRestArgsExpression = new BLangRestArgsExpression();
             bLangRestArgsExpression.expr = restVarRef;
             bLangRestArgsExpression.pos = generatedInitFunction.pos;
-            bLangRestArgsExpression.type = generatedInitFunction.restParam.type;
-            bLangRestArgsExpression.expectedType = bLangRestArgsExpression.type;
+            bLangRestArgsExpression.setBType(generatedInitFunction.restParam.getBType());
+            bLangRestArgsExpression.expectedType = bLangRestArgsExpression.getBType();
             invocation.restArgs.add(bLangRestArgsExpression);
         }
         invocation.exprSymbol =
@@ -1135,8 +1138,8 @@ public class Desugar extends BLangNodeVisitor {
 
         if (recordTypeNode.isAnonymous && recordTypeNode.isLocal) {
             BLangUserDefinedType userDefinedType = desugarLocalAnonRecordTypeNode(recordTypeNode);
-            TypeDefBuilderHelper.addTypeDefinition(recordTypeNode.type, recordTypeNode.type.tsymbol, recordTypeNode,
-                                                   env);
+            TypeDefBuilderHelper.addTypeDefinition(recordTypeNode.getBType(), recordTypeNode.getBType().tsymbol,
+                                                   recordTypeNode, env);
             recordTypeNode.desugared = true;
             result = userDefinedType;
             return;
@@ -1146,7 +1149,7 @@ public class Desugar extends BLangNodeVisitor {
     }
 
     private BLangUserDefinedType desugarLocalAnonRecordTypeNode(BLangRecordTypeNode recordTypeNode) {
-        return ASTBuilderUtil.createUserDefineTypeNode(recordTypeNode.symbol.name.value, recordTypeNode.type,
+        return ASTBuilderUtil.createUserDefineTypeNode(recordTypeNode.symbol.name.value, recordTypeNode.getBType(),
                                                        recordTypeNode.pos);
     }
 
@@ -1223,7 +1226,7 @@ public class Desugar extends BLangNodeVisitor {
         // We need to create type-defs for local anonymous types with type param.
         if (!isDistinctError && errorType.isLocal && errorType.isAnonymous && hasTypeParam) {
             BLangUserDefinedType userDefinedType = desugarLocalAnonRecordTypeNode(errorType);
-            TypeDefBuilderHelper.addTypeDefinition(errorType.type, errorType.type.tsymbol, errorType, env);
+            TypeDefBuilderHelper.addTypeDefinition(errorType.getBType(), errorType.getBType().tsymbol, errorType, env);
             errorType.desugared = true;
             result = userDefinedType;
             return;
@@ -1232,8 +1235,9 @@ public class Desugar extends BLangNodeVisitor {
     }
 
     private BLangUserDefinedType desugarLocalAnonRecordTypeNode(BLangErrorType errorTypeNode) {
-        return ASTBuilderUtil.createUserDefineTypeNode(errorTypeNode.type.tsymbol.name.value, errorTypeNode.type,
-                errorTypeNode.pos);
+        return ASTBuilderUtil.createUserDefineTypeNode(errorTypeNode.getBType().tsymbol.name.value,
+                                                       errorTypeNode.getBType(),
+                                                       errorTypeNode.pos);
     }
 
     @Override
@@ -1317,8 +1321,8 @@ public class Desugar extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangInferredTypedescDefaultNode inferTypedescExpr) {
-        BType constraintType = ((BTypedescType) inferTypedescExpr.type).constraint;
-        result = ASTBuilderUtil.createTypedescExpr(inferTypedescExpr.pos, inferTypedescExpr.type, constraintType);
+        BType constraintType = ((BTypedescType) inferTypedescExpr.getBType()).constraint;
+        result = ASTBuilderUtil.createTypedescExpr(inferTypedescExpr.pos, inferTypedescExpr.getBType(), constraintType);
     }
 
     @Override
@@ -1341,7 +1345,8 @@ public class Desugar extends BLangNodeVisitor {
             annAttachmentNode.expr = rewrite(annAttachmentNode.expr, env);
             for (AttachPoint point : annAttachmentNode.annotationSymbol.points) {
                 if (!point.source) {
-                    annAttachmentNode.expr = visitCloneReadonly(annAttachmentNode.expr, annAttachmentNode.expr.type);
+                    annAttachmentNode.expr = visitCloneReadonly(annAttachmentNode.expr,
+                                                                annAttachmentNode.expr.getBType());
                     break;
                 }
             }
@@ -1366,7 +1371,7 @@ public class Desugar extends BLangNodeVisitor {
         // Return if this assignment is not a safe assignment
         BLangExpression bLangExpression = rewriteExpr(varNode.expr);
         if (bLangExpression != null) {
-            bLangExpression = addConversionExprIfRequired(bLangExpression, varNode.type);
+            bLangExpression = addConversionExprIfRequired(bLangExpression, varNode.getBType());
         }
         varNode.expr = bLangExpression;
 
@@ -1392,11 +1397,11 @@ public class Desugar extends BLangNodeVisitor {
             }
         }
         BLangSimpleVariableDef tempVarDef = createVarDef(String.format("$let_var_%d_$", letCount++),
-                expr.type, expr, expr.pos);
+                                                         expr.getBType(), expr, expr.pos);
         BLangSimpleVarRef tempVarRef = ASTBuilderUtil.createVariableRef(expr.pos, tempVarDef.var.symbol);
         blockStmt.addStatement(tempVarDef);
         BLangStatementExpression stmtExpr = ASTBuilderUtil.createStatementExpression(blockStmt, tempVarRef);
-        stmtExpr.type = expr.type;
+        stmtExpr.setBType(expr.getBType());
         result = rewrite(stmtExpr, env);
         this.env = prevEnv;
     }
@@ -1464,7 +1469,7 @@ public class Desugar extends BLangNodeVisitor {
         // Create error destruct block stmt.
         final BLangBlockStmt blockStmt = ASTBuilderUtil.createBlockStmt(varNode.pos);
 
-        BType errorType = varNode.type == null ? symTable.errorType : varNode.type;
+        BType errorType = varNode.getBType() == null ? symTable.errorType : varNode.getBType();
         // Create a simple var for the error 'error x = ($error$)'.
         String name = anonModelHelper.getNextErrorVarKey(env.enclPkg.packageID);
         BVarSymbol errorVarSymbol = new BVarSymbol(0, names.fromString(name), this.env.scope.owner.pkgID,
@@ -1505,12 +1510,12 @@ public class Desugar extends BLangNodeVisitor {
     private void createRestFieldVarDefStmts(BLangTupleVariable parentTupleVariable, BLangBlockStmt blockStmt,
                                             BVarSymbol tupleVarSymbol) {
         final BLangSimpleVariable arrayVar = (BLangSimpleVariable) parentTupleVariable.restVariable;
-        boolean isTupleType = parentTupleVariable.type.tag == TypeTags.TUPLE;
+        boolean isTupleType = parentTupleVariable.getBType().tag == TypeTags.TUPLE;
         Location pos = blockStmt.pos;
         if (arrayVar != null) {
             // T[] t = [];
             BLangArrayLiteral arrayExpr = createArrayLiteralExprNode();
-            arrayExpr.type = arrayVar.type;
+            arrayExpr.setBType(arrayVar.getBType());
             arrayVar.expr = arrayExpr;
             BLangSimpleVariableDef arrayVarDef = ASTBuilderUtil.createVariableDefStmt(arrayVar.pos, blockStmt);
             arrayVarDef.var = arrayVar;
@@ -1523,7 +1528,7 @@ public class Desugar extends BLangNodeVisitor {
 
             BLangLiteral startIndexLiteral = (BLangLiteral) TreeBuilder.createLiteralExpression();
             startIndexLiteral.value = (long) parentTupleVariable.memberVariables.size();
-            startIndexLiteral.type = symTable.intType;
+            startIndexLiteral.setBType(symTable.intType);
             BLangInvocation lengthInvocation = createLengthInvocation(pos, tupleExpr);
             BLangInvocation intRangeInvocation = replaceWithIntRange(pos, startIndexLiteral,
                     getModifiedIntRangeEndExpr(lengthInvocation));
@@ -1536,8 +1541,8 @@ public class Desugar extends BLangNodeVisitor {
             final BLangSimpleVariable foreachVariable = ASTBuilderUtil.createVariable(pos,
                     "$foreach$i", foreach.varType);
             foreachVariable.symbol = new BVarSymbol(0, names.fromIdNode(foreachVariable.name),
-                    this.env.scope.owner.pkgID, foreachVariable.type,
-                    this.env.scope.owner, pos, VIRTUAL);
+                                                    this.env.scope.owner.pkgID, foreachVariable.getBType(),
+                                                    this.env.scope.owner, pos, VIRTUAL);
             BLangSimpleVarRef foreachVarRef = ASTBuilderUtil.createVariableRef(pos, foreachVariable.symbol);
             foreach.variableDefinitionNode = ASTBuilderUtil.createVariableDef(pos, foreachVariable);
             foreach.isDeclaredWithVar = true;
@@ -1546,7 +1551,7 @@ public class Desugar extends BLangNodeVisitor {
             // t[t.length()] = <T> tupleLiteral[$foreach$i];
             BLangIndexBasedAccess indexAccessExpr = ASTBuilderUtil.createIndexAccessExpr(arrayVarRef,
                     createLengthInvocation(pos, arrayVarRef));
-            indexAccessExpr.type = ((BArrayType) parentTupleVariable.restVariable.type).eType;
+            indexAccessExpr.setBType(((BArrayType) parentTupleVariable.restVariable.getBType()).eType);
             createAssignmentStmt(indexAccessExpr, foreachBody, foreachVarRef, tupleVarSymbol, null);
             foreach.body = foreachBody;
             blockStmt.addStatement(foreach);
@@ -1688,7 +1693,7 @@ public class Desugar extends BLangNodeVisitor {
 
             if (variable.getKind() == NodeKind.ERROR_VARIABLE) {
                 BLangIndexBasedAccess arrayAccessExpr = ASTBuilderUtil.createIndexBasesAccessExpr(
-                        parentRecordVariable.pos, variable.type, recordVarSymbol, indexExpr);
+                        parentRecordVariable.pos, variable.getBType(), recordVarSymbol, indexExpr);
                 if (parentIndexAccessExpr != null) {
                     arrayAccessExpr.expr = parentIndexAccessExpr;
                 }
@@ -1702,17 +1707,17 @@ public class Desugar extends BLangNodeVisitor {
             // map<any> restParam = $map$_0.filter($lambdaArg$_0);
 
             Location pos = parentBlockStmt.pos;
-            BMapType restParamType = (BMapType) ((BLangVariable) parentRecordVariable.restParam).type;
+            BMapType restParamType = (BMapType) ((BLangVariable) parentRecordVariable.restParam).getBType();
             BLangSimpleVarRef variableReference;
 
             if (parentIndexAccessExpr != null) {
                 BLangSimpleVariable mapVariable =
                         ASTBuilderUtil.createVariable(pos, "$map$_1",
-                                                      parentIndexAccessExpr.type, null,
+                                                      parentIndexAccessExpr.getBType(), null,
                                                       new BVarSymbol(0, names.fromString("$map$_1"),
                                                                      this.env.scope.owner.pkgID,
-                                                                     parentIndexAccessExpr.type, this.env.scope.owner,
-                                                                     pos, VIRTUAL));
+                                                                     parentIndexAccessExpr.getBType(),
+                                                                     this.env.scope.owner, pos, VIRTUAL));
                 mapVariable.expr = parentIndexAccessExpr;
                 BLangSimpleVariableDef variableDef = ASTBuilderUtil.createVariableDefStmt(pos, parentBlockStmt);
                 variableDef.var = mapVariable;
@@ -1737,7 +1742,7 @@ public class Desugar extends BLangNodeVisitor {
             BLangSimpleVariableDef restParamVarDef = ASTBuilderUtil.createVariableDefStmt(pos,
                     parentBlockStmt);
             restParamVarDef.var = restParam;
-            restParamVarDef.var.type = restParamType;
+            restParamVarDef.var.setBType(restParamType);
             restParam.expr = varRef;
         }
     }
@@ -1751,13 +1756,13 @@ public class Desugar extends BLangNodeVisitor {
 
         BVarSymbol convertedErrorVarSymbol;
         if (parentIndexBasedAccess != null) {
-            BType prevType = parentIndexBasedAccess.type;
-            parentIndexBasedAccess.type = symTable.anyType;
+            BType prevType = parentIndexBasedAccess.getBType();
+            parentIndexBasedAccess.setBType(symTable.anyType);
             BLangSimpleVariableDef errorVarDef = createVarDef(GENERATED_ERROR_VAR + UNDERSCORE + errorCount++,
                     symTable.errorType,
                     addConversionExprIfRequired(parentIndexBasedAccess, symTable.errorType),
                     parentErrorVariable.pos);
-            parentIndexBasedAccess.type = prevType;
+            parentIndexBasedAccess.setBType(prevType);
             parentBlockStmt.addStatement(errorVarDef);
             convertedErrorVarSymbol = errorVarDef.var.symbol;
         } else {
@@ -1765,8 +1770,10 @@ public class Desugar extends BLangNodeVisitor {
         }
 
         if (parentErrorVariable.message != null) {
-            parentErrorVariable.message.expr = generateErrorMessageBuiltinFunction(parentErrorVariable.message.pos,
-                    parentErrorVariable.message.type, convertedErrorVarSymbol, null);
+            parentErrorVariable.message.expr =
+                    generateErrorMessageBuiltinFunction(parentErrorVariable.message.pos,
+                                                        parentErrorVariable.message.getBType(), convertedErrorVarSymbol,
+                                                        null);
 
             if (names.fromIdNode(parentErrorVariable.message.name) == Names.IGNORE) {
                 parentErrorVariable.message = null;
@@ -1778,8 +1785,10 @@ public class Desugar extends BLangNodeVisitor {
         }
 
         if (parentErrorVariable.cause != null) {
-            parentErrorVariable.cause.expr = generateErrorCauseLanglibFunction(parentErrorVariable.cause.pos,
-                    parentErrorVariable.cause.type, convertedErrorVarSymbol, null);
+            parentErrorVariable.cause.expr =
+                    generateErrorCauseLanglibFunction(parentErrorVariable.cause.pos,
+                                                      parentErrorVariable.cause.getBType(), convertedErrorVarSymbol,
+                                                      null);
             BLangVariable errorCause = parentErrorVariable.cause;
 
             if (errorCause.getKind() == NodeKind.ERROR_VARIABLE) {
@@ -1808,8 +1817,9 @@ public class Desugar extends BLangNodeVisitor {
                 convertedErrorVarSymbol, null);
 
         BLangSimpleVariableDef detailTempVarDef = createVarDef("$error$detail",
-                parentErrorVariable.detailExpr.type, parentErrorVariable.detailExpr, parentErrorVariable.pos);
-        detailTempVarDef.type = parentErrorVariable.detailExpr.type;
+                                                               parentErrorVariable.detailExpr.getBType(),
+                                                               parentErrorVariable.detailExpr, parentErrorVariable.pos);
+        detailTempVarDef.setBType(parentErrorVariable.detailExpr.getBType());
         parentBlockStmt.addStatement(detailTempVarDef);
 
         this.env.scope.define(names.fromIdNode(detailTempVarDef.var.name), detailTempVarDef.var.symbol);
@@ -1830,12 +1840,13 @@ public class Desugar extends BLangNodeVisitor {
                     .collect(Collectors.toList());
 
             BLangSimpleVariable filteredDetail = generateRestFilter(detailVarRef, parentErrorVariable.pos, keysToRemove,
-                    parentErrorVariable.restDetail.type, parentBlockStmt);
+                                                                    parentErrorVariable.restDetail.getBType(),
+                                                                    parentBlockStmt);
 
             BLangSimpleVariableDef variableDefStmt = ASTBuilderUtil.createVariableDefStmt(pos, parentBlockStmt);
             variableDefStmt.var = ASTBuilderUtil.createVariable(pos,
                     parentErrorVariable.restDetail.name.value,
-                    filteredDetail.type,
+                                                                filteredDetail.getBType(),
                     ASTBuilderUtil.createVariableRef(pos, filteredDetail.symbol),
                     parentErrorVariable.restDetail.symbol);
         }
@@ -1875,7 +1886,7 @@ public class Desugar extends BLangNodeVisitor {
         BLangSimpleVariable mapVariable = defVariable(pos, targetType, parentBlockStmt, typeCastExpr, name);
 
         BLangInvocation entriesInvocation = generateMapEntriesInvocation(
-                ASTBuilderUtil.createVariableRef(pos, mapVariable.symbol), typeCastExpr.type);
+                ASTBuilderUtil.createVariableRef(pos, mapVariable.symbol), typeCastExpr.getBType());
         String entriesVarName = "$map$ref$entries$" + UNDERSCORE + restNum;
         BType entriesType = new BMapType(TypeTags.MAP,
                 new BTupleType(Arrays.asList(symTable.stringType, ((BMapType) targetType).constraint)), null);
@@ -1910,19 +1921,19 @@ public class Desugar extends BLangNodeVisitor {
         invocationNode.expr = expr;
         invocationNode.symbol = symResolver.lookupLangLibMethod(type, names.fromString("entries"));
         invocationNode.requiredArgs = Lists.of(expr);
-        invocationNode.type = invocationNode.symbol.type.getReturnType();
+        invocationNode.setBType(invocationNode.symbol.type.getReturnType());
         invocationNode.langLibInvocation = true;
         return invocationNode;
     }
 
     private BLangInvocation generateMapMapInvocation(Location pos, BLangSimpleVariable filteredVar,
                                                      BLangLambdaFunction backToMapLambda) {
-        BLangInvocation invocationNode = createInvocationNode("map", new ArrayList<>(), filteredVar.type);
+        BLangInvocation invocationNode = createInvocationNode("map", new ArrayList<>(), filteredVar.getBType());
 
         invocationNode.expr = ASTBuilderUtil.createVariableRef(pos, filteredVar.symbol);
-        invocationNode.symbol = symResolver.lookupLangLibMethod(filteredVar.type, names.fromString("map"));
+        invocationNode.symbol = symResolver.lookupLangLibMethod(filteredVar.getBType(), names.fromString("map"));
         invocationNode.requiredArgs = Lists.of(ASTBuilderUtil.createVariableRef(pos, filteredVar.symbol));
-        invocationNode.type = invocationNode.symbol.type.getReturnType();
+        invocationNode.setBType(invocationNode.symbol.type.getReturnType());
         invocationNode.requiredArgs.add(backToMapLambda);
         return invocationNode;
     }
@@ -1941,7 +1952,7 @@ public class Desugar extends BLangNodeVisitor {
         function.requiredParams.add(inputParameter);
 
         BLangUserDefinedType constraintTypeNode = (BLangUserDefinedType) TreeBuilder.createUserDefinedTypeNode();
-        constraintTypeNode.type = constraint;
+        constraintTypeNode.setBType(constraint);
         function.returnTypeNode = constraintTypeNode;
 
         BLangBlockFunctionBody functionBlock = ASTBuilderUtil.createBlockFunctionBody(pos, new ArrayList<>());
@@ -1951,7 +1962,7 @@ public class Desugar extends BLangNodeVisitor {
                 ASTBuilderUtil.createIndexBasesAccessExpr(pos, constraint, keyValSymbol,
                                                           ASTBuilderUtil
                                                                   .createLiteral(pos, symTable.intType, (long) 1));
-        BLangSimpleVariableDef tupSecondElem = createVarDef("$val", indexBasesAccessExpr.type,
+        BLangSimpleVariableDef tupSecondElem = createVarDef("$val", indexBasesAccessExpr.getBType(),
                                                             indexBasesAccessExpr, pos);
         functionBlock.addStatement(tupSecondElem);
 
@@ -1962,10 +1973,10 @@ public class Desugar extends BLangNodeVisitor {
         // Create function symbol before visiting desugar phase for the function
         BInvokableSymbol functionSymbol = Symbols.createFunctionSymbol(Flags.asMask(function.flagSet),
                                                                        new Name(function.name.value),
-                                                                       env.enclPkg.packageID, function.type,
+                                                                       env.enclPkg.packageID, function.getBType(),
                                                                        env.enclEnv.enclVarSym, true, function.pos,
                                                                        VIRTUAL);
-        functionSymbol.retType = function.returnTypeNode.type;
+        functionSymbol.retType = function.returnTypeNode.getBType();
         functionSymbol.params = function.requiredParams.stream()
                 .map(param -> param.symbol)
                 .collect(Collectors.toList());
@@ -1982,12 +1993,14 @@ public class Desugar extends BLangNodeVisitor {
     private BLangInvocation generateMapFilterInvocation(Location pos,
                                                         BLangSimpleVariable entriesInvocationVar,
                                                         BLangLambdaFunction filter) {
-        BLangInvocation invocationNode = createInvocationNode("filter", new ArrayList<>(), entriesInvocationVar.type);
+        BLangInvocation invocationNode = createInvocationNode("filter", new ArrayList<>(),
+                                                              entriesInvocationVar.getBType());
 
         invocationNode.expr = ASTBuilderUtil.createVariableRef(pos, entriesInvocationVar.symbol);
-        invocationNode.symbol = symResolver.lookupLangLibMethod(entriesInvocationVar.type, names.fromString("filter"));
+        invocationNode.symbol = symResolver.lookupLangLibMethod(entriesInvocationVar.getBType(),
+                                                                names.fromString("filter"));
         invocationNode.requiredArgs = Lists.of(ASTBuilderUtil.createVariableRef(pos, entriesInvocationVar.symbol));
-        invocationNode.type = invocationNode.symbol.type.getReturnType();
+        invocationNode.setBType(invocationNode.symbol.type.getReturnType());
         invocationNode.requiredArgs.add(filter);
 
         return invocationNode;
@@ -2001,7 +2014,7 @@ public class Desugar extends BLangNodeVisitor {
                                                                                      env.enclPkg.packageID, varType,
                                                                                      env.scope.owner, pos, VIRTUAL));
         BLangSimpleVariableDef constructedMap = ASTBuilderUtil.createVariableDef(pos, detailMap);
-        constructedMap.type = varType;
+        constructedMap.setBType(varType);
         parentBlockStmt.addStatement(constructedMap);
         env.scope.define(varName, detailMap.symbol);
         return detailMap;
@@ -2015,7 +2028,8 @@ public class Desugar extends BLangNodeVisitor {
 
         if (valueBindingPatternKind == NodeKind.VARIABLE) {
             BLangSimpleVariableDef errorDetailVar = createVarDef(((BLangSimpleVariable) valueBindingPattern).name.value,
-                    valueBindingPattern.type, detailEntryVar, valueBindingPattern.pos);
+                                                                 valueBindingPattern.getBType(), detailEntryVar,
+                                                                 valueBindingPattern.pos);
             parentBlockStmt.addStatement(errorDetailVar);
             return;
         }
@@ -2032,7 +2046,7 @@ public class Desugar extends BLangNodeVisitor {
     private BLangExpression createErrorDetailVar(BLangErrorVariable.BLangErrorDetailEntry detailEntry,
                                                  BVarSymbol tempDetailVarSymbol) {
         BLangExpression detailEntryVar = createIndexBasedAccessExpr(
-                detailEntry.valueBindingPattern.type,
+                detailEntry.valueBindingPattern.getBType(),
                 detailEntry.valueBindingPattern.pos,
                 createStringLiteral(detailEntry.key.pos, detailEntry.key.value),
                 tempDetailVarSymbol, null);
@@ -2048,7 +2062,7 @@ public class Desugar extends BLangNodeVisitor {
         BLangExpression currentExpr;
         for (BLangExpression expr : exprs) {
             currentExpr = expr;
-            if (expr.type.tag != TypeTags.STRING && expr.type.tag != TypeTags.XML) {
+            if (expr.getBType().tag != TypeTags.STRING && expr.getBType().tag != TypeTags.XML) {
                 currentExpr = getToStringInvocationOnExpr(expr);
             }
 
@@ -2058,9 +2072,9 @@ public class Desugar extends BLangNodeVisitor {
             }
 
             BType binaryExprType =
-                    TypeTags.isXMLTypeTag(concatExpr.type.tag) || TypeTags.isXMLTypeTag(currentExpr.type.tag)
-                            ? symTable.xmlType
-                            : symTable.stringType;
+                    TypeTags.isXMLTypeTag(concatExpr.getBType().tag)
+                            || TypeTags.isXMLTypeTag(currentExpr.getBType().tag) ?
+                            symTable.xmlType : symTable.stringType;
             concatExpr =
                     ASTBuilderUtil.createBinaryExpr(concatExpr.pos, concatExpr, currentExpr,
                             binaryExprType, OperatorKind.ADD, null);
@@ -2121,12 +2135,12 @@ public class Desugar extends BLangNodeVisitor {
 
         BLangTypedescExpr typedescExpr = new BLangTypedescExpr();
         typedescExpr.resolvedType = targetType;
-        typedescExpr.type = typedescType;
+        typedescExpr.setBType(typedescType);
 
         invocationNode.expr = typedescExpr;
         invocationNode.symbol = symResolver.lookupLangLibMethod(typedescType, names.fromString(CLONE_WITH_TYPE));
         invocationNode.requiredArgs = Lists.of(ASTBuilderUtil.createVariableRef(pos, source), typedescExpr);
-        invocationNode.type = BUnionType.create(null, targetType, symTable.errorType);
+        invocationNode.setBType(BUnionType.create(null, targetType, symTable.errorType));
         return invocationNode;
     }
 
@@ -2155,7 +2169,7 @@ public class Desugar extends BLangNodeVisitor {
         BLangIndexBasedAccess indexBasesAccessExpr =
                 ASTBuilderUtil.createIndexBasesAccessExpr(pos, symTable.anyType, keyValSymbol, ASTBuilderUtil
                         .createLiteral(pos, symTable.intType, (long) 0));
-        BLangSimpleVariableDef tupFirstElem = createVarDef("$key", indexBasesAccessExpr.type,
+        BLangSimpleVariableDef tupFirstElem = createVarDef("$key", indexBasesAccessExpr.getBType(),
                                                            indexBasesAccessExpr, pos);
         functionBlock.addStatement(tupFirstElem);
 
@@ -2194,14 +2208,14 @@ public class Desugar extends BLangNodeVisitor {
         ifStmt.body = ifBlock;
 
         BLangGroupExpr groupExpr = new BLangGroupExpr();
-        groupExpr.type = symTable.booleanType;
+        groupExpr.setBType(symTable.booleanType);
 
         BLangBinaryExpr binaryExpr = ASTBuilderUtil.createBinaryExpr(location, converted,
                 ASTBuilderUtil.createLiteral(location, symTable.stringType, key),
                 symTable.booleanType, OperatorKind.EQUAL, null);
 
         binaryExpr.opSymbol = (BOperatorSymbol) symResolver.resolveBinaryOperator(
-                binaryExpr.opKind, binaryExpr.lhsExpr.type, binaryExpr.rhsExpr.type);
+                binaryExpr.opKind, binaryExpr.lhsExpr.getBType(), binaryExpr.rhsExpr.getBType());
 
         groupExpr.expression = binaryExpr;
         ifStmt.expr = groupExpr;
@@ -2210,7 +2224,7 @@ public class Desugar extends BLangNodeVisitor {
     BLangLambdaFunction createLambdaFunction(BLangFunction function, BInvokableSymbol functionSymbol) {
         BLangLambdaFunction lambdaFunction = (BLangLambdaFunction) TreeBuilder.createLambdaFunctionNode();
         lambdaFunction.function = function;
-        lambdaFunction.type = functionSymbol.type;
+        lambdaFunction.setBType(functionSymbol.type);
         lambdaFunction.capturedClosureEnv = env;
         return lambdaFunction;
     }
@@ -2223,10 +2237,10 @@ public class Desugar extends BLangNodeVisitor {
         // Create function symbol before visiting desugar phase for the function
         BInvokableSymbol functionSymbol = Symbols.createFunctionSymbol(Flags.asMask(function.flagSet),
                                                                        new Name(function.name.value),
-                                                                       env.enclPkg.packageID, function.type,
+                                                                       env.enclPkg.packageID, function.getBType(),
                                                                        env.enclEnv.enclVarSym, true, function.pos,
                                                                        VIRTUAL);
-        functionSymbol.retType = function.returnTypeNode.type;
+        functionSymbol.retType = function.returnTypeNode.getBType();
         functionSymbol.params = function.requiredParams.stream()
                 .map(param -> param.symbol)
                 .collect(Collectors.toList());
@@ -2246,7 +2260,7 @@ public class Desugar extends BLangNodeVisitor {
         function.requiredParams.add(inputParameter);
         BLangValueType booleanTypeKind = new BLangValueType();
         booleanTypeKind.typeKind = TypeKind.BOOLEAN;
-        booleanTypeKind.type = symTable.booleanType;
+        booleanTypeKind.setBType(symTable.booleanType);
         function.returnTypeNode = booleanTypeKind;
 
         BLangBlockFunctionBody functionBlock = ASTBuilderUtil.createBlockFunctionBody(pos, new ArrayList<>());
@@ -2293,8 +2307,8 @@ public class Desugar extends BLangNodeVisitor {
                 parentBlockStmt);
         simpleVariableDef.var = simpleVariable;
 
-        simpleVariable.expr = createIndexBasedAccessExpr(simpleVariable.type, simpleVariable.pos,
-                indexExpr, tupleVarSymbol, parentArrayAccessExpr);
+        simpleVariable.expr = createIndexBasedAccessExpr(simpleVariable.getBType(), simpleVariable.pos,
+                                                         indexExpr, tupleVarSymbol, parentArrayAccessExpr);
     }
 
     @Override
@@ -2309,7 +2323,7 @@ public class Desugar extends BLangNodeVisitor {
 
         assignNode.varRef = rewriteExpr(assignNode.varRef);
         assignNode.expr = rewriteExpr(assignNode.expr);
-        assignNode.expr = addConversionExprIfRequired(rewriteExpr(assignNode.expr), assignNode.varRef.type);
+        assignNode.expr = addConversionExprIfRequired(rewriteExpr(assignNode.expr), assignNode.varRef.getBType());
         result = assignNode;
     }
 
@@ -2368,13 +2382,13 @@ public class Desugar extends BLangNodeVisitor {
 
             // T[] t = [];
             BLangSimpleVarRef restParam = (BLangSimpleVarRef) tupleVarRef.restParam;
-            BArrayType restParamType = (BArrayType) restParam.type;
+            BArrayType restParamType = (BArrayType) restParam.getBType();
             BLangArrayLiteral arrayExpr = createArrayLiteralExprNode();
-            arrayExpr.type = restParamType;
+            arrayExpr.setBType(restParamType);
 
             BLangAssignment restParamAssignment = ASTBuilderUtil.createAssignmentStmt(pos, blockStmt);
             restParamAssignment.varRef = restParam;
-            restParamAssignment.varRef.type = restParamType;
+            restParamAssignment.varRef.setBType(restParamType);
             restParamAssignment.expr = arrayExpr;
 
             // foreach var $foreach$i in tupleTypes.length()...tupleLiteral.length() {
@@ -2382,7 +2396,7 @@ public class Desugar extends BLangNodeVisitor {
             // }
             BLangLiteral startIndexLiteral = (BLangLiteral) TreeBuilder.createLiteralExpression();
             startIndexLiteral.value = (long) tupleVarRef.expressions.size();
-            startIndexLiteral.type = symTable.intType;
+            startIndexLiteral.setBType(symTable.intType);
             BLangInvocation lengthInvocation = createLengthInvocation(pos, tupleExpr);
             BLangInvocation intRangeInvocation = replaceWithIntRange(pos, startIndexLiteral,
                     getModifiedIntRangeEndExpr(lengthInvocation));
@@ -2395,7 +2409,7 @@ public class Desugar extends BLangNodeVisitor {
             final BLangSimpleVariable foreachVariable = ASTBuilderUtil.createVariable(pos,
                     "$foreach$i", foreach.varType);
             foreachVariable.symbol = new BVarSymbol(0, names.fromIdNode(foreachVariable.name),
-                                                    this.env.scope.owner.pkgID, foreachVariable.type,
+                                                    this.env.scope.owner.pkgID, foreachVariable.getBType(),
                                                     this.env.scope.owner, pos, VIRTUAL);
             BLangSimpleVarRef foreachVarRef = ASTBuilderUtil.createVariableRef(pos, foreachVariable.symbol);
             foreach.variableDefinitionNode = ASTBuilderUtil.createVariableDef(pos, foreachVariable);
@@ -2405,7 +2419,7 @@ public class Desugar extends BLangNodeVisitor {
             // t[t.length()] = <T> tupleLiteral[$foreach$i];
             BLangIndexBasedAccess indexAccessExpr = ASTBuilderUtil.createIndexAccessExpr(restParam,
                     createLengthInvocation(pos, restParam));
-            indexAccessExpr.type = restParamType.eType;
+            indexAccessExpr.setBType(restParamType.eType);
             createAssignmentStmt(indexAccessExpr, foreachBody, foreachVarRef, tupleVarSymbol, null);
 
             foreach.body = foreachBody;
@@ -2415,11 +2429,11 @@ public class Desugar extends BLangNodeVisitor {
 
     private BLangInvocation createLengthInvocation(Location pos, BLangExpression collection) {
         BInvokableSymbol lengthInvokableSymbol = (BInvokableSymbol) symResolver
-                .lookupLangLibMethod(collection.type, names.fromString(LENGTH_FUNCTION_NAME));
+                .lookupLangLibMethod(collection.getBType(), names.fromString(LENGTH_FUNCTION_NAME));
         BLangInvocation lengthInvocation = ASTBuilderUtil.createInvocationExprForMethod(pos, lengthInvokableSymbol,
                 Lists.of(collection), symResolver);
         lengthInvocation.argExprs = lengthInvocation.requiredArgs;
-        lengthInvocation.type = lengthInvokableSymbol.type.getReturnType();
+        lengthInvocation.setBType(lengthInvokableSymbol.type.getReturnType());
         return lengthInvocation;
     }
 
@@ -2479,11 +2493,11 @@ public class Desugar extends BLangNodeVisitor {
                                             arrayAccessExpr);
 
                 BLangRecordTypeNode recordTypeNode = TypeDefBuilderHelper.createRecordTypeNode(
-                        (BRecordType) recordVarRef.type, env.enclPkg.packageID, symTable, recordVarRef.pos);
+                        (BRecordType) recordVarRef.getBType(), env.enclPkg.packageID, symTable, recordVarRef.pos);
                 recordTypeNode.initFunction = TypeDefBuilderHelper
                         .createInitFunctionForRecordType(recordTypeNode, env, names, symTable);
-                TypeDefBuilderHelper
-                        .addTypeDefinition(recordVarRef.type, recordVarRef.type.tsymbol, recordTypeNode, env);
+                TypeDefBuilderHelper.addTypeDefinition(recordVarRef.getBType(), recordVarRef.getBType().tsymbol,
+                                                       recordTypeNode, env);
 
                 continue;
             }
@@ -2494,7 +2508,7 @@ public class Desugar extends BLangNodeVisitor {
                 BLangLiteral indexExpr = ASTBuilderUtil.createLiteral(errorVarRef.pos, symTable.intType,
                         (long) index);
                 BLangIndexBasedAccess arrayAccessExpr = ASTBuilderUtil.createIndexBasesAccessExpr(
-                        parentTupleVariable.pos, expression.type, tupleVarSymbol, indexExpr);
+                        parentTupleVariable.pos, expression.getBType(), tupleVarSymbol, indexExpr);
                 if (parentIndexAccessExpr != null) {
                     arrayAccessExpr.expr = parentIndexAccessExpr;
                 }
@@ -2519,10 +2533,11 @@ public class Desugar extends BLangNodeVisitor {
             }
         }
 
-        BLangExpression assignmentExpr = createIndexBasedAccessExpr(accessibleExpression.type, accessibleExpression.pos,
-                indexExpr, tupleVarSymbol, parentArrayAccessExpr);
+        BLangExpression assignmentExpr =
+                createIndexBasedAccessExpr(accessibleExpression.getBType(), accessibleExpression.pos, indexExpr,
+                                           tupleVarSymbol, parentArrayAccessExpr);
 
-        assignmentExpr = addConversionExprIfRequired(assignmentExpr, accessibleExpression.type);
+        assignmentExpr = addConversionExprIfRequired(assignmentExpr, accessibleExpression.getBType());
 
         final BLangAssignment assignmentStmt = ASTBuilderUtil.createAssignmentStmt(parentBlockStmt.pos,
                 parentBlockStmt);
@@ -2548,7 +2563,7 @@ public class Desugar extends BLangNodeVisitor {
         if (types.isValueType(varType)) {
             BLangTypeConversionExpr castExpr = (BLangTypeConversionExpr) TreeBuilder.createTypeConversionNode();
             castExpr.expr = arrayAccess;
-            castExpr.type = varType;
+            castExpr.setBType(varType);
             assignmentExpr = castExpr;
         } else {
             assignmentExpr = arrayAccess;
@@ -2652,7 +2667,7 @@ public class Desugar extends BLangNodeVisitor {
             // map<any> restParam = $map$_0.filter($lambdaArg$_0);
 
             Location pos = parentBlockStmt.pos;
-            BMapType restParamType = (BMapType) ((BLangSimpleVarRef) parentRecordVarRef.restParam).type;
+            BMapType restParamType = (BMapType) ((BLangSimpleVarRef) parentRecordVarRef.restParam).getBType();
             BLangSimpleVarRef variableReference;
 
             if (parentIndexAccessExpr != null) {
@@ -2685,7 +2700,7 @@ public class Desugar extends BLangNodeVisitor {
             // Create rest param variable definition
             BLangAssignment restParamAssignment = ASTBuilderUtil.createAssignmentStmt(pos, parentBlockStmt);
             restParamAssignment.varRef = restParam;
-            restParamAssignment.varRef.type = restParamType;
+            restParamAssignment.varRef.setBType(restParamType);
             restParamAssignment.expr = varRef;
         }
     }
@@ -2697,7 +2712,7 @@ public class Desugar extends BLangNodeVisitor {
             BLangAssignment message = ASTBuilderUtil.createAssignmentStmt(parentBlockStmt.pos, parentBlockStmt);
             message.expr = generateErrorMessageBuiltinFunction(parentErrorVarRef.message.pos,
                     symTable.stringType, errorVarySymbol, parentIndexAccessExpr);
-            message.expr = addConversionExprIfRequired(message.expr, parentErrorVarRef.message.type);
+            message.expr = addConversionExprIfRequired(message.expr, parentErrorVarRef.message.getBType());
             message.varRef = parentErrorVarRef.message;
         }
 
@@ -2706,7 +2721,7 @@ public class Desugar extends BLangNodeVisitor {
             BLangAssignment cause = ASTBuilderUtil.createAssignmentStmt(parentBlockStmt.pos, parentBlockStmt);
             cause.expr = generateErrorCauseLanglibFunction(parentErrorVarRef.cause.pos,
                     symTable.errorType, errorVarySymbol, parentIndexAccessExpr);
-            cause.expr = addConversionExprIfRequired(cause.expr, parentErrorVarRef.cause.type);
+            cause.expr = addConversionExprIfRequired(cause.expr, parentErrorVarRef.cause.getBType());
             cause.varRef = parentErrorVarRef.cause;
         }
 
@@ -2722,7 +2737,7 @@ public class Desugar extends BLangNodeVisitor {
         BLangSimpleVariableDef detailTempVarDef = createVarDef("$error$detail$" + UNDERSCORE + errorCount++,
                                                                symTable.detailType, errorDetailBuiltinFunction,
                                                                parentErrorVarRef.pos);
-        detailTempVarDef.type = symTable.detailType;
+        detailTempVarDef.setBType(symTable.detailType);
         parentBlockStmt.addStatement(detailTempVarDef);
         this.env.scope.define(names.fromIdNode(detailTempVarDef.var.name), detailTempVarDef.var.symbol);
 
@@ -2732,9 +2747,10 @@ public class Desugar extends BLangNodeVisitor {
             BLangVariableReference ref = (BLangVariableReference) detail.expr;
 
             // create a index based access
-            BLangExpression detailEntryVar = createIndexBasedAccessExpr(ref.type, ref.pos,
-                    createStringLiteral(detail.name.pos, detail.name.value),
-                    detailTempVarDef.var.symbol, null);
+            BLangExpression detailEntryVar =
+                    createIndexBasedAccessExpr(ref.getBType(), ref.pos,
+                                               createStringLiteral(detail.name.pos, detail.name.value),
+                                               detailTempVarDef.var.symbol, null);
             if (detailEntryVar.getKind() == NodeKind.INDEX_BASED_ACCESS_EXPR) {
                 BLangIndexBasedAccess bLangIndexBasedAccess = (BLangIndexBasedAccess) detailEntryVar;
                 bLangIndexBasedAccess.originalType = symTable.cloneableType;
@@ -2749,9 +2765,9 @@ public class Desugar extends BLangNodeVisitor {
             BLangSimpleVarRef detailVarRef = ASTBuilderUtil.createVariableRef(parentErrorVarRef.restVar.pos,
                     detailTempVarDef.var.symbol);
 
-            BLangSimpleVariable filteredDetail = generateRestFilter(detailVarRef, parentErrorVarRef.restVar.pos,
-                    extractedKeys,
-                    parentErrorVarRef.restVar.type, parentBlockStmt);
+            BLangSimpleVariable filteredDetail =
+                    generateRestFilter(detailVarRef, parentErrorVarRef.restVar.pos, extractedKeys,
+                                       parentErrorVarRef.restVar.getBType(), parentBlockStmt);
             BLangAssignment restAssignment = ASTBuilderUtil.createAssignmentStmt(parentErrorVarRef.restVar.pos,
                     parentBlockStmt);
             restAssignment.varRef = parentErrorVarRef.restVar;
@@ -2759,7 +2775,7 @@ public class Desugar extends BLangNodeVisitor {
                     filteredDetail.symbol);
         }
 
-        BErrorType errorType = (BErrorType) parentErrorVarRef.type;
+        BErrorType errorType = (BErrorType) parentErrorVarRef.getBType();
         if (errorType.detailType.getKind() == TypeKind.RECORD) {
             // Create empty record init attached func
             BRecordTypeSymbol tsymbol = (BRecordTypeSymbol) errorType.detailType.tsymbol;
@@ -2958,14 +2974,14 @@ public class Desugar extends BLangNodeVisitor {
         BLangBinaryExpr shouldRetryCheck = ASTBuilderUtil.createBinaryExpr(pos, isErrorCheck, shouldRetryRef,
                 symTable.booleanType, OperatorKind.AND, null);
         BLangGroupExpr rhsCheck =  new BLangGroupExpr();
-        rhsCheck.type = symTable.booleanType;
+        rhsCheck.setBType(symTable.booleanType);
         rhsCheck.expression = shouldRetryCheck;
 
         BLangLiteral nillLiteral = createLiteral(pos, symTable.nilType, null);
         BLangBinaryExpr equalToNullCheck = ASTBuilderUtil.createBinaryExpr(pos, retryResultRef, nillLiteral,
                 symTable.booleanType, OperatorKind.EQUAL, null);
         BLangGroupExpr lhsCheck =  new BLangGroupExpr();
-        lhsCheck.type = symTable.booleanType;
+        lhsCheck.setBType(symTable.booleanType);
         lhsCheck.expression = equalToNullCheck;
 
         // while($retryResult$ == () ||($retryResult$ is error && $shouldRetry$))
@@ -3056,7 +3072,7 @@ public class Desugar extends BLangNodeVisitor {
                 .lookup(names.fromString("DefaultRetryManager")).symbol;
         BType retryManagerType = retryManagerTypeSymbol.type;
         if (retrySpec.retryManagerType != null) {
-            retryManagerType = retrySpec.retryManagerType.type;
+            retryManagerType = retrySpec.retryManagerType.getBType();
         }
 
         //<RetryManagerType> $retryManager$ = new;
@@ -3080,7 +3096,7 @@ public class Desugar extends BLangNodeVisitor {
         shouldRetryInvocation.requiredArgs = Lists.of(trapResultRef);
         shouldRetryInvocation.argExprs = shouldRetryInvocation.requiredArgs;
         shouldRetryInvocation.symbol = shouldRetryFuncSymbol;
-        shouldRetryInvocation.type = shouldRetryFuncSymbol.retType;
+        shouldRetryInvocation.setBType(shouldRetryFuncSymbol.retType);
         shouldRetryInvocation.langLibInvocation = false;
         return shouldRetryInvocation;
     }
@@ -3097,7 +3113,7 @@ public class Desugar extends BLangNodeVisitor {
 
     protected BLangTypeTestExpr createTypeCheckExpr(Location pos, BLangExpression expr, BLangType type) {
         BLangTypeTestExpr testExpr = ASTBuilderUtil.createTypeTestExpr(pos, expr, type);
-        testExpr.type = symTable.booleanType;
+        testExpr.setBType(symTable.booleanType);
         return testExpr;
     }
 
@@ -3131,7 +3147,7 @@ public class Desugar extends BLangNodeVisitor {
             BLangExpressionStmt transactionExprStmt = (BLangExpressionStmt) TreeBuilder.createExpressionStatementNode();
             transactionExprStmt.pos = location;
             transactionExprStmt.expr = retryTransactionStmtExpr;
-            transactionExprStmt.type = symTable.nilType;
+            transactionExprStmt.setBType(symTable.nilType);
             return rewrite(transactionExprStmt, env);
         }
     }
@@ -3223,14 +3239,15 @@ public class Desugar extends BLangNodeVisitor {
         // var $temp2$ = 3;
         // var $temp1$ = 2;
         do {
-            BLangSimpleVariableDef tempIndexVarDef = createVarDef("$temp" + ++indexExprCount + "$",
-                    ((BLangIndexBasedAccess) varRef).indexExpr.type, ((BLangIndexBasedAccess) varRef).indexExpr,
-                    compoundAssignment.pos);
+            BLangSimpleVariableDef tempIndexVarDef =
+                    createVarDef("$temp" + ++indexExprCount + "$",
+                                 ((BLangIndexBasedAccess) varRef).indexExpr.getBType(),
+                                 ((BLangIndexBasedAccess) varRef).indexExpr, compoundAssignment.pos);
             BLangSimpleVarRef tempVarRef = ASTBuilderUtil.createVariableRef(tempIndexVarDef.pos,
                     tempIndexVarDef.var.symbol);
             statements.add(0, tempIndexVarDef);
             varRefs.add(0, tempVarRef);
-            types.add(0, varRef.type);
+            types.add(0, varRef.getBType());
 
             varRef = (BLangValueExpression) ((BLangIndexBasedAccess) varRef).expr;
         } while (varRef.getKind() == NodeKind.INDEX_BASED_ACCESS_EXPR);
@@ -3239,14 +3256,16 @@ public class Desugar extends BLangNodeVisitor {
         BLangExpression var = varRef;
         for (int ref = 0; ref < varRefs.size(); ref++) {
             var = ASTBuilderUtil.createIndexAccessExpr(var, varRefs.get(ref));
-            var.type = types.get(ref);
+            var.setBType(types.get(ref));
         }
-        var.type = compoundAssignment.varRef.type;
+        var.setBType(compoundAssignment.varRef.getBType());
 
         // Create the right hand side binary expression of the assignment. ex: c[$temp3$][$temp2$][$temp1$] + y
         BLangExpression rhsExpression = ASTBuilderUtil.createBinaryExpr(compoundAssignment.pos, var,
-                compoundAssignment.expr, compoundAssignment.type, compoundAssignment.opKind, null);
-        rhsExpression.type = compoundAssignment.modifiedExpr.type;
+                                                                        compoundAssignment.expr,
+                                                                        compoundAssignment.getBType(),
+                                                                        compoundAssignment.opKind, null);
+        rhsExpression.setBType(compoundAssignment.modifiedExpr.getBType());
 
         // Create assignment statement. ex: a[$temp3$][$temp2$][$temp1$] = a[$temp3$][$temp2$][$temp1$] + y;
         BLangAssignment assignStmt = ASTBuilderUtil.createAssignmentStmt(compoundAssignment.pos, var,
@@ -3349,9 +3368,10 @@ public class Desugar extends BLangNodeVisitor {
         // Create a variable definition to store the value of the match expression
         String matchExprVarName = GEN_VAR_PREFIX.value;
         BLangSimpleVariable matchExprVar =
-                ASTBuilderUtil.createVariable(matchStmt.expr.pos, matchExprVarName, matchStmt.expr.type, matchStmt.expr,
+                ASTBuilderUtil.createVariable(matchStmt.expr.pos, matchExprVarName, matchStmt.expr.getBType(),
+                                              matchStmt.expr,
                                               new BVarSymbol(0, names.fromString(matchExprVarName),
-                                                             this.env.scope.owner.pkgID, matchStmt.expr.type,
+                                                             this.env.scope.owner.pkgID, matchStmt.expr.getBType(),
                                                              this.env.scope.owner, matchStmt.expr.pos, VIRTUAL));
 
         // Now create a variable definition node
@@ -3385,10 +3405,11 @@ public class Desugar extends BLangNodeVisitor {
         String matchExprVarName = GEN_VAR_PREFIX.value;
 
         BLangExpression matchExpr = matchStatement.expr;
-        BLangSimpleVariable matchExprVar = ASTBuilderUtil.createVariable(matchExpr.pos,
-                matchExprVarName, matchExpr.type, matchExpr, new BVarSymbol(0,
-                        names.fromString(matchExprVarName), this.env.scope.owner.pkgID, matchExpr.type,
-                        this.env.scope.owner, matchExpr.pos, VIRTUAL));
+        BLangSimpleVariable matchExprVar =
+                ASTBuilderUtil.createVariable(matchExpr.pos, matchExprVarName, matchExpr.getBType(), matchExpr,
+                                              new BVarSymbol(0, names.fromString(matchExprVarName),
+                                                             this.env.scope.owner.pkgID, matchExpr.getBType(),
+                                                             this.env.scope.owner, matchExpr.pos, VIRTUAL));
 
         BLangSimpleVariableDef matchExprVarDef = ASTBuilderUtil.createVariableDef(matchBlockStmt.pos, matchExprVar);
         matchBlockStmt.stmts.add(matchExprVarDef);
@@ -3507,10 +3528,10 @@ public class Desugar extends BLangNodeVisitor {
     private BLangExpression createConditionForWildCardMatchPattern(BLangWildCardMatchPattern wildCardMatchPattern,
                                                                    BLangSimpleVarRef matchExprVarRef) {
         BLangExpression lhsCheck = createLiteral(wildCardMatchPattern.pos, symTable.booleanType,
-                types.isAssignable(matchExprVarRef.type, wildCardMatchPattern.type));
+                types.isAssignable(matchExprVarRef.getBType(), wildCardMatchPattern.getBType()));
 
         BLangValueType anyType = (BLangValueType) TreeBuilder.createValueTypeNode();
-        anyType.type = symTable.anyType;
+        anyType.setBType(symTable.anyType);
         anyType.typeKind = TypeKind.ANY;
         BLangExpression rhsCheck = createTypeCheckExpr(wildCardMatchPattern.pos, matchExprVarRef, anyType);
 
@@ -3526,7 +3547,7 @@ public class Desugar extends BLangNodeVisitor {
     private BLangExpression createConditionForWildCardBindingPattern(BLangWildCardBindingPattern wildCardBindingPattern,
                                                                      BLangSimpleVarRef matchExprVarRef) {
         return ASTBuilderUtil.createLiteral(wildCardBindingPattern.pos, symTable.booleanType,
-                types.isAssignable(matchExprVarRef.type, wildCardBindingPattern.type));
+                types.isAssignable(matchExprVarRef.getBType(), wildCardBindingPattern.getBType()));
     }
 
     private BLangExpression createConditionForCaptureBindingPattern(BLangCaptureBindingPattern captureBindingPattern,
@@ -3542,7 +3563,7 @@ public class Desugar extends BLangNodeVisitor {
     private BLangExpression createConditionForListBindingPattern(BLangListBindingPattern listBindingPattern,
                                                                  BLangSimpleVarRef matchExprVarRef) {
         Location pos = listBindingPattern.pos;
-        BType bindingPatternType = listBindingPattern.type;
+        BType bindingPatternType = listBindingPattern.getBType();
 
         BLangSimpleVariableDef resultVarDef = createVarDef("$listBindingPatternResult$", symTable.booleanType, null,
                 pos);
@@ -3579,7 +3600,9 @@ public class Desugar extends BLangNodeVisitor {
 
         for (int i = 0; i < bindingPatterns.size(); i++) {
             BLangExpression memberPatternCondition = createConditionForListMemberPattern(i, bindingPatterns.get(i),
-                    tempCastVarDef, ifBlock, bindingPatterns.get(i).type, pos);
+                                                                                         tempCastVarDef, ifBlock,
+                                                                                         bindingPatterns.get(i)
+                                                                                                 .getBType(), pos);
             if (memberPatternCondition.getKind() == NodeKind.LITERAL) {
                 if ((Boolean) ((BLangLiteral) memberPatternCondition).value) {
                     continue;
@@ -3606,7 +3629,7 @@ public class Desugar extends BLangNodeVisitor {
 
         BLangStatementExpression statementExpression = ASTBuilderUtil.createStatementExpression(mainBlockStmt,
                 resultVarRef);
-        statementExpression.type = symTable.booleanType;
+        statementExpression.setBType(symTable.booleanType);
         return statementExpression;
     }
 
@@ -3656,7 +3679,7 @@ public class Desugar extends BLangNodeVisitor {
         BLangSimpleVarRef resultVarRef = ASTBuilderUtil.createVariableRef(pos, resultVarDef.var.symbol);
         blockStmt.addStatement(resultVarDef);
 
-        if (listBindingPattern.type == symTable.noType) {
+        if (listBindingPattern.getBType() == symTable.noType) {
             return createConditionForUnmatchedPattern(resultVarRef, blockStmt);
         }
 
@@ -3666,10 +3689,10 @@ public class Desugar extends BLangNodeVisitor {
                 ASTBuilderUtil.createAssignmentStmt(pos, resultVarRef, getBooleanLiteral(true));
         blockStmt.addStatement(failureResult);
 
-        List<BType> memberTupleTypes = ((BTupleType) varRef.type).getTupleTypes();
+        List<BType> memberTupleTypes = ((BTupleType) varRef.getBType()).getTupleTypes();
         List<BLangBindingPattern> bindingPatterns = listBindingPattern.bindingPatterns;
 
-        BLangSimpleVariableDef tempCastVarDef = createVarDef("$castTemp$", varRef.type, varRef, pos);
+        BLangSimpleVariableDef tempCastVarDef = createVarDef("$castTemp$", varRef.getBType(), varRef, pos);
         BLangSimpleVarRef tempCastVarRef = ASTBuilderUtil.createVariableRef(pos,
                 tempCastVarDef.var.symbol);
         blockStmt.addStatement(tempCastVarDef);
@@ -3703,7 +3726,7 @@ public class Desugar extends BLangNodeVisitor {
 
         BLangStatementExpression statementExpression = ASTBuilderUtil.createStatementExpression(blockStmt,
                 resultVarRef);
-        statementExpression.type = symTable.booleanType;
+        statementExpression.setBType(symTable.booleanType);
         return statementExpression;
     }
 
@@ -3748,7 +3771,7 @@ public class Desugar extends BLangNodeVisitor {
     private BLangExpression createConditionForMappingBindingPattern(BLangMappingBindingPattern mappingBindingPattern,
                                                                     BLangSimpleVarRef matchExprVarRef) {
 
-        BType bindingPatternType = mappingBindingPattern.type;
+        BType bindingPatternType = mappingBindingPattern.getBType();
         Location pos = mappingBindingPattern.pos;
 
         BLangSimpleVariableDef resultVarDef = createVarDef("$mappingBindingPatternResult$", symTable.booleanType,
@@ -3788,7 +3811,7 @@ public class Desugar extends BLangNodeVisitor {
             Location restPatternPos = restBindingPattern.pos;
             List<String> keysToRemove = getKeysToRemove(mappingBindingPattern);
             BMapType entriesType = new BMapType(TypeTags.MAP, new BTupleType(Arrays.asList(symTable.stringType,
-                    ((BMapType) restBindingPattern.type).constraint)), null);
+                    ((BMapType) restBindingPattern.getBType()).constraint)), null);
             BLangInvocation entriesInvocation = generateMapEntriesInvocation(tempCastVarRef, entriesType);
             BLangSimpleVariableDef entriesVarDef = createVarDef("$entries$", entriesType, entriesInvocation,
                     restPatternPos);
@@ -3799,7 +3822,7 @@ public class Desugar extends BLangNodeVisitor {
                     restPatternPos);
             tempBlockStmt.addStatement(filtersVarDef);
             BLangLambdaFunction backToMapLambda = generateEntriesToMapLambda(restPatternPos,
-                    ((BMapType) mappingBindingPattern.restBindingPattern.type).constraint);
+                    ((BMapType) mappingBindingPattern.restBindingPattern.getBType()).constraint);
             BLangInvocation mapInvocation = generateMapMapInvocation(restPatternPos, filtersVarDef.var,
                     backToMapLambda);
             BLangSimpleVarRef restMatchPatternVarRef =
@@ -3811,7 +3834,7 @@ public class Desugar extends BLangNodeVisitor {
 
         BLangStatementExpression statementExpression = ASTBuilderUtil.createStatementExpression(mainBlockStmt,
                 resultVarRef);
-        statementExpression.type = symTable.booleanType;
+        statementExpression.setBType(symTable.booleanType);
 
         addAsRecordTypeDefinition(bindingPatternType, pos);
         return statementExpression;
@@ -3819,7 +3842,7 @@ public class Desugar extends BLangNodeVisitor {
 
     private BLangExpression createConditionForErrorBindingPattern(BLangErrorBindingPattern errorBindingPattern,
                                                                   BLangSimpleVarRef matchExprVarRef) {
-        BType bindingPatternType = errorBindingPattern.type;
+        BType bindingPatternType = errorBindingPattern.getBType();
         Location pos = errorBindingPattern.pos;
 
         BLangSimpleVariableDef resultVarDef = createVarDef("errorBindingPatternResult$", symTable.booleanType, null,
@@ -3858,7 +3881,7 @@ public class Desugar extends BLangNodeVisitor {
 
         BLangStatementExpression statementExpression = ASTBuilderUtil.createStatementExpression(mainBlockStmt,
                 resultVarRef);
-        statementExpression.type = symTable.booleanType;
+        statementExpression.setBType(symTable.booleanType);
         return statementExpression;
     }
 
@@ -3872,8 +3895,8 @@ public class Desugar extends BLangNodeVisitor {
             Location messagePos = errorBindingPattern.errorMessageBindingPattern.pos;
             BLangInvocation messageInvocation = createLangLibInvocationNode(ERROR_MESSAGE_FUNCTION_NAME, varRef,
                     new ArrayList<>(), null, messagePos);
-            BLangSimpleVariableDef messageVarDef = createVarDef("$errorMessage$", messageInvocation.type,
-                    messageInvocation, messagePos);
+            BLangSimpleVariableDef messageVarDef = createVarDef("$errorMessage$", messageInvocation.getBType(),
+                                                                messageInvocation, messagePos);
             ifBlock.addStatement(messageVarDef);
             BLangSimpleVarRef messageVarRef = ASTBuilderUtil.createVariableRef(messagePos, messageVarDef.var.symbol);
             condition = createConditionForErrorMessageBindingPattern(errorBindingPattern.errorMessageBindingPattern,
@@ -3884,8 +3907,8 @@ public class Desugar extends BLangNodeVisitor {
             Location errorCausePos = errorBindingPattern.errorCauseBindingPattern.pos;
             BLangInvocation causeInvocation = createLangLibInvocationNode(ERROR_CAUSE_FUNCTION_NAME, varRef,
                     new ArrayList<>(), null, errorCausePos);
-            BLangSimpleVariableDef causeVarDef = createVarDef("$errorCause$", causeInvocation.type,
-                    causeInvocation, errorCausePos);
+            BLangSimpleVariableDef causeVarDef = createVarDef("$errorCause$", causeInvocation.getBType(),
+                                                              causeInvocation, errorCausePos);
             ifBlock.addStatement(causeVarDef);
             BLangSimpleVarRef causeVarRef = ASTBuilderUtil.createVariableRef(errorCausePos, causeVarDef.var.symbol);
             BLangExpression errorCauseCondition =
@@ -3900,8 +3923,8 @@ public class Desugar extends BLangNodeVisitor {
             Location errorFieldPos = errorBindingPattern.errorFieldBindingPatterns.pos;
             BLangInvocation errorDetailInvocation = createLangLibInvocationNode(ERROR_DETAIL_FUNCTION_NAME,
                     varRef, new ArrayList<>(), null, errorFieldPos);
-            BLangSimpleVariableDef errorDetailVarDef = createVarDef("$errorDetail$", errorDetailInvocation.type,
-                    errorDetailInvocation, errorFieldPos);
+            BLangSimpleVariableDef errorDetailVarDef = createVarDef("$errorDetail$", errorDetailInvocation.getBType(),
+                                                                    errorDetailInvocation, errorFieldPos);
             ifBlock.addStatement(errorDetailVarDef);
             BLangSimpleVarRef errorDetailVarRef = ASTBuilderUtil.createVariableRef(errorFieldPos,
                     errorDetailVarDef.var.symbol);
@@ -3935,8 +3958,9 @@ public class Desugar extends BLangNodeVisitor {
                 BLangSimpleVariableDef filtersVarDef = createVarDef("$filteredVarDef$", entriesType, filterInvocation,
                         restPatternPos);
                 restPatternBlock.addStatement(filtersVarDef);
-                BLangLambdaFunction backToMapLambda = generateEntriesToMapLambda(restPatternPos,
-                        ((BMapType) errorBindingPattern.errorFieldBindingPatterns.restBindingPattern.type).constraint);
+                BType errFieldRestType = errorBindingPattern.errorFieldBindingPatterns.restBindingPattern.getBType();
+                BLangLambdaFunction backToMapLambda =
+                        generateEntriesToMapLambda(restPatternPos, ((BMapType) errFieldRestType).constraint);
                 BLangInvocation mapInvocation = generateMapMapInvocation(restPatternPos, filtersVarDef.var,
                         backToMapLambda);
                 BLangSimpleVarRef restMatchPatternVarRef =
@@ -3952,7 +3976,7 @@ public class Desugar extends BLangNodeVisitor {
     private BLangExpression createConditionForListMatchPattern(BLangListMatchPattern listMatchPattern,
                                                                BLangSimpleVarRef matchExprVarRef) {
         Location pos = listMatchPattern.pos;
-        BType matchPatternType = listMatchPattern.type;
+        BType matchPatternType = listMatchPattern.getBType();
 
         BLangSimpleVariableDef resultVarDef = createVarDef("$listPatternResult$", symTable.booleanType, null,
                 pos);
@@ -3989,7 +4013,9 @@ public class Desugar extends BLangNodeVisitor {
 
         for (int i = 0; i < matchPatterns.size(); i++) {
             BLangExpression memberPatternCondition = createConditionForListMemberPattern(i, matchPatterns.get(i),
-                    tempCastVarDef, ifBlock, matchPatterns.get(i).type, pos);
+                                                                                         tempCastVarDef, ifBlock,
+                                                                                         matchPatterns.get(i)
+                                                                                                 .getBType(), pos);
             if (memberPatternCondition.getKind() == NodeKind.LITERAL) {
                 if ((Boolean) ((BLangLiteral) memberPatternCondition).value) {
                     continue;
@@ -4017,7 +4043,7 @@ public class Desugar extends BLangNodeVisitor {
 
         BLangStatementExpression statementExpression = ASTBuilderUtil.createStatementExpression(mainBlockStmt,
                 resultVarRef);
-        statementExpression.type = symTable.booleanType;
+        statementExpression.setBType(symTable.booleanType);
         return statementExpression;
     }
 
@@ -4038,7 +4064,7 @@ public class Desugar extends BLangNodeVisitor {
 
     private BLangExpression createConditionForMappingMatchPattern(BLangMappingMatchPattern mappingMatchPattern,
                                                                   BLangSimpleVarRef matchExprVarRef) {
-        BType matchPatternType = mappingMatchPattern.type;
+        BType matchPatternType = mappingMatchPattern.getBType();
         Location pos = mappingMatchPattern.pos;
 
         BLangSimpleVariableDef resultVarDef = createVarDef("$mappingPatternResult$", symTable.booleanType, null, pos);
@@ -4077,7 +4103,7 @@ public class Desugar extends BLangNodeVisitor {
             Location restPatternPos = restMatchPattern.pos;
             List<String> keysToRemove = getKeysToRemove(mappingMatchPattern);
             BMapType entriesType = new BMapType(TypeTags.MAP, new BTupleType(Arrays.asList(symTable.stringType,
-                    ((BMapType) restMatchPattern.type).constraint)), null);
+                    ((BMapType) restMatchPattern.getBType()).constraint)), null);
             BLangInvocation entriesInvocation = generateMapEntriesInvocation(tempCastVarRef, entriesType);
             BLangSimpleVariableDef entriesVarDef = createVarDef("$entries$", entriesType, entriesInvocation,
                     restPatternPos);
@@ -4088,7 +4114,7 @@ public class Desugar extends BLangNodeVisitor {
                     restPatternPos);
             tempBlockStmt.addStatement(filtersVarDef);
             BLangLambdaFunction backToMapLambda = generateEntriesToMapLambda(restPatternPos,
-                    ((BMapType) restMatchPattern.type).constraint);
+                    ((BMapType) restMatchPattern.getBType()).constraint);
             BLangInvocation mapInvocation = generateMapMapInvocation(restPatternPos, filtersVarDef.var,
                     backToMapLambda);
             BLangSimpleVarRef restMatchPatternVarRef = declaredVarDef.get(restMatchPattern.getIdentifier().getValue());
@@ -4099,7 +4125,7 @@ public class Desugar extends BLangNodeVisitor {
 
         BLangStatementExpression statementExpression = ASTBuilderUtil.createStatementExpression(mainBlockStmt,
                 resultVarRef);
-        statementExpression.type = symTable.booleanType;
+        statementExpression.setBType(symTable.booleanType);
         addAsRecordTypeDefinition(matchPatternType, pos);
         return statementExpression;
     }
@@ -4142,9 +4168,10 @@ public class Desugar extends BLangNodeVisitor {
         String fieldName = fieldMatchPattern.fieldName.value;
         BLangMatchPattern matchPattern = fieldMatchPattern.matchPattern;
         BLangFieldBasedAccess fieldBasedAccessExpr = getFieldAccessExpression(fieldMatchPattern.pos, fieldName,
-                matchPattern.type, tempCastVarDef.var.symbol);
-        BLangSimpleVariableDef tempVarDef = createVarDef("$memberVarTemp$" + index + "_$", matchPattern.type,
-                fieldBasedAccessExpr, matchPattern.pos);
+                                                                              matchPattern.getBType(),
+                                                                              tempCastVarDef.var.symbol);
+        BLangSimpleVariableDef tempVarDef = createVarDef("$memberVarTemp$" + index + "_$", matchPattern.getBType(),
+                                                         fieldBasedAccessExpr, matchPattern.pos);
         BLangSimpleVarRef tempVarRef = ASTBuilderUtil.createVariableRef(matchPattern.pos, tempVarDef.var.symbol);
         blockStmt.addStatement(tempVarDef);
         return createVarCheckCondition(matchPattern, tempVarRef);
@@ -4177,9 +4204,10 @@ public class Desugar extends BLangNodeVisitor {
         String fieldName = fieldBindingPattern.fieldName.value;
         BLangBindingPattern bindingPattern = fieldBindingPattern.bindingPattern;
         BLangFieldBasedAccess fieldBasedAccessExpr = getFieldAccessExpression(fieldBindingPattern.pos, fieldName,
-                bindingPattern.type, tempCastVarDef.var.symbol);
-        BLangSimpleVariableDef tempVarDef = createVarDef("$memberVarTemp$" + index + "_$", bindingPattern.type,
-                fieldBasedAccessExpr, bindingPattern.pos);
+                                                                              bindingPattern.getBType(),
+                                                                              tempCastVarDef.var.symbol);
+        BLangSimpleVariableDef tempVarDef = createVarDef("$memberVarTemp$" + index + "_$", bindingPattern.getBType(),
+                                                         fieldBasedAccessExpr, bindingPattern.pos);
         BLangSimpleVarRef tempVarRef = ASTBuilderUtil.createVariableRef(bindingPattern.pos, tempVarDef.var.symbol);
         blockStmt.addStatement(tempVarDef);
         return createVarCheckCondition(bindingPattern, tempVarRef);
@@ -4212,7 +4240,7 @@ public class Desugar extends BLangNodeVisitor {
     private BLangExpression createVarCheckConditionForMappingBindingPattern(BLangMappingBindingPattern
                                                                                     mappingBindingPattern,
                                                                             BLangSimpleVarRef varRef) {
-        BType bindingPatternType = mappingBindingPattern.type;
+        BType bindingPatternType = mappingBindingPattern.getBType();
         Location pos = mappingBindingPattern.pos;
         BLangBlockStmt blockStmt = ASTBuilderUtil.createBlockStmt(pos);
 
@@ -4248,7 +4276,7 @@ public class Desugar extends BLangNodeVisitor {
 
         BLangStatementExpression statementExpression = ASTBuilderUtil.createStatementExpression(blockStmt,
                 resultVarRef);
-        statementExpression.type = symTable.booleanType;
+        statementExpression.setBType(symTable.booleanType);
         addAsRecordTypeDefinition(bindingPatternType, pos);
         return statementExpression;
     }
@@ -4263,7 +4291,7 @@ public class Desugar extends BLangNodeVisitor {
         Location restPatternPos = restBindingPattern.pos;
         List<String> keysToRemove = getKeysToRemove(mappingBindingPattern);
         BMapType entriesType = new BMapType(TypeTags.MAP, new BTupleType(Arrays.asList(symTable.stringType,
-                ((BMapType) restBindingPattern.type).constraint)), null);
+                ((BMapType) restBindingPattern.getBType()).constraint)), null);
         BLangInvocation entriesInvocation = generateMapEntriesInvocation(varRef, entriesType);
         BLangSimpleVariableDef entriesVarDef = createVarDef("$entries$", entriesType, entriesInvocation,
                 restPatternPos);
@@ -4275,7 +4303,7 @@ public class Desugar extends BLangNodeVisitor {
                 restPatternPos);
         blockStmt.addStatement(filtersVarDef);
         BLangLambdaFunction backToMapLambda = generateEntriesToMapLambda(restPatternPos,
-                ((BMapType) restBindingPattern.type).constraint);
+                ((BMapType) restBindingPattern.getBType()).constraint);
         BLangInvocation mapInvocation = generateMapMapInvocation(restPatternPos, filtersVarDef.var,
                 backToMapLambda);
         BLangSimpleVarRef restMatchPatternVarRef =
@@ -4300,10 +4328,10 @@ public class Desugar extends BLangNodeVisitor {
                 ASTBuilderUtil.createAssignmentStmt(pos, resultVarRef, getBooleanLiteral(true));
         blockStmt.addStatement(failureResult);
 
-        List<BType> memberTupleTypes = ((BTupleType) listMatchPattern.type).getTupleTypes();
+        List<BType> memberTupleTypes = ((BTupleType) listMatchPattern.getBType()).getTupleTypes();
         List<BLangMatchPattern> matchPatterns = listMatchPattern.matchPatterns;
 
-        BLangSimpleVariableDef tempCastVarDef = createVarDef("$castTemp$", listMatchPattern.type, varRef, pos);
+        BLangSimpleVariableDef tempCastVarDef = createVarDef("$castTemp$", listMatchPattern.getBType(), varRef, pos);
         blockStmt.addStatement(tempCastVarDef);
         BLangExpression condition = createConditionForListMemberPattern(0, matchPatterns.get(0),
                 tempCastVarDef, blockStmt, memberTupleTypes.get(0), pos);
@@ -4334,13 +4362,13 @@ public class Desugar extends BLangNodeVisitor {
 
         BLangStatementExpression statementExpression = ASTBuilderUtil.createStatementExpression(blockStmt,
                 resultVarRef);
-        statementExpression.type = symTable.booleanType;
+        statementExpression.setBType(symTable.booleanType);
         return statementExpression;
     }
 
     private BLangExpression createVarCheckConditionForMappingMatchPattern(BLangMappingMatchPattern mappingMatchPattern,
                                                                           BLangSimpleVarRef varRef) {
-        BRecordType recordType = (BRecordType) mappingMatchPattern.type;
+        BRecordType recordType = (BRecordType) mappingMatchPattern.getBType();
         Location pos = mappingMatchPattern.pos;
         BLangBlockStmt blockStmt = ASTBuilderUtil.createBlockStmt(pos);
 
@@ -4355,8 +4383,8 @@ public class Desugar extends BLangNodeVisitor {
                 ASTBuilderUtil.createAssignmentStmt(pos, resultVarRef, getBooleanLiteral(true));
         blockStmt.addStatement(failureResult);
 
-        BLangSimpleVariableDef tempCastVarDef = createVarDef("$castTemp$", mappingMatchPattern.type, varRef,
-                pos);
+        BLangSimpleVariableDef tempCastVarDef = createVarDef("$castTemp$", mappingMatchPattern.getBType(), varRef,
+                                                             pos);
         BLangSimpleVarRef tempCastVarRef = ASTBuilderUtil.createVariableRef(pos, tempCastVarDef.var.symbol);
         blockStmt.addStatement(tempCastVarDef);
 
@@ -4371,7 +4399,7 @@ public class Desugar extends BLangNodeVisitor {
             Location restPatternPos = restMatchPattern.pos;
             List<String> keysToRemove = getKeysToRemove(mappingMatchPattern);
             BMapType entriesType = new BMapType(TypeTags.MAP, new BTupleType(Arrays.asList(symTable.stringType,
-                    ((BMapType) restMatchPattern.type).constraint)), null);
+                    ((BMapType) restMatchPattern.getBType()).constraint)), null);
             BLangInvocation entriesInvocation = generateMapEntriesInvocation(tempCastVarRef, entriesType);
             BLangSimpleVariableDef entriesVarDef = createVarDef("$entries$", entriesType, entriesInvocation,
                     restPatternPos);
@@ -4382,7 +4410,7 @@ public class Desugar extends BLangNodeVisitor {
                     restPatternPos);
             tempBlockStmt.addStatement(filtersVarDef);
             BLangLambdaFunction backToMapLambda = generateEntriesToMapLambda(restPatternPos,
-                    ((BMapType) restMatchPattern.type).constraint);
+                    ((BMapType) restMatchPattern.getBType()).constraint);
             BLangInvocation mapInvocation = generateMapMapInvocation(restPatternPos, filtersVarDef.var,
                     backToMapLambda);
             BLangSimpleVarRef restMatchPatternVarRef =
@@ -4394,7 +4422,7 @@ public class Desugar extends BLangNodeVisitor {
 
         BLangStatementExpression statementExpression = ASTBuilderUtil.createStatementExpression(blockStmt,
                 resultVarRef);
-        statementExpression.type = symTable.booleanType;
+        statementExpression.setBType(symTable.booleanType);
         addAsRecordTypeDefinition(recordType, pos);
         return statementExpression;
     }
@@ -4415,7 +4443,7 @@ public class Desugar extends BLangNodeVisitor {
         }
         BLangRecordTypeNode recordTypeNode = new BLangRecordTypeNode();
         recordTypeNode.pos = pos;
-        recordTypeNode.type = recordType;
+        recordTypeNode.setBType(recordType);
         List<BLangSimpleVariable> typeDefFields = new ArrayList<>();
         for (BField field : recordType.fields.values()) {
             typeDefFields.add(ASTBuilderUtil.createVariable(field.pos, field.name.value, field.type, null,
@@ -4425,7 +4453,7 @@ public class Desugar extends BLangNodeVisitor {
         recordTypeNode.symbol = recordType.tsymbol;
         recordTypeNode.isAnonymous = true;
         recordTypeNode.isLocal = true;
-        recordTypeNode.type.tsymbol.scope = new Scope(recordTypeNode.type.tsymbol);
+        recordTypeNode.getBType().tsymbol.scope = new Scope(recordTypeNode.getBType().tsymbol);
         recordTypeNode.initFunction =
                 rewrite(TypeDefBuilderHelper.createInitFunctionForRecordType(recordTypeNode, env, names, symTable),
                         env);
@@ -4443,7 +4471,7 @@ public class Desugar extends BLangNodeVisitor {
 
     private BLangExpression createConditionForErrorMatchPattern(BLangErrorMatchPattern errorMatchPattern,
                                                                 BLangSimpleVarRef matchExprVarRef) {
-        BType matchPatternType = errorMatchPattern.type;
+        BType matchPatternType = errorMatchPattern.getBType();
         Location pos = errorMatchPattern.pos;
 
         BLangSimpleVariableDef resultVarDef = createVarDef("errorPatternResult$", symTable.booleanType, null, pos);
@@ -4481,7 +4509,7 @@ public class Desugar extends BLangNodeVisitor {
 
         BLangStatementExpression statementExpression = ASTBuilderUtil.createStatementExpression(mainBlockStmt,
                 resultVarRef);
-        statementExpression.type = symTable.booleanType;
+        statementExpression.setBType(symTable.booleanType);
         return statementExpression;
     }
 
@@ -4495,8 +4523,8 @@ public class Desugar extends BLangNodeVisitor {
             Location messagePos = errorMatchPattern.errorMessageMatchPattern.pos;
             BLangInvocation messageInvocation = createLangLibInvocationNode(ERROR_MESSAGE_FUNCTION_NAME, varRef,
                     new ArrayList<>(), null, messagePos);
-            BLangSimpleVariableDef messageVarDef = createVarDef("$errorMessage$", messageInvocation.type,
-                    messageInvocation, messagePos);
+            BLangSimpleVariableDef messageVarDef = createVarDef("$errorMessage$", messageInvocation.getBType(),
+                                                                messageInvocation, messagePos);
             ifBlock.addStatement(messageVarDef);
             BLangSimpleVarRef messageVarRef = ASTBuilderUtil.createVariableRef(messagePos, messageVarDef.var.symbol);
             condition = createConditionForErrorMessageMatchPattern(errorMatchPattern.errorMessageMatchPattern,
@@ -4507,8 +4535,8 @@ public class Desugar extends BLangNodeVisitor {
             Location errorCausePos = errorMatchPattern.errorCauseMatchPattern.pos;
             BLangInvocation causeInvocation = createLangLibInvocationNode(ERROR_CAUSE_FUNCTION_NAME, varRef,
                     new ArrayList<>(), null, errorCausePos);
-            BLangSimpleVariableDef causeVarDef = createVarDef("$errorCause$", causeInvocation.type,
-                    causeInvocation, errorCausePos);
+            BLangSimpleVariableDef causeVarDef = createVarDef("$errorCause$", causeInvocation.getBType(),
+                                                              causeInvocation, errorCausePos);
             ifBlock.addStatement(causeVarDef);
             BLangSimpleVarRef causeVarRef = ASTBuilderUtil.createVariableRef(errorCausePos, causeVarDef.var.symbol);
             BLangExpression errorCauseCondition =
@@ -4522,8 +4550,8 @@ public class Desugar extends BLangNodeVisitor {
             Location errorFieldPos = errorMatchPattern.errorFieldMatchPatterns.pos;
             BLangInvocation errorDetailInvocation = createLangLibInvocationNode(ERROR_DETAIL_FUNCTION_NAME,
                     varRef, new ArrayList<>(), null, errorFieldPos);
-            BLangSimpleVariableDef errorDetailVarDef = createVarDef("$errorDetail$", errorDetailInvocation.type,
-                    errorDetailInvocation, errorFieldPos);
+            BLangSimpleVariableDef errorDetailVarDef = createVarDef("$errorDetail$", errorDetailInvocation.getBType(),
+                                                                    errorDetailInvocation, errorFieldPos);
             ifBlock.addStatement(errorDetailVarDef);
             BLangSimpleVarRef errorDetailVarRef = ASTBuilderUtil.createVariableRef(errorFieldPos,
                     errorDetailVarDef.var.symbol);
@@ -4552,7 +4580,7 @@ public class Desugar extends BLangNodeVisitor {
                         restPatternPos);
                 restPatternBlock.addStatement(filtersVarDef);
                 BLangLambdaFunction backToMapLambda = generateEntriesToMapLambda(restPatternPos,
-                        ((BMapType) errorMatchPattern.errorFieldMatchPatterns.restMatchPattern.type).constraint);
+                        ((BMapType) errorMatchPattern.errorFieldMatchPatterns.restMatchPattern.getBType()).constraint);
                 BLangInvocation mapInvocation = generateMapMapInvocation(restPatternPos, filtersVarDef.var,
                         backToMapLambda);
                 BLangSimpleVarRef restMatchPatternVarRef =
@@ -4611,7 +4639,7 @@ public class Desugar extends BLangNodeVisitor {
 
             BLangExpression varCheckCondition = createConditionForNamedArgMatchPattern(matchPattern, tempVarRef);
             BLangExpression typeCheckCondition = createIsLikeExpression(matchPatternPos, tempVarRef,
-                    matchPattern.type);
+                                                                        matchPattern.getBType());
             varCheckCondition = ASTBuilderUtil.createBinaryExpr(pos, typeCheckCondition,
                    varCheckCondition, symTable.booleanType, OperatorKind.AND, null);
 
@@ -4636,7 +4664,7 @@ public class Desugar extends BLangNodeVisitor {
 
         BLangStatementExpression statementExpression = ASTBuilderUtil.createStatementExpression(mainBlockStmt,
                 resultVarRef);
-        statementExpression.type = symTable.booleanType;
+        statementExpression.setBType(symTable.booleanType);
         return statementExpression;
     }
 
@@ -4722,7 +4750,7 @@ public class Desugar extends BLangNodeVisitor {
 
         BLangStatementExpression statementExpression = ASTBuilderUtil.createStatementExpression(mainBlockStmt,
                 resultVarRef);
-        statementExpression.type = symTable.booleanType;
+        statementExpression.setBType(symTable.booleanType);
         return statementExpression;
     }
 
@@ -4813,7 +4841,7 @@ public class Desugar extends BLangNodeVisitor {
                                                                   BLangBlockStmt blockStmt) {
         BLangStatementExpression statementExpression = ASTBuilderUtil.createStatementExpression(blockStmt,
                 resultVarRef);
-        statementExpression.type = symTable.booleanType;
+        statementExpression.setBType(symTable.booleanType);
         return statementExpression;
     }
 
@@ -4830,15 +4858,16 @@ public class Desugar extends BLangNodeVisitor {
             // We need to create a new variable for the expression as well. This is needed because integer ranges can be
             // added as the expression so we cannot get the symbol in such cases.
             BVarSymbol dataSymbol = new BVarSymbol(0, names.fromString("$data$"),
-                    this.env.scope.owner.pkgID, foreach.collection.type, this.env.scope.owner, foreach.pos, VIRTUAL);
+                                                   this.env.scope.owner.pkgID, foreach.collection.getBType(),
+                                                   this.env.scope.owner, foreach.pos, VIRTUAL);
             BLangSimpleVariable dataVariable = ASTBuilderUtil.createVariable(foreach.pos, "$data$",
-                    foreach.collection.type, foreach.collection,
-                    dataSymbol);
+                                                                             foreach.collection.getBType(),
+                                                                             foreach.collection, dataSymbol);
             BLangSimpleVariableDef dataVarDef = ASTBuilderUtil.createVariableDef(foreach.pos, dataVariable);
 
             // Get the symbol of the variable (collection).
             BVarSymbol collectionSymbol = dataVariable.symbol;
-            switch (foreach.collection.type.tag) {
+            switch (foreach.collection.getBType().tag) {
                 case TypeTags.STRING:
                 case TypeTags.ARRAY:
                 case TypeTags.TUPLE:
@@ -4958,7 +4987,8 @@ public class Desugar extends BLangNodeVisitor {
         BVarSymbol thrownErrorVarSymbol = new BVarSymbol(0, new Name("$thrownError$"),
                 env.scope.owner.pkgID, symTable.errorType, env.scope.owner, onFailClause.pos, VIRTUAL);
         BLangSimpleVariable errorVar = ASTBuilderUtil.createVariable(onFailClause.pos, "$thrownError$",
-                onFailErrorVariableDef.var.type, null, thrownErrorVarSymbol);
+                                                                     onFailErrorVariableDef.var.getBType(), null,
+                                                                     thrownErrorVarSymbol);
         BLangLambdaFunction onFailFunc = createLambdaFunction(onFailClause.pos, "$onFailFunc$",
                 Lists.of(errorVar), onFailReturnType, onFailClause.body.stmts,
                 env, onFailClause.body.scope);
@@ -4966,7 +4996,8 @@ public class Desugar extends BLangNodeVisitor {
         onFailFunc.capturedClosureEnv = env;
         onFailFunc.parent = env.enclInvokable;
         BLangSimpleVarRef thrownErrorRef = ASTBuilderUtil.createVariableRef(onFailClause.pos, errorVar.symbol);
-        onFailErrorVariableDef.var.expr = addConversionExprIfRequired(thrownErrorRef, onFailErrorVariableDef.var.type);
+        onFailErrorVariableDef.var.expr = addConversionExprIfRequired(thrownErrorRef,
+                                                                      onFailErrorVariableDef.var.getBType());
         ((BLangBlockFunctionBody) onFailFunc.function.body).stmts.add(0, onFailErrorVariableDef);
         ((BLangBlockFunctionBody) onFailFunc.function.body).scope.define(onFailErrorVariableDef.var.symbol.name,
                 onFailErrorVariableDef.var.symbol);
@@ -4976,9 +5007,11 @@ public class Desugar extends BLangNodeVisitor {
         //    <"Content in on fail clause goes here">
         //  };
         BVarSymbol onFailVarSymbol = new BVarSymbol(0, names.fromString("$onFailFunc$"),
-                env.scope.owner.pkgID, onFailFunc.type, onFailFunc.function.symbol, onFailClause.pos, VIRTUAL);
-        BLangSimpleVariable onFailLambdaVariable = ASTBuilderUtil.createVariable(onFailClause.pos, "$onFailFunc$",
-                onFailFunc.type, onFailFunc, onFailVarSymbol);
+                                                    env.scope.owner.pkgID, onFailFunc.getBType(),
+                                                    onFailFunc.function.symbol, onFailClause.pos, VIRTUAL);
+        BLangSimpleVariable onFailLambdaVariable =
+                ASTBuilderUtil.createVariable(onFailClause.pos, "$onFailFunc$", onFailFunc.getBType(), onFailFunc,
+                                              onFailVarSymbol);
         onFailCallFuncDef = ASTBuilderUtil.createVariableDef(onFailClause.pos,
                 onFailLambdaVariable);
         result = onFailFunc;
@@ -4988,7 +5021,7 @@ public class Desugar extends BLangNodeVisitor {
                                                             BLangOnFailClause onFailClause, BLangFail fail) {
         BLangStatementExpression expression;
         BLangSimpleVarRef onFailFuncRef = new BLangSimpleVarRef.BLangLocalVarRef(onFailCallFuncDef.var.symbol);
-        onFailFuncRef.type = onFailCallFuncDef.var.type;
+        onFailFuncRef.setBType(onFailCallFuncDef.var.getBType());
         BLangBlockStmt onFailFuncBlock = ASTBuilderUtil.createBlockStmt(onFailClause.pos);
         onFailFuncBlock.stmts.add(onFailCallFuncDef);
 
@@ -5020,7 +5053,7 @@ public class Desugar extends BLangNodeVisitor {
             //  returns <TypeCast>$result$;
             BLangInvokableNode encInvokable = env.enclInvokable;
             expression =  ASTBuilderUtil.createStatementExpression(rewrite(onFailFuncBlock, env),
-                    addConversionExprIfRequired(resultRef, encInvokable.returnTypeNode.type));
+                    addConversionExprIfRequired(resultRef, encInvokable.returnTypeNode.getBType()));
         } else {
             expression = ASTBuilderUtil.createStatementExpression(rewrite(onFailFuncBlock, env),
                     ASTBuilderUtil.createLiteral(onFailClause.pos, symTable.nilType, Names.NIL_VALUE));
@@ -5155,7 +5188,7 @@ public class Desugar extends BLangNodeVisitor {
         BLangUserDefinedType recordType =
                 new BLangUserDefinedType(ASTBuilderUtil.createIdentifier(null, ""),
                                          ASTBuilderUtil.createIdentifier(null, ""));
-        recordType.type = type;
+        recordType.setBType(type);
         return recordType;
     }
 
@@ -5219,10 +5252,10 @@ public class Desugar extends BLangNodeVisitor {
         BLangLiteral nilLiteral = ASTBuilderUtil.createLiteral(lockNode.pos, symTable.nilType, Names.NIL_VALUE);
         BType nillableError = BUnionType.create(null, symTable.errorType, symTable.nilType);
         BLangStatementExpression statementExpression = createStatementExpression(lockNode.body, nilLiteral);
-        statementExpression.type = symTable.nilType;
+        statementExpression.setBType(symTable.nilType);
 
         BLangTrapExpr trapExpr = (BLangTrapExpr) TreeBuilder.createTrapExpressionNode();
-        trapExpr.type = nillableError;
+        trapExpr.setBType(nillableError);
         trapExpr.expr = statementExpression;
         BVarSymbol nillableErrorVarSymbol = new BVarSymbol(0, names.fromString("$errorResult"),
                                                            this.env.scope.owner.pkgID, nillableError,
@@ -5246,7 +5279,7 @@ public class Desugar extends BLangNodeVisitor {
 
         BLangTypeTestExpr isErrorTest =
                 ASTBuilderUtil.createTypeTestExpr(lockNode.pos, varRef, getErrorTypeNode());
-        isErrorTest.type = symTable.booleanType;
+        isErrorTest.setBType(symTable.booleanType);
 
         BLangIf ifelse = ASTBuilderUtil.createIfElseStmt(lockNode.pos, isErrorTest, ifBody, null);
         blockStmt.addStatement(ifelse);
@@ -5293,7 +5326,7 @@ public class Desugar extends BLangNodeVisitor {
                 trxBlockId, shouldRetryRef);
 
         BLangGroupExpr shouldNotPanic = new BLangGroupExpr();
-        shouldNotPanic.type = symTable.booleanType;
+        shouldNotPanic.setBType(symTable.booleanType);
         shouldNotPanic.expression = createNotBinaryExpression(pos, shouldPanicRef);
 
         BLangSimpleVarRef caughtError =  ASTBuilderUtil.createVariableRef(pos, trxOnFailErrorSym);
@@ -5481,11 +5514,11 @@ public class Desugar extends BLangNodeVisitor {
         internalOnFail.body.stmts.add(shouldRetryAssignment);
 
         BLangGroupExpr shouldNotRetryCheck = new BLangGroupExpr();
-        shouldNotRetryCheck.type = symTable.booleanType;
+        shouldNotRetryCheck.setBType(symTable.booleanType);
         shouldNotRetryCheck.expression = createNotBinaryExpression(pos, shouldRetryRef);
 
         BLangGroupExpr exitCheck = new BLangGroupExpr();
-        exitCheck.type = symTable.booleanType;
+        exitCheck.setBType(symTable.booleanType);
         exitCheck.expression = shouldNotRetryCheck;
 
         BLangBlockStmt exitLogicBlock = ASTBuilderUtil.createBlockStmt(pos);
@@ -5553,8 +5586,8 @@ public class Desugar extends BLangNodeVisitor {
         lambdaFunction.pos = pos;
         List<BType> paramTypes = new ArrayList<>();
         lambdaFunctionVariable.forEach(variable -> paramTypes.add(variable.symbol.type));
-        lambdaFunction.type = new BInvokableType(paramTypes, func.symbol.type.getReturnType(),
-                                                 null);
+        lambdaFunction.setBType(new BInvokableType(paramTypes, func.symbol.type.getReturnType(),
+                                                   null));
         return lambdaFunction;
     }
 
@@ -5565,7 +5598,7 @@ public class Desugar extends BLangNodeVisitor {
         BLangBlockFunctionBody body = (BLangBlockFunctionBody) TreeBuilder.createBlockFunctionBodyNode();
         body.scope = bodyScope;
         SymbolEnv bodyEnv = SymbolEnv.createFuncBodyEnv(body, env);
-        this.forceCastReturnType = ((BLangType) returnType).type;
+        this.forceCastReturnType = ((BLangType) returnType).getBType();
         body.stmts = rewriteStmt(fnBodyStmts, bodyEnv);
         this.forceCastReturnType = null;
         return createLambdaFunction(pos, functionNamePrefix, lambdaFunctionVariable, returnType, body);
@@ -5602,7 +5635,8 @@ public class Desugar extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangLiteral literalExpr) {
-        if (literalExpr.type.tag == TypeTags.ARRAY && ((BArrayType) literalExpr.type).eType.tag == TypeTags.BYTE) {
+        if (literalExpr.getBType().tag == TypeTags.ARRAY
+                && ((BArrayType) literalExpr.getBType()).eType.tag == TypeTags.BYTE) {
             // this is blob literal as byte array
             result = rewriteBlobLiteral(literalExpr);
             return;
@@ -5619,7 +5653,7 @@ public class Desugar extends BLangNodeVisitor {
             values = hexStringToByteArray(result[1]);
         }
         BLangArrayLiteral arrayLiteralNode = (BLangArrayLiteral) TreeBuilder.createArrayLiteralExpressionNode();
-        arrayLiteralNode.type = literalExpr.type;
+        arrayLiteralNode.setBType(literalExpr.getBType());
         arrayLiteralNode.pos = literalExpr.pos;
         arrayLiteralNode.exprs = new ArrayList<>();
         for (byte b : values) {
@@ -5649,22 +5683,22 @@ public class Desugar extends BLangNodeVisitor {
     public void visit(BLangListConstructorExpr listConstructor) {
         listConstructor.exprs = rewriteExprs(listConstructor.exprs);
         BLangExpression expr;
-        if (listConstructor.type.tag == TypeTags.TUPLE) {
-            expr = new BLangTupleLiteral(listConstructor.pos, listConstructor.exprs, listConstructor.type);
+        if (listConstructor.getBType().tag == TypeTags.TUPLE) {
+            expr = new BLangTupleLiteral(listConstructor.pos, listConstructor.exprs, listConstructor.getBType());
             result = rewriteExpr(expr);
-        } else if (listConstructor.type.tag == TypeTags.JSON) {
-            expr = new BLangJSONArrayLiteral(listConstructor.exprs, new BArrayType(listConstructor.type));
+        } else if (listConstructor.getBType().tag == TypeTags.JSON) {
+            expr = new BLangJSONArrayLiteral(listConstructor.exprs, new BArrayType(listConstructor.getBType()));
             result = rewriteExpr(expr);
-        } else if (getElementType(listConstructor.type).tag == TypeTags.JSON) {
-            expr = new BLangJSONArrayLiteral(listConstructor.exprs, listConstructor.type);
+        } else if (getElementType(listConstructor.getBType()).tag == TypeTags.JSON) {
+            expr = new BLangJSONArrayLiteral(listConstructor.exprs, listConstructor.getBType());
             result = rewriteExpr(expr);
-        } else if (listConstructor.type.tag == TypeTags.TYPEDESC) {
+        } else if (listConstructor.getBType().tag == TypeTags.TYPEDESC) {
             final BLangTypedescExpr typedescExpr = new BLangTypedescExpr();
             typedescExpr.resolvedType = listConstructor.typedescType;
-            typedescExpr.type = symTable.typeDesc;
+            typedescExpr.setBType(symTable.typeDesc);
             result = rewriteExpr(typedescExpr);
         } else {
-            expr = new BLangArrayLiteral(listConstructor.pos, listConstructor.exprs, listConstructor.type);
+            expr = new BLangArrayLiteral(listConstructor.pos, listConstructor.exprs, listConstructor.getBType());
             result = rewriteExpr(expr);
         }
     }
@@ -5679,11 +5713,11 @@ public class Desugar extends BLangNodeVisitor {
     public void visit(BLangArrayLiteral arrayLiteral) {
         arrayLiteral.exprs = rewriteExprs(arrayLiteral.exprs);
 
-        if (arrayLiteral.type.tag == TypeTags.JSON) {
-            result = new BLangJSONArrayLiteral(arrayLiteral.exprs, new BArrayType(arrayLiteral.type));
+        if (arrayLiteral.getBType().tag == TypeTags.JSON) {
+            result = new BLangJSONArrayLiteral(arrayLiteral.exprs, new BArrayType(arrayLiteral.getBType()));
             return;
-        } else if (getElementType(arrayLiteral.type).tag == TypeTags.JSON) {
-            result = new BLangJSONArrayLiteral(arrayLiteral.exprs, arrayLiteral.type);
+        } else if (getElementType(arrayLiteral.getBType()).tag == TypeTags.JSON) {
+            result = new BLangJSONArrayLiteral(arrayLiteral.exprs, arrayLiteral.getBType());
             return;
         }
         result = arrayLiteral;
@@ -5694,12 +5728,12 @@ public class Desugar extends BLangNodeVisitor {
         if (tupleLiteral.isTypedescExpr) {
             final BLangTypedescExpr typedescExpr = new BLangTypedescExpr();
             typedescExpr.resolvedType = tupleLiteral.typedescType;
-            typedescExpr.type = symTable.typeDesc;
+            typedescExpr.setBType(symTable.typeDesc);
             result = rewriteExpr(typedescExpr);
             return;
         }
         tupleLiteral.exprs.forEach(expr -> {
-            BType expType = expr.impConversionExpr == null ? expr.type : expr.impConversionExpr.type;
+            BType expType = expr.impConversionExpr == null ? expr.getBType() : expr.impConversionExpr.getBType();
             types.setImplicitCastExpr(expr, expType, symTable.anyType);
         });
         tupleLiteral.exprs = rewriteExprs(tupleLiteral.exprs);
@@ -5711,7 +5745,7 @@ public class Desugar extends BLangNodeVisitor {
         if (groupExpr.isTypedescExpr) {
             final BLangTypedescExpr typedescExpr = new BLangTypedescExpr();
             typedescExpr.resolvedType = groupExpr.typedescType;
-            typedescExpr.type = symTable.typeDesc;
+            typedescExpr.setBType(symTable.typeDesc);
             result = rewriteExpr(typedescExpr);
         } else {
             result = rewriteExpr(groupExpr.expression);
@@ -5738,7 +5772,7 @@ public class Desugar extends BLangNodeVisitor {
             qnameExpr.namespaceURI = qnameExpr.nsSymbol.namespaceURI;
             qnameExpr.isUsedInXML = false;
             qnameExpr.pos = varRefExpr.pos;
-            qnameExpr.type = symTable.stringType;
+            qnameExpr.setBType(symTable.stringType);
             result = qnameExpr;
             return;
         }
@@ -5779,7 +5813,7 @@ public class Desugar extends BLangNodeVisitor {
                 if (constSymbol.literalType.tag <= TypeTags.BOOLEAN || constSymbol.literalType.tag == TypeTags.NIL) {
                     BLangLiteral literal = ASTBuilderUtil.createLiteral(varRefExpr.pos, constSymbol.literalType,
                             constSymbol.value.value);
-                    result = rewriteExpr(addConversionExprIfRequired(literal, varRefExpr.type));
+                    result = rewriteExpr(addConversionExprIfRequired(literal, varRefExpr.getBType()));
                     return;
                 }
             }
@@ -5796,13 +5830,13 @@ public class Desugar extends BLangNodeVisitor {
             }
         }
 
-        genVarRefExpr.type = varRefExpr.type;
+        genVarRefExpr.setBType(varRefExpr.getBType());
         genVarRefExpr.pos = varRefExpr.pos;
 
         if ((varRefExpr.isLValue)
                 || genVarRefExpr.symbol.name.equals(IGNORE)) { //TODO temp fix to get this running in bvm
             genVarRefExpr.isLValue = varRefExpr.isLValue;
-            genVarRefExpr.type = varRefExpr.symbol.type;
+            genVarRefExpr.setBType(varRefExpr.symbol.type);
             result = genVarRefExpr;
             return;
         }
@@ -5810,8 +5844,8 @@ public class Desugar extends BLangNodeVisitor {
         // If the the variable is not used in lhs, then add a conversion if required.
         // This is done to make the types compatible for narrowed types.
         genVarRefExpr.isLValue = varRefExpr.isLValue;
-        BType targetType = genVarRefExpr.type;
-        genVarRefExpr.type = genVarRefExpr.symbol.type;
+        BType targetType = genVarRefExpr.getBType();
+        genVarRefExpr.setBType(genVarRefExpr.symbol.type);
         BLangExpression expression = addConversionExprIfRequired(genVarRefExpr, targetType);
         result = expression.impConversionExpr != null ? expression.impConversionExpr : expression;
     }
@@ -5827,9 +5861,9 @@ public class Desugar extends BLangNodeVisitor {
 
         // First get the type and then visit the expr. Order matters, since the desugar
         // can change the type of the expression, if it is type narrowed.
-        BType varRefType = types.getTypeWithEffectiveIntersectionTypes(fieldAccessExpr.expr.type);
+        BType varRefType = types.getTypeWithEffectiveIntersectionTypes(fieldAccessExpr.expr.getBType());
         fieldAccessExpr.expr = rewriteExpr(fieldAccessExpr.expr);
-        if (!types.isSameType(fieldAccessExpr.expr.type, varRefType)) {
+        if (!types.isSameType(fieldAccessExpr.expr.getBType(), varRefType)) {
             fieldAccessExpr.expr = addConversionExprIfRequired(fieldAccessExpr.expr, varRefType);
         }
 
@@ -5885,7 +5919,7 @@ public class Desugar extends BLangNodeVisitor {
                 targetVarRef = new BLangJSONAccessExpr(fieldAccessExpr.pos, fieldAccessExpr.expr, stringLit);
             } else {
                 BLangInvocation xmlAccessInvocation = rewriteXMLAttributeOrElemNameAccess(fieldAccessExpr);
-                xmlAccessInvocation.type = fieldAccessExpr.type;
+                xmlAccessInvocation.setBType(fieldAccessExpr.getBType());
                 result = xmlAccessInvocation;
                 return;
             }
@@ -5899,7 +5933,7 @@ public class Desugar extends BLangNodeVisitor {
         }
 
         targetVarRef.isLValue = fieldAccessExpr.isLValue;
-        targetVarRef.type = fieldAccessExpr.type;
+        targetVarRef.setBType(fieldAccessExpr.getBType());
         targetVarRef.optionalFieldAccess = fieldAccessExpr.optionalFieldAccess;
         result = targetVarRef;
     }
@@ -5923,7 +5957,7 @@ public class Desugar extends BLangNodeVisitor {
         func.flagSet.add(Flag.ANONYMOUS);
         func.body = (BLangBlockFunctionBody) TreeBuilder.createBlockFunctionBodyNode();
         func.symbol = funcSymbol;
-        func.type = funcSymbol.type;
+        func.setBType(funcSymbol.type);
         func.closureVarSymbols = new LinkedHashSet<>();
         // When we are supporting non var ref exprs we need to create a def, assign, get the ref and use it here.
         BLangExpression receiver = fieldAccessExpr.expr;
@@ -5935,7 +5969,8 @@ public class Desugar extends BLangNodeVisitor {
             receiverSymbol.closure = true;
             func.closureVarSymbols.add(new ClosureVarSymbol(receiverSymbol, pos));
         } else {
-            BLangSimpleVariableDef varDef = createVarDef("$$temp$obj$" + annonVarCount++, receiver.type, receiver, pos);
+            BLangSimpleVariableDef varDef = createVarDef("$$temp$obj$" + annonVarCount++, receiver.getBType(),
+                                                         receiver, pos);
             intermediateObjDef = varDef;
             varDef.var.symbol.closure = true;
             env.scope.define(varDef.var.symbol.name, varDef.var.symbol);
@@ -5953,7 +5988,7 @@ public class Desugar extends BLangNodeVisitor {
                     VIRTUAL);
             fParam.pos = pos;
             fParam.name = createIdentifier(pos, param.name.value);
-            fParam.type = param.type;
+            fParam.setBType(param.type);
             func.requiredParams.add(fParam);
             funcSymbol.params.add(fParam.symbol);
             funcSymbol.scope.define(fParam.symbol.name, fParam.symbol);
@@ -5971,7 +6006,7 @@ public class Desugar extends BLangNodeVisitor {
             restParam.symbol = new BVarSymbol(0, restSym.name, env.enclPkg.packageID, restSym.type, funcSymbol, pos,
                     VIRTUAL);
             restParam.pos = pos;
-            restParam.type = restSym.type;
+            restParam.setBType(restSym.type);
             funcSymbol.restParam = restParam.symbol;
             funcSymbol.scope.define(restParam.symbol.name, restParam.symbol);
 
@@ -5979,8 +6014,8 @@ public class Desugar extends BLangNodeVisitor {
             BLangRestArgsExpression restArgExpr = new BLangRestArgsExpression();
             restArgExpr.expr = restArg;
             restArgExpr.pos = pos;
-            restArgExpr.type = restSym.type;
-            restArgExpr.expectedType = restArgExpr.type;
+            restArgExpr.setBType(restSym.type);
+            restArgExpr.expectedType = restArgExpr.getBType();
             restArgs.add(restArgExpr);
         }
 
@@ -5997,13 +6032,13 @@ public class Desugar extends BLangNodeVisitor {
         env.enclPkg.topLevelNodes.add(func);
         //env.enclPkg.lambdaFunctions.add(lambdaFunction);
         lambdaFunction.parent = env.enclInvokable;
-        lambdaFunction.type = func.type;
+        lambdaFunction.setBType(func.getBType());
 
         if (intermediateObjDef == null) {
             return rewrite(lambdaFunction, env);
         } else {
             BLangStatementExpression expr = createStatementExpression(intermediateObjDef, rewrite(lambdaFunction, env));
-            expr.type = lambdaFunction.type;
+            expr.setBType(lambdaFunction.getBType());
             return rewrite(expr, env);
         }
     }
@@ -6019,7 +6054,7 @@ public class Desugar extends BLangNodeVisitor {
         invocationNode.expr = receiver;
 
         invocationNode.symbol = invocableSymbol;
-        invocationNode.type = ((BInvokableType) invocableSymbol.type).retType;
+        invocationNode.setBType(((BInvokableType) invocableSymbol.type).retType);
         invocationNode.requiredArgs = requiredArgs;
         invocationNode.restArgs = restArgs;
         return invocationNode;
@@ -6029,13 +6064,13 @@ public class Desugar extends BLangNodeVisitor {
         BLangStatementExpression statementExpression = new BLangStatementExpression();
         BLangBlockStmt block = new BLangBlockStmt();
         statementExpression.stmt = block;
-        BUnionType fieldAccessType = BUnionType.create(null, fieldAccessExpr.type, symTable.errorType);
+        BUnionType fieldAccessType = BUnionType.create(null, fieldAccessExpr.getBType(), symTable.errorType);
         Location pos = fieldAccessExpr.pos;
         BLangSimpleVariableDef result = createVarDef("$mapAccessResult$", fieldAccessType, null, pos);
         block.addStatement(result);
         BLangSimpleVarRef resultRef = ASTBuilderUtil.createVariableRef(pos, result.var.symbol);
-        resultRef.type = fieldAccessType;
-        statementExpression.type = fieldAccessType;
+        resultRef.setBType(fieldAccessType);
+        statementExpression.setBType(fieldAccessType);
 
 
         // create map access expr to get the field from it.
@@ -6043,8 +6078,8 @@ public class Desugar extends BLangNodeVisitor {
         BLangLiteral mapIndex = ASTBuilderUtil.createLiteral(
                         fieldAccessExpr.field.pos, symTable.stringType, fieldAccessExpr.field.value);
         BLangMapAccessExpr mapAccessExpr = new BLangMapAccessExpr(pos, fieldAccessExpr.expr, mapIndex);
-        BUnionType xmlOrNil = BUnionType.create(null, fieldAccessExpr.type, symTable.nilType);
-        mapAccessExpr.type = xmlOrNil;
+        BUnionType xmlOrNil = BUnionType.create(null, fieldAccessExpr.getBType(), symTable.nilType);
+        mapAccessExpr.setBType(xmlOrNil);
         BLangSimpleVariableDef mapResult = createVarDef("$mapAccess", xmlOrNil, mapAccessExpr, pos);
         BLangSimpleVarRef mapResultRef = ASTBuilderUtil.createVariableRef(pos, mapResult.var.symbol);
         block.addStatement(mapResult);
@@ -6063,7 +6098,7 @@ public class Desugar extends BLangNodeVisitor {
                 (BLangErrorConstructorExpr) TreeBuilder.createErrorConstructorExpressionNode();
         BSymbol symbol = symResolver.lookupMainSpaceSymbolInPackage(errorConstructorExpr.pos, env,
                 names.fromString(""), names.fromString("error"));
-        errorConstructorExpr.type = symbol.type;
+        errorConstructorExpr.setBType(symbol.type);
 
         List<BLangExpression> positionalArgs = new ArrayList<>();
         List<BLangNamedArgsExpression> namedArgs = new ArrayList<>();
@@ -6139,9 +6174,9 @@ public class Desugar extends BLangNodeVisitor {
 
         // First get the type and then visit the expr. Order matters, since the desugar
         // can change the type of the expression, if it is type narrowed.
-        BType varRefType = types.getTypeWithEffectiveIntersectionTypes(indexAccessExpr.expr.type);
+        BType varRefType = types.getTypeWithEffectiveIntersectionTypes(indexAccessExpr.expr.getBType());
         indexAccessExpr.expr = rewriteExpr(indexAccessExpr.expr);
-        if (!types.isSameType(indexAccessExpr.expr.type, varRefType)) {
+        if (!types.isSameType(indexAccessExpr.expr.getBType(), varRefType)) {
             indexAccessExpr.expr = addConversionExprIfRequired(indexAccessExpr.expr, varRefType);
         }
 
@@ -6168,8 +6203,8 @@ public class Desugar extends BLangNodeVisitor {
                 listConstructorExpr.exprs = ((BLangTableMultiKeyExpr) indexAccessExpr.indexExpr).multiKeyIndexExprs;
                 List<BType> memberTypes = new ArrayList<>();
                 ((BLangTableMultiKeyExpr) indexAccessExpr.indexExpr).multiKeyIndexExprs.
-                        forEach(expression -> memberTypes.add(expression.type));
-                listConstructorExpr.type = new BTupleType(memberTypes);
+                        forEach(expression -> memberTypes.add(expression.getBType()));
+                listConstructorExpr.setBType(new BTupleType(memberTypes));
                 indexAccessExpr.indexExpr = listConstructorExpr;
             }
             targetVarRef = new BLangTableAccessExpr(indexAccessExpr.pos, indexAccessExpr.expr,
@@ -6177,7 +6212,7 @@ public class Desugar extends BLangNodeVisitor {
         }
 
         targetVarRef.isLValue = indexAccessExpr.isLValue;
-        targetVarRef.type = indexAccessExpr.type;
+        targetVarRef.setBType(indexAccessExpr.getBType());
         result = targetVarRef;
     }
 
@@ -6203,24 +6238,24 @@ public class Desugar extends BLangNodeVisitor {
 
         BLangExpression errorDetail;
         BLangRecordLiteral recordLiteral = ASTBuilderUtil.createEmptyRecordLiteral(errorConstructorExpr.pos,
-                ((BErrorType) errorConstructorExpr.type).detailType);
+                ((BErrorType) errorConstructorExpr.getBType()).detailType);
         if (errorConstructorExpr.namedArgs.isEmpty()) {
-            errorDetail = visitCloneReadonly(rewriteExpr(recordLiteral), recordLiteral.type);
+            errorDetail = visitCloneReadonly(rewriteExpr(recordLiteral), recordLiteral.getBType());
         } else {
             for (BLangNamedArgsExpression namedArg : errorConstructorExpr.namedArgs) {
                 BLangRecordLiteral.BLangRecordKeyValueField member = new BLangRecordLiteral.BLangRecordKeyValueField();
                 member.key = new BLangRecordLiteral.BLangRecordKey(ASTBuilderUtil.createLiteral(namedArg.name.pos,
                         symTable.stringType, namedArg.name.value));
 
-                if (recordLiteral.type.tag == TypeTags.RECORD) {
+                if (recordLiteral.getBType().tag == TypeTags.RECORD) {
                     member.valueExpr = addConversionExprIfRequired(namedArg.expr, symTable.anyType);
                 } else {
-                    member.valueExpr = addConversionExprIfRequired(namedArg.expr, namedArg.expr.type);
+                    member.valueExpr = addConversionExprIfRequired(namedArg.expr, namedArg.expr.getBType());
                 }
                 recordLiteral.fields.add(member);
             }
             errorDetail = visitCloneReadonly(rewriteExpr(recordLiteral),
-                    ((BErrorType) errorConstructorExpr.type).detailType);
+                    ((BErrorType) errorConstructorExpr.getBType()).detailType);
         }
         errorConstructorExpr.errorDetail = errorDetail;
         result = errorConstructorExpr;
@@ -6264,7 +6299,7 @@ public class Desugar extends BLangNodeVisitor {
         BInvokableSymbol invSym = (BInvokableSymbol) invocation.symbol;
         if (Symbols.isFlagOn(invSym.retType.flags, Flags.PARAMETERIZED)) {
             BType retType = unifier.build(invSym.retType);
-            invocation.type = invocation.async ? new BFutureType(TypeTags.FUTURE, retType, null) : retType;
+            invocation.setBType(invocation.async ? new BFutureType(TypeTags.FUTURE, retType, null) : retType);
         }
 
         if (invocation.expr == null) {
@@ -6275,7 +6310,7 @@ public class Desugar extends BLangNodeVisitor {
             invocation.expr = ASTBuilderUtil.createVariableRef(invocation.pos, invocation.exprSymbol);
             invocation.expr = rewriteExpr(invocation.expr);
         }
-        switch (invocation.expr.type.tag) {
+        switch (invocation.expr.getBType().tag) {
             case TypeTags.OBJECT:
             case TypeTags.RECORD:
                 if (!invocation.langLibInvocation) {
@@ -6283,8 +6318,8 @@ public class Desugar extends BLangNodeVisitor {
                     argExprs.add(0, invocation.expr);
                     BLangAttachedFunctionInvocation attachedFunctionInvocation =
                             new BLangAttachedFunctionInvocation(invocation.pos, argExprs, invocation.restArgs,
-                                                                invocation.symbol, invocation.type, invocation.expr,
-                                                                async);
+                                                                invocation.symbol, invocation.getBType(),
+                                                                invocation.expr, async);
                     attachedFunctionInvocation.name = invocation.name;
                     attachedFunctionInvocation.annAttachments = invocation.annAttachments;
                     result = invRef = attachedFunctionInvocation;
@@ -6327,9 +6362,9 @@ public class Desugar extends BLangNodeVisitor {
         }
 
         // why we dont consider whole action invocation
-        BType originalInvType = genIExpr.type;
+        BType originalInvType = genIExpr.getBType();
         if (!genIExpr.async) {
-            genIExpr.type = returnTypeOfInvokable;
+            genIExpr.setBType(returnTypeOfInvokable);
         }
         this.result = addConversionExprIfRequired(genIExpr, originalInvType);
     }
@@ -6350,12 +6385,12 @@ public class Desugar extends BLangNodeVisitor {
     private BLangLiteral createNilLiteral() {
         BLangLiteral literal = (BLangLiteral) TreeBuilder.createLiteralExpression();
         literal.value = null;
-        literal.type = symTable.nilType;
+        literal.setBType(symTable.nilType);
         return literal;
     }
 
     public void visit(BLangTypeInit typeInitExpr) {
-        if (typeInitExpr.type.tag == TypeTags.STREAM) {
+        if (typeInitExpr.getBType().tag == TypeTags.STREAM) {
             result = rewriteExpr(desugarStreamTypeInit(typeInitExpr));
         } else {
             result = rewrite(desugarObjectTypeInit(typeInitExpr), env);
@@ -6367,7 +6402,7 @@ public class Desugar extends BLangNodeVisitor {
         BLangBlockStmt blockStmt = ASTBuilderUtil.createBlockStmt(typeInitExpr.pos);
 
         // Person $obj$ = new;
-        BType objType = getObjectType(typeInitExpr.type);
+        BType objType = getObjectType(typeInitExpr.getBType());
         BLangSimpleVariableDef objVarDef = createVarDef("$obj$", objType, typeInitExpr, typeInitExpr.pos);
         objVarDef.var.name.pos = symTable.builtinPos;
         BLangSimpleVarRef objVarRef = ASTBuilderUtil.createVariableRef(typeInitExpr.pos, objVarDef.var.symbol);
@@ -6376,22 +6411,22 @@ public class Desugar extends BLangNodeVisitor {
         typeInitExpr.initInvocation.symbol = ((BObjectTypeSymbol) objType.tsymbol).generatedInitializerFunc.symbol;
 
         // init() returning nil is the common case and the type test is not needed for it.
-        if (typeInitExpr.initInvocation.type.tag == TypeTags.NIL) {
+        if (typeInitExpr.initInvocation.getBType().tag == TypeTags.NIL) {
             BLangExpressionStmt initInvExpr = ASTBuilderUtil.createExpressionStmt(typeInitExpr.pos, blockStmt);
             initInvExpr.expr = typeInitExpr.initInvocation;
             typeInitExpr.initInvocation.name.value = Names.GENERATED_INIT_SUFFIX.value;
             BLangStatementExpression stmtExpr = createStatementExpression(blockStmt, objVarRef);
-            stmtExpr.type = objVarRef.symbol.type;
+            stmtExpr.setBType(objVarRef.symbol.type);
             return stmtExpr;
         }
 
         // var $temp$ = $obj$.init();
-        BLangSimpleVariableDef initInvRetValVarDef = createVarDef("$temp$", typeInitExpr.initInvocation.type,
+        BLangSimpleVariableDef initInvRetValVarDef = createVarDef("$temp$", typeInitExpr.initInvocation.getBType(),
                                                                   typeInitExpr.initInvocation, typeInitExpr.pos);
         blockStmt.addStatement(initInvRetValVarDef);
 
         // Person|error $result$;
-        BLangSimpleVariableDef resultVarDef = createVarDef("$result$", typeInitExpr.type, null, typeInitExpr.pos);
+        BLangSimpleVariableDef resultVarDef = createVarDef("$result$", typeInitExpr.getBType(), null, typeInitExpr.pos);
         blockStmt.addStatement(resultVarDef);
 
         // if ($temp$ is error) {
@@ -6406,7 +6441,7 @@ public class Desugar extends BLangNodeVisitor {
         BLangBlockStmt thenStmt = ASTBuilderUtil.createBlockStmt(symTable.builtinPos);
         BLangTypeTestExpr isErrorTest =
                 ASTBuilderUtil.createTypeTestExpr(symTable.builtinPos, initRetValVarRefInCondition, getErrorTypeNode());
-        isErrorTest.type = symTable.booleanType;
+        isErrorTest.setBType(symTable.booleanType);
 
         // If body
         BLangSimpleVarRef thenInitRetValVarRef =
@@ -6431,7 +6466,7 @@ public class Desugar extends BLangNodeVisitor {
         BLangSimpleVarRef resultVarRef =
                 ASTBuilderUtil.createVariableRef(symTable.builtinPos, resultVarDef.var.symbol);
         BLangStatementExpression stmtExpr = createStatementExpression(blockStmt, resultVarRef);
-        stmtExpr.type = resultVarRef.symbol.type;
+        stmtExpr.setBType(resultVarRef.symbol.type);
         return stmtExpr;
     }
 
@@ -6439,17 +6474,17 @@ public class Desugar extends BLangNodeVisitor {
         BInvokableSymbol symbol = (BInvokableSymbol) symTable.langInternalModuleSymbol.scope
                 .lookup(Names.CONSTRUCT_STREAM).symbol;
 
-        BType constraintType = ((BStreamType) typeInitExpr.type).constraint;
+        BType constraintType = ((BStreamType) typeInitExpr.getBType()).constraint;
         BType constraintTdType = new BTypedescType(constraintType, symTable.typeDesc.tsymbol);
         BLangTypedescExpr constraintTdExpr = new BLangTypedescExpr();
         constraintTdExpr.resolvedType = constraintType;
-        constraintTdExpr.type = constraintTdType;
+        constraintTdExpr.setBType(constraintTdType);
 
-        BType completionType = ((BStreamType) typeInitExpr.type).completionType;
+        BType completionType = ((BStreamType) typeInitExpr.getBType()).completionType;
         BType completionTdType = new BTypedescType(completionType, symTable.typeDesc.tsymbol);
         BLangTypedescExpr completionTdExpr = new BLangTypedescExpr();
         completionTdExpr.resolvedType = completionType;
-        completionTdExpr.type = completionTdType;
+        completionTdExpr.setBType(completionTdType);
 
         List<BLangExpression> args = new ArrayList<>(Lists.of(constraintTdExpr, completionTdExpr));
         if (!typeInitExpr.argsExpr.isEmpty()) {
@@ -6457,7 +6492,7 @@ public class Desugar extends BLangNodeVisitor {
         }
         BLangInvocation streamConstructInvocation = ASTBuilderUtil.createInvocationExprForMethod(
                 typeInitExpr.pos, symbol, args, symResolver);
-        streamConstructInvocation.type = new BStreamType(TypeTags.STREAM, constraintType, completionType, null);
+        streamConstructInvocation.setBType(new BStreamType(TypeTags.STREAM, constraintType, completionType, null));
         return streamConstructInvocation;
     }
 
@@ -6472,7 +6507,7 @@ public class Desugar extends BLangNodeVisitor {
         BLangSimpleVariable objVar = ASTBuilderUtil.createVariable(location, name, type, expr, (BVarSymbol) objSym);
         BLangSimpleVariableDef objVarDef = ASTBuilderUtil.createVariableDef(location);
         objVarDef.var = objVar;
-        objVarDef.type = objVar.type;
+        objVarDef.setBType(objVar.getBType());
         return objVarDef;
     }
 
@@ -6491,14 +6526,14 @@ public class Desugar extends BLangNodeVisitor {
 
     BLangErrorType getErrorTypeNode() {
         BLangErrorType errorTypeNode = (BLangErrorType) TreeBuilder.createErrorTypeNode();
-        errorTypeNode.type = symTable.errorType;
+        errorTypeNode.setBType(symTable.errorType);
         errorTypeNode.pos = symTable.builtinPos;
         return errorTypeNode;
     }
 
     BLangErrorType getErrorOrNillTypeNode() {
         BLangErrorType errorTypeNode = (BLangErrorType) TreeBuilder.createErrorTypeNode();
-        errorTypeNode.type = symTable.errorOrNilType;
+        errorTypeNode.setBType(symTable.errorOrNilType);
         return errorTypeNode;
     }
 
@@ -6515,7 +6550,8 @@ public class Desugar extends BLangNodeVisitor {
          * }
          *
          */
-        BLangSimpleVariableDef resultVarDef = createVarDef("$ternary_result$", ternaryExpr.type, null, ternaryExpr.pos);
+        BLangSimpleVariableDef resultVarDef =
+                createVarDef("$ternary_result$", ternaryExpr.getBType(), null, ternaryExpr.pos);
         BLangBlockStmt thenBody = ASTBuilderUtil.createBlockStmt(ternaryExpr.pos);
         BLangBlockStmt elseBody = ASTBuilderUtil.createBlockStmt(ternaryExpr.pos);
 
@@ -6537,7 +6573,7 @@ public class Desugar extends BLangNodeVisitor {
 
         BLangBlockStmt blockStmt = ASTBuilderUtil.createBlockStmt(ternaryExpr.pos, Lists.of(resultVarDef, ifElse));
         BLangStatementExpression stmtExpr = createStatementExpression(blockStmt, resultVarRef);
-        stmtExpr.type = ternaryExpr.type;
+        stmtExpr.setBType(ternaryExpr.getBType());
 
         result = rewriteExpr(stmtExpr);
     }
@@ -6577,15 +6613,15 @@ public class Desugar extends BLangNodeVisitor {
                 keyValue.keyExpr = rewriteExpr(keyValue.keyExpr);
             }
         });
-        BLangExpression expr = new BLangWaitForAllExpr.BLangWaitLiteral(waitExpr.keyValuePairs, waitExpr.type);
+        BLangExpression expr = new BLangWaitForAllExpr.BLangWaitLiteral(waitExpr.keyValuePairs, waitExpr.getBType());
         result = rewriteExpr(expr);
     }
 
     @Override
     public void visit(BLangTrapExpr trapExpr) {
         trapExpr.expr = rewriteExpr(trapExpr.expr);
-        if (trapExpr.expr.type.tag != TypeTags.NIL) {
-            trapExpr.expr = addConversionExprIfRequired(trapExpr.expr, trapExpr.type);
+        if (trapExpr.expr.getBType().tag != TypeTags.NIL) {
+            trapExpr.expr = addConversionExprIfRequired(trapExpr.expr, trapExpr.getBType());
         }
         result = trapExpr;
     }
@@ -6618,8 +6654,8 @@ public class Desugar extends BLangNodeVisitor {
         binaryExpr.rhsExpr = rewriteExpr(binaryExpr.rhsExpr);
         result = binaryExpr;
 
-        int rhsExprTypeTag = binaryExpr.rhsExpr.type.tag;
-        int lhsExprTypeTag = binaryExpr.lhsExpr.type.tag;
+        int rhsExprTypeTag = binaryExpr.rhsExpr.getBType().tag;
+        int lhsExprTypeTag = binaryExpr.lhsExpr.getBType().tag;
 
         // Check for int and byte ==, != or === comparison and add type conversion to int for byte
         if (rhsExprTypeTag != lhsExprTypeTag && (binaryExpr.opKind == OperatorKind.EQUAL ||
@@ -6645,7 +6681,7 @@ public class Desugar extends BLangNodeVisitor {
             if (!isBinaryShiftOperator && !isArithmeticOperator) {
                 return;
             }
-            if (types.isValueType(binaryExpr.lhsExpr.type)) {
+            if (types.isValueType(binaryExpr.lhsExpr.getBType())) {
                 return;
             }
         }
@@ -6657,7 +6693,7 @@ public class Desugar extends BLangNodeVisitor {
                         binaryExpr.lhsExpr.pos, symTable.xmlType);
                 return;
             }
-            binaryExpr.rhsExpr = createTypeCastExpr(binaryExpr.rhsExpr, binaryExpr.lhsExpr.type);
+            binaryExpr.rhsExpr = createTypeCastExpr(binaryExpr.rhsExpr, binaryExpr.lhsExpr.getBType());
             return;
         }
 
@@ -6668,27 +6704,27 @@ public class Desugar extends BLangNodeVisitor {
                         binaryExpr.rhsExpr.pos, symTable.xmlType);
                 return;
             }
-            binaryExpr.lhsExpr = createTypeCastExpr(binaryExpr.lhsExpr, binaryExpr.rhsExpr.type);
+            binaryExpr.lhsExpr = createTypeCastExpr(binaryExpr.lhsExpr, binaryExpr.rhsExpr.getBType());
             return;
         }
 
         if (lhsExprTypeTag == TypeTags.DECIMAL) {
-            binaryExpr.rhsExpr = createTypeCastExpr(binaryExpr.rhsExpr, binaryExpr.lhsExpr.type);
+            binaryExpr.rhsExpr = createTypeCastExpr(binaryExpr.rhsExpr, binaryExpr.lhsExpr.getBType());
             return;
         }
 
         if (rhsExprTypeTag == TypeTags.DECIMAL) {
-            binaryExpr.lhsExpr = createTypeCastExpr(binaryExpr.lhsExpr, binaryExpr.rhsExpr.type);
+            binaryExpr.lhsExpr = createTypeCastExpr(binaryExpr.lhsExpr, binaryExpr.rhsExpr.getBType());
             return;
         }
 
         if (lhsExprTypeTag == TypeTags.FLOAT) {
-            binaryExpr.rhsExpr = createTypeCastExpr(binaryExpr.rhsExpr, binaryExpr.lhsExpr.type);
+            binaryExpr.rhsExpr = createTypeCastExpr(binaryExpr.rhsExpr, binaryExpr.lhsExpr.getBType());
             return;
         }
 
         if (rhsExprTypeTag == TypeTags.FLOAT) {
-            binaryExpr.lhsExpr = createTypeCastExpr(binaryExpr.lhsExpr, binaryExpr.rhsExpr.type);
+            binaryExpr.lhsExpr = createTypeCastExpr(binaryExpr.lhsExpr, binaryExpr.rhsExpr.getBType());
             return;
         }
 
@@ -6715,7 +6751,7 @@ public class Desugar extends BLangNodeVisitor {
             return;
         }
         if (TypeTags.isXMLTypeTag(lhsExprTypeTag) && !TypeTags.isXMLTypeTag(rhsExprTypeTag)) {
-            if (types.checkTypeContainString(binaryExpr.rhsExpr.type)) {
+            if (types.checkTypeContainString(binaryExpr.rhsExpr.getBType())) {
                 binaryExpr.rhsExpr = ASTBuilderUtil.createXMLTextLiteralNode(binaryExpr, binaryExpr.rhsExpr,
                         binaryExpr.rhsExpr.pos, symTable.xmlType);
                 return;
@@ -6724,7 +6760,7 @@ public class Desugar extends BLangNodeVisitor {
             return;
         }
         if (TypeTags.isXMLTypeTag(rhsExprTypeTag) && !TypeTags.isXMLTypeTag(lhsExprTypeTag)) {
-            if (types.checkTypeContainString(binaryExpr.lhsExpr.type)) {
+            if (types.checkTypeContainString(binaryExpr.lhsExpr.getBType())) {
                 binaryExpr.lhsExpr = ASTBuilderUtil.createXMLTextLiteralNode(binaryExpr, binaryExpr.lhsExpr,
                         binaryExpr.rhsExpr.pos, symTable.xmlType);
                 return;
@@ -6732,8 +6768,8 @@ public class Desugar extends BLangNodeVisitor {
             binaryExpr.lhsExpr = createTypeCastExpr(binaryExpr.lhsExpr, symTable.xmlType);
             return;
         }
-        binaryExpr.lhsExpr = createTypeCastExpr(binaryExpr.lhsExpr, binaryExpr.type);
-        binaryExpr.rhsExpr = createTypeCastExpr(binaryExpr.rhsExpr, binaryExpr.type);
+        binaryExpr.lhsExpr = createTypeCastExpr(binaryExpr.lhsExpr, binaryExpr.getBType());
+        binaryExpr.rhsExpr = createTypeCastExpr(binaryExpr.rhsExpr, binaryExpr.getBType());
     }
 
     private void createTypeCastExprForBinaryShiftExpr(BLangBinaryExpr binaryExpr, int lhsExprTypeTag,
@@ -6806,7 +6842,7 @@ public class Desugar extends BLangNodeVisitor {
                 .lookup(Names.CREATE_INT_RANGE).symbol;
         BLangInvocation createIntRangeInvocation = ASTBuilderUtil.createInvocationExprForMethod(location, symbol,
                 new ArrayList<>(Lists.of(lhsExpr, rhsExpr)), symResolver);
-        createIntRangeInvocation.type = symTable.intRangeType;
+        createIntRangeInvocation.setBType(symTable.intRangeType);
         return createIntRangeInvocation;
     }
 
@@ -6815,8 +6851,8 @@ public class Desugar extends BLangNodeVisitor {
             return;
         }
 
-        int rhsExprTypeTag = binaryExpr.rhsExpr.type.tag;
-        int lhsExprTypeTag = binaryExpr.lhsExpr.type.tag;
+        int rhsExprTypeTag = binaryExpr.rhsExpr.getBType().tag;
+        int lhsExprTypeTag = binaryExpr.lhsExpr.getBType().tag;
         if (rhsExprTypeTag != TypeTags.BYTE && lhsExprTypeTag != TypeTags.BYTE) {
             return;
         }
@@ -6860,7 +6896,7 @@ public class Desugar extends BLangNodeVisitor {
         BLangMatchExpression matchExpr = ASTBuilderUtil.createMatchExpression(elvisExpr.lhsExpr);
         matchExpr.patternClauses.add(getMatchNullPatternGivenExpression(elvisExpr.pos,
                 rewriteExpr(elvisExpr.rhsExpr)));
-        matchExpr.type = elvisExpr.type;
+        matchExpr.setBType(elvisExpr.getBType());
         matchExpr.pos = elvisExpr.pos;
         result = rewriteExpr(matchExpr);
     }
@@ -6891,13 +6927,13 @@ public class Desugar extends BLangNodeVisitor {
         binaryExpr.pos = pos;
         binaryExpr.opKind = OperatorKind.BITWISE_XOR;
         binaryExpr.lhsExpr = unaryExpr.expr;
-        if (TypeTags.BYTE == unaryExpr.type.tag) {
-            binaryExpr.type = symTable.byteType;
+        if (TypeTags.BYTE == unaryExpr.getBType().tag) {
+            binaryExpr.setBType(symTable.byteType);
             binaryExpr.rhsExpr = ASTBuilderUtil.createLiteral(pos, symTable.byteType, 0xffL);
             binaryExpr.opSymbol = (BOperatorSymbol) symResolver.resolveBinaryOperator(OperatorKind.BITWISE_XOR,
                     symTable.byteType, symTable.byteType);
         } else {
-            binaryExpr.type = symTable.intType;
+            binaryExpr.setBType(symTable.intType);
             binaryExpr.rhsExpr = ASTBuilderUtil.createLiteral(pos, symTable.intType, -1L);
             binaryExpr.opSymbol = (BOperatorSymbol) symResolver.resolveBinaryOperator(OperatorKind.BITWISE_XOR,
                     symTable.intType, symTable.intType);
@@ -6944,13 +6980,13 @@ public class Desugar extends BLangNodeVisitor {
 
         // Create function body with return node
         BLangValueType returnType = (BLangValueType) TreeBuilder.createValueTypeNode();
-        returnType.type = bLangArrowFunction.body.expr.type;
+        returnType.setBType(bLangArrowFunction.body.expr.getBType());
         bLangFunction.setReturnTypeNode(returnType);
         bLangFunction.setBody(populateArrowExprBodyBlock(bLangArrowFunction));
 
         bLangArrowFunction.params.forEach(bLangFunction::addParameter);
         lambdaFunction.parent = bLangArrowFunction.parent;
-        lambdaFunction.type = bLangArrowFunction.funcType;
+        lambdaFunction.setBType(bLangArrowFunction.funcType);
 
         // Create function symbol.
         BLangFunction funcNode = lambdaFunction.function;
@@ -6972,11 +7008,12 @@ public class Desugar extends BLangNodeVisitor {
 
         funcSymbol.params = paramSymbols;
         funcSymbol.restParam = getRestSymbol(funcNode);
-        funcSymbol.retType = funcNode.returnTypeNode.type;
+        funcSymbol.retType = funcNode.returnTypeNode.getBType();
 
         // Create function type.
         List<BType> paramTypes = paramSymbols.stream().map(paramSym -> paramSym.type).collect(Collectors.toList());
-        funcNode.type = new BInvokableType(paramTypes, getRestType(funcSymbol), funcNode.returnTypeNode.type, null);
+        funcNode.setBType(
+                new BInvokableType(paramTypes, getRestType(funcSymbol), funcNode.returnTypeNode.getBType(), null));
 
         lambdaFunction.function.pos = bLangArrowFunction.pos;
         lambdaFunction.function.body.pos = bLangArrowFunction.pos;
@@ -7105,10 +7142,10 @@ public class Desugar extends BLangNodeVisitor {
     @Override
     public void visit(BLangRawTemplateLiteral rawTemplateLiteral) {
         Location pos = rawTemplateLiteral.pos;
-        BObjectType objType = (BObjectType) rawTemplateLiteral.type;
+        BObjectType objType = (BObjectType) rawTemplateLiteral.getBType();
         BLangClassDefinition objClassDef =
                 desugarTemplateLiteralObjectTypedef(rawTemplateLiteral.strings, objType, pos);
-        BObjectType classObjType = (BObjectType) objClassDef.type;
+        BObjectType classObjType = (BObjectType) objClassDef.getBType();
 
         BVarSymbol insertionsSym = classObjType.fields.get("insertions").symbol;
         BLangListConstructorExpr insertionsList = ASTBuilderUtil.createListConstructorExpr(pos, insertionsSym.type);
@@ -7204,16 +7241,16 @@ public class Desugar extends BLangNodeVisitor {
     private BLangFunction createUserDefinedObjectInitFn(BLangClassDefinition classDefn, SymbolEnv env) {
         BLangFunction initFunction =
                 TypeDefBuilderHelper.createInitFunctionForStructureType(classDefn.pos, classDefn.symbol, env,
-                        names, Names.USER_DEFINED_INIT_SUFFIX,
-                        symTable, classDefn.type);
-        BObjectTypeSymbol typeSymbol = ((BObjectTypeSymbol) classDefn.type.tsymbol);
+                                                                        names, Names.USER_DEFINED_INIT_SUFFIX,
+                                                                        symTable, classDefn.getBType());
+        BObjectTypeSymbol typeSymbol = ((BObjectTypeSymbol) classDefn.getBType().tsymbol);
         typeSymbol.initializerFunc = new BAttachedFunction(Names.USER_DEFINED_INIT_SUFFIX, initFunction.symbol,
-                                                           (BInvokableType) initFunction.type, classDefn.pos);
+                                                           (BInvokableType) initFunction.getBType(), classDefn.pos);
         classDefn.initFunction = initFunction;
-        initFunction.returnTypeNode.type = symTable.nilType;
+        initFunction.returnTypeNode.setBType(symTable.nilType);
 
         BLangBlockFunctionBody initFuncBody = (BLangBlockFunctionBody) initFunction.body;
-        BInvokableType initFnType = (BInvokableType) initFunction.type;
+        BInvokableType initFnType = (BInvokableType) initFunction.getBType();
         for (BLangSimpleVariable field : classDefn.fields) {
             if (field.expr != null) {
                 continue;
@@ -7226,11 +7263,11 @@ public class Desugar extends BLangNodeVisitor {
             param.flagSet.add(Flag.FINAL);
             initFunction.symbol.scope.define(paramSym.name, paramSym);
             initFunction.symbol.params.add(paramSym);
-            initFnType.paramTypes.add(param.type);
+            initFnType.paramTypes.add(param.getBType());
             initFunction.requiredParams.add(param);
 
             BLangSimpleVarRef paramRef = ASTBuilderUtil.createVariableRef(initFunction.pos, paramSym);
-            BLangAssignment fieldInit = createStructFieldUpdate(initFunction, paramRef, fieldSym, field.type,
+            BLangAssignment fieldInit = createStructFieldUpdate(initFunction, paramRef, fieldSym, field.getBType(),
                                                                 initFunction.receiver.symbol, field.name);
             initFuncBody.addStatement(fieldInit);
         }
@@ -7240,13 +7277,13 @@ public class Desugar extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangWorkerSend workerSendNode) {
-        workerSendNode.expr = visitCloneInvocation(rewriteExpr(workerSendNode.expr), workerSendNode.expr.type);
+        workerSendNode.expr = visitCloneInvocation(rewriteExpr(workerSendNode.expr), workerSendNode.expr.getBType());
         result = workerSendNode;
     }
 
     @Override
     public void visit(BLangWorkerSyncSendExpr syncSendExpr) {
-        syncSendExpr.expr = visitCloneInvocation(rewriteExpr(syncSendExpr.expr), syncSendExpr.expr.type);
+        syncSendExpr.expr = visitCloneInvocation(rewriteExpr(syncSendExpr.expr), syncSendExpr.expr.getBType());
         result = syncSendExpr;
     }
 
@@ -7448,7 +7485,7 @@ public class Desugar extends BLangNodeVisitor {
         invocationNode.requiredArgs = requiredArgs;
         invocationNode.restArgs = rewriteExprs(restArgs);
 
-        invocationNode.type = ((BInvokableType) invocationNode.symbol.type).getReturnType();
+        invocationNode.setBType(((BInvokableType) invocationNode.symbol.type).getReturnType());
         invocationNode.langLibInvocation = true;
         return invocationNode;
     }
@@ -7540,9 +7577,10 @@ public class Desugar extends BLangNodeVisitor {
         String matchTempResultVarName = GEN_VAR_PREFIX.value + "temp_result";
         BLangSimpleVariable tempResultVar =
                 ASTBuilderUtil.createVariable(bLangMatchExpression.pos, matchTempResultVarName,
-                                              bLangMatchExpression.type, null,
+                                              bLangMatchExpression.getBType(), null,
                                               new BVarSymbol(0, names.fromString(matchTempResultVarName),
-                                                             this.env.scope.owner.pkgID, bLangMatchExpression.type,
+                                                             this.env.scope.owner.pkgID,
+                                                             bLangMatchExpression.getBType(),
                                                              this.env.scope.owner, bLangMatchExpression.pos, VIRTUAL));
 
         BLangSimpleVariableDef tempResultVarDef =
@@ -7562,7 +7600,7 @@ public class Desugar extends BLangNodeVisitor {
                     ASTBuilderUtil.createVariableRef(bLangMatchExpression.pos, tempResultVar.symbol);
 
             // Create an assignment node. Add a conversion from rhs to lhs of the pattern, if required.
-            pattern.expr = addConversionExprIfRequired(pattern.expr, tempResultVarRef.type);
+            pattern.expr = addConversionExprIfRequired(pattern.expr, tempResultVarRef.getBType());
             BLangAssignment assignmentStmt =
                     ASTBuilderUtil.createAssignmentStmt(pattern.pos, tempResultVarRef, pattern.expr);
             BLangBlockStmt patternBody = ASTBuilderUtil.createBlockStmt(pattern.pos, Lists.of(assignmentStmt));
@@ -7577,7 +7615,7 @@ public class Desugar extends BLangNodeVisitor {
         BLangVariableReference tempResultVarRef =
                 ASTBuilderUtil.createVariableRef(bLangMatchExpression.pos, tempResultVar.symbol);
         BLangStatementExpression statementExpr = createStatementExpression(stmts, tempResultVarRef);
-        statementExpr.type = bLangMatchExpression.type;
+        statementExpr.setBType(bLangMatchExpression.getBType());
         result = rewriteExpr(statementExpr);
     }
 
@@ -7607,9 +7645,9 @@ public class Desugar extends BLangNodeVisitor {
         // Create a temporary variable to hold the checked expression result value e.g. _$$_
         String checkedExprVarName = GEN_VAR_PREFIX.value;
         BLangSimpleVariable checkedExprVar =
-                ASTBuilderUtil.createVariable(checkedExpr.pos, checkedExprVarName, checkedExpr.type, null,
+                ASTBuilderUtil.createVariable(checkedExpr.pos, checkedExprVarName, checkedExpr.getBType(), null,
                                               new BVarSymbol(0, names.fromString(checkedExprVarName),
-                                                             this.env.scope.owner.pkgID, checkedExpr.type,
+                                                             this.env.scope.owner.pkgID, checkedExpr.getBType(),
                                                              this.env.scope.owner, checkedExpr.pos, VIRTUAL));
         BLangSimpleVariableDef checkedExprVarDef = ASTBuilderUtil.createVariableDef(checkedExpr.pos, checkedExprVar);
         checkedExprVarDef.desugared = true;
@@ -7642,7 +7680,7 @@ public class Desugar extends BLangNodeVisitor {
 
         BLangStatementExpression statementExpr = createStatementExpression(
                 generatedStmtBlock, tempCheckedExprVarRef);
-        statementExpr.type = checkedExpr.type;
+        statementExpr.setBType(checkedExpr.getBType());
         result = rewriteExpr(statementExpr);
     }
 
@@ -7657,7 +7695,7 @@ public class Desugar extends BLangNodeVisitor {
     @Override
     public void visit(BLangTypeTestExpr typeTestExpr) {
         BLangExpression expr = typeTestExpr.expr;
-        if (types.isValueType(expr.type)) {
+        if (types.isValueType(expr.getBType())) {
             addConversionExprIfRequired(expr, symTable.anyType);
         }
         typeTestExpr.expr = rewriteExpr(expr);
@@ -7673,11 +7711,11 @@ public class Desugar extends BLangNodeVisitor {
         binaryExpr.lhsExpr = annotAccessExpr.expr;
         binaryExpr.rhsExpr = ASTBuilderUtil.createLiteral(annotAccessExpr.pkgAlias.pos, symTable.stringType,
                                                           annotAccessExpr.annotationSymbol.bvmAlias());
-        binaryExpr.type = annotAccessExpr.type;
+        binaryExpr.setBType(annotAccessExpr.getBType());
         binaryExpr.opSymbol = new BOperatorSymbol(names.fromString(OperatorKind.ANNOT_ACCESS.value()), null,
-                                                  new BInvokableType(Lists.of(binaryExpr.lhsExpr.type,
-                                                                              binaryExpr.rhsExpr.type),
-                                                                     annotAccessExpr.type, null), null,
+                                                  new BInvokableType(Lists.of(binaryExpr.lhsExpr.getBType(),
+                                                                              binaryExpr.rhsExpr.getBType()),
+                                                                     annotAccessExpr.getBType(), null), null,
                                                   symTable.builtinPos, VIRTUAL);
         result = rewriteExpr(binaryExpr);
     }
@@ -7745,7 +7783,7 @@ public class Desugar extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangConstRef constantRef) {
-        result = ASTBuilderUtil.createLiteral(constantRef.pos, constantRef.type, constantRef.value);
+        result = ASTBuilderUtil.createLiteral(constantRef.pos, constantRef.getBType(), constantRef.value);
     }
 
     // private functions
@@ -7761,7 +7799,7 @@ public class Desugar extends BLangNodeVisitor {
         iteratorInvocation.pos = pos;
         iteratorInvocation.expr = dataReference;
         iteratorInvocation.symbol = iteratorInvokableSymbol;
-        iteratorInvocation.type = iteratorInvokableSymbol.retType;
+        iteratorInvocation.setBType(iteratorInvokableSymbol.retType);
         iteratorInvocation.argExprs = Lists.of(dataReference);
         iteratorInvocation.requiredArgs = iteratorInvocation.argExprs;
         iteratorInvocation.langLibInvocation = isIteratorFuncFromLangLib;
@@ -7793,7 +7831,7 @@ public class Desugar extends BLangNodeVisitor {
         BLangInvocation nextInvocation = createIteratorNextInvocation(pos, iteratorSymbol);
 
         // we are inside the while loop. hence the iterator cannot be nil. hence remove nil from iterator's type
-        nextInvocation.expr.type = types.getSafeType(nextInvocation.expr.type, true, false);
+        nextInvocation.expr.setBType(types.getSafeType(nextInvocation.expr.getBType(), true, false));
 
         return ASTBuilderUtil.createAssignmentStmt(pos, resultReferenceInAssignment, nextInvocation, false);
     }
@@ -7809,7 +7847,7 @@ public class Desugar extends BLangNodeVisitor {
         nextInvocation.requiredArgs = Lists.of(ASTBuilderUtil.createVariableRef(pos, iteratorSymbol));
         nextInvocation.argExprs = nextInvocation.requiredArgs;
         nextInvocation.symbol = nextFuncSymbol;
-        nextInvocation.type = nextFuncSymbol.retType;
+        nextInvocation.setBType(nextFuncSymbol.retType);
         return nextInvocation;
     }
 
@@ -7837,8 +7875,8 @@ public class Desugar extends BLangNodeVisitor {
         BLangFieldBasedAccess fieldBasedAccessExpression =
                 ASTBuilderUtil.createFieldAccessExpr(resultReferenceInVariableDef, valueIdentifier);
         fieldBasedAccessExpression.pos = pos;
-        fieldBasedAccessExpression.type = varType;
-        fieldBasedAccessExpression.originalType = fieldBasedAccessExpression.type;
+        fieldBasedAccessExpression.setBType(varType);
+        fieldBasedAccessExpression.originalType = fieldBasedAccessExpression.getBType();
         return fieldBasedAccessExpression;
     }
 
@@ -7861,7 +7899,7 @@ public class Desugar extends BLangNodeVisitor {
 
         // TODO: 2/28/18 need to find a good way to refer to symbols
         invocationNode.symbol = symTable.rootScope.lookup(new Name(functionName)).symbol;
-        invocationNode.type = retType;
+        invocationNode.setBType(retType);
         invocationNode.requiredArgs = args;
         return invocationNode;
     }
@@ -7881,14 +7919,14 @@ public class Desugar extends BLangNodeVisitor {
         invocationNode.pkgAlias = (BLangIdentifier) TreeBuilder.createIdentifierNode();
 
         invocationNode.expr = onExpr;
-        invocationNode.symbol = symResolver.lookupLangLibMethod(onExpr.type, names.fromString(functionName));
+        invocationNode.symbol = symResolver.lookupLangLibMethod(onExpr.getBType(), names.fromString(functionName));
 
         ArrayList<BLangExpression> requiredArgs = new ArrayList<>();
         requiredArgs.add(onExpr);
         requiredArgs.addAll(args);
         invocationNode.requiredArgs = requiredArgs;
 
-        invocationNode.type = retType != null ? retType : ((BInvokableSymbol) invocationNode.symbol).retType;
+        invocationNode.setBType(retType != null ? retType : ((BInvokableSymbol) invocationNode.symbol).retType);
         invocationNode.langLibInvocation = true;
         return invocationNode;
     }
@@ -7913,7 +7951,7 @@ public class Desugar extends BLangNodeVisitor {
         requiredArgs.addAll(args);
         invocationNode.requiredArgs = requiredArgs;
 
-        invocationNode.type = retType != null ? retType : ((BInvokableSymbol) invocationNode.symbol).retType;
+        invocationNode.setBType(retType != null ? retType : ((BInvokableSymbol) invocationNode.symbol).retType);
         invocationNode.langLibInvocation = true;
         return invocationNode;
     }
@@ -7921,7 +7959,7 @@ public class Desugar extends BLangNodeVisitor {
     private BLangArrayLiteral createArrayLiteralExprNode() {
         BLangArrayLiteral expr = (BLangArrayLiteral) TreeBuilder.createArrayLiteralExpressionNode();
         expr.exprs = new ArrayList<>();
-        expr.type = new BArrayType(symTable.anyType);
+        expr.setBType(new BArrayType(symTable.anyType));
         return expr;
     }
 
@@ -7936,17 +7974,17 @@ public class Desugar extends BLangNodeVisitor {
             expr = fieldBasedAccess;
         }
         expr.symbol = iExpr.symbol;
-        expr.type = iExpr.symbol.type;
+        expr.setBType(iExpr.symbol.type);
 
         BLangExpression rewritten = rewriteExpr(expr);
         result = new BFunctionPointerInvocation(iExpr, rewritten);
     }
 
     private BLangExpression visitCloneInvocation(BLangExpression expr, BType lhsType) {
-        if (types.isValueType(expr.type)) {
+        if (types.isValueType(expr.getBType())) {
             return expr;
         }
-        if (expr.type.tag == TypeTags.ERROR) {
+        if (expr.getBType().tag == TypeTags.ERROR) {
             return expr;
         }
         BLangInvocation cloneInvok = createLangLibInvocationNode("clone", expr, new ArrayList<>(), null, expr.pos);
@@ -7954,14 +7992,15 @@ public class Desugar extends BLangNodeVisitor {
     }
 
     private BLangExpression visitCloneReadonly(BLangExpression expr, BType lhsType) {
-        if (types.isValueType(expr.type)) {
+        if (types.isValueType(expr.getBType())) {
             return expr;
         }
-        if (expr.type.tag == TypeTags.ERROR) {
+        if (expr.getBType().tag == TypeTags.ERROR) {
             return expr;
         }
-        BLangInvocation cloneInvok = createLangLibInvocationNode("cloneReadOnly", expr, new ArrayList<>(), expr.type,
-                expr.pos);
+        BLangInvocation cloneInvok = createLangLibInvocationNode("cloneReadOnly", expr, new ArrayList<>(),
+                                                                 expr.getBType(),
+                                                                 expr.pos);
         return addConversionExprIfRequired(cloneInvok, lhsType);
     }
 
@@ -8057,7 +8096,7 @@ public class Desugar extends BLangNodeVisitor {
     private BLangLiteral createIntLiteral(long value) {
         BLangLiteral literal = (BLangLiteral) TreeBuilder.createLiteralExpression();
         literal.value = value;
-        literal.type = symTable.intType;
+        literal.setBType(symTable.intType);
         return literal;
     }
 
@@ -8068,14 +8107,14 @@ public class Desugar extends BLangNodeVisitor {
     }
 
     private BLangExpression createTypeCastExpr(BLangExpression expr, BType targetType) {
-        if (types.isSameType(expr.type, targetType)) {
+        if (types.isSameType(expr.getBType(), targetType)) {
             return expr;
         }
 
         BLangTypeConversionExpr conversionExpr = (BLangTypeConversionExpr) TreeBuilder.createTypeConversionNode();
         conversionExpr.pos = expr.pos;
         conversionExpr.expr = expr;
-        conversionExpr.type = targetType;
+        conversionExpr.setBType(targetType);
         conversionExpr.targetType = targetType;
         conversionExpr.internal = true;
         return conversionExpr;
@@ -8145,7 +8184,7 @@ public class Desugar extends BLangNodeVisitor {
             // to use for member access when adding such required arguments from the vararg.
             BLangExpression expr = ((BLangRestArgsExpression) restArgs.get(restArgCount - 1)).expr;
             Location varargExpPos = expr.pos;
-            varargVarType = expr.type;
+            varargVarType = expr.getBType();
             String varargVarName = DESUGARED_VARARG_KEY + UNDERSCORE + this.varargCount++;
 
             BVarSymbol varargVarSymbol = new BVarSymbol(0, names.fromString(varargVarName), this.env.scope.owner.pkgID,
@@ -8156,7 +8195,7 @@ public class Desugar extends BLangNodeVisitor {
 
             BLangSimpleVariableDef varDef = ASTBuilderUtil.createVariableDef(varargExpPos);
             varDef.var = var;
-            varDef.type = varargVarType;
+            varDef.setBType(varargVarType);
 
             blockStmt = createBlockStmt(varargExpPos);
             blockStmt.stmts.add(varDef);
@@ -8184,7 +8223,7 @@ public class Desugar extends BLangNodeVisitor {
             }
 
             arrayLiteral.exprs = exprs;
-            arrayLiteral.type = arrayType;
+            arrayLiteral.setBType(arrayType);
 
             if (restArgCount != 0) {
                 iExpr.restArgs = new ArrayList<>();
@@ -8209,7 +8248,7 @@ public class Desugar extends BLangNodeVisitor {
             // statement(s).
             BLangExpression firstNonRestArg = iExpr.requiredArgs.remove(0);
             BLangStatementExpression stmtExpression = createStatementExpression(blockStmt, firstNonRestArg);
-            stmtExpression.type = firstNonRestArg.type;
+            stmtExpression.setBType(firstNonRestArg.getBType());
             iExpr.requiredArgs.add(0, stmtExpression);
 
             // If there's no rest param, the vararg only provided for required/defaultable params.
@@ -8224,7 +8263,7 @@ public class Desugar extends BLangNodeVisitor {
             // required/defaultable parameter are added to the new array.
             BLangRestArgsExpression restArgsExpression = (BLangRestArgsExpression) restArgs.remove(0);
             BArrayType restParamType = (BArrayType) invokableSymbol.restParam.type;
-            if (restArgsExpression.type.tag == TypeTags.RECORD) {
+            if (restArgsExpression.getBType().tag == TypeTags.RECORD) {
                 BLangExpression expr = ASTBuilderUtil.createEmptyArrayLiteral(invokableSymbol.pos, restParamType);
                 restArgs.add(expr);
                 return;
@@ -8232,7 +8271,7 @@ public class Desugar extends BLangNodeVisitor {
             Location pos = restArgsExpression.pos;
 
             BLangArrayLiteral newArrayLiteral = createArrayLiteralExprNode();
-            newArrayLiteral.type = restParamType;
+            newArrayLiteral.setBType(restParamType);
 
             String name = DESUGARED_VARARG_KEY + UNDERSCORE + this.varargCount++;
             BVarSymbol varSymbol = new BVarSymbol(0, names.fromString(name), this.env.scope.owner.pkgID,
@@ -8242,7 +8281,7 @@ public class Desugar extends BLangNodeVisitor {
             BLangSimpleVariable var = createVariable(pos, name, restParamType, newArrayLiteral, varSymbol);
             BLangSimpleVariableDef varDef = ASTBuilderUtil.createVariableDef(pos);
             varDef.var = var;
-            varDef.type = restParamType;
+            varDef.setBType(restParamType);
 
             BLangLiteral startIndex = createIntLiteral(invokableSymbol.params.size() - originalRequiredArgCount);
             BLangInvocation lengthInvocation = createLengthInvocation(pos, varargRef);
@@ -8257,7 +8296,7 @@ public class Desugar extends BLangNodeVisitor {
             final BLangSimpleVariable foreachVariable = ASTBuilderUtil.createVariable(pos, "$foreach$i",
                                                                                       foreach.varType);
             foreachVariable.symbol = new BVarSymbol(0, names.fromIdNode(foreachVariable.name),
-                                                    this.env.scope.owner.pkgID, foreachVariable.type,
+                                                    this.env.scope.owner.pkgID, foreachVariable.getBType(),
                                                     this.env.scope.owner, pos, VIRTUAL);
             BLangSimpleVarRef foreachVarRef = ASTBuilderUtil.createVariableRef(pos, foreachVariable.symbol);
             foreach.variableDefinitionNode = ASTBuilderUtil.createVariableDef(pos, foreachVariable);
@@ -8272,12 +8311,12 @@ public class Desugar extends BLangNodeVisitor {
                         arrayType.size == (iExpr.requiredArgs.size() - originalRequiredArgCount)) {
                     // If the array was a closed array that provided only for the non rest params, set the rest param
                     // type as the element type to satisfy code gen. The foreach will not be executed at runtime.
-                    valueExpr.type = restParamType.eType;
+                    valueExpr.setBType(restParamType.eType);
                 } else {
-                    valueExpr.type = arrayType.eType;
+                    valueExpr.setBType(arrayType.eType);
                 }
             } else {
-                valueExpr.type = symTable.anyOrErrorType; // Use any|error for tuple since it's a ref array.
+                valueExpr.setBType(symTable.anyOrErrorType); // Use any|error for tuple since it's a ref array.
             }
 
             BLangExpression pushExpr = addConversionExprIfRequired(valueExpr, restParamType.eType);
@@ -8293,7 +8332,7 @@ public class Desugar extends BLangNodeVisitor {
             newArrayBlockStmt.addStatement(foreach);
 
             BLangStatementExpression newArrayStmtExpression = createStatementExpression(newArrayBlockStmt, arrayVarRef);
-            newArrayStmtExpression.type = restParamType;
+            newArrayStmtExpression.setBType(restParamType);
 
             restArgs.add(addConversionExprIfRequired(newArrayStmtExpression, restParamType));
             return;
@@ -8304,7 +8343,7 @@ public class Desugar extends BLangNodeVisitor {
         BArrayType restParamType = (BArrayType) invokableSymbol.restParam.type;
 
         BLangArrayLiteral arrayLiteral = (BLangArrayLiteral) TreeBuilder.createArrayLiteralExpressionNode();
-        arrayLiteral.type = restParamType;
+        arrayLiteral.setBType(restParamType);
 
         BType elemType = restParamType.eType;
         Location pos = restArgs.get(0).pos;
@@ -8328,7 +8367,7 @@ public class Desugar extends BLangNodeVisitor {
         BLangSimpleVariable var = createVariable(pos, name, restParamType, arrayLiteral, varSymbol);
         BLangSimpleVariableDef varDef = ASTBuilderUtil.createVariableDef(pos);
         varDef.var = var;
-        varDef.type = restParamType;
+        varDef.setBType(restParamType);
 
         BLangBlockStmt pushBlockStmt = createBlockStmt(pos);
         pushBlockStmt.stmts.add(varDef);
@@ -8342,7 +8381,7 @@ public class Desugar extends BLangNodeVisitor {
         expressionStmt.expr = pushInvocation;
 
         BLangStatementExpression stmtExpression = createStatementExpression(pushBlockStmt, arrayVarRef);
-        stmtExpression.type = restParamType;
+        stmtExpression.setBType(restParamType);
 
         iExpr.restArgs = new ArrayList<BLangExpression>(1) {{ add(stmtExpression); }};
     }
@@ -8364,7 +8403,7 @@ public class Desugar extends BLangNodeVisitor {
         boolean tupleTypedVararg = false;
 
         if (varargRef != null) {
-            varargType = varargRef.type;
+            varargType = varargRef.getBType();
             tupleTypedVararg = varargType.tag == TypeTags.TUPLE;
         }
 
@@ -8380,7 +8419,7 @@ public class Desugar extends BLangNodeVisitor {
             } else if (param.getFlags().contains(Flag.INCLUDED)) {
                 BLangRecordLiteral recordLiteral = (BLangRecordLiteral) TreeBuilder.createRecordLiteralNode();
                 BType paramType = param.type;
-                recordLiteral.type = paramType;
+                recordLiteral.setBType(paramType);
                 args.add(recordLiteral);
                 incRecordLiterals.add(recordLiteral);
                 if (((BRecordType) paramType).restFieldType != symTable.noType) {
@@ -8389,12 +8428,12 @@ public class Desugar extends BLangNodeVisitor {
             } else if (varargRef == null) {
                 // Else create a dummy expression with an ignore flag.
                 BLangExpression expr = new BLangIgnoreExpr();
-                expr.type = param.type;
+                expr.setBType(param.type);
                 args.add(expr);
             } else {
                 // If a vararg is provided, no parameter defaults are added and no named args are specified.
                 // Thus, any missing args should come from the vararg.
-                if (varargRef.type.tag == TypeTags.RECORD) {
+                if (varargRef.getBType().tag == TypeTags.RECORD) {
                     if (param.isDefaultable) {
                         BLangInvocation hasKeyInvocation = createLangLibInvocationNode(HAS_KEY, varargRef,
                                 List.of(createStringLiteral(param.pos, param.name.value)), null, varargRef.pos);
@@ -8409,7 +8448,7 @@ public class Desugar extends BLangNodeVisitor {
                         BLangFieldBasedAccess fieldBasedAccessExpression =
                                 ASTBuilderUtil.createFieldAccessExpr(varargRef,
                                         ASTBuilderUtil.createIdentifier(param.pos, param.name.value));
-                        fieldBasedAccessExpression.type = param.type;
+                        fieldBasedAccessExpression.setBType(param.type);
                         args.add(fieldBasedAccessExpression);
                     }
                 } else {
@@ -8435,7 +8474,7 @@ public class Desugar extends BLangNodeVisitor {
             boolean isAdditionalField = true;
             BLangNamedArgsExpression expr = (BLangNamedArgsExpression) namedArgs.get(name);
             for (BLangRecordLiteral recordLiteral : incRecordLiterals) {
-                LinkedHashMap<String, BField> fields = ((BRecordType) recordLiteral.type).fields;
+                LinkedHashMap<String, BField> fields = ((BRecordType) recordLiteral.getBType()).fields;
                 if (fields.containsKey(name) && fields.get(name).type.tag != TypeTags.NEVER) {
                     isAdditionalField = false;
                     createAndAddRecordFieldForIncRecordLiteral(recordLiteral, expr);
@@ -8584,7 +8623,7 @@ public class Desugar extends BLangNodeVisitor {
         }
 
         // Cast matched expression into matched type.
-        BType expectedType = matchExprVar.type;
+        BType expectedType = matchExprVar.getBType();
         if (pattern.getKind() == NodeKind.MATCH_STRUCTURED_PATTERN_CLAUSE) {
             BLangMatchStructuredBindingPatternClause matchPattern = (BLangMatchStructuredBindingPatternClause) pattern;
             expectedType = getStructuredBindingPatternType(matchPattern.bindingPatternVariable);
@@ -8620,7 +8659,7 @@ public class Desugar extends BLangNodeVisitor {
                 blockStmt.addStatement(varDefStmt);
                 BLangStatementExpression stmtExpr = createStatementExpression(blockStmt,
                                                                               structuredPattern.typeGuardExpr);
-                stmtExpr.type = symTable.booleanType;
+                stmtExpr.setBType(symTable.booleanType);
 
                 ifCondition = ASTBuilderUtil
                         .createBinaryExpr(pattern.pos, ifCondition, stmtExpr, symTable.booleanType, OperatorKind.AND,
@@ -8651,11 +8690,13 @@ public class Desugar extends BLangNodeVisitor {
         // Create a variable reference for _$$_
         BLangSimpleVarRef matchExprVarRef = ASTBuilderUtil.createVariableRef(patternClause.pos,
                 matchExprVar.symbol);
-        BLangExpression patternVarExpr = addConversionExprIfRequired(matchExprVarRef, patternClause.variable.type);
+        BLangExpression patternVarExpr = addConversionExprIfRequired(matchExprVarRef,
+                                                                     patternClause.variable.getBType());
 
         // Add the variable def statement
-        BLangSimpleVariable patternVar = ASTBuilderUtil.createVariable(patternClause.pos, "",
-                patternClause.variable.type, patternVarExpr, patternClause.variable.symbol);
+        BLangSimpleVariable patternVar =
+                ASTBuilderUtil.createVariable(patternClause.pos, "", patternClause.variable.getBType(),
+                                              patternVarExpr, patternClause.variable.symbol);
         BLangSimpleVariableDef patternVarDef = ASTBuilderUtil.createVariableDef(patternVar.pos, patternVar);
         patternClause.body.stmts.add(0, patternVarDef);
         body = patternClause.body;
@@ -8704,7 +8745,7 @@ public class Desugar extends BLangNodeVisitor {
             return expr;
         }
 
-        BType rhsType = expr.type;
+        BType rhsType = expr.getBType();
         if (types.isSameType(rhsType, lhsType)) {
             return expr;
         }
@@ -8731,7 +8772,7 @@ public class Desugar extends BLangNodeVisitor {
                 TreeBuilder.createTypeConversionNode();
         conversionExpr.expr = expr;
         conversionExpr.targetType = lhsType;
-        conversionExpr.type = lhsType;
+        conversionExpr.setBType(lhsType);
         conversionExpr.pos = expr.pos;
         conversionExpr.checkTypes = false;
         conversionExpr.internal = true;
@@ -8746,7 +8787,7 @@ public class Desugar extends BLangNodeVisitor {
             case MATCH_STATIC_PATTERN_CLAUSE:
                 BLangMatchStaticBindingPatternClause staticPattern =
                         (BLangMatchStaticBindingPatternClause) patternClause;
-                patternType = staticPattern.literal.type;
+                patternType = staticPattern.literal.getBType();
                 break;
             case MATCH_STRUCTURED_PATTERN_CLAUSE:
                 BLangMatchStructuredBindingPatternClause structuredPattern =
@@ -8755,7 +8796,7 @@ public class Desugar extends BLangNodeVisitor {
                 break;
             default:
                 BLangMatchTypedBindingPatternClause simplePattern = (BLangMatchTypedBindingPatternClause) patternClause;
-                patternType = simplePattern.variable.type;
+                patternType = simplePattern.variable.getBType();
                 break;
         }
 
@@ -8777,14 +8818,14 @@ public class Desugar extends BLangNodeVisitor {
             binaryExpr = ASTBuilderUtil.createBinaryExpr(patternClause.pos, lhsExpr, rhsExpr,
                     symTable.booleanType, OperatorKind.OR,
                     (BOperatorSymbol) symResolver.resolveBinaryOperator(OperatorKind.OR,
-                            lhsExpr.type, rhsExpr.type));
+                                                                        lhsExpr.getBType(), rhsExpr.getBType()));
             for (int i = 2; i < memberTypes.length; i++) {
                 lhsExpr = createPatternMatchBinaryExpr(patternClause, varSymbol, memberTypes[i]);
                 rhsExpr = binaryExpr;
                 binaryExpr = ASTBuilderUtil.createBinaryExpr(patternClause.pos, lhsExpr, rhsExpr,
                         symTable.booleanType, OperatorKind.OR,
                         (BOperatorSymbol) symResolver.resolveBinaryOperator(OperatorKind.OR,
-                                lhsExpr.type, rhsExpr.type));
+                                                                            lhsExpr.getBType(), rhsExpr.getBType()));
             }
         }
         return binaryExpr;
@@ -8840,7 +8881,7 @@ public class Desugar extends BLangNodeVisitor {
 
             // if rest param is null we treat it as an open record with anydata rest param
             recordVarType.restFieldType = recordVariable.restParam != null ?
-                        ((BMapType) ((BLangSimpleVariable) recordVariable.restParam).type).constraint :
+                        ((BMapType) ((BLangSimpleVariable) recordVariable.restParam).getBType()).constraint :
                     symTable.anydataType;
             recordSymbol.type = recordVarType;
             recordVarType.tsymbol = recordSymbol;
@@ -8883,7 +8924,7 @@ public class Desugar extends BLangNodeVisitor {
             return errorType;
         }
 
-        return bindingPatternVariable.type;
+        return bindingPatternVariable.getBType();
     }
 
     private BLangRecordTypeNode createRecordTypeNode(BLangErrorVariable errorVariable, BRecordType detailType) {
@@ -8898,7 +8939,7 @@ public class Desugar extends BLangNodeVisitor {
             BLangSimpleVariable fieldVar = ASTBuilderUtil.createVariable(
                     field.valueBindingPattern.pos,
                     symbol.name.value,
-                    field.valueBindingPattern.type,
+                    field.valueBindingPattern.getBType(),
                     field.valueBindingPattern.expr,
                     symbol);
             fieldList.add(fieldVar);
@@ -8956,7 +8997,7 @@ public class Desugar extends BLangNodeVisitor {
 
     BLangErrorType createErrorTypeNode(BErrorType errorType) {
         BLangErrorType errorTypeNode = (BLangErrorType) TreeBuilder.createErrorTypeNode();
-        errorTypeNode.type = errorType;
+        errorTypeNode.setBType(errorType);
         return errorTypeNode;
     }
 
@@ -9004,17 +9045,18 @@ public class Desugar extends BLangNodeVisitor {
         } else if (expression.getKind() == NodeKind.SIMPLE_VARIABLE_REF
                 && ((BLangSimpleVarRef) expression).variableName.value.equals(IGNORE.value)) {
             BLangValueType anyType = (BLangValueType) TreeBuilder.createValueTypeNode();
-            anyType.type = symTable.anyType;
+            anyType.setBType(symTable.anyType);
             anyType.typeKind = TypeKind.ANY;
             return ASTBuilderUtil.createTypeTestExpr(pos, varRef, anyType);
         } else {
             binaryExpr = ASTBuilderUtil
                     .createBinaryExpr(pos, varRef, expression, symTable.booleanType, OperatorKind.EQUAL, null);
-            BSymbol opSymbol = symResolver.resolveBinaryOperator(OperatorKind.EQUAL, varRef.type, expression.type);
+            BSymbol opSymbol = symResolver.resolveBinaryOperator(OperatorKind.EQUAL, varRef.getBType(),
+                                                                 expression.getBType());
             if (opSymbol == symTable.notFoundSymbol) {
                 opSymbol = symResolver
-                        .getBinaryEqualityForTypeSets(OperatorKind.EQUAL, symTable.anydataType, expression.type,
-                                binaryExpr);
+                        .getBinaryEqualityForTypeSets(OperatorKind.EQUAL, symTable.anydataType, expression.getBType(),
+                                                      binaryExpr);
             }
             binaryExpr.opSymbol = (BOperatorSymbol) opSymbol;
         }
@@ -9042,7 +9084,7 @@ public class Desugar extends BLangNodeVisitor {
         varRef.pos = variable.pos;
         varRef.variableName = variable.name;
         varRef.symbol = variable.symbol;
-        varRef.type = variable.type;
+        varRef.setBType(variable.getBType());
 
         BLangAssignment assignmentStmt = (BLangAssignment) TreeBuilder.createAssignmentNode();
         assignmentStmt.expr = variable.expr;
@@ -9053,7 +9095,7 @@ public class Desugar extends BLangNodeVisitor {
 
     private BLangAssignment createStructFieldUpdate(BLangFunction function, BLangSimpleVariable variable,
                                                     BVarSymbol selfSymbol) {
-        return createStructFieldUpdate(function, variable.expr, variable.symbol, variable.type, selfSymbol,
+        return createStructFieldUpdate(function, variable.expr, variable.symbol, variable.getBType(), selfSymbol,
                                        variable.name);
     }
 
@@ -9063,7 +9105,7 @@ public class Desugar extends BLangNodeVisitor {
         BLangSimpleVarRef selfVarRef = ASTBuilderUtil.createVariableRef(function.pos, selfSymbol);
         BLangFieldBasedAccess fieldAccess = ASTBuilderUtil.createFieldAccessExpr(selfVarRef, fieldName);
         fieldAccess.symbol = fieldSymbol;
-        fieldAccess.type = fieldType;
+        fieldAccess.setBType(fieldType);
         fieldAccess.isStoreOnCreation = true;
 
         BLangAssignment assignmentStmt = (BLangAssignment) TreeBuilder.createAssignmentNode();
@@ -9079,18 +9121,18 @@ public class Desugar extends BLangNodeVisitor {
         List<BType> exprTypes;
         List<BType> unmatchedTypes = new ArrayList<>();
 
-        if (bLangMatchExpression.expr.type.tag == TypeTags.UNION) {
-            BUnionType unionType = (BUnionType) bLangMatchExpression.expr.type;
+        if (bLangMatchExpression.expr.getBType().tag == TypeTags.UNION) {
+            BUnionType unionType = (BUnionType) bLangMatchExpression.expr.getBType();
             exprTypes = new ArrayList<>(unionType.getMemberTypes());
         } else {
-            exprTypes = Lists.of(bLangMatchExpression.type);
+            exprTypes = Lists.of(bLangMatchExpression.getBType());
         }
 
         // find the types that do not match to any of the patterns.
         for (BType type : exprTypes) {
             boolean assignable = false;
             for (BLangMatchExprPatternClause pattern : bLangMatchExpression.patternClauses) {
-                if (this.types.isAssignable(type, pattern.variable.type)) {
+                if (this.types.isAssignable(type, pattern.variable.getBType())) {
                     assignable = true;
                     break;
                 }
@@ -9146,27 +9188,27 @@ public class Desugar extends BLangNodeVisitor {
     }
 
     private BLangExpression rewriteSafeNavigationExpr(BLangAccessExpression accessExpr) {
-        BType originalExprType = accessExpr.type;
+        BType originalExprType = accessExpr.getBType();
         // Create a temp variable to hold the intermediate result of the acces expression.
         String matchTempResultVarName = GEN_VAR_PREFIX.value + "temp_result";
         BLangSimpleVariable tempResultVar =
-                ASTBuilderUtil.createVariable(accessExpr.pos, matchTempResultVarName, accessExpr.type, null,
+                ASTBuilderUtil.createVariable(accessExpr.pos, matchTempResultVarName, accessExpr.getBType(), null,
                                               new BVarSymbol(0, names.fromString(matchTempResultVarName),
-                                                             this.env.scope.owner.pkgID, accessExpr.type,
+                                                             this.env.scope.owner.pkgID, accessExpr.getBType(),
                                                              this.env.scope.owner, accessExpr.pos, VIRTUAL));
         BLangSimpleVariableDef tempResultVarDef = ASTBuilderUtil.createVariableDef(accessExpr.pos, tempResultVar);
         BLangVariableReference tempResultVarRef =
                 ASTBuilderUtil.createVariableRef(accessExpr.pos, tempResultVar.symbol);
 
         // Create a chain of match statements
-        handleSafeNavigation(accessExpr, accessExpr.type, tempResultVar);
+        handleSafeNavigation(accessExpr, accessExpr.getBType(), tempResultVar);
 
         // Create a statement-expression including the match statement
         BLangMatch matcEXpr = this.matchStmtStack.firstElement();
         BLangBlockStmt blockStmt =
                 ASTBuilderUtil.createBlockStmt(accessExpr.pos, Lists.of(tempResultVarDef, matcEXpr));
         BLangStatementExpression stmtExpression = createStatementExpression(blockStmt, tempResultVarRef);
-        stmtExpression.type = originalExprType;
+        stmtExpression.setBType(originalExprType);
 
         // Reset the variables
         this.matchStmtStack = new Stack<>();
@@ -9190,12 +9232,12 @@ public class Desugar extends BLangNodeVisitor {
         if (!(accessExpr.errorSafeNavigation || accessExpr.nilSafeNavigation)) {
             BType originalType = accessExpr.originalType;
             if (TypeTags.isXMLTypeTag(originalType.tag)) {
-                accessExpr.type = BUnionType.create(null, originalType, symTable.errorType);
+                accessExpr.setBType(BUnionType.create(null, originalType, symTable.errorType));
             } else {
-                accessExpr.type = originalType;
+                accessExpr.setBType(originalType);
             }
             if (this.safeNavigationAssignment != null) {
-                this.safeNavigationAssignment.expr = addConversionExprIfRequired(accessExpr, tempResultVar.type);
+                this.safeNavigationAssignment.expr = addConversionExprIfRequired(accessExpr, tempResultVar.getBType());
             }
             return;
         }
@@ -9218,22 +9260,22 @@ public class Desugar extends BLangNodeVisitor {
 
         boolean isAllTypesRecords = false;
         LinkedHashSet<BType> memTypes = new LinkedHashSet<>();
-        if (accessExpr.expr.type.tag == TypeTags.UNION) {
-            memTypes = new LinkedHashSet<>(((BUnionType) accessExpr.expr.type).getMemberTypes());
+        if (accessExpr.expr.getBType().tag == TypeTags.UNION) {
+            memTypes = new LinkedHashSet<>(((BUnionType) accessExpr.expr.getBType()).getMemberTypes());
             isAllTypesRecords = isAllTypesAreRecordsInUnion(memTypes);
         }
 
         // Add pattern to lift nil
         if (accessExpr.nilSafeNavigation) {
             matchStmt.patternClauses.add(getMatchNullPattern(accessExpr, tempResultVar));
-            matchStmt.type = type;
+            matchStmt.setBType(type);
             memTypes.remove(symTable.nilType);
         }
 
         // Add pattern to lift error, only if the safe navigation is used
         if (accessExpr.errorSafeNavigation) {
             matchStmt.patternClauses.add(getMatchErrorPattern(accessExpr, tempResultVar));
-            matchStmt.type = type;
+            matchStmt.setBType(type);
             matchStmt.pos = accessExpr.pos;
             memTypes.remove(symTable.errorType);
         }
@@ -9241,8 +9283,8 @@ public class Desugar extends BLangNodeVisitor {
         BLangMatchTypedBindingPatternClause successPattern = null;
         Name field = getFieldName(accessExpr);
         if (field == Names.EMPTY) {
-            successPattern = getSuccessPattern(accessExpr.expr.type, accessExpr, tempResultVar,
-                    accessExpr.errorSafeNavigation);
+            successPattern = getSuccessPattern(accessExpr.expr.getBType(), accessExpr, tempResultVar,
+                                               accessExpr.errorSafeNavigation);
             matchStmt.patternClauses.add(successPattern);
             pushToMatchStatementStack(matchStmt, accessExpr, successPattern);
             return;
@@ -9264,7 +9306,8 @@ public class Desugar extends BLangNodeVisitor {
 
         // Create the pattern for success scenario. i.e: not null and not error (if applicable).
         successPattern =
-                getSuccessPattern(accessExpr.expr.type, accessExpr, tempResultVar, accessExpr.errorSafeNavigation);
+                getSuccessPattern(accessExpr.expr.getBType(), accessExpr, tempResultVar,
+                                  accessExpr.errorSafeNavigation);
         matchStmt.patternClauses.add(successPattern);
         pushToMatchStatementStack(matchStmt, accessExpr, successPattern);
     }
@@ -9423,19 +9466,19 @@ public class Desugar extends BLangNodeVisitor {
         // Type of the field access expression should be always taken from the child type.
         // Because the type assigned to expression contains the inherited error/nil types,
         // and may not reflect the actual type of the child/field expr.
-        if (TypeTags.isXMLTypeTag(tempAccessExpr.expr.type.tag)) {
+        if (TypeTags.isXMLTypeTag(tempAccessExpr.expr.getBType().tag)) {
             // todo: add discription why this is special here
-            tempAccessExpr.type = BUnionType.create(null, accessExpr.originalType, symTable.errorType,
-                    symTable.nilType);
+            tempAccessExpr.setBType(BUnionType.create(null, accessExpr.originalType, symTable.errorType,
+                                                      symTable.nilType));
         } else {
-            tempAccessExpr.type = accessExpr.originalType;
+            tempAccessExpr.setBType(accessExpr.originalType);
         }
         tempAccessExpr.optionalFieldAccess = accessExpr.optionalFieldAccess;
 
         BLangVariableReference tempResultVarRef =
                 ASTBuilderUtil.createVariableRef(accessExpr.pos, tempResultVar.symbol);
 
-        BLangExpression assignmentRhsExpr = addConversionExprIfRequired(tempAccessExpr, tempResultVarRef.type);
+        BLangExpression assignmentRhsExpr = addConversionExprIfRequired(tempAccessExpr, tempResultVarRef.getBType());
         BLangAssignment assignmentStmt =
                 ASTBuilderUtil.createAssignmentStmt(accessExpr.pos, tempResultVarRef, assignmentRhsExpr, false);
         BLangBlockStmt patternBody = ASTBuilderUtil.createBlockStmt(accessExpr.pos, Lists.of(assignmentStmt));
@@ -9454,7 +9497,7 @@ public class Desugar extends BLangNodeVisitor {
         }
 
         BLangExpression varRef = ((BLangAccessExpression) expr).expr;
-        if (varRef.type.isNullable()) {
+        if (varRef.getBType().isNullable()) {
             return true;
         }
 
@@ -9502,11 +9545,11 @@ public class Desugar extends BLangNodeVisitor {
             BLangInvocation invocation = (BLangInvocation) expr;
             BVarSymbol interMediateSymbol = new BVarSymbol(0,
                                                            names.fromString(GEN_VAR_PREFIX.value + "i_intermediate"),
-                                                           this.env.scope.owner.pkgID, invocation.type,
+                                                           this.env.scope.owner.pkgID, invocation.getBType(),
                                                            this.env.scope.owner, expr.pos, VIRTUAL);
             BLangSimpleVariable intermediateVariable = ASTBuilderUtil.createVariable(expr.pos,
                                                                                      interMediateSymbol.name.value,
-                                                                                     invocation.type, invocation,
+                                                                                     invocation.getBType(), invocation,
                                                                                      interMediateSymbol);
             BLangSimpleVariableDef intermediateVariableDefinition = ASTBuilderUtil.createVariableDef(invocation.pos,
                     intermediateVariable);
@@ -9515,20 +9558,21 @@ public class Desugar extends BLangNodeVisitor {
             expr = ASTBuilderUtil.createVariableRef(invocation.pos, interMediateSymbol);
         }
 
-        if (expr.type.isNullable()) {
+        if (expr.getBType().isNullable()) {
             BLangTypeTestExpr isNillTest = ASTBuilderUtil.createTypeTestExpr(expr.pos, expr, getNillTypeNode());
-            isNillTest.type = symTable.booleanType;
+            isNillTest.setBType(symTable.booleanType);
 
             BLangBlockStmt thenStmt = ASTBuilderUtil.createBlockStmt(expr.pos);
 
             //Cloning the expression and set the nil lifted type.
             expr = cloneExpression(expr);
-            expr.type = types.getSafeType(expr.type, true, false);
+            expr.setBType(types.getSafeType(expr.getBType(), true, false));
 
-            if (isDefaultableMappingType(expr.type) && !root) { // TODO for records, type should be defaultable as well
+            // TODO for records, type should be defaultable as well
+            if (isDefaultableMappingType(expr.getBType()) && !root) {
                 // This will properly get desugered later to a json literal
                 BLangRecordLiteral jsonLiteral = (BLangRecordLiteral) TreeBuilder.createRecordLiteralNode();
-                jsonLiteral.type = expr.type;
+                jsonLiteral.setBType(expr.getBType());
                 jsonLiteral.pos = expr.pos;
                 BLangAssignment assignment = ASTBuilderUtil.createAssignmentStmt(expr.pos,
                         expr, jsonLiteral);
@@ -9536,13 +9580,13 @@ public class Desugar extends BLangNodeVisitor {
             } else {
                 BLangLiteral literal = (BLangLiteral) TreeBuilder.createLiteralExpression();
                 literal.value = ERROR_REASON_NULL_REFERENCE_ERROR;
-                literal.type = symTable.stringType;
+                literal.setBType(symTable.stringType);
 
                 BLangErrorConstructorExpr errorConstructorExpr =
                         (BLangErrorConstructorExpr) TreeBuilder.createErrorConstructorExpressionNode();
                 BSymbol symbol = symResolver.lookupMainSpaceSymbolInPackage(errorConstructorExpr.pos, env,
                         names.fromString(""), names.fromString("error"));
-                errorConstructorExpr.type = symbol.type;
+                errorConstructorExpr.setBType(symbol.type);
                 errorConstructorExpr.pos = expr.pos;
                 List<BLangExpression> positionalArgs = new ArrayList<>();
                 positionalArgs.add(literal);
@@ -9564,7 +9608,7 @@ public class Desugar extends BLangNodeVisitor {
     BLangValueType getNillTypeNode() {
         BLangValueType nillTypeNode = (BLangValueType) TreeBuilder.createValueTypeNode();
         nillTypeNode.typeKind = TypeKind.NIL;
-        nillTypeNode.type = symTable.nilType;
+        nillTypeNode.setBType(symTable.nilType);
         return nillTypeNode;
     }
 
@@ -9592,7 +9636,7 @@ public class Desugar extends BLangNodeVisitor {
         } else {
             varRef = cloneExpression(originalAccessExpr.expr);
         }
-        varRef.type = types.getSafeType(originalAccessExpr.expr.type, true, false);
+        varRef.setBType(types.getSafeType(originalAccessExpr.expr.getBType(), true, false));
 
         BLangAccessExpression accessExpr;
         switch (originalAccessExpr.getKind()) {
@@ -9618,7 +9662,7 @@ public class Desugar extends BLangNodeVisitor {
         // Type of the field access expression should be always taken from the child type.
         // Because the type assigned to expression contains the inherited error/nil types,
         // and may not reflect the actual type of the child/field expr.
-        accessExpr.type = originalAccessExpr.originalType;
+        accessExpr.setBType(originalAccessExpr.originalType);
         return accessExpr;
     }
 
@@ -9641,7 +9685,7 @@ public class Desugar extends BLangNodeVisitor {
     private BLangLiteral getBooleanLiteral(boolean value) {
         BLangLiteral literal = (BLangLiteral) TreeBuilder.createLiteralExpression();
         literal.value = value;
-        literal.type = symTable.booleanType;
+        literal.setBType(symTable.booleanType);
         literal.pos = symTable.builtinPos;
         return literal;
     }
@@ -9660,12 +9704,14 @@ public class Desugar extends BLangNodeVisitor {
     private BLangFunction createInitFunctionForClassDefn(BLangClassDefinition classDefinition, SymbolEnv env) {
         BLangFunction initFunction =
                 TypeDefBuilderHelper.createInitFunctionForStructureType(classDefinition.pos, classDefinition.symbol,
-                        env, names, Names.GENERATED_INIT_SUFFIX, symTable, classDefinition.type);
-        BObjectTypeSymbol typeSymbol = ((BObjectTypeSymbol) classDefinition.type.tsymbol);
+                                                                        env, names, Names.GENERATED_INIT_SUFFIX,
+                                                                        symTable, classDefinition.getBType());
+        BObjectTypeSymbol typeSymbol = ((BObjectTypeSymbol) classDefinition.getBType().tsymbol);
         typeSymbol.generatedInitializerFunc = new BAttachedFunction(Names.GENERATED_INIT_SUFFIX, initFunction.symbol,
-                (BInvokableType) initFunction.type, classDefinition.pos);
+                                                                    (BInvokableType) initFunction.getBType(),
+                                                                    classDefinition.pos);
         classDefinition.generatedInitFunction = initFunction;
-        initFunction.returnTypeNode.type = symTable.nilType;
+        initFunction.returnTypeNode.setBType(symTable.nilType);
         return rewrite(initFunction, env);
     }
 
@@ -9692,7 +9738,8 @@ public class Desugar extends BLangNodeVisitor {
          * }
          *
          */
-        BLangSimpleVariableDef resultVarDef = createVarDef("$result$", binaryExpr.type, null, symTable.builtinPos);
+        BLangSimpleVariableDef resultVarDef = createVarDef("$result$", binaryExpr.getBType(), null,
+                                                           symTable.builtinPos);
         BLangBlockStmt thenBody = ASTBuilderUtil.createBlockStmt(binaryExpr.pos);
         BLangBlockStmt elseBody = ASTBuilderUtil.createBlockStmt(binaryExpr.pos);
 
@@ -9728,7 +9775,7 @@ public class Desugar extends BLangNodeVisitor {
 
         BLangBlockStmt blockStmt = ASTBuilderUtil.createBlockStmt(binaryExpr.pos, Lists.of(resultVarDef, ifElse));
         BLangStatementExpression stmtExpr = createStatementExpression(blockStmt, resultVarRef);
-        stmtExpr.type = binaryExpr.type;
+        stmtExpr.setBType(binaryExpr.getBType());
 
         result = rewriteExpr(stmtExpr);
     }
@@ -9881,7 +9928,7 @@ public class Desugar extends BLangNodeVisitor {
 
     private BType getRestType(BLangFunction function) {
         if (function != null && function.restParam != null) {
-            return function.restParam.type;
+            return function.restParam.getBType();
         }
         return null;
     }
@@ -9903,7 +9950,7 @@ public class Desugar extends BLangNodeVisitor {
     private BLangRecordLiteral rewriteMappingConstructor(BLangRecordLiteral mappingConstructorExpr) {
         List<RecordLiteralNode.RecordField> fields = mappingConstructorExpr.fields;
 
-        BType type = mappingConstructorExpr.type;
+        BType type = mappingConstructorExpr.getBType();
         Location pos = mappingConstructorExpr.pos;
 
         List<RecordLiteralNode.RecordField> rewrittenFields = new ArrayList<>(fields.size());

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/MockDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/MockDesugar.java
@@ -156,7 +156,7 @@ public class MockDesugar {
             generatedMock.restParam = generateRestParam();                  // Rest Param
             generatedMock.returnTypeNode = generateReturnTypeNode();        // Return Type Node
             generatedMock.body = generateBody();                            // Body
-            generatedMock.type = generateSymbolInvokableType();             // Invokable Type
+            generatedMock.setBType(generateSymbolInvokableType());             // Invokable Type
             generatedMock.symbol = generateSymbol(functionName);            // Invokable Symbol
         } else {
             throw new IllegalStateException("Mock Function and Function to Mock cannot be null");
@@ -262,7 +262,7 @@ public class MockDesugar {
         BLangValueType typeNode = (BLangValueType) TreeBuilder.createValueTypeNode();
         typeNode.pos = this.bLangPackage.pos;
         typeNode.typeKind = this.importFunction.retType.getKind();
-        typeNode.type = this.importFunction.retType;
+        typeNode.setBType(this.importFunction.retType);
 
         return typeNode;
     }
@@ -356,7 +356,7 @@ public class MockDesugar {
         bLangFieldBasedAccess.originalType = fieldType;
         bLangFieldBasedAccess.isLValue = true;
         bLangFieldBasedAccess.expectedType = fieldType;
-        bLangFieldBasedAccess.type = fieldType;
+        bLangFieldBasedAccess.setBType(fieldType);
 
         return bLangFieldBasedAccess;
     }
@@ -398,7 +398,7 @@ public class MockDesugar {
         BLangTypeConversionExpr typeConversionExpr = (BLangTypeConversionExpr) TreeBuilder.createTypeConversionNode();
         typeConversionExpr.pos = bLangInvocation.pos;
         typeConversionExpr.expr = bLangInvocation;
-        typeConversionExpr.type = target;
+        typeConversionExpr.setBType(target);
         typeConversionExpr.targetType = target;
 
         return typeConversionExpr;
@@ -415,7 +415,7 @@ public class MockDesugar {
                 bLangPackage.pos, invokableSymbol, requiredArgs, symResolver);
         bLangInvocation.pkgAlias = (BLangIdentifier) createIdentifier("test");
         bLangInvocation.argExprs = argsExprs;
-        bLangInvocation.expectedType = bLangInvocation.type;
+        bLangInvocation.expectedType = bLangInvocation.getBType();
         bLangInvocation.restArgs = restArgs;
 
         return bLangInvocation;
@@ -543,7 +543,7 @@ public class MockDesugar {
         if (originalFunction == null) {
             type = this.importFunction.retType;
         } else {
-            type = ((BInvokableType) this.originalFunction.type).retType;
+            type = ((BInvokableType) this.originalFunction.getBType()).retType;
         }
 
         return type;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
@@ -248,11 +248,11 @@ public class QueryDesugar extends BLangNodeVisitor {
         List<BLangNode> clauses = queryExpr.getQueryClauses();
         Location pos = clauses.get(0).pos;
         BLangBlockStmt queryBlock = ASTBuilderUtil.createBlockStmt(pos);
-        BLangVariableReference streamRef = buildStream(clauses, queryExpr.type, env, queryBlock);
+        BLangVariableReference streamRef = buildStream(clauses, queryExpr.getBType(), env, queryBlock);
         BLangStatementExpression streamStmtExpr;
         if (queryExpr.isStream) {
             streamStmtExpr = ASTBuilderUtil.createStatementExpression(queryBlock, streamRef);
-            streamStmtExpr.type = streamRef.type;
+            streamStmtExpr.setBType(streamRef.getBType());
         } else if (queryExpr.isTable) {
             onConflictExpr = (onConflictExpr == null)
                     ? ASTBuilderUtil.createLiteral(pos, symTable.nilType, Names.NIL_VALUE)
@@ -261,19 +261,20 @@ public class QueryDesugar extends BLangNodeVisitor {
             BLangVariableReference result = getStreamFunctionVariableRef(queryBlock,
                     QUERY_ADD_TO_TABLE_FUNCTION, Lists.of(streamRef, tableRef, onConflictExpr), pos);
             streamStmtExpr = ASTBuilderUtil.createStatementExpression(queryBlock,
-                                                                      addTypeConversionExpr(result, queryExpr.type));
-            streamStmtExpr.type = tableRef.type;
+                                                                      addTypeConversionExpr(result,
+                                                                                            queryExpr.getBType()));
+            streamStmtExpr.setBType(tableRef.getBType());
             onConflictExpr = null;
         } else {
             BLangVariableReference result;
-            if (TypeTags.isXMLTypeTag(queryExpr.type.tag) || (queryExpr.type.tag == TypeTags.UNION &&
-                    ((BUnionType) queryExpr.type).getMemberTypes().stream()
+            if (TypeTags.isXMLTypeTag(queryExpr.getBType().tag) || (queryExpr.getBType().tag == TypeTags.UNION &&
+                    ((BUnionType) queryExpr.getBType()).getMemberTypes().stream()
                             .allMatch(memType -> TypeTags.isXMLTypeTag(memType.tag)))) {
                 result = getStreamFunctionVariableRef(queryBlock, QUERY_TO_XML_FUNCTION, Lists.of(streamRef), pos);
-            } else if (TypeTags.isStringTypeTag(queryExpr.type.tag)) {
+            } else if (TypeTags.isStringTypeTag(queryExpr.getBType().tag)) {
                 result = getStreamFunctionVariableRef(queryBlock, QUERY_TO_STRING_FUNCTION, Lists.of(streamRef), pos);
             } else {
-                BType arrayType = queryExpr.type;
+                BType arrayType = queryExpr.getBType();
                 if (arrayType.tag == TypeTags.UNION) {
                     arrayType = ((BUnionType) arrayType).getMemberTypes()
                             .stream().filter(m -> m.tag == TypeTags.ARRAY)
@@ -281,12 +282,12 @@ public class QueryDesugar extends BLangNodeVisitor {
                 }
                 BLangArrayLiteral arr = (BLangArrayLiteral) TreeBuilder.createArrayLiteralExpressionNode();
                 arr.exprs = new ArrayList<>();
-                arr.type = arrayType;
+                arr.setBType(arrayType);
                 result = getStreamFunctionVariableRef(queryBlock, QUERY_TO_ARRAY_FUNCTION,
                         Lists.of(streamRef, arr), pos);
             }
             streamStmtExpr = ASTBuilderUtil.createStatementExpression(queryBlock, result);
-            streamStmtExpr.type = result.type;
+            streamStmtExpr.setBType(result.getBType());
         }
         return streamStmtExpr;
     }
@@ -302,11 +303,11 @@ public class QueryDesugar extends BLangNodeVisitor {
         List<BLangNode> clauses = queryAction.getQueryClauses();
         Location pos = clauses.get(0).pos;
         BLangBlockStmt queryBlock = ASTBuilderUtil.createBlockStmt(pos);
-        BLangVariableReference streamRef = buildStream(clauses, queryAction.type, env, queryBlock);
+        BLangVariableReference streamRef = buildStream(clauses, queryAction.getBType(), env, queryBlock);
         BLangVariableReference result = getStreamFunctionVariableRef(queryBlock,
                 QUERY_CONSUME_STREAM_FUNCTION, symTable.errorOrNilType, Lists.of(streamRef), pos);
         BLangStatementExpression stmtExpr = ASTBuilderUtil.createStatementExpression(queryBlock, result);
-        stmtExpr.type = symTable.errorOrNilType;
+        stmtExpr.setBType(symTable.errorOrNilType);
         return stmtExpr;
     }
 
@@ -392,9 +393,10 @@ public class QueryDesugar extends BLangNodeVisitor {
                                        BLangExpression collection, BType resultType) {
         String name = getNewVarName();
         BVarSymbol dataSymbol = new BVarSymbol(0, names.fromString(name), env.scope.owner.pkgID,
-                                               collection.type, this.env.scope.owner, pos, VIRTUAL);
-        BLangSimpleVariable dataVariable = ASTBuilderUtil.createVariable(pos, name,
-                collection.type, addTypeConversionExpr(collection, collection.type), dataSymbol);
+                                               collection.getBType(), this.env.scope.owner, pos, VIRTUAL);
+        BLangSimpleVariable dataVariable =
+                ASTBuilderUtil.createVariable(pos, name, collection.getBType(),
+                                              addTypeConversionExpr(collection, collection.getBType()), dataSymbol);
         BLangSimpleVariableDef dataVarDef = ASTBuilderUtil.createVariableDef(pos, dataVariable);
         BLangVariableReference valueVarRef = ASTBuilderUtil.createVariableRef(pos, dataSymbol);
         blockStmt.addStatement(dataVarDef);
@@ -409,11 +411,11 @@ public class QueryDesugar extends BLangNodeVisitor {
         BType constraintTdType = new BTypedescType(constraintType, symTable.typeDesc.tsymbol);
         BLangTypedescExpr constraintTdExpr = new BLangTypedescExpr();
         constraintTdExpr.resolvedType = constraintType;
-        constraintTdExpr.type = constraintTdType;
+        constraintTdExpr.setBType(constraintTdType);
         BType completionTdType = new BTypedescType(completionType, symTable.typeDesc.tsymbol);
         BLangTypedescExpr completionTdExpr = new BLangTypedescExpr();
         completionTdExpr.resolvedType = completionType;
-        completionTdExpr.type = completionTdType;
+        completionTdExpr.setBType(completionTdType);
         return getStreamFunctionVariableRef(blockStmt, QUERY_CREATE_PIPELINE_FUNCTION,
                 Lists.of(valueVarRef, constraintTdExpr, completionTdExpr), pos);
     }
@@ -446,7 +448,7 @@ public class QueryDesugar extends BLangNodeVisitor {
         BLangFieldBasedAccess valueAccessExpr = desugar.getValueAccessExpression(inputClause.pos,
                 symTable.anyOrErrorType, frameSymbol);
         valueAccessExpr.expr = desugar.addConversionExprIfRequired(valueAccessExpr.expr,
-                types.getSafeType(valueAccessExpr.expr.type, true, false));
+                types.getSafeType(valueAccessExpr.expr.getBType(), true, false));
         VariableDefinitionNode variableDefinitionNode = inputClause.variableDefinitionNode;
         BLangVariable variable = (BLangVariable) variableDefinitionNode.getVariable();
         setSymbolOwner(variable, env.scope.owner);
@@ -592,11 +594,11 @@ public class QueryDesugar extends BLangNodeVisitor {
 
         BLangArrayLiteral sortFieldsArrayExpr = (BLangArrayLiteral) TreeBuilder.createArrayLiteralExpressionNode();
         sortFieldsArrayExpr.exprs = new ArrayList<>();
-        sortFieldsArrayExpr.type = new BArrayType(symTable.anydataType);
+        sortFieldsArrayExpr.setBType(new BArrayType(symTable.anydataType));
 
         BLangArrayLiteral sortModesArrayExpr = (BLangArrayLiteral) TreeBuilder.createArrayLiteralExpressionNode();
         sortModesArrayExpr.exprs = new ArrayList<>();
-        sortModesArrayExpr.type = new BArrayType(symTable.booleanType);
+        sortModesArrayExpr.setBType(new BArrayType(symTable.booleanType));
 
         // Each order-key expression is added to sortFieldsArrayExpr.
         // Corresponding order-direction is added to sortModesArrayExpr.
@@ -725,7 +727,7 @@ public class QueryDesugar extends BLangNodeVisitor {
     BLangVariableReference addTableConstructor(BLangQueryExpr queryExpr, BLangBlockStmt queryBlock) {
         // desugar `table<Customer> key(id, name) tab = table key(id, name);`
         Location pos = queryExpr.pos;
-        final BType type = queryExpr.type;
+        final BType type = queryExpr.getBType();
         String name = getNewVarName();
         BType tableType = type;
         if (type.tag == TypeTags.UNION) {
@@ -737,7 +739,7 @@ public class QueryDesugar extends BLangNodeVisitor {
         BLangTableConstructorExpr tableConstructorExpr = (BLangTableConstructorExpr)
                 TreeBuilder.createTableConstructorExpressionNode();
         tableConstructorExpr.pos = pos;
-        tableConstructorExpr.type = tableType;
+        tableConstructorExpr.setBType(tableType);
         if (!keyFieldIdentifiers.isEmpty()) {
             BLangTableKeySpecifier keySpecifier = (BLangTableKeySpecifier)
                     TreeBuilder.createTableKeySpecifierNode();
@@ -766,7 +768,7 @@ public class QueryDesugar extends BLangNodeVisitor {
                 TreeBuilder.createTypeConversionNode();
         conversionExpr.expr = expr;
         conversionExpr.targetType = type;
-        conversionExpr.type = type;
+        conversionExpr.setBType(type);
         conversionExpr.pos = expr.pos;
         conversionExpr.checkTypes = false;
         return conversionExpr;
@@ -898,7 +900,7 @@ public class QueryDesugar extends BLangNodeVisitor {
                                                                 Location pos) {
         String name = getNewVarName();
         BLangInvocation queryLibInvocation = createQueryLibInvocation(functionName, requiredArgs, pos);
-        type = (type == null) ? queryLibInvocation.type : type;
+        type = (type == null) ? queryLibInvocation.getBType() : type;
         BVarSymbol varSymbol = new BVarSymbol(0, new Name(name), env.scope.owner.pkgID, type, env.scope.owner, pos,
                                               VIRTUAL);
         BLangSimpleVariable variable = ASTBuilderUtil.createVariable(pos, name, type,
@@ -931,7 +933,7 @@ public class QueryDesugar extends BLangNodeVisitor {
         BInvokableSymbol symbol = getQueryLibInvokableSymbol(functionName);
         BLangInvocation bLangInvocation = ASTBuilderUtil
                 .createInvocationExprForMethod(pos, symbol, requiredArgs, symResolver);
-        bLangInvocation.type = symbol.retType;
+        bLangInvocation.setBType(symbol.retType);
         return bLangInvocation;
     }
 
@@ -953,8 +955,8 @@ public class QueryDesugar extends BLangNodeVisitor {
         BLangIdentifier valueIdentifier = ASTBuilderUtil.createIdentifier(pos, key);
         BLangFieldBasedAccess valueAccess = ASTBuilderUtil.createFieldAccessExpr(frame, valueIdentifier);
         valueAccess.pos = pos;
-        valueAccess.type = symTable.anyOrErrorType;
-        valueAccess.originalType = valueAccess.type;
+        valueAccess.setBType(symTable.anyOrErrorType);
+        valueAccess.originalType = valueAccess.getBType();
         return ASTBuilderUtil.createAssignmentStmt(pos, valueAccess, value);
     }
 
@@ -1161,7 +1163,7 @@ public class QueryDesugar extends BLangNodeVisitor {
     BLangValueType getNilTypeNode() {
         BLangValueType nilTypeNode = (BLangValueType) TreeBuilder.createValueTypeNode();
         nilTypeNode.typeKind = TypeKind.NIL;
-        nilTypeNode.type = symTable.nilType;
+        nilTypeNode.setBType(symTable.nilType);
         return nilTypeNode;
     }
 
@@ -1173,7 +1175,7 @@ public class QueryDesugar extends BLangNodeVisitor {
     BLangValueType getAnyTypeNode() {
         BLangValueType anyTypeNode = (BLangValueType) TreeBuilder.createValueTypeNode();
         anyTypeNode.typeKind = TypeKind.ANY;
-        anyTypeNode.type = symTable.anyType;
+        anyTypeNode.setBType(symTable.anyType);
         return anyTypeNode;
     }
 
@@ -1185,7 +1187,7 @@ public class QueryDesugar extends BLangNodeVisitor {
     BLangValueType getIntTypeNode() {
         BLangValueType intTypeNode = (BLangValueType) TreeBuilder.createValueTypeNode();
         intTypeNode.typeKind = TypeKind.INT;
-        intTypeNode.type = symTable.intType;
+        intTypeNode.setBType(symTable.intType);
         return intTypeNode;
     }
 
@@ -1196,7 +1198,7 @@ public class QueryDesugar extends BLangNodeVisitor {
      */
     BLangErrorType getErrorTypeNode() {
         BLangErrorType errorTypeNode = (BLangErrorType) TreeBuilder.createErrorTypeNode();
-        errorTypeNode.type = symTable.errorType;
+        errorTypeNode.setBType(symTable.errorType);
         return errorTypeNode;
     }
 
@@ -1208,7 +1210,7 @@ public class QueryDesugar extends BLangNodeVisitor {
     private BLangValueType getBooleanTypeNode() {
         BLangValueType booleanTypeNode = (BLangValueType) TreeBuilder.createValueTypeNode();
         booleanTypeNode.typeKind = TypeKind.BOOLEAN;
-        booleanTypeNode.type = symTable.booleanType;
+        booleanTypeNode.setBType(symTable.booleanType);
         return booleanTypeNode;
     }
 
@@ -1221,7 +1223,7 @@ public class QueryDesugar extends BLangNodeVisitor {
         BType frameType = getFrameTypeSymbol().type;
         BUnionType unionType = BUnionType.create(null, frameType, symTable.errorType, symTable.nilType);
         BLangUnionTypeNode unionTypeNode = (BLangUnionTypeNode) TreeBuilder.createUnionTypeNode();
-        unionTypeNode.type = unionType;
+        unionTypeNode.setBType(unionType);
         unionTypeNode.memberTypeNodes.add(getFrameTypeNode());
         unionTypeNode.memberTypeNodes.add(getErrorTypeNode());
         unionTypeNode.memberTypeNodes.add(getNilTypeNode());
@@ -1240,7 +1242,7 @@ public class QueryDesugar extends BLangNodeVisitor {
         unionTypeNode.memberTypeNodes.add(getAnyTypeNode());
         unionTypeNode.memberTypeNodes.add(getErrorTypeNode());
         unionTypeNode.memberTypeNodes.add(getNilTypeNode());
-        unionTypeNode.type = unionType;
+        unionTypeNode.setBType(unionType);
         unionTypeNode.desugared = true;
         return unionTypeNode;
     }
@@ -1255,12 +1257,12 @@ public class QueryDesugar extends BLangNodeVisitor {
         BRecordType frameType = (BRecordType) frameTypeSymbol.type;
 
         BLangUnionTypeNode restFieldType = (BLangUnionTypeNode) TreeBuilder.createUnionTypeNode();
-        restFieldType.type = frameType.restFieldType;
+        restFieldType.setBType(frameType.restFieldType);
         restFieldType.memberTypeNodes.add(getErrorTypeNode());
         restFieldType.memberTypeNodes.add(getAnyTypeNode());
 
         BLangRecordTypeNode frameTypeNode = (BLangRecordTypeNode) TreeBuilder.createRecordTypeNode();
-        frameTypeNode.type = frameType;
+        frameTypeNode.setBType(frameType);
         frameTypeNode.restFieldType = restFieldType;
         frameTypeNode.symbol = frameType.tsymbol;
         frameTypeNode.desugared = true;
@@ -1445,7 +1447,7 @@ public class QueryDesugar extends BLangNodeVisitor {
                 BLangFieldBasedAccess frameAccessExpr = desugar.getFieldAccessExpression(pos, identifier,
                         symTable.anyOrErrorType, currentFrameSymbol);
                 frameAccessExpr.expr = desugar.addConversionExprIfRequired(frameAccessExpr.expr,
-                        types.getSafeType(frameAccessExpr.expr.type, true, false));
+                        types.getSafeType(frameAccessExpr.expr.getBType(), true, false));
 
                 if (symbol instanceof BVarSymbol) {
                     ((BVarSymbol) symbol).originalSymbol = null;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ServiceDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ServiceDesugar.java
@@ -126,7 +126,7 @@ public class ServiceDesugar {
         final Location pos = variable.pos;
 
         // Find correct symbol.
-        BTypeSymbol listenerTypeSymbol = getListenerType(variable.type).tsymbol;
+        BTypeSymbol listenerTypeSymbol = getListenerType(variable.getBType()).tsymbol;
         final Name functionName = names
                 .fromString(Symbols.getAttachedFuncSymbolName(listenerTypeSymbol.name.value, method));
         BInvokableSymbol methodInvocationSymbol = (BInvokableSymbol) symResolver
@@ -166,22 +166,22 @@ public class ServiceDesugar {
             } else {
                 // Define anonymous listener variable.
                 BLangSimpleVariable listenerVar = ASTBuilderUtil
-                        .createVariable(pos, generateServiceListenerVarName(service) + count, attachExpr.type,
-                                attachExpr,
-                                null);
+                        .createVariable(pos, generateServiceListenerVarName(service) + count, attachExpr.getBType(),
+                                        attachExpr,
+                                        null);
                 ASTBuilderUtil.defineVariable(listenerVar, env.enclPkg.symbol, names);
                 listenerVar.symbol.flags |= Flags.LISTENER;
                 env.enclPkg.globalVars.add(listenerVar);
                 listenerVarRef = ASTBuilderUtil.createVariableRef(pos, listenerVar.symbol);
             }
 
-            if (types.containsErrorType(listenerVarRef.type)) {
+            if (types.containsErrorType(listenerVarRef.getBType())) {
                 BLangCheckedExpr listenerCheckExpr = ASTBuilderUtil.createCheckExpr(pos, listenerVarRef,
-                        getListenerType(listenerVarRef.type));
+                        getListenerType(listenerVarRef.getBType()));
                 listenerCheckExpr.equivalentErrorTypeList.add(symTable.errorType);
                 BLangSimpleVariable listenerWithoutErrors = ASTBuilderUtil.createVariable(pos,
                         generateServiceListenerVarName(service)  + "$CheckTemp" + count++,
-                        getListenerTypeWithoutError(listenerVarRef.type),
+                        getListenerTypeWithoutError(listenerVarRef.getBType()),
                         listenerCheckExpr,
                         null);
                 ASTBuilderUtil.defineVariable(listenerWithoutErrors, env.enclPkg.symbol, names);
@@ -192,7 +192,7 @@ public class ServiceDesugar {
 
             //      (.<init>)              ->      y.__attach(x, {});
             // Find correct symbol.
-            BTypeSymbol listenerTypeSymbol = getListenerType(listenerVarRef.type).tsymbol;
+            BTypeSymbol listenerTypeSymbol = getListenerType(listenerVarRef.getBType()).tsymbol;
             final Name functionName = names
                     .fromString(Symbols.getAttachedFuncSymbolName(listenerTypeSymbol.name.value, ATTACH_METHOD));
             BInvokableSymbol methodRef = (BInvokableSymbol) symResolver
@@ -267,12 +267,12 @@ public class ServiceDesugar {
         // If listener contain errors we need to cast this to a listener type so that, attached function invocation
         // call is generated in BIRGen. Casting to the first listener type should be fine as actual method invocation
         // is based on the value rather than the type.
-        BType listenerType = getListenerType(varRef.type);
-        if (!types.isSameType(listenerType, varRef.type)) {
+        BType listenerType = getListenerType(varRef.getBType());
+        if (!types.isSameType(listenerType, varRef.getBType())) {
             BLangTypeConversionExpr castExpr = (BLangTypeConversionExpr) TreeBuilder.createTypeConversionNode();
             castExpr.expr = varRef;
-            castExpr.type = listenerType;
-            castExpr.targetType = castExpr.type;
+            castExpr.setBType(listenerType);
+            castExpr.targetType = castExpr.getBType();
             methodInvocation.expr = castExpr;
         } else {
             methodInvocation.expr = varRef;
@@ -287,7 +287,7 @@ public class ServiceDesugar {
     }
 
     void engageCustomServiceDesugar(BLangService service, SymbolEnv env) {
-        List<BType> expressionTypes = service.attachedExprs.stream().map(expression -> expression.type)
+        List<BType> expressionTypes = service.attachedExprs.stream().map(expression -> expression.getBType())
                 .collect(Collectors.toList());
         service.serviceClass.functions.stream().filter(fun -> Symbols.isFlagOn(fun.symbol.flags, Flags.RESOURCE))
                 .forEach(func -> engageCustomResourceDesugar(func, env, expressionTypes));

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/TransactionDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/TransactionDesugar.java
@@ -205,10 +205,10 @@ public class TransactionDesugar extends BLangNodeVisitor {
         BLangLiteral nilLiteral = ASTBuilderUtil.createLiteral(pos, symTable.nilType, Names.NIL_VALUE);
         BLangStatementExpression statementExpression =
                 createStatementExpression(transactionNode.transactionBody, nilLiteral);
-        statementExpression.type = symTable.nilType;
+        statementExpression.setBType(symTable.nilType);
 
         BLangTrapExpr trapExpr = (BLangTrapExpr) TreeBuilder.createTrapExpressionNode();
-        trapExpr.type = transactionReturnType;
+        trapExpr.setBType(transactionReturnType);
         trapExpr.expr = statementExpression;
 
         //error? $trapResult = trap <Transaction Body>
@@ -235,7 +235,7 @@ public class TransactionDesugar extends BLangNodeVisitor {
 
         BLangTypeTestExpr isErrorTest =
                 ASTBuilderUtil.createTypeTestExpr(pos, trapResultRef, desugar.getErrorTypeNode());
-        isErrorTest.type = symTable.booleanType;
+        isErrorTest.setBType(symTable.booleanType);
 
         //if($trapResult$ is error) {
         //     fail $trapResult$;
@@ -418,15 +418,15 @@ public class TransactionDesugar extends BLangNodeVisitor {
         BType errorType = transactionErrorSymbol.type;
 
         BLangErrorType trxErrorTypeNode = (BLangErrorType) TreeBuilder.createErrorTypeNode();
-        trxErrorTypeNode.type = errorType;
+        trxErrorTypeNode.setBType(errorType);
         BLangSimpleVarRef trxResultRef = ASTBuilderUtil.createVariableRef(pos, trxFuncResultSymbol);
 
         // $trxError$ is TransactionError
         BLangTypeTestExpr testExpr = ASTBuilderUtil.createTypeTestExpr(pos, trxResultRef, trxErrorTypeNode);
-        testExpr.type = symTable.booleanType;
+        testExpr.setBType(symTable.booleanType);
 
         BLangGroupExpr transactionErrorCheckGroupExpr = new BLangGroupExpr();
-        transactionErrorCheckGroupExpr.type = symTable.booleanType;
+        transactionErrorCheckGroupExpr.setBType(symTable.booleanType);
         // !($trxError$ is TransactionError)
         transactionErrorCheckGroupExpr.expression =  desugar.createNotBinaryExpression(pos, testExpr);
 
@@ -458,7 +458,7 @@ public class TransactionDesugar extends BLangNodeVisitor {
         BLangExpressionStmt transactionExprStmt = (BLangExpressionStmt) TreeBuilder.createExpressionStatementNode();
         transactionExprStmt.pos = pos;
         transactionExprStmt.expr = checkedExpr;
-        transactionExprStmt.type = symTable.nilType;
+        transactionExprStmt.setBType(symTable.nilType);
         rollbackCheck.body.stmts.add(transactionExprStmt);
 
         // at this point;
@@ -512,7 +512,7 @@ public class TransactionDesugar extends BLangNodeVisitor {
         cleanUpTrx.expr = createCleanupTrxStmt(pos, trxBlockId);
         BLangStatementExpression rollbackStmtExpr = createStatementExpression(rollbackBlockStmt,
                 ASTBuilderUtil.createLiteral(pos, symTable.nilType, Names.NIL_VALUE));
-        rollbackStmtExpr.type = symTable.nilType;
+        rollbackStmtExpr.setBType(symTable.nilType);
 
         //at this point,
         //
@@ -578,9 +578,9 @@ public class TransactionDesugar extends BLangNodeVisitor {
         // }
         BLangIf commitResultValidationIf = ASTBuilderUtil.createIfStmt(pos, failureHandlerBlockStatement);
         BLangGroupExpr commitResultValidationGroupExpr = new BLangGroupExpr();
-        commitResultValidationGroupExpr.type = symTable.booleanType;
+        commitResultValidationGroupExpr.setBType(symTable.booleanType);
         BLangValueType stringType = (BLangValueType) TreeBuilder.createValueTypeNode();
-        stringType.type = symTable.stringType;
+        stringType.setBType(symTable.stringType);
         stringType.typeKind = TypeKind.STRING;
         commitResultValidationGroupExpr.expression = ASTBuilderUtil.createTypeTestExpr(pos, commitResultVarRef,
                 stringType);
@@ -602,7 +602,7 @@ public class TransactionDesugar extends BLangNodeVisitor {
         //}
         BLangIf failureValidationIf = ASTBuilderUtil.createIfStmt(pos, commitBlockStatement);
         BLangGroupExpr failureValidationGroupExpr = new BLangGroupExpr();
-        failureValidationGroupExpr.type = symTable.booleanType;
+        failureValidationGroupExpr.setBType(symTable.booleanType);
         BLangSimpleVarRef failureValidationExprVarRef = ASTBuilderUtil.createVariableRef(pos,
                 isTransactionFailedVariable.symbol);
         List<BType> paramTypes = new ArrayList<>();
@@ -631,7 +631,7 @@ public class TransactionDesugar extends BLangNodeVisitor {
         // }
         BLangStatementExpression stmtExpr = createStatementExpression(commitBlockStatement,
                 outputVarRef);
-        stmtExpr.type = symTable.errorOrNilType;
+        stmtExpr.setBType(symTable.errorOrNilType);
         return stmtExpr;
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
@@ -786,7 +786,7 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
                     (BLangLiteral) TreeBuilder.createLiteralExpression() :
                     (BLangLiteral) TreeBuilder.createNumericLiteralExpression();
             literal.setValue(((BLangLiteral) constantNode.expr).value);
-            literal.type = constantNode.expr.type;
+            literal.setBType(constantNode.expr.getBType());
             literal.isConstant = true;
 
             // Create a new finite type node.
@@ -2493,7 +2493,7 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
             BLangLiteral nilLiteral = (BLangLiteral) TreeBuilder.createLiteralExpression();
             nilLiteral.pos = getPosition(returnStmtNode);
             nilLiteral.value = Names.NIL_VALUE;
-            nilLiteral.type = symTable.nilType;
+            nilLiteral.setBType(symTable.nilType);
             bLReturn.expr = nilLiteral;
         }
         return bLReturn;
@@ -3237,8 +3237,8 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
     public BLangNode transform(ByteArrayLiteralNode byteArrayLiteralNode) {
         BLangLiteral literal = (BLangLiteral) TreeBuilder.createLiteralExpression();
         literal.pos = getPosition(byteArrayLiteralNode);
-        literal.type = symTable.getTypeFromTag(TypeTags.BYTE_ARRAY);
-        literal.type.tag = TypeTags.BYTE_ARRAY;
+        literal.setBType(symTable.getTypeFromTag(TypeTags.BYTE_ARRAY));
+        literal.getBType().tag = TypeTags.BYTE_ARRAY;
         literal.value = getValueFromByteArrayNode(byteArrayLiteralNode);
         literal.originalValue = String.valueOf(literal.value);
         return literal;
@@ -4739,7 +4739,7 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
         BLangLiteral bLiteral = (BLangLiteral) TreeBuilder.createLiteralExpression();
         bLiteral.value = "";
         bLiteral.originalValue = "";
-        bLiteral.type = symTable.getTypeFromTag(TypeTags.STRING);
+        bLiteral.setBType(symTable.getTypeFromTag(TypeTags.STRING));
         return bLiteral;
     }
 
@@ -5140,7 +5140,7 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
     private BLangLiteral createEmptyStringLiteral(Location pos) {
         BLangLiteral bLiteral = (BLangLiteral) TreeBuilder.createLiteralExpression();
         bLiteral.pos = pos;
-        bLiteral.type = symTable.stringType;
+        bLiteral.setBType(symTable.stringType);
         bLiteral.value = "";
         bLiteral.originalValue = "";
         return bLiteral;
@@ -5290,8 +5290,8 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
         }
 
         bLiteral.pos = getPosition(literal);
-        bLiteral.type = symTable.getTypeFromTag(typeTag);
-        bLiteral.type.tag = typeTag;
+        bLiteral.setBType(symTable.getTypeFromTag(typeTag));
+        bLiteral.getBType().tag = typeTag;
         bLiteral.value = value;
         bLiteral.originalValue = originalValue;
         return bLiteral;
@@ -5300,7 +5300,7 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
     private BLangLiteral createStringLiteral(String value, Location pos) {
         BLangLiteral strLiteral = (BLangLiteral) TreeBuilder.createLiteralExpression();
         strLiteral.value = strLiteral.originalValue = value;
-        strLiteral.type = symTable.stringType;
+        strLiteral.setBType(symTable.stringType);
         strLiteral.pos = pos;
         return strLiteral;
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/NodeCloner.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/NodeCloner.java
@@ -293,7 +293,7 @@ public class NodeCloner extends BLangNodeVisitor {
             result.pos = sourceNode.pos;
             result.internal = sourceNode.internal;
             result.addWS(source.getWS());
-            result.type = sourceNode.type;
+            result.setBType(sourceNode.getBType());
         }
         return (T) result;
     }
@@ -330,7 +330,7 @@ public class NodeCloner extends BLangNodeVisitor {
         clone.originalValue = source.originalValue;
         clone.isFiniteContext = source.isFiniteContext;
         clone.isConstant = source.isConstant;
-        clone.type = source.type;
+        clone.setBType(source.getBType());
     }
 
     private void cloneBLangAccessExpression(BLangAccessExpression source, BLangAccessExpression clone) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -733,9 +733,9 @@ public class CodeAnalyzer extends BLangNodeVisitor {
             BTypeSymbol retryManagerTypeSymbol = (BObjectTypeSymbol) symTable.langErrorModuleSymbol.scope
                     .lookup(names.fromString("RetryManager")).symbol;
             BType abstractRetryManagerType = retryManagerTypeSymbol.type;
-            if (!types.isAssignable(retrySpec.retryManagerType.type, abstractRetryManagerType)) {
+            if (!types.isAssignable(retrySpec.retryManagerType.getBType(), abstractRetryManagerType)) {
                 dlog.error(retrySpec.pos, DiagnosticErrorCode.INVALID_INTERFACE_ON_NON_ABSTRACT_OBJECT,
-                        RETRY_MANAGER_OBJECT_SHOULD_RETRY_FUNC, retrySpec.retryManagerType.type);
+                           RETRY_MANAGER_OBJECT_SHOULD_RETRY_FUNC, retrySpec.retryManagerType.getBType());
             }
         }
     }
@@ -797,7 +797,7 @@ public class CodeAnalyzer extends BLangNodeVisitor {
 
         this.statementReturns = true;
         analyzeExpr(returnStmt.expr);
-        this.returnTypes.peek().add(returnStmt.expr.type);
+        this.returnTypes.peek().add(returnStmt.expr.getBType());
     }
 
     @Override
@@ -886,7 +886,7 @@ public class CodeAnalyzer extends BLangNodeVisitor {
             if (this.hasLastPatternInStatement || (hasLastPatternInClause && matchClause.matchGuard == null)) {
                 dlog.warning(matchPattern.pos, DiagnosticWarningCode.MATCH_STMT_PATTERN_UNREACHABLE);
             }
-            if (matchPattern.type == symTable.noType) {
+            if (matchPattern.getBType() == symTable.noType) {
                 dlog.warning(matchPattern.pos, DiagnosticWarningCode.MATCH_STMT_UNMATCHED_PATTERN);
             }
             if (patternListContainsSameVars) {
@@ -1189,7 +1189,7 @@ public class CodeAnalyzer extends BLangNodeVisitor {
                 constValAndType.put(((BLangLiteral) constPattern.expr).value, null);
                 break;
             case SIMPLE_VARIABLE_REF:
-                constValAndType.put(((BLangSimpleVarRef) constPattern.expr).variableName, constPattern.type);
+                constValAndType.put(((BLangSimpleVarRef) constPattern.expr).variableName, constPattern.getBType());
                 break;
         }
         return constValAndType;
@@ -1525,7 +1525,7 @@ public class CodeAnalyzer extends BLangNodeVisitor {
             BLangTypeTestExpr secondTypeTest = (BLangTypeTestExpr) secondMatchGuard.expr;
             return ((BLangSimpleVarRef) firstTypeTest.expr).variableName.toString().equals(
                     ((BLangSimpleVarRef) secondTypeTest.expr).variableName.toString()) &&
-                    firstTypeTest.typeNode.type.tag == secondTypeTest.typeNode.type.tag;
+                    firstTypeTest.typeNode.getBType().tag == secondTypeTest.typeNode.getBType().tag;
         }
         return false;
     }
@@ -1551,8 +1551,8 @@ public class CodeAnalyzer extends BLangNodeVisitor {
     @Override
     public void visit(BLangWildCardMatchPattern wildCardMatchPattern) {
         wildCardMatchPattern.isLastPattern =
-                wildCardMatchPattern.matchExpr != null && types.isAssignable(wildCardMatchPattern.matchExpr.type,
-                        symTable.anyType);
+                wildCardMatchPattern.matchExpr != null && types.isAssignable(wildCardMatchPattern.matchExpr.getBType(),
+                                                                             symTable.anyType);
     }
 
     @Override
@@ -1567,8 +1567,9 @@ public class CodeAnalyzer extends BLangNodeVisitor {
         switch (bindingPattern.getKind()) {
             case WILDCARD_BINDING_PATTERN:
                 varBindingPattern.isLastPattern =
-                        varBindingPattern.matchExpr != null && types.isAssignable(varBindingPattern.matchExpr.type,
-                        symTable.anyType);
+                        varBindingPattern.matchExpr != null && types.isAssignable(
+                                varBindingPattern.matchExpr.getBType(),
+                                symTable.anyType);
                 return;
             case CAPTURE_BINDING_PATTERN:
                 varBindingPattern.isLastPattern =
@@ -1578,9 +1579,10 @@ public class CodeAnalyzer extends BLangNodeVisitor {
                 if (varBindingPattern.matchExpr == null) {
                     return;
                 }
-                varBindingPattern.isLastPattern = types.isSameType(varBindingPattern.matchExpr.type,
-                        varBindingPattern.type) || types.isAssignable(varBindingPattern.matchExpr.type,
-                        varBindingPattern.type);
+                varBindingPattern.isLastPattern = types.isSameType(varBindingPattern.matchExpr.getBType(),
+                                                                   varBindingPattern.getBType()) || types.isAssignable(
+                        varBindingPattern.matchExpr.getBType(),
+                        varBindingPattern.getBType());
         }
     }
 
@@ -1599,7 +1601,8 @@ public class CodeAnalyzer extends BLangNodeVisitor {
         if (listMatchPattern.matchExpr == null) {
             return;
         }
-        listMatchPattern.isLastPattern = types.isSameType(listMatchPattern.type, listMatchPattern.matchExpr.type)
+        listMatchPattern.isLastPattern = types.isSameType(listMatchPattern.getBType(),
+                                                          listMatchPattern.matchExpr.getBType())
                 && !isConstMatchPatternExist(listMatchPattern);
     }
 
@@ -1897,9 +1900,9 @@ public class CodeAnalyzer extends BLangNodeVisitor {
                     checkLiteralSimilarity(precedingPattern, rhsExpr);
         }
 
-        switch (precedingPattern.type.tag) {
+        switch (precedingPattern.getBType().tag) {
             case TypeTags.MAP:
-                if (pattern.type.tag == TypeTags.MAP) {
+                if (pattern.getBType().tag == TypeTags.MAP) {
                     BLangRecordLiteral precedingRecordLiteral = (BLangRecordLiteral) precedingPattern;
                     Map<String, BLangExpression> recordLiteral = ((BLangRecordLiteral) pattern).fields
                             .stream()
@@ -1926,7 +1929,7 @@ public class CodeAnalyzer extends BLangNodeVisitor {
                 }
                 return false;
             case TypeTags.TUPLE:
-                if (pattern.type.tag == TypeTags.TUPLE) {
+                if (pattern.getBType().tag == TypeTags.TUPLE) {
                     BLangListConstructorExpr precedingTupleLiteral = (BLangListConstructorExpr) precedingPattern;
                     BLangListConstructorExpr tupleLiteral = (BLangListConstructorExpr) pattern;
                     if (precedingTupleLiteral.exprs.size() != tupleLiteral.exprs.size()) {
@@ -1963,14 +1966,14 @@ public class CodeAnalyzer extends BLangNodeVisitor {
                     return (precedingPatternSym.value.equals(literal.value));
                 }
 
-                if (types.isValueType(pattern.type)) {
+                if (types.isValueType(pattern.getBType())) {
                     // preceding pattern is a literal.
                     BLangLiteral precedingLiteral = precedingPattern.getKind() == NodeKind.GROUP_EXPR ?
                             (BLangLiteral) ((BLangGroupExpr) precedingPattern).expression :
                             (BLangLiteral) precedingPattern;
 
                     if (pattern.getKind() == NodeKind.SIMPLE_VARIABLE_REF) {
-                        if (pattern.type.tag != TypeTags.NONE) {
+                        if (pattern.getBType().tag != TypeTags.NONE) {
                             // pattern is a constant reference.
                             BConstantSymbol patternSym = (BConstantSymbol) ((BLangSimpleVarRef) pattern).symbol;
                             return patternSym.value.equals(precedingLiteral.value);
@@ -1987,7 +1990,7 @@ public class CodeAnalyzer extends BLangNodeVisitor {
                 return false;
             case TypeTags.ANY:
                 // preceding pattern is '_'. Hence will match all patterns except error that follow.
-                if (pattern.type.tag == TypeTags.ERROR) {
+                if (pattern.getBType().tag == TypeTags.ERROR) {
                     return false;
                 }
                 return true;
@@ -2015,7 +2018,7 @@ public class CodeAnalyzer extends BLangNodeVisitor {
                 BLangTypeTestExpr currentTypeTest = (BLangTypeTestExpr) currentGuard;
                 return ((BLangSimpleVarRef) precedingTypeTest.expr).variableName.toString().equals(
                         ((BLangSimpleVarRef) currentTypeTest.expr).variableName.toString()) &&
-                        precedingTypeTest.typeNode.type.tag == currentTypeTest.typeNode.type.tag;
+                        precedingTypeTest.typeNode.getBType().tag == currentTypeTest.typeNode.getBType().tag;
             }
             return false;
         }
@@ -2034,7 +2037,7 @@ public class CodeAnalyzer extends BLangNodeVisitor {
     private boolean checkStructuredPatternSimilarity(BLangVariable precedingVar,
                                                      BLangVariable var,
                                                      boolean errorTypeInMatchExpr) {
-        if (precedingVar.type.tag == TypeTags.SEMANTIC_ERROR || var.type.tag == TypeTags.SEMANTIC_ERROR) {
+        if (precedingVar.getBType().tag == TypeTags.SEMANTIC_ERROR || var.getBType().tag == TypeTags.SEMANTIC_ERROR) {
             return false;
         }
 
@@ -2165,15 +2168,15 @@ public class CodeAnalyzer extends BLangNodeVisitor {
      * @return true if the pattern is valid, else false.
      */
     private boolean isValidStaticMatchPattern(BType matchType, BLangExpression literal) {
-        if (literal.type.tag == TypeTags.NONE) {
+        if (literal.getBType().tag == TypeTags.NONE) {
             return true; // When matching '_'
         }
 
-        if (types.isSameType(literal.type, matchType)) {
+        if (types.isSameType(literal.getBType(), matchType)) {
             return true;
         }
 
-        if (TypeTags.ANY == literal.type.tag) {
+        if (TypeTags.ANY == literal.getBType().tag) {
             return true;
         }
 
@@ -2188,9 +2191,9 @@ public class CodeAnalyzer extends BLangNodeVisitor {
                         .stream()
                         .anyMatch(memberMatchType -> isValidStaticMatchPattern(memberMatchType, literal));
             case TypeTags.TUPLE:
-                if (literal.type.tag == TypeTags.TUPLE) {
+                if (literal.getBType().tag == TypeTags.TUPLE) {
                     BLangListConstructorExpr tupleLiteral = (BLangListConstructorExpr) literal;
-                    BTupleType literalTupleType = (BTupleType) literal.type;
+                    BTupleType literalTupleType = (BTupleType) literal.getBType();
                     BTupleType matchTupleType = (BTupleType) matchType;
                     if (literalTupleType.tupleTypes.size() != matchTupleType.tupleTypes.size()) {
                         return false;
@@ -2202,7 +2205,7 @@ public class CodeAnalyzer extends BLangNodeVisitor {
                 }
                 break;
             case TypeTags.MAP:
-                if (literal.type.tag == TypeTags.MAP) {
+                if (literal.getBType().tag == TypeTags.MAP) {
                     // if match type is map, check if literals match to the constraint
                     BLangRecordLiteral mapLiteral = (BLangRecordLiteral) literal;
                     return IntStream.range(0, mapLiteral.fields.size())
@@ -2212,7 +2215,7 @@ public class CodeAnalyzer extends BLangNodeVisitor {
                 }
                 break;
             case TypeTags.RECORD:
-                if (literal.type.tag == TypeTags.MAP) {
+                if (literal.getBType().tag == TypeTags.MAP) {
                     // if match type is record, the fields must match to the static pattern fields
                     BLangRecordLiteral mapLiteral = (BLangRecordLiteral) literal;
                     BRecordType recordMatchType = (BRecordType) matchType;
@@ -2244,7 +2247,7 @@ public class CodeAnalyzer extends BLangNodeVisitor {
                 }
                 break;
             case TypeTags.BYTE:
-                if (literal.type.tag == TypeTags.INT) {
+                if (literal.getBType().tag == TypeTags.INT) {
                     return true;
                 }
                 break;
@@ -2338,13 +2341,13 @@ public class CodeAnalyzer extends BLangNodeVisitor {
         }
         typeChecker.checkExpr(failNode.expr, env);
         if (!this.errorTypes.empty()) {
-            this.errorTypes.peek().add(getErrorTypes(failNode.expr.type));
+            this.errorTypes.peek().add(getErrorTypes(failNode.expr.getBType()));
         }
         if (!this.failureHandled) {
             this.statementReturns = true;
-            BType exprType = env.enclInvokable.getReturnTypeNode().type;
+            BType exprType = env.enclInvokable.getReturnTypeNode().getBType();
             this.returnTypes.peek().add(exprType);
-            if (!types.isAssignable(getErrorTypes(failNode.expr.type), exprType)) {
+            if (!types.isAssignable(getErrorTypes(failNode.expr.getBType()), exprType)) {
                 dlog.error(failNode.pos, DiagnosticErrorCode.FAIL_EXPR_NO_MATCHING_ERROR_RETURN_IN_ENCL_INVOKABLE);
             }
         }
@@ -2530,10 +2533,10 @@ public class CodeAnalyzer extends BLangNodeVisitor {
 
         int ownerSymTag = this.env.scope.owner.tag;
         if ((ownerSymTag & SymTag.RECORD) == SymTag.RECORD || (ownerSymTag & SymTag.OBJECT) == SymTag.OBJECT) {
-            analyzeExportableTypeRef(this.env.scope.owner, varNode.type.tsymbol, false, varNode.pos);
+            analyzeExportableTypeRef(this.env.scope.owner, varNode.getBType().tsymbol, false, varNode.pos);
         } else if ((ownerSymTag & SymTag.INVOKABLE) != SymTag.INVOKABLE) {
             // Only global level simpleVarRef, listeners etc.
-            analyzeExportableTypeRef(varNode.symbol, varNode.type.tsymbol, false, varNode.pos);
+            analyzeExportableTypeRef(varNode.symbol, varNode.getBType().tsymbol, false, varNode.pos);
         }
 
         varNode.annAttachments.forEach(annotationAttachment -> analyzeNode(annotationAttachment, env));
@@ -2774,7 +2777,7 @@ public class CodeAnalyzer extends BLangNodeVisitor {
             return;
         }
         // For other expressions, error is logged already.
-        if (expr.type == symTable.nilType) {
+        if (expr.getBType() == symTable.nilType) {
             dlog.error(exprStmtNode.pos, DiagnosticErrorCode.INVALID_EXPR_STATEMENT);
         }
     }
@@ -2827,7 +2830,7 @@ public class CodeAnalyzer extends BLangNodeVisitor {
 
         WorkerActionSystem was = this.workerActionSystemStack.peek();
 
-        BType type = workerSendNode.expr.type;
+        BType type = workerSendNode.expr.getBType();
         if (type == symTable.semanticError) {
             // Error of this is already printed as undef-var
             was.hasErrors = true;
@@ -2843,13 +2846,14 @@ public class CodeAnalyzer extends BLangNodeVisitor {
             was.hasErrors = true;
         }
 
-        if (!this.workerExists(workerSendNode.type, workerName)
+        if (!this.workerExists(workerSendNode.getBType(), workerName)
                 || (!isWorkerFromFunction(env, names.fromString(workerName)) && !workerName.equals("function"))) {
             this.dlog.error(workerSendNode.pos, DiagnosticErrorCode.UNDEFINED_WORKER, workerName);
             was.hasErrors = true;
         }
 
-        workerSendNode.type = createAccumulatedErrorTypeForMatchingRecive(workerSendNode.pos, workerSendNode.expr.type);
+        workerSendNode.setBType(
+                createAccumulatedErrorTypeForMatchingRecive(workerSendNode.pos, workerSendNode.expr.getBType()));
         was.addWorkerAction(workerSendNode);
         analyzeExpr(workerSendNode.expr);
         validateActionParentNode(workerSendNode.pos, workerSendNode.expr);
@@ -2899,7 +2903,8 @@ public class CodeAnalyzer extends BLangNodeVisitor {
             this.dlog.error(syncSendExpr.pos, DiagnosticErrorCode.UNDEFINED_WORKER, syncSendExpr.workerSymbol);
             was.hasErrors = true;
         }
-        syncSendExpr.type = createAccumulatedErrorTypeForMatchingRecive(syncSendExpr.pos, syncSendExpr.expr.type);
+        syncSendExpr.setBType(
+                createAccumulatedErrorTypeForMatchingRecive(syncSendExpr.pos, syncSendExpr.expr.getBType()));
         was.addWorkerAction(syncSendExpr);
         analyzeExpr(syncSendExpr.expr);
     }
@@ -3010,7 +3015,7 @@ public class CodeAnalyzer extends BLangNodeVisitor {
 
         Set<Object> names = new HashSet<>();
         Set<Object> neverTypedKeys = new HashSet<>();
-        BType type = recordLiteral.type;
+        BType type = recordLiteral.getBType();
         boolean isRecord = type.tag == TypeTags.RECORD;
         boolean isOpenRecord = isRecord && !((BRecordType) type).sealed;
 
@@ -3031,7 +3036,7 @@ public class CodeAnalyzer extends BLangNodeVisitor {
 
                 analyzeExpr(spreadOpExpr);
 
-                BType spreadOpExprType = spreadOpExpr.type;
+                BType spreadOpExprType = spreadOpExpr.getBType();
                 int spreadFieldTypeTag = spreadOpExprType.tag;
                 if (spreadFieldTypeTag == TypeTags.MAP) {
                     if (inclusiveTypeSpreadField != null) {
@@ -3082,7 +3087,8 @@ public class CodeAnalyzer extends BLangNodeVisitor {
                         if (bField.type.tag != TypeTags.NEVER) {
                             this.dlog.error(spreadOpExpr.pos,
                                             DiagnosticErrorCode.DUPLICATE_KEY_IN_RECORD_LITERAL_SPREAD_OP,
-                                            recordLiteral.type.getKind().typeName(), bField.symbol, spreadOpField);
+                                            recordLiteral.getBType().getKind().typeName(), bField.symbol,
+                                            spreadOpField);
                         }
                         continue;
                     }
@@ -3134,7 +3140,7 @@ public class CodeAnalyzer extends BLangNodeVisitor {
                     Object name = ((BLangLiteral) keyExpr).value;
                     if (names.contains(name)) {
                         this.dlog.error(keyExpr.pos, DiagnosticErrorCode.DUPLICATE_KEY_IN_RECORD_LITERAL,
-                                        recordLiteral.parent.type.getKind().typeName(), name);
+                                        recordLiteral.parent.getBType().getKind().typeName(), name);
                     } else if (inclusiveTypeSpreadField != null && !neverTypedKeys.contains(name)) {
                         this.dlog.error(keyExpr.pos,
                                         DiagnosticErrorCode.POSSIBLE_DUPLICATE_OF_FIELD_SPECIFIED_VIA_SPREAD_OP,
@@ -3158,7 +3164,7 @@ public class CodeAnalyzer extends BLangNodeVisitor {
             case WORKER_SYNC_SEND:
                 return;
             default:
-                if (varRefExpr.type != null && varRefExpr.type.tag == TypeTags.FUTURE) {
+                if (varRefExpr.getBType() != null && varRefExpr.getBType().tag == TypeTags.FUTURE) {
                     trackNamedWorkerReferences(varRefExpr);
                 }
         }
@@ -3333,7 +3339,7 @@ public class CodeAnalyzer extends BLangNodeVisitor {
     public void visit(BLangTypeInit cIExpr) {
         analyzeExprs(cIExpr.argsExpr);
         analyzeExpr(cIExpr.initInvocation);
-        BType type = cIExpr.type;
+        BType type = cIExpr.getBType();
         if (cIExpr.userDefinedType != null && Symbols.isFlagOn(type.tsymbol.flags, Flags.DEPRECATED)) {
             dlog.warning(cIExpr.pos, DiagnosticWarningCode.USAGE_OF_DEPRECATED_CONSTRUCT, type);
         }
@@ -3475,14 +3481,16 @@ public class CodeAnalyzer extends BLangNodeVisitor {
     private boolean validateBinaryExpr(BLangBinaryExpr binaryExpr) {
         // 1) For usual binary expressions the lhs or rhs can never be future types, so return true if both of
         // them are not future types
-        if (binaryExpr.lhsExpr.type.tag != TypeTags.FUTURE && binaryExpr.rhsExpr.type.tag != TypeTags.FUTURE) {
+        if (binaryExpr.lhsExpr.getBType().tag != TypeTags.FUTURE
+                && binaryExpr.rhsExpr.getBType().tag != TypeTags.FUTURE) {
             return true;
         }
 
         // 2) For binary expressions followed with wait lhs and rhs are always future types and this is allowed so
         // return true : wait f1 | f2[orgName + moduleName
         BLangNode parentNode = binaryExpr.parent;
-        if (binaryExpr.lhsExpr.type.tag == TypeTags.FUTURE || binaryExpr.rhsExpr.type.tag == TypeTags.FUTURE) {
+        if (binaryExpr.lhsExpr.getBType().tag == TypeTags.FUTURE
+                || binaryExpr.rhsExpr.getBType().tag == TypeTags.FUTURE) {
             if (parentNode == null) {
                 return false;
             }
@@ -3706,7 +3714,7 @@ public class CodeAnalyzer extends BLangNodeVisitor {
     }
 
     public void visit(BLangUserDefinedType userDefinedType) {
-        BTypeSymbol typeSymbol = userDefinedType.type.tsymbol;
+        BTypeSymbol typeSymbol = userDefinedType.getBType().tsymbol;
         if (typeSymbol != null && Symbols.isFlagOn(typeSymbol.flags, Flags.DEPRECATED)) {
             dlog.warning(userDefinedType.pos, DiagnosticWarningCode.USAGE_OF_DEPRECATED_CONSTRUCT, userDefinedType);
         }
@@ -3770,13 +3778,13 @@ public class CodeAnalyzer extends BLangNodeVisitor {
             return;
         }
 
-        BType exprType = env.enclInvokable.getReturnTypeNode().type;
+        BType exprType = env.enclInvokable.getReturnTypeNode().getBType();
 
-        if (!this.failureHandled && !types.isAssignable(getErrorTypes(checkedExpr.expr.type), exprType)) {
+        if (!this.failureHandled && !types.isAssignable(getErrorTypes(checkedExpr.expr.getBType()), exprType)) {
             dlog.error(checkedExpr.pos, DiagnosticErrorCode.CHECKED_EXPR_NO_MATCHING_ERROR_RETURN_IN_ENCL_INVOKABLE);
         }
         if (!this.errorTypes.empty()) {
-            this.errorTypes.peek().add(getErrorTypes(checkedExpr.expr.type));
+            this.errorTypes.peek().add(getErrorTypes(checkedExpr.expr.getBType()));
         }
         returnTypes.peek().add(exprType);
     }
@@ -3800,7 +3808,7 @@ public class CodeAnalyzer extends BLangNodeVisitor {
                 BLangFromClause fromClause = (BLangFromClause) clause;
                 BLangExpression collection = (BLangExpression) fromClause.getCollection();
                 if (fromCount > 1) {
-                    if (TypeTags.STREAM == collection.type.tag) {
+                    if (TypeTags.STREAM == collection.getBType().tag) {
                         this.dlog.error(collection.pos, DiagnosticErrorCode.NOT_ALLOWED_STREAM_USAGE_WITH_FROM);
                     }
                 }
@@ -3818,7 +3826,7 @@ public class CodeAnalyzer extends BLangNodeVisitor {
                 BLangFromClause fromClause = (BLangFromClause) clause;
                 BLangExpression collection = (BLangExpression) fromClause.getCollection();
                 if (fromCount > 1) {
-                    if (TypeTags.STREAM == collection.type.tag) {
+                    if (TypeTags.STREAM == collection.getBType().tag) {
                         this.dlog.error(collection.pos, DiagnosticErrorCode.NOT_ALLOWED_STREAM_USAGE_WITH_FROM);
                     }
                 }
@@ -3891,9 +3899,9 @@ public class CodeAnalyzer extends BLangNodeVisitor {
         this.returnWithinLambdaWrappingCheckStack.push(false);
         BLangVariable onFailVarNode = (BLangVariable) onFailClause.variableDefinitionNode.getVariable();
         for (BType errorType : errorTypes.peek()) {
-            if (!types.isAssignable(errorType, onFailVarNode.type)) {
+            if (!types.isAssignable(errorType, onFailVarNode.getBType())) {
                 dlog.error(onFailVarNode.pos, DiagnosticErrorCode.INCOMPATIBLE_ON_FAIL_ERROR_DEFINITION, errorType,
-                        onFailVarNode.type);
+                           onFailVarNode.getBType());
             }
         }
         analyzeNode(onFailClause.body, env);
@@ -3912,13 +3920,14 @@ public class CodeAnalyzer extends BLangNodeVisitor {
     @Override
     public void visit(BLangTypeTestExpr typeTestExpr) {
         analyzeNode(typeTestExpr.expr, env);
-        if (typeTestExpr.typeNode.type == symTable.semanticError || typeTestExpr.expr.type == symTable.semanticError) {
+        if (typeTestExpr.typeNode.getBType() == symTable.semanticError
+                || typeTestExpr.expr.getBType() == symTable.semanticError) {
             return;
         }
 
         // Check whether the condition is always true. If the variable type is assignable to target type,
         // then type check will always evaluate to true.
-        if (types.isAssignable(typeTestExpr.expr.type, typeTestExpr.typeNode.type)) {
+        if (types.isAssignable(typeTestExpr.expr.getBType(), typeTestExpr.typeNode.getBType())) {
             dlog.hint(typeTestExpr.pos, DiagnosticHintCode.UNNECESSARY_CONDITION);
             return;
         }
@@ -3927,9 +3936,9 @@ public class CodeAnalyzer extends BLangNodeVisitor {
         // It'll be only possible iff, the target type has been assigned to the source
         // variable at some point. To do that, a value of target type should be assignable
         // to the type of the source variable.
-        if (!intersectionExists(typeTestExpr.expr, typeTestExpr.typeNode.type)) {
-            dlog.error(typeTestExpr.pos, DiagnosticErrorCode.INCOMPATIBLE_TYPE_CHECK, typeTestExpr.expr.type,
-                       typeTestExpr.typeNode.type);
+        if (!intersectionExists(typeTestExpr.expr, typeTestExpr.typeNode.getBType())) {
+            dlog.error(typeTestExpr.pos, DiagnosticErrorCode.INCOMPATIBLE_TYPE_CHECK, typeTestExpr.expr.getBType(),
+                       typeTestExpr.typeNode.getBType());
         }
     }
 
@@ -3943,7 +3952,7 @@ public class CodeAnalyzer extends BLangNodeVisitor {
     }
 
     private boolean intersectionExists(BLangExpression expression, BType testType) {
-        BType expressionType = expression.type;
+        BType expressionType = expression.getBType();
 
         BType intersectionType = types.getTypeIntersection(
                 Types.IntersectionContext.compilerInternalNonGenerativeIntersectionContext(),
@@ -4010,8 +4019,8 @@ public class CodeAnalyzer extends BLangNodeVisitor {
      * @param node expression node to analyze
      */
     private <E extends BLangExpression> void checkAccess(E node) {
-        if (node.type != null) {
-            checkAccessSymbol(node.type.tsymbol, node.pos);
+        if (node.getBType() != null) {
+            checkAccessSymbol(node.getBType().tsymbol, node.pos);
         }
 
         //check for object new invocation
@@ -4286,8 +4295,8 @@ public class CodeAnalyzer extends BLangNodeVisitor {
     }
 
     private void validateWorkerActionParameters(BLangWorkerSend send, BLangWorkerReceive receive) {
-        types.checkType(receive, send.type, receive.type);
-        addImplicitCast(send.type, receive);
+        types.checkType(receive, send.getBType(), receive.getBType());
+        addImplicitCast(send.getBType(), receive);
         NodeKind kind = receive.parent.getKind();
         if (kind == NodeKind.TRAP_EXPR || kind == NodeKind.CHECK_EXPR || kind == NodeKind.CHECK_PANIC_EXPR ||
                 kind == NodeKind.FAIL) {
@@ -4303,7 +4312,7 @@ public class CodeAnalyzer extends BLangNodeVisitor {
             BLangSimpleVariable variable = (BLangSimpleVariable) send.parent;
 
             if (variable.isDeclaredWithVar) {
-                variable.type = variable.symbol.type = send.expectedType = receive.matchingSendsError;
+                variable.setBType(variable.symbol.type = send.expectedType = receive.matchingSendsError);
             }
         } else if (parentNodeKind == NodeKind.ASSIGNMENT) {
             BLangAssignment assignment = (BLangAssignment) send.parent;
@@ -4322,9 +4331,9 @@ public class CodeAnalyzer extends BLangNodeVisitor {
                             DiagnosticErrorCode.INCOMPATIBLE_TYPES);
         }
 
-        types.checkType(receive, send.type, receive.type);
+        types.checkType(receive, send.getBType(), receive.getBType());
 
-        addImplicitCast(send.type, receive);
+        addImplicitCast(send.getBType(), receive);
         NodeKind kind = receive.parent.getKind();
         if (kind == NodeKind.TRAP_EXPR || kind == NodeKind.CHECK_EXPR || kind == NodeKind.CHECK_PANIC_EXPR) {
             typeChecker.checkExpr((BLangExpression) receive.parent, receive.env);
@@ -4333,9 +4342,9 @@ public class CodeAnalyzer extends BLangNodeVisitor {
     }
 
     private void addImplicitCast(BType actualType, BLangWorkerReceive receive) {
-        if (receive.type != null && receive.type != symTable.semanticError) {
-            types.setImplicitCastExpr(receive, actualType, receive.type);
-            receive.type = actualType;
+        if (receive.getBType() != null && receive.getBType() != symTable.semanticError) {
+            types.setImplicitCastExpr(receive, actualType, receive.getBType());
+            receive.setBType(actualType);
         }
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CompilerPluginRunner.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CompilerPluginRunner.java
@@ -402,7 +402,7 @@ public class CompilerPluginRunner extends BLangNodeVisitor {
             BType listenerType;
             if ((listenerType = serviceListenerMap.get(plugin)) != null) {
                 for (BLangExpression expr : serviceNode.getAttachedExprs()) {
-                    if (!types.isSameType(expr.type, listenerType)) {
+                    if (!types.isSameType(expr.getBType(), listenerType)) {
                         continue;
                     }
                     isCurrentPluginProcessed = true;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ConstantValueResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ConstantValueResolver.java
@@ -91,12 +91,12 @@ public class ConstantValueResolver extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangLiteral literal) {
-        this.result = new BLangConstantValue(literal.value, literal.type);
+        this.result = new BLangConstantValue(literal.value, literal.getBType());
     }
 
     @Override
     public void visit(BLangNumericLiteral literal) {
-        this.result = new BLangConstantValue(literal.value, literal.type);
+        this.result = new BLangConstantValue(literal.value, literal.getBType());
     }
 
     @Override
@@ -157,7 +157,7 @@ public class ConstantValueResolver extends BLangNodeVisitor {
             mapConstVal.put(key, value);
         }
 
-        this.result = new BLangConstantValue(mapConstVal, recordLiteral.type);
+        this.result = new BLangConstantValue(mapConstVal, recordLiteral.getBType());
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
@@ -917,17 +917,17 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
         } else if (node.getKind() == NodeKind.STRING_TEMPLATE_LITERAL) {
             BLangStringTemplateLiteral stringTemplateLiteral = (BLangStringTemplateLiteral) node;
             for (BLangExpression expr : stringTemplateLiteral.exprs) {
-                result = result * 31 + getTypeHash(stringTemplateLiteral.type) + hash(expr);
+                result = result * 31 + getTypeHash(stringTemplateLiteral.getBType()) + hash(expr);
             }
         } else if (node.getKind() == NodeKind.LIST_CONSTRUCTOR_EXPR) {
             BLangListConstructorExpr listConstructorExpr = (BLangListConstructorExpr) node;
             for (BLangExpression expr : listConstructorExpr.exprs) {
-                result = result * 31 + getTypeHash(listConstructorExpr.type) + hash(expr);
+                result = result * 31 + getTypeHash(listConstructorExpr.getBType()) + hash(expr);
             }
         } else if (node.getKind() == NodeKind.TABLE_CONSTRUCTOR_EXPR) {
             BLangTableConstructorExpr tableConstructorExpr = (BLangTableConstructorExpr) node;
             for (BLangRecordLiteral recordLiteral : tableConstructorExpr.recordLiteralList) {
-                result = result * 31 + getTypeHash(tableConstructorExpr.type) + hash(recordLiteral);
+                result = result * 31 + getTypeHash(tableConstructorExpr.getBType()) + hash(recordLiteral);
             }
         } else if (node.getKind() == NodeKind.TYPE_CONVERSION_EXPR) {
             BLangTypeConversionExpr typeConversionExpr = (BLangTypeConversionExpr) node;
@@ -968,8 +968,8 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
 
     private List<String> getFieldNames(BLangTableConstructorExpr constructorExpr) {
         List<String> fieldNames = null;
-        if (constructorExpr.type.tag == TypeTags.TABLE) {
-            fieldNames = ((BTableType) constructorExpr.type).fieldNameList;
+        if (constructorExpr.getBType().tag == TypeTags.TABLE) {
+            fieldNames = ((BTableType) constructorExpr.getBType()).fieldNameList;
             if (fieldNames != null) {
                 return fieldNames;
             }
@@ -1302,7 +1302,7 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
     public void visit(BLangTypeInit typeInitExpr) {
         typeInitExpr.argsExpr.forEach(argExpr -> analyzeNode(argExpr, env));
         if (this.currDependentSymbol.peek() != null) {
-            addDependency(this.currDependentSymbol.peek(), typeInitExpr.type.tsymbol);
+            addDependency(this.currDependentSymbol.peek(), typeInitExpr.getBType().tsymbol);
         }
     }
 
@@ -1666,10 +1666,10 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
 
     public void visit(BLangServiceConstructorExpr serviceConstructorExpr) {
         if (this.currDependentSymbol.peek() != null) {
-            addDependency(this.currDependentSymbol.peek(), serviceConstructorExpr.type.tsymbol);
+            addDependency(this.currDependentSymbol.peek(), serviceConstructorExpr.getBType().tsymbol);
         }
 
-        addDependency(serviceConstructorExpr.type.tsymbol, serviceConstructorExpr.serviceNode.symbol);
+        addDependency(serviceConstructorExpr.getBType().tsymbol, serviceConstructorExpr.serviceNode.symbol);
         analyzeNode(serviceConstructorExpr.serviceNode, env);
     }
 
@@ -1919,7 +1919,7 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
                 BLangAccessExpression accessExpr = (BLangAccessExpression) varRef;
 
                 BLangExpression expr = accessExpr.expr;
-                BType type = expr.type;
+                BType type = expr.getBType();
                 if (isObjectMemberAccessWithSelf(accessExpr)) {
                     BObjectType objectType = (BObjectType) type;
 
@@ -1964,7 +1964,7 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
     private void checkFinalObjectFieldUpdate(BLangFieldBasedAccess fieldAccess) {
         BLangExpression expr = fieldAccess.expr;
 
-        BType exprType = expr.type;
+        BType exprType = expr.getBType();
 
         if (types.isSubTypeOfBaseType(exprType, TypeTags.OBJECT) &&
                 isFinalFieldInAllObjects(fieldAccess.pos, exprType, fieldAccess.field.value)) {
@@ -2036,7 +2036,7 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
     private void addVarIfInferredTypeIncludesError(BLangSimpleVariable variable) {
         BType typeIntersection =
                 types.getTypeIntersection(Types.IntersectionContext.compilerInternalIntersectionContext(),
-                                          variable.type, symTable.errorType, env);
+                                          variable.getBType(), symTable.errorType, env);
         if (typeIntersection != null &&
                 typeIntersection != symTable.semanticError && typeIntersection != symTable.noType) {
             unusedErrorVarsDeclaredWithVar.put(variable.symbol, variable.pos);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DocumentationAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DocumentationAnalyzer.java
@@ -535,7 +535,7 @@ public class DocumentationAnalyzer extends BLangNodeVisitor {
         } else if (returnParameter != null && !isExpected) {
             dlog.warning(returnParameter.pos, DiagnosticWarningCode.NO_DOCUMENTABLE_RETURN_PARAMETER);
         } else if (returnParameter != null) {
-            returnParameter.setReturnType(((BLangFunction) node).getReturnTypeNode().type);
+            returnParameter.setReturnType(((BLangFunction) node).getReturnTypeNode().getBType());
         }
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/IsAnydataUniqueVisitor.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/IsAnydataUniqueVisitor.java
@@ -230,7 +230,7 @@ public class IsAnydataUniqueVisitor implements UniqueTypeVisitor<Boolean> {
             return type.isAnyData;
         }
         for (BLangExpression value : type.getValueSpace()) {
-            if (!visit(value.type)) {
+            if (!visit(value.getBType())) {
                 type.isAnyData = false;
                 return false;
             }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -468,11 +468,11 @@ public class SymbolEnter extends BLangNodeVisitor {
 
     private void populateDistinctTypeIdsFromIncludedTypeReferences(BLangTypeDefinition typeDefinition) {
         if (typeDefinition.typeNode.getKind() == NodeKind.INTERSECTION_TYPE_NODE) {
-            if (typeDefinition.typeNode.type == null) {
+            if (typeDefinition.typeNode.getBType() == null) {
                 return;
             }
 
-            BType definingType = types.getTypeWithEffectiveIntersectionTypes(typeDefinition.typeNode.type);
+            BType definingType = types.getTypeWithEffectiveIntersectionTypes(typeDefinition.typeNode.getBType());
             if (definingType.tag != TypeTags.OBJECT) {
                 return;
             }
@@ -480,17 +480,17 @@ public class SymbolEnter extends BLangNodeVisitor {
 
             BLangIntersectionTypeNode typeNode = (BLangIntersectionTypeNode) typeDefinition.typeNode;
             for (BLangType constituentTypeNode : typeNode.getConstituentTypeNodes()) {
-                if (constituentTypeNode.type.tag != TypeTags.OBJECT) {
+                if (constituentTypeNode.getBType().tag != TypeTags.OBJECT) {
                     continue;
                 }
-                definigObjType.typeIdSet.add(((BObjectType) constituentTypeNode.type).typeIdSet);
+                definigObjType.typeIdSet.add(((BObjectType) constituentTypeNode.getBType()).typeIdSet);
             }
         } else if (typeDefinition.typeNode.getKind() == NodeKind.OBJECT_TYPE) {
             BLangObjectTypeNode objectTypeNode = (BLangObjectTypeNode) typeDefinition.typeNode;
-            BTypeIdSet typeIdSet = ((BObjectType) objectTypeNode.type).typeIdSet;
+            BTypeIdSet typeIdSet = ((BObjectType) objectTypeNode.getBType()).typeIdSet;
 
             for (BLangType typeRef : objectTypeNode.typeRefs) {
-                BType type = types.getTypeWithEffectiveIntersectionTypes(typeRef.type);
+                BType type = types.getTypeWithEffectiveIntersectionTypes(typeRef.getBType());
                 if (type.tag != TypeTags.OBJECT) {
                     continue;
                 }
@@ -502,10 +502,10 @@ public class SymbolEnter extends BLangNodeVisitor {
 
     private void populateDistinctTypeIdsFromIncludedTypeReferences(BLangClassDefinition typeDef) {
         BLangClassDefinition classDefinition = typeDef;
-        BTypeIdSet typeIdSet = ((BObjectType) classDefinition.type).typeIdSet;
+        BTypeIdSet typeIdSet = ((BObjectType) classDefinition.getBType()).typeIdSet;
 
         for (BLangType typeRef : classDefinition.typeRefs) {
-            BType type = types.getTypeWithEffectiveIntersectionTypes(typeRef.type);
+            BType type = types.getTypeWithEffectiveIntersectionTypes(typeRef.getBType());
             if (type.tag != TypeTags.OBJECT) {
                 continue;
             }
@@ -555,7 +555,8 @@ public class SymbolEnter extends BLangNodeVisitor {
         Set<String> includedFunctionNames = new HashSet<>();
 
         if (defineReadOnlyInclusionsOnly) {
-            for (BAttachedFunction function : ((BObjectTypeSymbol) classDefinition.type.tsymbol).referencedFunctions) {
+            for (BAttachedFunction function :
+                    ((BObjectTypeSymbol) classDefinition.getBType().tsymbol).referencedFunctions) {
                 includedFunctionNames.add(function.funcName.value);
             }
         }
@@ -565,7 +566,7 @@ public class SymbolEnter extends BLangNodeVisitor {
         // resolved by the time we reach here. It is achieved by ordering the typeDefs
         // according to the precedence.
         for (BLangType typeRef : classDefinition.typeRefs) {
-            BType type = typeRef.type;
+            BType type = typeRef.getBType();
             if (type == null || type == symTable.semanticError) {
                 return;
             }
@@ -615,7 +616,7 @@ public class SymbolEnter extends BLangNodeVisitor {
                 continue;
             }
 
-            int tag = classDefinition.type.tag;
+            int tag = classDefinition.getBType().tag;
             if (tag == TypeTags.OBJECT) {
                 if (isInvalidIncludedTypeInClass(referredType)) {
                     if (!defineReadOnlyInclusionsOnly) {
@@ -664,7 +665,7 @@ public class SymbolEnter extends BLangNodeVisitor {
                     objectType = (BObjectType) referredType;
                 }
 
-                if (classDefinition.type.tsymbol.owner != referredType.tsymbol.owner) {
+                if (classDefinition.getBType().tsymbol.owner != referredType.tsymbol.owner) {
                     boolean errored = false;
                     for (BField field : objectType.fields.values()) {
                         if (!Symbols.isPublic(field.symbol)) {
@@ -711,7 +712,7 @@ public class SymbolEnter extends BLangNodeVisitor {
                                 DiagnosticErrorCode.MISMATCHED_VISIBILITY_QUALIFIERS_IN_OBJECT_FIELD,
                                 existingVariable.name.value);
                     }
-                    if (types.isAssignable(existingVariable.type, field.type)) {
+                    if (types.isAssignable(existingVariable.getBType(), field.type)) {
                         continue;
                     }
                 }
@@ -786,7 +787,7 @@ public class SymbolEnter extends BLangNodeVisitor {
         }
 
         tSymbol.type = objectType;
-        classDefinition.type = objectType;
+        classDefinition.setBType(objectType);
         classDefinition.symbol = tSymbol;
 
         if (isDeprecated(classDefinition.annAttachments)) {
@@ -1441,7 +1442,7 @@ public class SymbolEnter extends BLangNodeVisitor {
         if (distinctFlagPresent) {
             if (definedType.getKind() == TypeKind.ERROR) {
                 BErrorType distinctType = getDistinctErrorType(typeDefinition, (BErrorType) definedType, typeDefSymbol);
-                typeDefinition.typeNode.type = distinctType;
+                typeDefinition.typeNode.setBType(distinctType);
                 definedType = distinctType;
             } else if (definedType.getKind() == TypeKind.INTERSECTION
                     && ((BIntersectionType) definedType).effectiveType.getKind() == TypeKind.ERROR) {
@@ -1450,7 +1451,7 @@ public class SymbolEnter extends BLangNodeVisitor {
             } else if (definedType.getKind() == TypeKind.OBJECT) {
                 BObjectType distinctType = getDistinctObjectType(typeDefinition, (BObjectType) definedType,
                                                                  typeDefSymbol);
-                typeDefinition.typeNode.type = distinctType;
+                typeDefinition.typeNode.setBType(distinctType);
                 definedType = distinctType;
             } else if (definedType.getKind() == TypeKind.UNION) {
                 validateUnionForDistinctType((BUnionType) definedType, typeDefinition.pos);
@@ -1490,7 +1491,7 @@ public class SymbolEnter extends BLangNodeVisitor {
         typeDefinition.symbol = typeDefSymbol;
         if (typeDefinition.hasCyclicReference) {
             // Workaround for https://github.com/ballerina-platform/ballerina-lang/issues/29742
-            typeDefinition.type.tsymbol = typeDefSymbol;
+            typeDefinition.getBType().tsymbol = typeDefSymbol;
         } else {
             boolean isLanglibModule = PackageID.isLangLibPackageID(this.env.enclPkg.packageID);
             if (isLanglibModule) {
@@ -1626,10 +1627,10 @@ public class SymbolEnter extends BLangNodeVisitor {
                 unionType.add(member);
             }
         }
-        typeDef.typeNode.type = unionType;
-        typeDef.typeNode.type.tsymbol.type = unionType;
+        typeDef.typeNode.setBType(unionType);
+        typeDef.typeNode.getBType().tsymbol.type = unionType;
         typeDef.symbol.type = unionType;
-        typeDef.type = unionType;
+        typeDef.setBType(unionType);
         return unionType;
     }
 
@@ -1691,8 +1692,8 @@ public class SymbolEnter extends BLangNodeVisitor {
                 // Type is pre-defined in symbol Table.
                 BType type = symTable.getLangLibSubType(typeDefinition.name.value);
                 typeDefinition.symbol = type.tsymbol;
-                typeDefinition.type = type;
-                typeDefinition.typeNode.type = type;
+                typeDefinition.setBType(type);
+                typeDefinition.typeNode.setBType(type);
                 typeDefinition.isBuiltinTypeDef = true;
                 break;
             }
@@ -1731,7 +1732,8 @@ public class SymbolEnter extends BLangNodeVisitor {
         defineNode(serviceNode.serviceVariable, env);
 
         Name generatedServiceName = names.fromString("service$" + serviceNode.serviceClass.symbol.name.value);
-        BType type = serviceNode.serviceClass.typeRefs.isEmpty() ? null : serviceNode.serviceClass.typeRefs.get(0).type;
+        BType type = serviceNode.serviceClass.typeRefs.isEmpty() ? null : serviceNode.serviceClass.typeRefs.get(0)
+                .getBType();
         BServiceSymbol serviceSymbol = new BServiceSymbol((BClassSymbol) serviceNode.serviceClass.symbol,
                                                           Flags.asMask(serviceNode.flagSet), generatedServiceName,
                                                           env.enclPkg.symbol.pkgID, type, env.enclPkg.symbol,
@@ -1773,7 +1775,7 @@ public class SymbolEnter extends BLangNodeVisitor {
         funcSymbol.markdownDocumentation = getMarkdownDocAttachment(funcNode.markdownDocumentationAttachment);
         SymbolEnv invokableEnv = SymbolEnv.createFunctionEnv(funcNode, funcSymbol.scope, env);
         defineInvokableSymbol(funcNode, funcSymbol, invokableEnv);
-        funcNode.type = funcSymbol.type;
+        funcNode.setBType(funcSymbol.type);
 
         if (isDeprecated(funcNode.annAttachments)) {
             funcSymbol.flags |= Flags.DEPRECATED;
@@ -1812,7 +1814,7 @@ public class SymbolEnter extends BLangNodeVisitor {
         funcSymbol.markdownDocumentation = getMarkdownDocAttachment(funcNode.markdownDocumentationAttachment);
         SymbolEnv invokableEnv = SymbolEnv.createFunctionEnv(funcNode, funcSymbol.scope, env);
         defineInvokableSymbol(funcNode, funcSymbol, invokableEnv);
-        funcNode.type = funcSymbol.type;
+        funcNode.setBType(funcSymbol.type);
 
         // Reset origin if it's the generated function node for a lambda
         if (Symbols.isFlagOn(funcSymbol.flags, Flags.LAMBDA)) {
@@ -1870,7 +1872,7 @@ public class SymbolEnter extends BLangNodeVisitor {
                     // eg: const decimal d = 5.0;
                     BLangFiniteTypeNode finiteType = (BLangFiniteTypeNode) constant.associatedTypeDefinition.typeNode;
                     BLangExpression valueSpaceExpr = finiteType.valueSpace.iterator().next();
-                    valueSpaceExpr.type = staticType;
+                    valueSpaceExpr.setBType(staticType);
                     defineNode(constant.associatedTypeDefinition, env);
 
                     constantSymbol.type = constant.associatedTypeDefinition.symbol.type;
@@ -1880,14 +1882,14 @@ public class SymbolEnter extends BLangNodeVisitor {
                     // types and continue the flow and let it fail at semantic analyzer.
                     defineNode(constant.associatedTypeDefinition, env);
                     constantSymbol.type = staticType;
-                    constantSymbol.literalType = constant.expr.type;
+                    constantSymbol.literalType = constant.expr.getBType();
                 }
             } else {
                 // A literal type constant is defined without the type.
                 // Then the type of the symbol is the finite type.
                 defineNode(constant.associatedTypeDefinition, env);
                 constantSymbol.type = constant.associatedTypeDefinition.symbol.type;
-                constantSymbol.literalType = constant.expr.type;
+                constantSymbol.literalType = constant.expr.getBType();
             }
         } else if (constant.typeNode != null) {
             constantSymbol.type = constantSymbol.literalType = staticType;
@@ -1921,11 +1923,11 @@ public class SymbolEnter extends BLangNodeVisitor {
     @Override
     public void visit(BLangSimpleVariable varNode) {
         // assign the type to var type node
-        if (varNode.type == null) {
+        if (varNode.getBType() == null) {
             if (varNode.typeNode != null) {
-                varNode.type = symResolver.resolveTypeNode(varNode.typeNode, env);
+                varNode.setBType(symResolver.resolveTypeNode(varNode.typeNode, env));
             } else {
-                varNode.type = symTable.noType;
+                varNode.setBType(symTable.noType);
             }
         }
 
@@ -1936,7 +1938,7 @@ public class SymbolEnter extends BLangNodeVisitor {
             return;
         }
 
-        BVarSymbol varSymbol = defineVarSymbol(varNode.name.pos, varNode.flagSet, varNode.type, varName, env,
+        BVarSymbol varSymbol = defineVarSymbol(varNode.name.pos, varNode.flagSet, varNode.getBType(), varName, env,
                                                varNode.internal);
         if (isDeprecated(varNode.annAttachments)) {
             varSymbol.flags |= Flags.DEPRECATED;
@@ -2010,12 +2012,12 @@ public class SymbolEnter extends BLangNodeVisitor {
             }
             return;
         }
-        if (varNode.type == null) {
-            varNode.type = symResolver.resolveTypeNode(varNode.typeNode, env);
+        if (varNode.getBType() == null) {
+            varNode.setBType(symResolver.resolveTypeNode(varNode.typeNode, env));
         }
         // To support variable forward referencing we need to symbol enter each tuple member with type at SymbolEnter.
         if (!(checkTypeAndVarCountConsistency(varNode, env))) {
-            varNode.type = symTable.semanticError;
+            varNode.setBType(symTable.semanticError);
             return;
         }
     }
@@ -2023,7 +2025,7 @@ public class SymbolEnter extends BLangNodeVisitor {
     boolean checkTypeAndVarCountConsistency(BLangTupleVariable var, SymbolEnv env) {
         if (var.symbol == null) {
             Name varName = names.fromString(anonymousModelHelper.getNextTupleVarKey(env.enclPkg.packageID));
-            var.symbol = defineVarSymbol(var.pos, var.flagSet, var.type, varName, env, var.internal);
+            var.symbol = defineVarSymbol(var.pos, var.flagSet, var.getBType(), varName, env, var.internal);
         }
         
         return checkTypeAndVarCountConsistency(var, null, env);
@@ -2041,9 +2043,9 @@ public class SymbolEnter extends BLangNodeVisitor {
           Consider anydata (a, b) = foo();
           Here, the type of 'a'and type of 'b' will be both anydata.
          */
-            switch (varNode.type.tag) {
+            switch (varNode.getBType().tag) {
                 case TypeTags.UNION:
-                    Set<BType> unionType = types.expandAndGetMemberTypesRecursive(varNode.type);
+                    Set<BType> unionType = types.expandAndGetMemberTypesRecursive(varNode.getBType());
                     List<BType> possibleTypes = new ArrayList<>();
                     for (BType type : unionType) {
                         if (!(TypeTags.TUPLE == type.tag &&
@@ -2060,7 +2062,8 @@ public class SymbolEnter extends BLangNodeVisitor {
                             dlog.error(varNode.pos, DiagnosticErrorCode.INVALID_LIST_BINDING_PATTERN);
                             return false;
                         }
-                        dlog.error(varNode.pos, DiagnosticErrorCode.INVALID_LIST_BINDING_PATTERN_DECL, varNode.type);
+                        dlog.error(varNode.pos, DiagnosticErrorCode.INVALID_LIST_BINDING_PATTERN_DECL,
+                                   varNode.getBType());
                         return false;
                     }
 
@@ -2074,7 +2077,7 @@ public class SymbolEnter extends BLangNodeVisitor {
                                 } else if (possibleType.tag == TypeTags.ARRAY) {
                                     memberTypes.add(((BArrayType) possibleType).eType);
                                 } else {
-                                    memberTupleTypes.add(varNode.type);
+                                    memberTupleTypes.add(varNode.getBType());
                                 }
                             }
 
@@ -2103,26 +2106,26 @@ public class SymbolEnter extends BLangNodeVisitor {
                 case TypeTags.ANYDATA:
                     List<BType> memberTupleTypes = new ArrayList<>();
                     for (int i = 0; i < varNode.memberVariables.size(); i++) {
-                        memberTupleTypes.add(varNode.type);
+                        memberTupleTypes.add(varNode.getBType());
                     }
                     tupleTypeNode = new BTupleType(memberTupleTypes);
                     if (varNode.restVariable != null) {
-                        tupleTypeNode.restType = varNode.type;
+                        tupleTypeNode.restType = varNode.getBType();
                     }
                     break;
                 case TypeTags.TUPLE:
-                    tupleTypeNode = (BTupleType) varNode.type;
+                    tupleTypeNode = (BTupleType) varNode.getBType();
                     break;
                 case TypeTags.ARRAY:
                     List<BType> tupleTypes = new ArrayList<>();
-                    BArrayType arrayType = (BArrayType) varNode.type;
+                    BArrayType arrayType = (BArrayType) varNode.getBType();
                     for (int i = 0; i < arrayType.size; i++) {
                         tupleTypes.add(arrayType.eType);
                     }
                     tupleTypeNode = new BTupleType(tupleTypes);
                     break;
                 default:
-                    dlog.error(varNode.pos, DiagnosticErrorCode.INVALID_LIST_BINDING_PATTERN_DECL, varNode.type);
+                    dlog.error(varNode.pos, DiagnosticErrorCode.INVALID_LIST_BINDING_PATTERN_DECL, varNode.getBType());
                     return false;
             }
         }
@@ -2144,9 +2147,9 @@ public class SymbolEnter extends BLangNodeVisitor {
                 Name varName = names.fromIdNode(simpleVar.name);
                 if (varName == Names.IGNORE) {
                     ignoredCount++;
-                    simpleVar.type = symTable.anyType;
-                    types.checkType(varNode.pos, type, simpleVar.type,
-                            DiagnosticErrorCode.INCOMPATIBLE_TYPES);
+                    simpleVar.setBType(symTable.anyType);
+                    types.checkType(varNode.pos, type, simpleVar.getBType(),
+                                    DiagnosticErrorCode.INCOMPATIBLE_TYPES);
                     continue;
                 }
             }
@@ -2220,12 +2223,12 @@ public class SymbolEnter extends BLangNodeVisitor {
             return;
         }
 
-        if (recordVar.type == null) {
-            recordVar.type = symResolver.resolveTypeNode(recordVar.typeNode, env);
+        if (recordVar.getBType() == null) {
+            recordVar.setBType(symResolver.resolveTypeNode(recordVar.typeNode, env));
         }
         // To support variable forward referencing we need to symbol enter each record member with type at SymbolEnter.
         if (!(symbolEnterAndValidateRecordVariable(recordVar, env))) {
-            recordVar.type = symTable.semanticError;
+            recordVar.setBType(symTable.semanticError);
             return;
         }
     }
@@ -2233,7 +2236,7 @@ public class SymbolEnter extends BLangNodeVisitor {
     boolean symbolEnterAndValidateRecordVariable(BLangRecordVariable var, SymbolEnv env) {
         if (var.symbol == null) {
             Name varName = names.fromString(anonymousModelHelper.getNextRecordVarKey(env.enclPkg.packageID));
-            var.symbol = defineVarSymbol(var.pos, var.flagSet, var.type, varName, env, var.internal);
+            var.symbol = defineVarSymbol(var.pos, var.flagSet, var.getBType(), varName, env, var.internal);
         }
 
         return validateRecordVariable(var, env);
@@ -2253,16 +2256,16 @@ public class SymbolEnter extends BLangNodeVisitor {
           Consider anydata {a, b} = foo();
           Here, the type of 'a'and type of 'b' will be both anydata.
          */
-        switch (recordVar.type.tag) {
+        switch (recordVar.getBType().tag) {
             case TypeTags.UNION:
-                BUnionType unionType = (BUnionType) recordVar.type;
+                BUnionType unionType = (BUnionType) recordVar.getBType();
                 Set<BType> bTypes = types.expandAndGetMemberTypesRecursive(unionType);
                 List<BType> possibleTypes = bTypes.stream()
                         .filter(rec -> doesRecordContainKeys(rec, recordVar.variableList, recordVar.restParam != null))
                         .collect(Collectors.toList());
 
                 if (possibleTypes.isEmpty()) {
-                    dlog.error(recordVar.pos, DiagnosticErrorCode.INVALID_RECORD_BINDING_PATTERN, recordVar.type);
+                    dlog.error(recordVar.pos, DiagnosticErrorCode.INVALID_RECORD_BINDING_PATTERN, recordVar.getBType());
                     return false;
                 }
 
@@ -2285,13 +2288,14 @@ public class SymbolEnter extends BLangNodeVisitor {
                 recordVarType = createSameTypedFieldsRecordType(recordVar, possibleTypes.get(0), env);
                 break;
             case TypeTags.RECORD:
-                recordVarType = (BRecordType) recordVar.type;
+                recordVarType = (BRecordType) recordVar.getBType();
                 break;
             case TypeTags.MAP:
-                recordVarType = createSameTypedFieldsRecordType(recordVar, ((BMapType) recordVar.type).constraint, env);
+                recordVarType = createSameTypedFieldsRecordType(recordVar,
+                                                                ((BMapType) recordVar.getBType()).constraint, env);
                 break;
             default:
-                dlog.error(recordVar.pos, DiagnosticErrorCode.INVALID_RECORD_BINDING_PATTERN, recordVar.type);
+                dlog.error(recordVar.pos, DiagnosticErrorCode.INVALID_RECORD_BINDING_PATTERN, recordVar.getBType());
                 return false;
         }
 
@@ -2441,13 +2445,13 @@ public class SymbolEnter extends BLangNodeVisitor {
                 Name varName = names.fromIdNode(simpleVar.name);
                 if (varName == Names.IGNORE) {
                     ignoredCount++;
-                    simpleVar.type = symTable.anyType;
+                    simpleVar.setBType(symTable.anyType);
                     if (!recordVarTypeFields.containsKey(variable.getKey().getValue())) {
                         continue;
                     }
                     types.checkType(variable.valueBindingPattern.pos,
-                            recordVarTypeFields.get((variable.getKey().getValue())).type, simpleVar.type,
-                            DiagnosticErrorCode.INCOMPATIBLE_TYPES);
+                                    recordVarTypeFields.get((variable.getKey().getValue())).type, simpleVar.getBType(),
+                                    DiagnosticErrorCode.INCOMPATIBLE_TYPES);
                     continue;
                 }
             }
@@ -2456,7 +2460,7 @@ public class SymbolEnter extends BLangNodeVisitor {
                 if (recordVarType.sealed) {
                     validRecord = false;
                     dlog.error(recordVar.pos, DiagnosticErrorCode.INVALID_FIELD_IN_RECORD_BINDING_PATTERN,
-                            variable.getKey().getValue(), recordVar.type);
+                               variable.getKey().getValue(), recordVar.getBType());
                 } else {
                     BType restType;
                     if (recordVarType.restFieldType.tag == TypeTags.ANYDATA ||
@@ -2593,13 +2597,13 @@ public class SymbolEnter extends BLangNodeVisitor {
             return;
         }
 
-        if (errorVar.type == null) {
-            errorVar.type = symResolver.resolveTypeNode(errorVar.typeNode, env);
+        if (errorVar.getBType() == null) {
+            errorVar.setBType(symResolver.resolveTypeNode(errorVar.typeNode, env));
         }
         // To support variable forward referencing we need to symbol enter each variable inside error variable
         // with type at SymbolEnter.
         if (!symbolEnterAndValidateErrorVariable(errorVar, env)) {
-            errorVar.type = symTable.semanticError;
+            errorVar.setBType(symTable.semanticError);
             return;
         }
     }
@@ -2607,7 +2611,7 @@ public class SymbolEnter extends BLangNodeVisitor {
     boolean symbolEnterAndValidateErrorVariable(BLangErrorVariable var, SymbolEnv env) {
         if (var.symbol == null) {
             Name varName = names.fromString(anonymousModelHelper.getNextErrorVarKey(env.enclPkg.packageID));
-            var.symbol = defineVarSymbol(var.pos, var.flagSet, var.type, varName, env, var.internal);
+            var.symbol = defineVarSymbol(var.pos, var.flagSet, var.getBType(), varName, env, var.internal);
         }
 
         return validateErrorVariable(var, env);
@@ -2615,9 +2619,9 @@ public class SymbolEnter extends BLangNodeVisitor {
 
     boolean validateErrorVariable(BLangErrorVariable errorVariable, SymbolEnv env) {
         BErrorType errorType;
-        switch (errorVariable.type.tag) {
+        switch (errorVariable.getBType().tag) {
             case TypeTags.UNION:
-                BUnionType unionType = ((BUnionType) errorVariable.type);
+                BUnionType unionType = ((BUnionType) errorVariable.getBType());
                 List<BErrorType> possibleTypes = unionType.getMemberTypes().stream()
                         .filter(type -> TypeTags.ERROR == type.tag)
                         .map(BErrorType.class::cast)
@@ -2625,7 +2629,7 @@ public class SymbolEnter extends BLangNodeVisitor {
 
                 if (possibleTypes.isEmpty()) {
                     dlog.error(errorVariable.pos, DiagnosticErrorCode.INVALID_ERROR_BINDING_PATTERN,
-                            errorVariable.type);
+                               errorVariable.getBType());
                     return false;
                 }
 
@@ -2643,13 +2647,14 @@ public class SymbolEnter extends BLangNodeVisitor {
                 }
                 break;
             case TypeTags.ERROR:
-                errorType = (BErrorType) errorVariable.type;
+                errorType = (BErrorType) errorVariable.getBType();
                 break;
             default:
-                dlog.error(errorVariable.pos, DiagnosticErrorCode.INVALID_ERROR_BINDING_PATTERN, errorVariable.type);
+                dlog.error(errorVariable.pos, DiagnosticErrorCode.INVALID_ERROR_BINDING_PATTERN,
+                           errorVariable.getBType());
                 return false;
         }
-        errorVariable.type = errorType;
+        errorVariable.setBType(errorType);
 
         if (!errorVariable.isInMatchStmt) {
             BLangSimpleVariable errorMsg = errorVariable.message;
@@ -2675,7 +2680,7 @@ public class SymbolEnter extends BLangNodeVisitor {
                     env.enclPkg.packageID, symTable.errorType,
                     env.scope.owner, errorVariable.pos, SOURCE);
             // TODO: detail type need to be a union representing all details of members of `errorType`
-            errorVariable.type = new BErrorType(errorTypeSymbol, symTable.detailType);
+            errorVariable.setBType(new BErrorType(errorTypeSymbol, symTable.detailType));
             return validateErrorVariable(errorVariable, env);
         }
 
@@ -2702,25 +2707,25 @@ public class SymbolEnter extends BLangNodeVisitor {
             BLangVariable boundVar = errorDetailEntry.valueBindingPattern;
             if (entryField != null) {
                 if ((entryField.symbol.flags & Flags.OPTIONAL) == Flags.OPTIONAL) {
-                    boundVar.type = BUnionType.create(null, entryField.type, symTable.nilType);
+                    boundVar.setBType(BUnionType.create(null, entryField.type, symTable.nilType));
                 } else {
-                    boundVar.type = entryField.type;
+                    boundVar.setBType(entryField.type);
                 }
             } else {
                 if (recordType.sealed) {
                     dlog.error(errorVariable.pos, DiagnosticErrorCode.INVALID_ERROR_BINDING_PATTERN,
-                            errorVariable.type);
-                    boundVar.type = symTable.semanticError;
+                               errorVariable.getBType());
+                    boundVar.setBType(symTable.semanticError);
                     return false;
                 } else {
-                    boundVar.type = BUnionType.create(null, recordType.restFieldType, symTable.nilType);
+                    boundVar.setBType(BUnionType.create(null, recordType.restFieldType, symTable.nilType));
                 }
             }
 
             boolean isIgnoredVar = boundVar.getKind() == NodeKind.VARIABLE
                     && ((BLangSimpleVariable) boundVar).name.value.equals(Names.IGNORE.value);
             if (!isIgnoredVar) {
-                defineMemberNode(boundVar, env, boundVar.type);
+                defineMemberNode(boundVar, env, boundVar.getBType());
             }
         }
 
@@ -2731,7 +2736,7 @@ public class SymbolEnter extends BLangNodeVisitor {
             BType constraint = getRestMapConstraintType(detailFields, matchedDetailFields, recordType);
             BMapType restType = new BMapType(TypeTags.MAP, constraint, typeSymbol);
             typeSymbol.type = restType;
-            errorVariable.restDetail.type = restType;
+            errorVariable.restDetail.setBType(restType);
             defineMemberNode(errorVariable.restDetail, env, restType);
         }
         return true;
@@ -2818,7 +2823,7 @@ public class SymbolEnter extends BLangNodeVisitor {
     }
 
     private void defineMemberNode(BLangVariable memberVar, SymbolEnv env, BType type) {
-        memberVar.type = type;
+        memberVar.setBType(type);
         // Module level variables declared with `var` already defined
         if ((env.scope.owner.tag & SymTag.PACKAGE) == SymTag.PACKAGE && memberVar.isDeclaredWithVar) {
             memberVar.symbol.type = type;
@@ -2891,7 +2896,7 @@ public class SymbolEnter extends BLangNodeVisitor {
 
     private void defineRecordTypeNode(BLangRecordTypeNode recordTypeNode, SymbolEnv env) {
         BRecordType recordType = (BRecordType) recordTypeNode.symbol.type;
-        recordTypeNode.type = recordType;
+        recordTypeNode.setBType(recordType);
 
         // Define all the fields
         resolveFields(recordType, recordTypeNode, env);
@@ -3187,9 +3192,9 @@ public class SymbolEnter extends BLangNodeVisitor {
                         .orElse(symTable.detailType);
 
                 ((BErrorType) typeDef.symbol.type).detailType = detailType;
-            } else if (typeNode.type != null && typeNode.type.tag == TypeTags.ERROR) {
+            } else if (typeNode.getBType() != null && typeNode.getBType().tag == TypeTags.ERROR) {
                 SymbolEnv typeDefEnv = SymbolEnv.createTypeEnv(typeNode, typeDef.symbol.scope, pkgEnv);
-                BType detailType = ((BErrorType) typeNode.type).detailType;
+                BType detailType = ((BErrorType) typeNode.getBType()).detailType;
                 if (detailType == symTable.noType) {
                     BErrorType type = (BErrorType) symResolver.resolveTypeNode(typeNode, typeDefEnv);
                     ((BErrorType) typeDef.symbol.type).detailType = type.detailType;
@@ -3267,10 +3272,10 @@ public class SymbolEnter extends BLangNodeVisitor {
 
         // analyze restFieldType for open records
         for (BLangType typeRef : recordTypeNode.typeRefs) {
-            if (typeRef.type.tag != TypeTags.RECORD) {
+            if (typeRef.getBType().tag != TypeTags.RECORD) {
                 continue;
             }
-            BType restFieldType = ((BRecordType) typeRef.type).restFieldType;
+            BType restFieldType = ((BRecordType) typeRef.getBType()).restFieldType;
             if (restFieldType == symTable.noType) {
                 continue;
             }
@@ -3308,7 +3313,7 @@ public class SymbolEnter extends BLangNodeVisitor {
         // collect resolved type refs from structural type
         structureType.typeInclusions = new ArrayList<>();
         for (BLangType tRef : structureTypeNode.typeRefs) {
-            BType type = tRef.type;
+            BType type = tRef.getBType();
             structureType.typeInclusions.add(type);
         }
 
@@ -3368,11 +3373,11 @@ public class SymbolEnter extends BLangNodeVisitor {
             // resolved by the time we reach here. It is achieved by ordering the typeDefs
             // according to the precedence.
             for (BLangType typeRef : objTypeNode.typeRefs) {
-                if (typeRef.type.tsymbol == null || typeRef.type.tsymbol.kind != SymbolKind.OBJECT) {
+                if (typeRef.getBType().tsymbol == null || typeRef.getBType().tsymbol.kind != SymbolKind.OBJECT) {
                     continue;
                 }
 
-                List<BAttachedFunction> functions = ((BObjectTypeSymbol) typeRef.type.tsymbol).attachedFuncs;
+                List<BAttachedFunction> functions = ((BObjectTypeSymbol) typeRef.getBType().tsymbol).attachedFuncs;
                 for (BAttachedFunction function : functions) {
                     defineReferencedFunction(typeDef.pos, typeDef.flagSet, objMethodsEnv,
                             typeRef, function, includedFunctionNames, typeDef.symbol,
@@ -3389,7 +3394,7 @@ public class SymbolEnter extends BLangNodeVisitor {
             BLangType typeNode = typeDefNode.typeNode;
             NodeKind kind = typeNode.getKind();
             if (kind == NodeKind.INTERSECTION_TYPE_NODE) {
-                BType currentType = typeNode.type;
+                BType currentType = typeNode.getBType();
 
                 if (currentType.tag != TypeTags.INTERSECTION) {
                     continue;
@@ -3418,7 +3423,7 @@ public class SymbolEnter extends BLangNodeVisitor {
 
                 if (hasNonReadOnlyElement) {
                     dlog.error(typeDefNode.typeNode.pos, DiagnosticErrorCode.INVALID_INTERSECTION_TYPE, typeNode);
-                    typeNode.type = symTable.semanticError;
+                    typeNode.setBType(symTable.semanticError);
                 }
 
                 continue;
@@ -3428,14 +3433,14 @@ public class SymbolEnter extends BLangNodeVisitor {
             BStructureType mutableType;
 
             if (kind == NodeKind.OBJECT_TYPE) {
-                BObjectType currentType = (BObjectType) typeNode.type;
+                BObjectType currentType = (BObjectType) typeNode.getBType();
                 mutableType = currentType.mutableType;
                 if (mutableType == null) {
                     continue;
                 }
                 immutableType = currentType;
             } else if (kind == NodeKind.RECORD_TYPE) {
-                BRecordType currentType = (BRecordType) typeNode.type;
+                BRecordType currentType = (BRecordType) typeNode.getBType();
                 mutableType = currentType.mutableType;
                 if (mutableType == null) {
                     continue;
@@ -3451,7 +3456,7 @@ public class SymbolEnter extends BLangNodeVisitor {
 
             if (!types.isSelectivelyImmutableType(mutableType, true)) {
                 dlog.error(typeDefNode.typeNode.pos, DiagnosticErrorCode.INVALID_INTERSECTION_TYPE, immutableType);
-                typeNode.type = symTable.semanticError;
+                typeNode.setBType(symTable.semanticError);
             }
         }
     }
@@ -3615,10 +3620,10 @@ public class SymbolEnter extends BLangNodeVisitor {
     }
 
     private void setReadOnlynessOfClassDef(BLangClassDefinition classDef, SymbolEnv pkgEnv) {
-        BObjectType objectType = (BObjectType) classDef.type;
+        BObjectType objectType = (BObjectType) classDef.getBType();
         Location pos = classDef.pos;
 
-        if (Symbols.isFlagOn(classDef.type.flags, Flags.READONLY)) {
+        if (Symbols.isFlagOn(classDef.getBType().flags, Flags.READONLY)) {
             if (!types.isSelectivelyImmutableType(objectType, new HashSet<>())) {
                 dlog.error(pos, DiagnosticErrorCode.INVALID_READONLY_OBJECT_TYPE, objectType);
                 return;
@@ -3639,8 +3644,8 @@ public class SymbolEnter extends BLangNodeVisitor {
                 }
             }
 
-            classDef.type.tsymbol.flags |= Flags.READONLY;
-            classDef.type.flags |= Flags.READONLY;
+            classDef.getBType().tsymbol.flags |= Flags.READONLY;
+            classDef.getBType().flags |= Flags.READONLY;
         }
     }
 
@@ -3698,9 +3703,9 @@ public class SymbolEnter extends BLangNodeVisitor {
                 }
             }
             if (varNode.flagSet.contains(Flag.INCLUDED)) {
-                if (varNode.type.getKind() == TypeKind.RECORD) {
+                if (varNode.getBType().getKind() == TypeKind.RECORD) {
                     symbol.flags |= Flags.INCLUDED;
-                    LinkedHashMap<String, BField> fields = ((BRecordType) varNode.type).fields;
+                    LinkedHashMap<String, BField> fields = ((BRecordType) varNode.getBType()).fields;
                     for (String fieldName : fields.keySet()) {
                         BField field = fields.get(fieldName);
                         if (field.symbol.type.tag != TypeTags.NEVER) {
@@ -3722,7 +3727,7 @@ public class SymbolEnter extends BLangNodeVisitor {
             symResolver.resolveTypeNode(invokableNode.returnTypeNode, invokableEnv);
         }
         invokableSymbol.params = paramSymbols;
-        BType retType = invokableNode.returnTypeNode.type;
+        BType retType = invokableNode.returnTypeNode.getBType();
         invokableSymbol.retType = retType;
 
         symResolver.validateInferTypedescParams(invokableNode.pos, invokableNode.getParameters(), retType);
@@ -3865,7 +3870,7 @@ public class SymbolEnter extends BLangNodeVisitor {
         }
 
         //Set cached receiver to the init function
-        initFunction.receiver = ASTBuilderUtil.createReceiver(object.pos, object.type);
+        initFunction.receiver = ASTBuilderUtil.createReceiver(object.pos, object.getBType());
 
         initFunction.attachedFunction = true;
         initFunction.flagSet.add(Flag.ATTACHED);
@@ -3879,7 +3884,7 @@ public class SymbolEnter extends BLangNodeVisitor {
         }
 
         //Set cached receiver to the init function
-        initFunction.receiver = ASTBuilderUtil.createReceiver(classDefinition.pos, classDefinition.type);
+        initFunction.receiver = ASTBuilderUtil.createReceiver(classDefinition.pos, classDefinition.getBType());
 
         initFunction.attachedFunction = true;
         initFunction.flagSet.add(Flag.ATTACHED);
@@ -3888,7 +3893,7 @@ public class SymbolEnter extends BLangNodeVisitor {
 
     private void defineAttachedFunctions(BLangFunction funcNode, BInvokableSymbol funcSymbol,
                                          SymbolEnv invokableEnv, boolean isValidAttachedFunc) {
-        BTypeSymbol typeSymbol = funcNode.receiver.type.tsymbol;
+        BTypeSymbol typeSymbol = funcNode.receiver.getBType().tsymbol;
 
         // Check whether there exists a struct field with the same name as the function name.
         if (isValidAttachedFunc) {
@@ -3905,7 +3910,7 @@ public class SymbolEnter extends BLangNodeVisitor {
 
     private void validateFunctionsAttachedToRecords(BLangFunction funcNode, BInvokableSymbol funcSymbol) {
         BInvokableType funcType = (BInvokableType) funcSymbol.type;
-        BRecordTypeSymbol recordSymbol = (BRecordTypeSymbol) funcNode.receiver.type.tsymbol;
+        BRecordTypeSymbol recordSymbol = (BRecordTypeSymbol) funcNode.receiver.getBType().tsymbol;
 
         recordSymbol.initializerFunc = new BAttachedFunction(
                 names.fromIdNode(funcNode.name), funcSymbol, funcType, funcNode.pos);
@@ -3914,7 +3919,7 @@ public class SymbolEnter extends BLangNodeVisitor {
     private void validateFunctionsAttachedToObject(BLangFunction funcNode, BInvokableSymbol funcSymbol) {
 
         BInvokableType funcType = (BInvokableType) funcSymbol.type;
-        BObjectTypeSymbol objectSymbol = (BObjectTypeSymbol) funcNode.receiver.type.tsymbol;
+        BObjectTypeSymbol objectSymbol = (BObjectTypeSymbol) funcNode.receiver.getBType().tsymbol;
         BAttachedFunction attachedFunc;
         if (funcNode.getKind() == NodeKind.RESOURCE_FUNC) {
             attachedFunc = createResourceFunction(funcNode, funcSymbol, funcType);
@@ -3995,7 +4000,7 @@ public class SymbolEnter extends BLangNodeVisitor {
         varRef.variableName = (BLangIdentifier) createIdentifier(fieldVar.name.getValue());
         varRef.pkgAlias = (BLangIdentifier) TreeBuilder.createIdentifierNode();
         varRef.symbol = fieldVar;
-        varRef.type = fieldVar.type;
+        varRef.setBType(fieldVar.type);
 
         //Create RHS variable reference
         BLangSimpleVarRef exprVar = (BLangSimpleVarRef) TreeBuilder.createSimpleVariableReferenceNode();
@@ -4003,7 +4008,7 @@ public class SymbolEnter extends BLangNodeVisitor {
         exprVar.variableName = (BLangIdentifier) createIdentifier(varSym.name.getValue());
         exprVar.pkgAlias = (BLangIdentifier) TreeBuilder.createIdentifierNode();
         exprVar.symbol = varSym;
-        exprVar.type = varSym.type;
+        exprVar.setBType(varSym.type);
 
         //Create assignment statement
         BLangAssignment assignmentStmt = (BLangAssignment) TreeBuilder.createAssignmentNode();
@@ -4026,17 +4031,17 @@ public class SymbolEnter extends BLangNodeVisitor {
             return true;
         }
 
-        if (funcNode.receiver.type == null) {
-            funcNode.receiver.type = symResolver.resolveTypeNode(funcNode.receiver.typeNode, env);
+        if (funcNode.receiver.getBType() == null) {
+            funcNode.receiver.setBType(symResolver.resolveTypeNode(funcNode.receiver.typeNode, env));
         }
-        if (funcNode.receiver.type.tag == TypeTags.SEMANTIC_ERROR) {
+        if (funcNode.receiver.getBType().tag == TypeTags.SEMANTIC_ERROR) {
             return true;
         }
 
-        if (funcNode.receiver.type.tag == TypeTags.OBJECT
-                && !this.env.enclPkg.symbol.pkgID.equals(funcNode.receiver.type.tsymbol.pkgID)) {
+        if (funcNode.receiver.getBType().tag == TypeTags.OBJECT
+                && !this.env.enclPkg.symbol.pkgID.equals(funcNode.receiver.getBType().tsymbol.pkgID)) {
             dlog.error(funcNode.receiver.pos, DiagnosticErrorCode.FUNC_DEFINED_ON_NON_LOCAL_TYPE,
-                    funcNode.name.value, funcNode.receiver.type.toString());
+                       funcNode.name.value, funcNode.receiver.getBType().toString());
             return false;
         }
         return true;
@@ -4045,14 +4050,14 @@ public class SymbolEnter extends BLangNodeVisitor {
     private Name getFuncSymbolName(BLangFunction funcNode) {
         if (funcNode.receiver != null) {
             return names.fromString(Symbols.getAttachedFuncSymbolName(
-                    funcNode.receiver.type.tsymbol.name.value, funcNode.name.value));
+                    funcNode.receiver.getBType().tsymbol.name.value, funcNode.name.value));
         }
         return names.fromIdNode(funcNode.name);
     }
 
     private Name getFieldSymbolName(BLangSimpleVariable receiver, BLangSimpleVariable variable) {
         return names.fromString(Symbols.getAttachedFuncSymbolName(
-                receiver.type.tsymbol.name.value, variable.name.value));
+                receiver.getBType().tsymbol.name.value, variable.name.value));
     }
 
     private MarkdownDocAttachment getMarkdownDocAttachment(BLangMarkdownDocumentation docNode) {
@@ -4114,7 +4119,7 @@ public class SymbolEnter extends BLangNodeVisitor {
             }
 
             int referredTypeTag = referredType.tag;
-            if (structureTypeNode.type.tag == TypeTags.OBJECT) {
+            if (structureTypeNode.getBType().tag == TypeTags.OBJECT) {
                 if (referredTypeTag != TypeTags.OBJECT) {
                     DiagnosticErrorCode errorCode = DiagnosticErrorCode.INCOMPATIBLE_TYPE_REFERENCE;
 
@@ -4129,7 +4134,7 @@ public class SymbolEnter extends BLangNodeVisitor {
                 }
 
                 BObjectType objectType = (BObjectType) referredType;
-                if (structureTypeNode.type.tsymbol.owner != referredType.tsymbol.owner) {
+                if (structureTypeNode.getBType().tsymbol.owner != referredType.tsymbol.owner) {
                     for (BField field : objectType.fields.values()) {
                         if (!Symbols.isPublic(field.symbol)) {
                             dlog.error(typeRef.pos, DiagnosticErrorCode.INCOMPATIBLE_TYPE_REFERENCE_NON_PUBLIC_MEMBERS,
@@ -4150,7 +4155,7 @@ public class SymbolEnter extends BLangNodeVisitor {
                 }
             }
 
-            if (structureTypeNode.type.tag == TypeTags.RECORD && referredTypeTag != TypeTags.RECORD) {
+            if (structureTypeNode.getBType().tag == TypeTags.RECORD && referredTypeTag != TypeTags.RECORD) {
                 dlog.error(typeRef.pos, DiagnosticErrorCode.INCOMPATIBLE_RECORD_TYPE_REFERENCE, typeRef);
                 invalidTypeRefs.add(typeRef);
                 return Stream.empty();
@@ -4169,7 +4174,7 @@ public class SymbolEnter extends BLangNodeVisitor {
                                 DiagnosticErrorCode.MISMATCHED_VISIBILITY_QUALIFIERS_IN_OBJECT_FIELD,
                                 existingVariable.name.value);
                     }
-                    return !types.isAssignable(existingVariable.type, f.type);
+                    return !types.isAssignable(existingVariable.getBType(), f.type);
                 }
                 return true;
             }).map(field -> {
@@ -4368,7 +4373,7 @@ public class SymbolEnter extends BLangNodeVisitor {
             invokableType.tsymbol.flags |= Flags.TRANSACTIONAL;
         }
 
-        variable.type = invokableType;
+        variable.setBType(invokableType);
     }
 
     private SymbolOrigin getOrigin(Name name, Set<Flag> flags) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -499,7 +499,7 @@ public class SymbolResolver extends BLangNodeVisitor {
             }
         }
 
-        typeNode.type = resultType;
+        typeNode.setBType(resultType);
         return resultType;
     }
 
@@ -1244,7 +1244,7 @@ public class SymbolResolver extends BLangNodeVisitor {
 
         BFiniteType finiteType = new BFiniteType(finiteTypeSymbol);
         for (BLangExpression literal : finiteTypeNode.valueSpace) {
-            ((BLangLiteral) literal).type = symTable.getTypeFromTag(((BLangLiteral) literal).type.tag);
+            ((BLangLiteral) literal).setBType(symTable.getTypeFromTag(((BLangLiteral) literal).getBType().tag));
             finiteType.addValue(literal);
         }
         finiteTypeSymbol.type = finiteType;
@@ -1510,8 +1510,8 @@ public class SymbolResolver extends BLangNodeVisitor {
         BLangType returnTypeNode = functionTypeNode.returnTypeNode;
         BType invokableType = createInvokableType(params, functionTypeNode.restParam, returnTypeNode,
                                                   Flags.asMask(functionTypeNode.flagSet), env, pos);
-        resultType = validateInferTypedescParams(pos, params, returnTypeNode == null ? null : returnTypeNode.type) ?
-                        invokableType : symTable.semanticError;
+        resultType = validateInferTypedescParams(pos, params, returnTypeNode == null ?
+                null : returnTypeNode.getBType()) ? invokableType : symTable.semanticError;
     }
 
     public BType createInvokableType(List<? extends BLangVariable> paramVars,
@@ -1552,7 +1552,7 @@ public class SymbolResolver extends BLangNodeVisitor {
             if (type == symTable.noType) {
                 return symTable.noType;
             }
-            paramNode.type = type;
+            paramNode.setBType(type);
             paramTypes.add(type);
 
             long paramFlags = Flags.asMask(paramNode.flagSet);
@@ -1584,7 +1584,7 @@ public class SymbolResolver extends BLangNodeVisitor {
             if (restType == symTable.noType) {
                 return symTable.noType;
             }
-            restVariable.type = restType;
+            restVariable.setBType(restType);
             restParam = new BVarSymbol(Flags.asMask(restVariable.flagSet),
                                        names.fromIdNode(((BLangSimpleVariable) restVariable).name),
                                        env.enclPkg.symbol.pkgID, restType, env.scope.owner, restVariable.pos, SOURCE);
@@ -1856,12 +1856,13 @@ public class SymbolResolver extends BLangNodeVisitor {
     private void visitBuiltInTypeNode(BLangType typeNode, TypeKind typeKind, SymbolEnv env) {
         Name typeName = names.fromTypeKind(typeKind);
         BSymbol typeSymbol = lookupMemberSymbol(typeNode.pos, symTable.rootScope,
-                env, typeName, SymTag.TYPE);
+                                                env, typeName, SymTag.TYPE);
         if (typeSymbol == symTable.notFoundSymbol) {
             dlog.error(typeNode.pos, diagCode, typeName);
         }
 
-        resultType = typeNode.type = typeSymbol.type;
+        typeNode.setBType(typeSymbol.type);
+        resultType = typeSymbol.type;
     }
 
     private void addNamespacesInScope(Map<Name, BXMLNSSymbol> namespaces, SymbolEnv env) {
@@ -1888,7 +1889,7 @@ public class SymbolResolver extends BLangNodeVisitor {
             return env.enclPkg.symbol.pkgID == symbol.pkgID;
         }
         if (env.enclType != null) {
-            return env.enclType.type.tsymbol == symbol.owner;
+            return env.enclType.getBType().tsymbol == symbol.owner;
         }
         return isMemberAllowed(env, symbol);
     }
@@ -2113,7 +2114,7 @@ public class SymbolResolver extends BLangNodeVisitor {
         Location inferDefaultLocation = null;
 
         for (BLangVariable parameter : parameters) {
-            BType type = parameter.type;
+            BType type = parameter.getBType();
             BLangExpression expr = parameter.expr;
             if (type != null && type.tag == TypeTags.TYPEDESC && expr != null &&
                     expr.getKind() == NodeKind.INFER_TYPEDESC_EXPR) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeNarrower.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeNarrower.java
@@ -144,7 +144,7 @@ public class TypeNarrower extends BLangNodeVisitor {
         if (env.scope.entries.containsKey(varName)) {
             originalType = env.scope.entries.get(varName).symbol.type;
         } else {
-            originalType = varRef.type;
+            originalType = varRef.getBType();
         }
         BType remainingType = types.getRemainingMatchExprType(originalType, typeToRemove);
         if (remainingType == symTable.semanticError) {
@@ -257,7 +257,7 @@ public class TypeNarrower extends BLangNodeVisitor {
 
         BVarSymbol varSymbol = (BVarSymbol) symbol;
 
-        setNarrowedTypeInfo(typeTestExpr, varSymbol, typeTestExpr.typeNode.type);
+        setNarrowedTypeInfo(typeTestExpr, varSymbol, typeTestExpr.typeNode.getBType());
     }
 
     // Private methods
@@ -382,7 +382,7 @@ public class TypeNarrower extends BLangNodeVisitor {
                 env.scope.owner, expr.pos, SOURCE);
 
         BFiniteType finiteType = new BFiniteType(finiteTypeSymbol);
-        expr.type = symTable.getTypeFromTag(expr.type.tag);
+        expr.setBType(symTable.getTypeFromTag(expr.getBType().tag));
         finiteType.addValue(expr);
         finiteTypeSymbol.type = finiteType;
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -195,15 +195,15 @@ public class Types {
                            BType actualType,
                            BType expType,
                            DiagnosticCode diagCode) {
-        expr.type = checkType(expr.pos, actualType, expType, diagCode);
-        if (expr.type.tag == TypeTags.SEMANTIC_ERROR) {
-            return expr.type;
+        expr.setBType(checkType(expr.pos, actualType, expType, diagCode));
+        if (expr.getBType().tag == TypeTags.SEMANTIC_ERROR) {
+            return expr.getBType();
         }
 
         // Set an implicit cast expression, if applicable
         setImplicitCastExpr(expr, actualType, expType);
 
-        return expr.type;
+        return expr.getBType();
     }
 
     public BType checkType(Location pos,
@@ -366,7 +366,7 @@ public class Types {
     }
 
     boolean finiteTypeContainsNumericTypeValues(BFiniteType finiteType) {
-        return finiteType.getValueSpace().stream().anyMatch(valueExpr -> isBasicNumericType(valueExpr.type));
+        return finiteType.getValueSpace().stream().anyMatch(valueExpr -> isBasicNumericType(valueExpr.getBType()));
     }
 
     public boolean containsErrorType(BType type) {
@@ -393,11 +393,11 @@ public class Types {
     BType resolvePatternTypeFromMatchExpr(BLangErrorBindingPattern errorBindingPattern, BLangExpression matchExpr,
                                           SymbolEnv env) {
         if (matchExpr == null) {
-            return errorBindingPattern.type;
+            return errorBindingPattern.getBType();
         }
         BType intersectionType = getTypeIntersection(
                 IntersectionContext.compilerInternalIntersectionContext(),
-                matchExpr.type, errorBindingPattern.type, env);
+                matchExpr.getBType(), errorBindingPattern.getBType(), env);
         if (intersectionType == symTable.semanticError) {
             return symTable.noType;
         }
@@ -407,11 +407,11 @@ public class Types {
     public BType resolvePatternTypeFromMatchExpr(BLangListBindingPattern listBindingPattern,
                                                  BLangVarBindingPatternMatchPattern varBindingPatternMatchPattern,
                                                  SymbolEnv env) {
-        BTupleType listBindingPatternType = (BTupleType) listBindingPattern.type;
+        BTupleType listBindingPatternType = (BTupleType) listBindingPattern.getBType();
         if (varBindingPatternMatchPattern.matchExpr == null) {
             return listBindingPatternType;
         }
-        BType matchExprType = varBindingPatternMatchPattern.matchExpr.type;
+        BType matchExprType = varBindingPatternMatchPattern.matchExpr.getBType();
         BType intersectionType = getTypeIntersection(
                 IntersectionContext.compilerInternalIntersectionContext(),
                 matchExprType, listBindingPatternType, env);
@@ -426,7 +426,7 @@ public class Types {
         if (listMatchPattern.matchExpr == null) {
             return listMatchPatternType;
         }
-        BType matchExprType = listMatchPattern.matchExpr.type;
+        BType matchExprType = listMatchPattern.matchExpr.getBType();
         BType intersectionType = getTypeIntersection(
                 IntersectionContext.compilerInternalIntersectionContext(),
                 matchExprType, listMatchPatternType, env);
@@ -438,11 +438,11 @@ public class Types {
 
     BType resolvePatternTypeFromMatchExpr(BLangErrorMatchPattern errorMatchPattern, BLangExpression matchExpr) {
         if (matchExpr == null) {
-            return errorMatchPattern.type;
+            return errorMatchPattern.getBType();
         }
 
-        BType matchExprType = matchExpr.type;
-        BType patternType = errorMatchPattern.type;
+        BType matchExprType = matchExpr.getBType();
+        BType patternType = errorMatchPattern.getBType();
         if (isAssignable(matchExprType, patternType)) {
             return matchExprType;
         }
@@ -457,12 +457,12 @@ public class Types {
             if (constPatternExpr.getKind() == NodeKind.SIMPLE_VARIABLE_REF) {
                 return ((BLangSimpleVarRef) constPatternExpr).symbol.type;
             } else {
-                return constPatternExpr.type;
+                return constPatternExpr.getBType();
             }
         }
 
-        BType matchExprType = constPattern.matchExpr.type;
-        BType constMatchPatternExprType = constPatternExpr.type;
+        BType matchExprType = constPattern.matchExpr.getBType();
+        BType constMatchPatternExprType = constPatternExpr.getBType();
 
         if (constPatternExpr.getKind() == NodeKind.SIMPLE_VARIABLE_REF) {
             BLangSimpleVarRef constVarRef = (BLangSimpleVarRef) constPatternExpr;
@@ -513,7 +513,7 @@ public class Types {
         }
         BType intersectionType = getTypeIntersection(
                 IntersectionContext.compilerInternalIntersectionContext(),
-                mappingMatchPattern.matchExpr.type, patternType, env);
+                mappingMatchPattern.matchExpr.getBType(), patternType, env);
         if (intersectionType == symTable.semanticError) {
             return symTable.noType;
         }
@@ -523,13 +523,13 @@ public class Types {
     public BType resolvePatternTypeFromMatchExpr(BLangMappingBindingPattern mappingBindingPattern,
                                                  BLangVarBindingPatternMatchPattern varBindingPatternMatchPattern,
                                                  SymbolEnv env) {
-        BRecordType mappingBindingPatternType = (BRecordType) mappingBindingPattern.type;
+        BRecordType mappingBindingPatternType = (BRecordType) mappingBindingPattern.getBType();
         if (varBindingPatternMatchPattern.matchExpr == null) {
             return mappingBindingPatternType;
         }
         BType intersectionType = getTypeIntersection(
                 IntersectionContext.compilerInternalIntersectionContext(),
-                varBindingPatternMatchPattern.matchExpr.type,
+                varBindingPatternMatchPattern.matchExpr.getBType(),
                 mappingBindingPatternType, env);
         if (intersectionType == symTable.semanticError) {
             return symTable.noType;
@@ -1557,7 +1557,7 @@ public class Types {
     }
 
     public void setForeachTypedBindingPatternType(BLangForeach foreachNode) {
-        BType collectionType = foreachNode.collection.type;
+        BType collectionType = foreachNode.collection.getBType();
         BType varType;
         switch (collectionType.tag) {
             case TypeTags.STRING:
@@ -1705,7 +1705,7 @@ public class Types {
             return;
         }
 
-        BType collectionType = bLangInputClause.collection.type;
+        BType collectionType = bLangInputClause.collection.getBType();
         BType varType;
         switch (collectionType.tag) {
             case TypeTags.STRING:
@@ -1754,9 +1754,9 @@ public class Types {
                 break;
             case TypeTags.OBJECT:
                 // check for iterable objects
-                if (!isAssignable(bLangInputClause.collection.type, symTable.iterableType)) {
+                if (!isAssignable(bLangInputClause.collection.getBType(), symTable.iterableType)) {
                     dlog.error(bLangInputClause.collection.pos, DiagnosticErrorCode.INVALID_ITERABLE_OBJECT_TYPE,
-                            bLangInputClause.collection.type, symTable.iterableType);
+                               bLangInputClause.collection.getBType(), symTable.iterableType);
                     bLangInputClause.varType = symTable.semanticError;
                     bLangInputClause.resultType = symTable.semanticError;
                     bLangInputClause.nillableResultType = symTable.semanticError;
@@ -2291,7 +2291,7 @@ public class Types {
                 (BLangTypeConversionExpr) TreeBuilder.createTypeConversionNode();
         implicitConversionExpr.pos = expr.pos;
         implicitConversionExpr.expr = expr.impConversionExpr == null ? expr : expr.impConversionExpr;
-        implicitConversionExpr.type = expType;
+        implicitConversionExpr.setBType(expType);
         implicitConversionExpr.targetType = expType;
         implicitConversionExpr.internal = true;
         expr.impConversionExpr = implicitConversionExpr;
@@ -2889,7 +2889,7 @@ public class Types {
         for (BType type : memberTypes) {
             if (type.tag == TypeTags.FINITE) {
                 for (BLangExpression expr : ((BFiniteType) type).getValueSpace()) {
-                    isSameType = isSameOrderedType(expr.type, baseType);
+                    isSameType = isSameOrderedType(expr.getBType(), baseType);
                     if (!isSameType) {
                         return false;
                     }
@@ -2906,12 +2906,12 @@ public class Types {
 
     private boolean checkValueSpaceHasSameType(BFiniteType finiteType, BType baseType) {
         if (baseType.tag == TypeTags.FINITE) {
-            BType baseExprType = finiteType.getValueSpace().iterator().next().type;
+            BType baseExprType = finiteType.getValueSpace().iterator().next().getBType();
             return checkValueSpaceHasSameType(((BFiniteType) baseType), baseExprType);
         }
         boolean isValueSpaceSameType = false;
         for (BLangExpression expr : finiteType.getValueSpace()) {
-            isValueSpaceSameType = isSameOrderedType(expr.type, baseType);
+            isValueSpaceSameType = isSameOrderedType(expr.getBType(), baseType);
             if (!isValueSpaceSameType) {
                 break;
             }
@@ -3258,11 +3258,11 @@ public class Types {
                     .allMatch(valueExpr ->  unionMemberTypes.stream()
                             .anyMatch(targetMemType -> targetMemType.tag == TypeTags.FINITE ?
                                     isAssignableToFiniteType(targetMemType, (BLangLiteral) valueExpr) :
-                                    isAssignable(valueExpr.type, targetType, unresolvedTypes)));
+                                    isAssignable(valueExpr.getBType(), targetType, unresolvedTypes)));
         }
 
         return finiteType.getValueSpace().stream()
-                .allMatch(expression -> isAssignable(expression.type, targetType, unresolvedTypes));
+                .allMatch(expression -> isAssignable(expression.getBType(), targetType, unresolvedTypes));
     }
 
     boolean isAssignableToFiniteType(BType type, BLangLiteral literalExpr) {
@@ -3298,7 +3298,7 @@ public class Types {
         }
         Object baseValue = baseLiteral.value;
         Object candidateValue = candidateLiteral.value;
-        int candidateTypeTag = candidateLiteral.type.tag;
+        int candidateTypeTag = candidateLiteral.getBType().tag;
 
         // Numeric literal assignability is based on assignable type and numeric equivalency of values.
         // If the base numeric literal is,
@@ -3307,7 +3307,7 @@ public class Types {
         // (3) float: we can assign int simple literal(Not an int constant) or a float literal/constant with same value.
         // (4) decimal: we can assign int simple literal or float simple literal (Not int/float constants) or decimal
         // with the same value.
-        switch (baseLiteral.type.tag) {
+        switch (baseLiteral.getBType().tag) {
             case TypeTags.BYTE:
                 if (candidateTypeTag == TypeTags.BYTE || (candidateTypeTag == TypeTags.INT &&
                         !candidateLiteral.isConstant && isByteLiteralValue((Long) candidateValue))) {
@@ -3449,7 +3449,7 @@ public class Types {
                 .filter(
                         // case I: targetType - string ("foo" is assignable to string)
                         // case II: targetType - type Bar "foo"|"baz" ; ("foo" is assignable to Bar)
-                        expr -> isAssignable(expr.type, targetType) ||
+                        expr -> isAssignable(expr.getBType(), targetType) ||
                                 isAssignableToFiniteType(targetType, (BLangLiteral) expr) ||
                                 // type FooVal "foo";
                                 // case III:  targetType - boolean|FooVal ("foo" is assignable to FooVal)
@@ -3554,7 +3554,7 @@ public class Types {
                 BType firstTypeInUnion = memberTypes.iterator().next();
                 if (firstTypeInUnion.tag == TypeTags.FINITE) {
                     Set<BLangExpression> valSpace = ((BFiniteType) firstTypeInUnion).getValueSpace();
-                    BType baseExprType = valSpace.iterator().next().type;
+                    BType baseExprType = valSpace.iterator().next().getBType();
                     for (BType memType : memberTypes) {
                         if (memType.tag == TypeTags.FINITE) {
                             if (!checkValueSpaceHasSameType((BFiniteType) memType, baseExprType)) {
@@ -3575,12 +3575,12 @@ public class Types {
                 return true;
             case TypeTags.FINITE:
                 Set<BLangExpression> valSpace = ((BFiniteType) type).getValueSpace();
-                BType baseExprType = valSpace.iterator().next().type;
+                BType baseExprType = valSpace.iterator().next().getBType();
                 for (BLangExpression expr : valSpace) {
                     if (!checkValueSpaceHasSameType((BFiniteType) type, baseExprType)) {
                         return false;
                     }
-                    if (!validNumericTypeExists(expr.type)) {
+                    if (!validNumericTypeExists(expr.getBType())) {
                         return false;
                     }
                 }
@@ -3620,7 +3620,7 @@ public class Types {
             case TypeTags.FINITE:
                 Set<BLangExpression> valueSpace = ((BFiniteType) type).getValueSpace();
                 for (BLangExpression expr : valueSpace) {
-                    if (!validIntegerTypeExists(expr.type)) {
+                    if (!validIntegerTypeExists(expr.getBType())) {
                         return false;
                     }
                 }
@@ -3644,7 +3644,7 @@ public class Types {
                 BType firstTypeInUnion = memberTypes.iterator().next();
                 if (firstTypeInUnion.tag == TypeTags.FINITE) {
                     Set<BLangExpression> valSpace = ((BFiniteType) firstTypeInUnion).getValueSpace();
-                    BType baseExprType = valSpace.iterator().next().type;
+                    BType baseExprType = valSpace.iterator().next().getBType();
                     for (BType memType : memberTypes) {
                         if (memType.tag == TypeTags.FINITE) {
                             if (!checkValueSpaceHasSameType((BFiniteType) memType, baseExprType)) {
@@ -3665,12 +3665,12 @@ public class Types {
                 return true;
             case TypeTags.FINITE:
                 Set<BLangExpression> valSpace = ((BFiniteType) type).getValueSpace();
-                BType baseExprType = valSpace.iterator().next().type;
+                BType baseExprType = valSpace.iterator().next().getBType();
                 for (BLangExpression expr : valSpace) {
                     if (!checkValueSpaceHasSameType((BFiniteType) type, baseExprType)) {
                         return false;
                     }
-                    if (!validStringOrXmlTypeExists(expr.type)) {
+                    if (!validStringOrXmlTypeExists(expr.getBType())) {
                         return false;
                     }
                 }
@@ -3707,7 +3707,7 @@ public class Types {
             case TypeTags.FINITE:
                 Set<BLangExpression> valSpace = ((BFiniteType) type).getValueSpace();
                 for (BLangExpression expr : valSpace) {
-                    if (!checkTypeContainString(expr.type)) {
+                    if (!checkTypeContainString(expr.getBType())) {
                         return false;
                     }
                 }
@@ -3743,7 +3743,7 @@ public class Types {
             case TypeTags.FINITE:
                 BFiniteType expType = (BFiniteType) bType;
                 expType.getValueSpace().forEach(value -> {
-                    memberTypes.add(value.type);
+                    memberTypes.add(value.getBType());
                 });
                 break;
             case TypeTags.UNION:
@@ -4798,7 +4798,7 @@ public class Types {
         for (BLangExpression valueExpr : originalType.getValueSpace()) {
             boolean matchExists = false;
             for (BType remType : removeTypes) {
-                if (isAssignable(valueExpr.type, remType) ||
+                if (isAssignable(valueExpr.getBType(), remType) ||
                         isAssignableToFiniteType(remType, (BLangLiteral) valueExpr)) {
                     matchExists = true;
                     break;
@@ -4893,14 +4893,14 @@ public class Types {
                 return isAllowedConstantType(((BMapType) type).constraint);
             case TypeTags.FINITE:
                 BLangExpression finiteValue = ((BFiniteType) type).getValueSpace().toArray(new BLangExpression[0])[0];
-                return isAllowedConstantType(finiteValue.type);
+                return isAllowedConstantType(finiteValue.getBType());
             default:
                 return false;
         }
     }
 
     public boolean isValidLiteral(BLangLiteral literal, BType targetType) {
-        BType literalType = literal.type;
+        BType literalType = literal.getBType();
         if (literalType.tag == targetType.tag) {
             return true;
         }
@@ -4938,7 +4938,7 @@ public class Types {
      * @param diagnosticCode    The code to log if the return type is invalid
      */
     public void validateErrorOrNilReturn(BLangFunction function, DiagnosticCode diagnosticCode) {
-        BType returnType = function.returnTypeNode.type;
+        BType returnType = function.returnTypeNode.getBType();
 
         if (returnType.tag == TypeTags.NIL) {
             return;
@@ -4952,7 +4952,7 @@ public class Types {
             }
         }
 
-        dlog.error(function.returnTypeNode.pos, diagnosticCode, function.returnTypeNode.type.toString());
+        dlog.error(function.returnTypeNode.pos, diagnosticCode, function.returnTypeNode.getBType().toString());
     }
 
     /**
@@ -5077,7 +5077,7 @@ public class Types {
 
         while (iterator.hasNext()) {
             BLangExpression value = (BLangExpression) iterator.next();
-            if (!isSameBasicType(value.type, firstElement.type)) {
+            if (!isSameBasicType(value.getBType(), firstElement.getBType())) {
                 return false;
             }
             if (!defaultFillValuePresent && isImplicitDefaultValue(value)) {
@@ -5152,7 +5152,7 @@ public class Types {
     private Set<BType> getValueTypes(Set<BLangExpression> valueSpace) {
         Set<BType> uniqueType = new HashSet<>();
         for (BLangExpression expression : valueSpace) {
-            uniqueType.add(expression.type);
+            uniqueType.add(expression.getBType());
         }
         return uniqueType;
     }
@@ -5160,7 +5160,7 @@ public class Types {
     private boolean isImplicitDefaultValue(BLangExpression expression) {
         if ((expression.getKind() == NodeKind.LITERAL) || (expression.getKind() == NodeKind.NUMERIC_LITERAL)) {
             BLangLiteral literalExpression = (BLangLiteral) expression;
-            BType literalExprType = literalExpression.type;
+            BType literalExprType = literalExpression.getBType();
             Object value = literalExpression.getValue();
             switch (literalExprType.getKind()) {
                 case INT:
@@ -5271,7 +5271,7 @@ public class Types {
                 for (BType memType : memberTypes) {
                     if (memType.tag == TypeTags.FINITE && firstTypeInUnion.tag == TypeTags.FINITE) {
                         Set<BLangExpression> valSpace = ((BFiniteType) firstTypeInUnion).getValueSpace();
-                        BType baseExprType = valSpace.iterator().next().type;
+                        BType baseExprType = valSpace.iterator().next().getBType();
                         if (!checkValueSpaceHasSameType((BFiniteType) memType, baseExprType)) {
                             return false;
                         }
@@ -5300,12 +5300,12 @@ public class Types {
             case TypeTags.FINITE:
                 boolean isValueSpaceOrdered = false;
                 Set<BLangExpression> valSpace = ((BFiniteType) type).getValueSpace();
-                BType baseExprType = valSpace.iterator().next().type;
+                BType baseExprType = valSpace.iterator().next().getBType();
                 for (BLangExpression expr : valSpace) {
                     if (!checkValueSpaceHasSameType((BFiniteType) type, baseExprType)) {
                         return false;
                     }
-                    isValueSpaceOrdered = isOrderedType(expr.type, hasCycle);
+                    isValueSpaceOrdered = isOrderedType(expr.getBType(), hasCycle);
                     if (!isValueSpaceOrdered) {
                         break;
                     }
@@ -5359,7 +5359,7 @@ public class Types {
                 return findCompatibleType(memberTypes.iterator().next());
             default:
                 Set<BLangExpression> valueSpace = ((BFiniteType) type).getValueSpace();
-                return findCompatibleType(valueSpace.iterator().next().type);
+                return findCompatibleType(valueSpace.iterator().next().getBType());
         }
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
@@ -270,7 +270,7 @@ public class SymbolTable {
         initializeTSymbol(xmlTextType, Names.XML_TEXT, PackageID.XML);
 
         BLangLiteral trueLiteral = new BLangLiteral();
-        trueLiteral.type = this.booleanType;
+        trueLiteral.setBType(this.booleanType);
         trueLiteral.value = Boolean.TRUE;
 
         defineCyclicUnionBasedInternalTypes();

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BFiniteType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BFiniteType.java
@@ -78,9 +78,9 @@ public class BFiniteType extends BType implements FiniteType {
     public String toString() {
         StringJoiner joiner = new StringJoiner("|");
         for (BLangExpression value : this.valueSpace) {
-            if (value.type.tag == TypeTags.FLOAT) {
+            if (value.getBType().tag == TypeTags.FLOAT) {
                 joiner.add(value.toString() + "f");
-            } else if (value.type.tag == TypeTags.DECIMAL) {
+            } else if (value.getBType().tag == TypeTags.DECIMAL) {
                 joiner.add(value.toString() + "d");
             } else {
                 joiner.add(value.toString());
@@ -96,7 +96,7 @@ public class BFiniteType extends BType implements FiniteType {
 
     public void addValue(BLangExpression value) {
         this.valueSpace.add(value);
-        if (!nullable && value.type.isNullable()) {
+        if (!nullable && value.getBType().isNullable()) {
             nullable = true;
         }
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangNode.java
@@ -29,10 +29,7 @@ import java.util.Set;
  */
 public abstract class BLangNode implements Node {
 
-    /**
-     * The type of this node.
-     */
-    public BType type;
+    private BType type;
     public BLangNode parent = null;
 
     /**
@@ -61,6 +58,24 @@ public abstract class BLangNode implements Node {
      */
     public BLangNode cloneRef;
     public int cloneAttempt;
+
+    /**
+     * Sets the specified type as the type of the node.
+     *
+     * @param type The type of the node
+     */
+    public void setBType(BType type) {
+        this.type = type;
+    }
+
+    /**
+     * Gets the type of the node.
+     *
+     * @return The type of the node
+     */
+    public BType getBType() {
+        return this.type;
+    }
 
     public Location getPosition() {
         return pos;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangRecordVariable.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangRecordVariable.java
@@ -81,7 +81,7 @@ public class BLangRecordVariable extends BLangVariable implements RecordVariable
 
     @Override
     public String toString() {
-        return String.valueOf(type) + " {" + variableList.stream()
+        return String.valueOf(getBType()) + " {" + variableList.stream()
                 .map(BLangRecordVariableKeyValue::toString)
                 .collect(Collectors.joining(",")) + "} = " + this.expr;
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangSimpleVariable.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangSimpleVariable.java
@@ -69,6 +69,6 @@ public class BLangSimpleVariable extends BLangVariable implements SimpleVariable
         if (symbol != null && symbol.name != null) {
             varName = symbol.name.value;
         }
-        return String.valueOf(type) + " " + varName + (expr != null ? " = " + String.valueOf(expr) : "");
+        return String.valueOf(getBType()) + " " + varName + (expr != null ? " = " + String.valueOf(expr) : "");
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangVariable.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangVariable.java
@@ -104,6 +104,6 @@ public abstract class BLangVariable extends BLangNode implements VariableNode {
 
     @Override
     public String toString() {
-        return String.valueOf(type) + " " + (expr != null ? " = " + String.valueOf(expr) : "");
+        return String.valueOf(getBType()) + " " + (expr != null ? " = " + String.valueOf(expr) : "");
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangConstant.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangConstant.java
@@ -109,7 +109,7 @@ public class BLangConstant extends BLangVariable implements ConstantNode, TypeDe
 
     @Override
     public String toString() {
-        return (typeNode == null ? String.valueOf(type) : String.valueOf(typeNode)) + " " + symbol.name.value +
+        return (typeNode == null ? String.valueOf(getBType()) : String.valueOf(typeNode)) + " " + symbol.name.value +
                 " = " + String.valueOf(expr);
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangInvocation.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangInvocation.java
@@ -160,7 +160,7 @@ public class BLangInvocation extends BLangExpression implements InvocationNode {
             this.pos = location;
             this.expr = varRef;
             this.symbol = bSymbol;
-            this.type = retType;
+            this.setBType(retType);
         }
 
         public BFunctionPointerInvocation(BLangInvocation parent, BLangExpression varRef) {
@@ -171,7 +171,7 @@ public class BLangInvocation extends BLangExpression implements InvocationNode {
             this.symbol = parent.symbol;
             this.async = parent.async;
             this.expr = varRef;
-            this.type = parent.type;
+            this.setBType(parent.getBType());
         }
 
         @Override
@@ -197,7 +197,7 @@ public class BLangInvocation extends BLangExpression implements InvocationNode {
             this.requiredArgs = requiredArgs;
             this.restArgs = restArgs;
             this.symbol = symbol;
-            this.type = type;
+            this.setBType(type);
             this.expr = expr;
             this.async = async;
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangIsLikeExpr.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangIsLikeExpr.java
@@ -68,6 +68,6 @@ public class BLangIsLikeExpr extends BLangExpression implements IsLikeExpression
 
     @Override
     public String toString() {
-        return String.valueOf(expr) + " isLike " + typeNode.type;
+        return String.valueOf(expr) + " isLike " + typeNode.getBType();
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangListConstructorExpr.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangListConstructorExpr.java
@@ -76,7 +76,7 @@ public class BLangListConstructorExpr extends BLangExpression implements ListCon
         public BLangArrayLiteral(Location pos, List<BLangExpression> exprs, BType tupleType) {
             this.pos = pos;
             this.exprs = exprs;
-            this.type = tupleType;
+            this.setBType(tupleType);
         }
 
         @Override
@@ -105,7 +105,7 @@ public class BLangListConstructorExpr extends BLangExpression implements ListCon
         public BLangTupleLiteral(Location pos, List<BLangExpression> exprs, BType tupleType) {
             this.pos = pos;
             this.exprs = exprs;
-            this.type = tupleType;
+            this.setBType(tupleType);
         }
 
         @Override
@@ -128,7 +128,7 @@ public class BLangListConstructorExpr extends BLangExpression implements ListCon
 
         public BLangJSONArrayLiteral(List<BLangExpression> exprs, BType jsonType) {
             this.exprs = exprs;
-            this.type = jsonType;
+            this.setBType(jsonType);
         }
 
         @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangLiteral.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangLiteral.java
@@ -37,7 +37,7 @@ public class BLangLiteral extends BLangExpression implements LiteralNode {
 
     public BLangLiteral(Object value, BType type) {
         this.value = value;
-        this.type = type;
+        this.setBType(type);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangObjectConstructorExpression.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangObjectConstructorExpression.java
@@ -70,8 +70,8 @@ public class BLangObjectConstructorExpression extends BLangExpression {
         }
 
         sb.append("object ");
-        if (referenceType != null && referenceType.type.name != null) {
-            sb.append(referenceType.type.name.getValue());
+        if (referenceType != null && referenceType.getBType().name != null) {
+            sb.append(referenceType.getBType().name.getValue());
         }
         sb.append(" {");
         sb.append(this.classNode.toString());

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangRecordLiteral.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangRecordLiteral.java
@@ -59,7 +59,7 @@ public class BLangRecordLiteral extends BLangExpression implements RecordLiteral
     public BLangRecordLiteral(Location pos, BType type) {
         this.pos = pos;
         fields = new ArrayList<>();
-        this.type = type;
+        this.setBType(type);
     }
 
     @Override
@@ -235,7 +235,7 @@ public class BLangRecordLiteral extends BLangExpression implements RecordLiteral
 
         public BLangStructLiteral(Location pos, BType structType, List<RecordField> fields) {
             super(pos);
-            this.type = structType;
+            this.setBType(structType);
             this.initializer = ((BRecordTypeSymbol) structType.tsymbol).initializerFunc;
             this.fields = fields;
         }
@@ -255,7 +255,7 @@ public class BLangRecordLiteral extends BLangExpression implements RecordLiteral
 
         public BLangMapLiteral(Location pos, BType mapType, List<RecordField> fields) {
             super(pos);
-            this.type = mapType;
+            this.setBType(mapType);
             this.fields = fields;
         }
 
@@ -276,7 +276,7 @@ public class BLangRecordLiteral extends BLangExpression implements RecordLiteral
 
         public BLangChannelLiteral(Location pos, BType channelType, String channelName) {
             super(pos);
-            this.type = channelType;
+            this.setBType(channelType);
             this.channelName = channelName;
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangWaitForAllExpr.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangWaitForAllExpr.java
@@ -110,7 +110,7 @@ public class BLangWaitForAllExpr extends BLangExpression implements WaitForAllEx
 
         public BLangWaitLiteral(List<BLangWaitKeyValue> keyValuePairs, BType structType) {
             this.keyValuePairs = keyValuePairs;
-            this.type = structType;
+            this.setBType(structType);
         }
 
         @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/types/BLangErrorType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/types/BLangErrorType.java
@@ -43,7 +43,7 @@ public class BLangErrorType extends BLangType implements ErrorTypeNode {
 
     @Override
     public String toString() {
-        return this.type.toString();
+        return this.getBType().toString();
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/types/BLangFiniteTypeNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/types/BLangFiniteTypeNode.java
@@ -68,9 +68,9 @@ public class BLangFiniteTypeNode extends BLangType implements FiniteTypeNode {
     public String toString() {
         StringJoiner stringJoiner = new StringJoiner(" | ");
         for (BLangExpression memberTypeNode : valueSpace) {
-            if (memberTypeNode.type.tag == TypeTags.FLOAT) {
+            if (memberTypeNode.getBType().tag == TypeTags.FLOAT) {
                 stringJoiner.add(memberTypeNode.toString() + NumericLiteralSupport.FLOAT_DISCRIMINATOR);
-            } else if (memberTypeNode.type.tag == TypeTags.DECIMAL) {
+            } else if (memberTypeNode.getBType().tag == TypeTags.DECIMAL) {
                 stringJoiner.add(memberTypeNode.toString() + NumericLiteralSupport.DECIMAL_DISCRIMINATOR);
             } else {
                 stringJoiner.add(memberTypeNode.toString());

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ImmutableTypeCloner.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ImmutableTypeCloner.java
@@ -151,7 +151,7 @@ public class ImmutableTypeCloner {
                 BType immutableFieldType = typeField.symbol.type = ImmutableTypeCloner.getImmutableIntersectionType(
                         pos, types, (SelectivelyImmutableReferenceType) type, typeDefEnv, symbolTable,
                         anonymousModelHelper, names, classDef.flagSet);
-                classField.type = typeField.type = immutableFieldType;
+                classField.setBType(typeField.type = immutableFieldType);
             }
 
             typeField.symbol.flags |= Flags.FINAL;
@@ -428,7 +428,7 @@ public class ImmutableTypeCloner {
                                                 pkgEnv);
         PackageID pkgID = env.enclPkg.symbol.pkgID;
 
-        BType immutableType = immutableTypeDefinition.type;
+        BType immutableType = immutableTypeDefinition.getBType();
         if (immutableType.tag == TypeTags.RECORD) {
             defineUndefinedImmutableRecordFields((BRecordType) immutableType, pos, pkgID, immutableTypeDefinition,
                                                  types, env, symTable, anonymousModelHelper, names);
@@ -536,7 +536,7 @@ public class ImmutableTypeCloner {
                                                                      origStructureType.tsymbol.pkgID)),
                 ASTBuilderUtil.createIdentifier(pos, origStructureType.tsymbol.name.value));
         origTypeRef.pos = pos;
-        origTypeRef.type = origStructureType;
+        origTypeRef.setBType(origStructureType);
         immutableStructureTypeNode.typeRefs.add(origTypeRef);
     }
 
@@ -762,7 +762,7 @@ public class ImmutableTypeCloner {
         }
 
         BLangUnionTypeNode unionTypeNode = (BLangUnionTypeNode) TreeBuilder.createUnionTypeNode();
-        unionTypeNode.type = effectiveType;
+        unionTypeNode.setBType(effectiveType);
         BLangTypeDefinition typeDefinition = TypeDefBuilderHelper.addTypeDefinition(effectiveType,
                                                                                     effectiveType.tsymbol,
                                                                                     unionTypeNode, env);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/TypeDefBuilderHelper.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/TypeDefBuilderHelper.java
@@ -97,7 +97,7 @@ public class TypeDefBuilderHelper {
     public static BLangRecordTypeNode createRecordTypeNode(List<BLangSimpleVariable> typeDefFields,
                                                            BRecordType recordType, Location pos) {
         BLangRecordTypeNode recordTypeNode = (BLangRecordTypeNode) TreeBuilder.createRecordTypeNode();
-        recordTypeNode.type = recordType;
+        recordTypeNode.setBType(recordType);
         recordTypeNode.fields = typeDefFields;
         recordTypeNode.symbol = recordType.tsymbol;
         recordTypeNode.pos = pos;
@@ -108,7 +108,7 @@ public class TypeDefBuilderHelper {
     public static BLangObjectTypeNode createObjectTypeNode(List<BLangSimpleVariable> typeDefFields,
                                                            BObjectType objectType, Location pos) {
         BLangObjectTypeNode objectTypeNode = (BLangObjectTypeNode) TreeBuilder.createObjectTypeNode();
-        objectTypeNode.type = objectType;
+        objectTypeNode.setBType(objectType);
         objectTypeNode.fields = typeDefFields;
         objectTypeNode.symbol = objectType.tsymbol;
         objectTypeNode.pos = pos;
@@ -119,10 +119,12 @@ public class TypeDefBuilderHelper {
     public static BLangFunction createInitFunctionForRecordType(BLangRecordTypeNode recordTypeNode, SymbolEnv env,
                                                                 Names names, SymbolTable symTable) {
         BLangFunction initFunction = createInitFunctionForStructureType(recordTypeNode.pos, recordTypeNode.symbol, env,
-                names, Names.INIT_FUNCTION_SUFFIX, symTable, recordTypeNode.type);
-        BStructureTypeSymbol structureSymbol = ((BStructureTypeSymbol) recordTypeNode.type.tsymbol);
+                                                                        names, Names.INIT_FUNCTION_SUFFIX, symTable,
+                                                                        recordTypeNode.getBType());
+        BStructureTypeSymbol structureSymbol = ((BStructureTypeSymbol) recordTypeNode.getBType().tsymbol);
         structureSymbol.initializerFunc = new BAttachedFunction(initFunction.symbol.name, initFunction.symbol,
-                                                                (BInvokableType) initFunction.type, initFunction.pos);
+                                                                (BInvokableType) initFunction.getBType(),
+                                                                initFunction.pos);
         recordTypeNode.initFunction = initFunction;
         structureSymbol.scope.define(structureSymbol.initializerFunc.symbol.name,
                                      structureSymbol.initializerFunc.symbol);
@@ -150,13 +152,13 @@ public class TypeDefBuilderHelper {
         initFunction.flagSet.add(Flag.ATTACHED);
 
         // Create the function type
-        initFunction.type = new BInvokableType(new ArrayList<>(), symTable.nilType, null);
+        initFunction.setBType(new BInvokableType(new ArrayList<>(), symTable.nilType, null));
 
         // Create the function symbol
         Name funcSymbolName = names.fromString(Symbols.getAttachedFuncSymbolName(structTypeName, suffix.value));
         initFunction.symbol = Symbols
                 .createFunctionSymbol(Flags.asMask(initFunction.flagSet), funcSymbolName, env.enclPkg.symbol.pkgID,
-                                      initFunction.type, symbol, initFunction.body != null,
+                                      initFunction.getBType(), symbol, initFunction.body != null,
                                       initFunction.pos, VIRTUAL);
         initFunction.symbol.scope = new Scope(initFunction.symbol);
         initFunction.symbol.scope.define(receiverSymbol.name, receiverSymbol);
@@ -166,13 +168,13 @@ public class TypeDefBuilderHelper {
         // Create the function type symbol
         BInvokableTypeSymbol tsymbol = Symbols.createInvokableTypeSymbol(SymTag.FUNCTION_TYPE,
                                                                          initFunction.symbol.flags,
-                                                                         env.enclPkg.packageID, initFunction.type,
+                                                                         env.enclPkg.packageID, initFunction.getBType(),
                                                                          initFunction.symbol, initFunction.pos,
                                                                          VIRTUAL);
         tsymbol.params = initFunction.symbol.params;
         tsymbol.restParam = initFunction.symbol.restParam;
         tsymbol.returnType = initFunction.symbol.retType;
-        initFunction.type.tsymbol = tsymbol;
+        initFunction.getBType().tsymbol = tsymbol;
 
         receiverSymbol.owner = initFunction.symbol;
 
@@ -186,7 +188,7 @@ public class TypeDefBuilderHelper {
                                                         SymbolEnv env) {
         BLangTypeDefinition typeDefinition = (BLangTypeDefinition) TreeBuilder.createTypeDefinition();
         typeDefinition.typeNode = typeNode;
-        typeDefinition.type = type;
+        typeDefinition.setBType(type);
         typeDefinition.symbol = symbol;
         typeDefinition.name = createIdentifier(symbol.pos, symbol.name.value);
         typeDefinition.pos = typeNode.getPosition();
@@ -201,12 +203,12 @@ public class TypeDefBuilderHelper {
         for (BField field : objType.fields.values()) {
             BVarSymbol symbol = field.symbol;
             BLangSimpleVariable fieldVar = ASTBuilderUtil.createVariable(field.pos, symbol.name.value, field.type,
-                    null, symbol);
+                                                                         null, symbol);
             fieldList.add(fieldVar);
         }
 
         BLangClassDefinition classDefNode = (BLangClassDefinition) TreeBuilder.createClassDefNode();
-        classDefNode.type = objType;
+        classDefNode.setBType(objType);
         classDefNode.fields = fieldList;
         classDefNode.symbol = classTSymbol;
         classDefNode.pos = pos;
@@ -219,20 +221,20 @@ public class TypeDefBuilderHelper {
     public static BLangErrorType createBLangErrorType(Location pos, BErrorType type, SymbolEnv env,
                                                       BLangAnonymousModelHelper anonymousModelHelper) {
         BLangErrorType errorType = (BLangErrorType) TreeBuilder.createErrorTypeNode();
-        errorType.type = type;
+        errorType.setBType(type);
 
         BLangUserDefinedType userDefinedTypeNode = (BLangUserDefinedType) TreeBuilder.createUserDefinedTypeNode();
         userDefinedTypeNode.pos = pos;
         userDefinedTypeNode.pkgAlias = (BLangIdentifier) TreeBuilder.createIdentifierNode();
 
-        BType  detailType = type.detailType;
+        BType detailType = type.detailType;
 
         String typeName = detailType.tsymbol != null
                 ? detailType.tsymbol.name.value
                 : anonymousModelHelper.getNextAnonymousIntersectionErrorDetailTypeName(env.enclPkg.packageID);
 
         userDefinedTypeNode.typeName = createIdentifier(pos, typeName);
-        userDefinedTypeNode.type = detailType;
+        userDefinedTypeNode.setBType(detailType);
         errorType.detailType = userDefinedTypeNode;
 
         return errorType;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/Unifier.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/Unifier.java
@@ -611,7 +611,7 @@ public class Unifier implements BTypeVisitor<BType, BType> {
 
             BLangNamedArgsExpression namedArgsExpression = (BLangNamedArgsExpression) arg;
             if (namedArgsExpression.name.value.equals(paramName)) {
-                return getConstraintTypeIfNotError(namedArgsExpression.expr.type);
+                return getConstraintTypeIfNotError(namedArgsExpression.expr.getBType());
             }
         }
 
@@ -624,10 +624,10 @@ public class Unifier implements BTypeVisitor<BType, BType> {
             BLangExpression argAtIndex = requiredArgs.get(index);
 
             if (argAtIndex.getKind() != NodeKind.NAMED_ARGS_EXPR) {
-                return getConstraintTypeIfNotError(argAtIndex.type);
+                return getConstraintTypeIfNotError(argAtIndex.getBType());
             }
         } else if (!restArgs.isEmpty()) {
-            BType restArgType = restArgs.get(0).type;
+            BType restArgType = restArgs.get(0).getBType();
 
             if (restArgType.tag == TypeTags.RECORD) {
                 return getConstraintTypeIfNotError(((BRecordType) restArgType).fields.get(paramName).type);
@@ -653,7 +653,7 @@ public class Unifier implements BTypeVisitor<BType, BType> {
         BLangTypedescExpr typedescExpr = (BLangTypedescExpr) TreeBuilder.createTypeAccessNode();
         typedescExpr.pos = this.symbolTable.builtinPos;
         typedescExpr.resolvedType = expType;
-        typedescExpr.type = new BTypedescType(expType, null);
+        typedescExpr.setBType(new BTypedescType(expType, null));
 
         BLangNamedArgsExpression namedArgsExpression = (BLangNamedArgsExpression) TreeBuilder.createNamedArgNode();
         BLangIdentifier identifierNode = (BLangIdentifier) TreeBuilder.createIdentifierNode();
@@ -682,7 +682,7 @@ public class Unifier implements BTypeVisitor<BType, BType> {
 
                 if (arg.getKind() != NodeKind.NAMED_ARGS_EXPR) {
                     // If this is a positional arg, it should correspond to the current param.
-                    paramValueTypes.put(params.get(paramIndex).name.value, arg.type);
+                    paramValueTypes.put(params.get(paramIndex).name.value, arg.getBType());
                     argIndex++;
                     continue;
                 } else {
@@ -726,7 +726,7 @@ public class Unifier implements BTypeVisitor<BType, BType> {
                 BLangNamedArgsExpression namedArg = (BLangNamedArgsExpression) requiredArgs.get(argIndex);
 
                 if (name.equals(namedArg.name.value)) {
-                    paramValueTypes.put(name, namedArg.type);
+                    paramValueTypes.put(name, namedArg.getBType());
                     argProvided = true;
                     break;
                 }
@@ -743,7 +743,7 @@ public class Unifier implements BTypeVisitor<BType, BType> {
     }
 
     private void populateParamMapFromRestArg(List<BVarSymbol> params, int currentParamIndex, BLangExpression restArg) {
-        BType type = restArg.type;
+        BType type = restArg.getBType();
         int tag = type.tag;
         if (tag == TypeTags.RECORD) {
             populateParamMapFromRecordRestArg(params, currentParamIndex, (BRecordType) type);
@@ -814,7 +814,7 @@ public class Unifier implements BTypeVisitor<BType, BType> {
                 return symbolTable.noType;
             }
 
-            BType paramType = requiredParam.type;
+            BType paramType = requiredParam.getBType();
             if (paramType.tag != TypeTags.TYPEDESC) {
                 return symbolTable.noType;
             }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/annotations/AnnotationAttachmentTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/annotations/AnnotationAttachmentTest.java
@@ -464,13 +464,13 @@ public class AnnotationAttachmentTest {
             Assert.assertEquals(expression.getKind(), NodeKind.RECORD_LITERAL_EXPR);
             BLangRecordLiteral recordLiteral = (BLangRecordLiteral) expression;
             Assert.assertEquals(recordLiteral.getFields().size(), 0);
-            Assert.assertTrue(recordLiteral.type.tag == TypeTags.RECORD_TYPE_TAG
-                    || recordLiteral.type.tag == TypeTags.MAP_TAG);
-            if (recordLiteral.type.tag == TypeTags.RECORD_TYPE_TAG) {
-                Assert.assertEquals(recordLiteral.type.tsymbol.name.value, typeName);
+            Assert.assertTrue(recordLiteral.getBType().tag == TypeTags.RECORD_TYPE_TAG
+                    || recordLiteral.getBType().tag == TypeTags.MAP_TAG);
+            if (recordLiteral.getBType().tag == TypeTags.RECORD_TYPE_TAG) {
+                Assert.assertEquals(recordLiteral.getBType().tsymbol.name.value, typeName);
             } else {
-                Assert.assertEquals(recordLiteral.type.tag, TypeTags.MAP_TAG);
-                Assert.assertEquals(((BMapType) recordLiteral.type).constraint.tag, TypeTags.INT_TAG);
+                Assert.assertEquals(recordLiteral.getBType().tag, TypeTags.MAP_TAG);
+                Assert.assertEquals(((BMapType) recordLiteral.getBType()).constraint.tag, TypeTags.INT_TAG);
             }
             i++;
         }


### PR DESCRIPTION
## Purpose
This PR encapsulates the `type` field in `BLangNode`. This was done as a prerequisite to addressing #29903. 

The reason behind this change is because we plan on addressing #29903 by introducing a new field to `BLangExpression`. To keep that field consistent, we have to ensure that this field gets set when the `type` field gets set. Can't do that with `type` being directly accessible. Hence this change.

## Approach
- Introduced 2 new methods to the `Node` interface: `setBType(BType type)` and `BType getBType()`. 
- Migrated all direct usages of `type` field to the above 2 methods. 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
