### PR TITLE
Implement `equals()` and `hashCode()` for `BSymbol`, `BTypeSymbol`, `BType` and their sub classes

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BAnnotationSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BAnnotationSymbol.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import static org.wso2.ballerinalang.compiler.semantics.model.symbols.SymTag.ANNOTATION;
@@ -99,5 +100,24 @@ public class BAnnotationSymbol extends BTypeSymbol implements AnnotationSymbol {
             points = EnumSet.noneOf(AttachPoint.Point.class);
         }
         return AttachPoints.asMask(points);
+    }
+
+    // Generated equals() and hashCode() implementations
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (!(o instanceof BAnnotationSymbol)) {
+            return false;
+        }
+        BAnnotationSymbol that = (BAnnotationSymbol) o;
+        return maskedPoints == that.maskedPoints && Objects.equals(attachedType, that.attachedType) &&
+                Objects.equals(points, that.points) && Objects.equals(annots, that.annots);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), attachedType, points, maskedPoints, annots);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BClassSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BClassSymbol.java
@@ -28,6 +28,7 @@ import org.wso2.ballerinalang.compiler.util.Names;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * {@code BClassSymbol} represents a class symbol in a scope.
@@ -67,5 +68,27 @@ public class BClassSymbol extends BObjectTypeSymbol implements Annotatable {
         copy.initializerFunc = initializerFunc;
         copy.isLabel = true;
         return copy;
+    }
+
+    // Generated equals() and hashCode() implementations
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof BClassSymbol)) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        BClassSymbol that = (BClassSymbol) o;
+        return isServiceDecl == that.isServiceDecl && Objects.equals(annots, that.annots);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), isServiceDecl, annots);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BConstantSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BConstantSymbol.java
@@ -26,6 +26,8 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.tree.BLangConstantValue;
 import org.wso2.ballerinalang.compiler.util.Name;
 
