### PR TITLE
Introduce --dump-build-time flag to BuildCommand

### DIFF
--- a/cli/ballerina-cli/spotbugs-exclude.xml
+++ b/cli/ballerina-cli/spotbugs-exclude.xml
@@ -45,6 +45,10 @@
         <Class name="io.ballerina.cli.launcher.LauncherUtils"/>
         <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"/>
     </Match>
+    <Match>
+        <Class name="io.ballerina.cli.utils.BuildTime"/>
+        <Bug pattern="URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"/>
+    </Match>
     <Match>>
         <Package name="io.ballerina.cli.launcher"/>
     </Match>

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/BuildCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/BuildCommand.java
@@ -76,7 +76,6 @@ public class BuildCommand implements BLauncherCmd {
         this.outStream = outStream;
         this.errStream = errStream;
         this.exitWhenFinish = false;
-        this.skipCopyLibsFromDist = true;
         this.dumpBuildTime = dumpBuildTime;
     }
 

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/BuildCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/BuildCommand.java
@@ -23,8 +23,10 @@ import io.ballerina.cli.task.CleanTargetDirTask;
 import io.ballerina.cli.task.CompileTask;
 import io.ballerina.cli.task.CreateBalaTask;
 import io.ballerina.cli.task.CreateExecutableTask;
+import io.ballerina.cli.task.DumpBuildTimeTask;
 import io.ballerina.cli.task.ResolveMavenDependenciesTask;
 import io.ballerina.cli.task.RunTestsTask;
+import io.ballerina.cli.utils.BuildTime;
 import io.ballerina.cli.utils.FileUtils;
 import io.ballerina.projects.BuildOptions;
 import io.ballerina.projects.BuildOptionsBuilder;
