### PR TITLE
Improve file deletion in stdlibs

### DIFF
--- a/stdlib/file/src/main/java/org/ballerinalang/stdlib/file/nativeimpl/Utils.java
+++ b/stdlib/file/src/main/java/org/ballerinalang/stdlib/file/nativeimpl/Utils.java
@@ -176,10 +176,7 @@ public class Utils {
                 Path directory = Paths.get(removeFile.getCanonicalPath());
                 Files.walkFileTree(directory, new RecursiveFileVisitor());
             } else {
-                if (!removeFile.delete()) {
-                    return FileUtils.getBallerinaError(FileConstants.FILE_SYSTEM_ERROR,
-                            "Error while deleting " + removeFile.getCanonicalPath());
-                }
+                Files.delete(removeFile.toPath());
             }
             return null;
         } catch (IOException ex) {

--- a/stdlib/file/src/test/java/org/ballerinalang/stdlib/file/FileTest.java
+++ b/stdlib/file/src/test/java/org/ballerinalang/stdlib/file/FileTest.java
@@ -150,7 +150,6 @@ public class FileTest {
             assertTrue(returns[0] instanceof BError);
             BError error = (BError) returns[0];
             assertEquals(error.getReason(), FileConstants.FILE_SYSTEM_ERROR);
-            assertTrue(((BMap) error.getDetails()).get("message").stringValue().contains("Error while deleting "));
 
             // Remove directory with recursive true
             BValue[] args2 = {new BString(tempSourceDirPath.toString()), new BBoolean(true)};


### PR DESCRIPTION
## Purpose
> `File.delete()` returns `false` with giving any proper reason. The real reason cannot be known. `Files.delete()` is much more improved and throws IOException if it cannot be deleted which is captured in the `catch`

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/31381

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [X] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
