### PR TITLE
Associate mapping constructor keys with their relevant field symbols

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
@@ -1517,6 +1517,15 @@ class SymbolFinder extends BaseVisitor {
     }
 
     @Override
+    public void visit(BLangRecordLiteral.BLangRecordKey recordKey) {
+        if (setEnclosingNode(recordKey.fieldSymbol, recordKey.pos)) {
+            return;
+        }
+
+        lookupNode(recordKey.expr);
+    }
+
+    @Override
     public void visit(BLangRecordLiteral.BLangRecordSpreadOperatorField spreadOperatorField) {
         lookupNode(spreadOperatorField.expr);
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -6364,7 +6364,10 @@ public class TypeChecker extends BLangNodeVisitor {
                 if (keyValueField) {
                     BLangRecordKeyValueField keyValField = (BLangRecordKeyValueField) field;
                     BLangRecordKey key = keyValField.key;
-                    fieldType = checkRecordLiteralKeyExpr(key.expr, key.computedKey, (BRecordType) mappingType);
+                    TypeSymbolPair typeSymbolPair = checkRecordLiteralKeyExpr(key.expr, key.computedKey,
+                                                                              (BRecordType) mappingType);
+                    fieldType = typeSymbolPair.determinedType;
+                    key.fieldSymbol = typeSymbolPair.fieldSymbol;
                     readOnlyConstructorField = keyValField.readonly;
                     pos = key.expr.pos;
                     fieldName = getKeyValueFieldName(keyValField);
@@ -6388,12 +6391,14 @@ public class TypeChecker extends BLangNodeVisitor {
                     boolean errored = false;
                     for (BField bField : ((BRecordType) spreadExprType).fields.values()) {
                         BType specFieldType = bField.type;
-                        BType expectedFieldType = checkRecordLiteralKeyByName(spreadExpr.pos, this.env, bField.name,
+                        BSymbol fieldSymbol = symResolver.resolveStructField(spreadExpr.pos, this.env, bField.name,
+                                                                             mappingType.tsymbol);
+                        BType expectedFieldType = checkRecordLiteralKeyByName(spreadExpr.pos, fieldSymbol, bField.name,
                                                                               (BRecordType) mappingType);
                         if (expectedFieldType != symTable.semanticError &&
                                 !types.isAssignable(specFieldType, expectedFieldType)) {
                             dlog.error(spreadExpr.pos, DiagnosticErrorCode.INCOMPATIBLE_TYPES_FIELD,
-                                    expectedFieldType, bField.name, specFieldType);
+                                       expectedFieldType, bField.name, specFieldType);
                             if (!errored) {
                                 errored = true;
                             }
@@ -6402,7 +6407,9 @@ public class TypeChecker extends BLangNodeVisitor {
                     return errored ? symTable.semanticError : symTable.noType;
                 } else {
                     BLangRecordVarNameField varNameField = (BLangRecordVarNameField) field;
-                    fieldType = checkRecordLiteralKeyExpr(varNameField, false, (BRecordType) mappingType);
+                    TypeSymbolPair typeSymbolPair = checkRecordLiteralKeyExpr(varNameField, false,
+                                                                              (BRecordType) mappingType);
+                    fieldType = typeSymbolPair.determinedType;
                     readOnlyConstructorField = varNameField.readonly;
                     pos = varNameField.pos;
                     fieldName = getVarNameFieldName(varNameField);
@@ -6493,14 +6500,15 @@ public class TypeChecker extends BLangNodeVisitor {
         return checkExpr(exprToCheck, this.env, fieldType);
     }
 
-    private BType checkRecordLiteralKeyExpr(BLangExpression keyExpr, boolean computedKey, BRecordType recordType) {
+    private TypeSymbolPair checkRecordLiteralKeyExpr(BLangExpression keyExpr, boolean computedKey,
+                                                     BRecordType recordType) {
         Name fieldName;
 
         if (computedKey) {
             checkExpr(keyExpr, this.env, symTable.stringType);
 
             if (keyExpr.getBType() == symTable.semanticError) {
-                return symTable.semanticError;
+                return new TypeSymbolPair(null, symTable.semanticError);
             }
 
             LinkedHashSet<BType> fieldTypes = recordType.fields.values().stream()
@@ -6511,7 +6519,7 @@ public class TypeChecker extends BLangNodeVisitor {
                 fieldTypes.add(recordType.restFieldType);
             }
 
-            return BUnionType.create(null, fieldTypes);
+            return new TypeSymbolPair(null, BUnionType.create(null, fieldTypes));
         } else if (keyExpr.getKind() == NodeKind.SIMPLE_VARIABLE_REF) {
             BLangSimpleVarRef varRef = (BLangSimpleVarRef) keyExpr;
             fieldName = names.fromIdNode(varRef.variableName);
@@ -6519,23 +6527,25 @@ public class TypeChecker extends BLangNodeVisitor {
             fieldName = names.fromString((String) ((BLangLiteral) keyExpr).value);
         } else {
             dlog.error(keyExpr.pos, DiagnosticErrorCode.INVALID_RECORD_LITERAL_KEY);
-            return symTable.semanticError;
+            return new TypeSymbolPair(null, symTable.semanticError);
         }
 
         // Check whether the struct field exists
-        return checkRecordLiteralKeyByName(keyExpr.pos, this.env, fieldName, recordType);
+        BSymbol fieldSymbol = symResolver.resolveStructField(keyExpr.pos, this.env, fieldName, recordType.tsymbol);
+        BType type = checkRecordLiteralKeyByName(keyExpr.pos, fieldSymbol, fieldName, recordType);
+
+        return new TypeSymbolPair(fieldSymbol instanceof BVarSymbol ? (BVarSymbol) fieldSymbol : null, type);
     }
 
-    private BType checkRecordLiteralKeyByName(Location location, SymbolEnv env, Name key,
+    private BType checkRecordLiteralKeyByName(Location location, BSymbol fieldSymbol, Name key,
                                               BRecordType recordType) {
-        BSymbol fieldSymbol = symResolver.resolveStructField(location, env, key, recordType.tsymbol);
         if (fieldSymbol != symTable.notFoundSymbol) {
             return fieldSymbol.type;
         }
 
         if (recordType.sealed) {
             dlog.error(location, DiagnosticErrorCode.UNDEFINED_STRUCTURE_FIELD_WITH_TYPE, key,
-                    recordType.tsymbol.type.getKind().typeName(), recordType);
+                       recordType.tsymbol.type.getKind().typeName(), recordType);
             return symTable.semanticError;
         }
 
@@ -8217,6 +8227,16 @@ public class TypeChecker extends BLangNodeVisitor {
             this.types = types;
             this.required = required;
             this.readonly = readonly;
+        }
+    }
+
+    private static class TypeSymbolPair {
+        private BVarSymbol fieldSymbol;
+        private BType determinedType;
+
+        public TypeSymbolPair(BVarSymbol fieldSymbol, BType determinedType) {
+            this.fieldSymbol = fieldSymbol;
+            this.determinedType = determinedType;
         }
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsInExprsTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsInExprsTest.java
@@ -99,6 +99,7 @@ public class FindRefsInExprsTest extends FindAllReferencesTest {
                 },
                 {92, 15, location(92, 15, 19),
                         List.of(location(92, 15, 19),
+                                location(94, 17, 21),
                                 location(95, 18, 22))
                 },
                 {93, 12, location(93, 12, 15),
@@ -113,6 +114,7 @@ public class FindRefsInExprsTest extends FindAllReferencesTest {
                 },
                 {98, 26, location(92, 15, 19),
                         List.of(location(92, 15, 19),
+                                location(94, 17, 21),
                                 location(95, 18, 22))
                 },
                 // Query exprs
@@ -127,11 +129,17 @@ public class FindRefsInExprsTest extends FindAllReferencesTest {
                 },
                 {115, 20, location(102, 11, 15),
                         List.of(location(102, 11, 15),
+                                location(108, 18, 22),
+                                location(109, 18, 22),
+                                location(110, 18, 22),
                                 location(115, 17, 21),
                                 location(116, 25, 29))
                 },
                 {116, 28, location(102, 11, 15),
                         List.of(location(102, 11, 15),
+                                location(108, 18, 22),
+                                location(109, 18, 22),
+                                location(110, 18, 22),
                                 location(115, 17, 21),
                                 location(116, 25, 29))
                 },
@@ -139,7 +147,16 @@ public class FindRefsInExprsTest extends FindAllReferencesTest {
                 {121, 15, location(120, 8, 11),
                         List.of(location(120, 8, 11),
                                 location(121, 14, 17))
-                }
+                },
+                // Keys in mapping constructor
+                {128, 8, location(138, 11, 15),
+                        List.of(location(128, 8, 12),
+                                location(138, 11, 15))
+                },
+                {131, 11, location(125, 12, 16),
+                        List.of(location(125, 12, 16),
+                                location(131, 11, 15))
+                },
         };
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsInExprsTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsInExprsTest.java
@@ -149,13 +149,21 @@ public class FindRefsInExprsTest extends FindAllReferencesTest {
                                 location(121, 14, 17))
                 },
                 // Keys in mapping constructor
-                {128, 8, location(138, 11, 15),
+                {128, 8, location(144, 11, 15),
                         List.of(location(128, 8, 12),
-                                location(138, 11, 15))
+                                location(144, 11, 15))
                 },
                 {131, 11, location(125, 12, 16),
                         List.of(location(125, 12, 16),
                                 location(131, 11, 15))
+                },
+                {154, 11, location(154, 11, 15),
+                        List.of(location(135, 8, 12),
+                                location(154, 11, 15))
+                },
+                {158, 15, location(158, 15, 19),
+                        List.of(location(137, 18, 22),
+                                location(158, 15, 19))
                 },
         };
     }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/SymbolsInMappingConstructorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/SymbolsInMappingConstructorTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.semantic.api.test.symbols;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.SymbolKind;
+import io.ballerina.projects.Document;
+import io.ballerina.projects.Project;
+import io.ballerina.tools.text.LinePosition;
+import org.ballerinalang.test.BCompileUtil;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.ballerina.compiler.api.symbols.SymbolKind.PARAMETER;
+import static io.ballerina.compiler.api.symbols.SymbolKind.RECORD_FIELD;
+import static io.ballerina.compiler.api.symbols.SymbolKind.VARIABLE;
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDefaultModulesSemanticModel;
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDocumentForSingleSource;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Test cases for use of symbol() with mapping constructors.
+ *
+ * @since 2.0.0
+ */
+public class SymbolsInMappingConstructorTest {
+
+    private SemanticModel model;
+    private Document srcFile;
+
+    @BeforeClass
+    public void setup() {
+        Project project = BCompileUtil.loadProject("test-src/symbols/symbols_in_mapping_constructor_test.bal");
+        model = getDefaultModulesSemanticModel(project);
+        srcFile = getDocumentForSingleSource(project);
+    }
+
+    @Test(dataProvider = "FieldPosProvider")
+    public void testFields(int line, int col, SymbolKind kind, String name) {
+        Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, col));
+        Assert.assertTrue(symbol.isPresent());
+        assertEquals(symbol.get().kind(), kind);
+        assertEquals(symbol.get().getName().get(), name);
+    }
+
+    @DataProvider(name = "FieldPosProvider")
+    public Object[][] getSpecificFieldPos() {
+        return new Object[][]{
+                {17, 20, RECORD_FIELD, "city"},
+                {17, 39, RECORD_FIELD, "country"},
+                {20, 8, RECORD_FIELD, "name"},
+                {21, 8, PARAMETER, "age"},
+//                {22, 10, FUNCTION, "foo"}, https://github.com/ballerina-platform/ballerina-lang/issues/31803
+                {23, 11, VARIABLE, "adrs"},
+        };
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/SymbolsInMappingConstructorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/SymbolsInMappingConstructorTest.java
@@ -73,6 +73,8 @@ public class SymbolsInMappingConstructorTest {
                 {21, 8, PARAMETER, "age"},
 //                {22, 10, FUNCTION, "foo"}, https://github.com/ballerina-platform/ballerina-lang/issues/31803
                 {23, 11, VARIABLE, "adrs"},
+                {27, 8, RECORD_FIELD, "name"},
+                {29, 18, RECORD_FIELD, "city"},
         };
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/find-all-ref/find_var_ref_in_exprs.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/find-all-ref/find_var_ref_in_exprs.bal
@@ -121,3 +121,26 @@ function testXMLNavigation() {
     xml val = xml `<foo><bar>0</bar></foo>`;
     xml bar = val/<bar>;
 }
+
+function testMappingConstructor(string name, int age) {
+    Address adrs = {city: "Colombo 3", country: "Sri Lanka"};
+
+    Person p = {
+        name: name,
+        age,
+        [bar()]: "BAR",
+        ...adrs
+    };
+}
+
+function bar() returns string => "bar";
+
+type Person record {
+    string name;
+    int age;
+};
+
+type Address record {
+    string city;
+    string country;
+};

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/find-all-ref/find_var_ref_in_exprs.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/find-all-ref/find_var_ref_in_exprs.bal
@@ -131,6 +131,12 @@ function testMappingConstructor(string name, int age) {
         [bar()]: "BAR",
         ...adrs
     };
+
+    var john = <Person2>{
+        name: "John Doe",
+        age: 25,
+        address: {city: "Colombo", country: "Sri Lanka"}
+    };
 }
 
 function bar() returns string => "bar";
@@ -143,4 +149,14 @@ type Person record {
 type Address record {
     string city;
     string country;
+};
+
+public type Person2 record {
+    string name;
+    int age;
+
+    record {|
+        string city;
+        string country;
+    |} address;
 };

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbols/symbols_in_mapping_constructor_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbols/symbols_in_mapping_constructor_test.bal
@@ -1,0 +1,38 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+function getPerson(string name, int age) {
+    Address adrs = {city: "Colombo 3", country: "Sri Lanka"};
+
+    Person p = {
+        name: name,
+        age,
+        [foo()]: "FOO",
+        ...adrs
+    };
+}
+
+function foo() returns string => "foo";
+
+type Person record {
+    string name;
+    int age;
+};
+
+type Address record {
+    string city;
+    string country;
+};

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbols/symbols_in_mapping_constructor_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbols/symbols_in_mapping_constructor_test.bal
@@ -23,6 +23,12 @@ function getPerson(string name, int age) {
         [foo()]: "FOO",
         ...adrs
     };
+
+    var john = <Person2>{
+        name: "John Doe",
+        age: 25,
+        address: {city: "Colombo", country: "Sri Lanka"}
+    };
 }
 
 function foo() returns string => "foo";
@@ -35,4 +41,14 @@ type Person record {
 type Address record {
     string city;
     string country;
+};
+
+public type Person2 record {
+    string name;
+    int age;
+
+    record {|
+        string city;
+        string country;
+    |} address;
 };

--- a/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
+++ b/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
@@ -105,6 +105,7 @@
 
             <!--Symbols-->
             <class name="io.ballerina.semantic.api.test.symbols.FunctionSymbolTest" />
+            <class name="io.ballerina.semantic.api.test.symbols.SymbolsInMappingConstructorTest" />
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
## Purpose
Previously we hadn't associated the keys in mapping constructors with the respective field symbols of them. This led to APIs like `symbol()` and `references()` to behave incorrectly since they couldn't figure out the relationship between the keys and the record fields. With this PR, we establish that link between the keys and the fields.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
