### PR TITLE
Handle java.lang.OutOfMemoryError

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/scheduling/Scheduler.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/scheduling/Scheduler.java
@@ -22,6 +22,7 @@ import io.ballerina.runtime.api.async.StrandMetadata;
 import io.ballerina.runtime.api.constants.RuntimeConstants;
 import io.ballerina.runtime.api.creators.ErrorCreator;
 import io.ballerina.runtime.api.types.Type;
+import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.api.values.BFunctionPointer;
 import io.ballerina.runtime.api.values.BObject;
@@ -438,6 +439,11 @@ public class Scheduler {
     private Throwable createError(Throwable t) {
         if (t instanceof StackOverflowError) {
             BError error = ErrorCreator.createError(BallerinaErrorReasons.STACK_OVERFLOW_ERROR);
+            error.setStackTrace(t.getStackTrace());
+            return error;
+        } else if (t instanceof OutOfMemoryError) {
+            BError error = ErrorCreator.createError(BallerinaErrorReasons.JAVA_OUT_OF_MEMORY_ERROR,
+                    StringUtils.fromString(t.getMessage()));
             error.setStackTrace(t.getStackTrace());
             return error;
         }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/util/exceptions/BallerinaErrorReasons.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/util/exceptions/BallerinaErrorReasons.java
@@ -54,6 +54,8 @@ public class BallerinaErrorReasons {
     public static final BString JAVA_NULL_REFERENCE_ERROR =
             StringUtils.fromString(BALLERINA_PREFIX.concat("JavaNullReferenceError"));
     public static final String JAVA_CLASS_NOT_FOUND_ERROR = BALLERINA_PREFIX.concat("JavaClassNotFoundError");
+    public static final BString JAVA_OUT_OF_MEMORY_ERROR =
+            StringUtils.fromString(BALLERINA_PREFIX.concat("OutOfMemoryError"));
 
     public static final BString BALLERINA_PREFIXED_CONVERSION_ERROR =
             StringUtils.fromString(BALLERINA_PREFIX.concat("ConversionError"));

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/BRunUtil.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/BRunUtil.java
@@ -1316,7 +1316,11 @@ public class BRunUtil {
     }
 
     public static String runMain(CompileResult compileResult, String... args) {
-        ExitDetails exitDetails = run(compileResult, args);
+        return runMain(compileResult, new ArrayList<>(), args);
+    }
+
+    public static String runMain(CompileResult compileResult, List<String> javaOpts, String... args) {
+        ExitDetails exitDetails = run(compileResult, javaOpts, args);
         if (exitDetails.exitCode != 0) {
             throw new RuntimeException(exitDetails.errorOutput);
         }
@@ -1324,6 +1328,10 @@ public class BRunUtil {
     }
 
     public static ExitDetails run(CompileResult compileResult, String... args) {
+        return run(compileResult, new ArrayList<>(), args);
+    }
+
+    public static ExitDetails run(CompileResult compileResult, List<String> javaOpts, String... args) {
         PackageManifest packageManifest = compileResult.packageManifest();
         String initClassName = JarResolver.getQualifiedClassName(packageManifest.org().toString(),
                 packageManifest.name().toString(),
@@ -1333,12 +1341,15 @@ public class BRunUtil {
 
         try {
             final List<String> actualArgs = new ArrayList<>();
-            actualArgs.add(0, "java");
-            actualArgs.add(1, "-Xmx2048m");
-            actualArgs.add(2, "-cp");
+            int index = 0;
+            actualArgs.add(index++, "java");
+            for (int i = 0; i < javaOpts.size(); i++) {
+                actualArgs.add(index++, javaOpts.get(i));
+            }
+            actualArgs.add(index++, "-cp");
             String classPath = System.getProperty("java.class.path") + ":" + getClassPath(classLoader);
-            actualArgs.add(3, classPath);
-            actualArgs.add(4, initClassName);
+            actualArgs.add(index++, classPath);
+            actualArgs.add(index++, initClassName);
             actualArgs.addAll(Arrays.asList(args));
 
             final Runtime runtime = Runtime.getRuntime();

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/BRunUtil.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/BRunUtil.java
@@ -1334,10 +1334,11 @@ public class BRunUtil {
         try {
             final List<String> actualArgs = new ArrayList<>();
             actualArgs.add(0, "java");
-            actualArgs.add(1, "-cp");
+            actualArgs.add(1, "-Xmx2048m");
+            actualArgs.add(2, "-cp");
             String classPath = System.getProperty("java.class.path") + ":" + getClassPath(classLoader);
-            actualArgs.add(2, classPath);
-            actualArgs.add(3, initClassName);
+            actualArgs.add(3, classPath);
+            actualArgs.add(4, initClassName);
             actualArgs.addAll(Arrays.asList(args));
 
             final Runtime runtime = Runtime.getRuntime();

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/ErrorTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/ErrorTest.java
@@ -22,7 +22,6 @@ import org.ballerinalang.core.model.values.BValue;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
-import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -76,15 +75,12 @@ public class ErrorTest {
         BRunUtil.invoke(compileResult, "testSelfReferencingError");
     }
 
-    @Test
+    @Test(description = "Test runtime out of memory error", expectedExceptions = java.lang.RuntimeException.class,
+            expectedExceptionsMessageRegExp = "error: \\{ballerina}OutOfMemoryError \\{\"message\":\"Java heap " +
+                    "space\"}.*")
     public void testRuntimeOOMError() {
-        try {
-            CompileResult compileResult = BCompileUtil.compile("test-src/jvm/runtime-oom-error.bal");
-            BRunUtil.runMain(compileResult, new String[]{});
-        } catch (Throwable e) {
-            return;
-        }
-        Assert.fail("runtime out of memory errors are not handled");
+        CompileResult compileResult = BCompileUtil.compile("test-src/jvm/runtime-oom-error.bal");
+        BRunUtil.runMain(compileResult);
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/ErrorTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/ErrorTest.java
@@ -26,6 +26,9 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Test cases to cover error related tests on JBallerina.
  *
@@ -80,7 +83,10 @@ public class ErrorTest {
                     "space\"}.*")
     public void testRuntimeOOMError() {
         CompileResult compileResult = BCompileUtil.compile("test-src/jvm/runtime-oom-error.bal");
-        BRunUtil.runMain(compileResult);
+        final List<String> javaOpts = new ArrayList<>();
+        javaOpts.add(0, "-Xms256m");
+        javaOpts.add(1, "-Xmx256m");
+        BRunUtil.runMain(compileResult, javaOpts);
     }
 
     @AfterClass


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues.

Ballerina error is now thrown instead of java.lang.OutOfMemoryError

Fixes #13159

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
