### PR TITLE
[LS] Fix finding default value for intersection types giving CCE

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -313,16 +313,20 @@ public class CommonUtil {
             case INTERSECTION:
                 TypeSymbol effectiveType = ((IntersectionTypeSymbol) rawType).effectiveTypeDescriptor();
                 effectiveType = getRawType(effectiveType);
-                typeString = "()";
-                // Right now, intersection types can only have readonly and another type only. Therefore, not doing 
-                // further checks here.
-                // Get the member type from intersection which is not readonly and get its default value
-                Optional<TypeSymbol> memberType = ((IntersectionTypeSymbol) effectiveType)
-                        .memberTypeDescriptors().stream()
-                        .filter(typeSymbol -> typeSymbol.typeKind() != TypeDescKind.READONLY)
-                        .findAny();
-                if (memberType.isPresent()) {
-                    typeString = getDefaultValueForType(memberType.get());
+                if (effectiveType.typeKind() == TypeDescKind.INTERSECTION) {
+                    // Right now, intersection types can only have readonly and another type only. Therefore, not doing 
+                    // further checks here. Get the member type from intersection which is not readonly and get its 
+                    // default value
+                    typeString = "()";
+                    Optional<TypeSymbol> memberType = ((IntersectionTypeSymbol) effectiveType)
+                            .memberTypeDescriptors().stream()
+                            .filter(typeSymbol -> typeSymbol.typeKind() != TypeDescKind.READONLY)
+                            .findAny();
+                    if (memberType.isPresent()) {
+                        typeString = getDefaultValueForType(memberType.get());
+                    }
+                } else {
+                    typeString = getDefaultValueForType(effectiveType);
                 }
                 break;
             case TABLE:

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config42.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config42.json
@@ -1,0 +1,43 @@
+{
+  "position": {
+    "line": 12,
+    "character": 8
+  },
+  "source": "expression_context/source/mapping_expr_ctx_source42.bal",
+  "items": [
+    {
+      "label": "readonly",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "P",
+      "filterText": "readonly",
+      "insertText": "readonly ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "endLine",
+      "kind": "Field",
+      "detail": "(record {| readonly Position startLine; readonly Position endLine; |}).endLine",
+      "sortText": "G",
+      "insertText": "endLine: ${1:{line: 0, offset: 0}}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "startLine",
+      "kind": "Field",
+      "detail": "(record {| readonly Position startLine; readonly Position endLine; |}).startLine",
+      "sortText": "G",
+      "insertText": "startLine: ${2:{line: 0, offset: 0}}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Fill record {| readonly Position startLine; readonly Position endLine; |} Required Fields",
+      "kind": "Property",
+      "detail": "record {| readonly Position startLine; readonly Position endLine; |}",
+      "sortText": "Q",
+      "filterText": "fill",
+      "insertText": "endLine: {line: 0, offset: 0},\nstartLine: {line: 0, offset: 0}",
+      "insertTextFormat": "Snippet"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config43.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config43.json
@@ -1,0 +1,43 @@
+{
+  "position": {
+    "line": 12,
+    "character": 8
+  },
+  "source": "expression_context/source/mapping_expr_ctx_source43.bal",
+  "items": [
+    {
+      "label": "readonly",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "P",
+      "filterText": "readonly",
+      "insertText": "readonly ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "endLine",
+      "kind": "Field",
+      "detail": "(record {| Position startLine; Position endLine; |}).endLine",
+      "sortText": "G",
+      "insertText": "endLine: ${1:{line: 0, offset: 0}}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "startLine",
+      "kind": "Field",
+      "detail": "(record {| Position startLine; Position endLine; |}).startLine",
+      "sortText": "G",
+      "insertText": "startLine: ${2:{line: 0, offset: 0}}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Fill record {| Position startLine; Position endLine; |} Required Fields",
+      "kind": "Property",
+      "detail": "record {| Position startLine; Position endLine; |}",
+      "sortText": "Q",
+      "filterText": "fill",
+      "insertText": "endLine: {line: 0, offset: 0},\nstartLine: {line: 0, offset: 0}",
+      "insertTextFormat": "Snippet"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config44.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config44.json
@@ -1,0 +1,43 @@
+{
+  "position": {
+    "line": 14,
+    "character": 8
+  },
+  "source": "expression_context/source/mapping_expr_ctx_source44.bal",
+  "items": [
+    {
+      "label": "readonly",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "P",
+      "filterText": "readonly",
+      "insertText": "readonly ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "endLine",
+      "kind": "Field",
+      "detail": "(record {| Position startLine; Position endLine; |}).endLine",
+      "sortText": "G",
+      "insertText": "endLine: ${1:{line: 0, offset: 0}}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "startLine",
+      "kind": "Field",
+      "detail": "(record {| Position startLine; Position endLine; |}).startLine",
+      "sortText": "G",
+      "insertText": "startLine: ${2:{line: 0, offset: 0}}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Fill record {| Position startLine; Position endLine; |} Required Fields",
+      "kind": "Property",
+      "detail": "record {| Position startLine; Position endLine; |}",
+      "sortText": "Q",
+      "filterText": "fill",
+      "insertText": "endLine: {line: 0, offset: 0},\nstartLine: {line: 0, offset: 0}",
+      "insertTextFormat": "Snippet"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/mapping_expr_ctx_source42.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/mapping_expr_ctx_source42.bal
@@ -1,0 +1,15 @@
+type Position readonly & record {|
+    int line;
+    int offset;
+|};
+
+type Range readonly & record {|
+    Position startLine;
+    Position endLine;
+|};
+
+function test() {
+    Range range = {
+        
+    };
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/mapping_expr_ctx_source43.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/mapping_expr_ctx_source43.bal
@@ -1,0 +1,15 @@
+type Position readonly & record {|
+    int line;
+    int offset;
+|};
+
+type Range record {|
+    Position startLine;
+    Position endLine;
+|};
+
+function test() {
+    Range range = {
+        
+    };
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/mapping_expr_ctx_source44.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/mapping_expr_ctx_source44.bal
@@ -1,0 +1,17 @@
+type PositionRec record {|
+    int line;
+    int offset;
+|};
+
+type Position readonly & PositionRec;
+
+type Range record {|
+    Position startLine;
+    Position endLine;
+|};
+
+function test() {
+    Range range = {
+        
+    };
+}


### PR DESCRIPTION
## Purpose
$subject

Fixes #31423

## Approach
Added a check if the effective type of an intersection type is also an intersection type

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
