### PR TITLE
[LS] Add intermediate caluse completions to query pipeline context

### DIFF
--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config19.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config19.json
@@ -1,0 +1,108 @@
+{
+  "position": {
+    "line": 7,
+    "character": 54
+  },
+  "source": "query_expression/source/query_expr_ctx_source19.bal",
+  "items": [
+    {
+      "label": "from",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "P",
+      "filterText": "from",
+      "insertText": "from ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "from clause",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "O",
+      "filterText": "from",
+      "insertText": "from ${1:var} ${2:item} in ${3}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "where",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "P",
+      "filterText": "where",
+      "insertText": "where ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "let",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "P",
+      "filterText": "let",
+      "insertText": "let",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "let clause",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "O",
+      "filterText": "let",
+      "insertText": "let ${1:var} ${2:varName} = ${3}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "join",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "P",
+      "filterText": "join",
+      "insertText": "join ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "join clause",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "O",
+      "filterText": "join",
+      "insertText": "join ${1:var} ${2:varName} in ${3:expr} on ${3:onExpr} equals ${3:equalsExpr}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "order by",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "P",
+      "filterText": "order by",
+      "insertText": "order by ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "limit",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "P",
+      "filterText": "limit",
+      "insertText": "limit ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "select",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "P",
+      "filterText": "select",
+      "insertText": "select ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "do",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "O",
+      "filterText": "do",
+      "insertText": "do {\n\t${1}\n}",
+      "insertTextFormat": "Snippet"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config20.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config20.json
@@ -1,0 +1,108 @@
+{
+  "position": {
+    "line": 9,
+    "character": 27
+  },
+  "source": "query_expression/source/query_expr_ctx_source20.bal",
+  "items": [
+    {
+      "label": "from",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "P",
+      "filterText": "from",
+      "insertText": "from ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "from clause",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "O",
+      "filterText": "from",
+      "insertText": "from ${1:var} ${2:item} in ${3}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "where",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "P",
+      "filterText": "where",
+      "insertText": "where ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "let",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "P",
+      "filterText": "let",
+      "insertText": "let",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "let clause",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "O",
+      "filterText": "let",
+      "insertText": "let ${1:var} ${2:varName} = ${3}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "join",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "P",
+      "filterText": "join",
+      "insertText": "join ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "join clause",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "O",
+      "filterText": "join",
+      "insertText": "join ${1:var} ${2:varName} in ${3:expr} on ${3:onExpr} equals ${3:equalsExpr}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "order by",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "P",
+      "filterText": "order by",
+      "insertText": "order by ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "limit",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "P",
+      "filterText": "limit",
+      "insertText": "limit ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "do",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "O",
+      "filterText": "do",
+      "insertText": "do {\n\t${1}\n}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "select",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "P",
+      "filterText": "select",
+      "insertText": "select ",
+      "insertTextFormat": "Snippet"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config21.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config21.json
@@ -1,0 +1,108 @@
+{
+  "position": {
+    "line": 9,
+    "character": 54
+  },
+  "source": "query_expression/source/query_expr_ctx_source21.bal",
+  "items": [
+    {
+      "label": "from",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "P",
+      "filterText": "from",
+      "insertText": "from ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "from clause",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "O",
+      "filterText": "from",
+      "insertText": "from ${1:var} ${2:item} in ${3}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "where",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "P",
+      "filterText": "where",
+      "insertText": "where ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "let",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "P",
+      "filterText": "let",
+      "insertText": "let",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "let clause",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "O",
+      "filterText": "let",
+      "insertText": "let ${1:var} ${2:varName} = ${3}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "join",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "P",
+      "filterText": "join",
+      "insertText": "join ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "join clause",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "O",
+      "filterText": "join",
+      "insertText": "join ${1:var} ${2:varName} in ${3:expr} on ${3:onExpr} equals ${3:equalsExpr}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "order by",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "P",
+      "filterText": "order by",
+      "insertText": "order by ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "limit",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "P",
+      "filterText": "limit",
+      "insertText": "limit ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "select",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "P",
+      "filterText": "select",
+      "insertText": "select ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "do",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "O",
+      "filterText": "do",
+      "insertText": "do {\n\t${1}\n}",
+      "insertTextFormat": "Snippet"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/source/query_expr_ctx_source19.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/source/query_expr_ctx_source19.bal
@@ -1,0 +1,15 @@
+function testIterableOperation() {
+    Customer c1 = {id: 1, name: "Melina", noOfItems: 12};
+    Customer c2 = {id: 2, name: "James", noOfItems: 5};
+    Customer c3 = {id: 3, name: "Anne", noOfItems: 20};
+
+    Customer[] customerList = [c1, c2, c3];
+
+    Customer[] filtered = from var c in customerList w
+}
+
+type Customer record {|
+    readonly int id;
+    readonly string name;
+    int noOfItems;
+|};

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/source/query_expr_ctx_source20.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/source/query_expr_ctx_source20.bal
@@ -1,0 +1,19 @@
+function testIterableOperation() {
+    Customer c1 = {id: 1, name: "Melina", noOfItems: 12};
+    Customer c2 = {id: 2, name: "James", noOfItems: 5};
+    Customer c3 = {id: 3, name: "Anne", noOfItems: 20};
+
+    Customer[] customerList = [c1, c2, c3];
+
+    Customer[] filtered = from var c in customerList1
+                          where c.noOfItems > 10
+                          w
+                          select c;
+
+}
+
+type Customer record {|
+    readonly int id;
+    readonly string name;
+    int noOfItems;
+|};

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/source/query_expr_ctx_source21.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/source/query_expr_ctx_source21.bal
@@ -1,0 +1,21 @@
+import ballerina/module1;
+
+function testIterableOperation() {
+    Customer c1 = {id: 1, name: "Melina", noOfItems: 12};
+    Customer c2 = {id: 2, name: "James", noOfItems: 5};
+    Customer c3 = {id: 3, name: "Anne", noOfItems: 20};
+
+    Customer[] customerList = [c1, c2, c3];
+
+    Customer[] filtered = from var c in customerList w
+
+    module1:TestRecord1 rec = {
+        recField1: 10
+    }
+}
+
+type Customer record {|
+    readonly int id;
+    readonly string name;
+    int noOfItems;
+|};


### PR DESCRIPTION
## Purpose
$subject to cover the following scenario.
```ballerina
models:PET pet1 = new (1000,2);
models:PET pet2 = new (2000,1);
models:PET pet3 = new (900,6);

models:PET[] allpets = [pet1,pet2,pet3];

models:PET[] listResult =from var pet in allpets 
    where pet.value > 1000 w<cursor>
```

Fixes #30968

## Samples
![pic](https://user-images.githubusercontent.com/35211477/122711900-9efd9d80-d280-11eb-8c20-9246bdcfecea.png)


## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
