### PR TITLE
Fix remote debug issue with the flag `--debug=<PORT>`

### DIFF
--- a/distribution/zip/jballerina/bin/bal
+++ b/distribution/zip/jballerina/bin/bal
@@ -261,7 +261,7 @@ if [[ $1 == "native-img" ]]; then
         echo "Please set GRAALVM_HOME for native image generation"
     fi
 # if 1st arg is "run" and 2nd or 3rd arg ends with ".jar".
-elif [[ $1 == "run" && ( $2 == *.jar || $4 == *.jar ) ]]; then
+elif [[ $1 == "run" && ( $2 == *.jar || $3 == *.jar || $4 == *.jar ) ]]; then
       # if 2nd arg end with ".jar".
       if [[ $2 == *.jar ]]; then
           $JAVACMD \
@@ -273,6 +273,12 @@ elif [[ $1 == "run" && ( $2 == *.jar || $4 == *.jar ) ]]; then
             $CMD_LINE_ARGS \
             -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=$3 \
             -jar "${@:4}" # ignores "run"
+      elif [[ $2 == --debug=* ]] && [[ $3 == *.jar ]]; then
+          PORT=$(echo $2 | cut -d '=' -f 2)
+          $JAVACMD \
+            $CMD_LINE_ARGS \
+            -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=$PORT \
+            -jar "${@:3}" # ignores "run"
       fi
 else
     $JAVACMD \

--- a/distribution/zip/jballerina/bin/bal.bat
+++ b/distribution/zip/jballerina/bin/bal.bat
@@ -151,6 +151,9 @@ set CMD_LINE_ARGS=-Xbootclasspath/a:%BALLERINA_XBOOTCLASSPATH% -Xms256m -Xmx1024
 set jar=%2
 if "%1" == "run" if not "%2" == "" if "%jar:~-4%" == ".jar" goto runJarFile
 
+set jar=%3
+if "%1" == "run" if not "%2" == "" if "%2:~0,8%" == "--debug=" if "%jar:~-4%" == ".jar" goto runJarDebugModeWithDebugFlagAndPortTogether
+
 set jar=%4
 if "%1" == "run" if not "%2" == "" if "%2" == "--debug" if "%jar:~-4%" == ".jar" goto runJarDebugMode
 
@@ -166,6 +169,12 @@ goto end
 :runJarDebugMode
 for /f "tokens=3,*" %%a in ("%*") do set ARGS=%%b
 "%JAVA_HOME%\bin\java" %CMD_LINE_ARGS% -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=%3 -jar %ARGS%
+goto end
+
+:runJarDebugModeWithDebugFlagAndPortTogether
+set PORT=%%2:~8%
+for /f "tokens=2,*" %%a in ("%*") do set ARGS=%%b
+"%JAVA_HOME%\bin\java" %CMD_LINE_ARGS% -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=%PORT -jar %ARGS%
 goto end
 
 :end

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/remote/BallerinaRunRemoteDebugTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/remote/BallerinaRunRemoteDebugTest.java
@@ -69,8 +69,19 @@ public class BallerinaRunRemoteDebugTest extends BaseTestCase {
         clientLeecher.waitForText(20000);
     }
 
-    @Test
+    @Test(description = "Test for executable jar in debug mode with ballerina command" +
+        "`bal run --debug 5005 <EXECUTABLE_JAR_PATH>`")
     public void testSuspendOnBallerinaJarRun() throws BallerinaTestException {
+        suspendOnBallerinaJarRun("--debug");
+    }
+
+    @Test(description = "Test for executable jar in debug mode with ballerina command" +
+        "`bal run --debug=5005 <EXECUTABLE_JAR_PATH>`")
+    public void testSuspendOnBallerinaJarRunWithDebugFlagAndPortTogether() throws BallerinaTestException {
+        suspendOnBallerinaJarRun("--debug=");
+    }
+
+    private void suspendOnBallerinaJarRun(String debugFlag) throws BallerinaTestException {
         String executablePath = Paths.get("target", "bin", testProjectName.replaceAll("-", "_") + ".jar")
             .toFile().getPath();
         LogLeecher clientLeecher = new LogLeecher(executablePath);
@@ -81,8 +92,14 @@ public class BallerinaRunRemoteDebugTest extends BaseTestCase {
         int port = findFreePort();
         String msg = REMOTE_DEBUG_LISTENING + port;
         clientLeecher = new LogLeecher(msg);
-        balClient.debugMain("run", new String[]{"--debug", String.valueOf(port), executablePath}, null,
-            new String[]{}, new LogLeecher[]{clientLeecher}, debugTestRunner.testProjectPath, 10);
+
+        if (debugFlag.equals("--debug=")) {
+            balClient.debugMain("run", new String[]{"--debug=" + port, executablePath}, null,
+                new String[]{}, new LogLeecher[]{clientLeecher}, debugTestRunner.testProjectPath, 10);
+        } else {
+            balClient.debugMain("run", new String[]{"--debug", String.valueOf(port), executablePath}, null,
+                new String[]{}, new LogLeecher[]{clientLeecher}, debugTestRunner.testProjectPath, 10);
+        }
         clientLeecher.waitForText(20000);
     }
 


### PR DESCRIPTION
## Purpose
This PR will fix the remote debug issue with the flag `--debug=<PORT>`.
`bal run --debug=<PORT> <EXECUTABLE_JAR_PATH>`


Fixes https://github.com/ballerina-platform/ballerina-lang/issues/31430

