### PR TITLE
Fix compiler crash for self referring record in configurable variables

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -887,7 +887,7 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
 
     private boolean isSupportedConfigType(BType type, List<String> errors, String varName,
                                           Set<BType> unresolvedTypes) {
-        if (!unresolvedTypes.add(type) && isRecordType(type)) {
+        if (!unresolvedTypes.add(type)) {
             return true;
         }
         switch (type.getKind()) {
@@ -949,17 +949,6 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
                         types.isAssignable(type, symTable.xmlType);
         }
         return true;
-    }
-
-    private boolean isRecordType(BType type) {
-        switch (type.tag) {
-            case TypeTags.RECORD:
-                return true;
-            case TypeTags.INTERSECTION:
-                return isRecordType(((BIntersectionType) type).effectiveType);
-            default:
-                return false;
-        }
     }
 
     private void analyzeTypeNode(BLangType typeNode, SymbolEnv env) {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/globalvar/GlobalVarNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/globalvar/GlobalVarNegativeTest.java
@@ -101,8 +101,7 @@ public class GlobalVarNegativeTest {
                 "record field type '(json & readonly)' of field 'person1.jsonField' is not supported", 71, 1);
         BAssertUtil.validateError(result, i++, "configurable variable currently not supported for '(Person2 & " +
                 "readonly)'\n\t" +
-                "union member type '(json & readonly)' is not supported\n\t" +
-                "record field type '(json & readonly)' of field 'person2.jsonField' is not supported", 72, 1);
+                "union member type '(json & readonly)' is not supported", 72, 1);
         BAssertUtil.validateError(result, i++, "configurable variable currently not supported for '(Person3 & " +
                 "readonly)'\n\t" +
                 "array element type 'json & readonly' is not supported", 73, 1);

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/variabledef/configurable_var_positive.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/variabledef/configurable_var_positive.bal
@@ -55,3 +55,7 @@ type Parent record {|
 |};
 
 configurable Parent p = ?;
+
+type CyclicUnion int|CyclicUnion[];
+
+configurable CyclicUnion unionVar = ?;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/variabledef/configurable_var_positive.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/variabledef/configurable_var_positive.bal
@@ -48,3 +48,10 @@ type ClientConfiguration record {|
 |};
 
 configurable table<ClientConfiguration> tableVar = ?;
+
+type Parent record {|
+    string name;
+    Parent child?;
+|};
+
+configurable Parent p = ?;


### PR DESCRIPTION
## Purpose
$subject

Fixes #31295 

## Approach
adding `unresolvedTypes` check to the recursive method

## Samples
```ballerina
type Person record {|
    string name;
    Person child?;
|};

configurable Person p = ?; 
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
