### PR TITLE
Avoid defining new types for error intersections that define already-existing types

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -1107,7 +1107,7 @@ public class SymbolEnter extends BLangNodeVisitor {
         this.unresolvedRecordDueToFields = new HashSet<>(typeDefs.size());
         this.resolveRecordsUnresolvedDueToFields = false;
         for (BLangNode typeDef : typeDefs) {
-            if (isErrorIntersectionType(typeDef, env)) {
+            if (isErrorIntersectionTypeCreatingNewType(typeDef, env)) {
                 populateUndefinedErrorIntersection((BLangTypeDefinition) typeDef, env);
                 continue;
             }
@@ -1157,7 +1157,7 @@ public class SymbolEnter extends BLangNodeVisitor {
         this.intersectionTypes.add(typeDef);
     }
 
-    private boolean isErrorIntersectionType(BLangNode typeDef, SymbolEnv env) {
+    private boolean isErrorIntersectionTypeCreatingNewType(BLangNode typeDef, SymbolEnv env) {
         boolean isIntersectionType = typeDef.getKind() == NodeKind.TYPE_DEFINITION
                 && ((BLangTypeDefinition) typeDef).typeNode.getKind() == NodeKind.INTERSECTION_TYPE_NODE;
         if (!isIntersectionType) {
@@ -1167,13 +1167,15 @@ public class SymbolEnter extends BLangNodeVisitor {
         BLangIntersectionTypeNode intersectionTypeNode =
                 (BLangIntersectionTypeNode) ((BLangTypeDefinition) typeDef).typeNode;
 
+        Set<BType> errorTypes = new HashSet<>();
+
         for (BLangType type : intersectionTypeNode.constituentTypeNodes) {
             BType bType = symResolver.resolveTypeNode(type, env);
             if (bType.tag == TypeTags.ERROR) {
-                return true;
+                errorTypes.add(bType);
             }
         }
-        return false;
+        return errorTypes.size() > 1;
     }
 
     private void checkErrors(SymbolEnv env, BLangNode unresolvedType, BLangNode currentTypeOrClassNode,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -2011,11 +2011,8 @@ public class SymbolResolver extends BLangNodeVisitor {
             return symTable.semanticError;
         }
 
-        if (isErrorIntersection) {
+        if (isErrorIntersection && !isAlreadyExistingType) {
             BType detailType = ((BErrorType) potentialIntersectionType).detailType;
-            if (isAlreadyExistingType) {
-                potentialIntersectionType = types.createErrorType(detailType, potentialIntersectionType.flags, env);
-            }
 
             boolean existingErrorDetailType = false;
             if (detailType.tsymbol != null) {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/intersection/IntersectionTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/intersection/IntersectionTypeTest.java
@@ -136,6 +136,16 @@ public class IntersectionTypeTest {
     }
 
     @Test
+    public void testSingleErrorIntersectionWithReadOnly() {
+        BRunUtil.invoke(errorIntersectionResults, "testSingleErrorIntersectionWithReadOnly");
+    }
+
+    @Test
+    public void testMultipleErrorIntersectionWithReadOnly() {
+        BRunUtil.invoke(errorIntersectionResults, "testMultipleErrorIntersectionWithReadOnly");
+    }
+
+    @Test
     public void testErrorIntersectionNegative() {
         CompileResult result = BCompileUtil.compile("test-src/types/intersection/error_intersection_type_negative.bal");
 
@@ -173,6 +183,16 @@ public class IntersectionTypeTest {
                 "invalid intersection type 'E & ErrorX': no intersection", 82, 22);
         validateError(result, index++,
                 "invalid intersection: field 'x' contains a default value in type 'DetailX'", 82, 26);
+        validateError(result, index++, "missing error detail arg for error detail field 'code'", 92, 39);
+        validateError(result, index++, "missing error detail arg for error detail field 'code'", 93, 48);
+        validateError(result, index++, "error constructor does not accept additional detail args 'c' when error " +
+                "detail type 'record {| int code; anydata...; |}' contains individual field descriptors", 93, 60);
+        validateError(result, index++, "missing error detail arg for error detail field 'code'", 94, 47);
+        validateError(result, index++, "missing error detail arg for error detail field 'code'", 95, 47);
+        validateError(result, index++, "missing error detail arg for error detail field 'code'", 96, 47);
+        validateError(result, index++, "error constructor does not accept additional detail args 'oth' when error " +
+                "detail type 'record {| boolean fatal?; int code; int...; |}' contains individual field descriptors",
+                96, 59);
 
         assertEquals(result.getErrorCount(), index);
     }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/intersection/error_intersection_type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/intersection/error_intersection_type.bal
@@ -220,6 +220,69 @@ public function testDistinctErrorWithSameTypeIdsButDifferentTypes() {
     assertEquality(x is E2, false);
 }
 
+function funcWithSingleErrorIntersectionWithReadOnly() returns (error & readonly)? => error("oops!");
+
+type ErrorIntersectionWithReadOnly error & readonly;
+type ErrorIntersectionWithReadOnlyTwo readonly & error<record { int code; }> & readonly;
+
+function testSingleErrorIntersectionWithReadOnly() {
+    error? x = funcWithSingleErrorIntersectionWithReadOnly();
+    assertEquality(true, x is error);
+    error err = <error> x;
+    assertEquality("oops!", err.message());
+    assertEquality(0, err.detail().length());
+
+    readonly & error y = error("oops again!", code = 101);
+    assertEquality("oops again!", y.message());
+    assertEquality(1, y.detail().length());
+    assertEquality(101, y.detail()["code"]);
+
+    ErrorIntersectionWithReadOnly z = error("error!", code = 204);
+    assertEquality("error!", z.message());
+    assertEquality(1, z.detail().length());
+    assertEquality(204, z.detail()["code"]);
+
+    ErrorIntersectionWithReadOnlyTwo w = error("error again!", code = 4);
+    assertEquality("error again!", w.message());
+    assertEquality(1, w.detail().length());
+    assertEquality(4, w.detail()["code"]);
+}
+
+type MyError1 error<record { int code; }>;
+type MyError2 error<record {| boolean fatal?;  int...; |}>;
+
+type MultipleErrorIntersectionWithReadOnly MyError2 & MyError1 & readonly;
+
+function testMultipleErrorIntersectionWithReadOnly() {
+    MyError1 & readonly & MyError2 x = error("e1", code = 123);
+    assertEquality("e1", x.message());
+    assertEquality(1, x.detail().length());
+    assertEquality(123, x.detail().code);
+
+    readonly & MyError1 & MyError2 y = error("e2", fatal = true, code = 245);
+    assertEquality("e2", y.message());
+    assertEquality(2, y.detail().length());
+    assertEquality(245, y.detail().code);
+    assertEquality(true, y.detail()?.fatal);
+
+    MultipleErrorIntersectionWithReadOnly z = error("e3", fatal = false, code = 132);
+    assertEquality("e3", z.message());
+    assertEquality(2, z.detail().length());
+    assertEquality(132, z.detail().code);
+    assertEquality(false, z.detail()?.fatal);
+
+    readonly & error & error v = error("error error!", code = 102);
+    assertEquality("error error!", v.message());
+    assertEquality(1, v.detail().length());
+    assertEquality(102, v.detail()["code"]);
+
+    error & error u = error("errors!", code = 102, fatal = true);
+    assertEquality("errors!", u.message());
+    assertEquality(2, u.detail().length());
+    assertEquality(102, u.detail()["code"]);
+    assertEquality(true, u.detail()["fatal"]);
+}
+
 function assertEquality(any|error actual, any|error expected) {
     if expected is anydata && actual is anydata && expected == actual {
         return;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/intersection/error_intersection_type_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/intersection/error_intersection_type_negative.bal
@@ -80,3 +80,18 @@ type CloseDetailWithBuildInDetail2 ErrorX & error;
 
 type E distinct error;
 type EDash distinct (E & ErrorX);
+
+type ErrorIntersectionWithReadOnly readonly & error<record { int code; }> & readonly;
+
+type MyError1 error<record { int code; }>;
+type MyError2 error<record {| boolean fatal?;  int...; |}>;
+
+type MultipleErrorIntersectionWithReadOnly MyError2 & MyError1 & readonly;
+
+function testInvalidArgsForErrorIntersectionWithReadOnly() {
+    ErrorIntersectionWithReadOnly a = error("e1");
+    error<record { int code; }> & readonly b = error("e2", c = 123);
+    MultipleErrorIntersectionWithReadOnly c = error("e3");
+    MultipleErrorIntersectionWithReadOnly d = error("e4", fatal = false);
+    MultipleErrorIntersectionWithReadOnly e = error("e5", oth = false);
+}


### PR DESCRIPTION
## Purpose
$title.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/31379

## Approach
If an intersection with error types defines an already existing type, we will no longer define a new type.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
