### PR TITLE
Allow function pointer invocation on object fields

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -478,6 +478,11 @@ public class SymbolResolver extends BLangNodeVisitor {
         return lookupMemberSymbol(pos, objectSymbol.scope, env, fieldName, SymTag.VARIABLE);
     }
 
+    public BSymbol resolveInvocableObjectField(Location pos, SymbolEnv env, Name fieldName,
+                                               BObjectTypeSymbol objectTypeSymbol) {
+        return lookupMemberSymbol(pos, objectTypeSymbol.scope, env, fieldName, SymTag.VARIABLE);
+    }
+
     public BType resolveTypeNode(BLangType typeNode, SymbolEnv env) {
         return resolveTypeNode(typeNode, env, DiagnosticErrorCode.UNKNOWN_TYPE);
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/action/start/ObjectFieldFunctionPointerStartActionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/action/start/ObjectFieldFunctionPointerStartActionTest.java
@@ -1,0 +1,65 @@
+/*
+*  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing,
+*  software distributed under the License is distributed on an
+*  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+*  KIND, either express or implied.  See the License for the
+*  specific language governing permissions and limitations
+*  under the License.
+*/
+package org.ballerinalang.test.action.start;
+
+import org.ballerinalang.test.BCompileUtil;
+import org.ballerinalang.test.BRunUtil;
+import org.ballerinalang.test.CompileResult;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.ballerinalang.test.BAssertUtil.validateError;
+
+/**
+ * Test start action invocation of function pointers which are fields of a class/object with start action syntax.
+ *
+ * @since 2.0
+ */
+public class ObjectFieldFunctionPointerStartActionTest {
+
+    private CompileResult result;
+
+    @BeforeClass
+    public void setup() {
+        result = BCompileUtil.compile(
+                "test-src/action/start/object_field_start_method_invocation.bal");
+    }
+
+    @Test
+    public void testInvocationOfObjectField() {
+        BRunUtil.invoke(result, "testInvocationOfObjectField");
+    }
+
+    @Test
+    public void testInvocationOfObjectFieldWithMutableState() {
+        BRunUtil.invoke(result, "testInvocationOfObjectFieldWithMutableState");
+    }
+
+    @Test
+    public void testMethodCallNegativeCases() {
+        CompileResult neg = BCompileUtil.compile(
+                "test-src/action/start/object_field_start_action_method_invocation_negative.bal");
+        int i = 0;
+        validateError(neg, i++, "missing required parameter '' in call to 'g()'", 30, 25);
+        validateError(neg, i++, "incompatible types: expected 'future<string>', found 'future<int>'", 31, 31);
+        validateError(neg, i++, "incompatible types: expected 'int', found 'string'", 32, 40);
+        validateError(neg, i++, "incompatible types: expected 'int', found 'string'", 34, 25);
+        Assert.assertEquals(i,  neg.getErrorCount());
+    }
+}

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/invocations/ObjectFieldFunctionPointerInvocationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/invocations/ObjectFieldFunctionPointerInvocationTest.java
@@ -1,0 +1,66 @@
+/*
+*  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing,
+*  software distributed under the License is distributed on an
+*  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+*  KIND, either express or implied.  See the License for the
+*  specific language governing permissions and limitations
+*  under the License.
+*/
+package org.ballerinalang.test.expressions.invocations;
+
+import org.ballerinalang.test.BCompileUtil;
+import org.ballerinalang.test.BRunUtil;
+import org.ballerinalang.test.CompileResult;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.ballerinalang.test.BAssertUtil.validateError;
+
+/**
+ * Test invocation of function pointers which are fields of a class/object with method invocation syntax.
+ *
+ * @since 2.0
+ */
+public class ObjectFieldFunctionPointerInvocationTest {
+
+    private CompileResult funcInvocationExpResult;
+
+    @BeforeClass
+    public void setup() {
+        funcInvocationExpResult = BCompileUtil.compile(
+                "test-src/expressions/invocations/object_field_method_invocation.bal");
+    }
+
+    @Test
+    public void testInvocationOfObjectField() {
+        BRunUtil.invoke(funcInvocationExpResult, "testInvocationOfObjectField");
+    }
+
+    @Test
+    public void testInvocationOfObjectFieldWithMutableState() {
+        BRunUtil.invoke(funcInvocationExpResult, "testInvocationOfObjectFieldWithMutableState");
+    }
+
+    @Test
+    public void testMethodCallNegativeCases() {
+        CompileResult neg = BCompileUtil.compile(
+                "test-src/expressions/invocations/object_field_method_invocation_negative.bal");
+        int i = 0;
+        validateError(neg, i++, "too many arguments in call to 'f()'", 29, 13);
+        validateError(neg, i++, "missing required parameter '' in call to 'g()'", 31, 17);
+        validateError(neg, i++, "incompatible types: expected 'string', found 'int'", 32, 23);
+        validateError(neg, i++, "incompatible types: expected 'int', found 'string'", 33, 26);
+        validateError(neg, i++, "incompatible types: expected 'int', found 'string'", 35, 19);
+        Assert.assertEquals(i,  neg.getErrorCount());
+    }
+}

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/FunctionPointersNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/FunctionPointersNegativeTest.java
@@ -83,10 +83,9 @@ public class FunctionPointersNegativeTest {
     public void testFPInvalidInvocation() {
         CompileResult result = BCompileUtil.compile("test-src/expressions/lambda/negative" +
                 "/fp_invalid_invocation_negative.bal");
-        Assert.assertEquals(result.getErrorCount(), 2);
+        Assert.assertEquals(result.getErrorCount(), 1);
         int i = 0;
         BAssertUtil.validateError(result, i++, "undefined field 'getFullName' in record 'Person'", 35, 20);
-        BAssertUtil.validateError(result, i, "undefined method 'getLname' in object 'Employee'", 83, 11);
     }
 
     @Test

--- a/tests/jballerina-unit-test/src/test/resources/test-src/action/start/object_field_start_action_method_invocation_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/action/start/object_field_start_action_method_invocation_negative.bal
@@ -1,0 +1,35 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+class F {
+    function () returns int f = function() returns int => 1;
+    function (int) returns int g = function(int i) returns int => i;
+    function (int...) returns int k = function(int... r) returns int {
+        return r[0];
+    };
+}
+
+function (int) fk = function(int i) {
+};
+
+function extraArg() {
+    F f = new ();
+    future<int> iDash = start f.g(); //  missing required parameter '' in call to 'g()'
+    future<string> iInvalid = start f.g(0); // incompatible types: expected 'future<string>', found 'future<int>'
+    future<int> argInvalid = start f.g("hello"); // incompatible types: expected 'int', found 'string'
+    var restSum = start f.k();
+    restSum = start f.k("hi"); //incompatible types: expected 'int', found 'string'
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/action/start/object_field_start_method_invocation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/action/start/object_field_start_method_invocation.bal
@@ -1,0 +1,140 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+class F {
+    function () returns int f = function() returns int => 1;
+    function () returns int fooDel = foo;
+
+    function foo() returns int {
+        return 333;
+    }
+}
+
+type T object {
+    function () returns int f;
+};
+
+class D {
+    function () returns int foo;
+
+    function init() {
+        F f = new F();
+        self.foo = f.foo;
+    }
+}
+
+function foo() returns int {
+    return 222;
+}
+
+isolated class CoreState {
+    private int i = 0;
+
+    isolated function inc() {
+        lock {
+            self.i = self.i + 1;
+        }
+    }
+
+    isolated function dec() {
+        lock {
+            self.i = self.i - 1;
+        }
+    }
+
+    isolated function get() returns int {
+        lock {
+            return self.i;
+        }
+    }
+
+    isolated function init(int i) {
+        self.i = i;
+    }
+}
+
+isolated class Proxy {
+    private CoreState state;
+
+    final isolated function () inc;
+    final isolated function () dec;
+    final isolated function () returns int get;
+
+    isolated function init(int i) {
+        self.state = new (i);
+        self.inc = self.state.inc;
+        self.dec = self.state.dec;
+        self.get = self.state.get;
+    }
+}
+
+public function testInvocationOfObjectField() {
+    F f = new ();
+    var ff = start f.f();
+    var fr = wait ff;
+    assertEquals(1, fr);
+    var fooDelF = start f.fooDel();
+    var fooDel = wait fooDelF;
+    assertEquals(foo(), fooDel);
+
+    D d = new ();
+    var ffooF = start f.foo();
+    var ffoo = wait ffooF;
+    var dfooF = start d.foo();
+    var dfoo = wait dfooF;
+    assertEquals(ffoo, dfoo);
+
+    T t = new F();
+    var tfF = start t.f();
+    var tf = wait tfF;
+    assertEquals(1, tf);
+}
+public isolated function testInvocationOfObjectFieldWithMutableState() {
+    Proxy proxy = new (10);
+    proxy.inc();
+
+    var getF = start proxy.get();
+    var getR = wait getF;
+    assertEquals(11, getR);
+
+    proxy.dec();
+
+    getF = start proxy.get();
+    getR = wait getF;
+    assertEquals(10, getR);
+
+    proxy.dec();
+    proxy.dec();
+    proxy.dec();
+    proxy.dec();
+    proxy.dec();
+
+    getF = start proxy.get();
+    getR = wait getF;
+    assertEquals(5, getR);
+}
+
+isolated function assertEquals(anydata|error expected, anydata|error actual) {
+    if (actual is anydata && expected is anydata && actual == expected) {
+        return;
+    } else if (actual === expected) {
+        return;
+    }
+
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
+    panic error("expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/invocations/object_field_method_invocation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/invocations/object_field_method_invocation.bal
@@ -1,0 +1,131 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+class F {
+    function () returns int f = function() returns int => 1;
+    function () returns int fooDel = foo;
+    //function () returns int selfFooDel;
+
+    function foo() returns int {
+        return 333;
+    }
+
+// todo: uncomment after fixing https://github.com/ballerina-platform/ballerina-lang/issues/28457
+//  function init() {
+//     self.selfFooDel = self.foo;
+// }
+}
+
+type T object {
+    function () returns int f;
+};
+
+class D {
+    function () returns int foo;
+
+    function init() {
+        F f = new F();
+        self.foo = f.foo;
+    }
+
+}
+
+function foo() returns int {
+    return 222;
+}
+
+isolated class CoreState {
+    private int i = 0;
+
+    isolated function inc() {
+        lock {
+            self.i = self.i + 1;
+        }
+    }
+
+    isolated function dec() {
+        lock {
+            self.i = self.i - 1;
+        }
+    }
+
+    isolated function get() returns int {
+        lock {
+            return self.i;
+        }
+    }
+
+    isolated function init(int i) {
+        self.i = i;
+    }
+}
+
+isolated class Proxy {
+    private CoreState state;
+
+    final isolated function () inc;
+    final isolated function () dec;
+    final isolated function () returns int get;
+
+    isolated function init(int i) {
+        self.state = new (i);
+        self.inc = self.state.inc;
+        self.dec = self.state.dec;
+        self.get = self.state.get;
+    }
+}
+
+public function testInvocationOfObjectField() {
+    F f = new ();
+
+    assertEquals(1, f.f());
+    assertEquals(foo(), f.fooDel());
+    //assertEquals(333, f.selfFooDel());
+
+    D d = new ();
+    assertEquals(f.foo(), d.foo());
+
+    T t = new F();
+    assertEquals(1, t.f());
+}
+public isolated function testInvocationOfObjectFieldWithMutableState() {
+
+
+    Proxy proxy = new (10);
+    proxy.inc();
+    assertEquals(11, proxy.get());
+    proxy.dec();
+    assertEquals(10, proxy.get());
+
+    proxy.dec();
+    proxy.dec();
+    proxy.dec();
+    proxy.dec();
+    proxy.dec();
+    assertEquals(5, proxy.get());
+}
+
+isolated function assertEquals(anydata|error expected, anydata|error actual) {
+    if (actual is anydata && expected is anydata && actual == expected) {
+        return;
+    } else if (actual === expected) {
+        return;
+    }
+
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
+    panic error("expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/invocations/object_field_method_invocation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/invocations/object_field_method_invocation.bal
@@ -40,7 +40,6 @@ class D {
         F f = new F();
         self.foo = f.foo;
     }
-
 }
 
 function foo() returns int {
@@ -90,7 +89,6 @@ isolated class Proxy {
 
 public function testInvocationOfObjectField() {
     F f = new ();
-
     assertEquals(1, f.f());
     assertEquals(foo(), f.fooDel());
     //assertEquals(333, f.selfFooDel());
@@ -102,8 +100,6 @@ public function testInvocationOfObjectField() {
     assertEquals(1, t.f());
 }
 public isolated function testInvocationOfObjectFieldWithMutableState() {
-
-
     Proxy proxy = new (10);
     proxy.inc();
     assertEquals(11, proxy.get());

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/invocations/object_field_method_invocation_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/invocations/object_field_method_invocation_negative.bal
@@ -1,0 +1,36 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+class F {
+    function () returns int f = function() returns int => 1;
+    function (int) returns int g = function(int i) returns int => i;
+    function (int...) returns int k = function(int... r) returns int {
+        return r[0];
+    };
+}
+
+function (int) fk = function(int i) {
+};
+
+function extraArg() {
+    int i = (new F()).f(1); // too many arguments in call to 'f()'
+    F f = new ();
+    int iDash = f.g(); //  missing required parameter '' in call to 'g()'
+    string iInvalid = f.g(0); // incompatible types: expected 'string', found 'int'
+    int argInvalid = f.g("hello"); // incompatible types: expected 'int', found 'string'
+    int restSum = f.k();
+    restSum = f.k("hi"); //incompatible types: expected 'int', found 'string'
+}


### PR DESCRIPTION
## Purpose
```ballerina
class C {
    function () returns int foo = function () returns int => 1;
}

public function main() {
    C c = new;
    int i = c.foo(); // allow direct function pointer invocation
}
```

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/31710

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
