### PR TITLE
Fix `self` variable visibility issue related to services

### DIFF
--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/variable/JVMValueType.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/variable/JVMValueType.java
@@ -53,10 +53,10 @@ public enum JVMValueType {
     XML_TEXT("io.ballerina.runtime.internal.values.XmlText"),
     XML_ATTRIB_MAP("io.ballerina.runtime.internal.values.AttributeMapValueImpl"),
     FP_VALUE("io.ballerina.runtime.internal.values.FPValue"),
-    ANON_TYPE("anonType"),
     BTYPE_OBJECT("BObjectType"),
     BTYPE_RECORD("BRecordType"),
-    BTYPE_JSON("BJsonType");
+    BTYPE_JSON("BJsonType"),
+    BTYPE_SERVICE("BServiceType");
 
     private final String value;
 

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/variable/JVMValueType.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/variable/JVMValueType.java
@@ -53,7 +53,7 @@ public enum JVMValueType {
     XML_TEXT("io.ballerina.runtime.internal.values.XmlText"),
     XML_ATTRIB_MAP("io.ballerina.runtime.internal.values.AttributeMapValueImpl"),
     FP_VALUE("io.ballerina.runtime.internal.values.FPValue"),
-    ANON_SERVICE("anonService"),
+    ANON_TYPE("anonType"),
     BTYPE_OBJECT("BObjectType"),
     BTYPE_RECORD("BRecordType"),
     BTYPE_JSON("BJsonType");

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/variable/VariableFactory.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/variable/VariableFactory.java
@@ -172,7 +172,7 @@ public class VariableFactory {
             return new BXmlItem(context, varName, value);
         } else if (valueTypeName.equals(JVMValueType.XML_ATTRIB_MAP.getString())) {
             return new BXmlItemAttributeMap(context, varName, value);
-        } else if (valueTypeName.contains(JVMValueType.ANON_SERVICE.getString())) {
+        } else if (valueTypeName.contains(JVMValueType.ANON_TYPE.getString())) {
             return new BService(context, varName, value);
         } else if (valueTypeName.contains(JVMValueType.MAP_VALUE.getString()) && !isRecord(value)) {
             if (isJson(value)) {

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/variable/VariableFactory.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/variable/VariableFactory.java
@@ -53,6 +53,7 @@ import static org.ballerinalang.debugadapter.evaluation.utils.EvaluationUtils.ST
 import static org.ballerinalang.debugadapter.variable.VariableUtils.isJson;
 import static org.ballerinalang.debugadapter.variable.VariableUtils.isObject;
 import static org.ballerinalang.debugadapter.variable.VariableUtils.isRecord;
+import static org.ballerinalang.debugadapter.variable.VariableUtils.isService;
 
 /**
  * Factory implementation of ballerina debug variable types.
@@ -172,8 +173,6 @@ public class VariableFactory {
             return new BXmlItem(context, varName, value);
         } else if (valueTypeName.equals(JVMValueType.XML_ATTRIB_MAP.getString())) {
             return new BXmlItemAttributeMap(context, varName, value);
-        } else if (valueTypeName.contains(JVMValueType.ANON_TYPE.getString())) {
-            return new BService(context, varName, value);
         } else if (valueTypeName.contains(JVMValueType.MAP_VALUE.getString()) && !isRecord(value)) {
             if (isJson(value)) {
                 return new BJson(context, varName, value);
@@ -185,6 +184,8 @@ public class VariableFactory {
                 return new BObject(context, varName, value);
             } else if (isRecord(value)) {
                 return new BRecord(context, varName, value);
+            } else if (isService(value)) {
+                return new BService(context, varName, value);
             }
         }
         // If the variable doesn't match any of the above types, returns as a variable with type "unknown".

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/variable/VariableUtils.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/variable/VariableUtils.java
@@ -142,6 +142,21 @@ public class VariableUtils {
     }
 
     /**
+     * Verifies whether a given JDI value is a ballerina service variable instance.
+     *
+     * @param value JDI value instance.
+     * @return true the given JDI value is a ballerina service variable instance.
+     */
+     static boolean isService(Value value) {
+        try {
+            return getFieldValue(value, FIELD_TYPE).map(type -> type.type().name().endsWith
+                (JVMValueType.BTYPE_SERVICE.getString())).orElse(false);
+        } catch (DebugVariableException e) {
+            return false;
+        }
+    }
+
+    /**
      * Verifies whether a given JDI value is a ballerina JSON variable instance.
      *
      * @param value JDI value instance.

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/variable/types/BObject.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/variable/types/BObject.java
@@ -35,7 +35,11 @@ public class BObject extends NamedCompoundVariable {
     private static final String OBJECT_FIELD_PATTERN_IDENTIFIER = "$value$";
 
     public BObject(SuspendedContext context, String name, Value value) {
-        super(context, name, BVariableType.OBJECT, value);
+        this(context, name, BVariableType.OBJECT, value);
+    }
+
+    public BObject(SuspendedContext context, String name, BVariableType bVarType, Value value) {
+        super(context, name, bVarType, value);
     }
 
     @Override

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/variable/types/BService.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/variable/types/BService.java
@@ -18,22 +18,20 @@ package org.ballerinalang.debugadapter.variable.types;
 
 import com.sun.jdi.Value;
 import org.ballerinalang.debugadapter.SuspendedContext;
-import org.ballerinalang.debugadapter.variable.BSimpleVariable;
-import org.ballerinalang.debugadapter.variable.BVariableType;
 
 /**
  * Ballerina service variable type.
  */
-public class BService extends BSimpleVariable {
+public class BService extends BObject {
 
-    private static final String ANON_SERVICE = "anonymous service";
+    private static final String TYPE_SERVICE = "service";
 
     public BService(SuspendedContext context, String name, Value value) {
-        super(context, name, BVariableType.SERVICE, value);
+        super(context, name, value);
     }
 
     @Override
     public String computeValue() {
-        return ANON_SERVICE;
+        return TYPE_SERVICE;
     }
 }

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/variable/types/BService.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/variable/types/BService.java
@@ -26,7 +26,7 @@ import org.ballerinalang.debugadapter.variable.BVariableType;
 public class BService extends BObject {
 
     public BService(SuspendedContext context, String name, Value value) {
-        super(context, name, value);
+        super(context, name, BVariableType.SERVICE, value);
     }
 
     @Override

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/variable/types/BService.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/variable/types/BService.java
@@ -18,13 +18,12 @@ package org.ballerinalang.debugadapter.variable.types;
 
 import com.sun.jdi.Value;
 import org.ballerinalang.debugadapter.SuspendedContext;
+import org.ballerinalang.debugadapter.variable.BVariableType;
 
 /**
  * Ballerina service variable type.
  */
 public class BService extends BObject {
-
-    private static final String TYPE_SERVICE = "service";
 
     public BService(SuspendedContext context, String name, Value value) {
         super(context, name, value);
@@ -32,6 +31,11 @@ public class BService extends BObject {
 
     @Override
     public String computeValue() {
-        return TYPE_SERVICE;
+        return BVariableType.SERVICE.getString();
+    }
+
+    @Override
+    public BVariableType getBType() {
+        return BVariableType.SERVICE;
     }
 }

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/evaluation/ExpressionEvaluationBaseTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/evaluation/ExpressionEvaluationBaseTest.java
@@ -70,6 +70,7 @@ public abstract class ExpressionEvaluationBaseTest extends BaseTestCase {
     protected static final String TABLE_VAR = "tableWithKeyVar";
     protected static final String STREAM_VAR = "oddNumberStream";
     protected static final String NEVER_VAR = "neverVar";
+    protected static final String SERVICE_VAR = "serviceVar";
 
     protected static final String GLOBAL_VAR_01 = "nameWithoutType";
     protected static final String GLOBAL_VAR_02 = "nameWithType";

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/evaluation/ExpressionEvaluationTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/evaluation/ExpressionEvaluationTest.java
@@ -168,7 +168,7 @@ public class ExpressionEvaluationTest extends ExpressionEvaluationBaseTest {
         debugTestRunner.assertExpression(context, ANON_OBJECT_VAR, "Person_\\ /<>:@[`{~π_ƮέŞŢ", "object");
         // TODO - Need to enable
         // service object variable test
-        // debugTestRunner.assertExpression(context, SERVICE_VAR, "service", "object");
+        // debugTestRunner.assertExpression(context, SERVICE_VAR, "service", "service");
 
         // Todo - Enable after fixing https://github.com/ballerina-platform/ballerina-lang/issues/26139
         // debugTestRunner.assertExpression(context, GL, "Ballerina", "string");

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/evaluation/ExpressionEvaluationTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/evaluation/ExpressionEvaluationTest.java
@@ -166,6 +166,9 @@ public class ExpressionEvaluationTest extends ExpressionEvaluationBaseTest {
         debugTestRunner.assertExpression(context, JSON_VAR, "map<json> (size = 2)", "json");
         // anonymous object variable test (AnonPerson object)
         debugTestRunner.assertExpression(context, ANON_OBJECT_VAR, "Person_\\ /<>:@[`{~π_ƮέŞŢ", "object");
+        // TODO - Need to enable
+        // service object variable test
+        // debugTestRunner.assertExpression(context, SERVICE_VAR, "service", "object");
 
         // Todo - Enable after fixing https://github.com/ballerina-platform/ballerina-lang/issues/26139
         // debugTestRunner.assertExpression(context, GL, "Ballerina", "string");
@@ -197,6 +200,9 @@ public class ExpressionEvaluationTest extends ExpressionEvaluationBaseTest {
         debugTestRunner.assertExpression(context, RECORD_VAR + ".grades.maths", "80", "int");
         // optional field access
         debugTestRunner.assertExpression(context, RECORD_VAR + "?.undefined", "()", "nil");
+        // TODO - Need to enable
+        // service object field access
+        // debugTestRunner.assertExpression(context, SERVICE_VAR + ".i", "5", "int");
     }
 
     @Override

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/variables/VariableVisibilityTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/variables/VariableVisibilityTest.java
@@ -284,7 +284,7 @@ public class VariableVisibilityTest extends BaseTestCase {
         debugTestRunner.assertVariable(localVariables, "ĠĿŐΒȂɭ_ /:@[`{~π_json", "map<json> (size = 0)", "json");
 
         // service variable visibility test
-        debugTestRunner.assertVariable(localVariables, "serviceVar", "service", "object");
+        debugTestRunner.assertVariable(localVariables, "serviceVar", "service", "service");
     }
 
     @Test(dependsOnMethods = "globalVariableVisibilityTest",

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/variables/VariableVisibilityTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/variables/VariableVisibilityTest.java
@@ -54,17 +54,17 @@ public class VariableVisibilityTest extends BaseTestCase {
 
         debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 117));
         debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 198));
-        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 209));
-        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 209));
-        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 216));
-        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 223));
-        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 232));
-        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 238));
-        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 245));
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 217));
+//        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 217));
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 224));
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 231));
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 240));
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 246));
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 253));
         // Todo - enable after fixing https://github.com/ballerina-platform/ballerina-lang/issues/27738
         // debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 241));
