### PR TITLE
Support multiple configurable TOML sections to represent module

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/configurable/providers/toml/ModuleInfo.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/configurable/providers/toml/ModuleInfo.java
@@ -32,7 +32,6 @@ import java.util.Set;
 public class ModuleInfo {
     private final Set<String> moduleNames = new HashSet<>();
     private final Set<String> orgNames = new HashSet<>();
-    private final Set<String> subModules = new HashSet<>();
 
     private final Set<Module> moduleSet;
     private boolean hasModuleAmbiguity;
@@ -46,10 +45,6 @@ public class ModuleInfo {
             String rootModuleName = rootModule.getName();
             if (rootModuleName.startsWith(entry.getOrg())) {
                 hasModuleAmbiguity = true;
-            }
-            String moduleName = entry.getName();
-            if (moduleName.startsWith(rootModuleName + ".")) {
-                subModules.add(moduleName.replaceFirst(rootModuleName + ".", "").split("\\.")[0]);
             }
             orgNames.add(entry.getOrg());
             Collections.addAll(moduleNames, entry.getName().split("\\."));
@@ -66,10 +61,6 @@ public class ModuleInfo {
 
     boolean containsModule(String nodeName) {
         return moduleNames.contains(nodeName);
-    }
-
-    boolean containsOnlySubModules(Set<String> nodeSet) {
-        return subModules.containsAll(nodeSet);
     }
 
     Module getModuleFromName(String nodeName) {

--- a/bvm/ballerina-runtime/src/test/java/io/ballerina/runtime/test/config/CliConfigProviderTest.java
+++ b/bvm/ballerina-runtime/src/test/java/io/ballerina/runtime/test/config/CliConfigProviderTest.java
@@ -97,4 +97,22 @@ public class CliConfigProviderTest {
                         PredefinedTypes.TYPE_STRING, StringUtils.fromString("=abc~!@#$%^&*()_+=-210|}{?>\\=<")}
         };
     }
+
+    @Test
+    public void testMultipleArgumentPrefixForModuleConfig() {
+        RuntimeDiagnosticLog diagnosticLog = new RuntimeDiagnosticLog();
+        VariableKey a = new VariableKey(ROOT_MODULE, "a", PredefinedTypes.TYPE_STRING, true);
+        VariableKey b = new VariableKey(ROOT_MODULE, "b", PredefinedTypes.TYPE_STRING, true);
+        VariableKey c = new VariableKey(ROOT_MODULE, "c", PredefinedTypes.TYPE_STRING, true);
+        ConfigResolver configResolver =
+                new ConfigResolver(Map.ofEntries(Map.entry(ROOT_MODULE, new VariableKey[]{a, b, c})), diagnosticLog,
+                        List.of(new CliProvider(ROOT_MODULE,
+                                new String[]{"-Ca=aaa", "-CrootMod.b=bbb", "-CrootOrg.rootMod.c=ccc"})));
+        Map<VariableKey, Object> configValueMap = configResolver.resolveConfigs();
+        Assert.assertEquals(diagnosticLog.getErrorCount(), 0);
+        Assert.assertEquals(diagnosticLog.getWarningCount(), 0);
+        Assert.assertEquals(configValueMap.get(a), StringUtils.fromString("aaa"));
+        Assert.assertEquals(configValueMap.get(b), StringUtils.fromString("bbb"));
+        Assert.assertEquals(configValueMap.get(c), StringUtils.fromString("ccc"));
+    }
 }

--- a/bvm/ballerina-runtime/src/test/java/io/ballerina/runtime/test/config/TomlProviderTest.java
+++ b/bvm/ballerina-runtime/src/test/java/io/ballerina/runtime/test/config/TomlProviderTest.java
@@ -270,6 +270,16 @@ public class TomlProviderTest {
         Module clashingModule4 = new Module("test_module", "util", "1.0.0");
         VariableKey[] clashingVariableKeys4 = getSimpleVariableKeys(clashingModule4);
 
+        VariableKey[] rootVariables = {new VariableKey(ROOT_MODULE, "a", PredefinedTypes.TYPE_STRING, true),
+                new VariableKey(ROOT_MODULE, "b", PredefinedTypes.TYPE_STRING, true),
+                new VariableKey(ROOT_MODULE, "c", PredefinedTypes.TYPE_STRING, true)};
+        VariableKey[] subModuleVariables = {new VariableKey(subModule, "a", PredefinedTypes.TYPE_STRING, true),
+                new VariableKey(subModule, "b", PredefinedTypes.TYPE_STRING, true),
+                new VariableKey(subModule, "c", PredefinedTypes.TYPE_STRING, true)};
+        VariableKey[] importedVariables = {new VariableKey(importedModule, "a", PredefinedTypes.TYPE_STRING, true),
+                new VariableKey(importedModule, "b", PredefinedTypes.TYPE_STRING, true),
+                new VariableKey(importedModule, "c", PredefinedTypes.TYPE_STRING, true)};
+
         Set<Module> moduleSet = Set.of(ROOT_MODULE);
         return new Object[][]{
                 {Map.ofEntries(Map.entry(ROOT_MODULE, rootVariableKeys), Map.entry(subModule, subVariableKeys),
@@ -467,6 +477,59 @@ public class TomlProviderTest {
                                 Map.entry(importedVariableKeys[1], fromString("four"))),
                         List.of(new TomlFileProvider(ROOT_MODULE, getConfigPath("ConfigClashingModule10.toml"),
                                 Set.of(ROOT_MODULE, subModule, clashingModule3)))
+                },
+                {Map.ofEntries(Map.entry(ROOT_MODULE, rootVariables)),
+                        Map.ofEntries(Map.entry(rootVariables[0], fromString("value a")),
+                                Map.entry(rootVariables[1], fromString("value b")),
+                                Map.entry(rootVariables[2], fromString("value c"))),
+                        List.of(new TomlFileProvider(ROOT_MODULE, getConfigPath("DifferentModuleSections_root.toml"),
+                                Set.of(ROOT_MODULE)))
+                },
+                {Map.ofEntries(Map.entry(subModule, subModuleVariables)),
+                        Map.ofEntries(Map.entry(subModuleVariables[0], fromString("value a")),
+                                Map.entry(subModuleVariables[1], fromString("value b")),
+                                Map.entry(subModuleVariables[2], fromString("value c"))),
+                        List.of(new TomlFileProvider(ROOT_MODULE, getConfigPath("DifferentModuleSections_sub.toml"),
+                                Set.of(subModule)))
+                },
+                {Map.ofEntries(Map.entry(importedModule, importedVariables)),
+                        Map.ofEntries(Map.entry(importedVariables[0], fromString("value a")),
+                                Map.entry(importedVariables[1], fromString("value b")),
+                                Map.entry(importedVariables[2], fromString("value c"))),
+                        List.of(new TomlFileProvider(ROOT_MODULE, getConfigPath("DifferentModuleSections_imported" +
+                                ".toml"), Set.of(importedModule)))
+                },
+                {Map.ofEntries(Map.entry(ROOT_MODULE, rootVariables), Map.entry(subModule, subModuleVariables),
+                        Map.entry(importedModule, importedVariables)),
+                        Map.ofEntries(Map.entry(rootVariables[0], fromString("value a")),
+                                Map.entry(rootVariables[1], fromString("value b")),
+                                Map.entry(rootVariables[2], fromString("value c")),
+                                Map.entry(subModuleVariables[0], fromString("value a")),
+                                Map.entry(subModuleVariables[1], fromString("value b")),
+                                Map.entry(subModuleVariables[2], fromString("value c")),
+                                Map.entry(importedVariables[0], fromString("value a")),
+                                Map.entry(importedVariables[1], fromString("value b")),
+                                Map.entry(importedVariables[2], fromString("value c"))),
+                        List.of(new TomlFileProvider(ROOT_MODULE, getConfigPath("DifferentModuleSections.toml"),
+                                Set.of(ROOT_MODULE, subModule, importedModule)))
+                },
+                {Map.ofEntries(Map.entry(ROOT_MODULE, rootVariableKeys),
+                        Map.entry(clashingModule1, clashingVariableKeys1)),
+                        Map.ofEntries(Map.entry(rootVariableKeys[0], 54L),
+                                Map.entry(rootVariableKeys[1], fromString("abc")),
+                                Map.entry(clashingVariableKeys1[0], 32L),
+                                Map.entry(clashingVariableKeys1[1], fromString("pqr"))),
+                        List.of(new TomlFileProvider(ROOT_MODULE, getConfigPath("DifferentModuleSections_clash1.toml"),
+                                Set.of(ROOT_MODULE, clashingModule1)))
+                },
+                {Map.ofEntries(Map.entry(subModule, subVariableKeys),
+                        Map.entry(clashingModule2, clashingVariableKeys2)),
+                        Map.ofEntries(Map.entry(subVariableKeys[0], 12L),
+                                Map.entry(subVariableKeys[1], fromString("apple")),
+                                Map.entry(clashingVariableKeys2[0], 34L),
+                                Map.entry(clashingVariableKeys2[1], fromString("orange"))),
+                        List.of(new TomlFileProvider(ROOT_MODULE, getConfigPath("DifferentModuleSections_clash2.toml"),
+                                Set.of(subModule, clashingModule2)))
                 },
         };
 

--- a/bvm/ballerina-runtime/src/test/resources/config_files/DifferentModuleSections.toml
+++ b/bvm/ballerina-runtime/src/test/resources/config_files/DifferentModuleSections.toml
@@ -1,0 +1,19 @@
+a = "value a"
+
+[test_module]
+b = "value b"
+
+[rootOrg.test_module]
+c = "value c"
+
+[test_module.util.foo]
+a = "value a"
+b = "value b"
+
+[rootOrg.test_module.util.foo]
+c = "value c"
+
+[myOrg.mod12]
+a = "value a"
+b = "value b"
+c = "value c"

--- a/bvm/ballerina-runtime/src/test/resources/config_files/DifferentModuleSections_clash1.toml
+++ b/bvm/ballerina-runtime/src/test/resources/config_files/DifferentModuleSections_clash1.toml
@@ -1,0 +1,9 @@
+[test_module]
+intVar = 54
+
+[rootOrg.test_module]
+stringVar = "abc"
+
+[myOrg.test_module]
+intVar = 32
+stringVar = "pqr"

--- a/bvm/ballerina-runtime/src/test/resources/config_files/DifferentModuleSections_clash2.toml
+++ b/bvm/ballerina-runtime/src/test/resources/config_files/DifferentModuleSections_clash2.toml
@@ -1,0 +1,9 @@
+[rootOrg.test_module.util.foo]
+intVar = 12
+
+[test_module.util.foo]
+stringVar = "apple"
+
+[myOrg.test_module.util.foo]
+intVar = 34
+stringVar = "orange"

--- a/bvm/ballerina-runtime/src/test/resources/config_files/DifferentModuleSections_imported.toml
+++ b/bvm/ballerina-runtime/src/test/resources/config_files/DifferentModuleSections_imported.toml
@@ -1,0 +1,4 @@
+[myOrg.mod12]
+a = "value a"
+b = "value b"
+c = "value c"

--- a/bvm/ballerina-runtime/src/test/resources/config_files/DifferentModuleSections_record.toml
+++ b/bvm/ballerina-runtime/src/test/resources/config_files/DifferentModuleSections_record.toml
@@ -1,0 +1,11 @@
+[person1]
+name = "John"
+age = 12
+
+[test_module.person2]
+name = "Jack"
+age = 14
+
+[rootOrg.test_module.person3]
+name = "Jim"
+age = 16

--- a/bvm/ballerina-runtime/src/test/resources/config_files/DifferentModuleSections_root.toml
+++ b/bvm/ballerina-runtime/src/test/resources/config_files/DifferentModuleSections_root.toml
@@ -1,0 +1,7 @@
+a = "value a"
+
+[test_module]
+b = "value b"
+
+[rootOrg.test_module]
+c = "value c"

--- a/bvm/ballerina-runtime/src/test/resources/config_files/DifferentModuleSections_sub.toml
+++ b/bvm/ballerina-runtime/src/test/resources/config_files/DifferentModuleSections_sub.toml
@@ -1,0 +1,6 @@
+[test_module.util.foo]
+a = "value a"
+b = "value b"
+
+[rootOrg.test_module.util.foo]
+c = "value c"


### PR DESCRIPTION
## Purpose
$subject

Fixes #29989 
Fixes #29996

## Approach
Caching a list of TOML nodes in `moduleNodeMap` instead of a single node to denote a module. 

## Samples
In main.bal from module `test_module` of org `testOrg`, 

```ballerina
configurable string a = ?;
configurable string b = ?;
configurable string c = ?;
```

In Config.toml

```toml
a = "a"

[test_module]
b = "b"

[testOrg.test_module]
c = "c"
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
