### PR TITLE
[Debugger] Improve expression evaluation error handling

### DIFF
--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JBallerinaDebugServer.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JBallerinaDebugServer.java
@@ -31,6 +31,8 @@ import org.ballerinalang.debugadapter.config.ClientAttachConfigHolder;
 import org.ballerinalang.debugadapter.config.ClientConfigHolder;
 import org.ballerinalang.debugadapter.config.ClientConfigurationException;
 import org.ballerinalang.debugadapter.config.ClientLaunchConfigHolder;
+import org.ballerinalang.debugadapter.evaluation.EvaluationException;
+import org.ballerinalang.debugadapter.evaluation.EvaluationExceptionKind;
 import org.ballerinalang.debugadapter.evaluation.ExpressionEvaluator;
 import org.ballerinalang.debugadapter.jdi.JdiProxyException;
 import org.ballerinalang.debugadapter.jdi.LocalVariableProxyImpl;
@@ -446,8 +448,11 @@ public class JBallerinaDebugServer implements IDebugProtocolServer {
             response.setNamedVariables(dapVariable.getNamedVariables());
             response.setVariablesReference(dapVariable.getVariablesReference());
             return CompletableFuture.completedFuture(response);
+        } catch (EvaluationException e) {
+            context.getOutputLogger().sendErrorOutput(e.getMessage());
+            return CompletableFuture.completedFuture(response);
         } catch (Exception e) {
-            LOGGER.error(e.getMessage(), e);
+            context.getOutputLogger().sendErrorOutput(EvaluationExceptionKind.PREFIX + "internal error");
             return CompletableFuture.completedFuture(response);
         }
     }

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JDIEventProcessor.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JDIEventProcessor.java
@@ -371,13 +371,13 @@ public class JDIEventProcessor {
                 Value evaluatorResult = evaluator.evaluate(expression);
                 String condition = VariableFactory.getVariable(ctx, evaluatorResult).getDapVariable().getValue();
                 return condition.equalsIgnoreCase(CONDITION_TRUE);
-            } catch (JdiProxyException e) {
-                context.getOutputLogger().sendConsoleOutput(String.format("Warning: Skipping conditional breakpoint " +
-                        "at line: %d, due to an internal error", lineNumber));
-                return false;
             } catch (EvaluationException e) {
                 context.getOutputLogger().sendConsoleOutput(String.format("Warning: Skipping conditional breakpoint " +
                         "at line: %d, due to: %s%s", lineNumber, System.lineSeparator(), e.getMessage()));
+                return false;
+            } catch (Exception e) {
+                context.getOutputLogger().sendConsoleOutput(String.format("Warning: Skipping conditional breakpoint " +
+                        "at line: %d, due to an internal error", lineNumber));
                 return false;
             }
         });

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JDIEventProcessor.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JDIEventProcessor.java
@@ -35,6 +35,7 @@ import com.sun.jdi.request.EventRequest;
 import com.sun.jdi.request.StepRequest;
 import org.ballerinalang.debugadapter.config.ClientConfigHolder;
 import org.ballerinalang.debugadapter.config.ClientLaunchConfigHolder;
+import org.ballerinalang.debugadapter.evaluation.EvaluationException;
 import org.ballerinalang.debugadapter.evaluation.ExpressionEvaluator;
 import org.ballerinalang.debugadapter.jdi.JdiProxyException;
 import org.ballerinalang.debugadapter.jdi.StackFrameProxyImpl;
@@ -176,7 +177,7 @@ public class JDIEventProcessor {
         // the condition evaluation.
         context.getEventManager().classPrepareRequests().forEach(EventRequest::disable);
         context.getEventManager().breakpointRequests().forEach(BreakpointRequest::disable);
-        CompletableFuture<Boolean> resultFuture = evaluateBreakpointCondition(condition, event.thread());
+        CompletableFuture<Boolean> resultFuture = evaluateBreakpointCondition(condition, event.thread(), lineNumber);
         try {
             Boolean result = resultFuture.get(5000, TimeUnit.MILLISECONDS);
             if (result) {
@@ -354,7 +355,8 @@ public class JDIEventProcessor {
      * @param threadReference suspended thread reference, which should be used to get the top stack frame
      * @return result of the given breakpoint condition (logical expression).
      */
-    private CompletableFuture<Boolean> evaluateBreakpointCondition(String expression, ThreadReference threadReference) {
+    private CompletableFuture<Boolean> evaluateBreakpointCondition(String expression, ThreadReference threadReference,
+                                                                   int lineNumber) {
         return CompletableFuture.supplyAsync(() -> {
             try {
                 ThreadReferenceProxyImpl thread = context.getAdapter().getAllThreads()
@@ -370,7 +372,12 @@ public class JDIEventProcessor {
                 String condition = VariableFactory.getVariable(ctx, evaluatorResult).getDapVariable().getValue();
                 return condition.equalsIgnoreCase(CONDITION_TRUE);
             } catch (JdiProxyException e) {
-                LOGGER.error(e.getMessage(), e);
+                context.getOutputLogger().sendConsoleOutput(String.format("Warning: Skipping conditional breakpoint " +
+                        "at line: %d, due to an internal error", lineNumber));
+                return false;
+            } catch (EvaluationException e) {
+                context.getOutputLogger().sendConsoleOutput(String.format("Warning: Skipping conditional breakpoint " +
+                        "at line: %d, due to: %s%s", lineNumber, System.lineSeparator(), e.getMessage()));
                 return false;
             }
         });

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/ExpressionEvaluator.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/ExpressionEvaluator.java
@@ -45,17 +45,15 @@ public class ExpressionEvaluator {
     /**
      * Evaluates a given ballerina expression w.r.t. the debug context.
      */
-    public Value evaluate(String expression) {
+    public Value evaluate(String expression) throws EvaluationException {
         try {
             ExpressionNode parsedExpression = expressionValidator.validateAndGetResult(expression);
             Evaluator evaluator = evaluatorBuilder.build(parsedExpression);
             return evaluator.evaluate().getJdiValue();
         } catch (EvaluationException e) {
-            return context.getAttachedVm().mirrorOf(e.getMessage());
+            throw e;
         } catch (Exception e) {
-            String message = EvaluationExceptionKind.PREFIX + "internal error";
-            LOGGER.error(message, e);
-            return context.getAttachedVm().mirrorOf(message);
+            throw new EvaluationException(EvaluationExceptionKind.PREFIX + "internal error");
         }
     }
 }

--- a/tests/jballerina-debugger-integration-test/src/test/resources/testng.xml
+++ b/tests/jballerina-debugger-integration-test/src/test/resources/testng.xml
@@ -59,7 +59,7 @@ under the License.
 
             <!--Debugger Expression Evaluation Tests-->
             <class name="org.ballerinalang.debugger.test.adapter.evaluation.ExpressionEvaluationTest"/>
-<!--            <class name="org.ballerinalang.debugger.test.adapter.evaluation.ExpressionEvaluationNegativeTest"/>-->
+            <class name="org.ballerinalang.debugger.test.adapter.evaluation.ExpressionEvaluationNegativeTest"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
## Purpose
This PR 
- refactors and improves error handling mechanism. Now the debugger sends an error output event instead of sending as a string inside the evaluation response.
- fixes the regression issue introduced with 
- fixes https://github.com/ballerina-platform/ballerina-lang/issues/31607
- fixes https://github.com/ballerina-platform/ballerina-lang/issues/31609

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [x] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [x] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
