### PR TITLE
Add checks for running jar files with options

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/RunCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/RunCommand.java
@@ -86,7 +86,7 @@ public class RunCommand implements BLauncherCmd {
     private Boolean observabilityIncluded;
 
     private static final String runCmd =
-            "bal run <executable-jar> \n" +
+            "bal run [--debug] <executable-jar> \n" +
             "    bal run [--experimental] [--offline]\n" +
             "                  [<ballerina-file | package-path>] [-- program-args...]\n ";
 
@@ -121,7 +121,7 @@ public class RunCommand implements BLauncherCmd {
             if (!argList.get(0).equals("--")) { // project path provided
                 this.projectPath = Paths.get(argList.get(0));
                 if (RunCommand.JAR_EXTENSION_MATCHER.matches(this.projectPath)) {
-                    CommandUtil.printError(this.errStream, "options are not allowed when executing jar files",
+                    CommandUtil.printError(this.errStream, "unsupported option(s) provided for jar execution",
                             runCmd, true);
                     CommandUtil.exitError(this.exitWhenFinish);
                     return;
@@ -195,7 +195,7 @@ public class RunCommand implements BLauncherCmd {
 
     @Override
     public void printUsage(StringBuilder out) {
-        out.append("  bal run <executable-jar>\n");
+        out.append("  bal run [--debug] <executable-jar>\n");
         out.append("  bal run [--offline] [<balfile> | <project-path>]\n" +
                 "[--] [args...] \n");
     }

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/RunCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/RunCommand.java
@@ -80,8 +80,10 @@ public class RunCommand implements BLauncherCmd {
             "when run is used with a source file or a module.")
     private Boolean observabilityIncluded;
 
-    private static final String runCmd = "bal run [--experimental] [--offline]\n" +
-            "                  [<executable-jar | ballerina-file | package-path>] [-- program-args...]";
+    private static final String runCmd =
+            "bal run <executable-jar> \n" +
+            "    bal run [--experimental] [--offline]\n" +
+            "                  [<ballerina-file | package-path>] [-- program-args...]\n ";
 
     public RunCommand() {
         this.projectPath = Paths.get(System.getProperty(ProjectConstants.USER_DIR));
@@ -182,7 +184,8 @@ public class RunCommand implements BLauncherCmd {
 
     @Override
     public void printUsage(StringBuilder out) {
-        out.append("  bal run [--offline] [<balfile> | <project-path> | executable-jar]\n" +
+        out.append("  bal run <executable-jar>\n");
+        out.append("  bal run [--offline] [<balfile> | <project-path>]\n" +
                 "[--] [args...] \n");
     }
 

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/RunCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/RunCommand.java
@@ -35,7 +35,9 @@ import io.ballerina.projects.util.ProjectConstants;
 import picocli.CommandLine;
 
 import java.io.PrintStream;
+import java.nio.file.FileSystems;
 import java.nio.file.Path;
+import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
@@ -55,6 +57,9 @@ public class RunCommand implements BLauncherCmd {
     private final PrintStream errStream;
     private Path projectPath;
     private boolean exitWhenFinish;
+
+    private static final PathMatcher JAR_EXTENSION_MATCHER =
+            FileSystems.getDefault().getPathMatcher("glob:**.jar");
 
     @CommandLine.Parameters(description = "Program arguments")
     private List<String> argList = new ArrayList<>();
@@ -115,6 +120,12 @@ public class RunCommand implements BLauncherCmd {
         if (!argList.isEmpty()) {
             if (!argList.get(0).equals("--")) { // project path provided
                 this.projectPath = Paths.get(argList.get(0));
+                if (RunCommand.JAR_EXTENSION_MATCHER.matches(this.projectPath)) {
+                    CommandUtil.printError(this.errStream, "options are not allowed when executing jar files",
+                            runCmd, true);
+                    CommandUtil.exitError(this.exitWhenFinish);
+                    return;
+                }
                 if (argList.size() > 1 && !argList.get(1).equals("--")) {
                     CommandUtil.printError(this.errStream,
                             "unmatched command argument found: " + argList.get(1), runCmd, false);

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/RunCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/RunCommand.java
@@ -86,7 +86,7 @@ public class RunCommand implements BLauncherCmd {
     private Boolean observabilityIncluded;
 
     private static final String runCmd =
-            "bal run [--debug] <executable-jar> \n" +
+            "bal run [--debug <port>] <executable-jar> \n" +
             "    bal run [--experimental] [--offline]\n" +
             "                  [<ballerina-file | package-path>] [-- program-args...]\n ";
 
@@ -195,7 +195,7 @@ public class RunCommand implements BLauncherCmd {
 
     @Override
     public void printUsage(StringBuilder out) {
-        out.append("  bal run [--debug] <executable-jar>\n");
+        out.append("  bal run [--debug <port>] <executable-jar>\n");
         out.append("  bal run [--offline] [<balfile> | <project-path>]\n" +
                 "[--] [args...] \n");
     }

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/RunCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/RunCommandTest.java
@@ -155,4 +155,30 @@ public class RunCommandTest extends BaseCommandTest {
         // No assertions required since the command will fail upon expected behavior
         runCommand.execute();
     }
+
+    @Test(description = "Run a jar file")
+    public void testRunJarFile() {
+        Path projectPath = this.testResources.resolve("jar-file");
+        System.setProperty("user.dir", this.testResources.resolve("jar-file").toString());
+
+        // Run build command to generate jar file
+        BuildCommand buildCommand = new BuildCommand(projectPath, printStream, printStream, false, true);
+        buildCommand.execute();
+        Assert.assertTrue(projectPath.resolve("target").resolve("bin").resolve("foo.jar").toFile().exists());
+
+        // Try to run the har file
+        Path tempFile = projectPath.resolve("foo.jar");
+        RunCommand runCommand = new RunCommand(projectPath, printStream, false);
+
+        String args = "--offline";
+        new CommandLine(runCommand).setEndOfOptionsDelimiter("").setUnmatchedOptionsArePositionalParams(true)
+                .parse(projectPath.toString(), args, tempFile.toString());
+
+        try {
+            runCommand.execute();
+        } catch (BLauncherException e) {
+            Assert.assertTrue(e.getDetailedMessages().get(0)
+                    .contains("unsupported option(s) provided for jar execution"));
+        }
+    }
 }

--- a/cli/ballerina-cli/src/test/resources/test-resources/jar-file/Ballerina.toml
+++ b/cli/ballerina-cli/src/test/resources/test-resources/jar-file/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "wso2"
+name = "foo"
+version = "0.1.0"

--- a/cli/ballerina-cli/src/test/resources/test-resources/jar-file/main.bal
+++ b/cli/ballerina-cli/src/test/resources/test-resources/jar-file/main.bal
@@ -1,0 +1,4 @@
+
+public function main() {
+
+}

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ProjectFiles.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ProjectFiles.java
@@ -51,6 +51,9 @@ public class ProjectFiles {
             FileSystems.getDefault().getPathMatcher("glob:**.bal");
     public static final PathMatcher BALA_EXTENSION_MATCHER =
             FileSystems.getDefault().getPathMatcher("glob:**.bala");
+    public static final PathMatcher JAR_EXTENSION_MATCHER =
+            FileSystems.getDefault().getPathMatcher("glob:**.jar");
+
 
     private ProjectFiles() {
     }
@@ -230,6 +233,9 @@ public class ProjectFiles {
         }
 
         if (!Files.isRegularFile(filePath) || !ProjectFiles.BAL_EXTENSION_MATCHER.matches(filePath)) {
+            if (ProjectFiles.JAR_EXTENSION_MATCHER.matches(filePath)) {
+                throw new ProjectException("Options are not allowed when executing jar files");
+            }
             throw new ProjectException("Invalid Ballerina source file(.bal): " + filePath);
         }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ProjectFiles.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ProjectFiles.java
@@ -51,9 +51,6 @@ public class ProjectFiles {
             FileSystems.getDefault().getPathMatcher("glob:**.bal");
     public static final PathMatcher BALA_EXTENSION_MATCHER =
             FileSystems.getDefault().getPathMatcher("glob:**.bala");
-    public static final PathMatcher JAR_EXTENSION_MATCHER =
-            FileSystems.getDefault().getPathMatcher("glob:**.jar");
-
 
     private ProjectFiles() {
     }
@@ -233,9 +230,6 @@ public class ProjectFiles {
         }
 
         if (!Files.isRegularFile(filePath) || !ProjectFiles.BAL_EXTENSION_MATCHER.matches(filePath)) {
-            if (ProjectFiles.JAR_EXTENSION_MATCHER.matches(filePath)) {
-                throw new ProjectException("Options are not allowed when executing jar files");
-            }
             throw new ProjectException("Invalid Ballerina source file(.bal): " + filePath);
         }
 


### PR DESCRIPTION
## Purpose
Displays an error message when using flags when running jar files

Fixes #24259

```
bal run --offline foo.jar
ballerina: Options are not allowed when executing jar files

USAGE:
    bal run <executable-jar> 
    bal run [--experimental] [--offline]
                  [<ballerina-file | package-path>] [-- program-args...]
```

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