-        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 278));
-        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 256));
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 286));
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 264));
         debugTestRunner.initDebugSession(DebugUtils.DebuggeeExecutionKind.RUN);
     }
 
@@ -115,25 +115,25 @@ public class VariableVisibilityTest extends BaseTestCase {
         debugTestRunner.resumeProgram(debugHitInfo.getRight(), DebugTestRunner.DebugResumeKind.NEXT_BREAKPOINT);
         debugHitInfo = debugTestRunner.waitForDebugHit(10000);
         localVariables = debugTestRunner.fetchVariables(debugHitInfo.getRight(), DebugTestRunner.VariableScope.LOCAL);
-        Assert.assertEquals(localVariables.size(), 44);
+        Assert.assertEquals(localVariables.size(), 45);
 
         // local variable visibility test inside `else` statement.
         debugTestRunner.resumeProgram(debugHitInfo.getRight(), DebugTestRunner.DebugResumeKind.NEXT_BREAKPOINT);
         debugHitInfo = debugTestRunner.waitForDebugHit(10000);
         localVariables = debugTestRunner.fetchVariables(debugHitInfo.getRight(), DebugTestRunner.VariableScope.LOCAL);
-        Assert.assertEquals(localVariables.size(), 44);
+        Assert.assertEquals(localVariables.size(), 45);
 
         // local variable visibility test inside `else-if` statement.
         debugTestRunner.resumeProgram(debugHitInfo.getRight(), DebugTestRunner.DebugResumeKind.NEXT_BREAKPOINT);
         debugHitInfo = debugTestRunner.waitForDebugHit(10000);
         localVariables = debugTestRunner.fetchVariables(debugHitInfo.getRight(), DebugTestRunner.VariableScope.LOCAL);
-        Assert.assertEquals(localVariables.size(), 44);
+        Assert.assertEquals(localVariables.size(), 45);
 
         // local variable visibility test inside `while` loop.
         debugTestRunner.resumeProgram(debugHitInfo.getRight(), DebugTestRunner.DebugResumeKind.NEXT_BREAKPOINT);
         debugHitInfo = debugTestRunner.waitForDebugHit(10000);
         localVariables = debugTestRunner.fetchVariables(debugHitInfo.getRight(), DebugTestRunner.VariableScope.LOCAL);
-        Assert.assertEquals(localVariables.size(), 44);
+        Assert.assertEquals(localVariables.size(), 45);
 
         // local variable visibility test inside `foreach` loop.
         debugTestRunner.resumeProgram(debugHitInfo.getRight(), DebugTestRunner.DebugResumeKind.NEXT_BREAKPOINT);
@@ -145,7 +145,7 @@ public class VariableVisibilityTest extends BaseTestCase {
         debugTestRunner.resumeProgram(debugHitInfo.getRight(), DebugTestRunner.DebugResumeKind.NEXT_BREAKPOINT);
         debugHitInfo = debugTestRunner.waitForDebugHit(10000);
         localVariables = debugTestRunner.fetchVariables(debugHitInfo.getRight(), DebugTestRunner.VariableScope.LOCAL);
-        Assert.assertEquals(localVariables.size(), 45);
+        Assert.assertEquals(localVariables.size(), 46);
 
         // Todo - enable after fixing https://github.com/ballerina-platform/ballerina-lang/issues/27738
         // local variable visibility test inside `foreach` statement + lambda function.
@@ -283,6 +283,9 @@ public class VariableVisibilityTest extends BaseTestCase {
         debugTestRunner.assertVariable(localVariables, " /:@[`{~π_var", "IL with special characters in var", "string");
         debugTestRunner.assertVariable(localVariables, "üňĩćőđę_var", "IL with unicode characters in var", "string");
         debugTestRunner.assertVariable(localVariables, "ĠĿŐΒȂɭ_ /:@[`{~π_json", "map<json> (size = 0)", "json");
+
+        // service variable visibility test
+        debugTestRunner.assertVariable(localVariables, "serviceVar", "service", "object");
     }
 
     @Test(dependsOnMethods = "globalVariableVisibilityTest",
@@ -412,6 +415,11 @@ public class VariableVisibilityTest extends BaseTestCase {
         debugTestRunner.assertVariable(tableWithoutKeyChildVariables, "[0]", "Employee", "record");
         debugTestRunner.assertVariable(tableWithoutKeyChildVariables, "[1]", "Employee", "record");
         debugTestRunner.assertVariable(tableWithoutKeyChildVariables, "[2]", "Employee", "record");
+
+        // service child variable visibility test
+        Map<String, Variable> serviceChildVariables =
+            debugTestRunner.fetchChildVariables(localVariables.get("serviceVar"));
+        debugTestRunner.assertVariable(serviceChildVariables, "i", "5", "int");
     }
 
     @AfterClass(alwaysRun = true)

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/variables/VariableVisibilityTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/variables/VariableVisibilityTest.java
@@ -55,7 +55,6 @@ public class VariableVisibilityTest extends BaseTestCase {
         debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 117));
         debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 198));
         debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 217));
