### PR TITLE
Refactor offline mode in package resolution

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Bootstrap.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Bootstrap.java
@@ -204,7 +204,7 @@ public class Bootstrap {
         PackageName pkgName = PackageName.from(packageID.name.getValue());
         PackageVersion pkgVersion = PackageVersion.from(packageID.getPackageVersion().toString());
         PackageDescriptor packageDescriptor = PackageDescriptor.from(pkgOrg, pkgName, pkgVersion);
-        return ResolutionRequest.from(packageDescriptor, PackageDependencyScope.DEFAULT);
+        return ResolutionRequest.from(packageDescriptor, PackageDependencyScope.DEFAULT, false);
     }
 
     private BPackageSymbol getSymbolFromCache(CompilerContext context, PackageID packageID) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageResolution.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageResolution.java
@@ -241,7 +241,8 @@ public class PackageResolution {
         // 1) Create ResolutionRequest instances for each direct dependency of the bala
         LinkedHashSet<ResolutionRequest> resolutionRequests = new LinkedHashSet<>();
         for (PackageDescriptor packageDescriptor : directDependenciesOfBALA) {
-            resolutionRequests.add(ResolutionRequest.from(packageDescriptor, PackageDependencyScope.DEFAULT));
+            resolutionRequests.add(ResolutionRequest.from(packageDescriptor, PackageDependencyScope.DEFAULT,
+                    rootPackageContext.project().buildOptions().offlineBuild()));
         }
 
         // 2) Resolve direct dependencies. My assumption is that, all these dependencies comes from BALAs
@@ -503,7 +504,8 @@ public class PackageResolution {
         }
 
         private ResolutionResponse resolvePackage(PackageDescriptor pkgDesc, PackageDependencyScope scope) {
-            ResolutionRequest resolutionRequest = ResolutionRequest.from(pkgDesc, scope);
+            ResolutionRequest resolutionRequest = ResolutionRequest
+                    .from(pkgDesc, scope, rootPkgContext.project().buildOptions().offlineBuild());
             return packageResolver.resolvePackages(
                     List.of(resolutionRequest), rootPkgContext.project()).get(0);
         }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/directory/BuildProject.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/directory/BuildProject.java
@@ -80,9 +80,6 @@ public class BuildProject extends Project {
      * @return BuildProject instance
      */
     public static BuildProject load(Path projectPath, BuildOptions buildOptions) {
-        // todo this is an ugly hack to get the offline build working we need to refactor this later
-        System.setProperty(ProjectConstants.BALLERINA_OFFLINE_FLAG, String.valueOf(buildOptions.offlineBuild()));
-
         ProjectEnvironmentBuilder environmentBuilder = ProjectEnvironmentBuilder.getDefaultBuilder();
         return load(environmentBuilder, projectPath, buildOptions);
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/directory/ProjectLoader.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/directory/ProjectLoader.java
@@ -43,8 +43,6 @@ public class ProjectLoader {
     }
 
     public static Project loadProject(Path path, BuildOptions buildOptions) {
-        // todo this is an ugly hack to get the offline build working we need to refactor this later
-        System.setProperty(ProjectConstants.BALLERINA_OFFLINE_FLAG, String.valueOf(buildOptions.offlineBuild()));
         return loadProject(path, ProjectEnvironmentBuilder.getDefaultBuilder(), buildOptions);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/directory/SingleFileProject.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/directory/SingleFileProject.java
@@ -26,7 +26,6 @@ import io.ballerina.projects.ProjectEnvironmentBuilder;
 import io.ballerina.projects.ProjectException;
 import io.ballerina.projects.ProjectKind;
 import io.ballerina.projects.internal.PackageConfigCreator;
-import io.ballerina.projects.util.ProjectConstants;
 
 import java.nio.file.Path;
 import java.util.Optional;
@@ -61,9 +60,6 @@ public class SingleFileProject extends Project {
     }
 
     public static SingleFileProject load(Path filePath, BuildOptions buildOptions) {
-        // todo this is an ugly hack to get the offline build working we need to refactor this later
-        System.setProperty(ProjectConstants.BALLERINA_OFFLINE_FLAG, String.valueOf(buildOptions.offlineBuild()));
-
         PackageConfig packageConfig = PackageConfigCreator.createSingleFileProjectConfig(filePath);
         ProjectEnvironmentBuilder environmentBuilder = ProjectEnvironmentBuilder.getDefaultBuilder();
         SingleFileProject singleFileProject = new SingleFileProject(environmentBuilder, filePath, buildOptions);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/environment/ResolutionRequest.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/environment/ResolutionRequest.java
@@ -35,14 +35,17 @@ import java.util.Optional;
 public final class ResolutionRequest {
     private final PackageDescriptor packageDesc;
     private final PackageDependencyScope scope;
+    private final boolean offline;
 
-    private ResolutionRequest(PackageDescriptor packageDescriptor, PackageDependencyScope scope) {
+    private ResolutionRequest(PackageDescriptor packageDescriptor, PackageDependencyScope scope, boolean offline) {
         this.packageDesc = packageDescriptor;
         this.scope = scope;
+        this.offline = offline;
     }
 
-    public static ResolutionRequest from(PackageDescriptor packageDescriptor, PackageDependencyScope scope) {
-        return new ResolutionRequest(packageDescriptor, scope);
+    public static ResolutionRequest from(PackageDescriptor packageDescriptor, PackageDependencyScope scope,
+                                         boolean offline) {
+        return new ResolutionRequest(packageDescriptor, scope, offline);
     }
 
     public PackageOrg orgName() {
@@ -67,6 +70,10 @@ public final class ResolutionRequest {
 
     public Optional<String> repositoryName() {
         return packageDesc.repository();
+    }
+
+    public boolean offline() {
+        return offline;
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/PackageDependencyGraphBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/PackageDependencyGraphBuilder.java
@@ -160,7 +160,8 @@ public class PackageDependencyGraphBuilder {
         for (Vertex directDependencyNode : directDependencyNodes) {
             StaticPackageDependency directPkgDep = vertices.get(directDependencyNode);
             // Create a resolution request
-            ResolutionRequest resolutionRequest = ResolutionRequest.from(directPkgDep.pkgDesc, directPkgDep.scope);
+            ResolutionRequest resolutionRequest = ResolutionRequest.from(directPkgDep.pkgDesc, directPkgDep.scope,
+                    currentProject.buildOptions().offlineBuild());
             List<ResolutionResponse> resolutionResponses = packageResolver.resolvePackages(
                     Collections.singletonList(resolutionRequest), currentProject);
             ResolutionResponse resolutionResponse = resolutionResponses.get(0);
@@ -185,7 +186,8 @@ public class PackageDependencyGraphBuilder {
         List<ResolutionRequest> resolutionRequests = new ArrayList<>();
         for (Vertex transitiveDependencyNode : transitiveDependencyNodes) {
             StaticPackageDependency transitivePkgDep = vertices.get(transitiveDependencyNode);
-            resolutionRequests.add(ResolutionRequest.from(transitivePkgDep.pkgDesc, transitivePkgDep.scope));
+            resolutionRequests.add(ResolutionRequest.from(
+                    transitivePkgDep.pkgDesc, transitivePkgDep.scope, currentProject.buildOptions().offlineBuild()));
         }
 
         List<ResolutionResponse> resolutionResponses = packageResolver.resolvePackages(

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/environment/DefaultPackageResolver.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/environment/DefaultPackageResolver.java
@@ -192,7 +192,7 @@ public class DefaultPackageResolver implements PackageResolver {
         // Load the latest version
         ResolutionRequest newResolutionReq = ResolutionRequest.from(
                 PackageDescriptor.from(resolutionRequest.orgName(), resolutionRequest.packageName(),
-                        latestVersion), resolutionRequest.scope());
+                        latestVersion), resolutionRequest.scope(), resolutionRequest.offline());
 
         // Check if the package is already in cache to avoid
         // duplicating package instances in the WritablePackageCache.
@@ -215,7 +215,7 @@ public class DefaultPackageResolver implements PackageResolver {
             } else {
                 ResolutionRequest newResolutionReq = ResolutionRequest.from(
                         PackageDescriptor.from(resolutionRequest.orgName(), resolutionRequest.packageName(),
-                                versionList.get(0)), resolutionRequest.scope());
+                                versionList.get(0)), resolutionRequest.scope(), resolutionRequest.offline());
                 resolvedPackage = Optional.ofNullable(loadFromCache(newResolutionReq));
                 if (resolvedPackage.isEmpty()) {
                     resolvedPackage = ballerinaDistRepo.getPackage(newResolutionReq);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/RemotePackageRepository.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/RemotePackageRepository.java
@@ -8,7 +8,6 @@ import io.ballerina.projects.Settings;
 import io.ballerina.projects.environment.Environment;
 import io.ballerina.projects.environment.PackageRepository;
 import io.ballerina.projects.environment.ResolutionRequest;
-import io.ballerina.projects.util.ProjectConstants;
 import org.ballerinalang.central.client.CentralAPIClient;
 import org.ballerinalang.central.client.exceptions.CentralClientException;
 import org.ballerinalang.central.client.exceptions.ConnectionErrorException;
@@ -38,16 +37,10 @@ public class RemotePackageRepository implements PackageRepository {
 
     private FileSystemRepository fileSystemRepo;
     private CentralAPIClient client;
-    private boolean isOffline;
 
     private RemotePackageRepository(FileSystemRepository fileSystemRepo, CentralAPIClient client) {
         this.fileSystemRepo = fileSystemRepo;
         this.client = client;
-
-        // todo this is an ugly hack to get the offline build working
-        // we need to properly refactor this later
-        String offlineFlag = System.getProperty(ProjectConstants.BALLERINA_OFFLINE_FLAG);
-        this.isOffline = (offlineFlag != null && offlineFlag.equals("true"));
     }
 
     public static RemotePackageRepository from(Environment environment, Path cacheDirectory, String repoUrl,
@@ -94,7 +87,7 @@ public class RemotePackageRepository implements PackageRepository {
         Path packagePathInBalaCache = this.fileSystemRepo.bala.resolve(orgName).resolve(packageName);
 
         // If environment is online pull from central
-        if (!isOffline) {
+        if (!resolutionRequest.offline()) {
             for (String supportedPlatform : SUPPORTED_PLATFORMS) {
                 try {
                     this.client.pullPackage(orgName, packageName, version, packagePathInBalaCache, supportedPlatform,
@@ -121,7 +114,7 @@ public class RemotePackageRepository implements PackageRepository {
         Set<PackageVersion> packageVersions = new HashSet<>(fileSystemRepo.getPackageVersions(resolutionRequest));
 
         // If environment is offline we return the local versions
-        if (isOffline) {
+        if (resolutionRequest.offline()) {
             return new ArrayList<>(packageVersions);
         }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/RemotePackageRepository.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/RemotePackageRepository.java
@@ -113,7 +113,7 @@ public class RemotePackageRepository implements PackageRepository {
         // First, Get local versions
         Set<PackageVersion> packageVersions = new HashSet<>(fileSystemRepo.getPackageVersions(resolutionRequest));
 
-        // If environment is offline we return the local versions
+        // If the resolution request specifies to resolve offline, we return the local version
         if (resolutionRequest.offline()) {
             return new ArrayList<>(packageVersions);
         }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/ProjectConstants.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/ProjectConstants.java
@@ -103,7 +103,6 @@ public class ProjectConstants {
     public static final String DIFF_UTILS_JAR = "java-diff-utils-4.5.jar";
     public static final String REPORT_DIR_NAME = "report";
 
-    public static final String BALLERINA_OFFLINE_FLAG = "ballerina.offline.flag";
     public static final String BALA_DOCS_DIR = "docs";
     public static final String REPOSITORIES_DIR = "repositories";
     public static final String LOCAL_REPOSITORY_NAME = "local";

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/FileSystemRepositoryTests.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/FileSystemRepositoryTests.java
@@ -54,7 +54,7 @@ public class FileSystemRepositoryTests {
 
         ResolutionRequest resolutionRequest = ResolutionRequest.from(
                 PackageDescriptor.from(PackageOrg.from("hevayo"), PackageName.from("package_a"), null),
-                PackageDependencyScope.DEFAULT
+                PackageDependencyScope.DEFAULT, true
         );
         List<PackageVersion> versions = fileSystemRepository.getPackageVersions(resolutionRequest);
         Assert.assertEquals(versions.size(), 2);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSPackageLoader.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSPackageLoader.java
@@ -82,7 +82,7 @@ public class LSPackageLoader {
                 PackageName packageName = PackageName.from(nameComponent);
                 PackageVersion pkgVersion = PackageVersion.from(version);
                 PackageDescriptor pkdDesc = PackageDescriptor.from(packageOrg, packageName, pkgVersion);
-                ResolutionRequest request = ResolutionRequest.from(pkdDesc, PackageDependencyScope.DEFAULT);
+                ResolutionRequest request = ResolutionRequest.from(pkdDesc, PackageDependencyScope.DEFAULT, true);
 
                 Optional<Package> repoPackage = packageRepository.getPackage(request);
                 repoPackage.ifPresent(packages::add);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/connector/BallerinaConnectorServiceImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/connector/BallerinaConnectorServiceImpl.java
@@ -56,7 +56,6 @@ import io.ballerina.projects.environment.PackageResolver;
 import io.ballerina.projects.environment.ResolutionRequest;
 import io.ballerina.projects.environment.ResolutionResponse;
 import io.ballerina.projects.repos.TempDirCompilationCache;
-import io.ballerina.projects.util.ProjectConstants;
 import org.ballerinalang.compiler.BLangCompilerException;
 import org.ballerinalang.diagramutil.DiagramUtil;
 import org.ballerinalang.langserver.LSClientLogger;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/connector/BallerinaConnectorServiceImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/connector/BallerinaConnectorServiceImpl.java
@@ -143,13 +143,12 @@ public class BallerinaConnectorServiceImpl implements BallerinaConnectorService 
     }
 
     private Path resolveBalaPath(String org, String pkgName, String version) throws LSConnectorException {
-        // TODO this is to reset offline flag modified in BuildProject#load and SingleFileProject#load
-        System.setProperty(ProjectConstants.BALLERINA_OFFLINE_FLAG, String.valueOf(false));
         Environment environment = EnvironmentBuilder.buildDefault();
 
         PackageDescriptor packageDescriptor = PackageDescriptor.from(
         PackageOrg.from(org), PackageName.from(pkgName), PackageVersion.from(version));
-        ResolutionRequest resolutionRequest = ResolutionRequest.from(packageDescriptor, PackageDependencyScope.DEFAULT);
+        ResolutionRequest resolutionRequest = ResolutionRequest
+                .from(packageDescriptor, PackageDependencyScope.DEFAULT, false);
 
         PackageResolver packageResolver = environment.getService(PackageResolver.class);
         List<ResolutionResponse> resolutionResponses = packageResolver.resolvePackages(


### PR DESCRIPTION
## Purpose
> Refactor offline mode in package resolution
> Prerequisite for #30757

## Approach

Removed the usage of the system property `ballerina.offline.flag` to enable offline mode. Instead, the offline flag is set to `ResolutionRequest`. At the package resolution phase, this flag is retrieved from `project.buildOptions()`

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
