### PR TITLE
Refactor context type resolver to save broader type

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -59,6 +59,7 @@ import io.ballerina.tools.text.TextDocument;
 import io.ballerina.tools.text.TextRange;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.ballerinalang.langserver.codeaction.CodeActionModuleId;
 import org.ballerinalang.langserver.common.ImportsAcceptor;
 import org.ballerinalang.langserver.common.constants.PatternConstants;
@@ -373,19 +374,27 @@ public class CommonUtil {
      *
      * @param context Language server operation context
      * @param fields  Map of field descriptors
-     * @return {@link List}     List of completion items for the struct fields
+     * @param symbol  Pair of Raw TypeSymbol and broader TypeSymbol
+     * @return {@link List} List of completion items for the struct fields
      */
     public static List<LSCompletionItem> getRecordFieldCompletionItems(BallerinaCompletionContext context,
                                                                        Map<String, RecordFieldSymbol> fields,
-                                                                       TypeSymbol symbol) {
+                                                                       Pair<TypeSymbol, TypeSymbol> symbol) {
         List<LSCompletionItem> completionItems = new ArrayList<>();
         AtomicInteger fieldCounter = new AtomicInteger();
         fields.forEach((name, field) -> {
             fieldCounter.getAndIncrement();
             String insertText =
                     getRecordFieldCompletionInsertText(field, Collections.emptyList(), 0, fieldCounter.get());
-            String detail = symbol.getName().isPresent() ? (symbol.getName().get() + "." + name)
-                    : ("(" + symbol.signature() + ")." + name);
+
+            String detail;
+            if (symbol.getLeft().getName().isPresent()) {
+                detail = getModifiedTypeName(context, symbol.getLeft()) + "." + name;
+            } else if (symbol.getRight().getName().isPresent()) {
+                detail = getModifiedTypeName(context, symbol.getRight()) + "." + name;
+            } else {
+                detail = "(" + symbol.getLeft().signature() + ")." + name;
+            }
             CompletionItem fieldItem = new CompletionItem();
             fieldItem.setInsertText(insertText);
             fieldItem.setInsertTextFormat(InsertTextFormat.Snippet);
@@ -403,11 +412,12 @@ public class CommonUtil {
      *
      * @param context Language Server Operation Context
      * @param fields  A non empty map of fields
+     * @param symbol  Pair of Raw TypeSymbol and broader TypeSymbol
      * @return {@link LSCompletionItem}   Completion Item to fill all the options
      */
     public static LSCompletionItem getFillAllStructFieldsItem(BallerinaCompletionContext context,
                                                               Map<String, RecordFieldSymbol> fields,
-                                                              TypeSymbol symbol) {
+                                                              Pair<TypeSymbol, TypeSymbol> symbol) {
 
         List<String> fieldEntries = new ArrayList<>();
 
@@ -419,7 +429,14 @@ public class CommonUtil {
         }
 
         String label;
-        String detail = symbol.getName().isPresent() ? symbol.getName().get() : symbol.signature();
+        String detail;
+        if (symbol.getLeft().getName().isPresent()) {
+            detail = getModifiedTypeName(context, symbol.getLeft());
+        } else if (symbol.getRight().getName().isPresent()) {
+            detail = getModifiedTypeName(context, symbol.getRight());
+        } else {
+            detail = symbol.getLeft().signature();
+        }
         if (!requiredFields.isEmpty()) {
             label = "Fill " + detail + " Required Fields";
             for (Map.Entry<String, RecordFieldSymbol> entry : requiredFields.entrySet()) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/ContextTypeResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/ContextTypeResolver.java
@@ -106,6 +106,8 @@ public class ContextTypeResolver extends NodeTransformer<Optional<TypeSymbol>> {
 
     private final PositionedOperationContext context;
     private final List<Node> visitedNodes = new ArrayList<>();
+    private TypeSymbol broaderTypeSymbol;
+    private boolean isBroaderTypeSymbolSet = false;
 
     public ContextTypeResolver(PositionedOperationContext context) {
         this.context = context;
@@ -470,6 +472,10 @@ public class ContextTypeResolver extends NodeTransformer<Optional<TypeSymbol>> {
 
     private TypeSymbol getRawContextType(TypeSymbol typeSymbol) {
         TypeSymbol rawType = CommonUtil.getRawType(typeSymbol);
+        if (!this.isBroaderTypeSymbolSet) {
+            broaderTypeSymbol = typeSymbol;
+            isBroaderTypeSymbolSet = true;
+        }
         switch (rawType.typeKind()) {
             case MAP:
                 return ((MapTypeSymbol) rawType).typeParam();
@@ -548,5 +554,18 @@ public class ContextTypeResolver extends NodeTransformer<Optional<TypeSymbol>> {
         }
 
         return Optional.of(parameterSymbols.get().get(argIndex).typeDescriptor());
+    }
+
+    /**
+     * Returns the broader or original type symbol of the resolved type symbol for a given context.
+     *
+     * @return
+     */
+    public Optional<TypeSymbol> getBroaderTypeSymbol() {
+        if (isBroaderTypeSymbolSet) {
+            return Optional.ofNullable(broaderTypeSymbol);
+        } else {
+            return Optional.empty();
+        }
     }
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/annotation_ctx/config/functionAnnotation5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/annotation_ctx/config/functionAnnotation5.json
@@ -17,7 +17,7 @@
     {
       "label": "bar",
       "kind": "Field",
-      "detail": "(record {| string foo; int bar?; anydata...; |}).bar",
+      "detail": "module1:AnnotationType.bar",
       "sortText": "G",
       "insertText": "bar: ${1:0}",
       "insertTextFormat": "Snippet"
@@ -25,15 +25,15 @@
     {
       "label": "foo",
       "kind": "Field",
-      "detail": "(record {| string foo; int bar?; anydata...; |}).foo",
+      "detail": "module1:AnnotationType.foo",
       "sortText": "G",
       "insertText": "foo: \"${2}\"",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "Fill record {| string foo; int bar?; anydata...; |} Required Fields",
+      "label": "Fill module1:AnnotationType Required Fields",
       "kind": "Property",
-      "detail": "record {| string foo; int bar?; anydata...; |}",
+      "detail": "module1:AnnotationType",
       "sortText": "R",
       "filterText": "fill",
       "insertText": "foo: \"\"",

--- a/language-server/modules/langserver-core/src/test/resources/completion/annotation_ctx/config/functionAnnotation6.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/annotation_ctx/config/functionAnnotation6.json
@@ -17,7 +17,7 @@
     {
       "label": "bar",
       "kind": "Field",
-      "detail": "(record {| string foo; int bar?; anydata...; |}).bar",
+      "detail": "module1:AnnotationType.bar",
       "sortText": "G",
       "insertText": "bar: ${1:0}",
       "insertTextFormat": "Snippet"
@@ -25,15 +25,15 @@
     {
       "label": "foo",
       "kind": "Field",
-      "detail": "(record {| string foo; int bar?; anydata...; |}).foo",
+      "detail": "module1:AnnotationType.foo",
       "sortText": "G",
       "insertText": "foo: \"${2}\"",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "Fill record {| string foo; int bar?; anydata...; |} Required Fields",
+      "label": "Fill module1:AnnotationType Required Fields",
       "kind": "Property",
-      "detail": "record {| string foo; int bar?; anydata...; |}",
+      "detail": "module1:AnnotationType",
       "sortText": "R",
       "filterText": "fill",
       "insertText": "foo: \"\"",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config10.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config10.json
@@ -17,7 +17,7 @@
     {
       "label": "field1",
       "kind": "Field",
-      "detail": "(record {| int field1; string field2; boolean field3; anydata...; |}).field1",
+      "detail": "TestRecord2.field1",
       "sortText": "G",
       "insertText": "field1: ${1:0}",
       "insertTextFormat": "Snippet"
@@ -25,7 +25,7 @@
     {
       "label": "field3",
       "kind": "Field",
-      "detail": "(record {| int field1; string field2; boolean field3; anydata...; |}).field3",
+      "detail": "TestRecord2.field3",
       "sortText": "G",
       "insertText": "field3: ${2:false}",
       "insertTextFormat": "Snippet"
@@ -33,15 +33,15 @@
     {
       "label": "field2",
       "kind": "Field",
-      "detail": "(record {| int field1; string field2; boolean field3; anydata...; |}).field2",
+      "detail": "TestRecord2.field2",
       "sortText": "G",
       "insertText": "field2: \"${3}\"",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "Fill record {| int field1; string field2; boolean field3; anydata...; |} Required Fields",
+      "label": "Fill TestRecord2 Required Fields",
       "kind": "Property",
-      "detail": "record {| int field1; string field2; boolean field3; anydata...; |}",
+      "detail": "TestRecord2",
       "sortText": "R",
       "filterText": "fill",
       "insertText": "field1: 0,\nfield3: false,\nfield2: \"\"",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config11.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config11.json
@@ -17,7 +17,7 @@
     {
       "label": "field1",
       "kind": "Field",
-      "detail": "(record {| int field1; string field2; boolean field3; anydata...; |}).field1",
+      "detail": "TestRecord2.field1",
       "sortText": "G",
       "insertText": "field1: ${1:0}",
       "insertTextFormat": "Snippet"
@@ -25,7 +25,7 @@
     {
       "label": "field3",
       "kind": "Field",
-      "detail": "(record {| int field1; string field2; boolean field3; anydata...; |}).field3",
+      "detail": "TestRecord2.field3",
       "sortText": "G",
       "insertText": "field3: ${2:false}",
       "insertTextFormat": "Snippet"
@@ -33,15 +33,15 @@
     {
       "label": "field2",
       "kind": "Field",
-      "detail": "(record {| int field1; string field2; boolean field3; anydata...; |}).field2",
+      "detail": "TestRecord2.field2",
       "sortText": "G",
       "insertText": "field2: \"${3}\"",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "Fill record {| int field1; string field2; boolean field3; anydata...; |} Required Fields",
+      "label": "Fill TestRecord2 Required Fields",
       "kind": "Property",
-      "detail": "record {| int field1; string field2; boolean field3; anydata...; |}",
+      "detail": "TestRecord2",
       "sortText": "R",
       "filterText": "fill",
       "insertText": "field1: 0,\nfield3: false,\nfield2: \"\"",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config12.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config12.json
@@ -17,7 +17,7 @@
     {
       "label": "rec2Field1",
       "kind": "Field",
-      "detail": "(record {| int rec2Field1; string rec3Field2; anydata...; |}).rec2Field1",
+      "detail": "module1:TestRecord2.rec2Field1",
       "sortText": "G",
       "insertText": "rec2Field1: ${1:0}",
       "insertTextFormat": "Snippet"
@@ -25,15 +25,15 @@
     {
       "label": "rec3Field2",
       "kind": "Field",
-      "detail": "(record {| int rec2Field1; string rec3Field2; anydata...; |}).rec3Field2",
+      "detail": "module1:TestRecord2.rec3Field2",
       "sortText": "G",
       "insertText": "rec3Field2: \"${2}\"",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "Fill record {| int rec2Field1; string rec3Field2; anydata...; |} Required Fields",
+      "label": "Fill module1:TestRecord2 Required Fields",
       "kind": "Property",
-      "detail": "record {| int rec2Field1; string rec3Field2; anydata...; |}",
+      "detail": "module1:TestRecord2",
       "sortText": "R",
       "filterText": "fill",
       "insertText": "rec2Field1: 0,\nrec3Field2: \"\"",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config13.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config13.json
@@ -17,7 +17,7 @@
     {
       "label": "rec2Field1",
       "kind": "Field",
-      "detail": "(record {| int rec2Field1; string rec3Field2; anydata...; |}).rec2Field1",
+      "detail": "TestRecord1.rec2Field1",
       "sortText": "G",
       "insertText": "rec2Field1: ${1:0}",
       "insertTextFormat": "Snippet"
@@ -25,15 +25,15 @@
     {
       "label": "rec3Field2",
       "kind": "Field",
-      "detail": "(record {| int rec2Field1; string rec3Field2; anydata...; |}).rec3Field2",
+      "detail": "TestRecord1.rec3Field2",
       "sortText": "G",
       "insertText": "rec3Field2: \"${2}\"",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "Fill record {| int rec2Field1; string rec3Field2; anydata...; |} Required Fields",
+      "label": "Fill TestRecord1 Required Fields",
       "kind": "Property",
-      "detail": "record {| int rec2Field1; string rec3Field2; anydata...; |}",
+      "detail": "TestRecord1",
       "sortText": "R",
       "filterText": "fill",
       "insertText": "rec2Field1: 0,\nrec3Field2: \"\"",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config16.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config16.json
@@ -17,7 +17,7 @@
     {
       "label": "rec1f2",
       "kind": "Field",
-      "detail": "(record {| RecordName2 rec1f1; int rec1f2; anydata...; |}).rec1f2",
+      "detail": "RecordName.rec1f2",
       "sortText": "G",
       "insertText": "rec1f2: ${1:0}",
       "insertTextFormat": "Snippet"
@@ -25,15 +25,15 @@
     {
       "label": "rec1f1",
       "kind": "Field",
-      "detail": "(record {| RecordName2 rec1f1; int rec1f2; anydata...; |}).rec1f1",
+      "detail": "RecordName.rec1f1",
       "sortText": "G",
       "insertText": "rec1f1: {\n\trec2f1: ${1:0},\n\trec2f2: ${2:0}\n}",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "Fill record {| RecordName2 rec1f1; int rec1f2; anydata...; |} Required Fields",
+      "label": "Fill RecordName Required Fields",
       "kind": "Property",
-      "detail": "record {| RecordName2 rec1f1; int rec1f2; anydata...; |}",
+      "detail": "RecordName",
       "sortText": "R",
       "filterText": "fill",
       "insertText": "rec1f2: 0,\nrec1f1: {rec2f1: 0, rec2f2: 0}",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config17.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config17.json
@@ -17,7 +17,7 @@
     {
       "label": "rec2f1",
       "kind": "Field",
-      "detail": "(record {| int rec2f1; int rec2f2; anydata...; |}).rec2f1",
+      "detail": "RecordName.rec2f1",
       "sortText": "G",
       "insertText": "rec2f1: ${1:0}",
       "insertTextFormat": "Snippet"
@@ -25,15 +25,15 @@
     {
       "label": "rec2f2",
       "kind": "Field",
-      "detail": "(record {| int rec2f1; int rec2f2; anydata...; |}).rec2f2",
+      "detail": "RecordName.rec2f2",
       "sortText": "G",
       "insertText": "rec2f2: ${2:0}",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "Fill record {| int rec2f1; int rec2f2; anydata...; |} Required Fields",
+      "label": "Fill RecordName Required Fields",
       "kind": "Property",
-      "detail": "record {| int rec2f1; int rec2f2; anydata...; |}",
+      "detail": "RecordName",
       "sortText": "R",
       "filterText": "fill",
       "insertText": "rec2f1: 0,\nrec2f2: 0",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config18.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config18.json
@@ -17,7 +17,7 @@
     {
       "label": "rec1f2",
       "kind": "Field",
-      "detail": "(record {| RecordName2 rec1f1; int rec1f2; anydata...; |}).rec1f2",
+      "detail": "RecordName.rec1f2",
       "sortText": "G",
       "insertText": "rec1f2: ${1:0}",
       "insertTextFormat": "Snippet"
@@ -25,15 +25,15 @@
     {
       "label": "rec1f1",
       "kind": "Field",
-      "detail": "(record {| RecordName2 rec1f1; int rec1f2; anydata...; |}).rec1f1",
+      "detail": "RecordName.rec1f1",
       "sortText": "G",
       "insertText": "rec1f1: {\n\trec2f1: ${1:0},\n\trec2f2: ${2:0}\n}",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "Fill record {| RecordName2 rec1f1; int rec1f2; anydata...; |} Required Fields",
+      "label": "Fill RecordName Required Fields",
       "kind": "Property",
-      "detail": "record {| RecordName2 rec1f1; int rec1f2; anydata...; |}",
+      "detail": "RecordName",
       "sortText": "R",
       "filterText": "fill",
       "insertText": "rec1f2: 0,\nrec1f1: {rec2f1: 0, rec2f2: 0}",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config19.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config19.json
@@ -17,7 +17,7 @@
     {
       "label": "rec2f1",
       "kind": "Field",
-      "detail": "(record {| int rec2f1; int rec2f2; anydata...; |}).rec2f1",
+      "detail": "RecordName.rec2f1",
       "sortText": "G",
       "insertText": "rec2f1: ${1:0}",
       "insertTextFormat": "Snippet"
@@ -25,15 +25,15 @@
     {
       "label": "rec2f2",
       "kind": "Field",
-      "detail": "(record {| int rec2f1; int rec2f2; anydata...; |}).rec2f2",
+      "detail": "RecordName.rec2f2",
       "sortText": "G",
       "insertText": "rec2f2: ${2:0}",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "Fill record {| int rec2f1; int rec2f2; anydata...; |} Required Fields",
+      "label": "Fill RecordName Required Fields",
       "kind": "Property",
-      "detail": "record {| int rec2f1; int rec2f2; anydata...; |}",
+      "detail": "RecordName",
       "sortText": "R",
       "filterText": "fill",
       "insertText": "rec2f1: 0,\nrec2f2: 0",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config20.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config20.json
@@ -17,7 +17,7 @@
     {
       "label": "rec1f2",
       "kind": "Field",
-      "detail": "(record {| Record2 rec1f1; int rec1f2; anydata...; |}).rec1f2",
+      "detail": "Record1.rec1f2",
       "sortText": "G",
       "insertText": "rec1f2: ${1:0}",
       "insertTextFormat": "Snippet"
@@ -25,15 +25,15 @@
     {
       "label": "rec1f1",
       "kind": "Field",
-      "detail": "(record {| Record2 rec1f1; int rec1f2; anydata...; |}).rec1f1",
+      "detail": "Record1.rec1f1",
       "sortText": "G",
       "insertText": "rec1f1: {\n\trec2f1: ${1:0},\n\trec2f2: ${2:0}\n}",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "Fill record {| Record2 rec1f1; int rec1f2; anydata...; |} Required Fields",
+      "label": "Fill Record1 Required Fields",
       "kind": "Property",
-      "detail": "record {| Record2 rec1f1; int rec1f2; anydata...; |}",
+      "detail": "Record1",
       "sortText": "R",
       "filterText": "fill",
       "insertText": "rec1f2: 0,\nrec1f1: {rec2f1: 0, rec2f2: 0}",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config22.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config22.json
@@ -17,7 +17,7 @@
     {
       "label": "rec2f1",
       "kind": "Field",
-      "detail": "(record {| int rec2f1; int rec2f2; anydata...; |}).rec2f1",
+      "detail": "Record2.rec2f1",
       "sortText": "G",
       "insertText": "rec2f1: ${1:0}",
       "insertTextFormat": "Snippet"
@@ -25,15 +25,15 @@
     {
       "label": "rec2f2",
       "kind": "Field",
-      "detail": "(record {| int rec2f1; int rec2f2; anydata...; |}).rec2f2",
+      "detail": "Record2.rec2f2",
       "sortText": "G",
       "insertText": "rec2f2: ${2:0}",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "Fill record {| int rec2f1; int rec2f2; anydata...; |} Required Fields",
+      "label": "Fill Record2 Required Fields",
       "kind": "Property",
-      "detail": "record {| int rec2f1; int rec2f2; anydata...; |}",
+      "detail": "Record2",
       "sortText": "R",
       "filterText": "fill",
       "insertText": "rec2f1: 0,\nrec2f2: 0",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config27.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config27.json
@@ -17,7 +17,7 @@
     {
       "label": "address",
       "kind": "Field",
-      "detail": "(record {| string name; int age; Address address; |}).address",
+      "detail": "Person.address",
       "sortText": "G",
       "insertText": "address: {\n\tstreet: \"${1}\",\n\tcity: \"${2}\",\n\tpostalCode: \"${3}\"\n}",
       "insertTextFormat": "Snippet"
@@ -25,7 +25,7 @@
     {
       "label": "name",
       "kind": "Field",
-      "detail": "(record {| string name; int age; Address address; |}).name",
+      "detail": "Person.name",
       "sortText": "G",
       "insertText": "name: \"${2}\"",
       "insertTextFormat": "Snippet"
@@ -33,15 +33,15 @@
     {
       "label": "age",
       "kind": "Field",
-      "detail": "(record {| string name; int age; Address address; |}).age",
+      "detail": "Person.age",
       "sortText": "G",
       "insertText": "age: ${3:0}",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "Fill record {| string name; int age; Address address; |} Required Fields",
+      "label": "Fill Person Required Fields",
       "kind": "Property",
-      "detail": "record {| string name; int age; Address address; |}",
+      "detail": "Person",
       "sortText": "R",
       "filterText": "fill",
       "insertText": "address: {street: \"\", city: \"\", postalCode: \"\"},\nname: \"\",\nage: 0",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config27a.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config27a.json
@@ -17,7 +17,7 @@
     {
       "label": "address",
       "kind": "Field",
-      "detail": "(record {| string name; int age; Address address; |}).address",
+      "detail": "Person.address",
       "sortText": "G",
       "insertText": "address: {\n\tstreet: \"${1}\",\n\tcity: \"${2}\",\n\tpostalCode: \"${3}\"\n}",
       "insertTextFormat": "Snippet"
@@ -25,7 +25,7 @@
     {
       "label": "name",
       "kind": "Field",
-      "detail": "(record {| string name; int age; Address address; |}).name",
+      "detail": "Person.name",
       "sortText": "G",
       "insertText": "name: \"${2}\"",
       "insertTextFormat": "Snippet"
@@ -33,15 +33,15 @@
     {
       "label": "age",
       "kind": "Field",
-      "detail": "(record {| string name; int age; Address address; |}).age",
+      "detail": "Person.age",
       "sortText": "G",
       "insertText": "age: ${3:0}",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "Fill record {| string name; int age; Address address; |} Required Fields",
+      "label": "Fill Person Required Fields",
       "kind": "Property",
-      "detail": "record {| string name; int age; Address address; |}",
+      "detail": "Person",
       "sortText": "R",
       "filterText": "fill",
       "insertText": "address: {street: \"\", city: \"\", postalCode: \"\"},\nname: \"\",\nage: 0",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config28.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config28.json
@@ -17,7 +17,7 @@
     {
       "label": "address",
       "kind": "Field",
-      "detail": "(record {| string name; int age; Address address; |}).address",
+      "detail": "Person.address",
       "sortText": "G",
       "insertText": "address: {\n\tstreet: \"${1}\",\n\tcity: \"${2}\",\n\tpostalCode: \"${3}\"\n}",
       "insertTextFormat": "Snippet"
@@ -25,7 +25,7 @@
     {
       "label": "name",
       "kind": "Field",
-      "detail": "(record {| string name; int age; Address address; |}).name",
+      "detail": "Person.name",
       "sortText": "G",
       "insertText": "name: \"${2}\"",
       "insertTextFormat": "Snippet"
@@ -33,15 +33,15 @@
     {
       "label": "age",
       "kind": "Field",
-      "detail": "(record {| string name; int age; Address address; |}).age",
+      "detail": "Person.age",
       "sortText": "G",
       "insertText": "age: ${3:0}",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "Fill record {| string name; int age; Address address; |} Required Fields",
+      "label": "Fill Person Required Fields",
       "kind": "Property",
-      "detail": "record {| string name; int age; Address address; |}",
+      "detail": "Person",
       "sortText": "R",
       "filterText": "fill",
       "insertText": "address: {street: \"\", city: \"\", postalCode: \"\"},\nname: \"\",\nage: 0",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config30.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config30.json
@@ -17,7 +17,7 @@
     {
       "label": "address",
       "kind": "Field",
-      "detail": "(record {| string name; int age; Address address; |}).address",
+      "detail": "Person.address",
       "sortText": "G",
       "insertText": "address: {\n\tstreet: \"${1}\",\n\tcity: \"${2}\",\n\tpostalCode: \"${3}\"\n}",
       "insertTextFormat": "Snippet"
@@ -25,7 +25,7 @@
     {
       "label": "name",
       "kind": "Field",
-      "detail": "(record {| string name; int age; Address address; |}).name",
+      "detail": "Person.name",
       "sortText": "G",
       "insertText": "name: \"${2}\"",
       "insertTextFormat": "Snippet"
@@ -33,15 +33,15 @@
     {
       "label": "age",
       "kind": "Field",
-      "detail": "(record {| string name; int age; Address address; |}).age",
+      "detail": "Person.age",
       "sortText": "G",
       "insertText": "age: ${3:0}",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "Fill record {| string name; int age; Address address; |} Required Fields",
+      "label": "Fill Person Required Fields",
       "kind": "Property",
-      "detail": "record {| string name; int age; Address address; |}",
+      "detail": "Person",
       "sortText": "R",
       "filterText": "fill",
       "insertText": "address: {street: \"\", city: \"\", postalCode: \"\"},\nname: \"\",\nage: 0",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config31.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config31.json
@@ -17,7 +17,7 @@
     {
       "label": "address",
       "kind": "Field",
-      "detail": "(record {| string name; int age; Address address; |}).address",
+      "detail": "Person.address",
       "sortText": "G",
       "insertText": "address: {\n\tstreet: \"${1}\",\n\tcity: \"${2}\",\n\tpostalCode: \"${3}\"\n}",
       "insertTextFormat": "Snippet"
@@ -25,7 +25,7 @@
     {
       "label": "name",
       "kind": "Field",
-      "detail": "(record {| string name; int age; Address address; |}).name",
+      "detail": "Person.name",
       "sortText": "G",
       "insertText": "name: \"${2}\"",
       "insertTextFormat": "Snippet"
@@ -33,15 +33,15 @@
     {
       "label": "age",
       "kind": "Field",
-      "detail": "(record {| string name; int age; Address address; |}).age",
+      "detail": "Person.age",
       "sortText": "G",
       "insertText": "age: ${3:0}",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "Fill record {| string name; int age; Address address; |} Required Fields",
+      "label": "Fill Person Required Fields",
       "kind": "Property",
-      "detail": "record {| string name; int age; Address address; |}",
+      "detail": "Person",
       "sortText": "R",
       "filterText": "fill",
       "insertText": "address: {street: \"\", city: \"\", postalCode: \"\"},\nname: \"\",\nage: 0",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config32.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config32.json
@@ -17,7 +17,7 @@
     {
       "label": "address",
       "kind": "Field",
-      "detail": "(record {| string name; int age; Address address; |}).address",
+      "detail": "Person.address",
       "sortText": "G",
       "insertText": "address: {\n\tstreet: \"${1}\",\n\tcity: \"${2}\",\n\tpostalCode: \"${3}\"\n}",
       "insertTextFormat": "Snippet"
@@ -25,7 +25,7 @@
     {
       "label": "name",
       "kind": "Field",
-      "detail": "(record {| string name; int age; Address address; |}).name",
+      "detail": "Person.name",
       "sortText": "G",
       "insertText": "name: \"${2}\"",
       "insertTextFormat": "Snippet"
@@ -33,15 +33,15 @@
     {
       "label": "age",
       "kind": "Field",
-      "detail": "(record {| string name; int age; Address address; |}).age",
+      "detail": "Person.age",
       "sortText": "G",
       "insertText": "age: ${3:0}",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "Fill record {| string name; int age; Address address; |} Required Fields",
+      "label": "Fill Person Required Fields",
       "kind": "Property",
-      "detail": "record {| string name; int age; Address address; |}",
+      "detail": "Person",
       "sortText": "R",
       "filterText": "fill",
       "insertText": "address: {street: \"\", city: \"\", postalCode: \"\"},\nname: \"\",\nage: 0",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config32a.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config32a.json
@@ -17,7 +17,7 @@
     {
       "label": "address",
       "kind": "Field",
-      "detail": "(record {| string name; int age; Address address; |}).address",
+      "detail": "Person.address",
       "sortText": "G",
       "insertText": "address: {\n\tstreet: \"${1}\",\n\tcity: \"${2}\",\n\tpostalCode: \"${3}\"\n}",
       "insertTextFormat": "Snippet"
@@ -25,7 +25,7 @@
     {
       "label": "name",
       "kind": "Field",
-      "detail": "(record {| string name; int age; Address address; |}).name",
+      "detail": "Person.name",
       "sortText": "G",
       "insertText": "name: \"${2}\"",
       "insertTextFormat": "Snippet"
@@ -33,15 +33,15 @@
     {
       "label": "age",
       "kind": "Field",
-      "detail": "(record {| string name; int age; Address address; |}).age",
+      "detail": "Person.age",
       "sortText": "G",
       "insertText": "age: ${3:0}",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "Fill record {| string name; int age; Address address; |} Required Fields",
+      "label": "Fill Person Required Fields",
       "kind": "Property",
-      "detail": "record {| string name; int age; Address address; |}",
+      "detail": "Person",
       "sortText": "R",
       "filterText": "fill",
       "insertText": "address: {street: \"\", city: \"\", postalCode: \"\"},\nname: \"\",\nage: 0",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config33.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config33.json
@@ -17,7 +17,7 @@
     {
       "label": "Fa2",
       "kind": "Field",
-      "detail": "(record {| int Fa1; Bar Fa2; |}).Fa2",
+      "detail": "Foo.Fa2",
       "sortText": "G",
       "insertText": "Fa2: {\n\tBa1: ${1:0},\n\tBa2: \"${2}\"\n}",
       "insertTextFormat": "Snippet"
@@ -25,15 +25,15 @@
     {
       "label": "Fa1",
       "kind": "Field",
-      "detail": "(record {| int Fa1; Bar Fa2; |}).Fa1",
+      "detail": "Foo.Fa1",
       "sortText": "G",
       "insertText": "Fa1: ${2:0}",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "Fill record {| int Fa1; Bar Fa2; |} Required Fields",
+      "label": "Fill Foo Required Fields",
       "kind": "Property",
-      "detail": "record {| int Fa1; Bar Fa2; |}",
+      "detail": "Foo",
       "sortText": "R",
       "filterText": "fill",
       "insertText": "Fa2: {Ba1: 0, Ba2: \"\"},\nFa1: 0",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config34.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config34.json
@@ -17,7 +17,7 @@
     {
       "label": "Ba2",
       "kind": "Field",
-      "detail": "(record {| int Ba1; string Ba2; |}).Ba2",
+      "detail": "Bar.Ba2",
       "sortText": "G",
       "insertText": "Ba2: \"${1}\"",
       "insertTextFormat": "Snippet"
@@ -25,15 +25,15 @@
     {
       "label": "Ba1",
       "kind": "Field",
-      "detail": "(record {| int Ba1; string Ba2; |}).Ba1",
+      "detail": "Bar.Ba1",
       "sortText": "G",
       "insertText": "Ba1: ${2:0}",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "Fill record {| int Ba1; string Ba2; |} Required Fields",
+      "label": "Fill Bar Required Fields",
       "kind": "Property",
-      "detail": "record {| int Ba1; string Ba2; |}",
+      "detail": "Bar",
       "sortText": "R",
       "filterText": "fill",
       "insertText": "Ba2: \"\",\nBa1: 0",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config35.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config35.json
@@ -17,7 +17,7 @@
     {
       "label": "f1",
       "kind": "Field",
-      "detail": "(record {| int f1; string f2?; |}).f1",
+      "detail": "Foo.f1",
       "sortText": "G",
       "insertText": "f1: ${1:0}",
       "insertTextFormat": "Snippet"
@@ -25,15 +25,15 @@
     {
       "label": "f2",
       "kind": "Field",
-      "detail": "(record {| int f1; string f2?; |}).f2",
+      "detail": "Foo.f2",
       "sortText": "G",
       "insertText": "f2: \"${2}\"",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "Fill record {| int f1; string f2?; |} Required Fields",
+      "label": "Fill Foo Required Fields",
       "kind": "Property",
-      "detail": "record {| int f1; string f2?; |}",
+      "detail": "Foo",
       "sortText": "R",
       "filterText": "fill",
       "insertText": "f1: 0",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config36.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config36.json
@@ -17,7 +17,7 @@
     {
       "label": "optionalInt",
       "kind": "Field",
-      "detail": "(record {| int rec1Field1; string rec1Field2; int optionalInt?; anydata...; |}).optionalInt",
+      "detail": "module1:TestRecord1.optionalInt",
       "sortText": "G",
       "insertText": "optionalInt: ${1:0}",
       "insertTextFormat": "Snippet"
@@ -25,7 +25,7 @@
     {
       "label": "rec1Field1",
       "kind": "Field",
-      "detail": "(record {| int rec1Field1; string rec1Field2; int optionalInt?; anydata...; |}).rec1Field1",
+      "detail": "module1:TestRecord1.rec1Field1",
       "sortText": "G",
       "insertText": "rec1Field1: ${2:0}",
       "insertTextFormat": "Snippet"
@@ -33,15 +33,15 @@
     {
       "label": "rec1Field2",
       "kind": "Field",
-      "detail": "(record {| int rec1Field1; string rec1Field2; int optionalInt?; anydata...; |}).rec1Field2",
+      "detail": "module1:TestRecord1.rec1Field2",
       "sortText": "G",
       "insertText": "rec1Field2: \"${3}\"",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "Fill record {| int rec1Field1; string rec1Field2; int optionalInt?; anydata...; |} Required Fields",
+      "label": "Fill module1:TestRecord1 Required Fields",
       "kind": "Property",
-      "detail": "record {| int rec1Field1; string rec1Field2; int optionalInt?; anydata...; |}",
+      "detail": "module1:TestRecord1",
       "sortText": "R",
       "filterText": "fill",
       "insertText": "rec1Field1: 0,\nrec1Field2: \"\"",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config37.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config37.json
@@ -17,7 +17,7 @@
     {
       "label": "node",
       "kind": "Field",
-      "detail": "(record {| ballerina/module1:0.1.0:TestRecord1 record1; Err err1; Foo record2; table<Foo> key(f1) myTable; xml myXML; map<string> myMap; error myError; NodeCredential credentials; Node node; error|float randomNum; boolean isAlive; string[][] keywords; |}).node",
+      "detail": "MyConfig.node",
       "sortText": "G",
       "insertText": "node: ${1:new ({ip: \"\", port: 0, username: \"\", files: new ()}, 0, \"\")}",
       "insertTextFormat": "Snippet"
@@ -25,7 +25,7 @@
     {
       "label": "isAlive",
       "kind": "Field",
-      "detail": "(record {| ballerina/module1:0.1.0:TestRecord1 record1; Err err1; Foo record2; table<Foo> key(f1) myTable; xml myXML; map<string> myMap; error myError; NodeCredential credentials; Node node; error|float randomNum; boolean isAlive; string[][] keywords; |}).isAlive",
+      "detail": "MyConfig.isAlive",
       "sortText": "G",
       "insertText": "isAlive: ${2:false}",
       "insertTextFormat": "Snippet"
@@ -33,7 +33,7 @@
     {
       "label": "err1",
       "kind": "Field",
-      "detail": "(record {| ballerina/module1:0.1.0:TestRecord1 record1; Err err1; Foo record2; table<Foo> key(f1) myTable; xml myXML; map<string> myMap; error myError; NodeCredential credentials; Node node; error|float randomNum; boolean isAlive; string[][] keywords; |}).err1",
+      "detail": "MyConfig.err1",
       "sortText": "G",
       "insertText": "err1: ${3:error (\"\", message = \"\")}",
       "insertTextFormat": "Snippet"
@@ -41,7 +41,7 @@
     {
       "label": "myXML",
       "kind": "Field",
-      "detail": "(record {| ballerina/module1:0.1.0:TestRecord1 record1; Err err1; Foo record2; table<Foo> key(f1) myTable; xml myXML; map<string> myMap; error myError; NodeCredential credentials; Node node; error|float randomNum; boolean isAlive; string[][] keywords; |}).myXML",
+      "detail": "MyConfig.myXML",
       "sortText": "G",
       "insertText": "myXML: ${4:xml ``}",
       "insertTextFormat": "Snippet"
@@ -49,7 +49,7 @@
     {
       "label": "keywords",
       "kind": "Field",
-      "detail": "(record {| ballerina/module1:0.1.0:TestRecord1 record1; Err err1; Foo record2; table<Foo> key(f1) myTable; xml myXML; map<string> myMap; error myError; NodeCredential credentials; Node node; error|float randomNum; boolean isAlive; string[][] keywords; |}).keywords",
+      "detail": "MyConfig.keywords",
       "sortText": "G",
       "insertText": "keywords: [${5}]",
       "insertTextFormat": "Snippet"
@@ -57,7 +57,7 @@
     {
       "label": "credentials",
       "kind": "Field",
-      "detail": "(record {| ballerina/module1:0.1.0:TestRecord1 record1; Err err1; Foo record2; table<Foo> key(f1) myTable; xml myXML; map<string> myMap; error myError; NodeCredential credentials; Node node; error|float randomNum; boolean isAlive; string[][] keywords; |}).credentials",
+      "detail": "MyConfig.credentials",
       "sortText": "G",
       "insertText": "credentials: {\n\tip: \"${1}\",\n\tport: ${2:0},\n\tusername: \"${3}\",\n\tfiles: ${4:new ()}\n}",
       "insertTextFormat": "Snippet"
@@ -65,7 +65,7 @@
     {
       "label": "record2",
       "kind": "Field",
-      "detail": "(record {| ballerina/module1:0.1.0:TestRecord1 record1; Err err1; Foo record2; table<Foo> key(f1) myTable; xml myXML; map<string> myMap; error myError; NodeCredential credentials; Node node; error|float randomNum; boolean isAlive; string[][] keywords; |}).record2",
+      "detail": "MyConfig.record2",
       "sortText": "G",
       "insertText": "record2: {\n\tf1: ${1:0}\n}",
       "insertTextFormat": "Snippet"
@@ -73,7 +73,7 @@
     {
       "label": "record1",
       "kind": "Field",
-      "detail": "(record {| ballerina/module1:0.1.0:TestRecord1 record1; Err err1; Foo record2; table<Foo> key(f1) myTable; xml myXML; map<string> myMap; error myError; NodeCredential credentials; Node node; error|float randomNum; boolean isAlive; string[][] keywords; |}).record1",
+      "detail": "MyConfig.record1",
       "sortText": "G",
       "insertText": "record1: {${8}}",
       "insertTextFormat": "Snippet"
@@ -81,7 +81,7 @@
     {
       "label": "myMap",
       "kind": "Field",
-      "detail": "(record {| ballerina/module1:0.1.0:TestRecord1 record1; Err err1; Foo record2; table<Foo> key(f1) myTable; xml myXML; map<string> myMap; error myError; NodeCredential credentials; Node node; error|float randomNum; boolean isAlive; string[][] keywords; |}).myMap",
+      "detail": "MyConfig.myMap",
       "sortText": "G",
       "insertText": "myMap: ${9:{}}",
       "insertTextFormat": "Snippet"
@@ -89,7 +89,7 @@
     {
       "label": "myTable",
       "kind": "Field",
-      "detail": "(record {| ballerina/module1:0.1.0:TestRecord1 record1; Err err1; Foo record2; table<Foo> key(f1) myTable; xml myXML; map<string> myMap; error myError; NodeCredential credentials; Node node; error|float randomNum; boolean isAlive; string[][] keywords; |}).myTable",
+      "detail": "MyConfig.myTable",
       "sortText": "G",
       "insertText": "myTable: ${10:table [{f1: 0}]}",
       "insertTextFormat": "Snippet"
@@ -97,7 +97,7 @@
     {
       "label": "myError",
       "kind": "Field",
-      "detail": "(record {| ballerina/module1:0.1.0:TestRecord1 record1; Err err1; Foo record2; table<Foo> key(f1) myTable; xml myXML; map<string> myMap; error myError; NodeCredential credentials; Node node; error|float randomNum; boolean isAlive; string[][] keywords; |}).myError",
+      "detail": "MyConfig.myError",
       "sortText": "G",
       "insertText": "myError: ${11:error (\"\")}",
       "insertTextFormat": "Snippet"
@@ -105,15 +105,15 @@
     {
       "label": "randomNum",
       "kind": "Field",
-      "detail": "(record {| ballerina/module1:0.1.0:TestRecord1 record1; Err err1; Foo record2; table<Foo> key(f1) myTable; xml myXML; map<string> myMap; error myError; NodeCredential credentials; Node node; error|float randomNum; boolean isAlive; string[][] keywords; |}).randomNum",
+      "detail": "MyConfig.randomNum",
       "sortText": "G",
       "insertText": "randomNum: ${12:error (\"\")}",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "Fill record {| ballerina/module1:0.1.0:TestRecord1 record1; Err err1; Foo record2; table<Foo> key(f1) myTable; xml myXML; map<string> myMap; error myError; NodeCredential credentials; Node node; error|float randomNum; boolean isAlive; string[][] keywords; |} Required Fields",
+      "label": "Fill MyConfig Required Fields",
       "kind": "Property",
-      "detail": "record {| ballerina/module1:0.1.0:TestRecord1 record1; Err err1; Foo record2; table<Foo> key(f1) myTable; xml myXML; map<string> myMap; error myError; NodeCredential credentials; Node node; error|float randomNum; boolean isAlive; string[][] keywords; |}",
+      "detail": "MyConfig",
       "sortText": "R",
       "filterText": "fill",
       "insertText": "node: new ({ip: \"\", port: 0, username: \"\", files: new ()}, 0, \"\"),\nisAlive: false,\nerr1: error (\"\", message = \"\"),\nmyXML: xml ``,\nkeywords: [[]],\ncredentials: {ip: \"\", port: 0, username: \"\", files: new ()},\nrecord2: {f1: 0},\nrecord1: {},\nmyMap: {},\nmyTable: table [{f1: 0}],\nmyError: error (\"\"),\nrandomNum: error (\"\")",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config41.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config41.json
@@ -17,15 +17,15 @@
     {
       "label": "rec3Field2",
       "kind": "Field",
-      "detail": "(record {| int rec3Field1; int rec3Field2; anydata...; |}).rec3Field2",
+      "detail": "Rec3.rec3Field2",
       "sortText": "G",
       "insertText": "rec3Field2: ${1:0}",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "Fill record {| int rec3Field1; int rec3Field2; anydata...; |} Required Fields",
+      "label": "Fill Rec3 Required Fields",
       "kind": "Property",
-      "detail": "record {| int rec3Field1; int rec3Field2; anydata...; |}",
+      "detail": "Rec3",
       "sortText": "R",
       "filterText": "fill",
       "insertText": "rec3Field2: 0",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config42.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config42.json
@@ -17,7 +17,7 @@
     {
       "label": "endLine",
       "kind": "Field",
-      "detail": "(record {| readonly Position startLine; readonly Position endLine; |}).endLine",
+      "detail": "Range.endLine",
       "sortText": "G",
       "insertText": "endLine: ${1:{line: 0, offset: 0}}",
       "insertTextFormat": "Snippet"
@@ -25,15 +25,15 @@
     {
       "label": "startLine",
       "kind": "Field",
-      "detail": "(record {| readonly Position startLine; readonly Position endLine; |}).startLine",
+      "detail": "Range.startLine",
       "sortText": "G",
       "insertText": "startLine: ${2:{line: 0, offset: 0}}",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "Fill record {| readonly Position startLine; readonly Position endLine; |} Required Fields",
+      "label": "Fill Range Required Fields",
       "kind": "Property",
-      "detail": "record {| readonly Position startLine; readonly Position endLine; |}",
+      "detail": "Range",
       "sortText": "R",
       "filterText": "fill",
       "insertText": "endLine: {line: 0, offset: 0},\nstartLine: {line: 0, offset: 0}",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config43.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config43.json
@@ -17,7 +17,7 @@
     {
       "label": "endLine",
       "kind": "Field",
-      "detail": "(record {| Position startLine; Position endLine; |}).endLine",
+      "detail": "Range.endLine",
       "sortText": "G",
       "insertText": "endLine: ${1:{line: 0, offset: 0}}",
       "insertTextFormat": "Snippet"
@@ -25,15 +25,15 @@
     {
       "label": "startLine",
       "kind": "Field",
-      "detail": "(record {| Position startLine; Position endLine; |}).startLine",
+      "detail": "Range.startLine",
       "sortText": "G",
       "insertText": "startLine: ${2:{line: 0, offset: 0}}",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "Fill record {| Position startLine; Position endLine; |} Required Fields",
+      "label": "Fill Range Required Fields",
       "kind": "Property",
-      "detail": "record {| Position startLine; Position endLine; |}",
+      "detail": "Range",
       "sortText": "R",
       "filterText": "fill",
       "insertText": "endLine: {line: 0, offset: 0},\nstartLine: {line: 0, offset: 0}",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config44.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config44.json
@@ -17,7 +17,7 @@
     {
       "label": "endLine",
       "kind": "Field",
-      "detail": "(record {| Position startLine; Position endLine; |}).endLine",
+      "detail": "Range.endLine",
       "sortText": "G",
       "insertText": "endLine: ${1:{line: 0, offset: 0}}",
       "insertTextFormat": "Snippet"
@@ -25,15 +25,15 @@
     {
       "label": "startLine",
       "kind": "Field",
-      "detail": "(record {| Position startLine; Position endLine; |}).startLine",
+      "detail": "Range.startLine",
       "sortText": "G",
       "insertText": "startLine: ${2:{line: 0, offset: 0}}",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "Fill record {| Position startLine; Position endLine; |} Required Fields",
+      "label": "Fill Range Required Fields",
       "kind": "Property",
-      "detail": "record {| Position startLine; Position endLine; |}",
+      "detail": "Range",
       "sortText": "R",
       "filterText": "fill",
       "insertText": "endLine: {line: 0, offset: 0},\nstartLine: {line: 0, offset: 0}",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/projectls/modules/lsmod2/source1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/projectls/modules/lsmod2/source1.bal
@@ -1,0 +1,17 @@
+
+public type PositionRec record {|
+    int line;
+    int offset;
+|};
+
+public type Position readonly & PositionRec;
+
+public type Range record {|
+    Position startLine;
+    Position endLine;
+|};
+
+public type Edit record {|
+    Range range;
+    string edit;
+|};

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/projectls/modules/lsmod3/source1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/projectls/modules/lsmod3/source1.bal
@@ -1,0 +1,12 @@
+import projectls.lsmod2;
+
+public type Document record {|
+    string uri;
+    int id;
+|};
+
+function testFunction() {
+    lsmod2:Range | lsmod2:Edit | Document doc = {
+        u
+    }
+}


### PR DESCRIPTION
## Purpose
- Add a cache to context type resolver to save the boarder type(original type).
- Refactor detail of record field completion item

Fixes #31426

## Samples
![rsz_screenshot_from_2021-07-02_10-16-48](https://user-images.githubusercontent.com/35211477/124222230-f58b9700-db1e-11eb-96ea-7bf2c3dde52b.png)


## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
