### PR TITLE
Wrap on fail clause's content within a statement expression

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -2026,7 +2026,9 @@ public class BIRGen extends BLangNodeVisitor {
         BIRBasicBlock nextBB = new BIRBasicBlock(this.env.nextBBId(names));
         addToTrapStack(nextBB);
         env.enclBasicBlocks.add(nextBB);
-        this.env.enclBB.terminator = new BIRTerminator.GOTO(trapExpr.pos, nextBB);
+        if (this.env.enclBB.terminator == null) {
+            this.env.enclBB.terminator = new BIRTerminator.GOTO(trapExpr.pos, nextBB);
+        }
 
         env.enclFunc.errorTable.add(new BIRNode.BIRErrorEntry(trappedBlocks.get(0),
                 trappedBlocks.get(trappedBlocks.size() - 1), env.targetOperand, nextBB));

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -1130,7 +1130,9 @@ public class BIRGen extends BLangNodeVisitor {
         // Visit condition expression
         this.env.enclBB = onFailBB;
         failNode.exprStmt.accept(this);
-        this.env.enclBB.terminator = new BIRTerminator.GOTO(failNode.pos, this.env.enclOnFailEndBB);
+        if (this.env.enclBB.terminator == null) {
+            this.env.enclBB.terminator = new BIRTerminator.GOTO(failNode.pos, this.env.enclOnFailEndBB);
+        }
 
         // Statements after fail expression are unreachable, hence ignored
         BIRBasicBlock ignoreBlock = new BIRBasicBlock(this.env.nextBBId(names));

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -5317,7 +5317,7 @@ public class Desugar extends BLangNodeVisitor {
                 trxOnFailError);
         trxOnFailClause.body.scope.define(trxOnFailErrorSym.name, trxOnFailErrorSym);
 
-        // if (($trxError$ is error) && !($trxError$ is TransactionError) && transctional) {
+        // if (($trxError$ is error) && !($trxError$ is TransactionError) && transactional) {
         //     $shouldCleanUp$ = true;
         //     check panic rollback $trxError$;
         // }
@@ -5445,7 +5445,8 @@ public class Desugar extends BLangNodeVisitor {
             //                                  <Transaction Body>
             //                                 }
             //      if($trapResult$ is error) {
-            //          panic $trapResult$;
+            //          $shouldPanic$ = true;
+            //          error $trxError$ = <error> $trapResult$;
             //      }
             //      if ($shouldCleanUp$) {
             //          cleanupTransactionContext(1);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -4988,8 +4988,7 @@ public class Desugar extends BLangNodeVisitor {
     private BLangFail createOnFailInvocation(BLangOnFailClause onFailClause, BLangFail fail) {
         BLangBlockStmt onFailBody = ASTBuilderUtil.createBlockStmt(onFailClause.pos);
         onFailBody.stmts.addAll(onFailClause.body.stmts);
-        onFailBody.scope = onFailClause.body.scope;
-        onFailBody.mapSymbol = onFailClause.body.mapSymbol;
+        env.scope.entries.putAll(onFailClause.body.scope.entries);
         onFailBody.failureBreakMode = onFailClause.body.failureBreakMode;
 
         BVarSymbol onFailErrorVariableSymbol =
@@ -4998,7 +4997,7 @@ public class Desugar extends BLangNodeVisitor {
                 onFailErrorVariableSymbol.name.value, onFailErrorVariableSymbol.type, rewrite(fail.expr, env),
                 onFailErrorVariableSymbol);
         BLangSimpleVariableDef errorVarDef = ASTBuilderUtil.createVariableDef(onFailClause.pos, errorVar);
-        onFailBody.scope.define(onFailErrorVariableSymbol.name, onFailErrorVariableSymbol);
+        env.scope.define(onFailErrorVariableSymbol.name, onFailErrorVariableSymbol);
         onFailBody.stmts.add(0, errorVarDef);
 
         if (onFailClause.isInternal && fail.exprStmt != null) {
@@ -5317,7 +5316,7 @@ public class Desugar extends BLangNodeVisitor {
                 trxOnFailError);
         trxOnFailClause.body.scope.define(trxOnFailErrorSym.name, trxOnFailErrorSym);
 
-        // if (($trxError$ is error) && !($trxError$ is TransactionError) && transactional) {
+        // if (($trxError$ is error) && !($trxError$ is TransactionError) && transctional) {
         //     $shouldCleanUp$ = true;
         //     check panic rollback $trxError$;
         // }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -606,8 +606,6 @@ public class CodeAnalyzer extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangTransaction transactionNode) {
-        boolean prevLoopAlterNotAllowed = loopAlterNotAllowed;
-        loopAlterNotAllowed = true;
         this.checkStatementExecutionValidity(transactionNode);
         //Check whether transaction statement occurred in a transactional scope
         if (!transactionalFuncCheckStack.empty() && transactionalFuncCheckStack.peek()) {
@@ -652,19 +650,15 @@ public class CodeAnalyzer extends BLangNodeVisitor {
         this.doneWithinTransactionCheckStack.pop();
         analyzeOnFailClause(transactionNode.onFailClause);
         this.errorTypes.pop();
-        this.loopAlterNotAllowed = prevLoopAlterNotAllowed;
     }
 
     private void analyzeOnFailClause(BLangOnFailClause onFailClause) {
         if (onFailClause != null) {
-            boolean prevLoopAlterNotAllowed = loopAlterNotAllowed;
-            loopAlterNotAllowed = true;
             boolean currentStatementReturns = this.statementReturns;
             this.resetStatementReturns();
             this.resetLastStatement();
             analyzeNode(onFailClause, env);
             this.statementReturns = currentStatementReturns;
-            loopAlterNotAllowed = prevLoopAlterNotAllowed;
         }
     }
 
@@ -2275,8 +2269,6 @@ public class CodeAnalyzer extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangForeach foreach) {
-        boolean prevLoopAlterNotAllowed = loopAlterNotAllowed;
-        loopAlterNotAllowed = false;
         this.loopWithinTransactionCheckStack.push(true);
         this.errorTypes.push(new LinkedHashSet<>());
         boolean statementReturns = this.statementReturns;
@@ -2297,13 +2289,10 @@ public class CodeAnalyzer extends BLangNodeVisitor {
                 BLangBlockStmt.FailureBreakMode.BREAK_TO_OUTER_BLOCK : BLangBlockStmt.FailureBreakMode.NOT_BREAKABLE;
         analyzeOnFailClause(foreach.onFailClause);
         this.errorTypes.pop();
-        loopAlterNotAllowed = prevLoopAlterNotAllowed;
     }
 
     @Override
     public void visit(BLangWhile whileNode) {
-        boolean prevLoopAlterNotAllowed = loopAlterNotAllowed;
-        loopAlterNotAllowed = false;
         this.loopWithinTransactionCheckStack.push(true);
         this.errorTypes.push(new LinkedHashSet<>());
         boolean statementReturns = this.statementReturns;
@@ -2322,7 +2311,6 @@ public class CodeAnalyzer extends BLangNodeVisitor {
         analyzeExpr(whileNode.expr);
         analyzeOnFailClause(whileNode.onFailClause);
         this.errorTypes.pop();
-        this.loopAlterNotAllowed = prevLoopAlterNotAllowed;
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -304,7 +304,6 @@ public class CodeAnalyzer extends BLangNodeVisitor {
     private Stack<Boolean> returnWithinTransactionCheckStack = new Stack<>();
     private Stack<Boolean> doneWithinTransactionCheckStack = new Stack<>();
     private Stack<Boolean> transactionalFuncCheckStack = new Stack<>();
-    private Stack<Boolean> returnWithinLambdaWrappingCheckStack = new Stack<>();
     private BLangNode parent;
     private Names names;
     private SymbolEnv env;
@@ -790,10 +789,6 @@ public class CodeAnalyzer extends BLangNodeVisitor {
         if (checkReturnValidityInTransaction()) {
             this.dlog.error(returnStmt.pos, DiagnosticErrorCode.RETURN_CANNOT_BE_USED_TO_EXIT_TRANSACTION);
             return;
-        }
-        if (!this.returnWithinLambdaWrappingCheckStack.empty()) {
-            this.returnWithinLambdaWrappingCheckStack.pop();
-            this.returnWithinLambdaWrappingCheckStack.push(true);
         }
 
         this.statementReturns = true;
@@ -3897,7 +3892,6 @@ public class CodeAnalyzer extends BLangNodeVisitor {
         this.failVisited = false;
         this.resetLastStatement();
         this.resetErrorThrown();
-        this.returnWithinLambdaWrappingCheckStack.push(false);
         BLangVariable onFailVarNode = (BLangVariable) onFailClause.variableDefinitionNode.getVariable();
         for (BType errorType : errorTypes.peek()) {
             if (!types.isAssignable(errorType, onFailVarNode.getBType())) {
@@ -3907,8 +3901,6 @@ public class CodeAnalyzer extends BLangNodeVisitor {
         }
         analyzeNode(onFailClause.body, env);
         onFailClause.bodyContainsFail = this.failVisited;
-        onFailClause.statementBlockReturns = this.returnWithinLambdaWrappingCheckStack.peek();
-        this.returnWithinLambdaWrappingCheckStack.pop();
         this.resetErrorThrown();
         this.failVisited = currentFailVisited;
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -5588,30 +5588,6 @@ public class TypeChecker extends BLangNodeVisitor {
                 ((BLangFunction) encInvokable).closureVarSymbols.add(new ClosureVarSymbol(resolvedSymbol, pos));
             }
         }
-
-        // Iterate through parent nodes until a function node is met to find if the variable is used inside
-        // a transaction block to mark it as a closure, blocks inside transactions are desugared into functions later.
-        BLangNode node = env.node;
-        SymbolEnv cEnv = env;
-        while (node != null && node.getKind() != NodeKind.FUNCTION) {
-            if (node.getKind() == NodeKind.ON_FAIL) {
-                BLangOnFailClause onFailClause = (BLangOnFailClause) node;
-                SymbolEnv encInvokableEnv = findEnclosingInvokableEnv(env, encInvokable);
-                BSymbol resolvedSymbol = symResolver.lookupClosureVarSymbol(encInvokableEnv, symbol.name,
-                        SymTag.VARIABLE);
-                if (resolvedSymbol != symTable.notFoundSymbol && !resolvedSymbol.closure) {
-                    onFailClause.possibleClosureSymbols.add(resolvedSymbol);
-                }
-                break;
-            } else {
-                SymbolEnv enclEnv = cEnv.enclEnv;
-                if (enclEnv == null) {
-                    break;
-                }
-                cEnv = enclEnv;
-                node = cEnv.node;
-            }
-        }
     }
 
     private boolean isNotFunction(BSymbol funcSymbol) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/clauses/BLangOnFailClause.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/clauses/BLangOnFailClause.java
@@ -41,10 +41,8 @@ public class BLangOnFailClause extends BLangNode implements OnFailClauseNode {
     public VariableDefinitionNode variableDefinitionNode;
     public BType varType;
     public boolean isDeclaredWithVar;
-    public boolean statementBlockReturns;
     public boolean bodyContainsFail;
     public boolean isInternal;
-    public Set<BSymbol> possibleClosureSymbols = new HashSet<>();
 
     public BLangOnFailClause() {
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/clauses/BLangOnFailClause.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/clauses/BLangOnFailClause.java
@@ -21,14 +21,10 @@ import org.ballerinalang.model.clauses.OnFailClauseNode;
 import org.ballerinalang.model.tree.NodeKind;
 import org.ballerinalang.model.tree.statements.BlockStatementNode;
 import org.ballerinalang.model.tree.statements.VariableDefinitionNode;
-import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.tree.BLangNode;
 import org.wso2.ballerinalang.compiler.tree.BLangNodeVisitor;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangBlockStmt;
-
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * Implementation of "on-fail" clause statement.

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,9 +2,9 @@ org.gradle.caching=true
 org.gradle.parallel=true
 org.gradle.jvmargs='-Dfile.encoding=UTF-8'
 org.gradle.workers.max=3
-version=2.0.0-beta.3-SNAPSHOT
+version=2.0.0-beta.2-SNAPSHOT
 group=org.ballerinalang
 bootstrappedOn=1.1.0-alpha
-shortVersion=slbeta3
-versionDisplayText=Beta 3
+shortVersion=slbeta2
+versionDisplayText=Beta 2
 specVersion=2021R1

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/onfail/OnFailClauseTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/onfail/OnFailClauseTest.java
@@ -60,11 +60,9 @@ public class OnFailClauseTest {
         CompileResult negativeResult = BCompileUtil.compile(
                 "test-src/statements/onfail/on-fail-clause-negative-v2.bal");
 
-        Assert.assertEquals(negativeResult.getErrorCount(), 4);
+        Assert.assertEquals(negativeResult.getErrorCount(), 2);
         BAssertUtil.validateError(negativeResult, 0, "unreachable code", 21, 9);
         BAssertUtil.validateError(negativeResult, 1, "unreachable code", 23, 5);
-        BAssertUtil.validateError(negativeResult, 2, "continue not allowed here", 32, 13);
-        BAssertUtil.validateError(negativeResult, 3, "break not allowed here", 39, 13);
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/onfail/on-fail-clause-negative-v2.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/onfail/on-fail-clause-negative-v2.bal
@@ -23,24 +23,6 @@ function testQuery() returns error?{
     i = 7;
 }
 
-function loopAlterNotAllowed() {
-    int[] arr = [1, 2, 3];
-    foreach var item in arr {
-        do {
-            fail error("");
-        } on fail error varName {
-            continue;
-        }
-    }
-
-   foreach var item in arr {
-        transaction {
-            error? er =  commit;
-            break;
-        }
-   }
-}
-
 function getError() returns error {
     error err = error("Custom Error");
     return err;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/onfail/on-fail-clause.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/onfail/on-fail-clause.bal
@@ -27,7 +27,9 @@ function testOnFailEdgeTestcases() {
     testBreakWithinOnfail();
     assertEquality(" -> Before error thrown,  -> Error caught at level #1 -> Error caught at levet #2",
     testReturnWithinOnfail());
+    assertEquality(1, testIntReturnWithinOnfail());
     testBreakWithinOnfailForOuterLoop();
+    assertEquality(44, testLambdaFunctionWithOnFail());
 }
 
 function testUnreachableCodeWithIf(){
@@ -284,6 +286,21 @@ function testReturnWithinOnfail() returns string {
     return "should not reach here";
 }
 
+function testIntReturnWithinOnfail() returns int {
+    int i = 1;
+    while (i < 2) {
+        do {
+            fail getError();
+        } on fail error e {
+            fail getError();
+        }
+        i = i + 1;
+    } on fail error e {
+        return i;
+    }
+    return 0;
+}
+
 function testBreakWithinOnfailForOuterLoop() {
     string str = "";
     foreach int digit in 1...5 {
@@ -298,6 +315,24 @@ function testBreakWithinOnfailForOuterLoop() {
         str += "Looping with digit: " + digit.toString() + " ";
     }
     assertEquality("Looping with digit: 1 Looping with digit: 2 Looping with digit: 3 Loop broke with digit: 4", str);
+}
+
+function testLambdaFunctionWithOnFail() returns int {
+    var lambdaFunc = function () returns int {
+          int a = 10;
+          int b = 11;
+          int c = 0;
+          do {
+              error err = error("custom error", message = "error value");
+              c = a + b;
+              fail err;
+          } on fail error e {
+              function (int, int) returns int arrow = (x, y) => x + y + a + b + c;
+              a = arrow(1, 1);
+          }
+          return a;
+    };
+    return lambdaFunc();
 }
 
 function getCheckError()  returns int|error {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/onfail/on-fail-clause.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/onfail/on-fail-clause.bal
@@ -303,18 +303,22 @@ function testIntReturnWithinOnfail() returns int {
 
 function testBreakWithinOnfailForOuterLoop() {
     string str = "";
-    foreach int digit in 1...5 {
+    foreach int digit in 1 ... 5 {
         do {
-            if (digit > 3) {
-                fail getError();
-            }
+            fail getError();
         } on fail error e {
-            str += "Loop broke with digit: " + digit.toString();
-            break;
+            if (digit < 4) {
+                str += "Loop continued with digit: " + digit.toString() + " ->";
+                continue;
+            } else {
+                str += "Loop broke with digit: " + digit.toString();
+                break;
+            }
         }
-        str += "Looping with digit: " + digit.toString() + " ";
+        str += "-> should not reach here!";
     }
-    assertEquality("Looping with digit: 1 Looping with digit: 2 Looping with digit: 3 Loop broke with digit: 4", str);
+    assertEquality("Loop continued with digit: 1 ->Loop continued with digit: 2 ->Loop continued with digit: 3 " +
+    "->Loop broke with digit: 4", str);
 }
 
 function testLambdaFunctionWithOnFail() returns int {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/onfail/on-fail-clause.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/onfail/on-fail-clause.bal
@@ -25,6 +25,9 @@ function testOnFailEdgeTestcases() {
     testFailPassWithinOnFail();
     testTypeNarrowingInsideOnfail();
     testBreakWithinOnfail();
+    assertEquality(" -> Before error thrown,  -> Error caught at level #1 -> Error caught at levet #2",
+    testReturnWithinOnfail());
+    testBreakWithinOnfailForOuterLoop();
 }
 
 function testUnreachableCodeWithIf(){
@@ -260,6 +263,41 @@ function testBreakWithinOnfail() {
     }
 
     assertEquality("-> Before error thrown -> Error caught! Loop broke with digit: 1", str);
+}
+
+function testReturnWithinOnfail() returns string {
+    int i = 0;
+    string str = "";
+    while (i < 2) {
+        do {
+            str += " -> Before error thrown, ";
+            fail getError();
+        } on fail error e {
+            str += " -> Error caught at level #1";
+            fail getError();
+        }
+        i = i + 1;
+    } on fail error e {
+        str += " -> Error caught at levet #2";
+        return str;
+    }
+    return "should not reach here";
+}
+
+function testBreakWithinOnfailForOuterLoop() {
+    string str = "";
+    foreach int digit in 1...5 {
+        do {
+            if (digit > 3) {
+                fail getError();
+            }
+        } on fail error e {
+            str += "Loop broke with digit: " + digit.toString();
+            break;
+        }
+        str += "Looping with digit: " + digit.toString() + " ";
+    }
+    assertEquality("Looping with digit: 1 Looping with digit: 2 Looping with digit: 3 Loop broke with digit: 4", str);
 }
 
 function getCheckError()  returns int|error {


### PR DESCRIPTION
## Purpose
> When onfail body is wrapped within a lambda function, limitations arose while jumping to different basic blocks across different functions. This is because each function is visited separately at the BIR.
This lead us to restrict the usage of statements that changed the flow of control across blocks such as break and continue within onfail/transaction.

Fixes #31246

## Approach
> Wrap the on-fail body within a statement expression and use it while desugaring the fail statement. The scope entires are populated to the fail statement's enclosing scope.
> As we can have break/continue statements within onfail/transaction bodies, at BIR generation the terminator for specific statements such as traps should only be set only if the terminator is not already set.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