+import java.util.Objects;
+
 import static org.wso2.ballerinalang.compiler.semantics.model.symbols.SymTag.CONSTANT;
 
 /**
@@ -47,5 +49,23 @@ public class BConstantSymbol extends BVarSymbol implements ConstantSymbol {
     @Override
     public SymbolKind getKind() {
         return SymbolKind.CONSTANT;
+    }
+
+    // Generated equals() and hashCode() implementations
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (!(o instanceof BConstantSymbol)) {
+            return false;
+        }
+        BConstantSymbol that = (BConstantSymbol) o;
+        return Objects.equals(value, that.value) && Objects.equals(literalType, that.literalType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), value, literalType);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BEnumSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BEnumSymbol.java
@@ -29,6 +29,7 @@ import org.wso2.ballerinalang.compiler.util.Name;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Represents an enum.
@@ -65,5 +66,23 @@ public class BEnumSymbol extends BTypeSymbol implements Annotatable {
     @Override
     public List<? extends AnnotationSymbol> getAnnotations() {
         return this.annots;
+    }
+
+    // Generated equals() and hashCode() implementations
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (!(o instanceof BEnumSymbol)) {
+            return false;
+        }
+        BEnumSymbol that = (BEnumSymbol) o;
+        return Objects.equals(members, that.members) && Objects.equals(annots, that.annots);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), members, annots);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BInvokableSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BInvokableSymbol.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -74,6 +75,33 @@ public class BInvokableSymbol extends BVarSymbol implements InvokableSymbol {
         this.dependentGlobalVars = new HashSet<>();
         this.paramDefaultValTypes = new HashMap<>();
         this.kind = SymbolKind.FUNCTION;
+    }
+
+    // Generated equals() and hashCode() implementations
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (!(o instanceof BInvokableSymbol)) {
+            return false;
+        }
+        BInvokableSymbol that = (BInvokableSymbol) o;
+        return bodyExist == that.bodyExist && Objects.equals(params, that.params) && Objects.equals(
+                restParam, that.restParam) && Objects.equals(retType, that.retType) && Objects.equals(
+                paramDefaultValTypes, that.paramDefaultValTypes) && Objects.equals(receiverSymbol,
+                                                                                   that.receiverSymbol) &&
+                Objects.equals(enclForkName, that.enclForkName) && Objects.equals(source,
+                                                                                  that.source) &&
+                Objects.equals(strandName, that.strandName) && schedulerPolicy == that.schedulerPolicy &&
+                Objects.equals(dependentGlobalVars, that.dependentGlobalVars);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), params, restParam, retType, paramDefaultValTypes, receiverSymbol,
+                            bodyExist,
+                            enclForkName, source, strandName, schedulerPolicy, dependentGlobalVars);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BInvokableTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BInvokableTypeSymbol.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Represents a function type symbol.
@@ -51,6 +52,27 @@ public class BInvokableTypeSymbol extends BTypeSymbol {
         this.params = new ArrayList<>();
         this.returnTypeAnnots = new ArrayList<>();
         this.paramDefaultValTypes = new HashMap<>();
+    }
+
+    // Generated equals() and hashCode() implementations
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (!(o instanceof BInvokableTypeSymbol)) {
+            return false;
+        }
+        BInvokableTypeSymbol that = (BInvokableTypeSymbol) o;
+        return Objects.equals(params, that.params) && Objects.equals(restParam, that.restParam) &&
+                Objects.equals(returnType, that.returnType) && Objects.equals(returnTypeAnnots,
+                                                                              that.returnTypeAnnots) &&
+                Objects.equals(paramDefaultValTypes, that.paramDefaultValTypes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), params, restParam, returnType, returnTypeAnnots, paramDefaultValTypes);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BObjectTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BObjectTypeSymbol.java
@@ -27,6 +27,7 @@ import org.wso2.ballerinalang.compiler.util.Names;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * {@code BObjectTypeSymbol} represents a object symbol in a scope.
@@ -52,5 +53,28 @@ public class BObjectTypeSymbol extends BStructureTypeSymbol {
         copy.initializerFunc = initializerFunc;
         copy.isLabel = true;
         return copy;
+    }
+
+    // Generated equals() and hashCode() implementations
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof BObjectTypeSymbol)) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        BObjectTypeSymbol that = (BObjectTypeSymbol) o;
+        return Objects.equals(referencedFunctions, that.referencedFunctions) && Objects.equals(
+                generatedInitializerFunc, that.generatedInitializerFunc);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), referencedFunctions, generatedInitializerFunc);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BRecordTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BRecordTypeSymbol.java
@@ -45,4 +45,15 @@ public class BRecordTypeSymbol extends BStructureTypeSymbol {
         copy.isLabel = true;
         return copy;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof BRecordTypeSymbol)) {
+            return false;
+        }
+        return super.equals(o);
+    }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BServiceSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BServiceSymbol.java
@@ -25,6 +25,7 @@ import org.wso2.ballerinalang.compiler.util.Name;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -74,5 +75,27 @@ public class BServiceSymbol extends BSymbol {
     public void addListenerType(BType type) {
         assert type != null;
         this.listenerTypes.add(type);
+    }
+
+    // Generated equals() and hashCode() implementations
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (!(o instanceof BServiceSymbol)) {
+            return false;
+        }
+        BServiceSymbol that = (BServiceSymbol) o;
+        return Objects.equals(associatedClass, that.associatedClass) && Objects.equals(listenerTypes,
+                                                                                       that.listenerTypes) &&
+                Objects.equals(absResourcePath, that.absResourcePath) && Objects.equals(
+                attachPointStringLiteral, that.attachPointStringLiteral);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), associatedClass, listenerTypes, absResourcePath,
+                            attachPointStringLiteral);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BStructureTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BStructureTypeSymbol.java
@@ -26,6 +26,7 @@ import org.wso2.ballerinalang.compiler.util.Name;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * {@code BStructureTypeSymbol} represents a structure type symbol in a scope.
@@ -42,5 +43,28 @@ public abstract class BStructureTypeSymbol extends BTypeSymbol {
         super(symTag, flags, name, pkgID, type, owner, pos, origin);
         this.attachedFuncs = new ArrayList<>(0);
         this.kind = kind;
+    }
+
+    // Generated equals() and hashCode() implementations
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof BStructureTypeSymbol)) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        BStructureTypeSymbol that = (BStructureTypeSymbol) o;
+        return Objects.equals(attachedFuncs, that.attachedFuncs) && Objects.equals(initializerFunc,
+                                                                                   that.initializerFunc);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), attachedFuncs, initializerFunc);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BSymbol.java
@@ -31,6 +31,7 @@ import org.wso2.ballerinalang.util.Flags;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -116,5 +117,27 @@ public class BSymbol implements Symbol {
     @Override
     public String toString() {
         return name.toString();
+    }
+
+    // Generated equals() and hashCode() implementations
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof BSymbol)) return false;
+        BSymbol bSymbol = (BSymbol) o;
+        return tag == bSymbol.tag && flags == bSymbol.flags && tainted == bSymbol.tainted &&
+                closure == bSymbol.closure &&
+                Objects.equals(name, bSymbol.name) && Objects.equals(pkgID, bSymbol.pkgID) &&
+                kind == bSymbol.kind && Objects.equals(type, bSymbol.type) && Objects.equals(owner,
+                                                                                             bSymbol.owner) &&
+                Objects.equals(markdownDocumentation, bSymbol.markdownDocumentation) && Objects.equals(
+                pos, bSymbol.pos) && origin == bSymbol.origin && Objects.equals(scope, bSymbol.scope);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(tag, flags, name, pkgID, kind, type, owner, tainted, closure, markdownDocumentation, pos,
+                            origin, scope);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BSymbol.java
@@ -123,16 +123,20 @@ public class BSymbol implements Symbol {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof BSymbol)) return false;
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof BSymbol)) {
+            return false;
+        }
         BSymbol bSymbol = (BSymbol) o;
         return tag == bSymbol.tag && flags == bSymbol.flags && tainted == bSymbol.tainted &&
                 closure == bSymbol.closure &&
                 Objects.equals(name, bSymbol.name) && Objects.equals(pkgID, bSymbol.pkgID) &&
-                kind == bSymbol.kind && Objects.equals(type, bSymbol.type) && Objects.equals(owner,
-                                                                                             bSymbol.owner) &&
-                Objects.equals(markdownDocumentation, bSymbol.markdownDocumentation) && Objects.equals(
-                pos, bSymbol.pos) && origin == bSymbol.origin && Objects.equals(scope, bSymbol.scope);
+                kind == bSymbol.kind && Objects.equals(type, bSymbol.type)
+                && Objects.equals(owner, bSymbol.owner)
+                && Objects.equals(markdownDocumentation, bSymbol.markdownDocumentation)
+                && Objects.equals(pos, bSymbol.pos) && origin == bSymbol.origin && Objects.equals(scope, bSymbol.scope);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BTypeSymbol.java
@@ -25,6 +25,8 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.Names;
 
+import java.util.Objects;
+
 /**
  * @since 0.94
  */
