### PR TITLE
[LS] Fix index out of bound error in LSClientLogger

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSClientLogger.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSClientLogger.java
@@ -145,7 +145,7 @@ public class LSClientLogger {
         if (identifier != null) {
             result.append("uri: '").append(identifier.getUri().replaceFirst("file://", "")).append("'");
         }
-        if (position != null && position[0] != null) {
+        if (position != null && position.length > 0 && position[0] != null) {
             if (position.length == 2) {
                 // Range
                 result.append(", [").append(position[0].getLine() + 1)


### PR DESCRIPTION
## Purpose
$subject

Fixes #31454

## Approach
Add length check to position vararg array

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
