### PR TITLE
Fix issues with string unescaping

### DIFF
--- a/bvm/ballerina-runtime/build.gradle
+++ b/bvm/ballerina-runtime/build.gradle
@@ -26,7 +26,7 @@ dependencies {
         exclude group: 'org.apache.geronimo.specs', module: 'geronimo-stax-api_1.0_spec'
         exclude group: 'jaxen', module: 'jaxen'
     }
-    implementation 'org.apache.commons:commons-lang3'
+    implementation 'org.apache.commons:commons-text:1.9'
     implementation 'io.opentelemetry:opentelemetry-api'
     implementation('com.atomikos:transactions-jta:5.0.8') {
         exclude group: 'org.hibernate', module: 'hibernate'

--- a/bvm/ballerina-runtime/build.gradle
+++ b/bvm/ballerina-runtime/build.gradle
@@ -26,7 +26,7 @@ dependencies {
         exclude group: 'org.apache.geronimo.specs', module: 'geronimo-stax-api_1.0_spec'
         exclude group: 'jaxen', module: 'jaxen'
     }
-    implementation 'org.apache.commons:commons-text:1.9'
+    implementation 'org.apache.commons:commons-text'
     implementation 'io.opentelemetry:opentelemetry-api'
     implementation('com.atomikos:transactions-jta:5.0.8') {
         exclude group: 'org.hibernate', module: 'hibernate'

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/utils/IdentifierUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/utils/IdentifierUtils.java
@@ -18,7 +18,7 @@
 
 package io.ballerina.runtime.api.utils;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/utils/IdentifierUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/utils/IdentifierUtils.java
@@ -30,7 +30,7 @@ import java.util.regex.Pattern;
  */
 public class IdentifierUtils {
 
-    private static final String UNICODE_REGEX = "(\\\\*)\\\\u\\{([a-fA-F0-9]+)\\}";
+    private static final String UNICODE_REGEX = "\\\\(\\\\*)u\\{([a-fA-F0-9]+)\\}";
     public static final Pattern UNICODE_PATTERN = Pattern.compile(UNICODE_REGEX);
 
     private static final String CHAR_PREFIX = "$";

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/utils/IdentifierUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/utils/IdentifierUtils.java
@@ -83,7 +83,20 @@ public class IdentifierUtils {
         if (identifier.contains(ESCAPE_PREFIX)) {
             identifier = encodeSpecialCharacters(identifier);
         }
-        return StringEscapeUtils.unescapeJava(identifier);
+        return unescapeJava(identifier);
+    }
+
+    /**
+     * <p>Unescapes any Java literals found in the {@code String}.
+     * For example, it will turn a sequence of {@code '\'} and
+     * {@code 'n'} into a newline character, unless the {@code '\'}
+     * is preceded by another {@code '\'}.</p>
+     *
+     * @param str the {@code String} to unescape, may be null
+     * @return a new unescaped {@code String}, {@code null} if null string input
+     */
+    public static String unescapeJava(String str) {
+        return StringEscapeUtils.unescapeJava(str);
     }
 
     private static Identifier encodeGeneratedName(String identifier) {
@@ -147,7 +160,9 @@ public class IdentifierUtils {
         Matcher matcher = UNICODE_PATTERN.matcher(identifier);
         StringBuffer buffer = new StringBuffer(identifier.length());
         while (matcher.find()) {
-            String ch = String.valueOf((char) Integer.parseInt(matcher.group(1), 16));
+            int codePoint = Integer.parseInt(matcher.group(1), 16);
+            char[] chars = Character.toChars(codePoint);
+            String ch = String.valueOf(chars);
             matcher.appendReplacement(buffer, Matcher.quoteReplacement(ch));
         }
         matcher.appendTail(buffer);

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/utils/IdentifierUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/utils/IdentifierUtils.java
@@ -30,7 +30,7 @@ import java.util.regex.Pattern;
  */
 public class IdentifierUtils {
 
-    private static final String UNICODE_REGEX = "\\\\u\\{([a-fA-F0-9]+)\\}";
+    private static final String UNICODE_REGEX = "(\\\\*)\\\\u\\{([a-fA-F0-9]+)\\}";
     public static final Pattern UNICODE_PATTERN = Pattern.compile(UNICODE_REGEX);
 
     private static final String CHAR_PREFIX = "$";
@@ -160,13 +160,36 @@ public class IdentifierUtils {
         Matcher matcher = UNICODE_PATTERN.matcher(identifier);
         StringBuffer buffer = new StringBuffer(identifier.length());
         while (matcher.find()) {
-            int codePoint = Integer.parseInt(matcher.group(1), 16);
+            String leadingSlashes = matcher.group(1);
+            if (isEscapedNumericEscape(leadingSlashes)) {
+                // e.g. \\u{61}, \\\\u{61}
+                continue;    
+            }
+            
+            int codePoint = Integer.parseInt(matcher.group(2), 16);
             char[] chars = Character.toChars(codePoint);
             String ch = String.valueOf(chars);
-            matcher.appendReplacement(buffer, Matcher.quoteReplacement(ch));
+            matcher.appendReplacement(buffer, Matcher.quoteReplacement(leadingSlashes + ch));
         }
         matcher.appendTail(buffer);
         return String.valueOf(buffer);
+    }
+
+    /**
+     * Returns whether the <a href="https://ballerina.io/ballerina-spec/spec.html#NumericEscape">NumericEscape</a>
+     * is escaped, based on no. of leading backslashes.
+     *
+     * @param leadingSlashes preceding backslashes of the numeric escape.
+     *                       e.g. {@code \\u{61}} has 1 leading backslash.
+     * @return {@code true} if numeric escape is escaped, {@code false} otherwise.
+     */
+    public static boolean isEscapedNumericEscape(String leadingSlashes) {
+        return !isEven(leadingSlashes.length());
+    }
+
+    private static boolean isEven(int n) {
+        // (n & 1) is 0 when n is even.
+        return (n & 1) == 0;
     }
 
     private static boolean isUnicodePoint(String encodedName, int index) {

--- a/bvm/ballerina-runtime/src/main/java/module-info.java
+++ b/bvm/ballerina-runtime/src/main/java/module-info.java
@@ -1,7 +1,7 @@
 module io.ballerina.runtime {
     requires java.xml;
     requires woodstox.core.asl;
-    requires org.apache.commons.lang3;
+    requires org.apache.commons.text;
     requires axiom.api;
     requires java.logging;
     requires java.management;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
@@ -5267,8 +5267,7 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
 
             if (type != SyntaxKind.TEMPLATE_STRING && type != SyntaxKind.XML_TEXT_CONTENT) {
                 try {
-                    text = IdentifierUtils.unescapeUnicodeCodepoints(text);
-                    text = IdentifierUtils.unescapeJava(text);
+                    text = IdentifierUtils.unescapeJava(IdentifierUtils.unescapeUnicodeCodepoints(text));
                 } catch (Exception e) {
                     // We may reach here when the string literal has syntax diagnostics.
                     // Therefore mock the compiler with an empty string.
@@ -5328,7 +5327,7 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
             if ((decimalCodePoint >= Constants.MIN_UNICODE && decimalCodePoint <= Constants.MIDDLE_LIMIT_UNICODE)
                     || decimalCodePoint > Constants.MAX_UNICODE) {
 
-                int offset = matcher.end(1) + 1;
+                int offset = matcher.end(1);
                 String numericEscape = "\\u{" + hexCodePoint + "}";
                 BLangDiagnosticLocation numericEscapePos = new BLangDiagnosticLocation(currentCompUnitName,
                         pos.lineRange().startLine().line(),

--- a/gradle/javaProject.gradle
+++ b/gradle/javaProject.gradle
@@ -61,7 +61,7 @@ dependencies {
         implementation 'org.bitbucket.cowwoc:diff-match-patch:1.2'
 
         implementation 'org.apache.commons:commons-lang3:3.8.1'
-        implementation 'org.apache.commons:commons-text:1.7'
+        implementation 'org.apache.commons:commons-text:1.9'
         implementation 'org.apache.geronimo.specs:geronimo-stax-api_1.0_spec:1.0.1'
         implementation 'org.apache.mina:mina-core:2.0.16'
         implementation 'org.apache.maven:maven-plugin-api:3.6.0'

--- a/misc/toml-parser/build.gradle
+++ b/misc/toml-parser/build.gradle
@@ -26,7 +26,7 @@ configurations.all {
 dependencies {
     implementation project(':ballerina-tools-api')
     implementation 'com.google.code.gson:gson:2.8.6'
-    implementation 'org.apache.commons:commons-text:1.9'
+    implementation 'org.apache.commons:commons-text'
     testCompile 'org.testng:testng'
 }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/StringTemplateLiteralTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/StringTemplateLiteralTest.java
@@ -309,6 +309,11 @@ public class StringTemplateLiteralTest {
         BRunUtil.invoke(result, "testStringTemplateExprWithUnionType");
     }
 
+    @Test(description = "Test numeric escapes inside string template")
+    public void testNumericEscapes() {
+        BRunUtil.invoke(result, "testNumericEscapes");
+    }
+
     @AfterClass
     public void tearDown() {
         result = null;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/UnicodeNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/UnicodeNegativeTest.java
@@ -24,7 +24,7 @@ import org.ballerinalang.test.CompileResult;
 import org.testng.annotations.Test;
 
 /**
- * Test class to check the Unicode patterns.
+ * Negative test class to check the Unicode patterns.
  */
 public class UnicodeNegativeTest {
 
@@ -46,7 +46,6 @@ public class UnicodeNegativeTest {
         BAssertUtil.validateError(compileResult, index++, "invalid unicode '\\u{12FFFF}'", 25, 18);
         BAssertUtil.validateError(compileResult, index++, "invalid unicode '\\u{DFFFAAA}'", 25, 33);
         BAssertUtil.validateError(compileResult, index++, "invalid unicode '\\u{FFFFFFF}'", 25, 49);
-        BAssertUtil.validateError(compileResult, index++, "invalid string numeric escape sequence", 26, 17);
-        BAssertUtil.validateError(compileResult, index, "invalid unicode '\\u{001B['", 26, 17);
+        BAssertUtil.validateError(compileResult, index, "invalid string numeric escape sequence", 26, 17);
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/UnicodeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/UnicodeTest.java
@@ -26,7 +26,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /**
- * Negative test class to check the Unicode patterns.
+ * Test class to check the Unicode patterns.
  */
 public class UnicodeTest {
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/string/string-template-literal.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/string/string-template-literal.bal
@@ -222,9 +222,9 @@ function testNumericEscapes() {
         string s1 = string `\u{61}`;
         string s2 = string `\u{61}ppl\\u{65}`;
 
-        assertEquality(s1, "\\u{61}");
-        assertEquality(s1.toBytes().toString(), "[92,117,123,54,49,125]");
-        assertEquality(s2, "\\u{61}ppl\\\\u{65}");
+        assertEquality("\\u{61}", s1);
+        assertEquality("[92,117,123,54,49,125]", s1.toBytes().toString());
+        assertEquality("\\u{61}ppl\\\\u{65}", s2);
 }
 
 function assertEquality(anydata expected, anydata actual) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/string/string-template-literal.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/string/string-template-literal.bal
@@ -218,6 +218,15 @@ function testStringTemplateExprWithUnionType() {
     assertEquality("true", stringTemplateExprWithUnionType4());
 }
 
+function testNumericEscapes() {
+        string s1 = string `\u{61}`;
+        string s2 = string `\u{61}ppl\\u{65}`;
+
+        assertEquality(s1, "\\u{61}");
+        assertEquality(s1.toBytes().toString(), "[92,117,123,54,49,125]");
+        assertEquality(s2, "\\u{61}ppl\\\\u{65}");
+}
+
 function assertEquality(anydata expected, anydata actual) {
     if expected == actual {
         return;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/string/unicode.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/string/unicode.bal
@@ -23,12 +23,33 @@ function testUnicode() {
     string s4 = "ABC\u{644}\u{1048}CDE";
     string s5 = "ABC \u{0633} CDE";
     string s6 = "ABC \u{0633} CDE \u{0644} DEF \u{0644} XYZ";
+    string s7 = "\u{1F600}";
+    string s8 = "\u{1F600}\u{1F610}\u{1D702}Bar";
+    string s9 = "\u{41}";
+    string s10 = "\u{43}\u{061}\u{000074}";
 
-    if (s1 == "س" && s2 == "س" && s3 == "ABCل၈CDE" && s4 == "ABCل၈CDE" && s5 == "ABC س CDE"
-            && s6 == "ABC س CDE ل DEF ل XYZ") {
+    assertEquality(s1, "س");
+    assertEquality(s2, "س");
+    assertEquality(s3, "ABCل၈CDE");
+    assertEquality(s4, "ABCل၈CDE");
+    assertEquality(s5, "ABC س CDE");
+    assertEquality(s6, "ABC س CDE ل DEF ل XYZ");
+    assertEquality(s7, "😀");
+    assertEquality(s8, "😀😐𝜂Bar");
+    assertEquality(s9, "A");
+    assertEquality(s10, "Cat");
+
+    byte[] bArray = s9.toBytes();
+    assertEquality(s7.length(), 1);
+    assertEquality(bArray.length(), 1);
+    assertEquality(bArray.toString(), "[65]");
+}
+
+function assertEquality(anydata actual, anydata expected) {
+    if (actual == expected) {
         return;
     }
-    panic error(ASSERTION_ERROR_REASON, message = "expected 'س', 'س', 'ABCل၈CDE', 'ABCل၈CDE', 'ABC س CDE', "
-            + " 'ABC س CDE ل DEF ل XYZ', found " + s1 + "', '" + s2 + "', '" + s3 + "', '" + s4 + "', '"
-            + s5 + "', '" + s6 + "'");
+    
+    panic error(ASSERTION_ERROR_REASON,
+                 message = "expected '" + expected.toString() + "', found '" + actual.toString() + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/string/unicode.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/string/unicode.bal
@@ -43,6 +43,27 @@ function testUnicode() {
     assertEquality(s7.length(), 1);
     assertEquality(bArray.length(), 1);
     assertEquality(bArray.toString(), "[65]");
+
+    // Test NumericEscape Escaping
+    string s11 = "\\u{61}";
+    string s12 = "\\\u{61}";
+    string s13 = "\\\\u{61}";
+    string s14 = "\\\\\u{61}pp\\\u{6C}e";
+    string s15 = "\\\\u{61}pp\\\u{6C}e";
+    string s16 = "\\\\u{61}pp\\\\u{6C}e";
+    string s17 = "A\\u{61}\u{42}BE";
+    string s18 = "\\" + "u{61}";
+    string s19 = "\\u{D800}"; // no error for \u{D800} as it is escaped
+    
+    assertEquality(s11, "\\u{61}");
+    assertEquality(s12, "\\a");
+    assertEquality(s13, "\\\\u{61}");
+    assertEquality(s14, "\\\\app\\le");
+    assertEquality(s15, "\\\\u{61}pp\\le");
+    assertEquality(s16, "\\\\u{61}pp\\\\u{6C}e");
+    assertEquality(s17, "A\\u{61}BBE");
+    assertEquality(s18, s11);
+    assertEquality(s19, "\\u{D800}");
 }
 
 function assertEquality(anydata actual, anydata expected) {


### PR DESCRIPTION
## Purpose
$subject.

+ Fix unicode code point unescaping for code points > `0xFFFF`.
+ Fix `NumericEscape` escaping. 
e.g. `s = "\\u{61}"` should be unsecaped to `\u{61}`, not `\a`.
+ Fix `NumericEscape` escaping in template string.
e.g. ````s = string `\u{61}` ```` should be kept intact as `\u{61}`.

Fixes #31444 
Fixes #31717 
Fixes #31713 

## Approach
N/A

## Samples
N/A

## Remarks
N/A

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [x] Added necessary documentation  
  - [x] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples