### PR TITLE
Deprecate `type()` and introduce `typeOf()` in its place

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/SemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/SemanticModel.java
@@ -131,7 +131,9 @@ public interface SemanticModel {
      *
      * @param range the text range of the expression
      * @return the type of the expression
+     * @deprecated This method will be removed in a later version. Use typeOf() instead.
      */
+    @Deprecated
     Optional<TypeSymbol> type(LineRange range);
 
     /**
@@ -140,8 +142,28 @@ public interface SemanticModel {
      *
      * @param node The expression node of which the type is needed
      * @return The type if it's a valid expression node, if not, returns empty
+     * @deprecated Deprecated since this returns type for non-expression nodes as well. Use typeOf() instead.
      */
+    @Deprecated
     Optional<TypeSymbol> type(Node node);
+
+    /**
+     * Retrieves the type of the node in the specified text range. The node matching the specified range should be an
+     * expression. For any other kind of node, this will return empty.
+     *
+     * @param range the text range of the expression
+     * @return the type of the expression
+     */
+    Optional<TypeSymbol> typeOf(LineRange range);
+
+    /**
+     * Given a syntax tree node, returns the type of that node, if it is an expression node. For any other node, this
+     * will return empty.
+     *
+     * @param node The expression node of which the type is needed
+     * @return The type if it's a valid expression node, if not, returns empty
+     */
+    Optional<TypeSymbol> typeOf(Node node);
 
     /**
      * Get the diagnostics within the given text Span.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
@@ -48,6 +48,7 @@ import org.wso2.ballerinalang.compiler.tree.BLangFunction;
 import org.wso2.ballerinalang.compiler.tree.BLangNode;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import org.wso2.ballerinalang.compiler.tree.BLangTestablePackage;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangArrowFunction;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Name;
@@ -194,7 +195,8 @@ public class BallerinaSemanticModel implements SemanticModel {
             return Collections.emptyList();
         }
 
-        BLangNode node = new NodeFinder().lookupEnclosingContainer(this.bLangPackage, symbolLocation.get().lineRange());
+        BLangNode node = new NodeFinder(false)
+                .lookupEnclosingContainer(this.bLangPackage, symbolLocation.get().lineRange());
 
         ReferenceFinder refFinder = new ReferenceFinder(withDefinition);
         return refFinder.findReferences(node, getInternalSymbol(symbol));
@@ -210,7 +212,8 @@ public class BallerinaSemanticModel implements SemanticModel {
             return Collections.emptyList();
         }
 
-        BLangNode node = new NodeFinder().lookupEnclosingContainer(this.bLangPackage, symbolAtCursor.pos.lineRange());
+        BLangNode node = new NodeFinder(false)
+                .lookupEnclosingContainer(this.bLangPackage, symbolAtCursor.pos.lineRange());
 
         ReferenceFinder refFinder = new ReferenceFinder(withDefinition);
         return refFinder.findReferences(node, symbolAtCursor);
@@ -222,7 +225,7 @@ public class BallerinaSemanticModel implements SemanticModel {
     @Override
     public Optional<TypeSymbol> type(LineRange range) {
         BLangCompilationUnit compilationUnit = getCompilationUnit(range.filePath());
-        NodeFinder nodeFinder = new NodeFinder();
+        NodeFinder nodeFinder = new NodeFinder(true);
         BLangNode node = nodeFinder.lookup(compilationUnit, range);
 
         if (node == null) {
@@ -235,7 +238,7 @@ public class BallerinaSemanticModel implements SemanticModel {
     @Override
     public Optional<TypeSymbol> typeOf(LineRange range) {
         BLangCompilationUnit compilationUnit = getCompilationUnit(range.filePath());
-        NodeFinder nodeFinder = new NodeFinder();
+        NodeFinder nodeFinder = new NodeFinder(false);
         BLangNode node = nodeFinder.lookup(compilationUnit, range);
 
         if (!(node instanceof BLangExpression) && !isObjectConstructorExpr(node) && !isAnonFunctionExpr(node)) {
@@ -430,6 +433,7 @@ public class BallerinaSemanticModel implements SemanticModel {
     }
 
     private boolean isAnonFunctionExpr(BLangNode node) {
-        return node instanceof BLangFunction && ((BLangFunction) node).flagSet.contains(Flag.LAMBDA);
+        return (node instanceof BLangFunction && ((BLangFunction) node).flagSet.contains(Flag.LAMBDA))
+                || node instanceof BLangArrowFunction;
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
@@ -30,6 +30,7 @@ import io.ballerina.tools.diagnostics.Diagnostic;
 import io.ballerina.tools.diagnostics.Location;
 import io.ballerina.tools.text.LinePosition;
 import io.ballerina.tools.text.LineRange;
+import org.ballerinalang.model.elements.Flag;
 import org.ballerinalang.model.symbols.SymbolKind;
 import org.wso2.ballerinalang.compiler.diagnostic.BLangDiagnosticLocation;
 import org.wso2.ballerinalang.compiler.semantics.analyzer.SymbolResolver;
@@ -41,10 +42,13 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BVarSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
+import org.wso2.ballerinalang.compiler.tree.BLangClassDefinition;
 import org.wso2.ballerinalang.compiler.tree.BLangCompilationUnit;
+import org.wso2.ballerinalang.compiler.tree.BLangFunction;
 import org.wso2.ballerinalang.compiler.tree.BLangNode;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import org.wso2.ballerinalang.compiler.tree.BLangTestablePackage;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.util.Flags;
@@ -228,6 +232,19 @@ public class BallerinaSemanticModel implements SemanticModel {
         return Optional.ofNullable(typesFactory.getTypeDescriptor(node.getBType()));
     }
 
+    @Override
+    public Optional<TypeSymbol> typeOf(LineRange range) {
+        BLangCompilationUnit compilationUnit = getCompilationUnit(range.filePath());
+        NodeFinder nodeFinder = new NodeFinder();
+        BLangNode node = nodeFinder.lookup(compilationUnit, range);
+
+        if (!(node instanceof BLangExpression) && !isObjectConstructorExpr(node) && !isAnonFunctionExpr(node)) {
+            return Optional.empty();
+        }
+
+        return Optional.ofNullable(typesFactory.getTypeDescriptor(node.getDeterminedType()));
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -240,6 +257,17 @@ public class BallerinaSemanticModel implements SemanticModel {
         }
 
         return type(node.location().lineRange());
+    }
+
+    @Override
+    public Optional<TypeSymbol> typeOf(Node node) {
+        Optional<Location> nodeIdentifierLocation = node.apply(new SyntaxNodeToLocationMapper());
+
+        if (nodeIdentifierLocation.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return typeOf(node.location().lineRange());
     }
 
     /**
@@ -395,5 +423,13 @@ public class BallerinaSemanticModel implements SemanticModel {
 
     private boolean isFilteredVarSymbol(BSymbol symbol, Set<DiagnosticState> states) {
         return symbol instanceof BVarSymbol && !states.contains(((BVarSymbol) symbol).state);
+    }
+
+    private boolean isObjectConstructorExpr(BLangNode node) {
+        return node instanceof BLangClassDefinition && ((BLangClassDefinition) node).flagSet.contains(Flag.OBJECT_CTOR);
+    }
+
+    private boolean isAnonFunctionExpr(BLangNode node) {
+        return node instanceof BLangFunction && ((BLangFunction) node).flagSet.contains(Flag.LAMBDA);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/NodeFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/NodeFinder.java
@@ -195,6 +195,11 @@ class NodeFinder extends BaseVisitor {
     private LineRange range;
     private BLangNode enclosingNode;
     private BLangNode enclosingContainer;
+    private boolean allowExprStmts;
+
+    NodeFinder(boolean allowExprStmts) {
+        this.allowExprStmts = allowExprStmts;
+    }
 
     BLangNode lookup(BLangPackage module, LineRange range) {
         List<TopLevelNode> topLevelNodes = new ArrayList<>(module.topLevelNodes);
@@ -425,7 +430,10 @@ class NodeFinder extends BaseVisitor {
     @Override
     public void visit(BLangExpressionStmt exprStmtNode) {
         lookupNode(exprStmtNode.expr);
-        setEnclosingNode(exprStmtNode.expr, exprStmtNode.pos);
+
+        if (this.allowExprStmts) {
+            setEnclosingNode(exprStmtNode.expr, exprStmtNode.pos);
+        }
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/NodeFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/NodeFinder.java
@@ -630,13 +630,15 @@ class NodeFinder extends BaseVisitor {
 
     @Override
     public void visit(BLangInvocation invocationExpr) {
+        // Looking up args expressions since requiredArgs and restArgs get set only when compilation is successful
+        lookupNodes(invocationExpr.argExprs);
+        lookupNode(invocationExpr.expr);
+
         if (setEnclosingNode(invocationExpr, invocationExpr.name.pos)) {
             return;
         }
 
-        // Looking up args expressions since requiredArgs and restArgs get set only when compilation is successful
-        lookupNodes(invocationExpr.argExprs);
-        lookupNode(invocationExpr.expr);
+        setEnclosingNode(invocationExpr, invocationExpr.pos);
     }
 
     @Override
@@ -647,14 +649,15 @@ class NodeFinder extends BaseVisitor {
 
     @Override
     public void visit(BLangInvocation.BLangActionInvocation actionInvocationExpr) {
+        lookupNodes(actionInvocationExpr.argExprs);
+        lookupNodes(actionInvocationExpr.restArgs);
+        lookupNode(actionInvocationExpr.expr);
+
         if (setEnclosingNode(actionInvocationExpr, actionInvocationExpr.name.pos)) {
             return;
         }
 
-        lookupNodes(actionInvocationExpr.requiredArgs);
-        lookupNodes(actionInvocationExpr.restArgs);
-        lookupNode(actionInvocationExpr.expr);
-        lookupNodes(actionInvocationExpr.argExprs);
+        setEnclosingNode(actionInvocationExpr, actionInvocationExpr.pos);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
@@ -2216,7 +2216,9 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
         SyntaxKind kind = expressionNode.kind();
         switch (kind) {
             case XML_TEMPLATE_EXPRESSION:
-                return createXmlTemplateLiteral(expressionNode);
+                BLangNode xmlTemplateLiteral = createXmlTemplateLiteral(expressionNode);
+                xmlTemplateLiteral.pos = getPosition(expressionNode);
+                return xmlTemplateLiteral;
             case STRING_TEMPLATE_EXPRESSION:
                 return createStringTemplateLiteral(expressionNode.content(), getPosition(expressionNode));
             case RAW_TEMPLATE_EXPRESSION:

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -791,6 +791,7 @@ public class SymbolEnter extends BLangNodeVisitor {
 
         tSymbol.type = objectType;
         classDefinition.setBType(objectType);
+        classDefinition.setDeterminedType(objectType);
         classDefinition.symbol = tSymbol;
 
         if (isDeprecated(classDefinition.annAttachments)) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -377,7 +377,7 @@ public class TypeChecker extends BLangNodeVisitor {
             resultType = ((BIntersectionType) resultType).effectiveType;
         }
 
-        expr.setBType(resultType);
+        expr.setTypeCheckedType(resultType);
         expr.typeChecked = isTypeChecked;
         this.env = prevEnv;
         this.expType = preExpType;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -195,7 +195,9 @@ public class Types {
                            BType actualType,
                            BType expType,
                            DiagnosticCode diagCode) {
-        expr.setBType(checkType(expr.pos, actualType, expType, diagCode));
+        expr.setDeterminedType(actualType);
+        expr.setTypeCheckedType(checkType(expr.pos, actualType, expType, diagCode));
+
         if (expr.getBType().tag == TypeTags.SEMANTIC_ERROR) {
             return expr.getBType();
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangNode.java
@@ -29,7 +29,7 @@ import java.util.Set;
  */
 public abstract class BLangNode implements Node {
 
-    private BType type;
+    protected BType type;
     public BLangNode parent = null;
 
     /**

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangNode.java
@@ -60,12 +60,18 @@ public abstract class BLangNode implements Node {
     public int cloneAttempt;
 
     /**
+     * The actual type derived for this expression.
+     */
+    protected BType determinedType;
+
+    /**
      * Sets the specified type as the type of the node.
      *
      * @param type The type of the node
      */
     public void setBType(BType type) {
         this.type = type;
+        this.determinedType = type;
     }
 
     /**
@@ -75,6 +81,14 @@ public abstract class BLangNode implements Node {
      */
     public BType getBType() {
         return this.type;
+    }
+
+    public void setDeterminedType(BType type) {
+        this.determinedType = type;
+    }
+
+    public BType getDeterminedType() {
+        return this.determinedType;
     }
 
     public Location getPosition() {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangExpression.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangExpression.java
@@ -53,7 +53,8 @@ public abstract class BLangExpression extends BLangNode implements ExpressionNod
     public Map<BVarSymbol, NarrowedTypes> narrowedTypeInfo;
 
     public void setTypeCheckedType(BType type) {
-        super.setBType(type);
+        this.type = type;
+
         if (this.determinedType == null) {
             this.determinedType = type;
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangExpression.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangExpression.java
@@ -52,4 +52,10 @@ public abstract class BLangExpression extends BLangNode implements ExpressionNod
 
     public Map<BVarSymbol, NarrowedTypes> narrowedTypeInfo;
 
+    public void setTypeCheckedType(BType type) {
+        super.setBType(type);
+        if (this.determinedType == null) {
+            this.determinedType = type;
+        }
+    }
 }

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibXMLTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibXMLTest.java
@@ -386,13 +386,13 @@ public class LangLibXMLTest {
         constraintNegative = BCompileUtil.compile("test-src/xmllib_constrained_negative_test.bal");
         int i = 0;
         validateError(constraintNegative, i++, "incompatible types: expected 'xml:Comment', found 'xml:Element'",
-                20, 28);
+                20, 23);
         validateError(constraintNegative, i++, "incompatible types: expected 'xml:ProcessingInstruction', " +
-                "found 'xml:Element'", 21, 42);
+                "found 'xml:Element'", 21, 37);
         validateError(constraintNegative, i++, "incompatible types: expected 'xml<xml:Comment>', found 'xml:Element'",
-                25, 33);
+                25, 28);
         validateError(constraintNegative, i++, "incompatible types: expected 'xml<xml:ProcessingInstruction>'," +
-                " found 'xml:Element'", 26, 47);
+                " found 'xml:Element'", 26, 42);
         validateError(constraintNegative, i++, "incompatible types: expected 'xml:Comment', found 'xml<xml:Element>'",
                 29, 26);
         validateError(constraintNegative, i++, "incompatible types: expected 'xml<xml:Element>', found 'xml:Comment'",
@@ -404,21 +404,21 @@ public class LangLibXMLTest {
                 " found 'xml<(xml:Element|xml:Comment)>'", 41, 29);
 
         validateError(constraintNegative, i++, "incompatible types: expected 'xml:Element', found 'xml:Comment'",
-                45, 31);
+                45, 26);
         validateError(constraintNegative, i++, "incompatible types: expected 'xml:Element'," +
-                " found 'xml:ProcessingInstruction'", 46, 18);
+                " found 'xml:ProcessingInstruction'", 46, 13);
         validateError(constraintNegative, i++, "incompatible types: expected 'xml:Element', found 'xml:Text'",
-                47, 18);
+                47, 13);
         validateError(constraintNegative, i++, "incompatible types: expected 'xml:Element', found 'xml<xml:Comment>'",
                 50, 13);
         validateError(constraintNegative, i++, "incompatible types: expected 'xml<xml:Comment>', found 'xml:Element'",
-                52, 51);
+                52, 46);
         validateError(constraintNegative, i++, "incompatible types: expected 'xml<xml:Comment>'," +
                 " found 'xml<xml:Element>'", 55, 28);
         validateError(constraintNegative, i++, "incompatible types: expected 'xml:Element', found 'xml:Comment'",
-                60, 26);
+                60, 21);
         validateError(constraintNegative, i++, "incompatible types: expected 'xml:Element', found 'xml:Comment'",
-                62, 34);
+                62, 29);
         validateError(constraintNegative, i++, "incompatible types: expected 'xml:Element', found 'xml<xml:Comment>'",
                 65, 19);
         assertEquals(constraintNegative.getErrorCount(), i);

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ExpressionTypeTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ExpressionTypeTest.java
@@ -52,7 +52,7 @@ import static io.ballerina.compiler.api.symbols.TypeDescKind.STRING;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.TUPLE;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.TYPE_REFERENCE;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.UNION;
-import static io.ballerina.compiler.api.symbols.TypeDescKind.XML;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.XML_ELEMENT;
 import static org.testng.Assert.assertEquals;
 
 /**
@@ -89,22 +89,21 @@ public class ExpressionTypeTest {
 
     @Test
     public void testByteLiteral() {
-        TypeSymbol type = getExprType(19, 13, 19, 42);
+        TypeSymbol type = getExprType(19, 15, 19, 42);
         assertEquals(type.typeKind(), ARRAY);
         assertEquals(((ArrayTypeSymbol) type).memberTypeDescriptor().typeKind(), BYTE);
     }
 
-    @Test(dataProvider = "TemplateExprProvider")
-    public void testTemplateExprs(int sLine, int sCol, int eLine, int eCol, TypeDescKind kind) {
-        assertType(sLine, sCol, eLine, eCol, kind);
+    @Test
+    public void testStringTemplateExpr() {
+        assertType(23, 15, 23, 36, STRING);
     }
 
-    @DataProvider(name = "TemplateExprProvider")
-    public Object[][] getTemplateExprPos() {
-        return new Object[][]{
-                {23, 15, 23, 36, STRING},
-                {24, 12, 24, 45, XML},
-        };
+    @Test
+    public void testXMLTemplateExpr() {
+        TypeSymbol type = getExprType(24, 12, 24, 45);
+        assertEquals(type.typeKind(), TYPE_REFERENCE);
+        assertEquals(((TypeReferenceTypeSymbol) type).typeDescriptor().typeKind(), XML_ELEMENT);
     }
 
     @Test

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ExpressionTypeTestNew.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ExpressionTypeTestNew.java
@@ -1,0 +1,408 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.ballerina.semantic.api.test;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.ArrayTypeSymbol;
+import io.ballerina.compiler.api.symbols.FutureTypeSymbol;
+import io.ballerina.compiler.api.symbols.MapTypeSymbol;
+import io.ballerina.compiler.api.symbols.TupleTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
+import io.ballerina.semantic.api.test.util.SemanticAPITestUtils;
+import io.ballerina.tools.text.LinePosition;
+import io.ballerina.tools.text.LineRange;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.ballerina.compiler.api.symbols.TypeDescKind.ANYDATA;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.ARRAY;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.BOOLEAN;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.BYTE;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.DECIMAL;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.ERROR;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.FLOAT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.FUTURE;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.INT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.INTERSECTION;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.JSON;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.MAP;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.NIL;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.OBJECT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.RECORD;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.STRING;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.TUPLE;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.TYPE_REFERENCE;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.UNION;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.XML_ELEMENT;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests for the checking the types of expressions. This test is for the new API, typeOf().
+ *
+ * @since 2.0.0
+ */
+public class ExpressionTypeTestNew {
+
+    private SemanticModel model;
+
+    @BeforeClass
+    public void setup() {
+        model = SemanticAPITestUtils.getDefaultModulesSemanticModel("test-src/expressions_test.bal");
+    }
+
+    @Test(dataProvider = "LiteralPosProvider")
+    public void testLiterals(int sLine, int sCol, int eLine, int eCol, TypeDescKind kind) {
+        assertType(sLine, sCol, eLine, eCol, kind);
+    }
+
+    @DataProvider(name = "LiteralPosProvider")
+    public Object[][] getLiteralPos() {
+        return new Object[][]{
+                {17, 21, 17, 22, INT},
+                {17, 24, 17, 29, FLOAT},
+                {17, 31, 17, 36, DECIMAL},
+                {17, 38, 17, 42, BOOLEAN},
+                {17, 44, 17, 46, NIL},
+                {17, 48, 17, 53, STRING},
+                {18, 13, 18, 17, NIL},
+        };
+    }
+
+    @Test
+    public void testByteLiteral() {
+        TypeSymbol type = getExprType(19, 15, 19, 42);
+        assertEquals(type.typeKind(), ARRAY);
+        assertEquals(((ArrayTypeSymbol) type).memberTypeDescriptor().typeKind(), BYTE);
+    }
+
+    @Test
+    public void testStringTemplateExpr() {
+        assertType(23, 15, 23, 36, STRING);
+    }
+
+    @Test
+    public void testXMLTemplateExpr() {
+        TypeSymbol type = getExprType(24, 12, 24, 45);
+        assertEquals(type.typeKind(), TYPE_REFERENCE);
+        assertEquals(((TypeReferenceTypeSymbol) type).typeDescriptor().typeKind(), XML_ELEMENT);
+    }
+
+    @Test
+    public void testRawTemplate() {
+        TypeSymbol type = getExprType(25, 29, 25, 50);
+        assertEquals(type.typeKind(), TYPE_REFERENCE);
+
+        TypeSymbol objType = ((TypeReferenceTypeSymbol) type).typeDescriptor();
+        assertEquals(objType.typeKind(), OBJECT);
+
+        type = getExprType(25, 32, 25, 33);
+        assertEquals(type.typeKind(), STRING);
+    }
+
+    @Test
+    public void testArrayLiteral() {
+        TypeSymbol type = getExprType(29, 20, 29, 34);
+        assertEquals(type.typeKind(), ARRAY);
+
+        TypeSymbol memberType = ((ArrayTypeSymbol) type).memberTypeDescriptor();
+        assertEquals(memberType.typeKind(), STRING);
+    }
+
+    @Test(dataProvider = "TupleLiteralPosProvider")
+    public void testTupleLiteral(int sLine, int sCol, int eLine, int eCol, List<TypeDescKind> memberKinds) {
+        TypeSymbol type = getExprType(sLine, sCol, eLine, eCol);
+        assertEquals(type.typeKind(), TUPLE);
+
+        List<TypeSymbol> memberTypes = ((TupleTypeSymbol) type).memberTypeDescriptors();
+
+        assertEquals(memberTypes.size(), memberKinds.size());
+        for (int i = 0; i < memberTypes.size(); i++) {
+            TypeSymbol memberType = memberTypes.get(i);
+            assertEquals(memberType.typeKind(), memberKinds.get(i));
+        }
+    }
+
+    @DataProvider(name = "TupleLiteralPosProvider")
+    public Object[][] getTuplePos() {
+        return new Object[][]{
+                {30, 15, 30, 27, List.of(INT, INT, INT)},
+                {32, 31, 32, 49, List.of(INT, STRING, FLOAT)},
+        };
+    }
+
+    @Test
+    public void testMapLiteral() {
+        TypeSymbol type = getExprType(34, 20, 34, 34);
+        assertEquals(type.typeKind(), MAP);
+
+        TypeSymbol constraint = ((MapTypeSymbol) type).typeParam();
+        assertEquals(constraint.typeKind(), STRING);
+
+        assertType(34, 28, 34, 33, STRING);
+    }
+
+    @Test
+    public void testInferredMappingConstructorType() {
+        TypeSymbol type = getExprType(35, 13, 35, 43);
+        assertEquals(type.typeKind(), RECORD);
+
+        assertType(35, 14, 35, 20, STRING);
+        assertType(35, 22, 35, 31, STRING);
+        assertType(35, 33, 35, 39, STRING);
+        assertType(35, 41, 35, 42, INT);
+    }
+
+    @Test
+    public void testRecordLiteral() {
+        TypeSymbol type = getExprType(40, 16, 40, 43);
+        assertEquals(type.typeKind(), RECORD);
+
+        // Disabled ones due to #26628
+//        assertType(40, 17, 40, 21, STRING);
+        assertType(40, 23, 40, 33, STRING);
+//        assertType(40, 35, 40, 38, STRING);
+        assertType(40, 40, 40, 42, INT);
+    }
+
+    @Test
+    public void testJSONObject() {
+        TypeSymbol type = getExprType(42, 13, 42, 40);
+        assertEquals(type.typeKind(), MAP);
+
+        TypeSymbol constraint = ((MapTypeSymbol) type).typeParam();
+        assertEquals(constraint.typeKind(), JSON);
+
+        // Disabled ones due to #26628
+//        assertType(42, 14, 42, 18, STRING);
+        assertType(42, 20, 42, 30, STRING);
+//        assertType(42, 32, 42, 35, STRING);
+        assertType(42, 37, 42, 39, INT);
+    }
+
+    @Test(dataProvider = "FieldAccessPosProvider")
+    public void testFieldAccessExpr(int sLine, int sCol, int eLine, int eCol, TypeDescKind kind) {
+        assertType(sLine, sCol, eLine, eCol, kind);
+    }
+
+    @DataProvider(name = "FieldAccessPosProvider")
+    public Object[][] getFieldAccessPos() {
+        return new Object[][]{
+                // Field access
+                {51, 18, 51, 29, STRING},
+                {51, 18, 51, 24, RECORD},
+                // Optional Field access
+                {52, 15, 52, 26, UNION},
+                {52, 15, 52, 21, RECORD},
+                // Member access
+                {53, 21, 53, 35, STRING},
+                {53, 21, 53, 27, RECORD},
+                {53, 28, 53, 34, STRING},
+        };
+    }
+
+    @Test(dataProvider = "TypeInitPosProvider")
+    public void testObjecTypeInit(int sLine, int sCol, int eLine, int eCol) {
+        TypeSymbol type = getExprType(sLine, sCol, eLine, eCol);
+        assertEquals(type.typeKind(), TYPE_REFERENCE);
+        assertEquals(((TypeReferenceTypeSymbol) type).getName().get(), "PersonObj");
+        assertEquals(((TypeReferenceTypeSymbol) type).typeDescriptor().typeKind(), OBJECT);
+    }
+
+    @DataProvider(name = "TypeInitPosProvider")
+    public Object[][] getTypeInitPos() {
+        return new Object[][]{
+                {57, 19, 57, 33},
+                {58, 19, 58, 42}
+        };
+    }
+
+    @Test
+    public void testObjectConstructorExpr() {
+        assertType(64, 15, 68, 5, OBJECT);
+        assertType(65, 22, 65, 28, STRING);
+        assertType(67, 45, 67, 54, STRING);
+        assertType(67, 45, 67, 49, OBJECT);
+        assertType(67, 50, 67, 54, STRING);
+    }
+
+    @Test(dataProvider = "MiscExprPosProvider")
+    public void testMiscExprs(int sLine, int sCol, int eCol, TypeDescKind kind) {
+        assertType(sLine, sCol, eCol, kind);
+    }
+
+    @DataProvider(name = "MiscExprPosProvider")
+    public Object[][] getExprPos() {
+        return new Object[][]{
+                {72, 12, 15, INT},
+                {73, 12, 23, INT},
+                {73, 17, 23, INT},
+                {74, 12, 23, INT},
+                {75, 16, 22, BOOLEAN},
+                {76, 17, 22, STRING},
+                {78, 8, 20, BOOLEAN},
+                {78, 8, 10, ANYDATA},
+                {78, 14, 20, null},
+        };
+    }
+
+    @Test(dataProvider = "CheckingExprPosProvider")
+    public void testCheckingExprs(int sLine, int sCol, int eLine, int eCol, TypeDescKind kind) {
+        assertType(sLine, sCol, eLine, eCol, kind);
+    }
+
+    @DataProvider(name = "CheckingExprPosProvider")
+    public Object[][] getCheckingExprPos() {
+        return new Object[][]{
+                {86, 16, 86, 27, STRING},
+                {86, 22, 86, 27, UNION},
+                {87, 16, 87, 32, STRING},
+                {87, 27, 87, 32, UNION},
+        };
+    }
+
+    @Test(dataProvider = "CastingExprPosProvider")
+    public void testCastingExprs(int sLine, int sCol, int eLine, int eCol, TypeDescKind kind) {
+        assertType(sLine, sCol, eLine, eCol, kind);
+    }
+
+    @DataProvider(name = "CastingExprPosProvider")
+    public Object[][] getCastingExprPos() {
+        return new Object[][]{
+                {92, 15, 92, 25, STRING},
+                {92, 23, 92, 25, ANYDATA},
+                {93, 12, 93, 30, INT},
+                {93, 28, 93, 30, ANYDATA},
+        };
+    }
+
+    @Test
+    public void testInferredRecordTypeForInvalidExprs() {
+        assertType(97, 5, 97, 20, RECORD);
+    }
+
+    @Test
+    public void testStartAction() {
+        TypeSymbol type = getExprType(101, 4, 101, 21);
+        assertEquals(type.typeKind(), FUTURE);
+        assertEquals(((FutureTypeSymbol) type).typeParameter().get().typeKind(), NIL);
+    }
+
+    @Test(dataProvider = "CallExprPosProvider")
+    public void testFunctionCall(int sLine, int sCol, int eCol, TypeDescKind kind) {
+        assertType(sLine, sCol, eCol, kind);
+    }
+
+    @DataProvider(name = "CallExprPosProvider")
+    public Object[][] getCallExprPos() {
+        return new Object[][]{
+                {109, 4, 10, null},
+                {109, 4, 9, UNION},
+                {112, 15, 27, null},
+                {112, 15, 26, STRING},
+                {127, 4, 35, null},
+                {127, 4, 34, STRING},
+                {129, 12, 36, INT},
+                {129, 12, 37, null},
+                {130, 4, 35, BOOLEAN}
+        };
+    }
+
+    @Test
+    public void testExpressionsOfIntersectionTypes() {
+        assertType(135, 4, 21, INTERSECTION);
+        assertType(135, 4, 22, null);
+        assertType(137, 4, 24, null);
+        assertType(137, 4, 23, INTERSECTION);
+        assertType(139, 4, 26, UNION);
+
+        TypeSymbol t1 = getExprType(139, 4, 139, 26);
+        assertEquals(t1.typeKind(), UNION);
+        assertEquals(t1.signature(), "(Foo & readonly)|int|(string[] & readonly)");
+
+        assertType(141, 4, 27, null);
+        TypeSymbol t2 = getExprType(141, 4, 141, 26);
+        assertEquals(t2.typeKind(), UNION);
+        assertEquals(t2.signature(), "(int[] & readonly)?");
+
+        assertType(143, 4, 27, null);
+        TypeSymbol t3 = getExprType(143, 4, 143, 26);
+        assertEquals(t3.typeKind(), UNION);
+        assertEquals(t3.signature(), "(int[] & readonly)?");
+    }
+
+    @Test
+    public void testTypeWithinServiceDecl() {
+        assertType(118, 15, 118, 16, RECORD);
+    }
+
+    @Test
+    public void testTypeWithinDoAndOnFailClause() {
+        TypeSymbol exprType = getExprType(164, 16, 164, 23);
+        assertEquals(exprType.typeKind(), TYPE_REFERENCE);
+        assertEquals(exprType.getName().get(), "Foo");
+
+        exprType = getExprType(166, 12, 166, 42);
+        assertEquals(exprType.typeKind(), STRING);
+    }
+
+    @Test
+    public void testFuncCallForDependentlyTypedSignatures() {
+        TypeSymbol exprType = getExprType(172, 12, 172, 35);
+        assertEquals(exprType.typeKind(), INT);
+    }
+
+    @Test
+    public void testTypeOfExprInErroredStmt() {
+        TypeSymbol type = getExprType(177, 12, 177, 23);
+        assertEquals(type.typeKind(), UNION);
+
+        UnionTypeSymbol union = (UnionTypeSymbol) type;
+        assertEquals(union.memberTypeDescriptors().get(0).typeKind(), INT);
+        assertEquals(union.memberTypeDescriptors().get(1).typeKind(), ERROR);
+    }
+
+    private void assertType(int sLine, int sCol, int eLine, int eCol, TypeDescKind kind) {
+        TypeSymbol type = getExprType(sLine, sCol, eLine, eCol);
+        assertEquals(type.typeKind(), kind);
+    }
+
+    private void assertType(int line, int sCol, int eCol, TypeDescKind kind) {
+        Optional<TypeSymbol> type = model.typeOf(
+                LineRange.from("expressions_test.bal", LinePosition.from(line, sCol), LinePosition.from(line, eCol)));
+
+        if (kind == null) {
+            assertTrue(type.isEmpty());
+        } else {
+            assertEquals(type.get().typeKind(), kind);
+        }
+    }
+
+    private TypeSymbol getExprType(int sLine, int sCol, int eLine, int eCol) {
+        LinePosition start = LinePosition.from(sLine, sCol);
+        LinePosition end = LinePosition.from(eLine, eCol);
+        return model.typeOf(LineRange.from("expressions_test.bal", start, end)).get();
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/deprecated/TypeByAccessExprTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/deprecated/TypeByAccessExprTest.java
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-package io.ballerina.semantic.api.test.typebynode;
+package io.ballerina.semantic.api.test.typebynode.deprecated;
 
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.TypeDescKind;

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/deprecated/TypeByAnonFunctionTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/deprecated/TypeByAnonFunctionTest.java
@@ -16,54 +16,61 @@
  * under the License.
  */
 
-package io.ballerina.semantic.api.test.typebynode;
+package io.ballerina.semantic.api.test.typebynode.deprecated;
 
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.syntax.tree.ExplicitAnonymousFunctionExpressionNode;
 import io.ballerina.compiler.syntax.tree.FunctionCallExpressionNode;
-import io.ballerina.compiler.syntax.tree.MethodCallExpressionNode;
+import io.ballerina.compiler.syntax.tree.ImplicitAnonymousFunctionExpressionNode;
 import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.compiler.syntax.tree.NodeVisitor;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
 
-import static io.ballerina.compiler.api.symbols.TypeDescKind.INT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.FUNCTION;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.STRING;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 /**
- * Tests for getting the type of call expressions.
+ * Tests for getting the type of anonymous functions.
  *
  * @since 2.0.0
  */
 @Test
-public class TypeByCallExprTest extends TypeByNodeTest {
+public class TypeByAnonFunctionTest extends TypeByNodeTest {
 
     @Override
     String getTestSourcePath() {
-        return "test-src/type-by-node/type_by_call_expr.bal";
+        return "test-src/type-by-node/type_by_anon_function.bal";
     }
 
     @Override
     NodeVisitor getNodeVisitor(SemanticModel model) {
         return new NodeVisitor() {
             @Override
-            public void visit(FunctionCallExpressionNode functionCallExpressionNode) {
-                assertType(functionCallExpressionNode, model, INT);
+            public void visit(ExplicitAnonymousFunctionExpressionNode explicitAnonymousFunctionExpressionNode) {
+                assertType(explicitAnonymousFunctionExpressionNode, model, FUNCTION);
             }
 
             @Override
-            public void visit(MethodCallExpressionNode methodCallExpressionNode) {
-                assertType(methodCallExpressionNode, model, STRING);
+            public void visit(ImplicitAnonymousFunctionExpressionNode implicitAnonymousFunctionExpressionNode) {
+                assertType(implicitAnonymousFunctionExpressionNode, model, FUNCTION);
+                assertType(implicitAnonymousFunctionExpressionNode.params(), model, STRING);
+            }
+
+            @Override
+            public void visit(FunctionCallExpressionNode functionCallExpressionNode) {
+                assertType(functionCallExpressionNode, model, FUNCTION);
             }
         };
     }
 
     void verifyAssertCount() {
-        assertEquals(getAssertCount(), 2);
+        assertEquals(getAssertCount(), 4);
     }
 
     private void assertType(Node node, SemanticModel model, TypeDescKind typeKind) {

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/deprecated/TypeByCallExprTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/deprecated/TypeByCallExprTest.java
@@ -16,69 +16,60 @@
  * under the License.
  */
 
-package io.ballerina.semantic.api.test.typebynode;
+package io.ballerina.semantic.api.test.typebynode.deprecated;
 
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
-import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
-import io.ballerina.compiler.syntax.tree.CheckExpressionNode;
+import io.ballerina.compiler.syntax.tree.FunctionCallExpressionNode;
+import io.ballerina.compiler.syntax.tree.MethodCallExpressionNode;
 import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.compiler.syntax.tree.NodeVisitor;
-import io.ballerina.compiler.syntax.tree.TrapExpressionNode;
 import org.testng.annotations.Test;
 
-import java.util.List;
 import java.util.Optional;
 
-import static io.ballerina.compiler.api.symbols.TypeDescKind.ERROR;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.INT;
-import static io.ballerina.compiler.api.symbols.TypeDescKind.NIL;
-import static io.ballerina.compiler.api.symbols.TypeDescKind.UNION;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.STRING;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 /**
- * Tests for getting the type of checking exprs, trap expr etc.
+ * Tests for getting the type of call expressions.
  *
  * @since 2.0.0
  */
 @Test
-public class TypeByErrorHandlingExprTest extends TypeByNodeTest {
+public class TypeByCallExprTest extends TypeByNodeTest {
 
     @Override
     String getTestSourcePath() {
-        return "test-src/type-by-node/type_by_error_handling_exprs.bal";
+        return "test-src/type-by-node/type_by_call_expr.bal";
     }
 
     @Override
     NodeVisitor getNodeVisitor(SemanticModel model) {
         return new NodeVisitor() {
-
             @Override
-            public void visit(CheckExpressionNode checkExpressionNode) {
-                assertType(checkExpressionNode, model, INT);
+            public void visit(FunctionCallExpressionNode functionCallExpressionNode) {
+                assertType(functionCallExpressionNode, model, INT);
             }
 
             @Override
-            public void visit(TrapExpressionNode trapExpressionNode) {
-                Optional<TypeSymbol> type = assertType(trapExpressionNode, model, UNION);
-                List<TypeSymbol> members = ((UnionTypeSymbol) type.get()).memberTypeDescriptors();
-                assertEquals(members.get(0).typeKind(), NIL);
-                assertEquals(members.get(1).typeKind(), ERROR);
+            public void visit(MethodCallExpressionNode methodCallExpressionNode) {
+                assertType(methodCallExpressionNode, model, STRING);
             }
         };
     }
 
     void verifyAssertCount() {
-        assertEquals(getAssertCount(), 3);
+        assertEquals(getAssertCount(), 2);
     }
 
-    private Optional<TypeSymbol> assertType(Node node, SemanticModel model, TypeDescKind typeKind) {
+    private void assertType(Node node, SemanticModel model, TypeDescKind typeKind) {
         Optional<TypeSymbol> type = model.type(node);
         assertTrue(type.isPresent());
         assertEquals(type.get().typeKind(), typeKind);
         incrementAssertCount();
-        return type;
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/deprecated/TypeByConstructorExprTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/deprecated/TypeByConstructorExprTest.java
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-package io.ballerina.semantic.api.test.typebynode;
+package io.ballerina.semantic.api.test.typebynode.deprecated;
 
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.TypeDescKind;

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/deprecated/TypeByErrorHandlingExprTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/deprecated/TypeByErrorHandlingExprTest.java
@@ -16,37 +16,39 @@
  * under the License.
  */
 
-package io.ballerina.semantic.api.test.typebynode;
+package io.ballerina.semantic.api.test.typebynode.deprecated;
 
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
+import io.ballerina.compiler.syntax.tree.CheckExpressionNode;
 import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.compiler.syntax.tree.NodeVisitor;
-import io.ballerina.compiler.syntax.tree.TypeCastExpressionNode;
-import io.ballerina.compiler.syntax.tree.TypeTestExpressionNode;
-import io.ballerina.compiler.syntax.tree.TypeofExpressionNode;
+import io.ballerina.compiler.syntax.tree.TrapExpressionNode;
 import org.testng.annotations.Test;
 
+import java.util.List;
 import java.util.Optional;
 
-import static io.ballerina.compiler.api.symbols.TypeDescKind.BOOLEAN;
-import static io.ballerina.compiler.api.symbols.TypeDescKind.STRING;
-import static io.ballerina.compiler.api.symbols.TypeDescKind.TYPEDESC;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.ERROR;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.INT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.NIL;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.UNION;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 /**
- * Tests for getting the type of typeof and type cast exprs.
+ * Tests for getting the type of checking exprs, trap expr etc.
  *
  * @since 2.0.0
  */
 @Test
-public class TypeByTypeExprTest extends TypeByNodeTest {
+public class TypeByErrorHandlingExprTest extends TypeByNodeTest {
 
     @Override
     String getTestSourcePath() {
-        return "test-src/type-by-node/type_by_type_exprs.bal";
+        return "test-src/type-by-node/type_by_error_handling_exprs.bal";
     }
 
     @Override
@@ -54,18 +56,16 @@ public class TypeByTypeExprTest extends TypeByNodeTest {
         return new NodeVisitor() {
 
             @Override
-            public void visit(TypeCastExpressionNode typeCastExpressionNode) {
-                assertType(typeCastExpressionNode, model, STRING);
+            public void visit(CheckExpressionNode checkExpressionNode) {
+                assertType(checkExpressionNode, model, INT);
             }
 
             @Override
-            public void visit(TypeofExpressionNode typeofExpressionNode) {
-                assertType(typeofExpressionNode, model, TYPEDESC);
-            }
-
-            @Override
-            public void visit(TypeTestExpressionNode typeTestExpressionNode) {
-                assertType(typeTestExpressionNode, model, BOOLEAN);
+            public void visit(TrapExpressionNode trapExpressionNode) {
+                Optional<TypeSymbol> type = assertType(trapExpressionNode, model, UNION);
+                List<TypeSymbol> members = ((UnionTypeSymbol) type.get()).memberTypeDescriptors();
+                assertEquals(members.get(0).typeKind(), NIL);
+                assertEquals(members.get(1).typeKind(), ERROR);
             }
         };
     }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/deprecated/TypeByLiteralTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/deprecated/TypeByLiteralTest.java
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-package io.ballerina.semantic.api.test.typebynode;
+package io.ballerina.semantic.api.test.typebynode.deprecated;
 
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.ArrayTypeSymbol;

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/deprecated/TypeByMiscExprTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/deprecated/TypeByMiscExprTest.java
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-package io.ballerina.semantic.api.test.typebynode;
+package io.ballerina.semantic.api.test.typebynode.deprecated;
 
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.TypeDescKind;

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/deprecated/TypeByNodeTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/deprecated/TypeByNodeTest.java
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-package io.ballerina.semantic.api.test.typebynode;
+package io.ballerina.semantic.api.test.typebynode.deprecated;
 
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.syntax.tree.NodeVisitor;

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/deprecated/TypeByReferenceTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/deprecated/TypeByReferenceTest.java
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-package io.ballerina.semantic.api.test.typebynode;
+package io.ballerina.semantic.api.test.typebynode.deprecated;
 
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.TypeDescKind;

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/deprecated/TypeByTemplateExprTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/deprecated/TypeByTemplateExprTest.java
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-package io.ballerina.semantic.api.test.typebynode;
+package io.ballerina.semantic.api.test.typebynode.deprecated;
 
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.TypeDescKind;

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/deprecated/TypeByTypeExprTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/deprecated/TypeByTypeExprTest.java
@@ -16,67 +16,69 @@
  * under the License.
  */
 
-package io.ballerina.semantic.api.test.typebynode;
+package io.ballerina.semantic.api.test.typebynode.deprecated;
 
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
-import io.ballerina.compiler.syntax.tree.ExplicitAnonymousFunctionExpressionNode;
-import io.ballerina.compiler.syntax.tree.FunctionCallExpressionNode;
-import io.ballerina.compiler.syntax.tree.ImplicitAnonymousFunctionExpressionNode;
 import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.compiler.syntax.tree.NodeVisitor;
+import io.ballerina.compiler.syntax.tree.TypeCastExpressionNode;
+import io.ballerina.compiler.syntax.tree.TypeTestExpressionNode;
+import io.ballerina.compiler.syntax.tree.TypeofExpressionNode;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
 
-import static io.ballerina.compiler.api.symbols.TypeDescKind.FUNCTION;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.BOOLEAN;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.STRING;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.TYPEDESC;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 /**
- * Tests for getting the type of anonymous functions.
+ * Tests for getting the type of typeof and type cast exprs.
  *
  * @since 2.0.0
  */
 @Test
-public class TypeByAnonFunctionTest extends TypeByNodeTest {
+public class TypeByTypeExprTest extends TypeByNodeTest {
 
     @Override
     String getTestSourcePath() {
-        return "test-src/type-by-node/type_by_anon_function.bal";
+        return "test-src/type-by-node/type_by_type_exprs.bal";
     }
 
     @Override
     NodeVisitor getNodeVisitor(SemanticModel model) {
         return new NodeVisitor() {
+
             @Override
-            public void visit(ExplicitAnonymousFunctionExpressionNode explicitAnonymousFunctionExpressionNode) {
-                assertType(explicitAnonymousFunctionExpressionNode, model, FUNCTION);
+            public void visit(TypeCastExpressionNode typeCastExpressionNode) {
+                assertType(typeCastExpressionNode, model, STRING);
             }
 
             @Override
-            public void visit(ImplicitAnonymousFunctionExpressionNode implicitAnonymousFunctionExpressionNode) {
-                assertType(implicitAnonymousFunctionExpressionNode, model, FUNCTION);
-                assertType(implicitAnonymousFunctionExpressionNode.params(), model, STRING);
+            public void visit(TypeofExpressionNode typeofExpressionNode) {
+                assertType(typeofExpressionNode, model, TYPEDESC);
             }
 
             @Override
-            public void visit(FunctionCallExpressionNode functionCallExpressionNode) {
-                assertType(functionCallExpressionNode, model, FUNCTION);
+            public void visit(TypeTestExpressionNode typeTestExpressionNode) {
+                assertType(typeTestExpressionNode, model, BOOLEAN);
             }
         };
     }
 
     void verifyAssertCount() {
-        assertEquals(getAssertCount(), 4);
+        assertEquals(getAssertCount(), 3);
     }
 
-    private void assertType(Node node, SemanticModel model, TypeDescKind typeKind) {
+    private Optional<TypeSymbol> assertType(Node node, SemanticModel model, TypeDescKind typeKind) {
         Optional<TypeSymbol> type = model.type(node);
         assertTrue(type.isPresent());
         assertEquals(type.get().typeKind(), typeKind);
         incrementAssertCount();
+        return type;
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/newapi/TypeByAccessExprTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/newapi/TypeByAccessExprTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.semantic.api.test.typebynode.newapi;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
+import io.ballerina.compiler.syntax.tree.AnnotAccessExpressionNode;
+import io.ballerina.compiler.syntax.tree.FieldAccessExpressionNode;
+import io.ballerina.compiler.syntax.tree.IndexedExpressionNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NodeVisitor;
+import io.ballerina.compiler.syntax.tree.OptionalFieldAccessExpressionNode;
+import io.ballerina.compiler.syntax.tree.SimpleNameReferenceNode;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.ballerina.compiler.api.symbols.TypeDescKind.ERROR;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.INT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.NIL;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.RECORD;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.STRING;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.TYPE_REFERENCE;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.UNION;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests for getting the type of access exprs.
+ *
+ * @since 2.0.0
+ */
+@Test
+public class TypeByAccessExprTest extends TypeByNodeTest {
+
+    @Override
+    String getTestSourcePath() {
+        return "test-src/type-by-node/type_by_access_expr.bal";
+    }
+
+    @Override
+    NodeVisitor getNodeVisitor(SemanticModel model) {
+        return new NodeVisitor() {
+
+            @Override
+            public void visit(FieldAccessExpressionNode fieldAccessExpressionNode) {
+                if (((SimpleNameReferenceNode) fieldAccessExpressionNode.fieldName()).name().text().equals("name")) {
+                    assertType(fieldAccessExpressionNode, model, STRING);
+                } else {
+                    Optional<TypeSymbol> type = assertType(fieldAccessExpressionNode, model, UNION);
+                    assertUnionMembers((UnionTypeSymbol) type.get(), STRING, ERROR);
+                }
+            }
+
+            @Override
+            public void visit(OptionalFieldAccessExpressionNode optionalFieldAccessExpressionNode) {
+                TypeDescKind[] kinds;
+                if (((SimpleNameReferenceNode) optionalFieldAccessExpressionNode.fieldName())
+                        .name().text().equals("age")) {
+                    kinds = new TypeDescKind[]{INT, NIL};
+                } else {
+                    kinds = new TypeDescKind[]{STRING, ERROR, NIL};
+                }
+
+                Optional<TypeSymbol> type = assertType(optionalFieldAccessExpressionNode, model, UNION);
+                assertUnionMembers((UnionTypeSymbol) type.get(), kinds);
+            }
+
+            @Override
+            public void visit(IndexedExpressionNode indexedExpressionNode) {
+                if (indexedExpressionNode.keyExpression().size() == 1) {
+                    assertType(indexedExpressionNode, model, STRING);
+                } else {
+                    Optional<TypeSymbol> type = assertType(indexedExpressionNode, model, UNION);
+                    List<TypeSymbol> members = ((UnionTypeSymbol) type.get()).memberTypeDescriptors();
+                    assertEquals(members.get(0).typeKind(), TYPE_REFERENCE);
+                    assertEquals(((TypeReferenceTypeSymbol) members.get(0)).name(), "Person");
+                    assertEquals(((TypeReferenceTypeSymbol) members.get(0)).typeDescriptor().typeKind(), RECORD);
+                    assertEquals(members.get(1).typeKind(), NIL);
+                }
+            }
+
+            @Override
+            public void visit(AnnotAccessExpressionNode annotAccessExpressionNode) {
+                Optional<TypeSymbol> type = assertType(annotAccessExpressionNode, model, UNION);
+                List<TypeSymbol> members = ((UnionTypeSymbol) type.get()).memberTypeDescriptors();
+                assertEquals(members.get(0).typeKind(), TYPE_REFERENCE);
+                assertEquals(((TypeReferenceTypeSymbol) members.get(0)).name(), "Annot");
+                assertEquals(members.get(1).typeKind(), NIL);
+            }
+        };
+    }
+
+    void verifyAssertCount() {
+        assertEquals(getAssertCount(), 7);
+    }
+
+    private Optional<TypeSymbol> assertType(Node node, SemanticModel model, TypeDescKind typeKind) {
+        Optional<TypeSymbol> type = model.typeOf(node);
+        assertTrue(type.isPresent());
+        assertEquals(type.get().typeKind(), typeKind);
+        incrementAssertCount();
+        return type;
+    }
+
+    private void assertUnionMembers(UnionTypeSymbol type, TypeDescKind... kinds) {
+        List<TypeSymbol> members = type.memberTypeDescriptors();
+        for (int i = 0; i < kinds.length; i++) {
+            assertEquals(members.get(i).typeKind(), kinds[i]);
+        }
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/newapi/TypeByAnonFunctionTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/newapi/TypeByAnonFunctionTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.semantic.api.test.typebynode.newapi;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.syntax.tree.ExplicitAnonymousFunctionExpressionNode;
+import io.ballerina.compiler.syntax.tree.FunctionCallExpressionNode;
+import io.ballerina.compiler.syntax.tree.ImplicitAnonymousFunctionExpressionNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NodeVisitor;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.ballerina.compiler.api.symbols.TypeDescKind.FUNCTION;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests for getting the type of anonymous functions.
+ *
+ * @since 2.0.0
+ */
+@Test
+public class TypeByAnonFunctionTest extends TypeByNodeTest {
+
+    @Override
+    String getTestSourcePath() {
+        return "test-src/type-by-node/type_by_anon_function.bal";
+    }
+
+    @Override
+    NodeVisitor getNodeVisitor(SemanticModel model) {
+        return new NodeVisitor() {
+            @Override
+            public void visit(ExplicitAnonymousFunctionExpressionNode explicitAnonymousFunctionExpressionNode) {
+                assertType(explicitAnonymousFunctionExpressionNode, model, FUNCTION);
+            }
+
+            @Override
+            public void visit(ImplicitAnonymousFunctionExpressionNode implicitAnonymousFunctionExpressionNode) {
+                assertType(implicitAnonymousFunctionExpressionNode, model, FUNCTION);
+                assertType(implicitAnonymousFunctionExpressionNode.params(), model, null);
+            }
+
+            @Override
+            public void visit(FunctionCallExpressionNode functionCallExpressionNode) {
+                assertType(functionCallExpressionNode, model, FUNCTION);
+            }
+        };
+    }
+
+    void verifyAssertCount() {
+        assertEquals(getAssertCount(), 4);
+    }
+
+    private void assertType(Node node, SemanticModel model, TypeDescKind typeKind) {
+        Optional<TypeSymbol> type = model.typeOf(node);
+
+        if (typeKind != null) {
+            assertTrue(type.isPresent());
+            assertEquals(type.get().typeKind(), typeKind);
+        } else {
+            assertTrue(type.isEmpty());
+        }
+
+        incrementAssertCount();
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/newapi/TypeByCallExprTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/newapi/TypeByCallExprTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.semantic.api.test.typebynode.newapi;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.syntax.tree.FunctionCallExpressionNode;
+import io.ballerina.compiler.syntax.tree.MethodCallExpressionNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NodeVisitor;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.ballerina.compiler.api.symbols.TypeDescKind.INT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.STRING;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests for getting the type of call expressions.
+ *
+ * @since 2.0.0
+ */
+@Test
+public class TypeByCallExprTest extends TypeByNodeTest {
+
+    @Override
+    String getTestSourcePath() {
+        return "test-src/type-by-node/type_by_call_expr.bal";
+    }
+
+    @Override
+    NodeVisitor getNodeVisitor(SemanticModel model) {
+        return new NodeVisitor() {
+            @Override
+            public void visit(FunctionCallExpressionNode functionCallExpressionNode) {
+                assertType(functionCallExpressionNode, model, INT);
+            }
+
+            @Override
+            public void visit(MethodCallExpressionNode methodCallExpressionNode) {
+                assertType(methodCallExpressionNode, model, STRING);
+            }
+        };
+    }
+
+    void verifyAssertCount() {
+        assertEquals(getAssertCount(), 2);
+    }
+
+    private void assertType(Node node, SemanticModel model, TypeDescKind typeKind) {
+        Optional<TypeSymbol> type = model.typeOf(node);
+        assertTrue(type.isPresent());
+        assertEquals(type.get().typeKind(), typeKind);
+        incrementAssertCount();
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/newapi/TypeByConstructorExprTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/newapi/TypeByConstructorExprTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.semantic.api.test.typebynode.newapi;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.syntax.tree.ErrorConstructorExpressionNode;
+import io.ballerina.compiler.syntax.tree.ExplicitNewExpressionNode;
+import io.ballerina.compiler.syntax.tree.ImplicitNewExpressionNode;
+import io.ballerina.compiler.syntax.tree.ListConstructorExpressionNode;
+import io.ballerina.compiler.syntax.tree.MappingConstructorExpressionNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NodeVisitor;
+import io.ballerina.compiler.syntax.tree.ObjectConstructorExpressionNode;
+import io.ballerina.compiler.syntax.tree.TableConstructorExpressionNode;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.ballerina.compiler.api.symbols.TypeDescKind.ERROR;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.OBJECT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.RECORD;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.TABLE;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.TUPLE;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.TYPE_REFERENCE;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests for getting the type of constructor expressions.
+ *
+ * @since 2.0.0
+ */
+@Test
+public class TypeByConstructorExprTest extends TypeByNodeTest {
+
+    @Override
+    String getTestSourcePath() {
+        return "test-src/type-by-node/type_by_constructor_expr_test.bal";
+    }
+
+    @Override
+    NodeVisitor getNodeVisitor(SemanticModel model) {
+        return new NodeVisitor() {
+
+            @Override
+            public void visit(ListConstructorExpressionNode listConstructorExpressionNode) {
+                assertType(listConstructorExpressionNode, model, TUPLE);
+            }
+
+            @Override
+            public void visit(MappingConstructorExpressionNode mappingConstructorExpressionNode) {
+                assertType(mappingConstructorExpressionNode, model, RECORD);
+            }
+
+            @Override
+            public void visit(TableConstructorExpressionNode tableConstructorExpressionNode) {
+                assertType(tableConstructorExpressionNode, model, TABLE);
+            }
+
+            @Override
+            public void visit(ObjectConstructorExpressionNode objectConstructorExpressionNode) {
+                assertType(objectConstructorExpressionNode, model, OBJECT);
+            }
+
+            @Override
+            public void visit(ExplicitNewExpressionNode explicitNewExpressionNode) {
+                Optional<TypeSymbol> type = assertType(explicitNewExpressionNode, model, TYPE_REFERENCE);
+                assertEquals(((TypeReferenceTypeSymbol) type.get()).name(), "PersonObj");
+                assertEquals(((TypeReferenceTypeSymbol) type.get()).typeDescriptor().typeKind(), OBJECT);
+            }
+
+            @Override
+            public void visit(ImplicitNewExpressionNode implicitNewExpressionNode) {
+                Optional<TypeSymbol> type = assertType(implicitNewExpressionNode, model, TYPE_REFERENCE);
+                assertEquals(((TypeReferenceTypeSymbol) type.get()).name(), "PersonObj");
+                assertEquals(((TypeReferenceTypeSymbol) type.get()).typeDescriptor().typeKind(), OBJECT);
+            }
+
+            @Override
+            public void visit(ErrorConstructorExpressionNode errorConstructorExpressionNode) {
+                if (errorConstructorExpressionNode.typeReference().isEmpty()) {
+                    assertType(errorConstructorExpressionNode, model, ERROR);
+                } else {
+                    Optional<TypeSymbol> type = assertType(errorConstructorExpressionNode, model, TYPE_REFERENCE);
+                    assertEquals(((TypeReferenceTypeSymbol) type.get()).name(), "TimeOutError");
+                    assertEquals(((TypeReferenceTypeSymbol) type.get()).typeDescriptor().typeKind(), ERROR);
+                }
+            }
+        };
+    }
+
+    void verifyAssertCount() {
+        assertEquals(getAssertCount(), 8);
+    }
+
+    private Optional<TypeSymbol> assertType(Node node, SemanticModel model, TypeDescKind typeKind) {
+        Optional<TypeSymbol> type = model.typeOf(node);
+        assertTrue(type.isPresent());
+        assertEquals(type.get().typeKind(), typeKind);
+        incrementAssertCount();
+        return type;
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/newapi/TypeByErrorHandlingExprTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/newapi/TypeByErrorHandlingExprTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.semantic.api.test.typebynode.newapi;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
+import io.ballerina.compiler.syntax.tree.CheckExpressionNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NodeVisitor;
+import io.ballerina.compiler.syntax.tree.TrapExpressionNode;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.ballerina.compiler.api.symbols.TypeDescKind.ERROR;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.INT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.NIL;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.UNION;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests for getting the type of checking exprs, trap expr etc.
+ *
+ * @since 2.0.0
+ */
+@Test
+public class TypeByErrorHandlingExprTest extends TypeByNodeTest {
+
+    @Override
+    String getTestSourcePath() {
+        return "test-src/type-by-node/type_by_error_handling_exprs.bal";
+    }
+
+    @Override
+    NodeVisitor getNodeVisitor(SemanticModel model) {
+        return new NodeVisitor() {
+
+            @Override
+            public void visit(CheckExpressionNode checkExpressionNode) {
+                assertType(checkExpressionNode, model, INT);
+            }
+
+            @Override
+            public void visit(TrapExpressionNode trapExpressionNode) {
+                Optional<TypeSymbol> type = assertType(trapExpressionNode, model, UNION);
+                List<TypeSymbol> members = ((UnionTypeSymbol) type.get()).memberTypeDescriptors();
+                assertEquals(members.get(0).typeKind(), NIL);
+                assertEquals(members.get(1).typeKind(), ERROR);
+            }
+        };
+    }
+
+    void verifyAssertCount() {
+        assertEquals(getAssertCount(), 3);
+    }
+
+    private Optional<TypeSymbol> assertType(Node node, SemanticModel model, TypeDescKind typeKind) {
+        Optional<TypeSymbol> type = model.typeOf(node);
+        assertTrue(type.isPresent());
+        assertEquals(type.get().typeKind(), typeKind);
+        incrementAssertCount();
+        return type;
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/newapi/TypeByLiteralTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/newapi/TypeByLiteralTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.semantic.api.test.typebynode.newapi;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.ArrayTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.syntax.tree.BasicLiteralNode;
+import io.ballerina.compiler.syntax.tree.ByteArrayLiteralNode;
+import io.ballerina.compiler.syntax.tree.NilLiteralNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NodeVisitor;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.ballerina.compiler.api.symbols.TypeDescKind.ARRAY;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.BOOLEAN;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.BYTE;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.DECIMAL;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.FLOAT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.INT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.NIL;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.STRING;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests for getting the type of basic literals.
+ *
+ * @since 2.0.0
+ */
+@Test
+public class TypeByLiteralTest extends TypeByNodeTest {
+
+    @Override
+    String getTestSourcePath() {
+        return "test-src/type-by-node/type_by_literal.bal";
+    }
+
+    @Override
+    NodeVisitor getNodeVisitor(SemanticModel model) {
+        Map<String, TypeDescKind> literalKinds = new HashMap<>();
+        literalKinds.put("5", INT);
+        literalKinds.put("12.34", FLOAT);
+        literalKinds.put("34.5d", DECIMAL);
+        literalKinds.put("true", BOOLEAN);
+        literalKinds.put("\"foo\"", STRING);
+        literalKinds.put("null", NIL);
+        literalKinds.put("base64 `SGVsbG8gQmFsbGVyaW5h`", ARRAY);
+
+        return new NodeVisitor() {
+
+            @Override
+            public void visit(NilLiteralNode nilLiteralNode) {
+                assertType(nilLiteralNode, model, NIL);
+            }
+
+            @Override
+            public void visit(ByteArrayLiteralNode byteArrayLiteralNode) {
+                Optional<TypeSymbol> type = assertType(byteArrayLiteralNode, model, ARRAY);
+                assertEquals(((ArrayTypeSymbol) type.get()).memberTypeDescriptor().typeKind(), BYTE);
+                incrementAssertCount();
+            }
+
+            @Override
+            public void visit(BasicLiteralNode basicLiteralNode) {
+                assertType(basicLiteralNode, model, literalKinds.get(basicLiteralNode.literalToken().text()));
+            }
+        };
+    }
+
+    void verifyAssertCount() {
+        assertEquals(getAssertCount(), 9);
+    }
+
+    private Optional<TypeSymbol> assertType(Node node, SemanticModel model, TypeDescKind typeKind) {
+        Optional<TypeSymbol> type = model.typeOf(node);
+        assertTrue(type.isPresent());
+        assertEquals(type.get().typeKind(), typeKind);
+        incrementAssertCount();
+        return type;
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/newapi/TypeByMiscExprTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/newapi/TypeByMiscExprTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.semantic.api.test.typebynode.newapi;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.syntax.tree.BinaryExpressionNode;
+import io.ballerina.compiler.syntax.tree.ConditionalExpressionNode;
+import io.ballerina.compiler.syntax.tree.LetExpressionNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NodeVisitor;
+import io.ballerina.compiler.syntax.tree.TypeTestExpressionNode;
+import io.ballerina.compiler.syntax.tree.UnaryExpressionNode;
+import io.ballerina.compiler.syntax.tree.XMLFilterExpressionNode;
+import io.ballerina.compiler.syntax.tree.XMLStepExpressionNode;
+import org.ballerinalang.model.tree.OperatorKind;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.ballerina.compiler.api.symbols.TypeDescKind.BOOLEAN;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.INT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.OBJECT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.STRING;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.XML;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests for getting the type of misc. exprs.
+ *
+ * @since 2.0.0
+ */
+@Test
+public class TypeByMiscExprTest extends TypeByNodeTest {
+
+    @Override
+    String getTestSourcePath() {
+        return "test-src/type-by-node/type_by_misc_exprs.bal";
+    }
+
+    @Override
+    NodeVisitor getNodeVisitor(SemanticModel model) {
+        return new NodeVisitor() {
+            @Override
+            public void visit(UnaryExpressionNode unaryExpressionNode) {
+                assertType(unaryExpressionNode, model, INT);
+            }
+
+            @Override
+            public void visit(BinaryExpressionNode binaryExpressionNode) {
+                TypeDescKind typeKind;
+                switch (OperatorKind.valueFrom(binaryExpressionNode.operator().text())) {
+                    case SUB:
+                    case MUL:
+                    case ADD:
+                    case DIV:
+                        typeKind = INT;
+                        break;
+                    case GREATER_EQUAL:
+                    case NOT_EQUAL:
+                    case EQUAL:
+                    case AND:
+                        typeKind = BOOLEAN;
+                        break;
+                    case CLOSED_RANGE:
+                        typeKind = OBJECT;
+                        break;
+                    default:
+                        throw new IllegalStateException();
+                }
+
+                assertType(binaryExpressionNode, model, typeKind);
+                binaryExpressionNode.rhsExpr().accept(this);
+                binaryExpressionNode.lhsExpr().accept(this);
+            }
+
+            @Override
+            public void visit(TypeTestExpressionNode typeTestExpressionNode) {
+                assertType(typeTestExpressionNode, model, BOOLEAN);
+            }
+
+            @Override
+            public void visit(ConditionalExpressionNode conditionalExpressionNode) {
+                assertType(conditionalExpressionNode, model, STRING);
+                conditionalExpressionNode.lhsExpression().accept(this);
+            }
+
+            @Override
+            public void visit(LetExpressionNode letExpressionNode) {
+                assertType(letExpressionNode, model, INT);
+            }
+
+            @Override
+            public void visit(XMLFilterExpressionNode xmlFilterExpressionNode) {
+                assertType(xmlFilterExpressionNode, model, XML);
+            }
+
+            @Override
+            public void visit(XMLStepExpressionNode xmlStepExpressionNode) {
+                assertType(xmlStepExpressionNode, model, XML);
+            }
+        };
+    }
+
+    void verifyAssertCount() {
+        assertEquals(getAssertCount(), 16);
+    }
+
+    private void assertType(Node node, SemanticModel model, TypeDescKind typeKind) {
+        Optional<TypeSymbol> type = model.typeOf(node);
+        assertTrue(type.isPresent());
+        assertEquals(type.get().typeKind(), typeKind);
+        incrementAssertCount();
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/newapi/TypeByNodeTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/newapi/TypeByNodeTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.semantic.api.test.typebynode.newapi;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.syntax.tree.NodeVisitor;
+import io.ballerina.compiler.syntax.tree.SyntaxTree;
+import io.ballerina.projects.DocumentId;
+import io.ballerina.projects.ModuleId;
+import io.ballerina.projects.Package;
+import io.ballerina.projects.Project;
+import org.ballerinalang.test.BCompileUtil;
+import org.testng.annotations.Test;
+
+/**
+ * Tests for getting the type of an expression by giving the relevant syntax tree node as an arg.
+ *
+ * @since 2.0.0
+ */
+public abstract class TypeByNodeTest {
+
+    private int assertCount = 0;
+
+    @Test
+    public void testLookup() {
+        Project project = BCompileUtil.loadProject(getTestSourcePath());
+        Package currentPackage = project.currentPackage();
+        ModuleId defaultModuleId = currentPackage.getDefaultModule().moduleId();
+        DocumentId docId = currentPackage.getDefaultModule().documentIds().iterator().next();
+        SyntaxTree syntaxTree = currentPackage.getDefaultModule().document(docId).syntaxTree();
+        SemanticModel model = currentPackage.getCompilation().getSemanticModel(defaultModuleId);
+        syntaxTree.rootNode().accept(getNodeVisitor(model));
+        verifyAssertCount();
+    }
+
+    abstract String getTestSourcePath();
+
+    abstract NodeVisitor getNodeVisitor(SemanticModel model);
+
+    abstract void verifyAssertCount();
+
+    void incrementAssertCount() {
+        this.assertCount++;
+    }
+
+    int getAssertCount() {
+        return this.assertCount;
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/newapi/TypeByReferenceTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/newapi/TypeByReferenceTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.semantic.api.test.typebynode.newapi;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.syntax.tree.BuiltinSimpleNameReferenceNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NodeVisitor;
+import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
+import io.ballerina.compiler.syntax.tree.SimpleNameReferenceNode;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.ballerina.compiler.api.symbols.TypeDescKind.FLOAT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.INT;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests for getting the type of name references.
+ *
+ * @since 2.0.0
+ */
+@Test
+public class TypeByReferenceTest extends TypeByNodeTest {
+
+    @Override
+    String getTestSourcePath() {
+        return "test-src/type-by-node/type_by_reference_test.bal";
+    }
+
+    @Override
+    NodeVisitor getNodeVisitor(SemanticModel model) {
+        return new NodeVisitor() {
+
+            @Override
+            public void visit(SimpleNameReferenceNode simpleNameReferenceNode) {
+                assertType(simpleNameReferenceNode, model, FLOAT);
+            }
+
+            @Override
+            public void visit(QualifiedNameReferenceNode qualifiedNameReferenceNode) {
+                assertType(qualifiedNameReferenceNode, model, INT);
+            }
+
+            @Override
+            public void visit(BuiltinSimpleNameReferenceNode builtinSimpleNameReferenceNode) {
+                assertType(builtinSimpleNameReferenceNode, model, null);
+            }
+        };
+    }
+
+    void verifyAssertCount() {
+        assertEquals(getAssertCount(), 4);
+    }
+
+    private void assertType(Node node, SemanticModel model, TypeDescKind typeKind) {
+        Optional<TypeSymbol> type = model.typeOf(node);
+
+        if (typeKind != null) {
+            assertTrue(type.isPresent());
+            assertEquals(type.get().typeKind(), typeKind);
+        } else {
+            assertTrue(type.isEmpty());
+        }
+
+        incrementAssertCount();
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/newapi/TypeByTemplateExprTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/newapi/TypeByTemplateExprTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.semantic.api.test.typebynode.newapi;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NodeVisitor;
+import io.ballerina.compiler.syntax.tree.SyntaxKind;
+import io.ballerina.compiler.syntax.tree.TemplateExpressionNode;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.ballerina.compiler.api.symbols.TypeDescKind.OBJECT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.STRING;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.TYPE_REFERENCE;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.XML_ELEMENT;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests for getting the type of template expressions.
+ *
+ * @since 2.0.0
+ */
+@Test
+public class TypeByTemplateExprTest extends TypeByNodeTest {
+
+    @Override
+    String getTestSourcePath() {
+        return "test-src/type-by-node/type_by_template_expr.bal";
+    }
+
+    @Override
+    NodeVisitor getNodeVisitor(SemanticModel model) {
+        return new NodeVisitor() {
+
+            @Override
+            public void visit(TemplateExpressionNode templateExpressionNode) {
+                TypeDescKind expTypeKind;
+                switch (templateExpressionNode.kind()) {
+                    case STRING_TEMPLATE_EXPRESSION:
+                        expTypeKind = STRING;
+                        break;
+                    case XML_TEMPLATE_EXPRESSION:
+                        expTypeKind = TYPE_REFERENCE;
+                        break;
+                    case RAW_TEMPLATE_EXPRESSION:
+                        expTypeKind = TYPE_REFERENCE;
+                        break;
+                    default:
+                        throw new IllegalStateException();
+                }
+
+                assertType(templateExpressionNode, model, expTypeKind, templateExpressionNode.kind());
+            }
+        };
+    }
+
+    void verifyAssertCount() {
+        assertEquals(getAssertCount(), 3);
+    }
+
+    private void assertType(Node node, SemanticModel model, TypeDescKind typeKind, SyntaxKind nodeKind) {
+        Optional<TypeSymbol> type = model.typeOf(node);
+        assertTrue(type.isPresent());
+        assertEquals(type.get().typeKind(), typeKind);
+
+        if (nodeKind == SyntaxKind.RAW_TEMPLATE_EXPRESSION) {
+            assertEquals(type.get().getName().get(), "RawTemplate");
+            assertEquals(((TypeReferenceTypeSymbol) type.get()).typeDescriptor().typeKind(), OBJECT);
+        } else if (nodeKind == SyntaxKind.XML_TEMPLATE_EXPRESSION) {
+            assertEquals(type.get().getName().get(), "Element");
+            assertEquals(((TypeReferenceTypeSymbol) type.get()).typeDescriptor().typeKind(), XML_ELEMENT);
+        }
+
+        incrementAssertCount();
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/newapi/TypeByTypeExprTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/newapi/TypeByTypeExprTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.semantic.api.test.typebynode.newapi;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NodeVisitor;
+import io.ballerina.compiler.syntax.tree.TypeCastExpressionNode;
+import io.ballerina.compiler.syntax.tree.TypeTestExpressionNode;
+import io.ballerina.compiler.syntax.tree.TypeofExpressionNode;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.ballerina.compiler.api.symbols.TypeDescKind.BOOLEAN;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.STRING;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.TYPEDESC;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests for getting the type of typeof and type cast exprs.
+ *
+ * @since 2.0.0
+ */
+@Test
+public class TypeByTypeExprTest extends TypeByNodeTest {
+
+    @Override
+    String getTestSourcePath() {
+        return "test-src/type-by-node/type_by_type_exprs.bal";
+    }
+
+    @Override
+    NodeVisitor getNodeVisitor(SemanticModel model) {
+        return new NodeVisitor() {
+
+            @Override
+            public void visit(TypeCastExpressionNode typeCastExpressionNode) {
+                assertType(typeCastExpressionNode, model, STRING);
+            }
+
+            @Override
+            public void visit(TypeofExpressionNode typeofExpressionNode) {
+                assertType(typeofExpressionNode, model, TYPEDESC);
+            }
+
+            @Override
+            public void visit(TypeTestExpressionNode typeTestExpressionNode) {
+                assertType(typeTestExpressionNode, model, BOOLEAN);
+            }
+        };
+    }
+
+    void verifyAssertCount() {
+        assertEquals(getAssertCount(), 3);
+    }
+
+    private Optional<TypeSymbol> assertType(Node node, SemanticModel model, TypeDescKind typeKind) {
+        Optional<TypeSymbol> type = model.typeOf(node);
+        assertTrue(type.isPresent());
+        assertEquals(type.get().typeKind(), typeKind);
+        incrementAssertCount();
+        return type;
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/expressions_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/expressions_test.bal
@@ -173,6 +173,11 @@ function testDependentlyTypedSignatures() {
     int x = p.depFoo("bar", 10, 20);
 }
 
+function testExpr() {
+    TestClass tc = new;
+    int x = tc.testFn();
+}
+
 // utils
 
 class PersonObj {
@@ -204,5 +209,11 @@ public class Listener {
     }
 
     public function attach(service object {} s, string[]? name = ()) returns error? {
+    }
+}
+
+class TestClass {
+    function testFn() returns int|error {
+        return 1;
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
+++ b/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
@@ -27,6 +27,7 @@
             <class name="io.ballerina.semantic.api.test.DiagnosticsTest" />
             <class name="io.ballerina.semantic.api.test.DocumentationTest" />
             <class name="io.ballerina.semantic.api.test.ExpressionTypeTest" />
+            <class name="io.ballerina.semantic.api.test.ExpressionTypeTestNew" />
             <class name="io.ballerina.semantic.api.test.FieldSymbolTest" />
             <class name="io.ballerina.semantic.api.test.LangLibFunctionTest" />
             <class name="io.ballerina.semantic.api.test.ParameterSymbolTest" />
@@ -71,16 +72,27 @@
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByWorkerTest" />
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByXMLNSTest" />
 
-            <class name="io.ballerina.semantic.api.test.typebynode.TypeByAccessExprTest" />
-            <class name="io.ballerina.semantic.api.test.typebynode.TypeByAnonFunctionTest" />
-            <class name="io.ballerina.semantic.api.test.typebynode.TypeByCallExprTest" />
-            <class name="io.ballerina.semantic.api.test.typebynode.TypeByConstructorExprTest" />
-            <class name="io.ballerina.semantic.api.test.typebynode.TypeByErrorHandlingExprTest" />
-            <class name="io.ballerina.semantic.api.test.typebynode.TypeByLiteralTest" />
-            <class name="io.ballerina.semantic.api.test.typebynode.TypeByMiscExprTest" />
-            <class name="io.ballerina.semantic.api.test.typebynode.TypeByReferenceTest" />
-            <class name="io.ballerina.semantic.api.test.typebynode.TypeByTemplateExprTest" />
-            <class name="io.ballerina.semantic.api.test.typebynode.TypeByTypeExprTest" />
+            <class name="io.ballerina.semantic.api.test.typebynode.deprecated.TypeByAccessExprTest" />
+            <class name="io.ballerina.semantic.api.test.typebynode.deprecated.TypeByAnonFunctionTest" />
+            <class name="io.ballerina.semantic.api.test.typebynode.deprecated.TypeByCallExprTest" />
+            <class name="io.ballerina.semantic.api.test.typebynode.deprecated.TypeByConstructorExprTest" />
+            <class name="io.ballerina.semantic.api.test.typebynode.deprecated.TypeByErrorHandlingExprTest" />
+            <class name="io.ballerina.semantic.api.test.typebynode.deprecated.TypeByLiteralTest" />
+            <class name="io.ballerina.semantic.api.test.typebynode.deprecated.TypeByMiscExprTest" />
+            <class name="io.ballerina.semantic.api.test.typebynode.deprecated.TypeByReferenceTest" />
+            <class name="io.ballerina.semantic.api.test.typebynode.deprecated.TypeByTemplateExprTest" />
+            <class name="io.ballerina.semantic.api.test.typebynode.deprecated.TypeByTypeExprTest" />
+
+            <class name="io.ballerina.semantic.api.test.typebynode.newapi.TypeByAccessExprTest" />
+            <class name="io.ballerina.semantic.api.test.typebynode.newapi.TypeByAnonFunctionTest" />
+            <class name="io.ballerina.semantic.api.test.typebynode.newapi.TypeByCallExprTest" />
+            <class name="io.ballerina.semantic.api.test.typebynode.newapi.TypeByConstructorExprTest" />
+            <class name="io.ballerina.semantic.api.test.typebynode.newapi.TypeByErrorHandlingExprTest" />
+            <class name="io.ballerina.semantic.api.test.typebynode.newapi.TypeByLiteralTest" />
+            <class name="io.ballerina.semantic.api.test.typebynode.newapi.TypeByMiscExprTest" />
+            <class name="io.ballerina.semantic.api.test.typebynode.newapi.TypeByReferenceTest" />
+            <class name="io.ballerina.semantic.api.test.typebynode.newapi.TypeByTemplateExprTest" />
+            <class name="io.ballerina.semantic.api.test.typebynode.newapi.TypeByTypeExprTest" />
 
             <class name="io.ballerina.semantic.api.test.typedescriptors.TypeReferenceTSymbolTest" />
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/functions/FunctionSignatureNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/functions/FunctionSignatureNegativeTest.java
@@ -32,15 +32,15 @@ public class FunctionSignatureNegativeTest {
     @Test
     public void testFuncSignatureSemanticsNegative() {
         int i = 0;
-        CompileResult result = BCompileUtil.compile("test-src/functions/different-function-signatures" +
-                "-semantics-negative.bal");
+        CompileResult result =
+                BCompileUtil.compile("test-src/functions/different-function-signatures-semantics-negative.bal");
         String tooManyArguments = "too many arguments in call to ";
 
         BAssertUtil.validateError(result, i++, "redeclared symbol 'c'", 1, 73);
         BAssertUtil.validateError(result, i++, "redeclared argument 'a'", 17, 19);
         BAssertUtil.validateError(result, i++, "undefined defaultable parameter 'c'", 21, 19);
         BAssertUtil.validateError(result, i++, "incompatible types: expected 'int', found 'float'", 29, 20);
-        BAssertUtil.validateError(result, i++, "incompatible types: expected 'json', found 'xml:Text'", 40, 61);
+        BAssertUtil.validateError(result, i++, "incompatible types: expected 'json', found 'xml:Text'", 40, 56);
         BAssertUtil.validateError(result, i++, "missing required parameter 'a' in call to " +
                 "'functionWithOnlyPositionalParams()'", 57, 9);
         BAssertUtil.validateError(result, i++, "missing required parameter 'b' in call to " +

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/never/NeverTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/never/NeverTypeTest.java
@@ -142,7 +142,7 @@ public class NeverTypeTest {
         BAssertUtil.validateError(negativeCompileResult, i++,
                 "table key specifier mismatch with key constraint. expected: '1' fields but found '0'", 134, 37);
         BAssertUtil.validateError(negativeCompileResult, i++,
-                "incompatible types: expected 'xml<never>', found 'xml:Text'", 143, 26);
+                "incompatible types: expected 'xml<never>', found 'xml:Text'", 143, 21);
         BAssertUtil.validateError(negativeCompileResult, i++,
                 "incompatible types: expected 'string', found '(xml|xml:Text)'", 145, 17);
         BAssertUtil.validateError(negativeCompileResult, i++,

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLLiteralTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLLiteralTest.java
@@ -84,7 +84,7 @@ public class XMLLiteralTest {
 
         // XML elements with mismatching start and end tags
         BAssertUtil.validateError(negativeResult, index++, "mismatching start and end tags found in xml element",
-                                  54, 18);
+                                  54, 13);
         // XML interpolation is not allowed to interpolate XML namespace attributes
         BAssertUtil.validateError(negativeResult, index++, "xml namespaces cannot be interpolated", 63, 29);
         BAssertUtil.validateError(negativeResult, index++, "xml namespaces cannot be interpolated", 63, 47);
@@ -95,19 +95,19 @@ public class XMLLiteralTest {
         BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected " +
                 "'xml:Text', found 'xml:Comment'", 69, 26);
         BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected " +
-                        "'xml<(xml:Text|xml:Comment)>', found 'xml:Element'", 70, 43);
+                        "'xml<(xml:Text|xml:Comment)>', found 'xml:Element'", 70, 38);
         BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected " +
                 "'xml<(xml:Text|xml:Comment)>', found 'xml:Element'", 71, 43);
         BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected " +
                 "'xml<(xml:Text|xml:Comment)>', found 'xml:ProcessingInstruction'", 71, 90);
         BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected " +
-                "'(xml<xml:Text>|xml<xml:Comment>)', found 'xml:Element'", 72, 49);
+                "'(xml<xml:Text>|xml<xml:Comment>)', found 'xml:Element'", 72, 44);
         BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected " +
                 "'(xml<xml:Text>|xml<xml:Comment>)', found 'xml:Element'", 73, 49);
         BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected " +
                 "'(xml<xml:Text>|xml<xml:Comment>)', found 'xml:ProcessingInstruction'", 73, 96);
         BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected " +
-                "'(xml:Text|xml:Comment)', found 'xml:Element'", 74, 39);
+                "'(xml:Text|xml:Comment)', found 'xml:Element'", 74, 34);
         BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected " +
                         "'(xml:Text|xml:Comment)', found 'xml'", 75, 34);
         BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected " +

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLTextToStringConversionNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLTextToStringConversionNegativeTest.java
@@ -43,7 +43,7 @@ public class XMLTextToStringConversionNegativeTest {
         int i = 0;
         Assert.assertEquals(negativeResult.getErrorCount(), 20);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: " +
-                "expected 'string', found 'xml:Text'", 22, 22);
+                "expected 'string', found 'xml:Text'", 22, 17);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: " +
                 "expected 'string', found 'xml:Text'", 23, 17);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: " +
@@ -51,18 +51,18 @@ public class XMLTextToStringConversionNegativeTest {
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: " +
                 "expected 'string', found 'xml:Text'", 28, 17);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: " +
-                "expected 'string', found 'xml:Text'", 29, 42);
+                "expected 'string', found 'xml:Text'", 29, 37);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: " +
-                "expected 'string', found 'xml:Text'", 31, 31);
+                "expected 'string', found 'xml:Text'", 31, 26);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: " +
-                "expected 'string', found 'xml:Text'", 32, 13);
+                "expected 'string', found 'xml:Text'", 32, 8);
 
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: " +
-                "expected 'string', found 'xml:Text'", 40, 46);
+                "expected 'string', found 'xml:Text'", 40, 41);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: " +
-                "expected 'string', found 'xml:Text'", 41, 36);
+                "expected 'string', found 'xml:Text'", 41, 31);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: " +
-                "expected 'string', found 'xml:Text'", 42, 26);
+                "expected 'string', found 'xml:Text'", 42, 21);
 
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: " +
                 "expected 'string', found 'xml:Text'", 48, 9);


### PR DESCRIPTION
## Purpose
The old `type()` method was buggy. Although it was meant to give the type of expressions, it could be used to get the type of other constructs as well (e.g., variables, type nodes etc.). Therefore, this PR introduces a couple of changes to address that and another issue where expressions' types were set to compile error if the overall statement was deemed to be semantically incorrect. 

## Approach
- Added a new field to `BLangNode` called `determinedType`. This field holds the actual type determined for the expression, irrespective of the final result of the type checking. e.g.,
```ballerina
int x = foo(); // foo() returns a string
```
Previously, the type for `foo()` would be returned as compile error since the overall statement is semantically incorrect. But in reality, the expression `foo()` has a determinable type, independent of the context. The newly introduced `typeOf()` method returns this actual determined type instead of the final type.

- Deprecated `type()` and introduced `typeOf()` instead due to the above mentioned reasons and since changing the behaviour of `type()` would potentially cause major impact in downstream projects.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
