### PR TITLE
Fix syntaxTreeModify to accept dollar sign

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/BallerinaTreeModifyUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/BallerinaTreeModifyUtil.java
@@ -46,6 +46,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.regex.Matcher;
 
 /**
  * Represents a request for a Ballerina AST Modify.
@@ -89,7 +90,7 @@ public class BallerinaTreeModifyUtil {
             } else {
                 value = entry.getValue().getAsString();
             }
-            mapping = mapping.replaceAll("\\$" + key, value);
+            mapping = mapping.replaceAll("\\$" + key, Matcher.quoteReplacement(value));
         }
         return mapping;
     }


### PR DESCRIPTION
## Purpose
> Fix `resolveMapping` function failing to parse input value when expression input values includes *$* sign. This causes the `syntaxTreeModify` to throw an error

Fixes https://github.com/wso2-enterprise/choreo/issues/3814

## Approach
> `String.replaceAll` takes a regex pattern as its first parameter and second parameter. This fix suppresses the special meaning added by characters such as *$* sign in order to prevent parsing errors.
https://docs.oracle.com/javase/6/docs/api/java/lang/String.html#replaceAll%28java.lang.String,%20java.lang.String%29

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
