### PR TITLE
Fix incorrect results with int and string subtypes type test expression

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/TypeTags.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/TypeTags.java
@@ -32,21 +32,21 @@ public class TypeTags {
     public static final int BOOLEAN_TAG = STRING_TAG + 1;
 
     // subtypes of int & string
-    public static final int SIGNED32_INT_TAG = BOOLEAN_TAG + 1;
-    public static final int SIGNED16_INT_TAG = SIGNED32_INT_TAG + 1;
-    public static final int SIGNED8_INT_TAG = SIGNED16_INT_TAG + 1;
-    public static final int UNSIGNED32_INT_TAG = SIGNED8_INT_TAG + 1;
-    public static final int UNSIGNED16_INT_TAG = UNSIGNED32_INT_TAG + 1;
-    public static final int UNSIGNED8_INT_TAG = UNSIGNED16_INT_TAG + 1;
-    public static final int CHAR_STRING_TAG = UNSIGNED8_INT_TAG + 1;
+    public static final int SIGNED8_INT_TAG = BOOLEAN_TAG + 1;
+    public static final int UNSIGNED8_INT_TAG = SIGNED8_INT_TAG + 1;
+    public static final int SIGNED16_INT_TAG = UNSIGNED8_INT_TAG + 1;
+    public static final int UNSIGNED16_INT_TAG = SIGNED16_INT_TAG + 1;
+    public static final int SIGNED32_INT_TAG = UNSIGNED16_INT_TAG+ 1;
+    public static final int UNSIGNED32_INT_TAG = SIGNED32_INT_TAG + 1;
+    public static final int CHAR_STRING_TAG = UNSIGNED32_INT_TAG + 1;
 
-    public static final int JSON_TAG = CHAR_STRING_TAG + 1;
+    public static final int NULL_TAG = CHAR_STRING_TAG + 1;
+    public static final int JSON_TAG = NULL_TAG + 1;
     public static final int XML_TAG = JSON_TAG + 1;
     public static final int TABLE_TAG = XML_TAG + 1;
-    public static final int NULL_TAG = TABLE_TAG + 1;
 
     // subtypes of Xml & ()
-    public static final int XML_ELEMENT_TAG = NULL_TAG + 1;
+    public static final int XML_ELEMENT_TAG = TABLE_TAG + 1;
     public static final int XML_PI_TAG = XML_ELEMENT_TAG + 1;
     public static final int XML_COMMENT_TAG = XML_PI_TAG + 1;
     public static final int XML_TEXT_TAG = XML_COMMENT_TAG + 1;

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/TypeTags.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/TypeTags.java
@@ -36,7 +36,7 @@ public class TypeTags {
     public static final int UNSIGNED8_INT_TAG = SIGNED8_INT_TAG + 1;
     public static final int SIGNED16_INT_TAG = UNSIGNED8_INT_TAG + 1;
     public static final int UNSIGNED16_INT_TAG = SIGNED16_INT_TAG + 1;
-    public static final int SIGNED32_INT_TAG = UNSIGNED16_INT_TAG+ 1;
+    public static final int SIGNED32_INT_TAG = UNSIGNED16_INT_TAG + 1;
     public static final int UNSIGNED32_INT_TAG = SIGNED32_INT_TAG + 1;
     public static final int CHAR_STRING_TAG = UNSIGNED32_INT_TAG + 1;
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/utils/StringUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/utils/StringUtils.java
@@ -175,7 +175,7 @@ public class StringUtils {
             return ((BString) value).getValue();
         }
 
-        if (type.getTag() < TypeTags.JSON_TAG) {
+        if (type.getTag() < TypeTags.NULL_TAG) {
             return String.valueOf(value);
         }
 
@@ -246,7 +246,7 @@ public class StringUtils {
             }
         }
 
-        if (type.getTag() < TypeTags.JSON_TAG) {
+        if (type.getTag() < TypeTags.NULL_TAG) {
             return String.valueOf(value);
         }
 
@@ -360,7 +360,7 @@ public class StringUtils {
         if (type.getTag() == TypeTags.STRING_TAG) {
             return stringToJson((BString) value);
         }
-        if (type.getTag() < TypeTags.JSON_TAG) {
+        if (type.getTag() < TypeTags.NULL_TAG) {
             return String.valueOf(value);
         }
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -599,6 +599,11 @@ public class TypeChecker {
             return isUnionTypeMatch((BUnionType) sourceType, targetType, unresolvedTypes);
         }
 
+        if (sourceTypeTag == TypeTags.FINITE_TYPE_TAG &&
+                (targetTypeTag <= TypeTags.NULL_TAG || targetTypeTag == TypeTags.XML_TEXT_TAG)) {
+            return isFiniteTypeMatch((BFiniteType) sourceType, targetType);
+        }
+
         switch (targetTypeTag) {
             case TypeTags.BYTE_TAG:
             case TypeTags.SIGNED8_INT_TAG:
@@ -608,51 +613,27 @@ public class TypeChecker {
             case TypeTags.CHAR_STRING_TAG:
             case TypeTags.BOOLEAN_TAG:
             case TypeTags.NULL_TAG:
-                if (sourceTypeTag == TypeTags.FINITE_TYPE_TAG) {
-                    return isFiniteTypeMatch((BFiniteType) sourceType, targetType);
-                }
                 return sourceTypeTag == targetTypeTag;
             case TypeTags.STRING_TAG:
-                if (sourceTypeTag == TypeTags.FINITE_TYPE_TAG) {
-                    return isFiniteTypeMatch((BFiniteType) sourceType, targetType);
-                }
                 return TypeTags.isStringTypeTag(sourceTypeTag);
             case TypeTags.XML_TEXT_TAG:
-                if (sourceTypeTag == TypeTags.FINITE_TYPE_TAG) {
-                    return isFiniteTypeMatch((BFiniteType) sourceType, targetType);
-                }
                 if (sourceTypeTag == TypeTags.XML_TAG) {
                     return ((BXmlType) sourceType).constraint.getTag() == TypeTags.NEVER_TAG;
                 }
                 return sourceTypeTag == targetTypeTag;
             case TypeTags.INT_TAG:
-                if (sourceTypeTag == TypeTags.FINITE_TYPE_TAG) {
-                    return isFiniteTypeMatch((BFiniteType) sourceType, targetType);
-                }
-                return sourceTypeTag == TypeTags.BYTE_TAG || TypeTags.isIntegerTypeTag(sourceTypeTag);
+                return sourceTypeTag == TypeTags.INT_TAG || sourceTypeTag == TypeTags.BYTE_TAG ||
+                        (sourceTypeTag >= TypeTags.SIGNED8_INT_TAG && sourceTypeTag <= TypeTags.UNSIGNED32_INT_TAG);
             case TypeTags.SIGNED16_INT_TAG:
-                if (sourceTypeTag == TypeTags.FINITE_TYPE_TAG) {
-                    return isFiniteTypeMatch((BFiniteType) sourceType, targetType);
-                }
-                return sourceTypeTag == TypeTags.BYTE_TAG || sourceTypeTag == TypeTags.UNSIGNED8_INT_TAG ||
-                        sourceTypeTag == TypeTags.SIGNED8_INT_TAG || sourceTypeTag == TypeTags.SIGNED16_INT_TAG;
+                return sourceTypeTag == TypeTags.BYTE_TAG ||
+                        (sourceTypeTag >= TypeTags.SIGNED8_INT_TAG && sourceTypeTag <= TypeTags.SIGNED16_INT_TAG);
             case TypeTags.SIGNED32_INT_TAG:
-                if (sourceTypeTag == TypeTags.FINITE_TYPE_TAG) {
-                    return isFiniteTypeMatch((BFiniteType) sourceType, targetType);
-                }
-                return sourceTypeTag == TypeTags.BYTE_TAG || sourceTypeTag == TypeTags.UNSIGNED8_INT_TAG ||
-                        sourceTypeTag == TypeTags.SIGNED8_INT_TAG || sourceTypeTag == TypeTags.SIGNED16_INT_TAG ||
-                        sourceTypeTag == TypeTags.UNSIGNED16_INT_TAG || sourceTypeTag == TypeTags.SIGNED32_INT_TAG;
+                return sourceTypeTag == TypeTags.BYTE_TAG ||
+                        (sourceTypeTag >= TypeTags.SIGNED8_INT_TAG && sourceTypeTag <= TypeTags.SIGNED32_INT_TAG);
             case TypeTags.UNSIGNED16_INT_TAG:
-                if (sourceTypeTag == TypeTags.FINITE_TYPE_TAG) {
-                    return isFiniteTypeMatch((BFiniteType) sourceType, targetType);
-                }
                 return sourceTypeTag == TypeTags.BYTE_TAG || sourceTypeTag == TypeTags.UNSIGNED8_INT_TAG ||
                         sourceTypeTag == TypeTags.UNSIGNED16_INT_TAG;
             case TypeTags.UNSIGNED32_INT_TAG:
-                if (sourceTypeTag == TypeTags.FINITE_TYPE_TAG) {
-                    return isFiniteTypeMatch((BFiniteType) sourceType, targetType);
-                }
                 return sourceTypeTag == TypeTags.BYTE_TAG || sourceTypeTag == TypeTags.UNSIGNED8_INT_TAG ||
                         sourceTypeTag == TypeTags.UNSIGNED16_INT_TAG || sourceTypeTag == TypeTags.UNSIGNED32_INT_TAG;
             case TypeTags.ANY_TAG:
@@ -1937,7 +1918,7 @@ public class TypeChecker {
 
     private static boolean isMutable(Object value, Type sourceType) {
         // All the value types are immutable
-        if (value == null || sourceType.getTag() < TypeTags.JSON_TAG ||
+        if (value == null || sourceType.getTag() < TypeTags.NULL_TAG ||
                 sourceType.getTag() == TypeTags.FINITE_TYPE_TAG) {
             return false;
         }
@@ -2653,7 +2634,7 @@ public class TypeChecker {
     }
 
     private static boolean isSimpleBasicType(Type type) {
-        return type.getTag() < TypeTags.JSON_TAG;
+        return type.getTag() < TypeTags.NULL_TAG;
     }
 
     private static boolean isHandleType(Type type) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -601,22 +601,22 @@ public class TypeChecker {
 
         switch (targetTypeTag) {
             case TypeTags.BYTE_TAG:
-            case TypeTags.SIGNED32_INT_TAG:
-            case TypeTags.SIGNED16_INT_TAG:
             case TypeTags.SIGNED8_INT_TAG:
-            case TypeTags.UNSIGNED32_INT_TAG:
-            case TypeTags.UNSIGNED16_INT_TAG:
             case TypeTags.UNSIGNED8_INT_TAG:
             case TypeTags.FLOAT_TAG:
             case TypeTags.DECIMAL_TAG:
             case TypeTags.CHAR_STRING_TAG:
             case TypeTags.BOOLEAN_TAG:
             case TypeTags.NULL_TAG:
-            case TypeTags.STRING_TAG:
                 if (sourceTypeTag == TypeTags.FINITE_TYPE_TAG) {
                     return isFiniteTypeMatch((BFiniteType) sourceType, targetType);
                 }
                 return sourceTypeTag == targetTypeTag;
+            case TypeTags.STRING_TAG:
+                if (sourceTypeTag == TypeTags.FINITE_TYPE_TAG) {
+                    return isFiniteTypeMatch((BFiniteType) sourceType, targetType);
+                }
+                return TypeTags.isStringTypeTag(sourceTypeTag);
             case TypeTags.XML_TEXT_TAG:
                 if (sourceTypeTag == TypeTags.FINITE_TYPE_TAG) {
                     return isFiniteTypeMatch((BFiniteType) sourceType, targetType);
@@ -629,7 +629,32 @@ public class TypeChecker {
                 if (sourceTypeTag == TypeTags.FINITE_TYPE_TAG) {
                     return isFiniteTypeMatch((BFiniteType) sourceType, targetType);
                 }
-                return sourceTypeTag == TypeTags.BYTE_TAG || sourceTypeTag == TypeTags.INT_TAG;
+                return sourceTypeTag == TypeTags.BYTE_TAG || TypeTags.isIntegerTypeTag(sourceTypeTag);
+            case TypeTags.SIGNED16_INT_TAG:
+                if (sourceTypeTag == TypeTags.FINITE_TYPE_TAG) {
+                    return isFiniteTypeMatch((BFiniteType) sourceType, targetType);
+                }
+                return sourceTypeTag == TypeTags.BYTE_TAG || sourceTypeTag == TypeTags.UNSIGNED8_INT_TAG ||
+                        sourceTypeTag == TypeTags.SIGNED8_INT_TAG || sourceTypeTag == TypeTags.SIGNED16_INT_TAG;
+            case TypeTags.SIGNED32_INT_TAG:
+                if (sourceTypeTag == TypeTags.FINITE_TYPE_TAG) {
+                    return isFiniteTypeMatch((BFiniteType) sourceType, targetType);
+                }
+                return sourceTypeTag == TypeTags.BYTE_TAG || sourceTypeTag == TypeTags.UNSIGNED8_INT_TAG ||
+                        sourceTypeTag == TypeTags.SIGNED8_INT_TAG || sourceTypeTag == TypeTags.SIGNED16_INT_TAG ||
+                        sourceTypeTag == TypeTags.UNSIGNED16_INT_TAG || sourceTypeTag == TypeTags.SIGNED32_INT_TAG;
+            case TypeTags.UNSIGNED16_INT_TAG:
+                if (sourceTypeTag == TypeTags.FINITE_TYPE_TAG) {
+                    return isFiniteTypeMatch((BFiniteType) sourceType, targetType);
+                }
+                return sourceTypeTag == TypeTags.BYTE_TAG || sourceTypeTag == TypeTags.UNSIGNED8_INT_TAG ||
+                        sourceTypeTag == TypeTags.UNSIGNED16_INT_TAG;
+            case TypeTags.UNSIGNED32_INT_TAG:
+                if (sourceTypeTag == TypeTags.FINITE_TYPE_TAG) {
+                    return isFiniteTypeMatch((BFiniteType) sourceType, targetType);
+                }
+                return sourceTypeTag == TypeTags.BYTE_TAG || sourceTypeTag == TypeTags.UNSIGNED8_INT_TAG ||
+                        sourceTypeTag == TypeTags.UNSIGNED16_INT_TAG || sourceTypeTag == TypeTags.UNSIGNED32_INT_TAG;
             case TypeTags.ANY_TAG:
                 return checkIsAnyType(sourceType);
             case TypeTags.ANYDATA_TAG:

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExprTest.java
@@ -653,7 +653,8 @@ public class TypeCastExprTest {
                 { "testFiniteTypeArrayToSigned32IntArray" },
                 { "testFiniteTypeArrayToUnsigned32IntArray" },
                 { "testFiniteTypeArrayToSigned16IntArray" },
-                { "testFiniteTypeArrayToUnsigned16IntArray" }
+                { "testFiniteTypeArrayToUnsigned16IntArray" },
+                { "testIntSubtypeCastingWithErrors" }
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExprTest.java
@@ -630,8 +630,8 @@ public class TypeCastExprTest {
         Assert.assertEquals(returns[0].stringValue(), "{name:\"Pubudu\"}");
     }
 
-    @Test(dataProvider = "arrayTypesTestFunction")
-    public void testTypeTestsOfArrayTypes(String function) {
+    @Test(dataProvider = "typesTestExpressionTestFunction")
+    public void testTypeTestsExpression(String function) {
         BRunUtil.invoke(result, function);
     }
 
@@ -640,8 +640,8 @@ public class TypeCastExprTest {
         BRunUtil.invoke(result, function);
     }
 
-    @DataProvider(name = "arrayTypesTestFunction")
-    public Object[][] arrayTypesTestFunction() {
+    @DataProvider(name = "typesTestExpressionTestFunction")
+    public Object[][] typesTestExpressionTestFunction() {
         return new Object[][] {
                 { "testByteArrayToIntArray" },
                 { "testSigned32IntArrayToIntArray" },
@@ -649,7 +649,9 @@ public class TypeCastExprTest {
                 { "testUnsigned8IntArrayToSigned16IntArray" },
                 { "testUnsigned8IntArrayToUnsigned16IntArray" },
                 { "testCharArrayToStringArray" },
-                { "testMapOfCharToMapOfString" }
+                { "testMapOfCharToMapOfString" },
+                { "testFiniteTypeArrayToSigned32IntArray" },
+                { "testFiniteTypeToUnsigned32Int" }
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExprTest.java
@@ -643,21 +643,12 @@ public class TypeCastExprTest {
     @DataProvider(name = "typesTestExpressionTestFunctions")
     public Object[][] typesTestExpressionTestFunctions() {
         return new Object[][] {
-                { "testByteArrayToIntArray" },
-                { "testSigned32IntArrayToIntArray" },
-                { "testUnsigned16IntArrayToSigned32IntArray" },
-                { "testUnsigned8IntArrayToSigned16IntArray" },
-                { "testUnsigned8IntArrayToUnsigned16IntArray" },
-                { "testSigned8IntArrayToSigned16IntArray" },
-                { "testByteArrayToUnSigned32IntArray"},
+                { "testIntArrayCasting" },
+                { "testIntArrayCastingWithErrors" },
                 { "testCharArrayToStringArray" },
                 { "testMapOfCharToMapOfString" },
-                { "testFiniteTypeArrayToSigned32IntArray" },
-                { "testFiniteTypeArrayToUnsigned32IntArray" },
-                { "testFiniteTypeArrayToSigned16IntArray" },
-                { "testFiniteTypeArrayToUnsigned16IntArray" },
-                { "testIntSubtypeCastingWithErrors" },
-                { "testCharAOrCharBArrayToStringArray" }
+                { "testFiniteTypeArrayToIntArray" },
+                { "testFiniteTypeToStringArray" }
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExprTest.java
@@ -630,7 +630,7 @@ public class TypeCastExprTest {
         Assert.assertEquals(returns[0].stringValue(), "{name:\"Pubudu\"}");
     }
 
-    @Test(dataProvider = "ArrayTypesTestFunction")
+    @Test(dataProvider = "arrayTypesTestFunction")
     public void testTypeTestsOfArrayTypes(String function) {
         BRunUtil.invoke(result, function);
     }
@@ -640,8 +640,8 @@ public class TypeCastExprTest {
         BRunUtil.invoke(result, function);
     }
 
-    @DataProvider(name = "ArrayTypesTestFunction")
-    public Object[][] ArrayTypesTestFunction() {
+    @DataProvider(name = "arrayTypesTestFunction")
+    public Object[][] arrayTypesTestFunction() {
         return new Object[][] {
                 { "testByteArrayToIntArray" },
                 { "testSigned32IntArrayToIntArray" },

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExprTest.java
@@ -643,8 +643,8 @@ public class TypeCastExprTest {
     @DataProvider(name = "typesTestExpressionTestFunctions")
     public Object[][] typesTestExpressionTestFunctions() {
         return new Object[][] {
-                { "testIntArrayCasting" },
-                { "testIntArrayCastingWithErrors" },
+                { "testIntSubtypeArrayCasting" },
+                { "testIntSubtypeArrayCastingWithErrors" },
                 { "testCharArrayToStringArray" },
                 { "testMapOfCharToMapOfString" },
                 { "testFiniteTypeArrayToIntArray" },

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExprTest.java
@@ -648,13 +648,16 @@ public class TypeCastExprTest {
                 { "testUnsigned16IntArrayToSigned32IntArray" },
                 { "testUnsigned8IntArrayToSigned16IntArray" },
                 { "testUnsigned8IntArrayToUnsigned16IntArray" },
+                { "testSigned8IntArrayToSigned16IntArray" },
+                { "testByteArrayToUnSigned32IntArray"},
                 { "testCharArrayToStringArray" },
                 { "testMapOfCharToMapOfString" },
                 { "testFiniteTypeArrayToSigned32IntArray" },
                 { "testFiniteTypeArrayToUnsigned32IntArray" },
                 { "testFiniteTypeArrayToSigned16IntArray" },
                 { "testFiniteTypeArrayToUnsigned16IntArray" },
-                { "testIntSubtypeCastingWithErrors" }
+                { "testIntSubtypeCastingWithErrors" },
+                { "testCharAOrCharBArrayToStringArray" }
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExprTest.java
@@ -630,9 +630,27 @@ public class TypeCastExprTest {
         Assert.assertEquals(returns[0].stringValue(), "{name:\"Pubudu\"}");
     }
 
+    @Test(dataProvider = "ArrayTypesTestFunction")
+    public void testTypeTestsOfArrayTypes(String function) {
+        BRunUtil.invoke(result, function);
+    }
+
     @Test(dataProvider = "immutableArrayTypesTestFunctions")
     public void testCastOfImmutableArrayTypes(String function) {
         BRunUtil.invoke(result, function);
+    }
+
+    @DataProvider(name = "ArrayTypesTestFunction")
+    public Object[][] ArrayTypesTestFunction() {
+        return new Object[][] {
+                { "testByteArrayToIntArray" },
+                { "testSigned32IntArrayToIntArray" },
+                { "testUnsigned16IntArrayToSigned32IntArray" },
+                { "testUnsigned8IntArrayToSigned16IntArray" },
+                { "testUnsigned8IntArrayToUnsigned16IntArray" },
+                { "testCharArrayToStringArray" },
+                { "testMapOfCharToMapOfString" }
+        };
     }
 
     @DataProvider(name = "immutableArrayTypesTestFunctions")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExprTest.java
@@ -630,7 +630,7 @@ public class TypeCastExprTest {
         Assert.assertEquals(returns[0].stringValue(), "{name:\"Pubudu\"}");
     }
 
-    @Test(dataProvider = "typesTestExpressionTestFunction")
+    @Test(dataProvider = "typesTestExpressionTestFunctions")
     public void testTypeTestsExpression(String function) {
         BRunUtil.invoke(result, function);
     }
@@ -640,8 +640,8 @@ public class TypeCastExprTest {
         BRunUtil.invoke(result, function);
     }
 
-    @DataProvider(name = "typesTestExpressionTestFunction")
-    public Object[][] typesTestExpressionTestFunction() {
+    @DataProvider(name = "typesTestExpressionTestFunctions")
+    public Object[][] typesTestExpressionTestFunctions() {
         return new Object[][] {
                 { "testByteArrayToIntArray" },
                 { "testSigned32IntArrayToIntArray" },
@@ -651,7 +651,9 @@ public class TypeCastExprTest {
                 { "testCharArrayToStringArray" },
                 { "testMapOfCharToMapOfString" },
                 { "testFiniteTypeArrayToSigned32IntArray" },
-                { "testFiniteTypeToUnsigned32Int" }
+                { "testFiniteTypeArrayToUnsigned32IntArray" },
+                { "testFiniteTypeArrayToSigned16IntArray" },
+                { "testFiniteTypeArrayToUnsigned16IntArray" }
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typecast/type-casting.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typecast/type-casting.bal
@@ -93,11 +93,25 @@ function testFiniteTypeArrayToSigned32IntArray() {
     test:assertEquals(c, [1, 2]);
 }
 
-function testFiniteTypeToUnsigned32Int() {
-    IntOneOrTwo a = 2;
-    any b = a;
-    int:Unsigned32 c = <int:Unsigned32> b;
-    test:assertEquals(c, 2);
+function testFiniteTypeArrayToUnsigned32IntArray() {
+    IntOneOrTwo[] a = [1, 2];
+    any[] b = a;
+    int:Unsigned32[] c = <int:Unsigned32[]> b;
+    test:assertEquals(c, [1, 2]);
+}
+
+function testFiniteTypeArrayToSigned16IntArray() {
+    IntOneOrTwo[] a = [1, 2];
+    any[] b = a;
+    int:Signed16[] c = <int:Signed16[]> b;
+    test:assertEquals(c, [1, 2]);
+}
+
+function testFiniteTypeArrayToUnsigned16IntArray() {
+    IntOneOrTwo[] a = [1, 2];
+    any[] b = a;
+    int:Unsigned16[] c = <int:Unsigned16[]> b;
+    test:assertEquals(c, [1, 2]);
 }
 
 function testJsonIntToString() returns string|error {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typecast/type-casting.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typecast/type-casting.bal
@@ -1,5 +1,6 @@
 import ballerina/lang.'float as floats;
 import ballerina/lang.'int as ints;
+import ballerina/test;
 
 function floattoint(float value) returns (int) {
     int result;
@@ -25,6 +26,62 @@ function stringtoint(string value) returns int|error {
     //string to int should be a unsafe conversion
     result = check ints:fromString(value);
     return result;
+}
+
+function testByteArrayToIntArray() {
+    byte[] arr = [1, 128, 255];
+    any a = arr;
+    test:assertEquals(a is int[], true);
+    int[] intArray = <int[]> a;
+    test:assertEquals(intArray, [1, 128, 255]);
+}
+
+function testSigned32IntArrayToIntArray() {
+    int:Signed32[] arr = [1, 2, 3];
+    any a =  arr;
+    test:assertEquals(a is int[], true);
+    int[] intArray = <int[]> a;
+    test:assertEquals(intArray, [1, 2, 3]);
+}
+
+function testUnsigned16IntArrayToSigned32IntArray() {
+    int:Unsigned16[] arr = [5, 5050, 65535];
+    any a =  arr;
+    test:assertEquals(a is int[], true);
+    int:Signed32[] res = <int:Signed32[]> a;
+    test:assertEquals(res, [5, 5050, 65535]);
+}
+
+function testUnsigned8IntArrayToSigned16IntArray() {
+    int:Unsigned8[] arr = [5, 55, 255];
+    any a =  arr;
+    test:assertEquals(a is int[], true);
+    int:Signed16[] res = <int:Signed16[]> a;
+    test:assertEquals(res, [5, 55, 255]);
+}
+
+function testUnsigned8IntArrayToUnsigned16IntArray() {
+    int:Unsigned8[] arr = [5, 55, 255];
+    any a =  arr;
+    test:assertEquals(a is int[], true);
+    int:Unsigned16[] res = <int:Unsigned16[]> a;
+    test:assertEquals(res, [5, 55, 255]);
+}
+
+function testCharArrayToStringArray() {
+    string:Char[] arr = ["A", "a"];
+    any a =  arr;
+    test:assertEquals(a is string[], true);
+    string[] res = <string[]> a;
+    test:assertEquals(res, ["A", "a"]);
+}
+
+function testMapOfCharToMapOfString() {
+    map<string:Char> m = {};
+    any a = m;
+    test:assertEquals(a is map<string>, true);
+    map<string> res = <map<string>> a;
+    test:assertEquals(res, {});
 }
 
 function testJsonIntToString() returns string|error {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typecast/type-casting.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typecast/type-casting.bal
@@ -84,6 +84,22 @@ function testMapOfCharToMapOfString() {
     test:assertEquals(res, {});
 }
 
+type IntOneOrTwo 1|2;
+
+function testFiniteTypeArrayToSigned32IntArray() {
+    IntOneOrTwo[] a = [1, 2];
+    any[] b = a;
+    int:Signed32[] c = <int:Signed32[]> b;
+    test:assertEquals(c, [1, 2]);
+}
+
+function testFiniteTypeToUnsigned32Int() {
+    IntOneOrTwo a = 2;
+    any b = a;
+    int:Unsigned32 c = <int:Unsigned32> b;
+    test:assertEquals(c, 2);
+}
+
 function testJsonIntToString() returns string|error {
     json j = 5;
     int value;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typecast/type-casting.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typecast/type-casting.bal
@@ -31,7 +31,7 @@ function stringtoint(string value) returns int|error {
 function testByteArrayToIntArray() {
     byte[] arr = [1, 128, 255];
     any a = arr;
-    test:assertEquals(a is int[], true);
+    test:assertTrue(a is int[]);
     int[] intArray = <int[]> a;
     test:assertEquals(intArray, [1, 128, 255]);
 }
@@ -39,7 +39,7 @@ function testByteArrayToIntArray() {
 function testSigned32IntArrayToIntArray() {
     int:Signed32[] arr = [1, 2, 3];
     any a =  arr;
-    test:assertEquals(a is int[], true);
+    test:assertTrue(a is int[]);
     int[] intArray = <int[]> a;
     test:assertEquals(intArray, [1, 2, 3]);
 }
@@ -47,7 +47,7 @@ function testSigned32IntArrayToIntArray() {
 function testUnsigned16IntArrayToSigned32IntArray() {
     int:Unsigned16[] arr = [5, 5050, 65535];
     any a =  arr;
-    test:assertEquals(a is int[], true);
+    test:assertTrue(a is int[]);
     int:Signed32[] res = <int:Signed32[]> a;
     test:assertEquals(res, [5, 5050, 65535]);
 }
@@ -55,7 +55,7 @@ function testUnsigned16IntArrayToSigned32IntArray() {
 function testUnsigned8IntArrayToSigned16IntArray() {
     int:Unsigned8[] arr = [5, 55, 255];
     any a =  arr;
-    test:assertEquals(a is int[], true);
+    test:assertTrue(a is int[]);
     int:Signed16[] res = <int:Signed16[]> a;
     test:assertEquals(res, [5, 55, 255]);
 }
@@ -63,7 +63,7 @@ function testUnsigned8IntArrayToSigned16IntArray() {
 function testUnsigned8IntArrayToUnsigned16IntArray() {
     int:Unsigned8[] arr = [5, 55, 255];
     any a =  arr;
-    test:assertEquals(a is int[], true);
+    test:assertTrue(a is int[]);
     int:Unsigned16[] res = <int:Unsigned16[]> a;
     test:assertEquals(res, [5, 55, 255]);
 }
@@ -71,7 +71,7 @@ function testUnsigned8IntArrayToUnsigned16IntArray() {
 function testCharArrayToStringArray() {
     string:Char[] arr = ["A", "a"];
     any a =  arr;
-    test:assertEquals(a is string[], true);
+    test:assertTrue(a is string[]);
     string[] res = <string[]> a;
     test:assertEquals(res, ["A", "a"]);
 }
@@ -79,9 +79,18 @@ function testCharArrayToStringArray() {
 function testMapOfCharToMapOfString() {
     map<string:Char> m = {};
     any a = m;
-    test:assertEquals(a is map<string>, true);
+    test:assertTrue(a is map<string>);
     map<string> res = <map<string>> a;
     test:assertEquals(res, {});
+}
+
+function testIntSubtypeCastingWithErrors() {
+    int:Signed32[] arr = [1, 2, 3];
+    any a = arr;
+    var result = trap <int:Unsigned32[]> a;
+    test:assertTrue(result is error);
+    error err = <error> result;
+    assertEquality(err.detail()["message"], "incompatible types: 'lang.int:Signed32[]' cannot be cast to 'lang.int:Unsigned32[]'");
 }
 
 type IntOneOrTwo 1|2;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typecast/type-casting.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typecast/type-casting.bal
@@ -28,60 +28,121 @@ function stringtoint(string value) returns int|error {
     return result;
 }
 
-function testByteArrayToIntArray() {
-    byte[] arr = [1, 128, 255];
-    any a = arr;
-    test:assertTrue(a is int[]);
-    int[] intArray = <int[]> a;
-    test:assertEquals(intArray, [1, 128, 255]);
+function testIntArrayCasting() {
+
+    byte[] byteArray = [1, 128, 255];
+    int:Signed8[] signed8Array = [-128, 0, 127];
+    int:Signed16[] signed16Array = [-32768, 0, 32767];
+    int:Signed32[] signed32Array = [-20000, 0, 50000];
+    int:Unsigned8[] unsigned8Array = [1, 128, 255];
+    int:Unsigned16[] unsigned16Array = [5, 5050, 65535];
+    int:Unsigned32[] unsigned32Array = [0, 65536, 65555536];
+
+    any anyByteArray = byteArray;
+    any anySigned8Array = signed8Array;
+    any anySigned16Array = signed16Array;
+    any anySigned32Array = signed32Array;
+    any anyUnsigned8Array = unsigned8Array;
+    any anyUnsigned16Array = unsigned16Array;
+    any anyUnsigned32Array = unsigned32Array;
+
+    // byte
+    test:assertEquals(<int[]> anyByteArray, [1, 128, 255]);
+    test:assertEquals(<int:Signed16[]> anyByteArray, [1, 128, 255]);
+    test:assertEquals(<int:Signed32[]> anyByteArray, [1, 128, 255]);
+    test:assertEquals(<int:Unsigned16[]> anyByteArray, [1, 128, 255]);
+    test:assertEquals(<int:Unsigned32[]> anyByteArray, [1, 128, 255]);
+
+    // Unsigned8
+    test:assertEquals(<int[]> anyUnsigned8Array, [1, 128, 255]);
+    test:assertEquals(<int:Signed16[]> anyUnsigned8Array, [1, 128, 255]);
+    test:assertEquals(<int:Signed32[]> anyUnsigned8Array, [1, 128, 255]);
+    test:assertEquals(<int:Unsigned16[]> anyUnsigned8Array, [1, 128, 255]);
+    test:assertEquals(<int:Unsigned32[]> anyUnsigned8Array, [1, 128, 255]);
+
+    // Unsigned16
+    test:assertEquals(<int[]> anyUnsigned16Array, [5, 5050, 65535]);
+    test:assertEquals(<int:Signed32[]> anyUnsigned16Array, [5, 5050, 65535]);
+    test:assertEquals(<int:Unsigned32[]> anyUnsigned16Array, [5, 5050, 65535]);
+
+    // Unsigned32
+    test:assertEquals(<int[]> anyUnsigned32Array, [0, 65536, 65555536]);
+
+    // Signed8
+    test:assertEquals(<int[]> anySigned8Array, [-128, 0, 127]);
+    test:assertEquals(<int:Signed16[]> anySigned8Array, [-128, 0, 127]);
+    test:assertEquals(<int:Signed32[]> anySigned8Array, [-128, 0, 127]);
+
+    // Signed16
+    test:assertEquals(<int[]> anySigned16Array, [-32768, 0, 32767]);
+    test:assertEquals(<int:Signed32[]> anySigned16Array, [-32768, 0, 32767]);
+
+    // Signed32
+    test:assertEquals(<int[]> anySigned32Array, [-20000, 0, 50000]);
 }
 
-function testSigned32IntArrayToIntArray() {
-    int:Signed32[] arr = [1, 2, 3];
-    any a =  arr;
-    test:assertTrue(a is int[]);
-    int[] intArray = <int[]> a;
-    test:assertEquals(intArray, [1, 2, 3]);
-}
+function testIntArrayCastingWithErrors() {
+    int:Signed32[] signed32Array = [-2147483648, 0, 2147483647];
+    int:Unsigned32[] unsigned32Array = [0, 65536, 4294967295];
 
-function testUnsigned16IntArrayToSigned32IntArray() {
-    int:Unsigned16[] arr = [5, 5050, 65535];
-    any a =  arr;
-    test:assertTrue(a is int[]);
-    int:Signed32[] res = <int:Signed32[]> a;
-    test:assertEquals(res, [5, 5050, 65535]);
-}
+    any anySigned32Array = signed32Array;
+    any anyUnsigned32Array = unsigned32Array;
 
-function testSigned8IntArrayToSigned16IntArray() {
-    int:Signed8[] arr = [-128, 0, 127];
-    any a =  arr;
-    test:assertTrue(a is int:Signed32[]);
-    int:Signed16[] res = <int:Signed16[]> a;
-    test:assertEquals(res, [-128, 0, 127]);
-}
+    // casting of UnSigned32[] to Signed32[]
+    int:Signed32[]|error signed32OrError = trap <int:Signed32[]> anyUnsigned32Array;
+    error err = <error> signed32OrError;
+    assertEquality(err.detail()["message"], "incompatible types: 'lang.int:Unsigned32[]' cannot be cast to 'lang.int:Signed32[]'");
 
-function testByteArrayToUnSigned32IntArray() {
-    byte[] arr = [0, 128, 255];
-    any a =  arr;
-    test:assertTrue(a is int:Signed16[]);
-    int:Signed32[] res = <int:Signed32[]> a;
-    test:assertEquals(res, [0, 128, 255]);
-}
+    // casting of Unsigned32Array[] to Signed16[]
+    int:Signed16[]|error signed16OrError = trap <int:Signed16[]> anyUnsigned32Array;
+    err = <error> signed16OrError;
+    assertEquality(err.detail()["message"], "incompatible types: 'lang.int:Unsigned32[]' cannot be cast to 'lang.int:Signed16[]'");
 
-function testUnsigned8IntArrayToSigned16IntArray() {
-    int:Unsigned8[] arr = [5, 55, 255];
-    any a =  arr;
-    test:assertTrue(a is int[]);
-    int:Signed16[] res = <int:Signed16[]> a;
-    test:assertEquals(res, [5, 55, 255]);
-}
+    // casting of Unsigned32Array[] to Signed8[]
+    int:Signed8[]|error signed8OrError = trap <int:Signed8[]> anyUnsigned32Array;
+    err = <error> signed8OrError;
+    assertEquality(err.detail()["message"], "incompatible types: 'lang.int:Unsigned32[]' cannot be cast to 'lang.int:Signed8[]'");
 
-function testUnsigned8IntArrayToUnsigned16IntArray() {
-    int:Unsigned8[] arr = [5, 55, 255];
-    any a =  arr;
-    test:assertTrue(a is int[]);
-    int:Unsigned16[] res = <int:Unsigned16[]> a;
-    test:assertEquals(res, [5, 55, 255]);
+    // casting of Unsigned32Array[] to Unsigned16[]
+    int:Unsigned16[]|error unsigned16OrError = trap <int:Unsigned16[]> anyUnsigned32Array;
+    err = <error> unsigned16OrError;
+    assertEquality(err.detail()["message"], "incompatible types: 'lang.int:Unsigned32[]' cannot be cast to 'lang.int:Unsigned16[]'");
+
+    // casting of Unsigned32Array[] to Unsigned8[]
+    int:Unsigned8[]|error unsigned8OrError = trap <int:Unsigned8[]> anyUnsigned32Array;
+    err = <error> unsigned8OrError;
+    assertEquality(err.detail()["message"], "incompatible types: 'lang.int:Unsigned32[]' cannot be cast to 'lang.int:Unsigned8[]'");
+
+    // casting of Unsigned32Array[] to byte[]
+    byte[]|error byteArrayOrError = trap <byte[]> anyUnsigned32Array;
+    err = <error> byteArrayOrError;
+    assertEquality(err.detail()["message"], "incompatible types: 'lang.int:Unsigned32[]' cannot be cast to 'byte[]'");
+
+
+    // casting of Signed32[] to Signed16[]
+    int:Signed16[]|error signed16ArrayOrError = trap <int:Signed16[]> anySigned32Array;
+    err = <error> signed16ArrayOrError;
+    assertEquality(err.detail()["message"], "incompatible types: 'lang.int:Signed32[]' cannot be cast to 'lang.int:Signed16[]'");
+
+    // casting of Signed32[] to Signed8[]
+    int:Signed8[]|error signed8ArrayOrError = trap <int:Signed8[]> anySigned32Array;
+    err = <error> signed8ArrayOrError;
+    assertEquality(err.detail()["message"], "incompatible types: 'lang.int:Signed32[]' cannot be cast to 'lang.int:Signed8[]'");
+
+    // casting of Signed32[] to UnSigned32[]
+    int:Unsigned32[]|error unsigned32ArrayOrError = trap <int:Unsigned32[]> anySigned32Array;
+    err = <error> unsigned32ArrayOrError;
+    assertEquality(err.detail()["message"], "incompatible types: 'lang.int:Signed32[]' cannot be cast to 'lang.int:Unsigned32[]'");
+
+    // casting of Signed32[] to UnSigned16[]
+    int:Unsigned16[]|error unsigned16ArrayOrError = trap <int:Unsigned16[]> anySigned32Array;
+    err = <error> unsigned16ArrayOrError;
+    assertEquality(err.detail()["message"], "incompatible types: 'lang.int:Signed32[]' cannot be cast to 'lang.int:Unsigned16[]'");
+
+    // casting of Signed32[] to UnSigned8[]
+    int:Unsigned8[]|error unsigned8ArrayOrError = trap <int:Unsigned8[]> anySigned32Array;
+    err = <error> unsigned8ArrayOrError;
+    assertEquality(err.detail()["message"], "incompatible types: 'lang.int:Signed32[]' cannot be cast to 'lang.int:Unsigned8[]'");
 }
 
 function testCharArrayToStringArray() {
@@ -100,59 +161,28 @@ function testMapOfCharToMapOfString() {
     test:assertEquals(res, {});
 }
 
-function testIntSubtypeCastingWithErrors() {
-    int:Signed32[] a = [1, 2, 3];
-    any b = a;
-    var result = trap <int:Unsigned32[]> b;
-    test:assertTrue(result is error);
-    error err = <error> result;
-    assertEquality(err.detail()["message"], "incompatible types: 'lang.int:Signed32[]' cannot be cast to 'lang.int:Unsigned32[]'");
-
-    int:Signed8[] c = [-1, 0, 1];
-    any d = c;
-    result = trap <int:Unsigned16[]> d;
-    test:assertTrue(result is error);
-    err = <error> result;
-    assertEquality(err.detail()["message"], "incompatible types: 'lang.int:Signed8[]' cannot be cast to 'lang.int:Unsigned16[]'");
-}
-
 type IntOneOrTwo 1|2;
 
-function testFiniteTypeArrayToSigned32IntArray() {
-    IntOneOrTwo[] a = [1, 2];
-    any[] b = a;
-    int:Signed32[] c = <int:Signed32[]> b;
-    test:assertEquals(c, [1, 2]);
+function testFiniteTypeArrayToIntArray() {
+    IntOneOrTwo[] intOneOrTwoArray = [1, 2];
+    any anyIntOneOrTwoArray = intOneOrTwoArray;
+
+    test:assertEquals(<int:Signed32[]> anyIntOneOrTwoArray, [1, 2]);
+    test:assertEquals(<int:Signed16[]> anyIntOneOrTwoArray, [1, 2]);
+    test:assertEquals(<int:Signed8[]> anyIntOneOrTwoArray, [1, 2]);
+    test:assertEquals(<int:Unsigned32[]> anyIntOneOrTwoArray, [1, 2]);
+    test:assertEquals(<int:Unsigned16[]> anyIntOneOrTwoArray, [1, 2]);
+    test:assertEquals(<int:Unsigned8[]> anyIntOneOrTwoArray, [1, 2]);
 }
 
-function testFiniteTypeArrayToUnsigned32IntArray() {
-    IntOneOrTwo[] a = [1, 2];
-    any[] b = a;
-    int:Unsigned32[] c = <int:Unsigned32[]> b;
-    test:assertEquals(c, [1, 2]);
-}
+type AOrBOrC "A"|"B"|"C";
 
-function testFiniteTypeArrayToSigned16IntArray() {
-    IntOneOrTwo[] a = [1, 2];
-    any[] b = a;
-    int:Signed16[] c = <int:Signed16[]> b;
-    test:assertEquals(c, [1, 2]);
-}
+function testFiniteTypeToStringArray() {
+    AOrBOrC[] array = ["A", "C"];
+    any anyArray = array;
 
-function testFiniteTypeArrayToUnsigned16IntArray() {
-    IntOneOrTwo[] a = [1, 2];
-    any[] b = a;
-    int:Unsigned16[] c = <int:Unsigned16[]> b;
-    test:assertEquals(c, [1, 2]);
-}
-
-type CharAOrCharB "A"|"B";
-
-function testCharAOrCharBArrayToStringArray() {
-    CharAOrCharB[] a = ["A"];
-    any[] b = a;
-    string[] c = <string[]> b;
-    test:assertEquals(c, ["A"]);
+    test:assertEquals(<string[]> anyArray, ["A", "C"]);
+    test:assertEquals(<string:Char[]> anyArray, ["A", "C"]);
 }
 
 function testJsonIntToString() returns string|error {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typecast/type-casting.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typecast/type-casting.bal
@@ -52,6 +52,22 @@ function testUnsigned16IntArrayToSigned32IntArray() {
     test:assertEquals(res, [5, 5050, 65535]);
 }
 
+function testSigned8IntArrayToSigned16IntArray() {
+    int:Signed8[] arr = [-128, 0, 127];
+    any a =  arr;
+    test:assertTrue(a is int:Signed32[]);
+    int:Signed16[] res = <int:Signed16[]> a;
+    test:assertEquals(res, [-128, 0, 127]);
+}
+
+function testByteArrayToUnSigned32IntArray() {
+    byte[] arr = [0, 128, 255];
+    any a =  arr;
+    test:assertTrue(a is int:Signed16[]);
+    int:Signed32[] res = <int:Signed32[]> a;
+    test:assertEquals(res, [0, 128, 255]);
+}
+
 function testUnsigned8IntArrayToSigned16IntArray() {
     int:Unsigned8[] arr = [5, 55, 255];
     any a =  arr;
@@ -85,12 +101,19 @@ function testMapOfCharToMapOfString() {
 }
 
 function testIntSubtypeCastingWithErrors() {
-    int:Signed32[] arr = [1, 2, 3];
-    any a = arr;
-    var result = trap <int:Unsigned32[]> a;
+    int:Signed32[] a = [1, 2, 3];
+    any b = a;
+    var result = trap <int:Unsigned32[]> b;
     test:assertTrue(result is error);
     error err = <error> result;
     assertEquality(err.detail()["message"], "incompatible types: 'lang.int:Signed32[]' cannot be cast to 'lang.int:Unsigned32[]'");
+
+    int:Signed8[] c = [-1, 0, 1];
+    any d = c;
+    result = trap <int:Unsigned16[]> d;
+    test:assertTrue(result is error);
+    err = <error> result;
+    assertEquality(err.detail()["message"], "incompatible types: 'lang.int:Signed8[]' cannot be cast to 'lang.int:Unsigned16[]'");
 }
 
 type IntOneOrTwo 1|2;
@@ -121,6 +144,15 @@ function testFiniteTypeArrayToUnsigned16IntArray() {
     any[] b = a;
     int:Unsigned16[] c = <int:Unsigned16[]> b;
     test:assertEquals(c, [1, 2]);
+}
+
+type CharAOrCharB "A"|"B";
+
+function testCharAOrCharBArrayToStringArray() {
+    CharAOrCharB[] a = ["A"];
+    any[] b = a;
+    string[] c = <string[]> b;
+    test:assertEquals(c, ["A"]);
 }
 
 function testJsonIntToString() returns string|error {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typecast/type-casting.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typecast/type-casting.bal
@@ -28,7 +28,7 @@ function stringtoint(string value) returns int|error {
     return result;
 }
 
-function testIntArrayCasting() {
+function testIntSubtypeArrayCasting() {
 
     byte[] byteArray = [1, 128, 255];
     int:Signed8[] signed8Array = [-128, 0, 127];
@@ -81,68 +81,111 @@ function testIntArrayCasting() {
     test:assertEquals(<int[]> anySigned32Array, [-20000, 0, 50000]);
 }
 
-function testIntArrayCastingWithErrors() {
+function testIntSubtypeArrayCastingWithErrors() {
     int:Signed32[] signed32Array = [-2147483648, 0, 2147483647];
     int:Unsigned32[] unsigned32Array = [0, 65536, 4294967295];
+    int:Signed16[] signed16Array = [1, 2, 3];
+    int:Unsigned16[] unsigned16Array = [1, 2, 3];
+    int:Signed8[] signed8Array = [1, 2, 3];
+    int:Unsigned8[] unsigned8Array = [1, 2, 3];
 
     any anySigned32Array = signed32Array;
     any anyUnsigned32Array = unsigned32Array;
+    any anySigned16Array = signed16Array;
+    any anyUnsigned16Array = unsigned16Array;
+    any anySigned8Array = signed8Array;
+    any anyUnsigned8Array = unsigned8Array;
 
-    // casting of UnSigned32[] to Signed32[]
-    int:Signed32[]|error signed32OrError = trap <int:Signed32[]> anyUnsigned32Array;
-    error err = <error> signed32OrError;
+    // cast to Signed32[]
+    int:Signed32[]|error signed32ArrayOrError = trap <int:Signed32[]> anyUnsigned32Array;
+    error err = <error> signed32ArrayOrError;
     assertEquality(err.detail()["message"], "incompatible types: 'lang.int:Unsigned32[]' cannot be cast to 'lang.int:Signed32[]'");
 
-    // casting of Unsigned32Array[] to Signed16[]
-    int:Signed16[]|error signed16OrError = trap <int:Signed16[]> anyUnsigned32Array;
-    err = <error> signed16OrError;
-    assertEquality(err.detail()["message"], "incompatible types: 'lang.int:Unsigned32[]' cannot be cast to 'lang.int:Signed16[]'");
-
-    // casting of Unsigned32Array[] to Signed8[]
-    int:Signed8[]|error signed8OrError = trap <int:Signed8[]> anyUnsigned32Array;
-    err = <error> signed8OrError;
-    assertEquality(err.detail()["message"], "incompatible types: 'lang.int:Unsigned32[]' cannot be cast to 'lang.int:Signed8[]'");
-
-    // casting of Unsigned32Array[] to Unsigned16[]
-    int:Unsigned16[]|error unsigned16OrError = trap <int:Unsigned16[]> anyUnsigned32Array;
-    err = <error> unsigned16OrError;
-    assertEquality(err.detail()["message"], "incompatible types: 'lang.int:Unsigned32[]' cannot be cast to 'lang.int:Unsigned16[]'");
-
-    // casting of Unsigned32Array[] to Unsigned8[]
-    int:Unsigned8[]|error unsigned8OrError = trap <int:Unsigned8[]> anyUnsigned32Array;
-    err = <error> unsigned8OrError;
-    assertEquality(err.detail()["message"], "incompatible types: 'lang.int:Unsigned32[]' cannot be cast to 'lang.int:Unsigned8[]'");
-
-    // casting of Unsigned32Array[] to byte[]
-    byte[]|error byteArrayOrError = trap <byte[]> anyUnsigned32Array;
-    err = <error> byteArrayOrError;
-    assertEquality(err.detail()["message"], "incompatible types: 'lang.int:Unsigned32[]' cannot be cast to 'byte[]'");
-
-
-    // casting of Signed32[] to Signed16[]
-    int:Signed16[]|error signed16ArrayOrError = trap <int:Signed16[]> anySigned32Array;
-    err = <error> signed16ArrayOrError;
-    assertEquality(err.detail()["message"], "incompatible types: 'lang.int:Signed32[]' cannot be cast to 'lang.int:Signed16[]'");
-
-    // casting of Signed32[] to Signed8[]
-    int:Signed8[]|error signed8ArrayOrError = trap <int:Signed8[]> anySigned32Array;
-    err = <error> signed8ArrayOrError;
-    assertEquality(err.detail()["message"], "incompatible types: 'lang.int:Signed32[]' cannot be cast to 'lang.int:Signed8[]'");
-
-    // casting of Signed32[] to UnSigned32[]
+    // cast to UnSigned32[]
     int:Unsigned32[]|error unsigned32ArrayOrError = trap <int:Unsigned32[]> anySigned32Array;
     err = <error> unsigned32ArrayOrError;
     assertEquality(err.detail()["message"], "incompatible types: 'lang.int:Signed32[]' cannot be cast to 'lang.int:Unsigned32[]'");
 
-    // casting of Signed32[] to UnSigned16[]
-    int:Unsigned16[]|error unsigned16ArrayOrError = trap <int:Unsigned16[]> anySigned32Array;
+    unsigned32ArrayOrError = trap <int:Unsigned32[]> anySigned16Array;
+    err = <error> unsigned32ArrayOrError;
+    assertEquality(err.detail()["message"], "incompatible types: 'lang.int:Signed16[]' cannot be cast to 'lang.int:Unsigned32[]'");
+
+    unsigned32ArrayOrError = trap <int:Unsigned32[]> anySigned8Array;
+    err = <error> unsigned32ArrayOrError;
+    assertEquality(err.detail()["message"], "incompatible types: 'lang.int:Signed8[]' cannot be cast to 'lang.int:Unsigned32[]'");
+
+    // cast to Unsigned16[]
+    int:Unsigned16[]|error unsigned16ArrayOrError = trap <int:Unsigned16[]> anyUnsigned32Array;
+    err = <error> unsigned16ArrayOrError;
+    assertEquality(err.detail()["message"], "incompatible types: 'lang.int:Unsigned32[]' cannot be cast to 'lang.int:Unsigned16[]'");
+
+    unsigned16ArrayOrError = trap <int:Unsigned16[]> anySigned32Array;
     err = <error> unsigned16ArrayOrError;
     assertEquality(err.detail()["message"], "incompatible types: 'lang.int:Signed32[]' cannot be cast to 'lang.int:Unsigned16[]'");
 
-    // casting of Signed32[] to UnSigned8[]
-    int:Unsigned8[]|error unsigned8ArrayOrError = trap <int:Unsigned8[]> anySigned32Array;
+    unsigned16ArrayOrError = trap <int:Unsigned16[]> anySigned16Array;
+    err = <error> unsigned16ArrayOrError;
+    assertEquality(err.detail()["message"], "incompatible types: 'lang.int:Signed16[]' cannot be cast to 'lang.int:Unsigned16[]'");
+
+    unsigned16ArrayOrError = trap <int:Unsigned16[]> anySigned8Array;
+    err = <error> unsigned16ArrayOrError;
+    assertEquality(err.detail()["message"], "incompatible types: 'lang.int:Signed8[]' cannot be cast to 'lang.int:Unsigned16[]'");
+
+    // cast to Signed16[]
+    int:Signed16[]|error signed16ArrayOrError = trap <int:Signed16[]> anyUnsigned32Array;
+    err = <error> signed16ArrayOrError;
+    assertEquality(err.detail()["message"], "incompatible types: 'lang.int:Unsigned32[]' cannot be cast to 'lang.int:Signed16[]'");
+
+    signed16ArrayOrError = trap <int:Signed16[]> anySigned32Array;
+    err = <error> signed16ArrayOrError;
+    assertEquality(err.detail()["message"], "incompatible types: 'lang.int:Signed32[]' cannot be cast to 'lang.int:Signed16[]'");
+
+    signed16ArrayOrError = trap <int:Signed16[]> anyUnsigned16Array;
+    err = <error> signed16ArrayOrError;
+    assertEquality(err.detail()["message"], "incompatible types: 'lang.int:Unsigned16[]' cannot be cast to 'lang.int:Signed16[]'");
+
+    // cast to Signed8[]
+    int:Signed8[]|error signed8ArrayOrError = trap <int:Signed8[]> anyUnsigned32Array;
+    err = <error> signed8ArrayOrError;
+    assertEquality(err.detail()["message"], "incompatible types: 'lang.int:Unsigned32[]' cannot be cast to 'lang.int:Signed8[]'");
+
+    signed8ArrayOrError = trap <int:Signed8[]> anyUnsigned16Array;
+    err = <error> signed8ArrayOrError;
+    assertEquality(err.detail()["message"], "incompatible types: 'lang.int:Unsigned16[]' cannot be cast to 'lang.int:Signed8[]'");
+
+    signed8ArrayOrError = trap <int:Signed8[]> anyUnsigned8Array;
+    err = <error> signed8ArrayOrError;
+    assertEquality(err.detail()["message"], "incompatible types: 'lang.int:Unsigned8[]' cannot be cast to 'lang.int:Signed8[]'");
+
+    signed8ArrayOrError = trap <int:Signed8[]> anySigned32Array;
+    err = <error> signed8ArrayOrError;
+    assertEquality(err.detail()["message"], "incompatible types: 'lang.int:Signed32[]' cannot be cast to 'lang.int:Signed8[]'");
+
+    signed8ArrayOrError = trap <int:Signed8[]> anySigned16Array;
+    err = <error> signed8ArrayOrError;
+    assertEquality(err.detail()["message"], "incompatible types: 'lang.int:Signed16[]' cannot be cast to 'lang.int:Signed8[]'");
+
+    // cast to Unsigned8[]
+    int:Unsigned8[]|error unsigned8ArrayOrError = trap <int:Unsigned8[]> anyUnsigned32Array;
+    err = <error> unsigned8ArrayOrError;
+    assertEquality(err.detail()["message"], "incompatible types: 'lang.int:Unsigned32[]' cannot be cast to 'lang.int:Unsigned8[]'");
+
+    unsigned8ArrayOrError = trap <int:Unsigned8[]> anySigned32Array;
     err = <error> unsigned8ArrayOrError;
     assertEquality(err.detail()["message"], "incompatible types: 'lang.int:Signed32[]' cannot be cast to 'lang.int:Unsigned8[]'");
+
+    unsigned8ArrayOrError = trap <int:Unsigned8[]> anyUnsigned16Array;
+    err = <error> unsigned8ArrayOrError;
+    assertEquality(err.detail()["message"], "incompatible types: 'lang.int:Unsigned16[]' cannot be cast to 'lang.int:Unsigned8[]'");
+
+    unsigned8ArrayOrError = trap <int:Unsigned8[]> anySigned16Array;
+    err = <error> unsigned8ArrayOrError;
+    assertEquality(err.detail()["message"], "incompatible types: 'lang.int:Signed16[]' cannot be cast to 'lang.int:Unsigned8[]'");
+
+    unsigned8ArrayOrError = trap <int:Unsigned8[]> anySigned8Array;
+    err = <error> unsigned8ArrayOrError;
+    assertEquality(err.detail()["message"], "incompatible types: 'lang.int:Signed8[]' cannot be cast to 'lang.int:Unsigned8[]'");
+
 }
 
 function testCharArrayToStringArray() {


### PR DESCRIPTION
## Purpose
> This PR will fixes the incorrect results which occurred while using type test expression for `int` and `string` sub types. 

Fixes #30368

## Approach

## Samples

## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
