### PR TITLE
Fix completion issue for optional field access expression

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/FieldCompletionItemBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/FieldCompletionItemBuilder.java
@@ -20,8 +20,21 @@ package org.ballerinalang.langserver.completions.builder;
 import io.ballerina.compiler.api.symbols.ObjectFieldSymbol;
 import io.ballerina.compiler.api.symbols.RecordFieldSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.syntax.tree.FieldAccessExpressionNode;
+import io.ballerina.compiler.syntax.tree.MethodCallExpressionNode;
+import io.ballerina.compiler.syntax.tree.NonTerminalNode;
+import io.ballerina.compiler.syntax.tree.SyntaxKind;
+import io.ballerina.tools.text.LinePosition;
+import io.ballerina.tools.text.LineRange;
+import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionItemKind;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextEdit;
+
+import java.util.Collections;
+import java.util.Optional;
 
 /**
  * Completion item builder for the object fields and for record fields.
@@ -52,10 +65,26 @@ public class FieldCompletionItemBuilder {
      * Build the constant {@link CompletionItem}.
      *
      * @param symbol {@link RecordFieldSymbol}
+     * @param context Completion Context
      * @return {@link CompletionItem} generated completion item
      */
-    public static CompletionItem build(RecordFieldSymbol symbol) {
-        return getCompletionItem(symbol);
+    public static CompletionItem build(RecordFieldSymbol symbol, BallerinaCompletionContext context) {
+        String recordFieldName = symbol.getName().orElseThrow();
+        String insertText;
+        CompletionItem completionItem = new CompletionItem();
+        completionItem.setLabel(recordFieldName);
+        completionItem.setKind(CompletionItemKind.Field);
+
+        Optional<TextEdit> recordFieldAdditionalTextEdit = getRecordFieldAdditionalTextEdit(symbol, context);
+        if (recordFieldAdditionalTextEdit.isPresent()) {
+            insertText = "?." + recordFieldName;
+            completionItem.setAdditionalTextEdits(Collections.singletonList(recordFieldAdditionalTextEdit.get()));
+        } else {
+            insertText = recordFieldName;
+        }
+        completionItem.setInsertText(insertText);
+
+        return completionItem;
     }
 
     /**
@@ -66,5 +95,38 @@ public class FieldCompletionItemBuilder {
      */
     public static CompletionItem build(ObjectFieldSymbol symbol) {
         return getCompletionItem(symbol);
+    }
+
+    private static Optional<TextEdit> getRecordFieldAdditionalTextEdit(RecordFieldSymbol recordFieldSymbol,
+                                                                       BallerinaCompletionContext context) {
+        if (!recordFieldSymbol.isOptional()) {
+            return Optional.empty();
+        }
+
+        NonTerminalNode evalNode = context.getNodeAtCursor();
+        if (evalNode.kind() == SyntaxKind.SIMPLE_NAME_REFERENCE) {
+            evalNode = evalNode.parent();
+        }
+
+        LineRange dotTokenLineRange;
+        if (evalNode.kind() == SyntaxKind.FIELD_ACCESS) {
+            dotTokenLineRange = ((FieldAccessExpressionNode) evalNode).dotToken().lineRange();
+        } else if (evalNode.kind() == SyntaxKind.METHOD_CALL) {
+            // Added for safety
+            dotTokenLineRange = ((MethodCallExpressionNode) evalNode).dotToken().lineRange();
+        } else {
+            return Optional.empty();
+        }
+
+        LinePosition startLine = dotTokenLineRange.startLine();
+        LinePosition endLine = dotTokenLineRange.endLine();
+        TextEdit textEdit = new TextEdit();
+        Range range = new Range();
+        range.setStart(new Position(startLine.line(), startLine.offset()));
+        range.setEnd(new Position(endLine.line(), endLine.offset()));
+        textEdit.setRange(range);
+        textEdit.setNewText("");
+
+        return Optional.of(textEdit);
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/AbstractCompletionProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/AbstractCompletionProvider.java
@@ -189,7 +189,7 @@ public abstract class AbstractCompletionProvider<T extends Node> implements Ball
                 completionItems.add(new SymbolCompletionItem(ctx, symbol, xmlItem));
             } else if (symbol.kind() == RECORD_FIELD) {
                 RecordFieldSymbol recordFieldSymbol = (RecordFieldSymbol) symbol;
-                CompletionItem recFieldItem = FieldCompletionItemBuilder.build(recordFieldSymbol);
+                CompletionItem recFieldItem = FieldCompletionItemBuilder.build(recordFieldSymbol, ctx);
                 completionItems.add(new RecordFieldCompletionItem(ctx, recordFieldSymbol, recFieldItem));
             } else if (symbol.kind() == OBJECT_FIELD || symbol.kind() == CLASS_FIELD) {
                 ObjectFieldSymbol objectFieldSymbol = (ObjectFieldSymbol) symbol;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FieldAccessContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FieldAccessContext.java
@@ -48,9 +48,8 @@ public abstract class FieldAccessContext<T extends Node> extends AbstractComplet
      * @return {@link List} of filtered scope entries
      */
     protected List<LSCompletionItem> getEntries(BallerinaCompletionContext ctx,
-                                                ExpressionNode expr,
-                                                boolean optionalFieldAccess) {
-        FieldAccessCompletionResolver resolver = new FieldAccessCompletionResolver(ctx, optionalFieldAccess);
+                                                ExpressionNode expr) {
+        FieldAccessCompletionResolver resolver = new FieldAccessCompletionResolver(ctx);
         List<Symbol> symbolList = resolver.getVisibleEntries(expr);
 
         return this.getCompletionItemList(symbolList, ctx);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FieldAccessExpressionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FieldAccessExpressionNodeContext.java
@@ -40,7 +40,7 @@ public class FieldAccessExpressionNodeContext extends FieldAccessContext<FieldAc
     public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, FieldAccessExpressionNode node)
             throws LSCompletionException {
         ExpressionNode expression = node.expression();
-        List<LSCompletionItem> completionItems = getEntries(context, expression, false);
+        List<LSCompletionItem> completionItems = getEntries(context, expression);
         this.sort(context, node, completionItems);
 
         return completionItems;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MethodCallExpressionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MethodCallExpressionNodeContext.java
@@ -41,7 +41,7 @@ public class MethodCallExpressionNodeContext extends FieldAccessContext<MethodCa
     public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, MethodCallExpressionNode node)
             throws LSCompletionException {
         ExpressionNode expression = node.expression();
-        List<LSCompletionItem> completionItems = getEntries(context, expression, false);
+        List<LSCompletionItem> completionItems = getEntries(context, expression);
         this.sort(context, node, completionItems);
 
         return completionItems;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/OptionalFieldAccessExpressionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/OptionalFieldAccessExpressionNodeContext.java
@@ -37,7 +37,7 @@ public class OptionalFieldAccessExpressionNodeContext extends FieldAccessContext
     @Override
     public List<LSCompletionItem> getCompletions(BallerinaCompletionContext ctx, OptionalFieldAccessExpressionNode node)
             throws LSCompletionException {
-        List<LSCompletionItem> completionItems = getEntries(ctx, node.expression(), true);
+        List<LSCompletionItem> completionItems = getEntries(ctx, node.expression());
         this.sort(ctx, node, completionItems);
 
         return completionItems;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/ContextTypeResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/ContextTypeResolver.java
@@ -219,7 +219,7 @@ public class ContextTypeResolver extends NodeTransformer<Optional<TypeSymbol>> {
 
     @Override
     public Optional<TypeSymbol> transform(FieldAccessExpressionNode node) {
-        FieldAccessCompletionResolver resolver = new FieldAccessCompletionResolver(context, false);
+        FieldAccessCompletionResolver resolver = new FieldAccessCompletionResolver(context);
         List<Symbol> visibleEntries = resolver.getVisibleEntries(node.expression());
         NameReferenceNode nameRef = node.fieldName();
         if (nameRef.kind() != SyntaxKind.SIMPLE_NAME_REFERENCE) {

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config1.json
@@ -14,6 +14,29 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "testOptional",
+      "kind": "Field",
+      "detail": "int",
+      "sortText": "A",
+      "insertText": "?.testOptional",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 3,
+              "character": 24
+            },
+            "end": {
+              "line": 3,
+              "character": 25
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
       "label": "reduce(function () func, any|error initial)(any|error)",
       "kind": "Function",
       "detail": "Function",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config2.json
@@ -14,6 +14,29 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "testOptional",
+      "kind": "Field",
+      "detail": "int",
+      "sortText": "A",
+      "insertText": "?.testOptional",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 3,
+              "character": 24
+            },
+            "end": {
+              "line": 3,
+              "character": 25
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
       "label": "reduce(function () func, any|error initial)(any|error)",
       "kind": "Function",
       "detail": "Function",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config3.json
@@ -22,6 +22,29 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "optionalInt",
+      "kind": "Field",
+      "detail": "int",
+      "sortText": "A",
+      "insertText": "?.optionalInt",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 3,
+              "character": 34
+            },
+            "end": {
+              "line": 3,
+              "character": 35
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
       "label": "reduce(function () func, any|error initial)(any|error)",
       "kind": "Function",
       "detail": "Function",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config5.json
@@ -14,6 +14,29 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "testOptional",
+      "kind": "Field",
+      "detail": "int",
+      "sortText": "A",
+      "insertText": "?.testOptional",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 4,
+              "character": 20
+            },
+            "end": {
+              "line": 4,
+              "character": 21
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
       "label": "reduce(function () func, any|error initial)(any|error)",
       "kind": "Function",
       "detail": "Function",


### PR DESCRIPTION
## Purpose
With this, we Fix completion issue for optional field access expression and automatically suggest the optional fields over `.` and if it is an optional field, we replace with `?.`

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
