### PR TITLE
Fix setting nil type manually to stream completion when completion is given

### DIFF
--- a/ballerina-shell/modules/shell-core/src/test/resources/testcases/evaluator/streams.streams.json
+++ b/ballerina-shell/modules/shell-core/src/test/resources/testcases/evaluator/streams.streams.json
@@ -13,7 +13,7 @@
   },
   {
     "description": "Define Odd number generation stream.",
-    "code": "var oddNumberStream = new stream<int, error>(oddGen);"
+    "code": "var oddNumberStream = new stream<int, error?>(oddGen);"
   },
   {
     "description": "Get the next value from the stream.",

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -3431,7 +3431,6 @@ public class TypeChecker extends BLangNodeVisitor {
         LinkedHashSet<BType> retTypeMembers = new LinkedHashSet<>();
         retTypeMembers.add(recordType);
         retTypeMembers.addAll(types.getAllTypes(streamType.completionType));
-        retTypeMembers.add(symTable.nilType);
 
         BUnionType unionType = BUnionType.create(null);
         unionType.addAll(retTypeMembers);

--- a/docs/bir-spec/src/test/resources/test-src/types_and_operations.bal
+++ b/docs/bir-spec/src/test/resources/test-src/types_and_operations.bal
@@ -325,7 +325,7 @@ type Subscription record {|
 
 public function functionWithStreams() {
     OddNumberGenerator oddGen = new;
-    var oddNumberStream = new stream<int, error>(oddGen);
+    var oddNumberStream = new stream<int, error?>(oddGen);
 
     record {|int value;|}|error? oddNumber = oddNumberStream.next();
     if (oddNumber is ResultValue) {

--- a/misc/syntax-api-calls-gen/src/test/resources/bbe-examples/grpc_bidirectional_streaming_service.bal
+++ b/misc/syntax-api-calls-gen/src/test/resources/bbe-examples/grpc_bidirectional_streaming_service.bal
@@ -7,7 +7,7 @@ map<grpc:Caller> consMap = {};
 service Chat on new grpc:Listener(9090) {
 
     resource function  chat(grpc:Caller caller,
-                                stream<ChatMessage, error> clientStream) {
+                                stream<ChatMessage, error?> clientStream) {
         log:printInfo(string `${caller.getId()} connected to chat`);
         consMap[caller.getId().toString()] = <@untainted>caller;
         //Read and process each message in the client stream

--- a/misc/syntax-api-calls-gen/src/test/resources/bbe-examples/jdbc_batch_execute_operation.bal
+++ b/misc/syntax-api-calls-gen/src/test/resources/bbe-examples/jdbc_batch_execute_operation.bal
@@ -122,7 +122,7 @@ public function main() {
 }
 
 function checkData(jdbc:Client jdbcClient) {
-     stream<record{}, error> resultStream =
+     stream<record{}, error?> resultStream =
         jdbcClient->query("Select * from Customers");
 
      io:println("\nData in Customers table:");

--- a/misc/syntax-api-calls-gen/src/test/resources/bbe-examples/jdbc_complex_type_queries.bal
+++ b/misc/syntax-api-calls-gen/src/test/resources/bbe-examples/jdbc_complex_type_queries.bal
@@ -34,7 +34,7 @@ function queryBinaryType(jdbc:Client jdbcClient) {
     // The name and type of the attributes within the record from the
     // `resultStream` will be automatically identified based on the column
     // name and type of the query result.
-    stream<record{}, error> resultStream =
+    stream<record{}, error?> resultStream =
         jdbcClient->query("Select * from BINARY_TYPES");
 
     io:println("Result 1:");
@@ -50,8 +50,8 @@ function queryBinaryType(jdbc:Client jdbcClient) {
     // Since the `rowType` is provided as a `BinaryType`, the `resultStream` will
     // have `BinaryType` records.
     resultStream = jdbcClient->query("Select * from BINARY_TYPES", BinaryType);
-    stream<BinaryType, sql:Error> binaryResultStream
-    = <stream<BinaryType, sql:Error>>resultStream;
+    stream<BinaryType, sql:Error?> binaryResultStream
+    = <stream<BinaryType, sql:Error?>>resultStream;
 
     io:println("Result 2:");
     // Iterate the `binaryResultStream`.
@@ -71,7 +71,7 @@ function queryArrayType(jdbc:Client jdbcClient) {
     // The name and type of the attributes within the record from the `
     // resultStream` will be automatically identified based on the column
     // name and type of the query result.
-    stream<record{}, error> resultStream =
+    stream<record{}, error?> resultStream =
         jdbcClient->query("Select * from ARRAY_TYPES");
 
     io:println("Result 1:");
@@ -87,8 +87,8 @@ function queryArrayType(jdbc:Client jdbcClient) {
     // Since the `rowType` is provided as an `ArrayType`, the `resultStream` will
     // have `ArrayType` records.
     resultStream = jdbcClient->query("Select * from ARRAY_TYPES", ArrayType);
-    stream<ArrayType, sql:Error> arrayResultStream =
-        <stream<ArrayType, sql:Error>>resultStream;
+    stream<ArrayType, sql:Error?> arrayResultStream =
+        <stream<ArrayType, sql:Error?>>resultStream;
 
     io:println("Result 2:");
     // Iterate the `arrayResultStream`.
@@ -107,7 +107,7 @@ function queryDateTimeType(jdbc:Client jdbcClient) {
     // The name and type of the attributes within the record from
     // the `resultStream` will be automatically identified based on the
     // column name and type of the query result.
-    stream<record{}, error> resultStream =
+    stream<record{}, error?> resultStream =
         jdbcClient->query("Select * from DATE_TIME_TYPES");
 
     io:println("Result 1:");
@@ -126,8 +126,8 @@ function queryDateTimeType(jdbc:Client jdbcClient) {
     // string, and int types in Ballerina.
     resultStream = jdbcClient->query("Select * from DATE_TIME_TYPES",
         DateTimeType);
-    stream<DateTimeType, sql:Error> dateResultStream =
-        <stream<DateTimeType, sql:Error>>resultStream;
+    stream<DateTimeType, sql:Error?> dateResultStream =
+        <stream<DateTimeType, sql:Error?>>resultStream;
 
     io:println("Result 2:");
     // Iterate the `dateResultStream`.

--- a/misc/syntax-api-calls-gen/src/test/resources/bbe-examples/jdbc_parameterized_query.bal
+++ b/misc/syntax-api-calls-gen/src/test/resources/bbe-examples/jdbc_parameterized_query.bal
@@ -110,7 +110,7 @@ public function main() {
 }
 
 function checkData(jdbc:Client jdbcClient) {
-     stream<record{}, error> resultStream =
+     stream<record{}, error?> resultStream =
         jdbcClient->query("Select * from Customers");
 
      io:println("\nData in Customers table:");

--- a/misc/syntax-api-calls-gen/src/test/resources/bbe-examples/jdbc_query_operation.bal
+++ b/misc/syntax-api-calls-gen/src/test/resources/bbe-examples/jdbc_query_operation.bal
@@ -7,7 +7,7 @@ function simpleQuery(jdbc:Client jdbcClient) {
     // Select the rows in the database table via the query remote operation.
     // The result is returned as a stream and the elements of the stream can
     // be either a record or an error.
-    stream<record{}, error> resultStream =
+    stream<record{}, error?> resultStream =
         jdbcClient->query("Select * from Customers");
 
     // If there is any error during the execution of the SQL query or
@@ -31,7 +31,7 @@ function simpleQuery(jdbc:Client jdbcClient) {
 function countRows(jdbc:Client jdbcClient) {
     io:println("------ Start Count Total Rows -------");
     // The result of the count operation is provided as a record stream.
-    stream<record{}, error> resultStream =
+    stream<record{}, error?> resultStream =
         jdbcClient->query("Select count(*) as total from Customers");
 
     // Since the above count query will return only a single row,
@@ -74,12 +74,12 @@ function typedQuery(jdbc:Client jdbcClient) {
     io:println("------ Start Query With Type Description -------");
     // The result is returned as a Customer record stream and the elements
     // of the stream can be either a Customer record or an error.
-    stream<record{}, error> resultStream =
+    stream<record{}, error?> resultStream =
         jdbcClient->query("Select * from Customers", Customer);
 
     // Cast the generic record type to the Customer stream type.
-    stream<Customer, sql:Error> customerStream =
-        <stream<Customer, sql:Error>>resultStream;
+    stream<Customer, sql:Error?> customerStream =
+        <stream<Customer, sql:Error?>>resultStream;
 
     // Iterate the customer stream.
     error? e = customerStream.forEach(function(Customer customer) {

--- a/misc/syntax-api-calls-gen/src/test/resources/bbe-examples/mysql_call_stored_procedures.bal
+++ b/misc/syntax-api-calls-gen/src/test/resources/bbe-examples/mysql_call_stored_procedures.bal
@@ -129,10 +129,10 @@ function checkData(mysql:Client sqlClient) {
     if (retCall is sql:ProcedureCallResult) {
         io:println("Call stored procedure `InsertStudent` is successful.");
         // Process the returned result stream.
-        stream<record{}, sql:Error>? result = retCall.queryResult;
+        stream<record{}, sql:Error?>? result = retCall.queryResult;
         if (!(result is ())) {
-            stream<Student, sql:Error> studentStream = 
-                                    <stream<Student, sql:Error>> result;
+            stream<Student, sql:Error?> studentStream =
+                                    <stream<Student, sql:Error?>> result;
             sql:Error? e = studentStream.forEach(function(Student student) {
                                 io:println("Student details: ", student);
                            });

--- a/misc/syntax-api-calls-gen/src/test/resources/bbe-examples/mysql_complex_type_queries.bal
+++ b/misc/syntax-api-calls-gen/src/test/resources/bbe-examples/mysql_complex_type_queries.bal
@@ -30,7 +30,7 @@ function queryBinaryType(mysql:Client mysqlClient) {
     // The name and type of the attributes within the record from the
     // `resultStream` will be automatically identified based on the column
     // name and type of the query result.
-    stream<record{}, error> resultStream =
+    stream<record{}, error?> resultStream =
         mysqlClient->query("Select * from BINARY_TYPES");
 
     io:println("Result 1:");
@@ -46,7 +46,7 @@ function queryBinaryType(mysql:Client mysqlClient) {
     // Since the `rowType` is provided as a `BinaryType`, the `resultStream` will
     // have `BinaryType` records.
     resultStream = mysqlClient->query("Select * from BINARY_TYPES", BinaryType);
-    stream<BinaryType, sql:Error> binaryResultStream =
+    stream<BinaryType, sql:Error?> binaryResultStream =
         <stream<BinaryType, sql:Error>>resultStream;
 
     io:println("Result 2:");
@@ -67,7 +67,7 @@ function queryDateTimeType(mysql:Client mysqlClient) {
     // The name and type of the attributes within the record from the
     // `resultStream` will be automatically identified based on the column
     // name and type of the query result.
-    stream<record{}, error> resultStream =
+    stream<record{}, error?> resultStream =
         mysqlClient->query("Select * from DATE_TIME_TYPES");
 
     io:println("Result 1:");

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/evaluation/ExpressionEvaluationTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/evaluation/ExpressionEvaluationTest.java
@@ -158,7 +158,7 @@ public class ExpressionEvaluationTest extends ExpressionEvaluationBaseTest {
         // table variable test
         debugTestRunner.assertExpression(context, TABLE_VAR, "table<Employee> (entries = 3)", "table");
         // stream variable test
-        debugTestRunner.assertExpression(context, STREAM_VAR, "stream<int, error>", "stream");
+        debugTestRunner.assertExpression(context, STREAM_VAR, "stream<int, error?>", "stream");
         // never variable test
         debugTestRunner.assertExpression(context, NEVER_VAR, "XMLSequence (size = 0)", "xml");
         // json variable test

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/variables/VariableVisibilityTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/variables/VariableVisibilityTest.java
@@ -276,7 +276,7 @@ public class VariableVisibilityTest extends BaseTestCase {
         debugTestRunner.assertVariable(localVariables, "tableWithoutKeyVar", "table<Employee> (entries = 3)", "table");
 
         // stream variable visibility test
-        debugTestRunner.assertVariable(localVariables, "oddNumberStream", "stream<int, error>", "stream");
+        debugTestRunner.assertVariable(localVariables, "oddNumberStream", "stream<int, error?>", "stream");
 
         // variables with quoted identifiers visibility test
         debugTestRunner.assertVariable(localVariables, " /:@[`{~π_var", "\"IL with special characters in var\"",

--- a/tests/jballerina-debugger-integration-test/src/test/resources/project-based-tests/variable-tests/main.bal
+++ b/tests/jballerina-debugger-integration-test/src/test/resources/project-based-tests/variable-tests/main.bal
@@ -193,7 +193,7 @@ public function main() {
     Student clientObjectVar = new Student();
 
     typedesc<int> typedescVar = int;
-    stream<int, error> oddNumberStream = new stream<int, error>(new OddNumberGenerator());
+    stream<int, error?> oddNumberStream = new stream<int, error?>(new OddNumberGenerator());
 
     //------------------------ Other types ------------------------//
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/InferredDependentlyTypeFunctionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/InferredDependentlyTypeFunctionTest.java
@@ -82,15 +82,15 @@ public class InferredDependentlyTypeFunctionTest {
                 BCompileUtil.compile("test-src/javainterop/inferred_dependently_typed_func_signature_negative.bal");
         int index = 0;
         validateError(negativeResult, index++, "incompatible type for parameter 'rowType' with inferred " +
-                "typedesc value: expected 'typedesc<record {| int...; |}>', found 'typedesc<OpenRecord>'", 20, 37);
+                "typedesc value: expected 'typedesc<record {| int...; |}>', found 'typedesc<OpenRecord>'", 20, 38);
         validateError(negativeResult, index++, "incompatible types: expected 'typedesc<record {| int...; |}>', found " +
-                "'typedesc<OpenRecord>'", 21, 48);
+                "'typedesc<OpenRecord>'", 21, 49);
         validateError(negativeResult, index++, "cannot have more than one defaultable parameter with an inferred " +
                 "typedesc default", 28, 1);
         validateError(negativeResult, index++, "cannot have more than one defaultable parameter with an inferred " +
                 "typedesc default", 32, 5);
-        validateError(negativeResult, index++, "incompatible types: expected 'stream<record {| int x; |},error>', " +
-                "found 'stream<OpenRecord,error>'", 40, 43);
+        validateError(negativeResult, index++, "incompatible types: expected 'stream<record {| int x; |},error?>', " +
+                "found 'stream<OpenRecord,error?>'", 40, 44);
         validateError(negativeResult, index++, INVALID_RETURN_TYPE_ERROR, 42, 51);
         validateError(negativeResult, index++, INVALID_RETURN_TYPE_ERROR, 44, 46);
         validateError(negativeResult, index++, INVALID_RETURN_TYPE_ERROR, 46, 52);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryNegativeTests.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryNegativeTests.java
@@ -74,7 +74,7 @@ public class QueryNegativeTests {
         validateError(compileResult, index++, "incompatible types: 'int' is not an iterable collection",
                 416, 29);
         validateError(compileResult, index++, "incompatible types: expected 'error?', " +
-                        "found 'stream<record {| int a; |},error>'", 421, 12);
+                        "found 'stream<record {| int a; |},error?>'", 421, 12);
         validateError(compileResult, index++, "invalid record binding pattern with type 'anydata'", 426, 22);
         validateError(compileResult, index++, "undefined symbol 'k'", 427, 25);
         validateError(compileResult, index++, "invalid record binding pattern with type 'any'", 432, 22);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/stream/BStreamValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/stream/BStreamValueTest.java
@@ -135,9 +135,9 @@ public class BStreamValueTest {
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'record {| int value; |}?', " +
                 "found '(record {| int value; |}|error)?'", 106, 45);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected '(record {| int value; " +
-                "|}|CustomError)?', found '(record {| int value; |}|error)?'", 109, 48);
+                "|}|CustomError)?', found '(record {| int value; |}|error)?'", 109, 49);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected '(record {| int value; " +
-                "|}|CustomError)?', found '(record {| int value; |}|error)?'", 110, 44);
+                "|}|CustomError)?', found '(record {| int value; |}|error)?'", 110, 45);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'record {| int value; |}?', " +
                 "found '(record {| int value; |}|error)?'", 113, 35);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'record {| int value; |}?', " +
@@ -150,16 +150,16 @@ public class BStreamValueTest {
                 "'IteratorWithOutNext'", 160, 31);
         BAssertUtil.validateError(negativeResult, i++, "invalid stream constructor. expected a subtype of 'object { " +
                 "public isolated function next() returns (record {| int value; |}|error)?; }', but found " +
-                "'IteratorWithOutNext'", 161, 42);
+                "'IteratorWithOutNext'", 161, 43);
         BAssertUtil.validateError(negativeResult, i++, "invalid stream constructor. expected a subtype of 'object { " +
                 "public isolated function next() returns (record {| int value; |}|error)?; }', but found " +
-                "'IteratorWithOutNext'", 162, 38);
+                "'IteratorWithOutNext'", 162, 39);
         BAssertUtil.validateError(negativeResult, i++, "invalid stream constructor. expected a subtype of 'object { " +
                 "public isolated function next() returns (record {| int value; |}|CustomError)?; }', but found " +
-                "'IteratorWithOutNext'", 163, 48);
+                "'IteratorWithOutNext'", 163, 49);
         BAssertUtil.validateError(negativeResult, i++, "invalid stream constructor. expected a subtype of 'object { " +
                 "public isolated function next() returns (record {| int value; |}|CustomError)?; }', but found " +
-                "'IteratorWithOutNext'", 164, 44);
+                "'IteratorWithOutNext'", 164, 45);
         BAssertUtil.validateError(negativeResult, i++, "invalid stream constructor. expected a subtype of 'object { " +
                 "public isolated function next() returns record {| int value; |}?; }', but found " +
                 "'IteratorWithMismatchedNextA'", 178, 35);
@@ -168,40 +168,40 @@ public class BStreamValueTest {
                 "'IteratorWithMismatchedNextA'", 179, 31);
         BAssertUtil.validateError(negativeResult, i++, "invalid stream constructor. expected a subtype of 'object { " +
                 "public isolated function next() returns (record {| int value; |}|error)?; }', but found " +
-                "'IteratorWithMismatchedNextA'", 180, 42);
+                "'IteratorWithMismatchedNextA'", 180, 43);
         BAssertUtil.validateError(negativeResult, i++, "invalid stream constructor. expected a subtype of 'object { " +
                 "public isolated function next() returns (record {| int value; |}|error)?; }', but found " +
-                "'IteratorWithMismatchedNextA'", 181, 38);
+                "'IteratorWithMismatchedNextA'", 181, 39);
         BAssertUtil.validateError(negativeResult, i++, "invalid stream constructor. expected a subtype of 'object { " +
                 "public isolated function next() returns (record {| int value; |}|CustomError)?; }', but found " +
-                "'IteratorWithMismatchedNextA'", 182, 48);
+                "'IteratorWithMismatchedNextA'", 182, 49);
         BAssertUtil.validateError(negativeResult, i++, "invalid stream constructor. expected a subtype of 'object { " +
                 "public isolated function next() returns (record {| int value; |}|CustomError)?; }', but found " +
-                "'IteratorWithMismatchedNextA'", 183, 44);
+                "'IteratorWithMismatchedNextA'", 183, 45);
         BAssertUtil.validateError(negativeResult, i++, "incompatible mapping constructor expression for type '" +
                 "(record {| int val; |}|CustomError)?'", 191, 16);
         BAssertUtil.validateError(negativeResult, i++, "invalid stream constructor. expected a subtype of 'object { " +
                 "public isolated function next() returns (record {| int value; |}|error)?; }', but found " +
-                "'IteratorWithMismatchedNextC'", 198, 42);
+                "'IteratorWithMismatchedNextC'", 198, 43);
         BAssertUtil.validateError(negativeResult, i++, "invalid stream constructor. expected a subtype of 'object { " +
                 "public isolated function next() returns (record {| int value; |}|error)?; }', but found " +
-                "'IteratorWithMismatchedNextC'", 199, 38);
+                "'IteratorWithMismatchedNextC'", 199, 39);
         BAssertUtil.validateError(negativeResult, i++, "invalid stream constructor. expected a subtype of 'object { " +
                 "public isolated function next() returns (record {| string value; |}|error)?; }', but found " +
-                "'IteratorWithMismatchedNextC'", 202, 45);
+                "'IteratorWithMismatchedNextC'", 202, 46);
         BAssertUtil.validateError(negativeResult, i++, "invalid stream constructor. expected a subtype of 'object { " +
                 "public isolated function next() returns (record {| string value; |}|error)?; }', but found " +
-                "'IteratorWithMismatchedNextC'", 203, 41);
+                "'IteratorWithMismatchedNextC'", 203, 42);
         BAssertUtil.validateError(negativeResult, i++, "invalid stream constructor. expected a subtype of 'object { " +
                 "public isolated function next() returns (record {| string value; |}|CustomError)?; }', but found " +
-                "'IteratorWithMismatchedNextC'", 204, 51);
+                "'IteratorWithMismatchedNextC'", 204, 52);
         BAssertUtil.validateError(negativeResult, i++, "invalid stream constructor. expected a subtype of 'object { " +
                 "public isolated function next() returns (record {| string value; |}|CustomError)?; }', but found " +
-                "'IteratorWithMismatchedNextC'", 205, 47);
+                "'IteratorWithMismatchedNextC'", 205, 48);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected '(record {| string value; " +
-                "|}|CustomError1)?', found '(record {| int value; |}|CustomError)?'", 227, 52);
+                "|}|CustomError1)?', found '(record {| int value; |}|CustomError)?'", 227, 53);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected '(record {| string value; " +
-                "|}|CustomError1)?', found '(record {| int value; |}|CustomError)?'", 228, 48);
+                "|}|CustomError1)?', found '(record {| int value; |}|CustomError)?'", 228, 49);
         BAssertUtil.validateError(negativeResult, i++, "'new(itr, itr)' is not a valid constructor for streams type"
                 , 246, 27);
         BAssertUtil.validateError(negativeResult, i++, "'new(itr, itr)' is not a valid constructor for streams type"
@@ -209,11 +209,11 @@ public class BStreamValueTest {
         BAssertUtil.validateError(negativeResult, i++, "'new(itr, itr)' is not a valid constructor for streams type"
                 , 248, 34);
         BAssertUtil.validateError(negativeResult, i++, "'new(itr, itr)' is not a valid constructor for streams type"
-                , 249, 34);
+                , 249, 35);
         BAssertUtil.validateError(negativeResult, i++, "'new(itr, itr)' is not a valid constructor for streams type"
                 , 250, 34);
         BAssertUtil.validateError(negativeResult, i++, "'new(itr, itr)' is not a valid constructor for streams type"
-                , 251, 34);
+                , 251, 35);
         BAssertUtil.validateError(negativeResult, i++, "'new(itr, itr)' is not a valid constructor for streams type"
                 , 252, 19);
         BAssertUtil.validateError(negativeResult, i++, "'new(itr, itr)' is not a valid constructor for streams type"
@@ -226,27 +226,25 @@ public class BStreamValueTest {
                 "stream<int> value; |}?'", 332, 7);
         BAssertUtil.validateError(negativeResult, i++, "invalid stream constructor. expected a subtype of 'object { " +
                 "public isolated function next() returns (record {| int value; |}|error)?; }', but found " +
-                "'IteratorWithNonIsolatedNext'", 350, 42);
+                "'IteratorWithNonIsolatedNext'", 350, 43);
         BAssertUtil.validateError(negativeResult, i++, "invalid stream constructor. expected a subtype of 'object { " +
                 "public isolated function next() returns (record {| int value; |}|error)?; public isolated function " +
-                "close() returns error?; }', but found 'IteratorWithNonIsolatedNextAndIsolatedClose'", 351, 42);
+                "close() returns error?; }', but found 'IteratorWithNonIsolatedNextAndIsolatedClose'", 351, 43);
         BAssertUtil.validateError(negativeResult, i++, "invalid stream constructor. expected a subtype of 'object { " +
                 "public isolated function next() returns (record {| int value; |}|error)?; public isolated function " +
-                "close() returns error?; }', but found 'IteratorWithIsolatedNextAndNonIsolatedClose'", 352, 42);
+                "close() returns error?; }', but found 'IteratorWithIsolatedNextAndNonIsolatedClose'", 352, 43);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'stream<int>', found " +
-                "'stream<int,error>'", 371, 20);
+                "'stream<int,error?>'", 371, 20);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'stream<int>', found " +
-                "'stream<int,error>'", 372, 20);
+                "'stream<int,error?>'", 372, 20);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'stream<int>', found " +
-                "'stream<int,error>'", 373, 20);
-        BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'stream<int,error>', found " +
-                "'stream<int>'", 374, 20);
+                "'stream<int,error?>'", 373, 20);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'stream<int>', found " +
-                "'stream<int,error>'", 375, 20);
+                "'stream<int,error?>'", 375, 20);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'stream<int>', found " +
-                "'stream<int,error>'", 376, 20);
+                "'stream<int,error?>'", 376, 20);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'stream<int>', found " +
-                "'stream<int,error>'", 377, 20);
+                "'stream<int,error?>'", 377, 20);
 
         BAssertUtil.validateError(negativeResult, i++, "invalid stream constructor. expected a subtype " +
                 "of 'object { public isolated function next() returns record {| int value; |}?; }', but found " +

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/inferred_dependently_typed_func_signature_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/inferred_dependently_typed_func_signature_negative.bal
@@ -14,11 +14,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-function query(string q, typedesc<record {|int...;|}> rowType = <>) returns stream<rowType, error> = external;
+function query(string q, typedesc<record {|int...;|}> rowType = <>) returns stream<rowType, error?> = external;
 
 function testInvalidArgForInferTypedesc() {
-    stream<OpenRecord, error> stm = query("");
-    stream<OpenRecord, error> stm2 = query("", OpenRecord);
+    stream<OpenRecord, error?> stm = query("");
+    stream<OpenRecord, error?> stm2 = query("", OpenRecord);
 }
 
 type OpenRecord record {
@@ -26,18 +26,18 @@ type OpenRecord record {
 };
 
 function queryWithMultipleInferTypedescs(string q, typedesc<record {|int...;|}> rowType = <>,
-                                         typedesc<error> errorType = <>) returns stream<rowType, errorType> = external;
+                                         typedesc<error> errorType = <>) returns stream<rowType, errorType?> = external;
 
 class ClassWithMethodWithMultipleInferTypedescs {
     function queryWithMultipleInferTypedescs(typedesc<record {}> rowType = <>, typedesc<error> errorType = <>)
-                returns stream<rowType, errorType> = external;
+                returns stream<rowType, errorType?> = external;
 }
 
-stream<record {| int x; |}, error> stm = queryWithMultipleInferTypedescs("");
+stream<record {| int x; |}, error?> stm = queryWithMultipleInferTypedescs("");
 
 ClassWithMethodWithMultipleInferTypedescs cl = new;
-stream<record {| int x; |}, error> stm2 = cl.queryWithMultipleInferTypedescs();
-stream<record {| int x; |}, error> stm3 = cl.queryWithMultipleInferTypedescs(rowType = OpenRecord);
+stream<record {| int x; |}, error?> stm2 = cl.queryWithMultipleInferTypedescs();
+stream<record {| int x; |}, error?> stm3 = cl.queryWithMultipleInferTypedescs(rowType = OpenRecord);
 
 function func1(typedesc<string[]> t = <>) returns t|int[] = external;
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/query-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/query-negative.bal
@@ -417,7 +417,7 @@ public function testInvalidInputType() {
                 select 1;
 }
 
-function testIncompatibleSelectType(stream<string, error> clientStream) returns error? {
+function testIncompatibleSelectType(stream<string, error?> clientStream) returns error? {
     return from string num in clientStream select {a: 1};
 }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/simple-query-with-defined-type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/simple-query-with-defined-type.bal
@@ -342,9 +342,9 @@ function mutiplyBy2(int k) returns int {
 
 public function testQueryWithStream() returns boolean {
     NumberGenerator numGen = new;
-    var numberStream = new stream<int, error>(numGen);
+    var numberStream = new stream<int, error?>(numGen);
 
-    int[]|error oddNumberList = from int num in numberStream
+    int[]|error? oddNumberList = from int num in numberStream
                                  where (num % 2 == 1)
                                  select num;
     if (oddNumberList is error) {
@@ -357,9 +357,9 @@ public function testQueryWithStream() returns boolean {
 
 public function testQueryStreamWithError() {
     NumberGeneratorWithError numGen = new;
-    var numberStream = new stream<int, error>(numGen);
+    var numberStream = new stream<int, error?>(numGen);
 
-    int[]|error oddNumberList = from int num in numberStream
+    int[]|error? oddNumberList = from int num in numberStream
                                 where (num % 2 == 1)
                                 select num;
     if (oddNumberList is error) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/simple-query-with-var-type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/simple-query-with-var-type.bal
@@ -274,7 +274,7 @@ function testQueryExpressionWithSpreadOperatorV2() returns Teacher[] {
 
 public function testQueryWithStream() returns boolean {
     NumberGenerator numGen = new;
-    var numberStream = new stream<int, error>(numGen);
+    var numberStream = new stream<int, error?>(numGen);
 
     var oddNumberList = from var num in numberStream
                         where (num % 2 == 1)

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/stream/stream-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/stream/stream-negative.bal
@@ -58,11 +58,11 @@ function testIteratorWithCustomError() {
     IteratorWithCustomError itr = new();
 
     // correct
-    var streamA = new stream<int, CustomError>(itr);
-    stream<int, CustomError> streamB = new(itr);
+    var streamA = new stream<int, CustomError?>(itr);
+    stream<int, CustomError?> streamB = new(itr);
 
     var streamC = new stream<int, error?>(itr);
-    stream<int, error> streamD = new(itr);
+    stream<int, error?> streamD = new(itr);
 
     record {| int value; |}|CustomError? returnedValA = streamA.next();
     returnedValA = streamB.next();
@@ -106,8 +106,8 @@ function testIteratorWithGenericError() {
     record {| int value; |}? returnedValC = streamB.next();
 
     // incorrect (itr returns an `error` instead of `CustomError`)
-    var streamC = new stream<int, CustomError>(itr);
-    stream<int, CustomError> streamD = new(itr);
+    var streamC = new stream<int, CustomError?>(itr);
+    stream<int, CustomError?> streamD = new(itr);
 
     // incorrect (error type should be there in the stream<int, ?>)
     var streamE = new stream<int>(itr);
@@ -134,10 +134,10 @@ function testIteratorWithOutError() {
     returnedValA = streamB.next();
 
     // incorrect (error type shouldn't be there)
-    var streamC = new stream<int, error>(itr);
-    stream<int, error> streamD = new(itr);
-    var streamE = new stream<int, CustomError>(itr);
-    stream<int, CustomError> streamF = new(itr);
+    var streamC = new stream<int, error?>(itr);
+    stream<int, error?> streamD = new(itr);
+    var streamE = new stream<int, CustomError?>(itr);
+    stream<int, CustomError?> streamF = new(itr);
 
     // incorrect (next returns record {| int value; |}?)
     record {| int value; |}|error? returnedValB = streamA.next();
@@ -158,10 +158,10 @@ function testIteratorWithOutNext() {
     // incorrect (itr doesn't have a next() method implemented)
     var streamA = new stream<int>(itr);
     stream<int> streamB = new(itr);
-    var streamC = new stream<int, error>(itr);
-    stream<int, error> streamD = new(itr);
-    var streamE = new stream<int, CustomError>(itr);
-    stream<int, CustomError> streamF = new(itr);
+    var streamC = new stream<int, error?>(itr);
+    stream<int, error?> streamD = new(itr);
+    var streamE = new stream<int, CustomError?>(itr);
+    stream<int, CustomError?> streamF = new(itr);
 }
 
 class IteratorWithMismatchedNextA {
@@ -177,10 +177,10 @@ function testIteratorWithMismatchedNextA() {
     // incorrect (`next(int i)` of itr, doesn't match with `next()`)
     var streamA = new stream<int>(itr);
     stream<int> streamB = new(itr);
-    var streamC = new stream<int, error>(itr);
-    stream<int, error> streamD = new(itr);
-    var streamE = new stream<int, CustomError>(itr);
-    stream<int, CustomError> streamF = new(itr);
+    var streamC = new stream<int, error?>(itr);
+    stream<int, error?> streamD = new(itr);
+    var streamE = new stream<int, CustomError?>(itr);
+    stream<int, CustomError?> streamF = new(itr);
 }
 
 class IteratorWithMismatchedNextC {
@@ -195,14 +195,14 @@ class IteratorWithMismatchedNextC {
 function testIteratorWithMismatchedNextC() {
     IteratorWithMismatchedNextC itr = new();
     // correct
-    var streamA = new stream<int, error>(itr);
-    stream<int, error> streamB = new(itr);
+    var streamA = new stream<int, error?>(itr);
+    stream<int, error?> streamB = new(itr);
 
     // incorrect (`return type of `next()` of itr, doesn't match with value type)
-    var streamC = new stream<string, error>(itr);
-    stream<string, error> streamD = new(itr);
-    var streamE = new stream<string, CustomError>(itr);
-    stream<string, CustomError> streamF = new(itr);
+    var streamC = new stream<string, error?>(itr);
+    stream<string, error?> streamD = new(itr);
+    var streamE = new stream<string, CustomError?>(itr);
+    stream<string, CustomError?> streamF = new(itr);
 }
 
 class IteratorWithMismatchedError {
@@ -217,15 +217,15 @@ class IteratorWithMismatchedError {
 function testIteratorWithMismatchedError() {
     IteratorWithMismatchedError itr = new();
     // correct
-    var streamA = new stream<int, CustomError>(itr);
-    stream<int, CustomError> streamB = new(itr);
+    var streamA = new stream<int, CustomError?>(itr);
+    stream<int, CustomError?> streamB = new(itr);
 
-    var streamC = new stream<int, error>(itr);
-    stream<int, error> streamD = new(itr);
+    var streamC = new stream<int, error?>(itr);
+    stream<int, error?> streamD = new(itr);
 
     // incorrect (`CustomError` & `CustomError1` doesn't match)
-    var streamE = new stream<string, CustomError1>(itr);
-    stream<string, CustomError1> streamF = new(itr);
+    var streamE = new stream<string, CustomError1?>(itr);
+    stream<string, CustomError1?> streamF = new(itr);
 }
 
 function testInvalidStreamConstructor() {
@@ -236,8 +236,8 @@ function testInvalidStreamConstructor() {
     stream<int> streamB = new(itr);
 
     // incorrect (`IteratorWithOutError` does not return an error from next() method)
-    var streamC = new stream<int, CustomError>(itr);
-    stream<int, CustomError> streamD = new(itr);
+    var streamC = new stream<int, CustomError?>(itr);
+    stream<int, CustomError?> streamD = new(itr);
 }
 
 
@@ -246,12 +246,12 @@ function testInvalidStreamConstructs() returns boolean {
     stream<int> stream1 = new(itr, itr);
     stream<int> stream2 = new stream<int>(itr, itr);
     stream<int, never> stream3 = new(itr, itr);
-    stream<int, error> stream4 = new(itr, itr);
+    stream<int, error?> stream4 = new(itr, itr);
     stream<int, never> stream5 = new stream<int, never>(itr, itr);
-    stream<int, error> stream6 = new stream<int, error>(itr, itr);
+    stream<int, error?> stream6 = new stream<int, error?>(itr, itr);
     var stream7 = new stream<int>(itr, itr);
     var stream8 = new stream<int, never>(itr, itr);
-    var stream9 = new stream<int, error>(itr, itr);
+    var stream9 = new stream<int, error?>(itr, itr);
 }
 
 class IteratorWithIsolatedNext {
@@ -345,11 +345,11 @@ public function main() returns @tainted error? {
     IteratorWithNonIsolatedNext itr3 = new;
     IteratorWithNonIsolatedNextAndIsolatedClose itr4 = new;
     IteratorWithIsolatedNextAndNonIsolatedClose itr5 = new;
-    var intStr1 = new stream<int, error>(itr1);
-    var intStr2 = new stream<int, error>(itr2);
-    var intStr3 = new stream<int, error>(itr3);
-    var intStr4 = new stream<int, error>(itr4);
-    var intStr5 = new stream<int, error>(itr5);
+    var intStr1 = new stream<int, error?>(itr1);
+    var intStr2 = new stream<int, error?>(itr2);
+    var intStr3 = new stream<int, error?>(itr3);
+    var intStr4 = new stream<int, error?>(itr4);
+    var intStr5 = new stream<int, error?>(itr5);
 
     InvalidNumberStreamGenerator n = new ();
     stream<stream<int>> numberStream = new (n);
@@ -361,12 +361,12 @@ function testAssignabilityOfStreams() {
     stream<int> emptyStream1 = new;
     stream<int> emptyStream2 = new stream<int>();
     stream<int, ()> emptyStream3 = new;
-    stream<int, error> emptyStream4 = new;
+    stream<int, error?> emptyStream4 = new;
     stream<int, ()> emptyStream5 = new stream<int, ()>();
-    stream<int, error> emptyStream6 = new stream<int, error>();
+    stream<int, error?> emptyStream6 = new stream<int, error?>();
     var emptyStream7 = new stream<int>();
     var emptyStream8 = new stream<int, ()>();
-    var emptyStream9 = new stream<int, error>();
+    var emptyStream9 = new stream<int, error?>();
 
     emptyStream1 = emptyStream6;
     emptyStream2 = emptyStream9;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/stream/stream-value.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/stream/stream-value.bal
@@ -51,7 +51,7 @@ function getRecordValue((record {| int value; |}|error?)|(record {| int value; |
 }
 
 EvenNumberGenerator evenGen = new();
-stream<int,error> evenNumberStream = new(evenGen);
+stream<int,error?> evenNumberStream = new(evenGen);
 
 function testGlobalStreamConstruct() returns boolean {
     boolean testPassed = true;
@@ -75,7 +75,7 @@ function testStreamConstruct() returns boolean {
     boolean testPassed = true;
 
     OddNumberGenerator oddGen = new();
-    var oddNumberStream = new stream<int,error>(oddGen);
+    var oddNumberStream = new stream<int,error?>(oddGen);
 
     record {| int value; |}? oddNumber = getRecordValue(oddNumberStream.next());
     testPassed = testPassed && (oddNumber?.value == 3);
@@ -193,8 +193,8 @@ function testIteratorWithCustomError() returns boolean {
     boolean testPassed = true;
 
     IteratorWithCustomError numGen = new();
-    var intStreamA = new stream<int, CustomError>(numGen);
-    stream<int, CustomError> intStreamB = new(numGen);
+    var intStreamA = new stream<int, CustomError?>(numGen);
+    stream<int, CustomError?> intStreamB = new(numGen);
 
     var returnedVal = getRecordValue(intStreamA.next());
     testPassed = testPassed && (<int>returnedVal["value"] == 1);
@@ -229,8 +229,8 @@ function testIteratorWithGenericError() returns boolean {
     boolean testPassed = true;
 
     IteratorWithGenericError numGen = new();
-    var intStreamA = new stream<int, error>(numGen);
-    stream<int, error> intStreamB = new(numGen);
+    var intStreamA = new stream<int, error?>(numGen);
+    stream<int, error?> intStreamB = new(numGen);
 
     var returnedVal = getRecordValue(intStreamA.next());
     testPassed = testPassed && (<int>returnedVal["value"] == 1);
@@ -302,8 +302,8 @@ function testIteratorWithErrorUnion() returns boolean {
     boolean testPassed = true;
 
     IteratorWithErrorUnion numGen = new();
-    var intStreamA = new stream<int, Error>(numGen);
-    stream<int, Error> intStreamB = new(numGen);
+    var intStreamA = new stream<int, Error?>(numGen);
+    stream<int, Error?> intStreamB = new(numGen);
 
     var returnedVal = getRecordValue(intStreamA.next());
     testPassed = testPassed && (<int>returnedVal["value"] == 1);
@@ -388,12 +388,12 @@ function testEmptyStreamConstructs() returns boolean {
     stream<int> emptyStream1 = new;
     stream<int> emptyStream2 = new stream<int>();
     stream<int, ()> emptyStream3 = new;
-    stream<int, error> emptyStream4 = new;
+    stream<int, error?> emptyStream4 = new;
     stream<int, ()> emptyStream5 = new stream<int, ()>();
-    stream<int, error> emptyStream6 = new stream<int, error>();
+    stream<int, error?> emptyStream6 = new stream<int, error?>();
     var emptyStream7 = new stream<int>();
     var emptyStream8 = new stream<int, ()>();
-    var emptyStream9 = new stream<int, error>();
+    var emptyStream9 = new stream<int, error?>();
 
     testPassed = testPassed && (emptyStream1.next() === ());
     testPassed = testPassed && (emptyStream2.next() === ());
@@ -438,7 +438,7 @@ function testUnionOfStreamsAsFunctionParams() returns boolean {
     return testPassed;
 }
 
-function functionWithStreamArgs(stream<any|error> str) returns boolean {
+function functionWithStreamArgs(stream<any|error?> str) returns boolean {
     record {|any|error value;|}? res = str.next();
     if (res is record {|Foo value;|}) {
         return res.value == {v: "foo2"};


### PR DESCRIPTION
## Purpose
From the spec
> A stream is an object-like value that can generate a sequence of values. There is also a value associated with the completion of the generation of the sequence, which is either nil, indicating the generation of the sequence completed successfully, or an error. A stream belongs to type stream<T,C> if the values in the generated sequence all belong to T and if the completion value belongs to C. **_The type stream<T> is equivalent to stream<T,()>_**. A value belongs to a type stream (without the type-parameter) if it has basic type stream. **_A type stream<T,C> where C does not include nil describes an unbounded stream_.**

Fixes #31464 #31671

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
