### PR TITLE
Prevent showing diagnostics with severity `INTERNAL` in CLI/LS

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/CompileTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/CompileTask.java
@@ -79,7 +79,7 @@ public class CompileTask implements Task {
                 BuildTime.getInstance().codeGenDuration = System.currentTimeMillis() - start;
             }
             DiagnosticResult diagnosticResult = jBallerinaBackend.diagnosticResult();
-            diagnosticResult.diagnostics().forEach(d -> err.println(d.toString()));
+            diagnosticResult.diagnostics(false).forEach(d -> err.println(d.toString()));
             if (diagnosticResult.hasErrors()) {
                 throw createLauncherException("compilation contains errors");
             }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/DiagnosticResult.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/DiagnosticResult.java
@@ -111,7 +111,7 @@ public abstract class DiagnosticResult {
 
     private Collection<Diagnostic> getInternalExcluded(Collection<Diagnostic> diagnostics) {
         if (internalExcluded != null) {
-            return hints;
+            return internalExcluded;
         }
 
         internalExcluded = Diagnostics.excludeInternal(diagnostics);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/DiagnosticResult.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/DiagnosticResult.java
@@ -32,13 +32,18 @@ public abstract class DiagnosticResult {
     protected Collection<Diagnostic> errors;
     protected Collection<Diagnostic> warnings;
     protected Collection<Diagnostic> hints;
+    protected Collection<Diagnostic> internalExcluded;
 
     protected DiagnosticResult(Collection<Diagnostic> allDiagnostics) {
         this.allDiagnostics = Collections.unmodifiableCollection(allDiagnostics);
     }
 
     public Collection<Diagnostic> diagnostics() {
-        return allDiagnostics;
+        return diagnostics(true);
+    }
+
+    public Collection<Diagnostic> diagnostics(boolean includeInternal) {
+        return includeInternal ? allDiagnostics : getInternalExcluded(allDiagnostics);
     }
 
     public Collection<Diagnostic> errors() {
@@ -102,5 +107,14 @@ public abstract class DiagnosticResult {
 
         hints = Diagnostics.filterHints(diagnostics);
         return hints;
+    }
+
+    private Collection<Diagnostic> getInternalExcluded(Collection<Diagnostic> diagnostics) {
+        if (internalExcluded != null) {
+            return hints;
+        }
+
+        internalExcluded = Diagnostics.excludeInternal(diagnostics);
+        return internalExcluded;
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Diagnostics.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Diagnostics.java
@@ -21,6 +21,7 @@ import io.ballerina.tools.diagnostics.Diagnostic;
 import io.ballerina.tools.diagnostics.DiagnosticSeverity;
 
 import java.util.Collection;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**
@@ -46,6 +47,11 @@ public class Diagnostics {
         return filterDiagnostics(diagnostics, DiagnosticSeverity.HINT);
     }
 
+    public static Collection<Diagnostic> excludeInternal(Collection<Diagnostic> diagnostics) {
+        return filterDiagnostics(diagnostics,
+                diagnostic -> diagnostic.diagnosticInfo().severity() != DiagnosticSeverity.INTERNAL);
+    }
+
     public static boolean hasWarnings(Collection<Diagnostic> diagnostics) {
         return hasDiagnosticsWithSeverity(diagnostics, DiagnosticSeverity.WARNING);
     }
@@ -56,8 +62,13 @@ public class Diagnostics {
 
     private static Collection<Diagnostic> filterDiagnostics(Collection<Diagnostic> diagnostics,
                                                             DiagnosticSeverity severity) {
+        return filterDiagnostics(diagnostics, diagnostic -> diagnostic.diagnosticInfo().severity() == severity);
+    }
+    
+    private static Collection<Diagnostic> filterDiagnostics(Collection<Diagnostic> diagnostics,
+                                                            Predicate<Diagnostic> predicate) {
         return diagnostics.stream()
-                .filter(diagnostic -> diagnostic.diagnosticInfo().severity() == severity)
+                .filter(predicate)
                 .collect(Collectors.toList());
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/diagnostic/DiagnosticsHelper.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/diagnostic/DiagnosticsHelper.java
@@ -113,7 +113,8 @@ public class DiagnosticsHelper {
             projectRoot = projectRoot.getParent();
         }
         PackageCompilation compilation = workspace.waitAndGetPackageCompilation(context.filePath()).orElseThrow();
-        diagnosticMap.putAll(toDiagnosticsMap(compilation.diagnosticResult().diagnostics(), projectRoot));
+        // We do not send the internal diagnostics
+        diagnosticMap.putAll(toDiagnosticsMap(compilation.diagnosticResult().diagnostics(false), projectRoot));
         return diagnosticMap;
     }
 


### PR DESCRIPTION
## Purpose
$subject
Diagnostics with severity `INTERNAL` are not supposed to be shown in the CLI or LS. This did not came up till now since no one was producing diagnostics with severity `INTERNAL`. However, with https://github.com/ballerina-platform/module-ballerina-http/pull/465 and #30638, we have a requirement for compiler plugins to generate internal diagnostics. This PR addresses that.

This PR also fix a wrong logic used within `CommonUtil.findNode()` method in LS.

Fixes #31231
Fixes #31216

## Approach
Added an overloaded method to `DiagnosticResult` to get the diagnostics while excluding diagnostics of severity `INTERNAL`.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