@@ -56,5 +58,22 @@ public class BTypeSymbol extends BSymbol implements TypeSymbol {
                                                           origin);
         typeSymbol.isLabel = true;
         return typeSymbol;
+    }
+
+    // Generated equals() and hashCode() implementations
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof BTypeSymbol)) return false;
+        if (!super.equals(o)) return false;
+        BTypeSymbol that = (BTypeSymbol) o;
+        return isLabel == that.isLabel && isTypeParamResolved == that.isTypeParamResolved && Objects.equals(
+                typeParamTSymbol, that.typeParamTSymbol);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), isLabel, isTypeParamResolved, typeParamTSymbol);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BTypeSymbol.java
@@ -64,12 +64,18 @@ public class BTypeSymbol extends BSymbol implements TypeSymbol {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof BTypeSymbol)) return false;
-        if (!super.equals(o)) return false;
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof BTypeSymbol)) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
         BTypeSymbol that = (BTypeSymbol) o;
-        return isLabel == that.isLabel && isTypeParamResolved == that.isTypeParamResolved && Objects.equals(
-                typeParamTSymbol, that.typeParamTSymbol);
+        return isLabel == that.isLabel && isTypeParamResolved == that.isTypeParamResolved
+                && Objects.equals(typeParamTSymbol, that.typeParamTSymbol);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BVarSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BVarSymbol.java
@@ -30,6 +30,7 @@ import org.wso2.ballerinalang.compiler.util.Name;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import static org.wso2.ballerinalang.compiler.semantics.model.symbols.SymTag.VARIABLE;
 
