### PR TITLE
Fix NPE from compile-time configurable check

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -61,7 +61,6 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BArrayType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BErrorType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BField;
-import org.wso2.ballerinalang.compiler.semantics.model.types.BFiniteType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BIntersectionType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BInvokableType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BMapType;
@@ -892,7 +891,7 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
             case ANYDATA:
                 break;
             case FINITE:
-                return ((BFiniteType) type).isAnyData;
+                return types.isAnydata(type);
             case ARRAY:
                 BType elementType = ((BArrayType) type).eType;
                 if (elementType.tag == TypeTags.INTERSECTION) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/variabledef/configurable_var_positive.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/variabledef/configurable_var_positive.bal
@@ -36,3 +36,15 @@ configurable table<Person> key(name) tableVar2 = ?;
 
 configurable string|int|Person unionVar1 = ?;
 configurable anydata|Person unionVar2 = ?;
+
+enum HttpVersion {
+    HTTP_1_1,
+    HTTP_2
+}
+
+type ClientConfiguration record {|
+    HttpVersion httpVersion?;
+    map<anydata> customHeaders;
+|};
+
+configurable table<ClientConfiguration> tableVar = ?;


### PR DESCRIPTION
## Purpose
The compilation fails with NPE for the following code 
```ballerina
enum HttpVersion {
    HTTP_1_1,
    HTTP_2
}

type ClientConfiguration record {|
    HttpVersion httpVersion?;
|};

configurable table<ClientConfiguration> tableVar = ?;
```
error 
```
[2021-06-16 14:54:27,219] SEVERE {b7a.log.crash} - null 
java.lang.NullPointerException
        at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.isSupportedConfigType(SemanticAnalyzer.java:895)
        at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.isSupportedConfigType(SemanticAnalyzer.java:936)
        at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.isSupportedConfigType(SemanticAnalyzer.java:913)
        at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.isSupportedConfigType(SemanticAnalyzer.java:932)
        at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.isSupportedConfigType(SemanticAnalyzer.java:927)
        at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.isSupportedConfigType(SemanticAnalyzer.java:932)
        at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.checkSupportedConfigType(SemanticAnalyzer.java:881)
        at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.visit(SemanticAnalyzer.java:842)
        at org.wso2.ballerinalang.compiler.tree.BLangSimpleVariable.accept(BLangSimpleVariable.java:53)
        at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.analyzeNode(SemanticAnalyzer.java:3494)
        at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.analyzeNode(SemanticAnalyzer.java:3462)
        at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.analyzeDef(SemanticAnalyzer.java:3454)
        at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.visit(SemanticAnalyzer.java:329)
        at org.wso2.ballerinalang.compiler.tree.BLangPackage.accept(BLangPackage.java:165)
        at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.analyze(SemanticAnalyzer.java:294)
        at io.ballerina.projects.internal.CompilerPhaseRunner.typeCheck(CompilerPhaseRunner.java:204)
        at io.ballerina.projects.internal.CompilerPhaseRunner.performTypeCheckPhases(CompilerPhaseRunner.java:112)
        at io.ballerina.projects.ModuleContext.compileInternal(ModuleContext.java:383)
        at io.ballerina.projects.ModuleCompilationState$1.compile(ModuleCompilationState.java:45)
        at io.ballerina.projects.ModuleContext.compile(ModuleContext.java:329)
        at io.ballerina.projects.PackageCompilation.compileModulesInternal(PackageCompilation.java:174)
        at io.ballerina.projects.PackageCompilation.compileModules(PackageCompilation.java:166)
        at io.ballerina.projects.PackageCompilation.from(PackageCompilation.java:95)
        at io.ballerina.projects.PackageContext.getPackageCompilation(PackageContext.java:206)
        at io.ballerina.projects.Package.getCompilation(Package.java:134)
        at io.ballerina.cli.task.CompileTask.execute(CompileTask.java:64)
        at io.ballerina.cli.TaskExecutor.executeTasks(TaskExecutor.java:40)
        at io.ballerina.cli.cmd.RunCommand.execute(RunCommand.java:163)
        at java.base/java.util.Optional.ifPresent(Optional.java:183)
        at io.ballerina.cli.launcher.Main.main(Main.java:58)
```

Fixes #31223 

## Approach
Use `Types.isAnydata()` instead of FiniteType field which can be null in some cases.

## Samples

## Remarks
related https://github.com/ballerina-platform/ballerina-lang/pull/30668

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
