### PR TITLE
Upgrade the jackson-databind dependency

### DIFF
--- a/distribution/zip/jballerina-tools/build.gradle
+++ b/distribution/zip/jballerina-tools/build.gradle
@@ -69,7 +69,7 @@ configurations {
 
 dependencies {
     dist 'org.bytedeco:javacpp:1.4.2'
-    dist 'com.fasterxml.jackson.core:jackson-databind:2.8.6'
+    dist 'com.fasterxml.jackson.core:jackson-databind:2.12.4'
     dist 'com.fasterxml.jackson.core:jackson-core:2.8.6'
     dist 'com.fasterxml.jackson.core:jackson-annotations:2.8.0'
     dist 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.8'

--- a/distribution/zip/jballerina-tools/build.gradle
+++ b/distribution/zip/jballerina-tools/build.gradle
@@ -69,7 +69,7 @@ configurations {
 
 dependencies {
     dist 'org.bytedeco:javacpp:1.4.2'
-    dist 'com.fasterxml.jackson.core:jackson-databind:2.12.4'
+    dist 'com.fasterxml.jackson.core:jackson-databind:2.11.1'
     dist 'com.fasterxml.jackson.core:jackson-core:2.8.6'
     dist 'com.fasterxml.jackson.core:jackson-annotations:2.8.0'
     dist 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.8'

--- a/gradle/javaProject.gradle
+++ b/gradle/javaProject.gradle
@@ -35,7 +35,7 @@ dependencies {
         implementation 'commons-logging:commons-logging:1.1.1'
         implementation 'com.atlassian.commonmark:commonmark:0.11.0'
         implementation 'com.atlassian.commonmark:commonmark-ext-gfm-tables:0.11.0'
-        implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.4'
+        implementation 'com.fasterxml.jackson.core:jackson-databind:2.11.1'
         implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.9.8'
         implementation 'com.h2database:h2:1.4.199'
         implementation 'org.hsqldb:hsqldb:2.2.7'

--- a/gradle/javaProject.gradle
+++ b/gradle/javaProject.gradle
@@ -35,7 +35,7 @@ dependencies {
         implementation 'commons-logging:commons-logging:1.1.1'
         implementation 'com.atlassian.commonmark:commonmark:0.11.0'
         implementation 'com.atlassian.commonmark:commonmark-ext-gfm-tables:0.11.0'
-        implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.8'
+        implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.4'
         implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.9.8'
         implementation 'com.h2database:h2:1.4.199'
         implementation 'org.hsqldb:hsqldb:2.2.7'


### PR DESCRIPTION
## Purpose
* Upgrades the **com.fasterxml.jackson.core:jackson-databind** dependency packed inside the ballerina distribution to the latest stable version **2.11.1**.
* This dependency is used inside the Language Server and the Ballerina to OpenAPI Generator for handling Swagger, YAML, and JSON files.

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