@@ -67,6 +69,15 @@ public class BuildCommand implements BLauncherCmd {
         this.errStream = System.err;
         this.exitWhenFinish = true;
         this.skipCopyLibsFromDist = false;
+    }
+
+    public BuildCommand(Path projectPath, PrintStream outStream, PrintStream errStream, boolean dumpBuildTime) {
+        this.projectPath = projectPath;
+        this.outStream = outStream;
+        this.errStream = errStream;
+        this.exitWhenFinish = false;
+        this.skipCopyLibsFromDist = true;
+        this.dumpBuildTime = dumpBuildTime;
     }
 
     public BuildCommand(Path projectPath, PrintStream outStream, PrintStream errStream, boolean exitWhenFinish,
@@ -173,7 +184,11 @@ public class BuildCommand implements BLauncherCmd {
             description = "list conflicted classes when generating executable")
     private Boolean listConflictedClasses;
 
+    @CommandLine.Option(names = "--dump-build-time", description = "calculate and dump build time")
+    private Boolean dumpBuildTime;
+
     public void execute() {
+        long start = 0;
         if (this.helpFlag) {
             String commandUsageInfo = BLauncherCmd.getCommandUsageInfo(BUILD_COMMAND);
             this.errStream.println(commandUsageInfo);
@@ -203,7 +218,14 @@ public class BuildCommand implements BLauncherCmd {
                 return;
             }
             try {
+                if (buildOptions.dumpBuildTime()) {
+                    start = System.currentTimeMillis();
+                    BuildTime.getInstance().timestamp = start;
+                }
                 project = SingleFileProject.load(this.projectPath, buildOptions);
+                if (buildOptions.dumpBuildTime()) {
+                    BuildTime.getInstance().projectLoadDuration = System.currentTimeMillis() - start;
+                }
             } catch (ProjectException e) {
                 CommandUtil.printError(this.errStream, e.getMessage(), null, false);
                 CommandUtil.exitError(this.exitWhenFinish);
@@ -222,7 +244,14 @@ public class BuildCommand implements BLauncherCmd {
                 return;
             }
             try {
+                if (buildOptions.dumpBuildTime()) {
+                    start = System.currentTimeMillis();
+                    BuildTime.getInstance().timestamp = start;
+                }
                 project = BuildProject.load(this.projectPath, buildOptions);
+                if (buildOptions.dumpBuildTime()) {
+                    BuildTime.getInstance().projectLoadDuration = System.currentTimeMillis() - start;
+                }
             } catch (ProjectException e) {
                 CommandUtil.printError(this.errStream, e.getMessage(), null, false);
                 CommandUtil.exitError(this.exitWhenFinish);
@@ -297,6 +326,7 @@ public class BuildCommand implements BLauncherCmd {
                 .addTask(new CreateBalaTask(outStream), isSingleFileBuild || !this.compile)
                 // create the executable jar, skip if -c flag is provided
                 .addTask(new CreateExecutableTask(outStream, this.output), this.compile)
+                .addTask(new DumpBuildTimeTask(outStream), !project.buildOptions().dumpBuildTime())
                 .build();
 
         taskExecutor.executeTasks(project);
@@ -327,6 +357,7 @@ public class BuildCommand implements BLauncherCmd {
                 .dumpBir(dumpBIR)
                 .dumpBirFile(dumpBIRFile)
                 .listConflictedClasses(listConflictedClasses)
+                .dumpBuildTime(dumpBuildTime)
                 .build();
     }
 

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/CompileTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/CompileTask.java
@@ -18,6 +18,7 @@
 
 package io.ballerina.cli.task;
 
+import io.ballerina.cli.utils.BuildTime;
 import io.ballerina.projects.DiagnosticResult;
 import io.ballerina.projects.JBallerinaBackend;
 import io.ballerina.projects.JvmTarget;
@@ -61,8 +62,22 @@ public class CompileTask implements Task {
         this.out.println("\t" + sourceName);
 
         try {
+            long start = 0;
+            if (project.buildOptions().dumpBuildTime()) {
+                start = System.currentTimeMillis();
+                project.currentPackage().getResolution();
+                BuildTime.getInstance().packageResolutionDuration = System.currentTimeMillis() - start;
+                start = System.currentTimeMillis();
+            }
             PackageCompilation packageCompilation = project.currentPackage().getCompilation();
+            if (project.buildOptions().dumpBuildTime()) {
+                BuildTime.getInstance().packageCompilationDuration = System.currentTimeMillis() - start;
+                start = System.currentTimeMillis();
+            }
             JBallerinaBackend jBallerinaBackend = JBallerinaBackend.from(packageCompilation, JvmTarget.JAVA_11);
+            if (project.buildOptions().dumpBuildTime()) {
+                BuildTime.getInstance().codeGenDuration = System.currentTimeMillis() - start;
+            }
             DiagnosticResult diagnosticResult = jBallerinaBackend.diagnosticResult();
             diagnosticResult.diagnostics().forEach(d -> err.println(d.toString()));
             if (diagnosticResult.hasErrors()) {

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/CreateBalaTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/CreateBalaTask.java
@@ -72,8 +72,8 @@ public class CreateBalaTask implements Task {
             }
             emitResult = jBallerinaBackend.emit(JBallerinaBackend.OutputType.BALA, balaPath);
             if (project.buildOptions().dumpBuildTime()) {
-                BuildTime.getInstance().codeGenDuration = BuildTime.getInstance().codeGenDuration +
-                        (System.currentTimeMillis() - start);
+                BuildTime.getInstance().emitArtifactDuration = System.currentTimeMillis() - start;
+                BuildTime.getInstance().compile = true;
             }
         } catch (ProjectException e) {
             throw createLauncherException("BALA creation failed:" + e.getMessage());

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/CreateBalaTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/CreateBalaTask.java
@@ -18,6 +18,7 @@
 
 package io.ballerina.cli.task;
 
+import io.ballerina.cli.utils.BuildTime;
 import io.ballerina.projects.EmitResult;
 import io.ballerina.projects.JBallerinaBackend;
 import io.ballerina.projects.JvmTarget;
@@ -65,7 +66,15 @@ public class CreateBalaTask implements Task {
         try {
             PackageCompilation packageCompilation = project.currentPackage().getCompilation();
             jBallerinaBackend = JBallerinaBackend.from(packageCompilation, JvmTarget.JAVA_11);
+            long start = 0;
+            if (project.buildOptions().dumpBuildTime()) {
+                start = System.currentTimeMillis();
+            }
             emitResult = jBallerinaBackend.emit(JBallerinaBackend.OutputType.BALA, balaPath);
+            if (project.buildOptions().dumpBuildTime()) {
+                BuildTime.getInstance().codeGenDuration = BuildTime.getInstance().codeGenDuration +
+                        (System.currentTimeMillis() - start);
+            }
         } catch (ProjectException e) {
             throw createLauncherException("BALA creation failed:" + e.getMessage());
         }

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/CreateExecutableTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/CreateExecutableTask.java
@@ -18,6 +18,7 @@
 
 package io.ballerina.cli.task;
 
+import io.ballerina.cli.utils.BuildTime;
 import io.ballerina.cli.utils.FileUtils;
 import io.ballerina.projects.JBallerinaBackend;
 import io.ballerina.projects.JvmTarget;
@@ -89,7 +90,15 @@ public class CreateExecutableTask implements Task {
         try {
             PackageCompilation pkgCompilation = project.currentPackage().getCompilation();
             JBallerinaBackend jBallerinaBackend = JBallerinaBackend.from(pkgCompilation, JvmTarget.JAVA_11);
+            long start = 0;
+            if (project.buildOptions().dumpBuildTime()) {
+                start = System.currentTimeMillis();
+            }
             jBallerinaBackend.emit(JBallerinaBackend.OutputType.EXEC, executablePath);
+            if (project.buildOptions().dumpBuildTime()) {
+                BuildTime.getInstance().codeGenDuration = BuildTime.getInstance().codeGenDuration +
+                        (System.currentTimeMillis() - start);
+            }
 
             // Print warnings for conflicted jars
             if (!jBallerinaBackend.conflictedJars().isEmpty()) {

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/CreateExecutableTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/CreateExecutableTask.java
@@ -96,8 +96,8 @@ public class CreateExecutableTask implements Task {
             }
             jBallerinaBackend.emit(JBallerinaBackend.OutputType.EXEC, executablePath);
             if (project.buildOptions().dumpBuildTime()) {
-                BuildTime.getInstance().codeGenDuration = BuildTime.getInstance().codeGenDuration +
-                        (System.currentTimeMillis() - start);
+                BuildTime.getInstance().emitArtifactDuration = System.currentTimeMillis() - start;
+                BuildTime.getInstance().compile = false;
             }
 
             // Print warnings for conflicted jars

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/DumpBuildTimeTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/DumpBuildTimeTask.java
@@ -1,0 +1,83 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package io.ballerina.cli.task;
+
+import com.google.gson.Gson;
+import io.ballerina.cli.utils.BuildTime;
+import io.ballerina.projects.Project;
+import io.ballerina.projects.ProjectKind;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.PrintStream;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static io.ballerina.cli.launcher.LauncherUtils.createLauncherException;
+
+/**
+ * Task for generation build time file.
+ *
+ * @since 2.0.0
+ */
+public class DumpBuildTimeTask implements Task {
+    private final transient PrintStream out;
+    private final Path currentDir = Paths.get(System.getProperty("user.dir"));
+
+    public DumpBuildTimeTask(PrintStream out) {
+        this.out = out;
+    }
+
+    @Override
+    public void execute(Project project) {
+        if (project.buildOptions().dumpBuildTime()) {
+            BuildTime.getInstance().totalDuration = System.currentTimeMillis() - BuildTime.getInstance().timestamp;
+            BuildTime.getInstance().offline = project.buildOptions().offlineBuild();
+            Path buildTimeFile = getBuildTimeFilePath(project);
+            Path buildTimeFileRelativePath = Paths.get(System.getProperty("user.dir")).relativize(buildTimeFile);
+            this.out.println("\nDumping build time information\n\t" + buildTimeFileRelativePath);
+            persistBuildTimeToFile(buildTimeFile);
+        }
+    }
+
+    private void persistBuildTimeToFile(Path filepath) {
+        File jsonFile = new File(filepath.toString());
+        try (FileOutputStream fileOutputStream = new FileOutputStream(jsonFile)) {
+            try (Writer writer = new OutputStreamWriter(fileOutputStream, StandardCharsets.UTF_8)) {
+                Gson gson = new Gson();
+                String json = gson.toJson(BuildTime.getInstance());
+                writer.write(new String(json.getBytes(StandardCharsets.UTF_8), StandardCharsets.UTF_8));
+            } catch (IOException e) {
+                throw createLauncherException("couldn't write build time to file : " + e.getMessage());
+            }
+        } catch (IOException e) {
+            throw createLauncherException("couldn't write build time to file : " + e.getMessage());
+        }
+    }
+
+    private Path getBuildTimeFilePath(Project project) {
+        if (project.kind().equals(ProjectKind.BUILD_PROJECT)) {
+            return project.sourceRoot().resolve("target").resolve("build-time.json").toAbsolutePath();
+        }
+        return currentDir.resolve("build-time.json").toAbsolutePath();
+    }
+}

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/DumpBuildTimeTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/DumpBuildTimeTask.java
@@ -40,6 +40,7 @@ import static io.ballerina.cli.launcher.LauncherUtils.createLauncherException;
  * @since 2.0.0
  */
 public class DumpBuildTimeTask implements Task {
+    private static final String BUILD_TIME_JSON = "build-time.json";
     private final transient PrintStream out;
     private final Path currentDir = Paths.get(System.getProperty("user.dir"));
 
@@ -76,7 +77,7 @@ public class DumpBuildTimeTask implements Task {
 
     private Path getBuildTimeFilePath(Project project) {
         if (project.kind().equals(ProjectKind.BUILD_PROJECT)) {
-            return project.sourceRoot().resolve("target").resolve("build-time.json").toAbsolutePath();
+            return project.sourceRoot().resolve("target").resolve(BUILD_TIME_JSON).toAbsolutePath();
         }
         return currentDir.resolve("build-time.json").toAbsolutePath();
     }

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
@@ -20,6 +20,7 @@ package io.ballerina.cli.task;
 
 import com.google.gson.Gson;
 import io.ballerina.cli.launcher.LauncherUtils;
+import io.ballerina.cli.utils.BuildTime;
 import io.ballerina.projects.JBallerinaBackend;
 import io.ballerina.projects.JarLibrary;
 import io.ballerina.projects.JarResolver;
@@ -140,6 +141,10 @@ public class RunTestsTask implements Task {
 
     @Override
     public void execute(Project project) {
+        long start = 0;
+        if (project.buildOptions().dumpBuildTime()) {
+            start = System.currentTimeMillis();
+        }
         try {
             ProjectUtils.checkExecutePermission(project.sourceRoot());
         } catch (ProjectException e) {
@@ -254,6 +259,9 @@ public class RunTestsTask implements Task {
 
         // Cleanup temp cache for SingleFileProject
         cleanTempCache(project, cachesRoot);
+        if (project.buildOptions().dumpBuildTime()) {
+            BuildTime.getInstance().testingExecutionDuration = System.currentTimeMillis() - start;
+        }
     }
 
     private void generateCoverage(Project project, JBallerinaBackend jBallerinaBackend)

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/utils/BuildTime.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/utils/BuildTime.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package io.ballerina.cli.utils;
+
+/**
+ * Util class to capture build time information.
+ *
+ * @since 2.0.0
+ */
+public class BuildTime {
+
+    private static final BuildTime instance = new BuildTime();
+
+    public long timestamp;
+    public boolean offline;
+    public long projectLoadDuration;
+    public long packageResolutionDuration;
+    public long packageCompilationDuration;
+    public long codeGenDuration;
+    public long testingExecutionDuration;
+    public long totalDuration;
+
+    public static BuildTime getInstance() {
+        return instance;
+    }
+}

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/utils/BuildTime.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/utils/BuildTime.java
@@ -28,10 +28,12 @@ public class BuildTime {
 
     public long timestamp;
     public boolean offline;
+    public boolean compile;
     public long projectLoadDuration;
     public long packageResolutionDuration;
     public long packageCompilationDuration;
     public long codeGenDuration;
+    public long emitArtifactDuration;
     public long testingExecutionDuration;
     public long totalDuration;
 

--- a/cli/ballerina-cli/src/main/resources/cli-help/ballerina-build.help
+++ b/cli/ballerina-cli/src/main/resources/cli-help/ballerina-build.help
@@ -5,12 +5,12 @@ SYNOPSIS
        bal build
        bal build <ballerina-file-path> 
        bal build <ballerina-package-path>
-       bal build [--test-report] [--offline] [--experimental] [-o | --output] <output-path> 
+       bal build [--test-report] [--offline] [--experimental] [-o | --output] <output-path> [--dump-build-time]
                   <ballerina-file-path> 
-       bal build [-c | --compile] [--offline] [experimental] [--cloud] [--observability-included] 
+       bal build [-c | --compile] [--offline] [experimental] [--cloud] [--observability-included] [--dump-build-time]
                  [--skip-tests] [--list-conflicted-classes] <ballerina-package-path> 
-       bal build [-c | --compile] [--offline] [experimental] [--cloud] [--observability-included] 
-                 [--list-conflicted-classes] [--debug]  [--test-report] [--code-coverage] 
+       bal build [-c | --compile] [--offline] [experimental] [--cloud] [--observability-included] [--dump-build-time]
+                 [--list-conflicted-classes] [--debug]  [--test-report] [--code-coverage]
                  <ballerina-package-path>
          
 
@@ -70,6 +70,9 @@ OPTIONS
 
        --list-conflicted-classes
        		List the conflicting classes of conflicting JARs in the project.
+
+       --dump-build-time
+            Calculate and dump build time.
 
 
 EXAMPLES

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/BuildCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/BuildCommandTest.java
@@ -788,4 +788,36 @@ public class BuildCommandTest extends BaseCommandTest {
         Assert.assertTrue(buildLog.contains("unsupported coverage report format 'html' found. Only 'xml' format is " +
                 "supported."));
     }
+
+    @Test
+    public void testDumpBuildTimeForPackage() throws IOException {
+        Path projectPath = this.testResources.resolve("validApplicationProject");
+        System.setProperty("user.dir", projectPath.toString());
+        BuildCommand buildCommand = new BuildCommand(projectPath, printStream, printStream, true);
+        new CommandLine(buildCommand).parse();
+        buildCommand.execute();
+        String buildLog = readOutput(true);
+        Assert.assertEquals(buildLog.replaceAll("\r", ""), getOutput("dump-build-time-package.txt"));
+
+        Assert.assertTrue(Files.exists(projectPath.resolve("target").resolve("build-time.json")));
+        Assert.assertTrue(projectPath.resolve("target").resolve("build-time.json").toFile().length() > 0);
+    }
+
+    @Test
+    public void testDumpBuildTimeForStandaloneFile() throws IOException {
+        Path balFilePath = this.testResources.resolve("valid-bal-file").resolve("hello_world.bal");
+
+        System.setProperty("user.dir", this.testResources.resolve("valid-bal-file").toString());
+        BuildCommand buildCommand = new BuildCommand(balFilePath, printStream, printStream, true);
+        new CommandLine(buildCommand).parse(balFilePath.toString());
+        buildCommand.execute();
+        String buildLog = readOutput(true);
+        Assert.assertEquals(buildLog.replaceAll("\r", ""),
+                getOutput("dump-build-time-standalone.txt"));
+        Assert.assertTrue(Files.exists(this.testResources.resolve("valid-bal-file").resolve("build-time.json")));
+        Assert.assertTrue(
+                this.testResources.resolve("valid-bal-file").resolve("build-time.json").toFile().length() > 0);
+    }
+
+
 }

--- a/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/unix/dump-build-time-package.txt
+++ b/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/unix/dump-build-time-package.txt
@@ -1,0 +1,8 @@
+Compiling source
+	foo/winery:0.1.0
+
+Generating executable
+	target/bin/winery.jar
+
+Dumping build time information
+	target/build-time.json

--- a/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/unix/dump-build-time-standalone.txt
+++ b/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/unix/dump-build-time-standalone.txt
@@ -1,0 +1,8 @@
+Compiling source
+	hello_world.bal
+
+Generating executable
+	hello_world.jar
+
+Dumping build time information
+	build-time.json

--- a/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/windows/dump-build-time-package.txt
+++ b/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/windows/dump-build-time-package.txt
@@ -1,0 +1,8 @@
+Compiling source
+	foo/winery:0.1.0
+
+Generating executable
+	target\bin\winery.jar
+
+Dumping build time information
+	target\build-time.json

--- a/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/windows/dump-build-time-standalone.txt
+++ b/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/windows/dump-build-time-standalone.txt
@@ -1,0 +1,8 @@
+Compiling source
+	hello_world.bal
+
+Generating executable
+	hello_world.jar
+
+Dumping build time information
+	build-time.json

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BuildOptions.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BuildOptions.java
@@ -25,13 +25,14 @@ import java.util.Objects;
 public class BuildOptions {
     private Boolean testReport;
     private Boolean codeCoverage;
+    private Boolean dumpBuildTime;
     private CompilationOptions compilationOptions;
 
-    BuildOptions(Boolean testReport,
-                 Boolean codeCoverage,
+    BuildOptions(Boolean testReport, Boolean codeCoverage, Boolean dumpBuildTime,
                  CompilationOptions compilationOptions) {
         this.testReport = testReport;
         this.codeCoverage = codeCoverage;
+        this.dumpBuildTime = dumpBuildTime;
         this.compilationOptions = compilationOptions;
     }
 
@@ -41,6 +42,10 @@ public class BuildOptions {
 
     public boolean codeCoverage() {
         return toBooleanDefaultIfNull(codeCoverage);
+    }
+
+    public boolean dumpBuildTime() {
+        return toBooleanDefaultIfNull(dumpBuildTime);
     }
 
     public boolean skipTests() {
@@ -83,6 +88,8 @@ public class BuildOptions {
                 theirOptions.codeCoverage, () -> toBooleanDefaultIfNull(this.codeCoverage));
         this.testReport = Objects.requireNonNullElseGet(
                 theirOptions.testReport, () -> toBooleanDefaultIfNull(this.testReport));
+        this.dumpBuildTime = Objects.requireNonNullElseGet(
+                theirOptions.dumpBuildTime, () -> toBooleanDefaultIfNull(this.dumpBuildTime));
         this.compilationOptions = compilationOptions.acceptTheirs(theirOptions.compilationOptions());
 
         return this;
@@ -101,7 +108,7 @@ public class BuildOptions {
     public enum OptionName {
         TEST_REPORT("testReport"),
         CODE_COVERAGE("codeCoverage"),
-        B7A_CONFIG_FILE("b7aConfigFile")
+        DUMP_BUILD_TIME("dumpBuildTime")
         ;
 
         private String name;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BuildOptionsBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BuildOptionsBuilder.java
@@ -27,6 +27,7 @@ package io.ballerina.projects;
 public class BuildOptionsBuilder {
     private Boolean testReport;
     private Boolean codeCoverage;
+    private Boolean dumpBuildTime;
     private final CompilationOptionsBuilder compilationOptionsBuilder;
 
     public BuildOptionsBuilder() {
@@ -40,6 +41,11 @@ public class BuildOptionsBuilder {
 
     public BuildOptionsBuilder codeCoverage(Boolean value) {
         codeCoverage = value;
+        return this;
+    }
+
+    public BuildOptionsBuilder dumpBuildTime(Boolean value) {
+        dumpBuildTime = value;
         return this;
     }
 
@@ -85,6 +91,6 @@ public class BuildOptionsBuilder {
 
     public BuildOptions build() {
         CompilationOptions compilationOptions = compilationOptionsBuilder.build();
-        return new BuildOptions(testReport, codeCoverage, compilationOptions);
+        return new BuildOptions(testReport, codeCoverage, dumpBuildTime, compilationOptions);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ManifestBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ManifestBuilder.java
@@ -412,6 +412,8 @@ public class ManifestBuilder {
         boolean codeCoverage =
                 getBooleanFromBuildOptionsTableNode(tableNode, BuildOptions.OptionName.CODE_COVERAGE.toString());
         final TopLevelNode topLevelNode = tableNode.entries().get(CompilerOptionName.CLOUD.toString());
+        boolean dumpBuildTime =
+                getBooleanFromBuildOptionsTableNode(tableNode, BuildOptions.OptionName.DUMP_BUILD_TIME.toString());
         String cloud = "";
         if (topLevelNode != null) {
             cloud = getStringFromTomlTableNode(topLevelNode);
@@ -427,6 +429,7 @@ public class ManifestBuilder {
                 .codeCoverage(codeCoverage)
                 .cloud(cloud)
                 .listConflictedClasses(listConflictedClasses)
+                .dumpBuildTime(dumpBuildTime)
                 .build();
     }
 

--- a/distribution/zip/jballerina-tools/resources/command-completion/command-completion.csv
+++ b/distribution/zip/jballerina-tools/resources/command-completion/command-completion.csv
@@ -2,7 +2,7 @@ cmdname,flags
 add, -t --template
 bal, -v -h --help --version add bindgen build clean dist doc encrypt format grpc help init new openapi pull push run search shell test update version
 bindgen, -cp -m -mvn -o --classpath --maven --modules --output --public
-build, -c -o --cloud --code-coverage --coverage-format --compile --debug --experimental --list-conflicted-classes --observability-included --offline --output --skiptests --test-report
+build, -c -o --cloud --code-coverage --coverage-format --compile --debug --experimental --list-conflicted-classes --observability-included --offline --output --skiptests --test-report --dump-build-time
 dist, list pull remove update use
 doc, -c -e -o --combine --exclude --output --experimental 
 encrypt, 


### PR DESCRIPTION
## Purpose
> Introduce --dump-build-time flag to BuildCommand
Fixes #31238 

## Approach
`bal build --dump-build-time` will generate `target/built-time.json` with content simlar to following:
```json
{
    "timestamp": 1624304381716,
    "offline": false,
    "projectLoadDuration": 435,
    "packageResolutionDuration": 2579,
    "packageCompilationDuration": 175,
    "codeGenDuration": 547,
    "testingExecutionDuration": 0,
    "totalDuration": 3763
}
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
