### PR TITLE
Change implementation of outStream for Central API Client functions

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/BuildCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/BuildCommand.java
@@ -49,8 +49,6 @@ import static io.ballerina.cli.utils.CentralUtils.readSettings;
 import static io.ballerina.runtime.api.constants.RuntimeConstants.SYSTEM_PROP_BAL_DEBUG;
 import static org.ballerinalang.test.runtime.util.TesterinaConstants.JACOCO_XML_FORMAT;
 
-import static org.ballerinalang.central.client.CentralClientConstants.ENABLE_OUTPUT_STREAM;
-
 /**
  * This class represents the "bal build" command.
  *
@@ -278,8 +276,6 @@ public class BuildCommand implements BLauncherCmd {
             CommandUtil.exitError(this.exitWhenFinish);
             return;
         }
-
-        System.setProperty(ENABLE_OUTPUT_STREAM, "true");
 
         // Sets the debug port as a system property, which will be used when setting up debug args before running tests.
         if (!project.buildOptions().skipTests() && this.debugPort != null) {

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/BuildCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/BuildCommand.java
@@ -49,6 +49,8 @@ import static io.ballerina.cli.utils.CentralUtils.readSettings;
 import static io.ballerina.runtime.api.constants.RuntimeConstants.SYSTEM_PROP_BAL_DEBUG;
 import static org.ballerinalang.test.runtime.util.TesterinaConstants.JACOCO_XML_FORMAT;
 
+import static org.ballerinalang.central.client.CentralClientConstants.ENABLE_OUTPUT_STREAM;
+
 /**
  * This class represents the "bal build" command.
  *
@@ -275,8 +277,9 @@ public class BuildCommand implements BLauncherCmd {
                     true);
             CommandUtil.exitError(this.exitWhenFinish);
             return;
-
         }
+
+        System.setProperty(ENABLE_OUTPUT_STREAM, "true");
 
         // Sets the debug port as a system property, which will be used when setting up debug args before running tests.
         if (!project.buildOptions().skipTests() && this.debugPort != null) {

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PullCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PullCommand.java
@@ -25,6 +25,7 @@ import io.ballerina.projects.Settings;
 import io.ballerina.projects.util.ProjectConstants;
 import io.ballerina.projects.util.ProjectUtils;
 import org.ballerinalang.central.client.CentralAPIClient;
+import org.ballerinalang.central.client.CentralClientConstants;
 import org.ballerinalang.central.client.exceptions.CentralClientException;
 import org.ballerinalang.central.client.exceptions.PackageAlreadyExistsException;
 import org.ballerinalang.toml.exceptions.SettingsTomlException;
@@ -106,6 +107,8 @@ public class PullCommand implements BLauncherCmd {
         if (null != debugPort) {
             System.setProperty(SYSTEM_PROP_BAL_DEBUG, debugPort);
         }
+
+        System.setProperty(CentralClientConstants.ENABLE_OUTPUT_STREAM, "true");
 
         String resourceName = argList.get(0);
         String orgName;

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PushCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PushCommand.java
@@ -32,6 +32,7 @@ import io.ballerina.projects.repos.TempDirCompilationCache;
 import io.ballerina.projects.util.ProjectConstants;
 import io.ballerina.projects.util.ProjectUtils;
 import org.ballerinalang.central.client.CentralAPIClient;
+import org.ballerinalang.central.client.CentralClientConstants;
 import org.ballerinalang.central.client.exceptions.CentralClientException;
 import org.ballerinalang.central.client.exceptions.NoPackageException;
 import org.ballerinalang.toml.exceptions.SettingsTomlException;
@@ -131,6 +132,8 @@ public class PushCommand implements BLauncherCmd {
         if (null != debugPort) {
             System.setProperty(SYSTEM_PROP_BAL_DEBUG, debugPort);
         }
+
+        System.setProperty(CentralClientConstants.ENABLE_OUTPUT_STREAM, "true");
 
         if (argList == null || argList.isEmpty()) {
             try {

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/CompileTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/CompileTask.java
@@ -26,6 +26,7 @@ import io.ballerina.projects.PackageCompilation;
 import io.ballerina.projects.Project;
 import io.ballerina.projects.ProjectException;
 import io.ballerina.projects.directory.SingleFileProject;
+import org.ballerinalang.central.client.CentralClientConstants;
 
 import java.io.PrintStream;
 
@@ -60,6 +61,8 @@ public class CompileTask implements Task {
         }
         // Print the source
         this.out.println("\t" + sourceName);
+
+        System.setProperty(CentralClientConstants.ENABLE_OUTPUT_STREAM, "false");
 
         try {
             long start = 0;

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/CompileTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/CompileTask.java
@@ -62,7 +62,7 @@ public class CompileTask implements Task {
         // Print the source
         this.out.println("\t" + sourceName);
 
-        System.setProperty(CentralClientConstants.ENABLE_OUTPUT_STREAM, "false");
+        System.setProperty(CentralClientConstants.ENABLE_OUTPUT_STREAM, "true");
 
         try {
             long start = 0;

--- a/cli/central-client/src/main/java/org/ballerinalang/central/client/CentralAPIClient.java
+++ b/cli/central-client/src/main/java/org/ballerinalang/central/client/CentralAPIClient.java
@@ -352,8 +352,8 @@ public class CentralAPIClient {
     }
 
     public void pullPackage(String org, String name, String version, Path packagePathInBalaCache,
-                            String supportedPlatform, String ballerinaVersion, boolean isBuild) throws CentralClientException {
-
+                            String supportedPlatform, String ballerinaVersion, boolean isBuild)
+            throws CentralClientException {
         pullPackage(org, name, version, packagePathInBalaCache, supportedPlatform, ballerinaVersion, isBuild, false);
     }
 

--- a/cli/central-client/src/main/java/org/ballerinalang/central/client/CentralAPIClient.java
+++ b/cli/central-client/src/main/java/org/ballerinalang/central/client/CentralAPIClient.java
@@ -280,7 +280,7 @@ public class CentralAPIClient {
 
             // Successfully pushed
             if (packagePushResponse.code() == HTTP_NO_CONTENT) {
-                if (!enableOutputStream) {
+                if (enableOutputStream) {
                     this.outStream.println(packageSignature + " pushed to central successfully");
                 }
                 return;

--- a/cli/central-client/src/main/java/org/ballerinalang/central/client/CentralAPIClient.java
+++ b/cli/central-client/src/main/java/org/ballerinalang/central/client/CentralAPIClient.java
@@ -243,7 +243,14 @@ public class CentralAPIClient {
     }
 
     /**
-     * Pushing a package to registry.
+     * Push a package to registry.
+     *
+     * @param balaPath              The path to the bala file.
+     * @param org                   The organization of the package.
+     * @param name                  The name of the package.
+     * @param version               The version of the package.
+     * @param supportedPlatform     The supported platform.
+     * @param ballerinaVersion      The ballerina version.
      */
     public void pushPackage(Path balaPath, String org, String name, String version, String supportedPlatform,
                             String ballerinaVersion) throws CentralClientException {
@@ -348,7 +355,16 @@ public class CentralAPIClient {
     }
 
     /**
-     * Pulling a package.
+     * Pull a package from central.
+     *
+     * @param org                       The organization of the package.
+     * @param name                      The name of the package.
+     * @param version                   The version of the package.
+     * @param packagePathInBalaCache    The package path in Bala cache.
+     * @param supportedPlatform         The supported platform.
+     * @param ballerinaVersion          The ballerina version.
+     * @param isBuild                   If build option is enabled or not.
+     * @throws CentralClientException   Central Client exception.
      */
     public void pullPackage(String org, String name, String version, Path packagePathInBalaCache,
                             String supportedPlatform, String ballerinaVersion, boolean isBuild)

--- a/cli/central-client/src/main/java/org/ballerinalang/central/client/CentralAPIClient.java
+++ b/cli/central-client/src/main/java/org/ballerinalang/central/client/CentralAPIClient.java
@@ -241,12 +241,18 @@ public class CentralAPIClient {
             }
         }
     }
