### PR TITLE
Remove extra equal operator in gRPC Module.md

### DIFF
--- a/stdlib/grpc/src/main/ballerina/src/grpc/Module.md
+++ b/stdlib/grpc/src/main/ballerina/src/grpc/Module.md
@@ -250,7 +250,7 @@ The code snippet given below calls the above service using the auto-generated Ba
     ChatClient chatClient = new("http://localhost:9090");
 
     // Execute the service streaming call by registering a message listener.
-    grpc:StreamingClient|grpc:Error ep = = chatClient->chat(ChatMessageListener);
+    grpc:StreamingClient|grpc:Error ep = chatClient->chat(ChatMessageListener);
 
 // Send multiple messages to the server.
 string[] greets = ["Hi", "Hey", "GM"];


### PR DESCRIPTION
## Purpose
This is to remove the extra equal operator in the Ballerina 1.2.x gRPC Module.md.

Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/664

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