@@ -80,5 +81,25 @@ public class BVarSymbol extends BSymbol implements VariableSymbol, Annotatable {
     @Override
     public SymbolKind getKind() {
         return this.kind;
+    }
+
+    // Generated equals() and hashCode() implementations
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (!(o instanceof BVarSymbol)) {
+            return false;
+        }
+        BVarSymbol that = (BVarSymbol) o;
+        return isDefaultable == that.isDefaultable && isWildcard == that.isWildcard && Objects.equals(annots,
+                                                                                                      that.annots) &&
+                state == that.state && Objects.equals(originalSymbol, that.originalSymbol);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), annots, isDefaultable, isWildcard, state, originalSymbol);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BXMLNSSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BXMLNSSymbol.java
@@ -26,6 +26,8 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BNoType;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 
+import java.util.Objects;
+
 /**
  * @since 0.94
  */
@@ -51,5 +53,23 @@ public class BXMLNSSymbol extends BSymbol implements VariableSymbol {
     @Override
     public SymbolKind getKind() {
         return SymbolKind.XMLNS;
+    }
+
+    // Generated equals() and hashCode() implementations
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (!(o instanceof BXMLNSSymbol)) {
+            return false;
+        }
+        BXMLNSSymbol that = (BXMLNSSymbol) o;
+        return Objects.equals(namespaceURI, that.namespaceURI);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), namespaceURI);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BAnyType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BAnyType.java
@@ -25,6 +25,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.BTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.util.Flags;
 
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -98,5 +99,24 @@ public class BAnyType extends BBuiltInRefType implements SelectivelyImmutableRef
     @Override
     public void setIntersectionType(BIntersectionType intersectionType) {
         this.intersectionType = intersectionType;
+    }
+
+    // Generated equals() and hashCode() implementations
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (!(o instanceof BAnyType)) {
+            return false;
+        }
+        BAnyType bAnyType = (BAnyType) o;
+        return nullable == bAnyType.nullable && Objects.equals(intersectionType, bAnyType.intersectionType) &&
+                Objects.equals(immutableType, bAnyType.immutableType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), intersectionType, nullable, immutableType);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BArrayType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BArrayType.java
@@ -26,6 +26,7 @@ import org.wso2.ballerinalang.compiler.util.BArrayState;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.util.Flags;
 
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -126,5 +127,25 @@ public class BArrayType extends BType implements ArrayType {
     @Override
     public void setIntersectionType(BIntersectionType intersectionType) {
         this.intersectionType = intersectionType;
+    }
+
+    // Generated equals() and hashCode() implementations
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (!(o instanceof BArrayType)) {
+            return false;
+        }
+        BArrayType that = (BArrayType) o;
+        return size == that.size && Objects.equals(eType, that.eType) && Objects.equals(immutableType,
+                                                                                        that.immutableType) &&
+                state == that.state && Objects.equals(intersectionType, that.intersectionType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), eType, immutableType, size, state, intersectionType);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BErrorType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BErrorType.java
@@ -23,6 +23,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.BTypeSymbol;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.util.Flags;
 
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -83,5 +84,24 @@ public class BErrorType extends BType implements ErrorType {
     @Override
     public void setIntersectionType(BIntersectionType intersectionType) {
         this.intersectionType = intersectionType;
+    }
+
+    // Generated equals() and hashCode() implementations
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (!(o instanceof BErrorType)) {
+            return false;
+        }
+        BErrorType that = (BErrorType) o;
+        return Objects.equals(detailType, that.detailType) && Objects.equals(typeIdSet, that.typeIdSet) &&
+                Objects.equals(intersectionType, that.intersectionType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), detailType, typeIdSet, intersectionType);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BFiniteType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BFiniteType.java
@@ -28,6 +28,7 @@ import org.wso2.ballerinalang.util.Flags;
 
 import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.StringJoiner;
 