-    
+
     /**
      * Pushing a package to registry.
      */
+
     public void pushPackage(Path balaPath, String org, String name, String version, String supportedPlatform,
                             String ballerinaVersion) throws CentralClientException {
+        pushPackage(balaPath, org, name, version, supportedPlatform, ballerinaVersion, false);
+    }
+
+    public void pushPackage(Path balaPath, String org, String name, String version, String supportedPlatform,
+                            String ballerinaVersion, boolean disableOutStream) throws CentralClientException {
         String packageSignature = org + "/" + name + ":" + version;
         String url = this.baseUrl + "/" + PACKAGES;
         Optional<ResponseBody> body = Optional.empty();
@@ -263,12 +269,13 @@ public class CentralAPIClient {
                     .addFormDataPart("bala-file", fileName,
                             RequestBody.create(MediaType.parse(APPLICATION_OCTET_STREAM), balaPath.toFile()))
                     .build();
-    
+
             ProgressRequestBody balaFileReqBodyWithProgressBar = new ProgressRequestBody(balaFileReqBody,
                     packageSignature + " [project repo -> central]", this.outStream);
 
+            // If OutStream is disabled, then pass `balaFileReqBody` only
             Request pushRequest = getNewRequest(supportedPlatform, ballerinaVersion)
-                    .post(balaFileReqBodyWithProgressBar)
+                    .post(disableOutStream ? balaFileReqBody : balaFileReqBodyWithProgressBar)
                     .url(url)
                     .build();
 
@@ -277,7 +284,9 @@ public class CentralAPIClient {
 
             // Successfully pushed
             if (packagePushResponse.code() == HTTP_NO_CONTENT) {
-                this.outStream.println(packageSignature + " pushed to central successfully");
+                if (!disableOutStream) {
+                    this.outStream.println(packageSignature + " pushed to central successfully");
+                }
                 return;
             }
 

--- a/cli/central-client/src/main/java/org/ballerinalang/central/client/CentralAPIClient.java
+++ b/cli/central-client/src/main/java/org/ballerinalang/central/client/CentralAPIClient.java
@@ -352,7 +352,14 @@ public class CentralAPIClient {
     }
 
     public void pullPackage(String org, String name, String version, Path packagePathInBalaCache,
-            String supportedPlatform, String ballerinaVersion, boolean isBuild) throws CentralClientException {
+                            String supportedPlatform, String ballerinaVersion, boolean isBuild) throws CentralClientException {
+
+        pullPackage(org, name, version, packagePathInBalaCache, supportedPlatform, ballerinaVersion, isBuild, false);
+    }
+
+    public void pullPackage(String org, String name, String version, Path packagePathInBalaCache,
+                            String supportedPlatform, String ballerinaVersion, boolean isBuild,
+                            boolean disableOutStream) throws CentralClientException {
         String packageSignature =  org + "/" + name;
         String url = this.baseUrl + "/" + PACKAGES + "/" + org + "/" + name;
         // append version to url if available
@@ -399,8 +406,10 @@ public class CentralAPIClient {
                     Call downloadBalaRequestCall = client.newCall(downloadBalaRequest);
                     Response balaDownloadResponse = downloadBalaRequestCall.execute();
                     boolean isNightlyBuild = ballerinaVersion.contains("SNAPSHOT");
+
                     createBalaInHomeRepo(balaDownloadResponse, packagePathInBalaCache, org, name, isNightlyBuild,
-                            balaUrl.get(), balaFileName.get(), outStream, logFormatter);
+                            balaUrl.get(), balaFileName.get(), disableOutStream ? null : outStream, logFormatter);
+
                     return;
                 } else {
                     String errorMsg = logFormatter.formatLog(ERR_CANNOT_PULL_PACKAGE + "'" + packageSignature +

--- a/cli/central-client/src/main/java/org/ballerinalang/central/client/CentralClientConstants.java
+++ b/cli/central-client/src/main/java/org/ballerinalang/central/client/CentralClientConstants.java
@@ -40,4 +40,5 @@ public class CentralClientConstants {
     static final String CONTENT_DISPOSITION = "Content-Disposition";
     static final String APPLICATION_OCTET_STREAM = "application/octet-stream";
     static final String APPLICATION_JSON = "application/json";
+    public static final String ENABLE_OUTPUT_STREAM = "enableOutputStream";
 }

--- a/cli/central-client/src/main/java/org/ballerinalang/central/client/Utils.java
+++ b/cli/central-client/src/main/java/org/ballerinalang/central/client/Utils.java
@@ -205,8 +205,14 @@ public class Utils {
             try {
                 try (InputStream inputStream = body.get().byteStream();
                      FileOutputStream outputStream = new FileOutputStream(balaPath.toString())) {
-                    writeAndHandleProgress(inputStream, outputStream, resContentLength / 1024, fullPkgName,
-                            outStream, logFormatter);
+
+                    if (outStream == null) {
+                        writeAndHandleProgressWithoutLogging(inputStream, outputStream, fullPkgName, logFormatter);
+                    } else {
+                        writeAndHandleProgress(inputStream, outputStream, resContentLength / 1024, fullPkgName,
+                                outStream, logFormatter);
+                    }
+
                 } catch (IOException e) {
                     throw new CentralClientException(
                             logFormatter.formatLog("error occurred copying the bala file: " + e.getMessage()));
@@ -271,6 +277,23 @@ public class Utils {
             outStream.println(logFormatter.formatLog(fullPkgName + "pulling the package from central failed"));
         } finally {
             outStream.println(logFormatter.formatLog(fullPkgName + " pulled from central successfully"));
+        }
+    }
+
+    private static void writeAndHandleProgressWithoutLogging(InputStream inputStream, FileOutputStream outputStream,
+                                                             String fullPkgName, LogFormatter logFormatter) {
+        int count;
+        byte[] buffer = new byte[1024];
+
+        try {
+            while ((count = inputStream.read(buffer)) > 0) {
+                outputStream.write(buffer, 0, count);
+            }
+        } catch (IOException e) {
+            PrintStream printStream = System.out;
+
+            printStream.println(logFormatter.formatLog(fullPkgName + "pulling the package from central failed"));
+
         }
     }
 

--- a/cli/central-client/src/main/java/org/ballerinalang/central/client/Utils.java
+++ b/cli/central-client/src/main/java/org/ballerinalang/central/client/Utils.java
@@ -206,7 +206,7 @@ public class Utils {
                 try (InputStream inputStream = body.get().byteStream();
                      FileOutputStream outputStream = new FileOutputStream(balaPath.toString())) {
                     if (outStream == null) {
-                        writeAndHandleProgressWithoutLogging(inputStream, outputStream);
+                        writeAndHandleProgressQuietly(inputStream, outputStream);
                     } else {
                         writeAndHandleProgress(inputStream, outputStream, resContentLength / 1024, fullPkgName,
                                 outStream, logFormatter);
@@ -260,7 +260,8 @@ public class Utils {
      * @param logFormatter  log formatter
      */
     private static void writeAndHandleProgress(InputStream inputStream, FileOutputStream outputStream,
-            long totalSizeInKB, String fullPkgName, PrintStream outStream, LogFormatter logFormatter) {
+            long totalSizeInKB, String fullPkgName, PrintStream outStream, LogFormatter logFormatter)
+            throws IOException {
         int count;
         byte[] buffer = new byte[1024];
 
@@ -271,14 +272,12 @@ public class Utils {
                 outputStream.write(buffer, 0, count);
                 progressBar.step();
             }
-        } catch (IOException e) {
-            outStream.println(logFormatter.formatLog(fullPkgName + "pulling the package from central failed"));
         } finally {
             outStream.println(logFormatter.formatLog(fullPkgName + " pulled from central successfully"));
         }
     }
 
-    private static void writeAndHandleProgressWithoutLogging(InputStream inputStream, FileOutputStream outputStream)
+    private static void writeAndHandleProgressQuietly(InputStream inputStream, FileOutputStream outputStream)
             throws IOException {
         int count;
         byte[] buffer = new byte[1024];

--- a/cli/central-client/src/main/java/org/ballerinalang/central/client/Utils.java
+++ b/cli/central-client/src/main/java/org/ballerinalang/central/client/Utils.java
@@ -205,14 +205,12 @@ public class Utils {
             try {
                 try (InputStream inputStream = body.get().byteStream();
                      FileOutputStream outputStream = new FileOutputStream(balaPath.toString())) {
-
                     if (outStream == null) {
-                        writeAndHandleProgressWithoutLogging(inputStream, outputStream, fullPkgName, logFormatter);
+                        writeAndHandleProgressWithoutLogging(inputStream, outputStream);
                     } else {
                         writeAndHandleProgress(inputStream, outputStream, resContentLength / 1024, fullPkgName,
                                 outStream, logFormatter);
                     }
-
                 } catch (IOException e) {
                     throw new CentralClientException(
                             logFormatter.formatLog("error occurred copying the bala file: " + e.getMessage()));
@@ -280,20 +278,13 @@ public class Utils {
         }
     }
 
-    private static void writeAndHandleProgressWithoutLogging(InputStream inputStream, FileOutputStream outputStream,
-                                                             String fullPkgName, LogFormatter logFormatter) {
+    private static void writeAndHandleProgressWithoutLogging(InputStream inputStream, FileOutputStream outputStream)
+            throws IOException {
         int count;
         byte[] buffer = new byte[1024];
 
-        try {
-            while ((count = inputStream.read(buffer)) > 0) {
-                outputStream.write(buffer, 0, count);
-            }
-        } catch (IOException e) {
-            PrintStream printStream = System.out;
-
-            printStream.println(logFormatter.formatLog(fullPkgName + "pulling the package from central failed"));
-
+        while ((count = inputStream.read(buffer)) > 0) {
+            outputStream.write(buffer, 0, count);
         }
     }
 

--- a/cli/central-client/src/test/java/org/ballerinalang/central/client/TestCentralApiClient.java
+++ b/cli/central-client/src/test/java/org/ballerinalang/central/client/TestCentralApiClient.java
@@ -528,55 +528,6 @@ public class TestCentralApiClient extends CentralAPIClient {
         }
     }
 
-    @Test(description = "Test pull package without Logs", enabled = false)
-    public void testPullPackageWithoutLogs() throws IOException, CentralClientException {
-        System.setProperty(CentralClientConstants.ENABLE_OUTPUT_STREAM, "false");
-        final String balaUrl = "https://fileserver.dev-central.ballerina.io/2.0/wso2/sf/1.3.5/sf-2020r2-any-1.3.5.bala";
-        Path balaPath = UTILS_TEST_RESOURCES.resolve(TEST_BALA_NAME);
-        File balaFile = new File(String.valueOf(balaPath));
-        InputStream balaStream = null;
-
-        try {
-            balaStream = new FileInputStream(balaFile);
-
-            Request mockRequest = new Request.Builder()
-                    .get()
-                    .url("https://localhost:9090/registry/packages/foo/sf/1.3.5")
-                    .addHeader(ACCEPT_ENCODING, IDENTITY)
-                    .addHeader(ACCEPT, APPLICATION_OCTET_STREAM)
-                    .build();
-            Response mockResponse = new Response.Builder()
-                    .request(mockRequest)
-                    .protocol(Protocol.HTTP_1_1)
-                    .code(HttpURLConnection.HTTP_MOVED_TEMP)
-                    .addHeader(LOCATION, balaUrl)
-                    .addHeader(CONTENT_DISPOSITION, "attachment; filename=sf-2020r2-any-1.3.5.bala")
-                    .message("")
-                    .body(ResponseBody.create(
-                            MediaType.get(APPLICATION_OCTET_STREAM),
-                            Files.readAllBytes(balaPath)
-                    ))
-                    .build();
-
-            when(this.remoteCall.execute()).thenReturn(mockResponse);
-            when(this.client.newCall(any())).thenReturn(this.remoteCall);
-
-            this.pullPackage("foo", "sf", "1.3.5", TMP_DIR, ANY_PLATFORM, TEST_BAL_VERSION, false);
-
-            Assert.assertTrue(TMP_DIR.resolve("1.3.5").resolve("sf-2020r2-any-1.3.5.bala").toFile().exists());
-            String buildLog = readOutput();
-            given().with().pollInterval(Duration.ONE_SECOND).and().with().pollDelay(Duration.ONE_SECOND).await()
-                    .atMost(10, SECONDS)
-                    .until(() -> !(buildLog.contains("foo/sf:1.3.5 pulled from central successfully")));
-        } finally {
-            if (balaStream != null) {
-                balaStream.close();
-            }
-            cleanTmpDir();
-            System.setProperty(CentralClientConstants.ENABLE_OUTPUT_STREAM, "true");
-        }
-    }
-
     @Test(description = "Test push package without logs")
     public void testPushPackageWithoutLogs() throws IOException, CentralClientException {
         System.setProperty(CentralClientConstants.ENABLE_OUTPUT_STREAM, "false");


### PR DESCRIPTION
## Purpose
Add option to disable 'Printing to console' for Central API Client functions.

Inorder to fix the following issue :

> When the `CentralAPIClient` is pulling a module, it prints the success message (and progress) to stdout. Since language server and vscode language client communicates over the stdin/stdout using JSON RPC, above behavior cause non-json content to be written into stdout. This breaks the language server protocol and causes LS to not work there onward.

Fixes #31711

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
