### PR TITLE
Add parameter related APIs for remote functions

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/FunctionParameter.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/FunctionParameter.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except
@@ -15,21 +15,20 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-package io.ballerina.runtime.api.types;
 
-import io.ballerina.runtime.api.FunctionParameter;
+package io.ballerina.runtime.api;
 
 /**
- * {@code ResourceFunctionType} represents a resource function in Ballerina.
+ * {@code {@link FunctionParameter} represents the parameter of a function in ballerina.
  *
  * @since 2.0
  */
-public interface ResourceMethodType extends MethodType {
-    @Deprecated
-    String[] getParamNames();
-    String getAccessor();
-    String[] getResourcePath();
-    @Deprecated
-    Boolean[] getParamDefaultability();
-    FunctionParameter[] getParameters();
+public class FunctionParameter {
+    public final String name;
+    public final boolean isDefault;
+
+    public FunctionParameter(String name, Boolean isDefault) {
+        this.name = name;
+        this.isDefault = isDefault;
+    }
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/Parameter.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/Parameter.java
@@ -19,15 +19,15 @@
 package io.ballerina.runtime.api;
 
 /**
- * {@code {@link FunctionParameter} represents the parameter of a function in ballerina.
+ * {@code {@link Parameter } represents the parameter of a function in ballerina.
  *
  * @since 2.0
  */
-public class FunctionParameter {
+public class Parameter {
     public final String name;
     public final boolean isDefault;
 
-    public FunctionParameter(String name, Boolean isDefault) {
+    public Parameter(String name, Boolean isDefault) {
         this.name = name;
         this.isDefault = isDefault;
     }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/types/RemoteMethodType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/types/RemoteMethodType.java
@@ -27,4 +27,8 @@ public interface RemoteMethodType extends MethodType {
     ObjectType getParentObjectType();
 
     FunctionType getType();
+
+    String[] getParamNames();
+
+    Boolean[] getParamDefaultability();
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/types/RemoteMethodType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/types/RemoteMethodType.java
@@ -17,7 +17,7 @@
  */
 package io.ballerina.runtime.api.types;
 
-import io.ballerina.runtime.api.FunctionParameter;
+import io.ballerina.runtime.api.Parameter;
 
 /**
  * {@code {@link RemoteMethodType }} represents remote function type in ballerina.
@@ -30,5 +30,5 @@ public interface RemoteMethodType extends MethodType {
 
     FunctionType getType();
 
-    FunctionParameter[] getParameters();
+    Parameter[] getParameters();
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/types/RemoteMethodType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/types/RemoteMethodType.java
@@ -17,6 +17,8 @@
  */
 package io.ballerina.runtime.api.types;
 
+import io.ballerina.runtime.api.FunctionParameter;
+
 /**
  * {@code {@link RemoteMethodType }} represents remote function type in ballerina.
  *
@@ -28,7 +30,5 @@ public interface RemoteMethodType extends MethodType {
 
     FunctionType getType();
 
-    String[] getParamNames();
-
-    Boolean[] getParamDefaultability();
+    FunctionParameter[] getParameters();
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/types/ResourceMethodType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/types/ResourceMethodType.java
@@ -17,7 +17,7 @@
  */
 package io.ballerina.runtime.api.types;
 
-import io.ballerina.runtime.api.FunctionParameter;
+import io.ballerina.runtime.api.Parameter;
 
 /**
  * {@code ResourceFunctionType} represents a resource function in Ballerina.
@@ -31,5 +31,5 @@ public interface ResourceMethodType extends MethodType {
     String[] getResourcePath();
     @Deprecated
     Boolean[] getParamDefaultability();
-    FunctionParameter[] getParameters();
+    Parameter[] getParameters();
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BRemoteMethodType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BRemoteMethodType.java
@@ -17,6 +17,7 @@
  */
 package io.ballerina.runtime.internal.types;
 
+import io.ballerina.runtime.api.FunctionParameter;
 import io.ballerina.runtime.api.types.MethodType;
 import io.ballerina.runtime.api.types.RemoteMethodType;
 import io.ballerina.runtime.api.types.Type;
@@ -29,14 +30,12 @@ import java.util.StringJoiner;
  * @since 2.0
  */
 public class BRemoteMethodType extends BMethodType implements RemoteMethodType {
-    final String[] paramNames;
-    final Boolean[] paramDefaultability;
+    public final FunctionParameter[] parameters;
 
-    public BRemoteMethodType(String funcName, BObjectType parent, BFunctionType type, long flags, String[] paramNames,
-                             Boolean[] paramDefaultability) {
+    public BRemoteMethodType(String funcName, BObjectType parent, BFunctionType type, long flags,
+                             FunctionParameter[] parameters) {
         super(funcName, parent, type, flags);
-        this.paramNames = paramNames;
-        this.paramDefaultability = paramDefaultability;
+        this.parameters = parameters;
     }
 
     @Override
@@ -50,16 +49,11 @@ public class BRemoteMethodType extends BMethodType implements RemoteMethodType {
 
     @Override
     public <T extends MethodType> MethodType duplicate() {
-        return new BRemoteMethodType(funcName, parentObjectType, type, flags, paramNames, paramDefaultability);
+        return new BRemoteMethodType(funcName, parentObjectType, type, flags, parameters);
     }
 
     @Override
-    public String[] getParamNames() {
-        return paramNames;
-    }
-
-    @Override
-    public Boolean[] getParamDefaultability() {
-        return paramDefaultability;
+    public FunctionParameter[] getParameters() {
+        return parameters;
     }
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BRemoteMethodType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BRemoteMethodType.java
@@ -17,7 +17,7 @@
  */
 package io.ballerina.runtime.internal.types;
 
-import io.ballerina.runtime.api.FunctionParameter;
+import io.ballerina.runtime.api.Parameter;
 import io.ballerina.runtime.api.types.MethodType;
 import io.ballerina.runtime.api.types.RemoteMethodType;
 import io.ballerina.runtime.api.types.Type;
@@ -30,10 +30,10 @@ import java.util.StringJoiner;
  * @since 2.0
  */
 public class BRemoteMethodType extends BMethodType implements RemoteMethodType {
-    public final FunctionParameter[] parameters;
+    public final Parameter[] parameters;
 
     public BRemoteMethodType(String funcName, BObjectType parent, BFunctionType type, long flags,
-                             FunctionParameter[] parameters) {
+                             Parameter[] parameters) {
         super(funcName, parent, type, flags);
         this.parameters = parameters;
     }
@@ -53,7 +53,7 @@ public class BRemoteMethodType extends BMethodType implements RemoteMethodType {
     }
 
     @Override
-    public FunctionParameter[] getParameters() {
+    public Parameter[] getParameters() {
         return parameters;
     }
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BRemoteMethodType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BRemoteMethodType.java
@@ -29,9 +29,14 @@ import java.util.StringJoiner;
  * @since 2.0
  */
 public class BRemoteMethodType extends BMethodType implements RemoteMethodType {
+    final String[] paramNames;
+    final Boolean[] paramDefaultability;
 
-    public BRemoteMethodType(String funcName, BObjectType parent, BFunctionType type, long flags) {
+    public BRemoteMethodType(String funcName, BObjectType parent, BFunctionType type, long flags, String[] paramNames,
+                             Boolean[] paramDefaultability) {
         super(funcName, parent, type, flags);
+        this.paramNames = paramNames;
+        this.paramDefaultability = paramDefaultability;
     }
 
     @Override
@@ -45,6 +50,16 @@ public class BRemoteMethodType extends BMethodType implements RemoteMethodType {
 
     @Override
     public <T extends MethodType> MethodType duplicate() {
-        return new BRemoteMethodType(funcName, parentObjectType, type, flags);
+        return new BRemoteMethodType(funcName, parentObjectType, type, flags, paramNames, paramDefaultability);
+    }
+
+    @Override
+    public String[] getParamNames() {
+        return paramNames;
+    }
+
+    @Override
+    public Boolean[] getParamDefaultability() {
+        return paramDefaultability;
     }
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BResourceMethodType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BResourceMethodType.java
@@ -17,6 +17,7 @@
  */
 package io.ballerina.runtime.internal.types;
 
+import io.ballerina.runtime.api.FunctionParameter;
 import io.ballerina.runtime.api.types.MethodType;
 import io.ballerina.runtime.api.types.ResourceMethodType;
 import io.ballerina.runtime.api.types.Type;
@@ -32,19 +33,16 @@ public class BResourceMethodType extends BMethodType implements ResourceMethodTy
 
     public final String accessor;
     public final String[] resourcePath;
-    public final String[] paramNames;
-    public final Boolean[] paramDefaultability;
+    public final FunctionParameter[] parameters;
 
     public BResourceMethodType(String funcName, BObjectType parent, BFunctionType type, long flags,
-                               String accessor, String[] resourcePath, String[] paramNames,
-                                 Boolean[] paramDefaultbility) {
+                               String accessor, String[] resourcePath, FunctionParameter[] parameters) {
         super(funcName, parent, type, flags);
         this.type = type;
         this.flags = flags;
         this.accessor = accessor;
         this.resourcePath = resourcePath;
-        this.paramNames = paramNames;
-        this.paramDefaultability = paramDefaultbility;
+        this.parameters = parameters;
     }
 
     @Override
@@ -58,13 +56,18 @@ public class BResourceMethodType extends BMethodType implements ResourceMethodTy
         Type[] types = type.paramTypes;
         for (int i = 0; i < types.length; i++) {
             Type type = types[i];
-            sj.add(type.getName() + " " + paramNames[i]);
+            sj.add(type.getName() + " " + parameters[i].name);
         }
         return sj.toString();
     }
 
+    @Deprecated
     @Override
     public String[] getParamNames() {
+        String[] paramNames = new String[parameters.length];
+        for (int i = 0; i < parameters.length; i++) {
+            paramNames[i] = parameters[i].name;
+        }
         return paramNames;
     }
 
@@ -80,12 +83,21 @@ public class BResourceMethodType extends BMethodType implements ResourceMethodTy
 
     @Override
     public <T extends MethodType> MethodType duplicate() {
-        return new BResourceMethodType(funcName, parentObjectType, type, flags, accessor, resourcePath, paramNames,
-                paramDefaultability);
+        return new BResourceMethodType(funcName, parentObjectType, type, flags, accessor, resourcePath, parameters);
+    }
+
+    @Deprecated
+    @Override
+    public Boolean[] getParamDefaultability() {
+        Boolean[] paramDefaults = new Boolean[parameters.length];
+        for (int i = 0; i < parameters.length; i++) {
+            paramDefaults[i] = parameters[i].isDefault;
+        }
+        return paramDefaults;
     }
 
     @Override
-    public Boolean[] getParamDefaultability() {
-        return paramDefaultability;
+    public FunctionParameter[] getParameters() {
+        return parameters;
     }
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BResourceMethodType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BResourceMethodType.java
@@ -17,7 +17,7 @@
  */
 package io.ballerina.runtime.internal.types;
 
-import io.ballerina.runtime.api.FunctionParameter;
+import io.ballerina.runtime.api.Parameter;
 import io.ballerina.runtime.api.types.MethodType;
 import io.ballerina.runtime.api.types.ResourceMethodType;
 import io.ballerina.runtime.api.types.Type;
@@ -33,10 +33,10 @@ public class BResourceMethodType extends BMethodType implements ResourceMethodTy
 
     public final String accessor;
     public final String[] resourcePath;
-    public final FunctionParameter[] parameters;
+    public final Parameter[] parameters;
 
-    public BResourceMethodType(String funcName, BObjectType parent, BFunctionType type, long flags,
-                               String accessor, String[] resourcePath, FunctionParameter[] parameters) {
+    public BResourceMethodType(String funcName, BObjectType parent, BFunctionType type, long flags, String accessor,
+                               String[] resourcePath, Parameter[] parameters) {
         super(funcName, parent, type, flags);
         this.type = type;
         this.flags = flags;
@@ -97,7 +97,7 @@ public class BResourceMethodType extends BMethodType implements ResourceMethodTy
     }
 
     @Override
-    public FunctionParameter[] getParameters() {
+    public Parameter[] getParameters() {
         return parameters;
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
@@ -48,7 +48,7 @@ public class JvmConstants {
     public static final String ERROR_VALUE = "io/ballerina/runtime/internal/values/ErrorValue";
     public static final String BERROR = "io/ballerina/runtime/api/values/BError";
     public static final String STRING_VALUE = "java/lang/String";
-    public static final String FUNCTION_PARAMETER = "io/ballerina/runtime/api/FunctionParameter";
+    public static final String FUNCTION_PARAMETER = "io/ballerina/runtime/api/Parameter";
     public static final String B_STRING_VALUE = "io/ballerina/runtime/api/values/BString";
     public static final String NON_BMP_STRING_VALUE = "io/ballerina/runtime/internal/values/NonBmpStringValue";
     public static final String BMP_STRING_VALUE = "io/ballerina/runtime/internal/values/BmpStringValue";

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
@@ -48,6 +48,7 @@ public class JvmConstants {
     public static final String ERROR_VALUE = "io/ballerina/runtime/internal/values/ErrorValue";
     public static final String BERROR = "io/ballerina/runtime/api/values/BError";
     public static final String STRING_VALUE = "java/lang/String";
+    public static final String FUNCTION_PARAMETER = "io/ballerina/runtime/api/FunctionParameter";
     public static final String B_STRING_VALUE = "io/ballerina/runtime/api/values/BString";
     public static final String NON_BMP_STRING_VALUE = "io/ballerina/runtime/internal/values/NonBmpStringValue";
     public static final String BMP_STRING_VALUE = "io/ballerina/runtime/internal/values/BmpStringValue";

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTypeGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTypeGen.java
@@ -134,6 +134,7 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.ERROR_VAL
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.FIELD_IMPL;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.FINITE_TYPE_IMPL;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.FLOAT_TYPE;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.FUNCTION_PARAMETER;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.FUNCTION_POINTER;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.FUNCTION_TYPE_IMPL;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.FUTURE_TYPE_IMPL;
@@ -1350,37 +1351,33 @@ public class JvmTypeGen {
         // Load flags
         mv.visitLdcInsn(attachedFunc.symbol.flags);
 
-        List<BVarSymbol> params = attachedFunc.symbol.params;
-        mv.visitLdcInsn((long) params.size());
-        mv.visitInsn(L2I);
-        mv.visitTypeInsn(ANEWARRAY, STRING_VALUE);
-        for (int i = 0; i < params.size(); i++) {
-            BVarSymbol paramSymbol = params.get(i);
-            mv.visitInsn(DUP);
-            mv.visitLdcInsn((long) i);
-            mv.visitInsn(L2I);
-            mv.visitLdcInsn(paramSymbol.name.value);
-            mv.visitInsn(AASTORE);
-        }
-
-        mv.visitLdcInsn((long) params.size());
-        mv.visitInsn(L2I);
-        mv.visitTypeInsn(ANEWARRAY, BOOLEAN_VALUE);
-        for (int i = 0; i < params.size(); i++) {
-            BVarSymbol paramSymbol = params.get(i);
-            mv.visitInsn(DUP);
-            mv.visitLdcInsn((long) i);
-            mv.visitInsn(L2I);
-            mv.visitLdcInsn(paramSymbol.isDefaultable);
-            mv.visitMethodInsn(INVOKESTATIC, BOOLEAN_VALUE, VALUE_OF_METHOD,
-                    String.format("(Z)L%s;", BOOLEAN_VALUE), false);
-            mv.visitInsn(AASTORE);
-        }
+        loadFunctionParameters(mv, attachedFunc.symbol.params);
 
         mv.visitMethodInsn(INVOKESPECIAL, REMOTE_METHOD_TYPE_IMPL, JVM_INIT_METHOD,
-                String.format("(L%s;L%s;L%s;J[L%s;[L%s;)V", STRING_VALUE, OBJECT_TYPE_IMPL, FUNCTION_TYPE_IMPL,
-                        STRING_VALUE, BOOLEAN_VALUE), false);
+                String.format("(L%s;L%s;L%s;J[L%s;)V", STRING_VALUE, OBJECT_TYPE_IMPL, FUNCTION_TYPE_IMPL,
+                        FUNCTION_PARAMETER), false);
 
+    }
+
+    private void loadFunctionParameters(MethodVisitor mv, List<BVarSymbol> params) {
+        mv.visitLdcInsn((long) params.size());
+        mv.visitInsn(L2I);
+        mv.visitTypeInsn(ANEWARRAY, FUNCTION_PARAMETER);
+        for (int i = 0; i < params.size(); i++) {
+            BVarSymbol paramSymbol = params.get(i);
+            mv.visitInsn(DUP);
+            mv.visitLdcInsn((long) i);
+            mv.visitInsn(L2I);
+            mv.visitTypeInsn(NEW, FUNCTION_PARAMETER);
+            mv.visitInsn(DUP);
+            mv.visitLdcInsn(paramSymbol.name.value);
+            mv.visitLdcInsn(paramSymbol.isDefaultable);
+            mv.visitMethodInsn(INVOKESTATIC, BOOLEAN_VALUE, VALUE_OF_METHOD, String.format("(Z)L%s;", BOOLEAN_VALUE),
+                    false);
+            mv.visitMethodInsn(INVOKESPECIAL, FUNCTION_PARAMETER, JVM_INIT_METHOD, String.format("(L%s;L%s;)V",
+                    STRING_VALUE, BOOLEAN_VALUE), false);
+            mv.visitInsn(AASTORE);
+        }
     }
 
     private void createResourceFunction(MethodVisitor mv, BResourceFunction resourceFunction,
@@ -1422,38 +1419,11 @@ public class JvmTypeGen {
             mv.visitInsn(AASTORE);
         }
 
-        List<BVarSymbol> params = resourceFunction.symbol.params;
-        mv.visitLdcInsn((long) params.size());
-        mv.visitInsn(L2I);
-        mv.visitTypeInsn(ANEWARRAY, STRING_VALUE);
-        for (int i = 0; i < params.size(); i++) {
-            BVarSymbol paramSymbol = params.get(i);
-            mv.visitInsn(DUP);
-            mv.visitLdcInsn((long) i);
-            mv.visitInsn(L2I);
-            mv.visitLdcInsn(paramSymbol.name.value);
-            mv.visitInsn(AASTORE);
-        }
-
-        mv.visitLdcInsn((long) params.size());
-        mv.visitInsn(L2I);
-        mv.visitTypeInsn(ANEWARRAY, BOOLEAN_VALUE);
-        for (int i = 0; i < params.size(); i++) {
-            BVarSymbol paramSymbol = params.get(i);
-            mv.visitInsn(DUP);
-            mv.visitLdcInsn((long) i);
-            mv.visitInsn(L2I);
-            mv.visitLdcInsn(paramSymbol.isDefaultable);
-            mv.visitMethodInsn(INVOKESTATIC, BOOLEAN_VALUE, VALUE_OF_METHOD,
-                    String.format("(Z)L%s;", BOOLEAN_VALUE), false);
-            mv.visitInsn(AASTORE);
-        }
+        loadFunctionParameters(mv, resourceFunction.symbol.params);
 
         mv.visitMethodInsn(INVOKESPECIAL, RESOURCE_METHOD_TYPE_IMPL, JVM_INIT_METHOD,
-                String.format("(L%s;L%s;L%s;JL%s;[L%s;[L%s;[L%s;)V",
-                        STRING_VALUE, OBJECT_TYPE_IMPL, FUNCTION_TYPE_IMPL, STRING_VALUE, STRING_VALUE, STRING_VALUE,
-                        BOOLEAN_VALUE),
-                false);
+                String.format("(L%s;L%s;L%s;JL%s;[L%s;[L%s;)V", STRING_VALUE, OBJECT_TYPE_IMPL, FUNCTION_TYPE_IMPL,
+                        STRING_VALUE, STRING_VALUE, FUNCTION_PARAMETER), false);
     }
 
     // -------------------------------------------------------

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
@@ -18,8 +18,8 @@
 
 package org.ballerinalang.nativeimpl.jvm.runtime.api.tests;
 
-import io.ballerina.runtime.api.FunctionParameter;
 import io.ballerina.runtime.api.Module;
+import io.ballerina.runtime.api.Parameter;
 import io.ballerina.runtime.api.PredefinedTypes;
 import io.ballerina.runtime.api.creators.TypeCreator;
 import io.ballerina.runtime.api.creators.ValueCreator;
@@ -73,7 +73,7 @@ public class Values {
             return ValueCreator.createArrayValue(TypeCreator.createArrayType(tupleType, 0), 0);
         }
         RemoteMethodType remoteType = (RemoteMethodType) funcType.get();
-        FunctionParameter[] parameters = remoteType.getParameters();
+        Parameter[] parameters = remoteType.getParameters();
         int len = parameters.length;
         BListInitialValueEntry[] elements = new BListInitialValueEntry[len];
         for (int i = 0; i < len; i++) {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
@@ -18,6 +18,7 @@
 
 package org.ballerinalang.nativeimpl.jvm.runtime.api.tests;
 
+import io.ballerina.runtime.api.FunctionParameter;
 import io.ballerina.runtime.api.Module;
 import io.ballerina.runtime.api.PredefinedTypes;
 import io.ballerina.runtime.api.creators.TypeCreator;
@@ -64,11 +65,11 @@ public class Values {
         if (remoteType == null) {
             return ValueCreator.createArrayValue(TypeCreator.createArrayType(PredefinedTypes.TYPE_STRING, 0), 0);
         }
-        String[] paramNames = remoteType.getParamNames();
-        int len = paramNames.length;
+        FunctionParameter[] parameters = remoteType.getParameters();
+        int len = parameters.length;
         BString[] params = new BString[len];
         for (int i = 0; i < len; i++) {
-            params[i] = StringUtils.fromString(paramNames[i]);
+            params[i] = StringUtils.fromString(parameters[i].name);
         }
         return ValueCreator.createArrayValue(params);
     }
@@ -78,11 +79,11 @@ public class Values {
         if (remoteType == null) {
             return ValueCreator.createArrayValue(TypeCreator.createArrayType(PredefinedTypes.TYPE_BOOLEAN, 0), 0);
         }
-        Boolean[] paramDefaultability = remoteType.getParamDefaultability();
-        int len = paramDefaultability.length;
+        FunctionParameter[] parameters = remoteType.getParameters();
+        int len = parameters.length;
         boolean[] values = new boolean[len];
         for (int i = 0; i < len; i++) {
-            values[i] = paramDefaultability[i];
+            values[i] = parameters[i].isDefault;
         }
         return ValueCreator.createArrayValue(values);
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/runtime/api/RuntimeAPITest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/runtime/api/RuntimeAPITest.java
@@ -40,4 +40,10 @@ public class RuntimeAPITest {
         CompileResult result = BCompileUtil.compile("test-src/runtime/api/errors");
         BRunUtil.invoke(result, "main");
     }
+
+    @Test
+    public void remoteMethodTypeTest() {
+        CompileResult result = BCompileUtil.compile("test-src/runtime/api/types");
+        BRunUtil.invoke(result, "main");
+    }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/object/test_service_objects.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/object/test_service_objects.bal
@@ -120,25 +120,17 @@ function assertEquality(any|error actual, any|error expected) {
 }
 
 function testServiceRemoteMethod(serv:Service serviceVal) {
-    string[] paramNames = getRemoteParamNames(serviceVal, "getRemoteCounter");
-    assertEquality(paramNames.length(), 3);
-    assertEquality(paramNames[0], "num");
-    assertEquality(paramNames[1], "value");
-    assertEquality(paramNames[2], "msg");
-
-    boolean[] paramDefaultability = getRemoteParamDefaultability(serviceVal, "getRemoteCounter");
-    assertEquality(paramDefaultability.length(), 3);
-    assertEquality(paramDefaultability[0], false);
-    assertEquality(paramDefaultability[1], false);
-    assertEquality(paramDefaultability[2], true);
+    [string, boolean][] parameters = getRemoteParameters(serviceVal, "getRemoteCounter");
+    assertEquality(parameters.length(), 3);
+    assertEquality(parameters[0][0], "num");
+    assertEquality(parameters[0][1], false);
+    assertEquality(parameters[1][0], "value");
+    assertEquality(parameters[1][1], false);
+    assertEquality(parameters[2][0], "msg");
+    assertEquality(parameters[2][1], true);
 }
 
-public function getRemoteParamNames(service object {} s, string name) returns string[] = @java:Method {
+public function getRemoteParameters(service object {} s, string name) returns [string, boolean][] = @java:Method {
     'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values",
-    name: "getParamNames"
-} external;
-
-public function getRemoteParamDefaultability(service object {} s, string name) returns boolean[] = @java:Method {
-    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values",
-    name: "getParamDefaultability"
+    name: "getParameters"
 } external;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/object/test_service_objects.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/object/test_service_objects.bal
@@ -93,6 +93,8 @@ function testServiceObjectValue() {
 
     string[]? paramNames = getParamNames(serviceVal, "$get$foo$bar");
     assertEquality(paramNames, <string[]>["i", "j"]);
+
+    testServiceRemoteMethod(serviceVal);
 }
 
 
@@ -116,3 +118,27 @@ function assertEquality(any|error actual, any|error expected) {
     panic error("AssertionError",
             message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }
+
+function testServiceRemoteMethod(serv:Service serviceVal) {
+    string[] paramNames = getRemoteParamNames(serviceVal, "getRemoteCounter");
+    assertEquality(paramNames.length(), 3);
+    assertEquality(paramNames[0], "num");
+    assertEquality(paramNames[1], "value");
+    assertEquality(paramNames[2], "msg");
+
+    boolean[] paramDefaultability = getRemoteParamDefaultability(serviceVal, "getRemoteCounter");
+    assertEquality(paramDefaultability.length(), 3);
+    assertEquality(paramDefaultability[0], false);
+    assertEquality(paramDefaultability[1], false);
+    assertEquality(paramDefaultability[2], true);
+}
+
+public function getRemoteParamNames(service object {} s, string name) returns string[] = @java:Method {
+    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values",
+    name: "getParamNames"
+} external;
+
+public function getRemoteParamDefaultability(service object {} s, string name) returns boolean[] = @java:Method {
+    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values",
+    name: "getParamDefaultability"
+} external;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/service_test_project/main.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/service_test_project/main.bal
@@ -15,4 +15,7 @@ public service class Service {
     resource function get foo/bar(int i, string j) returns string {
         return i.toString() + j;
     }
+
+    remote function getRemoteCounter(int num, decimal value, string msg = "test message") {
+    }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/types/Ballerina.toml
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/types/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org= "testorg"
+name="runtime_api_types"
+version= "1.0.0"

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/types/main.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/types/main.bal
@@ -1,0 +1,33 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+import testorg/runtime_api_types.objects;
+
+public function main() {
+    objects:PublicClientObject obj = new ();
+    string[] paramNames = objects:getParamNames(obj, "getRemoteCounter");
+    test:assertEquals(paramNames.length(), 3);
+    test:assertEquals(paramNames[0], "num");
+    test:assertEquals(paramNames[1], "value");
+    test:assertEquals(paramNames[2], "msg");
+
+    boolean[] paramDefaultability = objects:getParamDefaultability(obj, "getRemoteCounter");
+    test:assertEquals(paramDefaultability.length(), 3);
+    test:assertEquals(paramDefaultability[0], false);
+    test:assertEquals(paramDefaultability[1], false);
+    test:assertEquals(paramDefaultability[2], true);
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/types/main.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/types/main.bal
@@ -19,15 +19,9 @@ import testorg/runtime_api_types.objects;
 
 public function main() {
     objects:PublicClientObject obj = new ();
-    string[] paramNames = objects:getParamNames(obj, "getRemoteCounter");
-    test:assertEquals(paramNames.length(), 3);
-    test:assertEquals(paramNames[0], "num");
-    test:assertEquals(paramNames[1], "value");
-    test:assertEquals(paramNames[2], "msg");
-
-    boolean[] paramDefaultability = objects:getParamDefaultability(obj, "getRemoteCounter");
-    test:assertEquals(paramDefaultability.length(), 3);
-    test:assertEquals(paramDefaultability[0], false);
-    test:assertEquals(paramDefaultability[1], false);
-    test:assertEquals(paramDefaultability[2], true);
+    [string,boolean] [] parameters = objects:getParameters(obj, "getRemoteCounter");
+    test:assertEquals(parameters.length(), 3);
+    test:assertEquals(parameters[0], ["num", false]);
+    test:assertEquals(parameters[1], ["value", false]);
+    test:assertEquals(parameters[2], ["msg", true]);
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/types/modules/objects/objects.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/types/modules/objects/objects.bal
@@ -1,0 +1,29 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/jballerina.java;
+public client class PublicClientObject {
+    remote function getRemoteCounter(int num, decimal value, string msg = "test message") {
+    }
+}
+
+public function getParamNames(PublicClientObject obj, string name) returns string[] = @java:Method {
+    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
+} external;
+
+public function getParamDefaultability(PublicClientObject obj, string name) returns boolean[] = @java:Method {
+    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
+} external;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/types/modules/objects/objects.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/types/modules/objects/objects.bal
@@ -15,15 +15,12 @@
 // under the License.
 
 import ballerina/jballerina.java;
+
 public client class PublicClientObject {
     remote function getRemoteCounter(int num, decimal value, string msg = "test message") {
     }
 }
 
-public function getParamNames(PublicClientObject obj, string name) returns string[] = @java:Method {
-    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
-} external;
-
-public function getParamDefaultability(PublicClientObject obj, string name) returns boolean[] = @java:Method {
+public function getParameters(PublicClientObject obj, string name) returns [string, boolean][] = @java:Method {
     'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
 } external;


### PR DESCRIPTION
## Purpose
$subject

Fixes #31581 

## Approach
Added the following APIs to `BRemoteMethodType` & `BResourceMethodType`
- `Parameter[] getParameters()`
The `Parameter` object contains the parameter name and the parameter defaultability values in the fields `name` and `isDefault`.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
