### PR TITLE
Fix issues with tuple type conversion

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeConverter.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeConverter.java
@@ -455,14 +455,9 @@ public class TypeConverter {
                 return true;
             }
         }
-        Set<Type> convertibleTypes;
+
         for (int i = 0; i < source.size(); i++) {
-            convertibleTypes = getConvertibleTypes(source.get(i), targetTypeElementType, unresolvedValues);
-            if (convertibleTypes.isEmpty()) {
-                return false;
-            }
-            if (convertibleTypes.size() != 1 && !convertibleTypes.contains(TypeChecker.getType(source.get(i)))
-                    && !hasIntegerSubTypes(convertibleTypes)) {
+            if (!isConvertibleToArrayInstance(source.get(i), targetTypeElementType, unresolvedValues)) {
                 return false;
             }
         }
@@ -488,28 +483,29 @@ public class TypeConverter {
             return false;
         }
 
-        Set<Type> convertibleTypes;
-
         for (int i = 0; i < targetTypeSize; i++) {
-            convertibleTypes = getConvertibleTypes(source.getRefValue(i), targetTypes.get(i), unresolvedValues);
-            if (convertibleTypes.isEmpty()) {
-                return false;
-            }
-            if (convertibleTypes.size() > 1 && !convertibleTypes.contains(TypeChecker.getType(source.getRefValue(i)))
-                    && !hasIntegerSubTypes(convertibleTypes)) {
+            if (!isConvertibleToArrayInstance(source.getRefValue(i), targetTypes.get(i), unresolvedValues)) {
                 return false;
             }
         }
 
         for (int i = targetTypeSize; i < sourceTypeSize; i++) {
-            convertibleTypes = getConvertibleTypes(source.getRefValue(i), targetRestType, unresolvedValues);
-            if (convertibleTypes.isEmpty()) {
+            if (!isConvertibleToArrayInstance(source.getRefValue(i), targetRestType, unresolvedValues)) {
                 return false;
             }
-            if (convertibleTypes.size() > 1 && !convertibleTypes.contains(TypeChecker.getType(source.getRefValue(i)))
-                    && !hasIntegerSubTypes(convertibleTypes)) {
-                return false;
-            }
+        }
+        return true;
+    }
+
+    private static boolean isConvertibleToArrayInstance(Object sourceElement, Type targetType,
+                                                        List<TypeValuePair> unresolvedValues) {
+        Set<Type> convertibleTypes = getConvertibleTypes(sourceElement, targetType, unresolvedValues);
+        if (convertibleTypes.isEmpty()) {
+            return false;
+        }
+        if (convertibleTypes.size() > 1 && !convertibleTypes.contains(TypeChecker.getType(sourceElement))
+                && !hasIntegerSubTypes(convertibleTypes)) {
+            return false;
         }
         return true;
     }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeConverter.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeConverter.java
@@ -476,10 +476,7 @@ public class TypeConverter {
         int targetTypeSize = targetTypes.size();
         Type targetRestType = targetType.getRestType();
 
-        if (sourceTypeSize < targetTypeSize) {
-            return false;
-        }
-        if (targetRestType == null && sourceTypeSize > targetTypeSize) {
+        if (sourceTypeSize < targetTypeSize || (targetRestType == null && sourceTypeSize > targetTypeSize)) {
             return false;
         }
 
@@ -500,9 +497,13 @@ public class TypeConverter {
     private static boolean isConvertibleToArrayInstance(Object sourceElement, Type targetType,
                                                         List<TypeValuePair> unresolvedValues) {
         Set<Type> convertibleTypes = getConvertibleTypes(sourceElement, targetType, unresolvedValues);
-        if (convertibleTypes.isEmpty()) {
+        if (convertibleTypes.isEmpty() || !isConvertible(convertibleTypes, sourceElement)) {
             return false;
         }
+        return true;
+    }
+
+    private static boolean isConvertible(Set<Type> convertibleTypes, Object sourceElement) {
         if (convertibleTypes.size() > 1 && !convertibleTypes.contains(TypeChecker.getType(sourceElement))
                 && !hasIntegerSubTypes(convertibleTypes)) {
             return false;

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibValueTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibValueTest.java
@@ -336,6 +336,8 @@ public class LangLibValueTest {
                 { "testCloneWithTypeToArrayOfRecord" },
                 { "testCloneWithTypeToArrayOfMap" },
                 { "testCloneWithTypeIntArrayToUnionArray" },
+                { "testCloneWithTypeArrayToTuple" },
+                { "testCloneWithTypeTuple" },
                 { "testCloneWithTypeIntSubTypeArray" },
                 { "testCloneWithTypeStringArray" },
                 { "testCloneWithTypeWithInferredArgument" },

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibValueTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibValueTest.java
@@ -336,25 +336,45 @@ public class LangLibValueTest {
                 { "testCloneWithTypeToArrayOfRecord" },
                 { "testCloneWithTypeToArrayOfMap" },
                 { "testCloneWithTypeIntArrayToUnionArray" },
-                { "testCloneWithTypeArrayToTuple" },
-                { "testCloneWithTypeTuple" },
                 { "testCloneWithTypeIntSubTypeArray" },
                 { "testCloneWithTypeStringArray" },
                 { "testCloneWithTypeWithInferredArgument" },
                 { "testCloneWithTypeWithImmutableTypes" },
                 { "testCloneWithTypeDecimalToInt"},
-                {"testCloneWithTypeDecimalToIntNegative"},
+                { "testCloneWithTypeDecimalToIntNegative" },
                 { "testCloneWithTypeDecimalToByte"},
                 { "testCloneWithTypeDecimalToIntSubType"},
                 { "testCloneWithTypeTupleToJSON"},
                 { "testCloneWithTypeImmutableStructuredTypes"},
-                {"testCloneWithTypeWithFiniteArrayTypeFromIntArray"},
+                { "testCloneWithTypeWithFiniteArrayTypeFromIntArray" },
                 { "testCloneWithTypeWithFiniteType" },
                 { "testCloneWithTypeWithUnionOfFiniteType" },
                 { "testCloneWithTypeWithFiniteArrayTypeFromIntArray" },
                 { "testCloneWithTypeWithUnionOfFiniteTypeArraysFromIntArray" },
                 { "testCloneWithTypeWithUnionTypeArrayFromIntArray" },
                 { "testCloneWithTypeWithFiniteTypeArrayFromIntArrayNegative" }
+        };
+    }
+
+    @Test(dataProvider = "cloneWithTypeToTupleTypeFunctions")
+    public void testCloneWithTypeToTuple(String function) {
+        BRunUtil.invoke(compileResult, function);
+    }
+
+    @DataProvider(name = "cloneWithTypeToTupleTypeFunctions")
+    public Object[][] cloneWithTypeToTupleTypeFunctions() {
+        return new Object[][] {
+                { "testCloneWithTypeArrayToTupleWithRestType" },
+                { "testCloneWithTypeArrayToTupleWithRestTypeUnionType" },
+                { "testCloneWithTypeArrayToUnionTupleNegative" },
+                { "testCloneWithTypeArrayToTupleWithMoreTargetTypes" },
+                { "testCloneWithTypeArrayToTupleWithUnionRestTypeNegative" },
+                { "testCloneWithTypeArrayToTupleNegative" },
+                { "testCloneWithTypeArrayToTupleWithStructureRestTypeNegative" },
+                { "testCloneWithTypeTupleRestType" },
+                { "testCloneWithTypeUnionTuple" },
+                { "testCloneWithTypeTupleRestTypeNegative" },
+                { "testCloneWithTypeUnionTupleRestTypeNegative" }
         };
     }
 

--- a/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
@@ -951,6 +951,14 @@ function testCloneWithTypeArrayToTuple() {
     messageString = message is error ? message.toString() : message.toString();
     assert(err.message(), "{ballerina/lang.typedesc}ConversionError");
     assert(messageString, "'int[]' value cannot be converted to '[(float|decimal),(int|byte)...]'");
+
+    [string, string:Char, string|string:Char]|error f = arr.cloneWithType();
+    assert(f is error, true);
+    err = <error> f;
+    message = err.detail()["message"];
+    messageString = message is error ? message.toString() : message.toString();
+    assert(err.message(), "{ballerina/lang.typedesc}ConversionError");
+    assert(messageString, "'int[]' value cannot be converted to '[string,lang.string:Char,(string|lang.string:Char)]'");
 }
 
 function testCloneWithTypeTuple() {
@@ -961,6 +969,22 @@ function testCloneWithTypeTuple() {
 
     [byte|int:Unsigned8, int|float, int|byte, byte|int:Unsigned32]|error b = t.cloneWithType();
     assert(checkpanic b, [1, 2.5, 3, 5]);
+
+    [string...]|error c = t.cloneWithType();
+    assert(c is error, true);
+    error err = <error> c;
+    var message = err.detail()["message"];
+    string messageString = message is error ? message.toString() : message.toString();
+    assert(err.message(), "{ballerina/lang.typedesc}ConversionError");
+    assert(messageString, "'[int,float,(int|float)...]' value cannot be converted to '[string...]'");
+
+    [int|float, decimal|int...]|error d = t.cloneWithType();
+    assert(d is error, true);
+    err = <error> d;
+    message = err.detail()["message"];
+    messageString = message is error ? message.toString() : message.toString();
+    assert(err.message(), "{ballerina/lang.typedesc}ConversionError");
+    assert(messageString, "'[int,float,(int|float)...]' value cannot be converted to '[(int|float),(decimal|int)...]'");
 }
 
 type StringArray string[];

--- a/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
@@ -919,6 +919,50 @@ function testCloneWithTypeIntArrayToUnionArray() {
     assert(messageString, "'float[]' value cannot be converted to '(lang.int:Signed16|lang.int:Unsigned8|decimal)[]'");
 }
 
+function testCloneWithTypeArrayToTuple() {
+    int[] arr = [1, 2, 3];
+
+    [decimal, byte...]|error a = arr.cloneWithType();
+    assert(checkpanic a, <[decimal, byte...]> [1.0, 2, 3]);
+
+    [int|decimal, byte|int:Unsigned8...]|error b = arr.cloneWithType();
+    assert(checkpanic b, [1, 2, 3]);
+
+    [int|decimal, byte|int:Unsigned8]|error c = arr.cloneWithType();
+    assert(c is error, true);
+    error err = <error> c;
+    var message = err.detail()["message"];
+    string messageString = message is error ? message.toString() : message.toString();
+    assert(err.message(), "{ballerina/lang.typedesc}ConversionError");
+    assert(messageString, "'int[]' value cannot be converted to '[(int|decimal),(byte|lang.int:Unsigned8)]'");
+
+    [int, float, decimal, byte]|error d = arr.cloneWithType();
+    assert(d is error, true);
+    err = <error> d;
+    message = err.detail()["message"];
+    messageString = message is error ? message.toString() : message.toString();
+    assert(err.message(), "{ballerina/lang.typedesc}ConversionError");
+    assert(messageString, "'int[]' value cannot be converted to '[int,float,decimal,byte]'");
+
+    [float|decimal, int|byte...]|error e = arr.cloneWithType();
+    assert(e is error, true);
+    err = <error> e;
+    message = err.detail()["message"];
+    messageString = message is error ? message.toString() : message.toString();
+    assert(err.message(), "{ballerina/lang.typedesc}ConversionError");
+    assert(messageString, "'int[]' value cannot be converted to '[(float|decimal),(int|byte)...]'");
+}
+
+function testCloneWithTypeTuple() {
+    [int, float, int|float...] t = [1, 2.5, 3, 5.2];
+
+    [float...]|error a = t.cloneWithType();
+    assert(checkpanic a, [1.0, 2.5, 3.0, 5.2]);
+
+    [byte|int:Unsigned8, int|float, int|byte, byte|int:Unsigned32]|error b = t.cloneWithType();
+    assert(checkpanic b, [1, 2.5, 3, 5]);
+}
+
 type StringArray string[];
 function testCloneWithTypeStringArray() {
    string anArray = "[\"hello\", \"world\"]";

--- a/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
@@ -919,15 +919,20 @@ function testCloneWithTypeIntArrayToUnionArray() {
     assert(messageString, "'float[]' value cannot be converted to '(lang.int:Signed16|lang.int:Unsigned8|decimal)[]'");
 }
 
-function testCloneWithTypeArrayToTuple() {
+function testCloneWithTypeArrayToTupleWithRestType() {
     int[] arr = [1, 2, 3];
-
     [decimal, byte...]|error a = arr.cloneWithType();
     assert(checkpanic a, <[decimal, byte...]> [1.0, 2, 3]);
+}
 
+function testCloneWithTypeArrayToTupleWithRestTypeUnionType() {
+    int[] arr = [1, 128, 255];
     [int|decimal, byte|int:Unsigned8...]|error b = arr.cloneWithType();
-    assert(checkpanic b, [1, 2, 3]);
+    assert(checkpanic b, [1, 128, 255]);
+}
 
+function testCloneWithTypeArrayToUnionTupleNegative() {
+    int[] arr = [1, 2, 3];
     [int|decimal, byte|int:Unsigned8]|error c = arr.cloneWithType();
     assert(c is error, true);
     error err = <error> c;
@@ -935,48 +940,68 @@ function testCloneWithTypeArrayToTuple() {
     string messageString = message is error ? message.toString() : message.toString();
     assert(err.message(), "{ballerina/lang.typedesc}ConversionError");
     assert(messageString, "'int[]' value cannot be converted to '[(int|decimal),(byte|lang.int:Unsigned8)]'");
+}
 
+function testCloneWithTypeArrayToTupleWithMoreTargetTypes() {
+    int[] arr = [1, 2];
     [int, float, decimal, byte]|error d = arr.cloneWithType();
     assert(d is error, true);
-    err = <error> d;
-    message = err.detail()["message"];
-    messageString = message is error ? message.toString() : message.toString();
+    error err = <error> d;
+    var message = err.detail()["message"];
+    string messageString = message is error ? message.toString() : message.toString();
     assert(err.message(), "{ballerina/lang.typedesc}ConversionError");
     assert(messageString, "'int[]' value cannot be converted to '[int,float,decimal,byte]'");
+}
 
+function testCloneWithTypeArrayToTupleWithUnionRestTypeNegative() {
+    int[] arr = [1, 2, 3];
     [float|decimal, int|byte...]|error e = arr.cloneWithType();
     assert(e is error, true);
-    err = <error> e;
-    message = err.detail()["message"];
-    messageString = message is error ? message.toString() : message.toString();
+    error err = <error> e;
+    var message = err.detail()["message"];
+    string messageString = message is error ? message.toString() : message.toString();
     assert(err.message(), "{ballerina/lang.typedesc}ConversionError");
     assert(messageString, "'int[]' value cannot be converted to '[(float|decimal),(int|byte)...]'");
+}
 
+function testCloneWithTypeArrayToTupleNegative() {
+    float[] arr = [1, 2.3, 3.5];
     [string, string:Char, string|string:Char]|error f = arr.cloneWithType();
     assert(f is error, true);
-    err = <error> f;
-    message = err.detail()["message"];
-    messageString = message is error ? message.toString() : message.toString();
+    error err = <error> f;
+    var message = err.detail()["message"];
+    string messageString = message is error ? message.toString() : message.toString();
     assert(err.message(), "{ballerina/lang.typedesc}ConversionError");
-    assert(messageString, "'int[]' value cannot be converted to '[string,lang.string:Char,(string|lang.string:Char)]'");
+    assert(messageString, "'float[]' value cannot be converted to '[string,lang.string:Char,(string|lang.string:Char)]'");
+}
 
+function testCloneWithTypeArrayToTupleWithStructureRestTypeNegative() {
+    int[] arr = [10, 20, 30];
     [map<int>, [string, int]...]|error g = arr.cloneWithType();
     assert(g is error, true);
-    err = <error> g;
-    message = err.detail()["message"];
-    messageString = message is error ? message.toString() : message.toString();
+    error err = <error> g;
+    var message = err.detail()["message"];
+    string messageString = message is error ? message.toString() : message.toString();
     assert(err.message(), "{ballerina/lang.typedesc}ConversionError");
     assert(messageString, "'int[]' value cannot be converted to '[map<int>,[string,int]...]'");
 }
 
-function testCloneWithTypeTuple() {
+function testCloneWithTypeTupleRestType() {
     [int, float, int|float...] t = [1, 2.5, 3, 5.2];
 
     [float...]|error a = t.cloneWithType();
     assert(checkpanic a, [1.0, 2.5, 3.0, 5.2]);
+}
+
+function testCloneWithTypeUnionTuple() {
+    [int, float, int|decimal...] t = [1, 2.5, 3, 4.2];
 
     [byte|int:Unsigned8, int|float, int|byte, byte|int:Unsigned32]|error b = t.cloneWithType();
-    assert(checkpanic b, [1, 2.5, 3, 5]);
+    assert(checkpanic b, [1, 2.5, 3, 4]);
+}
+
+function testCloneWithTypeTupleRestTypeNegative() {
+    [int, float, int|float...] t = [1, 2.5, 3, 5.2];
 
     [string...]|error c = t.cloneWithType();
     assert(c is error, true);
@@ -985,12 +1010,16 @@ function testCloneWithTypeTuple() {
     string messageString = message is error ? message.toString() : message.toString();
     assert(err.message(), "{ballerina/lang.typedesc}ConversionError");
     assert(messageString, "'[int,float,(int|float)...]' value cannot be converted to '[string...]'");
+}
+
+function testCloneWithTypeUnionTupleRestTypeNegative() {
+    [int, float, int|float...] t = [1, 2.5, 3, 5.2];
 
     [int|float, decimal|int...]|error d = t.cloneWithType();
     assert(d is error, true);
-    err = <error> d;
-    message = err.detail()["message"];
-    messageString = message is error ? message.toString() : message.toString();
+    error err = <error> d;
+    var message = err.detail()["message"];
+    string messageString = message is error ? message.toString() : message.toString();
     assert(err.message(), "{ballerina/lang.typedesc}ConversionError");
     assert(messageString, "'[int,float,(int|float)...]' value cannot be converted to '[(int|float),(decimal|int)...]'");
 }

--- a/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
@@ -959,6 +959,14 @@ function testCloneWithTypeArrayToTuple() {
     messageString = message is error ? message.toString() : message.toString();
     assert(err.message(), "{ballerina/lang.typedesc}ConversionError");
     assert(messageString, "'int[]' value cannot be converted to '[string,lang.string:Char,(string|lang.string:Char)]'");
+
+    [map<int>, [string, int]...]|error g = arr.cloneWithType();
+    assert(g is error, true);
+    err = <error> g;
+    message = err.detail()["message"];
+    messageString = message is error ? message.toString() : message.toString();
+    assert(err.message(), "{ballerina/lang.typedesc}ConversionError");
+    assert(messageString, "'int[]' value cannot be converted to '[map<int>,[string,int]...]'");
 }
 
 function testCloneWithTypeTuple() {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/conversion/NativeConversionNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/conversion/NativeConversionNegativeTest.java
@@ -74,14 +74,6 @@ public class NativeConversionNegativeTest {
         Assert.assertEquals(errorMsg, "'map<anydata>' value cannot be converted to 'StructWithoutDefaults'");
     }
 
-    @Test(description = "Test performing an invalid tuple conversion")
-    public void testTupleConversionFail() {
-        BValue[] returns = BRunUtil.invoke(negativeResult, "testTupleConversionFail");
-        String errorMsg = ((BMap<String, BValue>) ((BError) returns[0]).getDetails()).get("message").stringValue();
-        Assert.assertEquals(errorMsg, "'[T1,T1]' value cannot be converted to '[T1,"
-                + "T2]'");
-    }
-
     @Test(description = "Test converting an unsupported array to json")
     public void testArrayToJsonFail() {
         BValue[] returns = BRunUtil.invoke(negativeResult, "testArrayToJsonFail");

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/conversion/NativeConversionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/conversion/NativeConversionTest.java
@@ -578,8 +578,7 @@ public class NativeConversionTest {
 
     @Test
     public void testTupleConversion1() {
-        BValue[] returns = BRunUtil.invoke(compileResult, "testTupleConversion1");
-        Assert.assertEquals(returns.length, 2);
+        BRunUtil.invoke(compileResult, "testTupleConversion1");
     }
 
     @Test

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/conversion/native-conversion-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/conversion/native-conversion-negative.bal
@@ -109,16 +109,6 @@ function testEmptyMaptoStructWithoutDefaults () returns StructWithoutDefaults|er
     return testStruct;
 }
 
-function testTupleConversionFail() returns [T1, T2] | error {
-    T1 a = {};
-    T1 b = {};
-    [T1, T1] x = [a, b];
-    [T1, T2] x2;
-    anydata y = x;
-    var result = y.cloneWithType(T1_T2);
-    return result;
-}
-
 function testArrayToJsonFail() returns json|error {
     TX[] x = [];
     TX a = {};

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/conversion/native-conversion.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/conversion/native-conversion.bal
@@ -860,14 +860,14 @@ public class O1 {
 function testTupleConversion1() {
     T1 a = {};
     T2 b = {};
-    [T1, T2] x1 = [a, b];
-    [T1, T1] x2;
+    T1_T2 x1 = [a, b];
+    T1_T1 x2;
     anydata y = x1;
     x2 = checkpanic y.cloneWithType(T1_T1);
 
     T1 c = {};
-    [T1, T1] x3 = [a, c];
-    [T1, T2] x4;
+    T1_T1 x3 = [a, c];
+    T1_T2 x4;
     anydata z = x3;
     x4 = checkpanic z.cloneWithType(T1_T2);
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/conversion/native-conversion.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/conversion/native-conversion.bal
@@ -15,6 +15,7 @@
 // under the License.
 
 import ballerina/lang.'int as ints;
+import ballerina/test;
 
 type Person record {|
     string name = "";
@@ -54,6 +55,7 @@ type T2Array T2[];
 type IntArrayType int[];
 type Int_String [int, string];
 type T1_T1 [T1, T1];
+type T1_T2 [T1, T2];
 type personArray person[];
 
 function testStructToMap () returns (map<anydata> | error) {
@@ -855,14 +857,22 @@ public class O1 {
   public int y = 0;
 }
 
-function testTupleConversion1() returns [T1, T1]|error {
+function testTupleConversion1() {
     T1 a = {};
     T2 b = {};
-    [T1, T2] x = [a, b];
+    [T1, T2] x1 = [a, b];
     [T1, T1] x2;
-    anydata y = x;
-    x2 = check y.cloneWithType(T1_T1);
-    return x2;
+    anydata y = x1;
+    x2 = checkpanic y.cloneWithType(T1_T1);
+
+    T1 c = {};
+    [T1, T1] x3 = [a, c];
+    [T1, T2] x4;
+    anydata z = x3;
+    x4 = checkpanic z.cloneWithType(T1_T2);
+
+    test:assertEquals(x2, [{"x":0,"y":0}, {"x":0,"y":0,"z":0}]);
+    test:assertEquals(x4, [{"x":0,"y":0}, {"x":0,"y":0,"z":0}]);
 }
 
 function testTupleConversion2() returns [int, string]|error {


### PR DESCRIPTION
## Purpose
> Fixes the incorrect results with the conversion of tuple types using `cloneWithType()` 

Fixes #31747

## Approach

## Samples

## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
