### PR TITLE
Fix NPE thrown when the required configs not provided for metrics

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/metrics/DefaultMetricRegistry.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/metrics/DefaultMetricRegistry.java
@@ -17,6 +17,8 @@
  */
 package io.ballerina.runtime.observability.metrics;
 
+import io.ballerina.runtime.observability.metrics.noop.NoOpMetricProvider;
+
 import java.util.Objects;
 
 /**
@@ -24,8 +26,7 @@ import java.util.Objects;
  */
 public class DefaultMetricRegistry {
 
-    static boolean isNoOp;
-    private static MetricRegistry instance;
+    private static MetricRegistry instance = new MetricRegistry(new NoOpMetricProvider());
 
     /**
      * Get the default {@link MetricRegistry}.
@@ -42,7 +43,7 @@ public class DefaultMetricRegistry {
      * @param instance A new {@link MetricRegistry} instance.
      */
     public static void setInstance(MetricRegistry instance) {
-        if (!isNoOp && DefaultMetricRegistry.instance != null) {
+        if (!(DefaultMetricRegistry.instance.getMetricProvider() instanceof NoOpMetricProvider)) {
             throw new IllegalStateException("Default Metric Registry has already been set");
         }
         DefaultMetricRegistry.instance = Objects.requireNonNull(instance);

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/metrics/noop/NoOpCounter.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/metrics/noop/NoOpCounter.java
@@ -15,23 +15,38 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.ballerinalang.observe.noop;
+package io.ballerina.runtime.observability.metrics.noop;
 
 import io.ballerina.runtime.observability.metrics.AbstractMetric;
+import io.ballerina.runtime.observability.metrics.Counter;
 import io.ballerina.runtime.observability.metrics.MetricId;
-import io.ballerina.runtime.observability.metrics.PolledGauge;
 
 /**
- * Implementation of No-Op {@link PolledGauge}.
+ * Implementation of No-Op {@link Counter}.
  */
-public class NoOpPolledGauge extends AbstractMetric implements PolledGauge {
+public class NoOpCounter extends AbstractMetric implements Counter {
 
-    public NoOpPolledGauge(MetricId id) {
-        super(id);
+    public NoOpCounter(MetricId metricId) {
+        super(metricId);
     }
 
     @Override
-    public double getValue() {
+    public void reset() {
+        //no nothing.
+    }
+
+    @Override
+    public void increment(long amount) {
+        // Do nothing
+    }
+
+    @Override
+    public long getValue() {
+        return 0;
+    }
+
+    @Override
+    public long getValueThenReset() {
         return 0;
     }
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/metrics/noop/NoOpGauge.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/metrics/noop/NoOpGauge.java
@@ -15,45 +15,61 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.ballerinalang.observe.noop;
+package io.ballerina.runtime.observability.metrics.noop;
 
-import io.ballerina.runtime.observability.metrics.Counter;
+import io.ballerina.runtime.observability.metrics.AbstractMetric;
 import io.ballerina.runtime.observability.metrics.Gauge;
 import io.ballerina.runtime.observability.metrics.MetricId;
-import io.ballerina.runtime.observability.metrics.PolledGauge;
+import io.ballerina.runtime.observability.metrics.Snapshot;
 import io.ballerina.runtime.observability.metrics.StatisticConfig;
-import io.ballerina.runtime.observability.metrics.spi.MetricProvider;
-
-import java.util.function.ToDoubleFunction;
 
 /**
- * Provide No-Op implementations of metrics.
+ * Implementation of No-Op {@link Gauge}.
  */
-public class NoOpMetricProvider implements MetricProvider {
-    public static final String NAME = "noop";
+public class NoOpGauge extends AbstractMetric implements Gauge {
 
-    @Override
-    public String getName() {
-        return NAME;
+    public NoOpGauge(MetricId id) {
+        super(id);
     }
 
+
     @Override
-    public void init() {
+    public void increment(double amount) {
         // Do nothing
     }
 
     @Override
-    public Counter newCounter(MetricId metricId) {
-        return new NoOpCounter(metricId);
+    public void decrement(double amount) {
+        // Do nothing
     }
 
     @Override
-    public Gauge newGauge(MetricId metricId, StatisticConfig... statisticConfigs) {
-        return new NoOpGauge(metricId);
+    public void setValue(double value) {
+        // Do nothing
     }
 
     @Override
-    public <T> PolledGauge newPolledGauge(MetricId metricId, T obj, ToDoubleFunction<T> toDoubleFunction) {
-        return new NoOpPolledGauge(metricId);
+    public double getValue() {
+        return 0;
+    }
+
+    @Override
+    public long getCount() {
+        return 0;
+    }
+
+    @Override
+    public double getSum() {
+        return 0;
+    }
+
+    @Override
+    public Snapshot[] getSnapshots() {
+        return new Snapshot[0];
+    }
+
+    @Override
+    public StatisticConfig[] getStatisticsConfig() {
+        return new StatisticConfig[0];
     }
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/metrics/noop/NoOpMetricProvider.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/metrics/noop/NoOpMetricProvider.java
@@ -15,61 +15,45 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.ballerinalang.observe.noop;
+package io.ballerina.runtime.observability.metrics.noop;
 
-import io.ballerina.runtime.observability.metrics.AbstractMetric;
+import io.ballerina.runtime.observability.metrics.Counter;
 import io.ballerina.runtime.observability.metrics.Gauge;
 import io.ballerina.runtime.observability.metrics.MetricId;
-import io.ballerina.runtime.observability.metrics.Snapshot;
+import io.ballerina.runtime.observability.metrics.PolledGauge;
 import io.ballerina.runtime.observability.metrics.StatisticConfig;
+import io.ballerina.runtime.observability.metrics.spi.MetricProvider;
+
+import java.util.function.ToDoubleFunction;
 
 /**
- * Implementation of No-Op {@link Gauge}.
+ * Provide No-Op implementations of metrics.
  */
-public class NoOpGauge extends AbstractMetric implements Gauge {
-
-    public NoOpGauge(MetricId id) {
-        super(id);
-    }
-
+public class NoOpMetricProvider implements MetricProvider {
+    public static final String NAME = "noop";
 
     @Override
-    public void increment(double amount) {
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public void init() {
         // Do nothing
     }
 
     @Override
-    public void decrement(double amount) {
-        // Do nothing
+    public Counter newCounter(MetricId metricId) {
+        return new NoOpCounter(metricId);
     }
 
     @Override
-    public void setValue(double value) {
-        // Do nothing
+    public Gauge newGauge(MetricId metricId, StatisticConfig... statisticConfigs) {
+        return new NoOpGauge(metricId);
     }
 
     @Override
-    public double getValue() {
-        return 0;
-    }
-
-    @Override
-    public long getCount() {
-        return 0;
-    }
-
-    @Override
-    public double getSum() {
-        return 0;
-    }
-
-    @Override
-    public Snapshot[] getSnapshots() {
-        return new Snapshot[0];
-    }
-
-    @Override
-    public StatisticConfig[] getStatisticsConfig() {
-        return new StatisticConfig[0];
+    public <T> PolledGauge newPolledGauge(MetricId metricId, T obj, ToDoubleFunction<T> toDoubleFunction) {
+        return new NoOpPolledGauge(metricId);
     }
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/metrics/noop/NoOpPolledGauge.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/metrics/noop/NoOpPolledGauge.java
@@ -15,38 +15,23 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.ballerinalang.observe.noop;
+package io.ballerina.runtime.observability.metrics.noop;
 
 import io.ballerina.runtime.observability.metrics.AbstractMetric;
-import io.ballerina.runtime.observability.metrics.Counter;
 import io.ballerina.runtime.observability.metrics.MetricId;
+import io.ballerina.runtime.observability.metrics.PolledGauge;
 
 /**
- * Implementation of No-Op {@link Counter}.
+ * Implementation of No-Op {@link PolledGauge}.
  */
-public class NoOpCounter extends AbstractMetric implements Counter {
+public class NoOpPolledGauge extends AbstractMetric implements PolledGauge {
 
-    public NoOpCounter(MetricId metricId) {
-        super(metricId);
+    public NoOpPolledGauge(MetricId id) {
+        super(id);
     }
 
     @Override
-    public void reset() {
-        //no nothing.
-    }
-
-    @Override
-    public void increment(long amount) {
-        // Do nothing
-    }
-
-    @Override
-    public long getValue() {
-        return 0;
-    }
-
-    @Override
-    public long getValueThenReset() {
+    public double getValue() {
         return 0;
     }
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/tracer/noop/NoOpTracerProvider.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/tracer/noop/NoOpTracerProvider.java
@@ -15,7 +15,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.ballerinalang.observe.noop;
+package io.ballerina.runtime.observability.tracer.noop;
 
 import io.ballerina.runtime.observability.tracer.spi.TracerProvider;
 import io.opentelemetry.api.trace.Tracer;

--- a/bvm/ballerina-runtime/src/main/java/module-info.java
+++ b/bvm/ballerina-runtime/src/main/java/module-info.java
@@ -64,4 +64,6 @@ module io.ballerina.runtime {
             io.ballerina.lang.xml;
     exports io.ballerina.runtime.internal.configurable to io.ballerina.lang.internal;
     exports io.ballerina.runtime.internal.types to io.ballerina.lang.typedesc;
+    exports io.ballerina.runtime.observability.metrics.noop;
+    exports io.ballerina.runtime.observability.tracer.noop;
 }

--- a/observelib/observe-internal/src/main/java/org/ballerinalang/observe/NativeFunctions.java
+++ b/observelib/observe-internal/src/main/java/org/ballerinalang/observe/NativeFunctions.java
@@ -23,12 +23,12 @@ import io.ballerina.runtime.observability.ObserveUtils;
 import io.ballerina.runtime.observability.metrics.BallerinaMetricsObserver;
 import io.ballerina.runtime.observability.metrics.DefaultMetricRegistry;
 import io.ballerina.runtime.observability.metrics.MetricRegistry;
+import io.ballerina.runtime.observability.metrics.noop.NoOpMetricProvider;
 import io.ballerina.runtime.observability.metrics.spi.MetricProvider;
 import io.ballerina.runtime.observability.tracer.BallerinaTracingObserver;
 import io.ballerina.runtime.observability.tracer.TracersStore;
+import io.ballerina.runtime.observability.tracer.noop.NoOpTracerProvider;
 import io.ballerina.runtime.observability.tracer.spi.TracerProvider;
-import org.ballerinalang.observe.noop.NoOpMetricProvider;
-import org.ballerinalang.observe.noop.NoOpTracerProvider;
 
 import java.io.PrintStream;
 import java.util.ServiceLoader;


### PR DESCRIPTION
## Purpose
Fix NPE thrown when the required configs not provided for metrics

Fixes #29754

## Approach
Introduce a no-op metrics registry as the default metrics registry

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)