-//        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 217));
         debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 224));
         debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 231));
         debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 240));

--- a/tests/jballerina-debugger-integration-test/src/test/resources/project-based-tests/variable-tests/main.bal
+++ b/tests/jballerina-debugger-integration-test/src/test/resources/project-based-tests/variable-tests/main.bal
@@ -204,6 +204,14 @@ public function main() {
     string 'üňĩćőđę_var = "IL with unicode characters in var";
     json 'ĠĿŐΒȂɭ_\ \/\:\@\[\`\{\~\u{03C0}_json = {};
     
+    // service object
+    service object {} serviceVar = service object {
+        final int i = 5;
+        resource function get getResource() {
+            int k = self.i;
+        }
+    };
+
     // variable visibility in 'if' statement
     if (true) {
         intVar = 1;


### PR DESCRIPTION
## Purpose
This PR will fix `self` variable visibility and `self` expression evaluation issue related to services

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/30933

**Before the fix:**
<img width="1333" alt="Screen Shot 2021-06-14 at 10 55 11 AM" src="https://user-images.githubusercontent.com/11292766/121843075-39009b80-ccff-11eb-99a3-c6533f623b24.png">

**After the fix:**
<img width="1338" alt="Screen Shot 2021-06-14 at 10 48 43 AM" src="https://user-images.githubusercontent.com/11292766/121843102-4cac0200-ccff-11eb-89d8-62bdd5e95a36.png">


