### PR TITLE
Fix compiler check for configurable variable of record type with multiple unsupported fields

### DIFF
--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/globalvar/GlobalVarNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/globalvar/GlobalVarNegativeTest.java
@@ -92,44 +92,48 @@ public class GlobalVarNegativeTest {
                 "implicitly final", 37, 7);
         BAssertUtil.validateError(result, i++, "configurable variable currently not supported for '(table<Person> key" +
                 "(name)[] & readonly)'\n\t" +
-                "array element type 'table<Person> key(name) & readonly' is not supported", 67, 1);
+                "array element type 'table<Person> key(name) & readonly' is not supported", 71, 1);
         BAssertUtil.validateError(result, i++, "configurable variable currently not supported for '((table<Person> " +
                         "key(name) & readonly)[] & readonly)'\n\t" +
-                "array element type 'table<Person> key(name) & readonly' is not supported", 68, 1);
+                "array element type 'table<Person> key(name) & readonly' is not supported", 72, 1);
         BAssertUtil.validateError(result, i++, "configurable variable currently not supported for '(Person1 & " +
                 "readonly)'\n\t" +
-                "record field type '(json & readonly)' of field 'person1.jsonField' is not supported", 71, 1);
+                "record field type '(json & readonly)' of field 'person1.jsonField' is not supported", 75, 1);
         BAssertUtil.validateError(result, i++, "configurable variable currently not supported for '(Person2 & " +
                 "readonly)'\n\t" +
-                "union member type '(json & readonly)' is not supported", 72, 1);
+                "union member type '(json & readonly)' is not supported", 76, 1);
         BAssertUtil.validateError(result, i++, "configurable variable currently not supported for '(Person3 & " +
                 "readonly)'\n\t" +
-                "array element type 'json & readonly' is not supported", 73, 1);
+                "array element type 'json & readonly' is not supported", 77, 1);
         BAssertUtil.validateError(result, i++, "configurable variable currently not supported for '(Person4 & " +
                 "readonly)'\n\t" +
-                "record field type '(json & readonly)' of field 'person4.person.jsonField' is not supported", 74, 1);
+                "record field type '(json & readonly)' of field 'person4.person.jsonField' is not supported", 78, 1);
+        BAssertUtil.validateError(result, i++, "configurable variable currently not supported for '(Person5 & " +
+                "readonly)'\n\t" +
+                "record field type '(json & readonly)' of field 'person5.field1' is not supported\n\t" +
+                "record field type '(json & readonly)' of field 'person5.field2' is not supported", 79, 1);
         BAssertUtil.validateError(result, i++, "configurable variable currently not supported for '(table<map<json>> " +
                 "& readonly)'\n\t" +
-                "map constraint type '(json & readonly)' is not supported", 77, 1);
+                "map constraint type '(json & readonly)' is not supported", 82, 1);
         BAssertUtil.validateError(result, i++, "configurable variable currently not supported for '(table<Person1> & " +
                 "readonly)'\n\t" +
-                "record field type '(json & readonly)' of field 'tableVar2.jsonField' is not supported", 78, 1);
+                "record field type '(json & readonly)' of field 'tableVar2.jsonField' is not supported", 83, 1);
         BAssertUtil.validateError(result, i++, "configurable variable currently not supported for '(table<json> & " +
                 "readonly)'\n\t" +
-                "table constraint type '(json & readonly)' is not supported", 79, 1);
+                "table constraint type '(json & readonly)' is not supported", 84, 1);
         BAssertUtil.validateError(result, i++, "configurable variable currently not supported for '(json[] & " +
                 "readonly)'\n\t" +
-                "array element type 'json & readonly' is not supported", 82, 1);
+                "array element type 'json & readonly' is not supported", 87, 1);
         BAssertUtil.validateError(result, i++, "configurable variable currently not supported for '(map<json> & " +
                 "readonly)'\n\t" +
-                "map constraint type '(json & readonly)' is not supported", 85, 1);
+                "map constraint type '(json & readonly)' is not supported", 90, 1);
         BAssertUtil.validateError(result, i++, "configurable variable currently not supported for '((string|json) & " +
                 "readonly)'\n\t" +
-                "union member type '(json & readonly)' is not supported", 88, 1);
+                "union member type '(json & readonly)' is not supported", 93, 1);
         BAssertUtil.validateError(result, i++, "configurable variable currently not supported for '(json & readonly)" +
-                "'", 89, 1);
+                "'", 94, 1);
         BAssertUtil.validateError(result, i++, "configurable variable currently not supported for '([int,string] & " +
-                "readonly)'", 92, 1);
+                "readonly)'", 97, 1);
         Assert.assertEquals(result.getErrorCount(), i);
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/variabledef/configurable_global_var_decl_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/variabledef/configurable_global_var_decl_negative.bal
@@ -49,7 +49,6 @@ type Person1 record {|
 
 type Person2 record {|
     int|json unionField;
-    json jsonField;
 |};
 
 type Person3 record {|
@@ -59,6 +58,11 @@ type Person3 record {|
 type Person4 record {|
     string name;
     Person1 person;
+|};
+
+type Person5 record {|
+    json field1;
+    json field2;
 |};
 
 type Colors "Red" | "Green";
@@ -72,6 +76,7 @@ configurable Person1 person1 = ?;
 configurable Person2 person2 = ?;
 configurable Person3 person3 = ?;
 configurable Person4 person4 = ?;
+configurable Person5 person5 = ?;
 
 // Unsupported table constraint
 configurable table<map<json>> tableVar1 = ?;


### PR DESCRIPTION
## Purpose
$subject

Fixes #31323

## Approach
Added a method that analyses all fields with same type and evaluates each type.

## Samples
```ballerina
type Person record {|
    json field1;
    json field2;
|};

configurable Person test = ?;
```

error :
```
[main.bal:(16:1,16:27)] configurable variable currently not supported for '(hinduja/foo:0.1.0:Person & readonly)'
        record field type '(json & readonly)' of field 'test.field1' is not supported
        record field type '(json & readonly)' of field 'test.field2' is not supported
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