@@ -99,5 +100,24 @@ public class BFiniteType extends BType implements FiniteType {
         if (!nullable && value.getBType().isNullable()) {
             nullable = true;
         }
+    }
+
+    // Generated equals() and hashCode() implementations
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (!(o instanceof BFiniteType)) {
+            return false;
+        }
+        BFiniteType that = (BFiniteType) o;
+        return nullable == that.nullable && Objects.equals(valueSpace, that.valueSpace) &&
+                Objects.equals(isAnyData, that.isAnyData);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), valueSpace, nullable, isAnyData);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BFutureType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BFutureType.java
@@ -21,6 +21,8 @@ import org.wso2.ballerinalang.compiler.semantics.model.TypeVisitor;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BTypeSymbol;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 
+import java.util.Objects;
+
 /**
  * Represents an future type.
  *
@@ -64,5 +66,23 @@ public class BFutureType extends BBuiltInRefType implements ConstrainedType {
     @Override
     public void accept(TypeVisitor visitor) {
         visitor.visit(this);
+    }
+
+    // Generated equals() and hashCode() implementations
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (!(o instanceof BFutureType)) {
+            return false;
+        }
+        BFutureType that = (BFutureType) o;
+        return workerDerivative == that.workerDerivative && Objects.equals(constraint, that.constraint);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), constraint, workerDerivative);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BIntersectionType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BIntersectionType.java
@@ -29,6 +29,7 @@ import org.wso2.ballerinalang.util.Flags;
 
 import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.StringJoiner;
@@ -146,5 +147,25 @@ public class BIntersectionType extends BType implements IntersectionType {
     @Override
     public void setIntersectionType(BIntersectionType intersectionType) {
         this.intersectionType = intersectionType;
+    }
+
+    // Generated equals() and hashCode() implementations
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (!(o instanceof BIntersectionType)) {
+            return false;
+        }
+        BIntersectionType that = (BIntersectionType) o;
+        return Objects.equals(effectiveType, that.effectiveType) && Objects.equals(constituentTypes,
+                                                                                   that.constituentTypes) &&
+                Objects.equals(intersectionType, that.intersectionType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), effectiveType, constituentTypes, intersectionType);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BMapType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BMapType.java
@@ -25,6 +25,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.util.Flags;
 
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -88,5 +89,25 @@ public class BMapType extends BBuiltInRefType implements ConstrainedType, Select
     @Override
     public void setIntersectionType(BIntersectionType intersectionType) {
         this.intersectionType = intersectionType;
+    }
+
+    // Generated equals() and hashCode() implementations
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (!(o instanceof BMapType)) {
+            return false;
+        }
+        BMapType bMapType = (BMapType) o;
+        return Objects.equals(constraint, bMapType.constraint) && Objects.equals(immutableType,
+                                                                                 bMapType.immutableType) &&
+                Objects.equals(intersectionType, bMapType.intersectionType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), constraint, immutableType, intersectionType);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BObjectType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BObjectType.java
@@ -27,6 +27,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.util.Flags;
 
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -133,5 +134,25 @@ public class BObjectType extends BStructureType implements ObjectType {
     @Override
     public void setIntersectionType(BIntersectionType intersectionType) {
         this.intersectionType = intersectionType;
+    }
+
+    // Generated equals() and hashCode() implementations
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (!(o instanceof BObjectType)) {
+            return false;
+        }
+        BObjectType that = (BObjectType) o;
+        return Objects.equals(intersectionType, that.intersectionType) && Objects.equals(immutableType,
+                                                                                         that.immutableType) &&
+                Objects.equals(mutableType, that.mutableType) && Objects.equals(typeIdSet, that.typeIdSet);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), intersectionType, immutableType, mutableType, typeIdSet);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BParameterizedType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BParameterizedType.java
@@ -23,6 +23,8 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.BVarSymbol;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 
+import java.util.Objects;
+
 /**
  * This is a special type introduced to be used in the return type of an extern function. In extern function return
  * types, typedesc typed parameters of the function can be referred. This type is basically a wrapper created around
@@ -63,5 +65,24 @@ public class BParameterizedType extends BType {
     @Override
     public <T, R> R accept(BTypeVisitor<T, R> visitor, T t) {
         return visitor.visit(this, t);
+    }
+
+    // Generated equals() and hashCode() implementations
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (!(o instanceof BParameterizedType)) {
+            return false;
+        }
+        BParameterizedType that = (BParameterizedType) o;
+        return paramIndex == that.paramIndex && Objects.equals(paramSymbol, that.paramSymbol) &&
+                Objects.equals(paramValueType, that.paramValueType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), paramSymbol, paramValueType, paramIndex);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BReadonlyType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BReadonlyType.java
@@ -22,6 +22,8 @@ import org.ballerinalang.model.types.TypeKind;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BTypeSymbol;
 import org.wso2.ballerinalang.util.Flags;
 
+import java.util.Objects;
+
 /**
  * {@code BReadonlyType} represents the shapes that have their read-only bit on.
  * 
@@ -61,5 +63,23 @@ public class BReadonlyType extends BBuiltInRefType {
     @Override
     public TypeKind getKind() {
         return TypeKind.READONLY;
+    }
+
+    // Generated equals() and hashCode() implementations
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (!(o instanceof BReadonlyType)) {
+            return false;
+        }
+        BReadonlyType that = (BReadonlyType) o;
+        return nullable == that.nullable;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), nullable);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BRecordType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BRecordType.java
@@ -25,6 +25,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.util.Flags;
 
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -116,5 +117,27 @@ public class BRecordType extends BStructureType implements RecordType {
     @Override
     public void setIntersectionType(BIntersectionType intersectionType) {
         this.intersectionType = intersectionType;
+    }
+
+    // Generated equals() and hashCode() implementations
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (!(o instanceof BRecordType)) {
+            return false;
+        }
+        BRecordType that = (BRecordType) o;
+        return sealed == that.sealed && Objects.equals(restFieldType, that.restFieldType) &&
+                Objects.equals(isAnyData, that.isAnyData) && Objects.equals(immutableType, that.immutableType) &&
+                Objects.equals(mutableType, that.mutableType) && Objects.equals(intersectionType,
+                                                                                that.intersectionType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), sealed, restFieldType, isAnyData, immutableType, mutableType,
+                            intersectionType);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BStreamType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BStreamType.java
@@ -24,6 +24,8 @@ import org.wso2.ballerinalang.compiler.semantics.model.TypeVisitor;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BTypeSymbol;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 
+import java.util.Objects;
+
 /**
  * {@code BStreamType} represents stream data in Ballerina.
  *
@@ -68,5 +70,23 @@ public class BStreamType extends BBuiltInRefType implements StreamType {
     @Override
     public void accept(TypeVisitor visitor) {
         visitor.visit(this);
+    }
+
+    // Generated equals() and hashCode() implementations
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (!(o instanceof BStreamType)) {
+            return false;
+        }
+        BStreamType that = (BStreamType) o;
+        return Objects.equals(constraint, that.constraint) && Objects.equals(completionType, that.completionType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), constraint, completionType);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BStructureType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BStructureType.java
@@ -26,6 +26,7 @@ import org.wso2.ballerinalang.util.Flags;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * {@code BStructureType} represents structure type in Ballerina.
@@ -78,5 +79,23 @@ public abstract class BStructureType extends BType {
         }
 
         return value.startsWith("($");
+    }
+
+    // Generated equals() and hashCode() implementations
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (!(o instanceof BStructureType)) {
+            return false;
+        }
+        BStructureType that = (BStructureType) o;
+        return Objects.equals(fields, that.fields) && Objects.equals(typeInclusions, that.typeInclusions);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), fields, typeInclusions);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BTableType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BTableType.java
@@ -27,6 +27,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.util.Flags;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -113,5 +114,29 @@ public class BTableType extends BType implements TableType {
     @Override
     public void setIntersectionType(BIntersectionType intersectionType) {
         this.intersectionType = intersectionType;
+    }
+
+    // Generated equals() and hashCode() implementations
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (!(o instanceof BTableType)) {
+            return false;
+        }
+        BTableType that = (BTableType) o;
+        return isTypeInlineDefined == that.isTypeInlineDefined && Objects.equals(constraint, that.constraint) &&
+                Objects.equals(keyTypeConstraint, that.keyTypeConstraint) &&
+                Objects.equals(fieldNameList, that.fieldNameList) && Objects.equals(keyPos, that.keyPos) &&
+                Objects.equals(constraintPos, that.constraintPos) && Objects.equals(immutableType,
+                                                                                    that.immutableType) &&
+                Objects.equals(intersectionType, that.intersectionType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), constraint, keyTypeConstraint, fieldNameList, keyPos, isTypeInlineDefined,
+                            constraintPos, immutableType, intersectionType);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BTupleType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BTupleType.java
@@ -25,6 +25,7 @@ import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.util.Flags;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -178,6 +179,28 @@ public class BTupleType extends BType implements TupleType {
     public void setMemberTypes(List<BType> memberTypes) {
         assert memberTypes.size() == 0;
         this.tupleTypes = memberTypes;
+    }
+
+    // Generated equals() and hashCode() implementations
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (!(o instanceof BTupleType)) {
+            return false;
+        }
+        BTupleType that = (BTupleType) o;
+        return resolvingToString == that.resolvingToString && isCyclic == that.isCyclic &&
+                Objects.equals(tupleTypes, that.tupleTypes) && Objects.equals(restType, that.restType) &&
+                Objects.equals(isAnyData, that.isAnyData) && Objects.equals(immutableType, that.immutableType) &&
+                Objects.equals(intersectionType, that.intersectionType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), tupleTypes, restType, isAnyData, resolvingToString, isCyclic,
+                            immutableType, intersectionType);
     }
 
     private void setCyclicFlag(BType type) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BType.java
@@ -24,6 +24,8 @@ import org.wso2.ballerinalang.compiler.semantics.model.TypeVisitor;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BTypeSymbol;
 import org.wso2.ballerinalang.compiler.util.Names;
 
+import java.util.Objects;
+
 import static org.wso2.ballerinalang.compiler.util.TypeTags.BOOLEAN;
 import static org.wso2.ballerinalang.compiler.util.TypeTags.BYTE;
 import static org.wso2.ballerinalang.compiler.util.TypeTags.DECIMAL;
@@ -130,6 +132,25 @@ public class BType implements ValueType {
 
     protected String getQualifiedTypeName() {
         return tsymbol.pkgID.toString() + ":" + tsymbol.name;
+    }
+
+    // Generated equals() and hashCode() implementations
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (!(o instanceof BType)) {
+            return false;
+        }
+        BType bType = (BType) o;
+        return tag == bType.tag && flags == bType.flags && Objects.equals(tsymbol, bType.tsymbol) &&
+                Objects.equals(name, bType.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(tag, tsymbol, name, flags);
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BTypedescType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BTypedescType.java
@@ -23,6 +23,8 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.BTypeSymbol;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.util.Flags;
 
+import java.util.Objects;
+
 /**
  * @since 0.94
  */
