### PR TITLE
Save the heap dump files for run and test commands

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunExecutableTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunExecutableTask.java
@@ -42,7 +42,7 @@ import static io.ballerina.cli.launcher.LauncherUtils.createLauncherException;
 import static io.ballerina.cli.utils.DebugUtils.getDebugArgs;
 import static io.ballerina.cli.utils.DebugUtils.isInDebugMode;
 import static io.ballerina.runtime.api.constants.RuntimeConstants.MODULE_INIT_CLASS_NAME;
-import static io.ballerina.runtime.internal.util.RuntimeUtils.USER_DIR;
+import static org.wso2.ballerinalang.compiler.util.ProjectDirConstants.USER_DIR;
 
 /**
  * Task for running the executable.
@@ -98,7 +98,7 @@ public class RunExecutableTask implements Task {
             List<String> commands = new ArrayList<>();
             commands.add(System.getProperty("java.command"));
             commands.add("-XX:+HeapDumpOnOutOfMemoryError");
-            commands.add("-XX:HeapDumpPath=" + USER_DIR);
+            commands.add("-XX:HeapDumpPath=" + System.getProperty(USER_DIR));
             // Sets classpath with executable thin jar and all dependency jar paths.
             commands.add("-cp");
             commands.add(getAllClassPaths(jarResolver));

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunExecutableTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunExecutableTask.java
@@ -42,6 +42,7 @@ import static io.ballerina.cli.launcher.LauncherUtils.createLauncherException;
 import static io.ballerina.cli.utils.DebugUtils.getDebugArgs;
 import static io.ballerina.cli.utils.DebugUtils.isInDebugMode;
 import static io.ballerina.runtime.api.constants.RuntimeConstants.MODULE_INIT_CLASS_NAME;
+import static io.ballerina.runtime.internal.util.RuntimeUtils.USER_DIR;
 
 /**
  * Task for running the executable.
@@ -96,6 +97,8 @@ public class RunExecutableTask implements Task {
         try {
             List<String> commands = new ArrayList<>();
             commands.add(System.getProperty("java.command"));
+            commands.add("-XX:+HeapDumpOnOutOfMemoryError");
+            commands.add("-XX:HeapDumpPath=" + USER_DIR);
             // Sets classpath with executable thin jar and all dependency jar paths.
             commands.add("-cp");
             commands.add(getAllClassPaths(jarResolver));

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
@@ -76,7 +76,6 @@ import java.util.stream.Collectors;
 import static io.ballerina.cli.launcher.LauncherUtils.createLauncherException;
 import static io.ballerina.cli.utils.DebugUtils.getDebugArgs;
 import static io.ballerina.cli.utils.DebugUtils.isInDebugMode;
-import static io.ballerina.runtime.internal.util.RuntimeUtils.USER_DIR;
 import static org.ballerinalang.test.runtime.util.TesterinaConstants.COVERAGE_DIR;
 import static org.ballerinalang.test.runtime.util.TesterinaConstants.DATA_KEY_SEPARATOR;
 import static org.ballerinalang.test.runtime.util.TesterinaConstants.DOT;
@@ -91,6 +90,7 @@ import static org.ballerinalang.test.runtime.util.TesterinaConstants.TOOLS_DIR_N
 import static org.wso2.ballerinalang.compiler.util.ProjectDirConstants.BALLERINA_HOME;
 import static org.wso2.ballerinalang.compiler.util.ProjectDirConstants.BALLERINA_HOME_BRE;
 import static org.wso2.ballerinalang.compiler.util.ProjectDirConstants.BALLERINA_HOME_LIB;
+import static org.wso2.ballerinalang.compiler.util.ProjectDirConstants.USER_DIR;
 
 /**
  * Task for executing tests.
@@ -480,7 +480,7 @@ public class RunTestsTask implements Task {
         List<String> cmdArgs = new ArrayList<>();
         cmdArgs.add(System.getProperty("java.command"));
         cmdArgs.add("-XX:+HeapDumpOnOutOfMemoryError");
-        cmdArgs.add("-XX:HeapDumpPath=" + USER_DIR);
+        cmdArgs.add("-XX:HeapDumpPath=" + System.getProperty(USER_DIR));
 
         String mainClassName = TesterinaConstants.TESTERINA_LAUNCHER_CLASS_NAME;
 

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
@@ -76,6 +76,7 @@ import java.util.stream.Collectors;
 import static io.ballerina.cli.launcher.LauncherUtils.createLauncherException;
 import static io.ballerina.cli.utils.DebugUtils.getDebugArgs;
 import static io.ballerina.cli.utils.DebugUtils.isInDebugMode;
+import static io.ballerina.runtime.internal.util.RuntimeUtils.USER_DIR;
 import static org.ballerinalang.test.runtime.util.TesterinaConstants.COVERAGE_DIR;
 import static org.ballerinalang.test.runtime.util.TesterinaConstants.DATA_KEY_SEPARATOR;
 import static org.ballerinalang.test.runtime.util.TesterinaConstants.DOT;
@@ -478,6 +479,8 @@ public class RunTestsTask implements Task {
         String classPath = getClassPath(jBallerinaBackend, currentPackage);
         List<String> cmdArgs = new ArrayList<>();
         cmdArgs.add(System.getProperty("java.command"));
+        cmdArgs.add("-XX:+HeapDumpOnOutOfMemoryError");
+        cmdArgs.add("-XX:HeapDumpPath=" + USER_DIR);
 
         String mainClassName = TesterinaConstants.TESTERINA_LAUNCHER_CLASS_NAME;
 

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/TestCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/TestCommandTest.java
@@ -20,11 +20,14 @@ package io.ballerina.cli.cmd;
 
 import io.ballerina.cli.launcher.BLauncherException;
 import io.ballerina.projects.util.ProjectConstants;
+import org.apache.commons.io.filefilter.WildcardFileFilter;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import picocli.CommandLine;
 
+import java.io.File;
+import java.io.FileFilter;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -156,6 +159,23 @@ public class TestCommandTest extends BaseCommandTest {
         buildCommand.execute();
         String buildLog = readOutput(true);
         Assert.assertEquals(buildLog.replaceAll("\r", ""), getOutput("test-project.txt"));
+    }
+
+    @Test(description = "Test the heap dump generation for a project with an OOM error")
+    public void testHeapDumpGenerationForOOM() {
+        Path projectPath = this.testResources.resolve("oom-project");
+        System.setProperty(ProjectConstants.USER_DIR, projectPath.toString());
+        TestCommand testCommand = new TestCommand(projectPath, printStream, printStream, false);
+        new CommandLine(testCommand).parse();
+
+        try {
+            testCommand.execute();
+        } catch (BLauncherException e) {
+            System.out.println(projectPath.toString());
+            File projectDir = new File(projectPath.toString());
+            FileFilter fileFilter = new WildcardFileFilter("java_pid*.hprof");
+            Assert.assertTrue(Objects.requireNonNull(projectDir.listFiles(fileFilter)).length > 0);
+        }
     }
 
     static class Copy extends SimpleFileVisitor<Path> {

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/TestCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/TestCommandTest.java
@@ -171,7 +171,6 @@ public class TestCommandTest extends BaseCommandTest {
         try {
             testCommand.execute();
         } catch (BLauncherException e) {
-            System.out.println(projectPath.toString());
             File projectDir = new File(projectPath.toString());
             FileFilter fileFilter = new WildcardFileFilter("java_pid*.hprof");
             Assert.assertTrue(Objects.requireNonNull(projectDir.listFiles(fileFilter)).length > 0);

--- a/cli/ballerina-cli/src/test/resources/test-resources/oom-project/Ballerina.toml
+++ b/cli/ballerina-cli/src/test/resources/test-resources/oom-project/Ballerina.toml
@@ -1,0 +1,5 @@
+[package]
+org = "foo"
+name = "winery"
+version = "0.1.0"
+

--- a/cli/ballerina-cli/src/test/resources/test-resources/oom-project/Ballerina.toml
+++ b/cli/ballerina-cli/src/test/resources/test-resources/oom-project/Ballerina.toml
@@ -2,4 +2,3 @@
 org = "foo"
 name = "winery"
 version = "0.1.0"
-

--- a/cli/ballerina-cli/src/test/resources/test-resources/oom-project/main.bal
+++ b/cli/ballerina-cli/src/test/resources/test-resources/oom-project/main.bal
@@ -1,0 +1,4 @@
+public function main(string... args) {
+    int[] a = [];
+    a[(2147483647 - 9)] = 10;
+}

--- a/cli/ballerina-cli/src/test/resources/test-resources/oom-project/tests/main_tests.bal
+++ b/cli/ballerina-cli/src/test/resources/test-resources/oom-project/tests/main_tests.bal
@@ -1,0 +1,7 @@
+import ballerina/test;
+
+@test:Config {}
+public function testRunMain() {
+    int[] a = [];
+    a[(2147483647-9)] = 10;
+}

--- a/distribution/zip/jballerina/bin/bal
+++ b/distribution/zip/jballerina/bin/bal
@@ -218,7 +218,7 @@ BALLERINA_CLASSPATH=$BALLERINA_CLASSPATH:$BALLERINA_CLASSPATH_EXT
 CMD_LINE_ARGS="-Xbootclasspath/a:"$BALLERINA_XBOOTCLASSPATH" \
                -Xms256m -Xmx1024m \
                -XX:+HeapDumpOnOutOfMemoryError \
-               -XX:HeapDumpPath="$(pwd)/heap-dump.hprof" \
+               -XX:HeapDumpPath="$(pwd)" \
                $JAVA_OPTS \
                -classpath "$BALLERINA_CLASSPATH" \
                -Dballerina.home="$BALLERINA_HOME" \

--- a/distribution/zip/jballerina/bin/bal.bat
+++ b/distribution/zip/jballerina/bin/bal.bat
@@ -146,7 +146,7 @@ rem BALLERINA_CLASSPATH_EXT is for outsiders to additionally add
 rem classpath locations, e.g. AWS Lambda function libraries.
 if not "%BALLERINA_CLASSPATH_EXT%" == "" set BALLERINA_CLASSPATH=!BALLERINA_CLASSPATH!;%BALLERINA_CLASSPATH_EXT%
 
-set CMD_LINE_ARGS=-Xbootclasspath/a:%BALLERINA_XBOOTCLASSPATH% -Xms256m -Xmx1024m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath="%cd%\heap-dump.hprof"  -Dcom.sun.management.jmxremote -classpath "%BALLERINA_CLASSPATH%" %JAVA_OPTS% -Dballerina.home="%BALLERINA_HOME%" -Dballerina.target="jvm" -Djava.command="%JAVA_HOME%\bin\java" -Djava.opts="%JAVA_OPTS%" -Denable.nonblocking=false -Dfile.encoding=UTF8 -Dballerina.version=${project.version} -Djava.util.logging.config.class="org.ballerinalang.logging.util.LogConfigReader" -Djava.util.logging.manager="org.ballerinalang.logging.BLogManager"
+set CMD_LINE_ARGS=-Xbootclasspath/a:%BALLERINA_XBOOTCLASSPATH% -Xms256m -Xmx1024m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath="%cd%"  -Dcom.sun.management.jmxremote -classpath "%BALLERINA_CLASSPATH%" %JAVA_OPTS% -Dballerina.home="%BALLERINA_HOME%" -Dballerina.target="jvm" -Djava.command="%JAVA_HOME%\bin\java" -Djava.opts="%JAVA_OPTS%" -Denable.nonblocking=false -Dfile.encoding=UTF8 -Dballerina.version=${project.version} -Djava.util.logging.config.class="org.ballerinalang.logging.util.LogConfigReader" -Djava.util.logging.manager="org.ballerinalang.logging.BLogManager"
 
 set jar=%2
 if "%1" == "run" if "%jar:~-4%" == ".jar" goto runJar


### PR DESCRIPTION
## Purpose
* Save the heap dump files for the `bal run` command
* Save the heap dump files for the `bal test` command
* Add test cases for both scenarios
* The current heap dump saving approach for `bal run <jar-file>` doesn't support the saving of multiple heap dump files, therefore, it is changed to save multiple heap dumps.

Fixes #18359

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
