### PR TITLE
Remove the module alias from completion item detail when used inside the same module

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/FunctionCompletionItemBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/FunctionCompletionItemBuilder.java
@@ -155,7 +155,7 @@ public final class FunctionCompletionItemBuilder {
         if (functionSymbol != null) {
             FunctionTypeSymbol functionTypeDesc = functionSymbol.typeDescriptor();
             Optional<TypeSymbol> typeSymbol = functionTypeDesc.returnTypeDescriptor();
-            typeSymbol.ifPresent(symbol -> item.setDetail(symbol.signature()));
+            typeSymbol.ifPresent(symbol -> item.setDetail(CommonUtil.getModifiedTypeName(ctx, symbol)));
             List<String> funcArguments = getFuncArguments(functionSymbol, ctx);
             if (!funcArguments.isEmpty()) {
                 Command cmd = new Command("editor.action.triggerParameterHints", "editor.action.triggerParameterHints");

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/remote_action_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/remote_action_config1.json
@@ -8,7 +8,7 @@
     {
       "label": "post(string path, RequestMessage message, string targetType)",
       "kind": "Function",
-      "detail": "ballerina/module1:0.1.0:Response",
+      "detail": "module1:Response",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/remote_action_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/remote_action_config2.json
@@ -8,7 +8,7 @@
     {
       "label": "post(string path, RequestMessage message, string targetType)",
       "kind": "Function",
-      "detail": "ballerina/module1:0.1.0:Response",
+      "detail": "module1:Response",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/remote_action_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/remote_action_config3.json
@@ -8,7 +8,7 @@
     {
       "label": "post(string path, RequestMessage message, string targetType)",
       "kind": "Function",
-      "detail": "ballerina/module1:0.1.0:Response",
+      "detail": "mod:Response",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/remote_action_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/remote_action_config4.json
@@ -8,7 +8,7 @@
     {
       "label": "post(string path, RequestMessage message, string targetType)",
       "kind": "Function",
-      "detail": "ballerina/module1:0.1.0:Response",
+      "detail": "mod:Response",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/remote_action_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/remote_action_config5.json
@@ -8,7 +8,7 @@
     {
       "label": "post(string path, RequestMessage message, string targetType)",
       "kind": "Function",
-      "detail": "ballerina/module1:0.1.0:Response",
+      "detail": "module1:Response",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config19.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config19.json
@@ -182,7 +182,7 @@
     {
       "label": "iterator()",
       "kind": "Function",
-      "detail": "object {public isolated function next() returns record {| ballerina/lang.string:1.1.0:Char value; |}? ;}",
+      "detail": "object {public isolated function next() returns record {| string:Char value; |}? ;}",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config26.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config26.json
@@ -182,7 +182,7 @@
     {
       "label": "iterator()",
       "kind": "Function",
-      "detail": "object {public isolated function next() returns record {| ballerina/lang.string:1.1.0:Char value; |}? ;}",
+      "detail": "object {public isolated function next() returns record {| string:Char value; |}? ;}",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config4.json
@@ -109,7 +109,7 @@
     {
       "label": "filter(function () func)",
       "kind": "Function",
-      "detail": "xml<ballerina/lang.xml:0.8.0:Element|ballerina/lang.xml:0.8.0:Comment|ballerina/lang.xml:0.8.0:ProcessingInstruction|ballerina/lang.xml:0.8.0:Text>",
+      "detail": "xml<xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text>",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -128,7 +128,7 @@
     {
       "label": "iterator()",
       "kind": "Function",
-      "detail": "object {public isolated function next() returns record {| ballerina/lang.xml:0.8.0:Element|ballerina/lang.xml:0.8.0:Comment|ballerina/lang.xml:0.8.0:ProcessingInstruction|ballerina/lang.xml:0.8.0:Text value; |}? ;}",
+      "detail": "object {public isolated function next() returns record {| xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text value; |}? ;}",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -143,7 +143,7 @@
     {
       "label": "strip()",
       "kind": "Function",
-      "detail": "xml<ballerina/lang.xml:0.8.0:Element|ballerina/lang.xml:0.8.0:Comment|ballerina/lang.xml:0.8.0:ProcessingInstruction|ballerina/lang.xml:0.8.0:Text>",
+      "detail": "xml<xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text>",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -158,7 +158,7 @@
     {
       "label": "slice(int startIndex, int endIndex)",
       "kind": "Function",
-      "detail": "xml<ballerina/lang.xml:0.8.0:Element|ballerina/lang.xml:0.8.0:Comment|ballerina/lang.xml:0.8.0:ProcessingInstruction|ballerina/lang.xml:0.8.0:Text>",
+      "detail": "xml<xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text>",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -177,7 +177,7 @@
     {
       "label": "children()",
       "kind": "Function",
-      "detail": "xml<ballerina/lang.xml:0.8.0:Element|ballerina/lang.xml:0.8.0:Comment|ballerina/lang.xml:0.8.0:ProcessingInstruction|ballerina/lang.xml:0.8.0:Text>",
+      "detail": "xml<xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text>",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -192,7 +192,7 @@
     {
       "label": "get(int i)",
       "kind": "Function",
-      "detail": "xml<ballerina/lang.xml:0.8.0:Element|ballerina/lang.xml:0.8.0:Comment|ballerina/lang.xml:0.8.0:ProcessingInstruction|ballerina/lang.xml:0.8.0:Text>",
+      "detail": "xml<xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text>",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -211,7 +211,7 @@
     {
       "label": "elements(string? nm)",
       "kind": "Function",
-      "detail": "xml<ballerina/lang.xml:0.8.0:Element>",
+      "detail": "xml<xml:Element>",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -230,7 +230,7 @@
     {
       "label": "text()",
       "kind": "Function",
-      "detail": "ballerina/lang.xml:0.8.0:Text",
+      "detail": "xml:Text",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -245,7 +245,7 @@
     {
       "label": "elementChildren(string? nm)",
       "kind": "Function",
-      "detail": "xml<ballerina/lang.xml:0.8.0:Element>",
+      "detail": "xml<xml:Element>",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -264,7 +264,7 @@
     {
       "label": "map(function () func)",
       "kind": "Function",
-      "detail": "xml<xml<ballerina/lang.xml:0.8.0:Element|ballerina/lang.xml:0.8.0:Comment|ballerina/lang.xml:0.8.0:ProcessingInstruction|ballerina/lang.xml:0.8.0:Text>>",
+      "detail": "xml<xml<xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text>>",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/listener_decl/config/config11.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/listener_decl/config/config11.json
@@ -39,7 +39,7 @@
     {
       "label": "getListener()",
       "kind": "Function",
-      "detail": "ballerina/module1:0.1.0:Listener",
+      "detail": "module1:Listener",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/foreach_stmt_ctx_config13.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/foreach_stmt_ctx_config13.json
@@ -234,7 +234,7 @@
     {
       "label": "iterator()",
       "kind": "Function",
-      "detail": "object {public isolated function next() returns record {| ballerina/lang.string:1.1.0:Char value; |}? ;}",
+      "detail": "object {public isolated function next() returns record {| string:Char value; |}? ;}",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/foreach_stmt_ctx_config20.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/foreach_stmt_ctx_config20.json
@@ -109,7 +109,7 @@
     {
       "label": "filter(function () func)",
       "kind": "Function",
-      "detail": "xml<ballerina/lang.xml:0.8.0:Element|ballerina/lang.xml:0.8.0:Comment|ballerina/lang.xml:0.8.0:ProcessingInstruction|ballerina/lang.xml:0.8.0:Text>",
+      "detail": "xml<xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text>",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -128,7 +128,7 @@
     {
       "label": "iterator()",
       "kind": "Function",
-      "detail": "object {public isolated function next() returns record {| ballerina/lang.xml:0.8.0:Element|ballerina/lang.xml:0.8.0:Comment|ballerina/lang.xml:0.8.0:ProcessingInstruction|ballerina/lang.xml:0.8.0:Text value; |}? ;}",
+      "detail": "object {public isolated function next() returns record {| xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text value; |}? ;}",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -143,7 +143,7 @@
     {
       "label": "strip()",
       "kind": "Function",
-      "detail": "xml<ballerina/lang.xml:0.8.0:Element|ballerina/lang.xml:0.8.0:Comment|ballerina/lang.xml:0.8.0:ProcessingInstruction|ballerina/lang.xml:0.8.0:Text>",
+      "detail": "xml<xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text>",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -158,7 +158,7 @@
     {
       "label": "slice(int startIndex, int endIndex)",
       "kind": "Function",
-      "detail": "xml<ballerina/lang.xml:0.8.0:Element|ballerina/lang.xml:0.8.0:Comment|ballerina/lang.xml:0.8.0:ProcessingInstruction|ballerina/lang.xml:0.8.0:Text>",
+      "detail": "xml<xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text>",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -177,7 +177,7 @@
     {
       "label": "children()",
       "kind": "Function",
-      "detail": "xml<ballerina/lang.xml:0.8.0:Element|ballerina/lang.xml:0.8.0:Comment|ballerina/lang.xml:0.8.0:ProcessingInstruction|ballerina/lang.xml:0.8.0:Text>",
+      "detail": "xml<xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text>",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -192,7 +192,7 @@
     {
       "label": "get(int i)",
       "kind": "Function",
-      "detail": "xml<ballerina/lang.xml:0.8.0:Element|ballerina/lang.xml:0.8.0:Comment|ballerina/lang.xml:0.8.0:ProcessingInstruction|ballerina/lang.xml:0.8.0:Text>",
+      "detail": "xml<xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text>",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -211,7 +211,7 @@
     {
       "label": "elements(string? nm)",
       "kind": "Function",
-      "detail": "xml<ballerina/lang.xml:0.8.0:Element>",
+      "detail": "xml<xml:Element>",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -230,7 +230,7 @@
     {
       "label": "text()",
       "kind": "Function",
-      "detail": "ballerina/lang.xml:0.8.0:Text",
+      "detail": "xml:Text",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -245,7 +245,7 @@
     {
       "label": "elementChildren(string? nm)",
       "kind": "Function",
-      "detail": "xml<ballerina/lang.xml:0.8.0:Element>",
+      "detail": "xml<xml:Element>",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -264,7 +264,7 @@
     {
       "label": "map(function () func)",
       "kind": "Function",
-      "detail": "xml<xml<ballerina/lang.xml:0.8.0:Element|ballerina/lang.xml:0.8.0:Comment|ballerina/lang.xml:0.8.0:ProcessingInstruction|ballerina/lang.xml:0.8.0:Text>>",
+      "detail": "xml<xml<xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text>>",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/foreach_stmt_ctx_config24.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/foreach_stmt_ctx_config24.json
@@ -109,7 +109,7 @@
     {
       "label": "filter(function () func)",
       "kind": "Function",
-      "detail": "xml<ballerina/lang.xml:0.8.0:Element|ballerina/lang.xml:0.8.0:Comment|ballerina/lang.xml:0.8.0:ProcessingInstruction|ballerina/lang.xml:0.8.0:Text>",
+      "detail": "xml<xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text>",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -128,7 +128,7 @@
     {
       "label": "iterator()",
       "kind": "Function",
-      "detail": "object {public isolated function next() returns record {| ballerina/lang.xml:0.8.0:Element|ballerina/lang.xml:0.8.0:Comment|ballerina/lang.xml:0.8.0:ProcessingInstruction|ballerina/lang.xml:0.8.0:Text value; |}? ;}",
+      "detail": "object {public isolated function next() returns record {| xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text value; |}? ;}",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -143,7 +143,7 @@
     {
       "label": "strip()",
       "kind": "Function",
-      "detail": "xml<ballerina/lang.xml:0.8.0:Element|ballerina/lang.xml:0.8.0:Comment|ballerina/lang.xml:0.8.0:ProcessingInstruction|ballerina/lang.xml:0.8.0:Text>",
+      "detail": "xml<xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text>",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -158,7 +158,7 @@
     {
       "label": "slice(int startIndex, int endIndex)",
       "kind": "Function",
-      "detail": "xml<ballerina/lang.xml:0.8.0:Element|ballerina/lang.xml:0.8.0:Comment|ballerina/lang.xml:0.8.0:ProcessingInstruction|ballerina/lang.xml:0.8.0:Text>",
+      "detail": "xml<xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text>",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -177,7 +177,7 @@
     {
       "label": "children()",
       "kind": "Function",
-      "detail": "xml<ballerina/lang.xml:0.8.0:Element|ballerina/lang.xml:0.8.0:Comment|ballerina/lang.xml:0.8.0:ProcessingInstruction|ballerina/lang.xml:0.8.0:Text>",
+      "detail": "xml<xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text>",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -192,7 +192,7 @@
     {
       "label": "get(int i)",
       "kind": "Function",
-      "detail": "xml<ballerina/lang.xml:0.8.0:Element|ballerina/lang.xml:0.8.0:Comment|ballerina/lang.xml:0.8.0:ProcessingInstruction|ballerina/lang.xml:0.8.0:Text>",
+      "detail": "xml<xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text>",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -211,7 +211,7 @@
     {
       "label": "elements(string? nm)",
       "kind": "Function",
-      "detail": "xml<ballerina/lang.xml:0.8.0:Element>",
+      "detail": "xml<xml:Element>",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -230,7 +230,7 @@
     {
       "label": "text()",
       "kind": "Function",
-      "detail": "ballerina/lang.xml:0.8.0:Text",
+      "detail": "xml:Text",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -245,7 +245,7 @@
     {
       "label": "elementChildren(string? nm)",
       "kind": "Function",
-      "detail": "xml<ballerina/lang.xml:0.8.0:Element>",
+      "detail": "xml<xml:Element>",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -264,7 +264,7 @@
     {
       "label": "map(function () func)",
       "kind": "Function",
-      "detail": "xml<xml<ballerina/lang.xml:0.8.0:Element|ballerina/lang.xml:0.8.0:Comment|ballerina/lang.xml:0.8.0:ProcessingInstruction|ballerina/lang.xml:0.8.0:Text>>",
+      "detail": "xml<xml<xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text>>",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/template_expression/config/xml_template_expression_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/template_expression/config/xml_template_expression_config1.json
@@ -425,7 +425,7 @@
     {
       "label": "getXml()",
       "kind": "Function",
-      "detail": "ballerina/lang.xml:0.8.0:Element",
+      "detail": "xml:Element",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/template_expression/config/xml_template_expression_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/template_expression/config/xml_template_expression_config2.json
@@ -425,7 +425,7 @@
     {
       "label": "getXml()",
       "kind": "Function",
-      "detail": "ballerina/lang.xml:0.8.0:Element",
+      "detail": "xml:Element",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/project_var_def_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/project_var_def_ctx_config1.json
@@ -550,7 +550,7 @@
     {
       "label": "getPerson()",
       "kind": "Function",
-      "detail": "test/lsproject.models:0.1.0:Person",
+      "detail": "models:Person",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -584,7 +584,7 @@
     {
       "label": "getDriver(models:Person person)",
       "kind": "Function",
-      "detail": "test/lsproject.models:0.1.0:Driver",
+      "detail": "models:Driver",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/project_var_def_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/project_var_def_ctx_config2.json
@@ -558,7 +558,7 @@
     {
       "label": "getPerson()",
       "kind": "Function",
-      "detail": "test/lsproject.models:0.1.0:Person",
+      "detail": "models:Person",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -592,7 +592,7 @@
     {
       "label": "getDriver(models:Person person)",
       "kind": "Function",
-      "detail": "test/lsproject.models:0.1.0:Driver",
+      "detail": "models:Driver",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/project_var_def_ctx_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/project_var_def_ctx_config3.json
@@ -474,7 +474,7 @@
     {
       "label": "createVehicleModel(string name)",
       "kind": "Function",
-      "detail": "test/lsproject.models:0.1.0:Model",
+      "detail": "Model",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -544,7 +544,7 @@
     {
       "label": "createVehicle(Model model)",
       "kind": "Function",
-      "detail": "test/lsproject.models:0.1.0:Vehicle",
+      "detail": "Vehicle",
       "documentation": {
         "right": {
           "kind": "markdown",


### PR DESCRIPTION
## Purpose
$subject

Fixes #31791 

Changes this, 

![Screenshot from 2021-07-19 16-31-47](https://user-images.githubusercontent.com/46120162/126337465-d75750e8-3c05-4ee6-8a61-f28eea69edd0.png)

to following,

![Screenshot from 2021-07-20 19-29-50](https://user-images.githubusercontent.com/46120162/126337367-dd516510-a5d6-46ce-bff8-ebbe9f4db014.png)

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
