### PR TITLE
Fix `STEP_OVER` from the last line of object `init()` method doesn't hit the next line of the object initialization step issue

### DIFF
--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JBallerinaDebugServer.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JBallerinaDebugServer.java
@@ -283,9 +283,12 @@ public class JBallerinaDebugServer implements IDebugProtocolServer {
             if (loadedThreadFrames.containsKey(activeThread.uniqueID())) {
                 stackTraceResponse.setStackFrames(loadedThreadFrames.get(activeThread.uniqueID()));
             } else {
+                // if the active thread's top stack frame name is `$init$`, then send a `STEP_INTO` request.
+                // This is to avoid `$init$` stack frame information represented on the top of the call stack,
+                // as this stack frame does not give any useful information to the user.
                 if (activeThread.frames().get(0).location().method().name().equals(METHOD_INIT)) {
-                    prepareFor(DebugInstruction.STEP_OVER);
-                    eventProcessor.sendStepRequest(args.getThreadId(), StepRequest.STEP_OVER);
+                    prepareFor(DebugInstruction.STEP_IN);
+                    eventProcessor.sendStepRequest(args.getThreadId(), StepRequest.STEP_INTO);
                 }
                 StackFrame[] validFrames = activeThread.frames().stream()
                         .map(this::toDapStackFrame)

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JBallerinaDebugServer.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JBallerinaDebugServer.java
@@ -138,7 +138,7 @@ public class JBallerinaDebugServer implements IDebugProtocolServer {
     private static final String SCOPE_NAME_LOCAL = "Local";
     private static final String SCOPE_NAME_GLOBAL = "Global";
     private static final String VALUE_UNKNOWN = "unknown";
-    private static final String METHOD_INIT = "$init$";
+    private static final String J_INIT_FRAME_NAME = "$init$";
     private static final String COMPILATION_ERROR_MESSAGE = "error: compilation contains errors";
 
     public JBallerinaDebugServer() {
@@ -283,12 +283,18 @@ public class JBallerinaDebugServer implements IDebugProtocolServer {
             if (loadedThreadFrames.containsKey(activeThread.uniqueID())) {
                 stackTraceResponse.setStackFrames(loadedThreadFrames.get(activeThread.uniqueID()));
             } else {
-                // if the active thread's top stack frame name is `$init$`, then send a `STEP_INTO` request.
-                // This is to avoid `$init$` stack frame information represented on the top of the call stack,
-                // as this stack frame does not give any useful information to the user.
-                if (activeThread.frames().get(0).location().method().name().equals(METHOD_INIT)) {
-                    prepareFor(DebugInstruction.STEP_IN);
-                    eventProcessor.sendStepRequest(args.getThreadId(), StepRequest.STEP_INTO);
+                try {
+                    // If the active thread's top stack frame name is equal to `J_INIT_FRAME_NAME`,
+                    // need to abort the processing and send a `step-in` request to resume the VM to stop at its next state.
+                    // This is because the above state is related to java-level object initialisation and therefore
+                    // suspending the VM at that intermediate state does not provide any useful information to the user.
+                    if (activeThread.frames().get(0).location().method().name().equals(J_INIT_FRAME_NAME)) {
+                        prepareFor(DebugInstruction.STEP_IN);
+                        eventProcessor.sendStepRequest(args.getThreadId(), StepRequest.STEP_INTO);
+                    }
+                } catch (Exception ignored) {
+                    // Ignore the exception and continue the flow.
+                    // This will result in having `J_INIT_FRAME_NAME` on the top of the call stack.
                 }
                 StackFrame[] validFrames = activeThread.frames().stream()
                         .map(this::toDapStackFrame)

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JBallerinaDebugServer.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JBallerinaDebugServer.java
@@ -138,6 +138,7 @@ public class JBallerinaDebugServer implements IDebugProtocolServer {
     private static final String SCOPE_NAME_LOCAL = "Local";
     private static final String SCOPE_NAME_GLOBAL = "Global";
     private static final String VALUE_UNKNOWN = "unknown";
+    private static final String METHOD_INIT = "$init$";
     private static final String COMPILATION_ERROR_MESSAGE = "error: compilation contains errors";
 
     public JBallerinaDebugServer() {
@@ -282,6 +283,10 @@ public class JBallerinaDebugServer implements IDebugProtocolServer {
             if (loadedThreadFrames.containsKey(activeThread.uniqueID())) {
                 stackTraceResponse.setStackFrames(loadedThreadFrames.get(activeThread.uniqueID()));
             } else {
+                if (activeThread.frames().get(0).location().method().name().equals(METHOD_INIT)) {
+                    prepareFor(DebugInstruction.STEP_OVER);
+                    eventProcessor.sendStepRequest(args.getThreadId(), StepRequest.STEP_OVER);
+                }
                 StackFrame[] validFrames = activeThread.frames().stream()
                         .map(this::toDapStackFrame)
                         .filter(JBallerinaDebugServer::isValidFrame)

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JBallerinaDebugServer.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JBallerinaDebugServer.java
@@ -284,8 +284,8 @@ public class JBallerinaDebugServer implements IDebugProtocolServer {
                 stackTraceResponse.setStackFrames(loadedThreadFrames.get(activeThread.uniqueID()));
             } else {
                 try {
-                    // If the active thread's top stack frame name is equal to `J_INIT_FRAME_NAME`,
-                    // need to abort the processing and send a `step-in` request to resume the VM to stop at its next state.
+                    // If the active thread's top stack frame name is equal to `J_INIT_FRAME_NAME`, need to abort the
+                    // processing and send a `step-in` request to resume the VM to stop at its next state.
                     // This is because the above state is related to java-level object initialisation and therefore
                     // suspending the VM at that intermediate state does not provide any useful information to the user.
                     if (activeThread.frames().get(0).location().method().name().equals(J_INIT_FRAME_NAME)) {


### PR DESCRIPTION
## Purpose
This PR will fix `STEP_OVER` from the last line of the object `init()` method doesn't hit the next line of the object initialization step issue.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/30740


