### PR TITLE
Improve module variable cycle detection

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
@@ -522,6 +522,11 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
             return;
         }
 
+        if (symbol.owner.tag == SymTag.LET && env.enclVarSym != null) {
+            BVarSymbol dependentVar = env.enclVarSym;
+            addDependency(dependentVar, symbol);
+        }
+
         this.currDependentSymbol.push(symbol);
         if (variable.typeNode != null && variable.typeNode.getBType() != null) {
             recordGlobalVariableReferenceRelationship(variable.typeNode.getBType().tsymbol);
@@ -1924,7 +1929,8 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
         BSymbol ownerSymbol = this.env.scope.owner;
         boolean isInPkgLevel = ownerSymbol.getKind() == SymbolKind.PACKAGE;
         // Restrict to observations made in pkg level.
-        if (isInPkgLevel && (globalVarSymbol || symbol instanceof BTypeSymbol)) {
+        if (isInPkgLevel && (globalVarSymbol || symbol instanceof BTypeSymbol)
+            || (ownerSymbol.tag == SymTag.LET && globalVarSymbol)) {
             BSymbol dependent = this.currDependentSymbol.peek();
             addDependency(dependent, symbol);
         } else if (ownerSymbol.kind == SymbolKind.FUNCTION && globalVarSymbol) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
@@ -522,14 +522,14 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
             return;
         }
 
-        if (symbol.owner.tag == SymTag.LET && env.enclVarSym != null) {
-            BVarSymbol dependentVar = env.enclVarSym;
-            addDependency(dependentVar, symbol);
-        }
-
         this.currDependentSymbol.push(symbol);
         if (variable.typeNode != null && variable.typeNode.getBType() != null) {
             recordGlobalVariableReferenceRelationship(variable.typeNode.getBType().tsymbol);
+        }
+        boolean withInModuleVarLetExpr = symbol.owner.tag == SymTag.LET && isGlobalVarSymbol(env.enclVarSym);
+        if (withInModuleVarLetExpr) {
+            BVarSymbol dependentVar = env.enclVarSym;
+            this.currDependentSymbol.push(dependentVar);
         }
         try {
             if (variable.isDeclaredWithVar) {
@@ -554,6 +554,9 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
 
             addUninitializedVar(variable);
         } finally {
+            if (withInModuleVarLetExpr) {
+                this.currDependentSymbol.pop();
+            }
             this.currDependentSymbol.pop();
         }
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/cyclefind/GlobalVariableRefAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/cyclefind/GlobalVariableRefAnalyzer.java
@@ -69,6 +69,7 @@ public class GlobalVariableRefAnalyzer {
     private final List<List<NodeInfo>> cycles;
     private final List<NodeInfo> dependencyOrder;
     private int curNodeId;
+    private boolean cyclicErrorFound;
 
     public static GlobalVariableRefAnalyzer getInstance(CompilerContext context) {
         GlobalVariableRefAnalyzer refAnalyzer = context.get(REF_ANALYZER_KEY);
@@ -256,8 +257,8 @@ public class GlobalVariableRefAnalyzer {
         }
         sorted.addAll(dependencies);
 
-        if (cycles.stream().anyMatch(cycle -> cycle.size() > 1)) {
-            // Cyclic error found no need to sort.
+        // Cyclic error found no need to sort.
+        if (cyclicErrorFound) {
             return;
         }
 
@@ -293,6 +294,7 @@ public class GlobalVariableRefAnalyzer {
         this.dependencyOrder.clear();
         this.curNodeId = 0;
         this.globalVariablesDependsOn = new HashMap<>();
+        this.cyclicErrorFound = false;
     }
 
     private void pruneDependencyRelations() {
@@ -488,6 +490,7 @@ public class GlobalVariableRefAnalyzer {
 
             if (doesContainAGlobalVar(symbolsOfCycle)) {
                 emitErrorMessage(symbolsOfCycle);
+                this.cyclicErrorFound = true;
             }
         }
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/cyclefind/GlobalVariableRefAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/cyclefind/GlobalVariableRefAnalyzer.java
@@ -50,6 +50,7 @@ import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -518,7 +519,8 @@ public class GlobalVariableRefAnalyzer {
         List<BSymbol> secondSubList = new ArrayList<>(symbolsOfCycle.subList(splitFrom, len));
         secondSubList.addAll(firstSubList);
 
-        List<BLangIdentifier> names = secondSubList.stream().map(this::getNodeName).collect(Collectors.toList());
+        List<BLangIdentifier> names = secondSubList.stream()
+                .map(this::getNodeName).filter(Objects::nonNull).collect(Collectors.toList());
         dlog.error(firstNode.get().getPosition(), DiagnosticErrorCode.GLOBAL_VARIABLE_CYCLIC_DEFINITION, names);
     }
 
@@ -545,7 +547,7 @@ public class GlobalVariableRefAnalyzer {
                 }
             }
         }
-        throw new IllegalArgumentException("Cannot find topLevelNode: " + symbol);
+        return null;
     }
 
     private BSymbol getSymbol(Node node) {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/variabledef/ForwardReferencingGlobalDefinitionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/variabledef/ForwardReferencingGlobalDefinitionTest.java
@@ -119,6 +119,21 @@ public class ForwardReferencingGlobalDefinitionTest {
         Assert.assertEquals(cycle.getDiagnostics().length, i);
     }
 
+    @Test
+    public void moduleVariableWithLetExprCausingCycle() {
+        CompileResult cycle = BCompileUtil.compile("test-src/statements/variabledef/globalcycle/viaModuleLevelLetExpr");
+        int i = 0;
+        BAssertUtil.validateError(cycle, i++, "illegal cyclic reference '[fieldOne, conf1]'", 21, 1);
+        // This error should go away and cycling error should come here when #21382 is fixed.
+        BAssertUtil.validateError(cycle, i++, "let expressions are not yet supported for record fields", 30, 16);
+        BAssertUtil.validateError(cycle, i++, "illegal cyclic reference '[letRef, modVar]'", 17, 1);
+        BAssertUtil.validateError(cycle, i++,
+                "illegal cyclic reference '[modVarQueryLet1, queryRef, modVarQuery]'", 19, 1);
+        BAssertUtil.validateError(cycle, i++, "illegal cyclic reference '[modVarQueryLet2, queryRef2]'", 20, 1);
+
+        Assert.assertEquals(cycle.getDiagnostics().length, i);
+    }
+
     @Test(description = "Test compiler rejecting cyclic references in global variable definitions via object def")
     public void globalDefinitionsListenerDef() {
         CompileResult resultNegativeCycleFound = BCompileUtil.

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/variabledef/globalcycle/viaModuleLevelLetExpr/Ballerina.toml
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/variabledef/globalcycle/viaModuleLevelLetExpr/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "test_globalcycle"
+name = "viaModuleLevelLetExpr"
+version = "1.0.0"

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/variabledef/globalcycle/viaModuleLevelLetExpr/file01.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/variabledef/globalcycle/viaModuleLevelLetExpr/file01.bal
@@ -1,0 +1,31 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+type SimpleType record {
+    string? field1;
+};
+
+string fieldOne = let string? f1 = conf1.field1 in f1 is string ? f1 : "default-value-1";
+
+SimpleType conf1 = {
+    field1: fieldOne
+};
+
+string modVar = let string[] ar = [letRef] in ar[0];
+
+type RecordTypeWithDefaultLetExpr record {
+    int code = let int m = moduleCode in m + 1;
+};

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/variabledef/globalcycle/viaModuleLevelLetExpr/file02.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/variabledef/globalcycle/viaModuleLevelLetExpr/file02.bal
@@ -1,0 +1,28 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+string letRef = modVar;
+
+string[] modVarQueryLet1 = from var item in [queryRef, "hello", "world"] let string prefix = queryRef select prefix + item;
+string[] modVarQueryLet2 = from var item in ["hello", "world"] let string prefix = queryRef2 select prefix + item;
+string[] modVarQuery = from var item in [queryRef, "hello", "world"] select item;
+
+string queryRef = modVarQuery[0] + modVarQueryLet1[0];
+string queryRef2 = modVarQueryLet2[0];
+
+RecordTypeWithDefaultLetExpr recD = {};
+
+final int moduleCode = recD.code;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/variabledef/moduleVarReOrderingViaTypes/file02.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/variabledef/moduleVarReOrderingViaTypes/file02.bal
@@ -17,3 +17,16 @@
 final string name = "Jack Sparrow";
 
 record {|record {string n = p.n;} r = {};|} nestedRec = {};
+
+// Having a unrelated cycle should not stop re-ordering.
+function f1() {
+    lock {
+        f2();
+    }
+}
+
+function f2() {
+    if false {
+        _ = f1();
+    }
+}


### PR DESCRIPTION
Cycles that do not involve module variables should not stop the module variable re-ordering.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/31414
Fixes https://github.com/ballerina-platform/ballerina-lang/issues/31470

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
