### PR TITLE
Support returning package root when the package root itself is passed to ProjectPaths.packageRoot

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/ProjectPaths.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/ProjectPaths.java
@@ -49,7 +49,7 @@ public class ProjectPaths {
         }
 
         // check if the file is a regular file
-        if (!Files.isRegularFile(filepath)) {
+        if (!Files.isRegularFile(filepath) && !Files.isDirectory(filepath)) {
             throw new ProjectException("provided path is not a regular file: " + filepath);
         }
 
@@ -60,6 +60,10 @@ public class ProjectPaths {
         }
 
         Path absFilePath = filepath.toAbsolutePath().normalize();
+        if (projectRoot.get().toAbsolutePath().normalize().toString().equals(absFilePath.toString())) {
+            return absFilePath;
+        }
+
         if (hasBallerinaToml(projectRoot.get())) {
             // check if the file is a ballerina project related toml file
             if (isBallerinaRelatedToml(filepath)) {

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/ProjectPathsTest.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/ProjectPathsTest.java
@@ -77,6 +77,7 @@ public class ProjectPathsTest {
     @Test
     public void testPackageRoot() {
         // test package root of build project
+        Assert.assertEquals(ProjectPaths.packageRoot(buildProjectPath), buildProjectPath);
         Assert.assertEquals(ProjectPaths.packageRoot(buildProjectPath
                 .resolve(ProjectConstants.BALLERINA_TOML)), buildProjectPath);
         Assert.assertEquals(ProjectPaths.packageRoot(buildProjectPath


### PR DESCRIPTION
## Purpose
> Support returning package root when the package root itself is passed to ProjectPaths.packageRoot

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
