### PR TITLE
Enable `never` variable `ExpressionEvaluationTest`

### DIFF
--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/evaluation/ExpressionEvaluationTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/evaluation/ExpressionEvaluationTest.java
@@ -159,9 +159,8 @@ public class ExpressionEvaluationTest extends ExpressionEvaluationBaseTest {
         debugTestRunner.assertExpression(context, TABLE_VAR, "table<Employee> (entries = 3)", "table");
         // stream variable test
         debugTestRunner.assertExpression(context, STREAM_VAR, "stream<int, error>", "stream");
-        // TODO - Need to enable
         // never variable test
-        // debugTestRunner.assertExpression(context, NEVER_VAR, "XMLSequence (size = 0)", "xml");
+        debugTestRunner.assertExpression(context, NEVER_VAR, "XMLSequence (size = 0)", "xml");
         // json variable test
         debugTestRunner.assertExpression(context, JSON_VAR, "map<json> (size = 2)", "json");
         // anonymous object variable test (AnonPerson object)


### PR DESCRIPTION
## Purpose
This PR will enable `never` variable `ExpressionEvaluationTest`

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/31039

