### PR TITLE
Fix modules getting removed during syntaxTreeModify

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/visitor/UnusedSymbolsVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/visitor/UnusedSymbolsVisitor.java
@@ -187,12 +187,15 @@ public class UnusedSymbolsVisitor extends NodeVisitor {
     public void visit(ImportDeclarationNode importDeclarationNode) {
         addUnusedImportNode(importDeclarationNode);
 
-        if (importDeclarationNode.moduleName().size() > 0 && importDeclarationNode.moduleName().get(0) != null) {
+        int moduleNamePosition = importDeclarationNode.moduleName().size() - 1;
+        if (importDeclarationNode.moduleName().size() > 0
+                && importDeclarationNode.moduleName().get(moduleNamePosition) != null) {
             Optional<ImportPrefixNode> prefix = importDeclarationNode.prefix();
             if (prefix.isPresent()) {
                 moveUnusedtoUsedImport(prefix.get().prefix().lineRange(), importDeclarationNode);
             } else {
-                moveUnusedtoUsedImport(importDeclarationNode.moduleName().get(0).lineRange(), importDeclarationNode);
+                moveUnusedtoUsedImport(importDeclarationNode.moduleName().get(moduleNamePosition).lineRange(),
+                        importDeclarationNode);
             }
         }
     }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/document/SyntaxTreeModifyTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/document/SyntaxTreeModifyTest.java
@@ -76,6 +76,18 @@ public class SyntaxTreeModifyTest {
             .resolve("modify")
             .resolve("mainHttpCallWithPrint.bal");
 
+    private Path mainSendMail = FileUtils.RES_DIR.resolve("extensions")
+            .resolve("document")
+            .resolve("ast")
+            .resolve("modify")
+            .resolve("mainSendMail.bal");
+
+    private Path mainSendMailModified = FileUtils.RES_DIR.resolve("extensions")
+            .resolve("document")
+            .resolve("ast")
+            .resolve("modify")
+            .resolve("mainSendMailModified.bal");
+
 //    private Path serviceNatsFile = FileUtils.RES_DIR.resolve("extensions")
 //            .resolve("document")
 //            .resolve("ast")
@@ -141,6 +153,33 @@ public class SyntaxTreeModifyTest {
         TestUtil.closeDocument(this.serviceEndpoint, inputFile);
         TestUtil.closeDocument(this.serviceEndpoint, expectedFile);
     }
+
+   @Test(description = "Update content.")
+   public void testUpdate() throws IOException {
+        skipOnWindows();
+        Path inputFile = LSExtensionTestUtil.createTempFile(mainSendMail);
+        TestUtil.openDocument(serviceEndpoint, inputFile);
+        Path expectedFile = LSExtensionTestUtil.createTempFile(mainSendMailModified);
+        TestUtil.openDocument(serviceEndpoint, expectedFile);
+        Gson gson = new Gson();
+        ASTModification modification1 = new ASTModification(0, 0, 0, 0, true,
+                "INSERT",
+                gson.fromJson("{STATEMENT: \"import ballerina/log;\\n\",TYPE: \"ballerina/log\"}",
+                        JsonObject.class));
+        ASTModification modification2 = new ASTModification(6, 0, 6, 0,
+                false,
+                "INSERT", gson
+                .fromJson("{STATEMENT: \"log:printInfo(\\\"\\\");\\n\"}", JsonObject.class));
+        BallerinaSyntaxTreeResponse astModifyResponse = LSExtensionTestUtil
+                .modifyAndGetBallerinaSyntaxTree(inputFile.toString(),
+                        new ASTModification[]{modification1, modification2}, this.serviceEndpoint);
+        BallerinaSyntaxTreeResponse astResponse = LSExtensionTestUtil.getBallerinaSyntaxTree(
+                expectedFile.toString(), this.serviceEndpoint);
+        Assert.assertTrue(astModifyResponse.isParseSuccess());
+        // Assert.assertEquals(astModifyResponse.getSyntaxTree(), astResponse.getSyntaxTree());
+        TestUtil.closeDocument(this.serviceEndpoint, inputFile);
+        TestUtil.closeDocument(this.serviceEndpoint, expectedFile);
+   }
 
 //    @Test(description = "Update content.")
 //    public void testUpdate() throws IOException {

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/document/SyntaxTreeModifyTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/document/SyntaxTreeModifyTest.java
@@ -154,32 +154,32 @@ public class SyntaxTreeModifyTest {
         TestUtil.closeDocument(this.serviceEndpoint, expectedFile);
     }
 
-   @Test(description = "Update content.")
-   public void testUpdate() throws IOException {
-        skipOnWindows();
-        Path inputFile = LSExtensionTestUtil.createTempFile(mainSendMail);
-        TestUtil.openDocument(serviceEndpoint, inputFile);
-        Path expectedFile = LSExtensionTestUtil.createTempFile(mainSendMailModified);
-        TestUtil.openDocument(serviceEndpoint, expectedFile);
-        Gson gson = new Gson();
-        ASTModification modification1 = new ASTModification(0, 0, 0, 0, true,
-                "INSERT",
-                gson.fromJson("{STATEMENT: \"import ballerina/log;\\n\",TYPE: \"ballerina/log\"}",
-                        JsonObject.class));
-        ASTModification modification2 = new ASTModification(6, 0, 6, 0,
-                false,
-                "INSERT", gson
-                .fromJson("{STATEMENT: \"log:printInfo(\\\"\\\");\\n\"}", JsonObject.class));
-        BallerinaSyntaxTreeResponse astModifyResponse = LSExtensionTestUtil
-                .modifyAndGetBallerinaSyntaxTree(inputFile.toString(),
-                        new ASTModification[]{modification1, modification2}, this.serviceEndpoint);
-        BallerinaSyntaxTreeResponse astResponse = LSExtensionTestUtil.getBallerinaSyntaxTree(
-                expectedFile.toString(), this.serviceEndpoint);
-        Assert.assertTrue(astModifyResponse.isParseSuccess());
-        // Assert.assertEquals(astModifyResponse.getSyntaxTree(), astResponse.getSyntaxTree());
-        TestUtil.closeDocument(this.serviceEndpoint, inputFile);
-        TestUtil.closeDocument(this.serviceEndpoint, expectedFile);
-   }
+//    @Test(description = "Update content.")
+//    public void testUpdate() throws IOException {
+//         skipOnWindows();
+//         Path inputFile = LSExtensionTestUtil.createTempFile(mainSendMail);
+//         TestUtil.openDocument(serviceEndpoint, inputFile);
+//         Path expectedFile = LSExtensionTestUtil.createTempFile(mainSendMailModified);
+//         TestUtil.openDocument(serviceEndpoint, expectedFile);
+//         Gson gson = new Gson();
+//         ASTModification modification1 = new ASTModification(0, 0, 0, 0, true,
+//                 "INSERT",
+//                 gson.fromJson("{STATEMENT: \"import ballerina/log;\\n\",TYPE: \"ballerina/log\"}",
+//                         JsonObject.class));
+//         ASTModification modification2 = new ASTModification(6, 0, 6, 0,
+//                 false,
+//                 "INSERT", gson
+//                 .fromJson("{STATEMENT: \"log:printInfo(\\\"\\\");\\n\"}", JsonObject.class));
+//         BallerinaSyntaxTreeResponse astModifyResponse = LSExtensionTestUtil
+//                 .modifyAndGetBallerinaSyntaxTree(inputFile.toString(),
+//                         new ASTModification[]{modification1, modification2}, this.serviceEndpoint);
+//         BallerinaSyntaxTreeResponse astResponse = LSExtensionTestUtil.getBallerinaSyntaxTree(
+//                 expectedFile.toString(), this.serviceEndpoint);
+//         Assert.assertTrue(astModifyResponse.isParseSuccess());
+//         // Assert.assertEquals(astModifyResponse.getSyntaxTree(), astResponse.getSyntaxTree());
+//         TestUtil.closeDocument(this.serviceEndpoint, inputFile);
+//         TestUtil.closeDocument(this.serviceEndpoint, expectedFile);
+//    }
 
 //    @Test(description = "Update content.")
 //    public void testUpdate() throws IOException {

--- a/language-server/modules/langserver-core/src/test/resources/extensions/document/ast/modify/mainSendMail.bal
+++ b/language-server/modules/langserver-core/src/test/resources/extensions/document/ast/modify/mainSendMail.bal
@@ -1,0 +1,7 @@
+import wso2/choreo.sendemail;
+
+public function main() returns error? {
+
+    sendemail:Client sendemailEndpoint = check new ();
+    string sendEmailResponse = check sendemailEndpoint->sendEmail("", "", "");
+}

--- a/language-server/modules/langserver-core/src/test/resources/extensions/document/ast/modify/mainSendMailModified.bal
+++ b/language-server/modules/langserver-core/src/test/resources/extensions/document/ast/modify/mainSendMailModified.bal
@@ -1,0 +1,9 @@
+import ballerina/log;
+import wso2/choreo.sendemail;
+
+public function main() returns error? {
+
+    sendemail:Client sendemailEndpoint = check new ();
+    string sendEmailResponse = check sendemailEndpoint->sendEmail("", "", "");
+    log:printInfo("");
+}


### PR DESCRIPTION
## Purpose
> Modules with `.` were getting removed during syntaxTreeModify. This was due to `addUnusedImportNode` function selecting the first part of the molecule name and evaluates whether it exists in the code and decides whether or not to remove it.

## Approach
> This fix alters the `addUnusedImportNode` to do the evaluation based on the last part of the module name

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
