### PR TITLE
Fix type optimization failing on union of custom error

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
@@ -1552,16 +1552,16 @@ public class JvmInstructionGen {
         }
         BType errorType = null;
         BType otherType = null;
-        boolean foundError = false;
+        int foundError = 0;
         for (BType bType : unionMemberTypes) {
             if (bType.tag == TypeTags.ERROR) {
                 errorType = bType;
-                foundError = true;
+                foundError++;
             } else {
                 otherType = bType;
             }
         }
-        return foundError && (type.equals(errorType) || type.equals(otherType));
+        return foundError == 1 && (type.equals(errorType) || type.equals(otherType));
     }
 
     private void generateNegateBoolean() {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/TypeGuardTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/TypeGuardTest.java
@@ -526,31 +526,31 @@ public class TypeGuardTest {
     }
 
     @DataProvider(name = "finiteTypeAsBroaderTypesFunctions")
-    public Object[][] finiteTypeAsBroaderTypesFunctions() {
-        return new Object[][]{
-                {"testFiniteTypeAsBroaderTypes_1"},
-                {"testFiniteTypeAsBroaderTypes_2"},
-                {"testFiniteTypeAsBroaderTypes_3"},
-                {"testFiniteTypeAsBroaderTypes_4"}
+    public Object[] finiteTypeAsBroaderTypesFunctions() {
+        return new String[]{
+                "testFiniteTypeAsBroaderTypes_1",
+                "testFiniteTypeAsBroaderTypes_2",
+                "testFiniteTypeAsBroaderTypes_3",
+                "testFiniteTypeAsBroaderTypes_4"
         };
     }
 
     @DataProvider(name = "finiteTypeAsBroaderTypesAndFiniteTypeFunctions")
-    public Object[][] finiteTypeAsBroaderTypesAndFiniteTypeFunctions() {
-        return new Object[][]{
-                {"testFiniteTypeAsBroaderTypesAndFiniteType_1"},
-                {"testFiniteTypeAsBroaderTypesAndFiniteType_2"},
-                {"testFiniteTypeAsBroaderTypesAndFiniteType_3"},
-                {"testFiniteTypeAsBroaderTypesAndFiniteType_4"},
-                {"testFiniteTypeInUnionAsComplexFiniteTypes_1"},
-                {"testFiniteTypeInUnionAsComplexFiniteTypes_2"},
-                {"testFiniteTypeInUnionAsComplexFiniteTypes_3"},
-                {"testFiniteTypeInUnionAsComplexFiniteTypes_4"},
-                {"testFiniteTypeInUnionAsComplexFiniteTypes_5"},
-                {"testFiniteTypeInUnionAsComplexFiniteTypes_6"},
-                {"testFiniteTypeInUnionAsComplexFiniteTypes_7"},
-                {"testFiniteTypeAsFiniteTypeWithIntersectionPositive"},
-                {"testFiniteTypeAsBroaderTypeInStructurePositive"}
+    public Object[] finiteTypeAsBroaderTypesAndFiniteTypeFunctions() {
+        return new String[]{
+                "testFiniteTypeAsBroaderTypesAndFiniteType_1",
+                "testFiniteTypeAsBroaderTypesAndFiniteType_2",
+                "testFiniteTypeAsBroaderTypesAndFiniteType_3",
+                "testFiniteTypeAsBroaderTypesAndFiniteType_4",
+                "testFiniteTypeInUnionAsComplexFiniteTypes_1",
+                "testFiniteTypeInUnionAsComplexFiniteTypes_2",
+                "testFiniteTypeInUnionAsComplexFiniteTypes_3",
+                "testFiniteTypeInUnionAsComplexFiniteTypes_4",
+                "testFiniteTypeInUnionAsComplexFiniteTypes_5",
+                "testFiniteTypeInUnionAsComplexFiniteTypes_6",
+                "testFiniteTypeInUnionAsComplexFiniteTypes_7",
+                "testFiniteTypeAsFiniteTypeWithIntersectionPositive",
+                "testFiniteTypeAsBroaderTypeInStructurePositive"
         };
     }
 
@@ -646,71 +646,31 @@ public class TypeGuardTest {
         Assert.assertFalse(((BBoolean) returns[0]).booleanValue());
     }
 
-    @Test
-    public void testNarrowedTypeResetWithMultipleBranches() {
-        BRunUtil.invoke(result, "testNarrowedTypeResetWithMultipleBranches");
-    }
-
-    @Test
-    public void testNarrowedTypeResetWithNestedTypeGuards() {
-        BRunUtil.invoke(result, "testNarrowedTypeResetWithNestedTypeGuards");
-    }
-
-    @Test
-    public void testSameVarNameInDifferentScopes() {
-        BRunUtil.invoke(result, "testSameVarNameInDifferentScopes");
-    }
-
     @Test(description = "Test Typetest for TypeDefs when types are equal")
     public void testTypetestForTypedefs1() {
         BValue[] returns = BRunUtil.invoke(result, "testTypeDescTypeTest1");
-        Assert.assertEquals(BBoolean.TRUE, returns[0]);
+        Assert.assertEquals(returns[0], BBoolean.TRUE);
     }
 
     @Test(description = "Test Typetest for TypeDefs when types are not equal")
     public void testTypetestForTypedefs2() {
         BValue[] returns = BRunUtil.invoke(result, "testTypeDescTypeTest2");
-        Assert.assertEquals(BBoolean.TRUE, returns[0]);
+        Assert.assertEquals(returns[0], BBoolean.TRUE);
     }
 
-    @Test
-    public void testRecordIntersectionWithClosedRecordAndRecordWithOptionalField() {
-        BRunUtil.invoke(result, "testRecordIntersectionWithClosedRecordAndRecordWithOptionalField");
+    @Test(dataProvider = "functionNamesProvider")
+    public void testInvokeFunctions(String funcName) {
+        BRunUtil.invoke(result, funcName);
     }
 
-    @Test
-    public void testRecordIntersectionWithClosedRecordAndRecordWithOptionalField2() {
-        BRunUtil.invoke(result, "testRecordIntersectionWithClosedRecordAndRecordWithOptionalField2");
-    }
-
-    @Test
-    public void testRecordIntersectionWithDefaultValues() {
-        BRunUtil.invoke(result, "testRecordIntersectionWithDefaultValues");
-    }
-
-    @Test
-    public void testClosedRecordAndMapIntersection() {
-        BRunUtil.invoke(result, "testClosedRecordAndMapIntersection");
-    }
-
-    @Test
-    public void testIntersectionReadOnlyness() {
-        BRunUtil.invoke(result, "testIntersectionReadOnlyness");
-    }
-
-    @Test
-    public void testMapIntersection() {
-        BRunUtil.invoke(result, "testMapIntersection");
-    }
-
-    @Test
-    public void testJsonIntersection() {
-        BRunUtil.invoke(result, "testJsonIntersection");
-    }
-
-    @Test
-    public void testIntersectionWithIntersectionType() {
-        BRunUtil.invoke(result, "testIntersectionWithIntersectionType");
+    @DataProvider(name = "functionNamesProvider")
+    public Object[] getFunctionNames() {
+        return new String[]{"testCustomErrorType", "testIntersectionWithIntersectionType", "testJsonIntersection",
+                "testMapIntersection", "testIntersectionReadOnlyness", "testClosedRecordAndMapIntersection",
+                "testRecordIntersectionWithDefaultValues",
+                "testRecordIntersectionWithClosedRecordAndRecordWithOptionalField2",
+                "testRecordIntersectionWithClosedRecordAndRecordWithOptionalField", "testSameVarNameInDifferentScopes",
+                "testNarrowedTypeResetWithNestedTypeGuards", "testNarrowedTypeResetWithMultipleBranches"};
     }
 
     @Test

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/ifelse/type-guard.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/ifelse/type-guard.bal
@@ -15,6 +15,7 @@
 // under the License.
 
 import ballerina/lang.'value;
+import ballerina/test;
 // ========================== Basics ==========================
 
 
@@ -259,6 +260,7 @@ function testComplexTernary_1() returns string {
 
 function testComplexTernary_2() returns string {
     int|string|float|boolean|xml x = "string";
+    if(x is boolean) {return "boolean";}
     if (x is int|string|float|boolean) {
         return x is int ? "int" : (x is float ? "float" : (x is boolean ? "boolean" : x));
     } else {
@@ -929,6 +931,25 @@ function testTypeGuardForCustomErrorPositive() returns [boolean, boolean] {
 
     boolean isGenericError = a1 is error && a2 is error;
     return [isSpecificError, isGenericError];
+}
+function testCustomErrorType() {
+    Details d = { message: "detail message" };
+    MyError|MyErrorTwo e = error MyError(ERR_REASON, message = d.message);
+    if (e is MyErrorTwo) {
+        test:assertFail();
+    }
+    if (e is MyError) {
+    } else {
+        test:assertFail();
+    }
+    MyErrorTwo|MyError e1 = error MyError(ERR_REASON, message = d.message);
+    if (e1 is MyErrorTwo) {
+        test:assertFail();
+    }
+    if (e1 is MyError) {
+    } else {
+        test:assertFail();
+    }
 }
 
 function testTypeGuardForCustomErrorNegative() returns boolean {


### PR DESCRIPTION
## Purpose
> Fix type optimization failing on union of custom error
as in comment https://github.com/ballerina-platform/ballerina-lang/pull/30955#discussion_r652900197

## Approach
> Do not optimize if both types are errors in a union with error.

## Samples
> N/A

## Remarks
> N/A

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
