### PR TITLE
Fix modules getting removed during syntaxTreeModify

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/visitor/UnusedSymbolsVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/visitor/UnusedSymbolsVisitor.java
@@ -187,12 +187,13 @@ public class UnusedSymbolsVisitor extends NodeVisitor {
     public void visit(ImportDeclarationNode importDeclarationNode) {
         addUnusedImportNode(importDeclarationNode);
 
-        if (importDeclarationNode.moduleName().size() > 0 && importDeclarationNode.moduleName().get(importDeclarationNode.moduleName().size() - 1) != null) {
+        int moduleNamePosition = importDeclarationNode.moduleName().size() - 1;
+        if (importDeclarationNode.moduleName().size() > 0 && importDeclarationNode.moduleName().get(moduleNamePosition) != null) {
             Optional<ImportPrefixNode> prefix = importDeclarationNode.prefix();
             if (prefix.isPresent()) {
                 moveUnusedtoUsedImport(prefix.get().prefix().lineRange(), importDeclarationNode);
             } else {
-                moveUnusedtoUsedImport(importDeclarationNode.moduleName().get(importDeclarationNode.moduleName().size() - 1).lineRange(), importDeclarationNode);
+                moveUnusedtoUsedImport(importDeclarationNode.moduleName().get(moduleNamePosition).lineRange(), importDeclarationNode);
             }
         }
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/visitor/UnusedSymbolsVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/visitor/UnusedSymbolsVisitor.java
@@ -188,12 +188,14 @@ public class UnusedSymbolsVisitor extends NodeVisitor {
         addUnusedImportNode(importDeclarationNode);
 
         int moduleNamePosition = importDeclarationNode.moduleName().size() - 1;
-        if (importDeclarationNode.moduleName().size() > 0 && importDeclarationNode.moduleName().get(moduleNamePosition) != null) {
+        if (importDeclarationNode.moduleName().size() > 0
+                && importDeclarationNode.moduleName().get(moduleNamePosition) != null) {
             Optional<ImportPrefixNode> prefix = importDeclarationNode.prefix();
             if (prefix.isPresent()) {
                 moveUnusedtoUsedImport(prefix.get().prefix().lineRange(), importDeclarationNode);
             } else {
-                moveUnusedtoUsedImport(importDeclarationNode.moduleName().get(moduleNamePosition).lineRange(), importDeclarationNode);
+                moveUnusedtoUsedImport(importDeclarationNode.moduleName().get(moduleNamePosition).lineRange(),
+                        importDeclarationNode);
             }
         }
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/visitor/UnusedSymbolsVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/visitor/UnusedSymbolsVisitor.java
@@ -187,12 +187,12 @@ public class UnusedSymbolsVisitor extends NodeVisitor {
     public void visit(ImportDeclarationNode importDeclarationNode) {
         addUnusedImportNode(importDeclarationNode);
 
-        if (importDeclarationNode.moduleName().size() > 0 && importDeclarationNode.moduleName().get(0) != null) {
+        if (importDeclarationNode.moduleName().size() > 0 && importDeclarationNode.moduleName().get(importDeclarationNode.moduleName().size() - 1) != null) {
             Optional<ImportPrefixNode> prefix = importDeclarationNode.prefix();
             if (prefix.isPresent()) {
                 moveUnusedtoUsedImport(prefix.get().prefix().lineRange(), importDeclarationNode);
             } else {
-                moveUnusedtoUsedImport(importDeclarationNode.moduleName().get(0).lineRange(), importDeclarationNode);
+                moveUnusedtoUsedImport(importDeclarationNode.moduleName().get(importDeclarationNode.moduleName().size() - 1).lineRange(), importDeclarationNode);
             }
         }
     }


### PR DESCRIPTION
## Purpose
> Modules with `.` were getting removed during syntaxTreeModify. This was due to `addUnusedImportNode` function selecting the first part of the molecule name and evaluates whether it exists in the code and decides whether or not to remove it.


## Approach
> This fix alters the `addUnusedImportNode` to do the evaluation based on the last part of the module name

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
