### PR TITLE
Fix class cast exception when extern function returns ballerina union type

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCastGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCastGen.java
@@ -709,6 +709,8 @@ public class JvmCastGen {
                 mv.visitLabel(afterHandle);
                 break;
             case JTypeTags.JARRAY:
+                mv.visitMethodInsn(INVOKESTATIC, HANDLE_VALUE, DECIMAL_VALUE_OF_J_METHOD,
+                        String.format("(L%s;)L%s;", OBJECT, HANDLE_VALUE), false);
                 break;
             default:
                 throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'any'",

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/InstanceMethods.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/InstanceMethods.java
@@ -25,6 +25,8 @@ import io.ballerina.runtime.internal.values.BmpStringValue;
 import io.ballerina.runtime.internal.values.HandleValue;
 import io.ballerina.runtime.internal.values.ObjectValue;
 
+import java.nio.charset.StandardCharsets;
+
 /**
  * This class contains a set of utility instance methods required for interoperability testing.
  *
@@ -149,6 +151,22 @@ public class InstanceMethods {
             throw new InterruptedException();
         }
         return "handle ret";
+    }
+
+    public byte[] unionWithErrorReturnByteArray() throws InterruptedException {
+        byte[] byteArray = "Byte Test".getBytes();
+        if (false) {
+            throw new InterruptedException();
+        }
+        return byteArray;
+    }
+
+    public String[] unionWithErrorReturnStringArray() throws InterruptedException {
+        String[] strArray = {"makes", "integration", "easy"};
+        if (false) {
+            throw new InterruptedException();
+        }
+        return strArray;
     }
 
     public void errorDetail() throws JavaInteropTestCheckedException {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/InstanceMethods.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/InstanceMethods.java
@@ -25,8 +25,6 @@ import io.ballerina.runtime.internal.values.BmpStringValue;
 import io.ballerina.runtime.internal.values.HandleValue;
 import io.ballerina.runtime.internal.values.ObjectValue;
 
-import java.nio.charset.StandardCharsets;
-
 /**
  * This class contains a set of utility instance methods required for interoperability testing.
  *

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/InstanceMethods.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/InstanceMethods.java
@@ -159,7 +159,7 @@ public class InstanceMethods {
         return byteArray;
     }
 
-    public String[] unionWithErrorReturnStringArray() throws InterruptedException {
+    public String[] anyOrErrorReturnStringArray() throws InterruptedException {
         String[] strArray = {"makes", "integration", "easy"};
         if (false) {
             throw new InterruptedException();

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/StaticMethods.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/StaticMethods.java
@@ -235,6 +235,15 @@ public class StaticMethods {
         return (int) (a + 5);
     }
 
+    public static int[] acceptIntReturnIntArrayThrowsCheckedException(long a) throws JavaInteropTestCheckedException {
+        int arr[] = {1, 2, 3};
+        if (a == 1) {
+            return arr;
+        } else {
+            throw new JavaInteropTestCheckedException("Invalid state");
+        }
+    }
+
     public static ArrayValue getArrayValueFromMapWhichThrowsCheckedException(BString key, MapValue mapValue)
             throws JavaInteropTestCheckedException {
         ArrayValue arrayValue = (ArrayValue) ValueCreator.createArrayValue(intArrayType);
@@ -658,4 +667,6 @@ public class StaticMethods {
             return null;
         }
     }
+
+
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/RefTypeTests.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/RefTypeTests.java
@@ -323,9 +323,9 @@ public class RefTypeTests {
         Assert.assertTrue(returns instanceof ErrorValue);
         ErrorValue error = (ErrorValue) returns;
         Assert.assertEquals(error.getPrintableStackTrace(), "java.util.EmptyStackException\n" +
-                "\tat ballerina_types_as_interop_types:javaStackPop(ballerina_types_as_interop_types.bal:400)\n" +
+                "\tat ballerina_types_as_interop_types:javaStackPop(ballerina_types_as_interop_types.bal:419)\n" +
                 "\t   ballerina_types_as_interop_types:testThrowJavaException2(ballerina_types_as_interop_types.bal:" +
-                "392)");
+                "411)");
     }
 
     @Test

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/RefTypeTests.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/RefTypeTests.java
@@ -152,6 +152,11 @@ public class RefTypeTests {
         Assert.assertTrue(((BBoolean) returns[0]).booleanValue());
     }
 
+    @Test
+    public void interopWithHandleOrErrorReturn() {
+        BRunUtil.invoke(result, "interopWithHandleOrErrorReturn");
+    }
+
     @Test(description = "Test interoperability with ballerina json return")
     public void testInteropWithJsonReturns() {
         BValue[] returns = BRunUtil.invoke(result, "testJsonReturns");

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/basic/InstanceMethodTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/basic/InstanceMethodTest.java
@@ -276,10 +276,10 @@ public class InstanceMethodTest {
     }
 
     @DataProvider(name = "unionWithErrorTestFunctions")
-    public Object[][] unionWithErrorTestFunctions() {
-        return new Object[][] {
-                { "testUnionWithErrorReturnByteArray" },
-                { "testAnyOrErrorReturnStringArray" }
+    public Object[] unionWithErrorTestFunctions() {
+        return new String[] {
+             "testUnionWithErrorReturnByteArray",
+             "testAnyOrErrorReturnStringArray"
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/basic/InstanceMethodTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/basic/InstanceMethodTest.java
@@ -33,6 +33,7 @@ import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 /**
@@ -265,6 +266,23 @@ public class InstanceMethodTest {
         args[0] = new BHandleValue(testIns);
         BRunUtil.invoke(result, "testGetCurrentModule", args);
     }
+
+    @Test(dataProvider = "unionWithErrorTestFunctions")
+    public void testUnionWithErrorReturnArrays(String function) {
+        InstanceMethods testIns = new InstanceMethods();
+        BValue[] args = new BValue[1];
+        args[0] = new BHandleValue(testIns);
+        BRunUtil.invoke(result, function, args);
+    }
+
+    @DataProvider(name = "unionWithErrorTestFunctions")
+    public Object[][] unionWithErrorTestFunctions() {
+        return new Object[][] {
+                { "testUnionWithErrorReturnByteArray" },
+                { "testUnionWithErrorReturnByteArray" }
+        };
+    }
+
 
     @AfterClass
     public void tearDown() {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/basic/InstanceMethodTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/basic/InstanceMethodTest.java
@@ -279,7 +279,7 @@ public class InstanceMethodTest {
     public Object[][] unionWithErrorTestFunctions() {
         return new Object[][] {
                 { "testUnionWithErrorReturnByteArray" },
-                { "testUnionWithErrorReturnByteArray" }
+                { "testAnyOrErrorReturnStringArray" }
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/ballerina_types_as_interop_types.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/ballerina_types_as_interop_types.bal
@@ -1,4 +1,5 @@
 import ballerina/jballerina.java;
+import ballerina/test;
 
 public function interopWithArrayAndMap() returns int[] {
     map<int> mapVal = { "keyVal":8};
@@ -160,12 +161,30 @@ public function interopWithAnydataReturn() returns boolean {
     return true;
 }
 
+public function interopWithHandleOrErrorReturn() {
+    handle|error handleOrError = acceptIntReturnIntArrayThrowsCheckedException(1);
+    test:assertEquals(handleOrError is error, false);
+    test:assertEquals(handleOrError is handle, true);
+
+    handleOrError = acceptIntReturnIntArrayThrowsCheckedException(5);
+    test:assertEquals(handleOrError is error, true);
+    error err = <error> handleOrError;
+    var message = err.detail()["message"];
+    string messageString = message is error ? message.toString() : message.toString();
+    test:assertEquals(err.message(), "org.ballerinalang.nativeimpl.jvm.tests.JavaInteropTestCheckedException");
+    test:assertEquals(messageString, "Invalid state");
+}
+
 public function acceptIntAnydataReturn(int s) returns anydata= @java:Method {
     'class:"org/ballerinalang/nativeimpl/jvm/tests/StaticMethods",
     name:"acceptIntUnionReturn"
 } external;
 
 public function acceptIntReturnIntThrowsCheckedException(int a) returns int | error = @java:Method {
+    'class:"org/ballerinalang/nativeimpl/jvm/tests/StaticMethods"
+} external;
+
+public function acceptIntReturnIntArrayThrowsCheckedException(int a) returns handle|error = @java:Method {
     'class:"org/ballerinalang/nativeimpl/jvm/tests/StaticMethods"
 } external;
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/instance_method_tests.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/instance_method_tests.bal
@@ -15,6 +15,7 @@
 // under the License.
 
 import ballerina/jballerina.java;
+import ballerina/test;
 
 function testAcceptNothingAndReturnNothing(handle receiver) {
     increaseCounterByOne(receiver);
@@ -78,6 +79,18 @@ function testUnionWithErrorReturnThrows(handle receiver) returns error|int|boole
 
 function testUnionWithErrorReturnHandle(handle receiver) returns error|int|boolean|byte|handle {
      return unionWithErrorReturnHandle(receiver);
+}
+
+function testUnionWithErrorReturnByteArray(handle receiver) {
+    handle|error handleOrError = unionWithErrorReturnByteArray(receiver);
+    test:assertEquals(handleOrError is handle, true);
+    test:assertEquals(handleOrError is error, false);
+}
+
+function testUnionWithErrorReturnStringArray(handle receiver) {
+    any|error anyOrError = unionWithErrorReturnStringArray(receiver);
+    test:assertEquals(anyOrError is any, true);
+    test:assertEquals(anyOrError is error, false);
 }
 
 function testInstanceResolve() {
@@ -179,6 +192,14 @@ public function unionWithErrorReturnThrows(handle receiver) returns error|int|bo
 } external;
 
 public function unionWithErrorReturnHandle(handle receiver) returns error|int|boolean|byte|handle = @java:Method{
+    'class:"org/ballerinalang/nativeimpl/jvm/tests/InstanceMethods"
+} external;
+
+public function unionWithErrorReturnByteArray(handle receiver) returns handle|error = @java:Method{
+    'class:"org/ballerinalang/nativeimpl/jvm/tests/InstanceMethods"
+} external;
+
+public function unionWithErrorReturnStringArray(handle receiver) returns any|error = @java:Method{
     'class:"org/ballerinalang/nativeimpl/jvm/tests/InstanceMethods"
 } external;
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/instance_method_tests.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/instance_method_tests.bal
@@ -87,8 +87,8 @@ function testUnionWithErrorReturnByteArray(handle receiver) {
     test:assertEquals(handleOrError is error, false);
 }
 
-function testUnionWithErrorReturnStringArray(handle receiver) {
-    any|error anyOrError = unionWithErrorReturnStringArray(receiver);
+function testAnyOrErrorReturnStringArray(handle receiver) {
+    any|error anyOrError = anyOrErrorReturnStringArray(receiver);
     test:assertEquals(anyOrError is any, true);
     test:assertEquals(anyOrError is error, false);
 }
@@ -199,7 +199,7 @@ public function unionWithErrorReturnByteArray(handle receiver) returns handle|er
     'class:"org/ballerinalang/nativeimpl/jvm/tests/InstanceMethods"
 } external;
 
-public function unionWithErrorReturnStringArray(handle receiver) returns any|error = @java:Method{
+public function anyOrErrorReturnStringArray(handle receiver) returns any|error = @java:Method{
     'class:"org/ballerinalang/nativeimpl/jvm/tests/InstanceMethods"
 } external;
 


### PR DESCRIPTION
## Purpose
> This PR will fixes the class cast exception occurred while extern function returns ballerina union type and the Java program returns an array when using interop feature.

Fixes #30949

## Approach

## Samples

## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