@@ -62,5 +64,23 @@ public class BTypedescType extends BBuiltInRefType implements ConstrainedType {
     public void accept(TypeVisitor visitor) {
 
         visitor.visit(this);
+    }
+
+    // Generated equals() and hashCode() implementations
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (!(o instanceof BTypedescType)) {
+            return false;
+        }
+        BTypedescType that = (BTypedescType) o;
+        return Objects.equals(constraint, that.constraint);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), constraint);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BUnionType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BUnionType.java
@@ -29,6 +29,7 @@ import org.wso2.ballerinalang.util.Flags;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.StringJoiner;
@@ -494,5 +495,29 @@ public class BUnionType extends BType implements UnionType {
     @Override
     public void setIntersectionType(BIntersectionType intersectionType) {
         this.intersectionType = intersectionType;
+    }
+
+    // Generated equals() and hashCode() implementations
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (!(o instanceof BUnionType)) {
+            return false;
+        }
+        BUnionType that = (BUnionType) o;
+        return resolvingToString == that.resolvingToString && nullable == that.nullable && isCyclic == that.isCyclic &&
+                Objects.equals(immutableType, that.immutableType) &&
+                Objects.equals(intersectionType, that.intersectionType) &&
+                Objects.equals(cachedToString, that.cachedToString) && Objects.equals(memberTypes, that.memberTypes) &&
+                Objects.equals(isAnyData, that.isAnyData) && Objects.equals(isPureType, that.isPureType) &&
+                Objects.equals(originalMemberTypes, that.originalMemberTypes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), immutableType, resolvingToString, intersectionType, nullable,
+                            cachedToString, memberTypes, isAnyData, isPureType, isCyclic, originalMemberTypes);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BXMLSubType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BXMLSubType.java
@@ -23,6 +23,7 @@ import org.ballerinalang.model.types.TypeKind;
 import org.wso2.ballerinalang.compiler.semantics.model.TypeVisitor;
 import org.wso2.ballerinalang.compiler.util.Names;
 
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -96,5 +97,24 @@ public class BXMLSubType extends BType implements SelectivelyImmutableReferenceT
     @Override
     public void setIntersectionType(BIntersectionType intersectionType) {
         this.intersectionType = intersectionType;
+    }
+
+    // Generated equals() and hashCode() implementations
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (!(o instanceof BXMLSubType)) {
+            return false;
+        }
+        BXMLSubType that = (BXMLSubType) o;
+        return Objects.equals(immutableType, that.immutableType) && Objects.equals(intersectionType,
+                                                                                   that.intersectionType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), immutableType, intersectionType);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BXMLType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BXMLType.java
@@ -24,6 +24,7 @@ import org.wso2.ballerinalang.compiler.util.Names;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.util.Flags;
 
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -85,5 +86,25 @@ public class BXMLType extends BBuiltInRefType implements SelectivelyImmutableRef
     @Override
     public void setIntersectionType(BIntersectionType intersectionType) {
         this.intersectionType = intersectionType;
+    }
+
+    // Generated equals() and hashCode() implementations
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (!(o instanceof BXMLType)) {
+            return false;
+        }
+        BXMLType bxmlType = (BXMLType) o;
+        return Objects.equals(constraint, bxmlType.constraint) && Objects.equals(immutableType,
+                                                                                 bxmlType.immutableType) &&
+                Objects.equals(intersectionType, bxmlType.intersectionType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), constraint, immutableType, intersectionType);
     }
 }


### PR DESCRIPTION
## Purpose
This PR adds implementations for `equals()` and `hashCode()` methods for `BSymbol`, `BTypeSymbol`, `BType` and their sub classes. This is done to avoid different instances of aforementioned classes being collected in memory when they are used in instances like keys in a map.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
