### PR TITLE
Re-enable remote debugging tests on the 1.2.x branch

### DIFF
--- a/tests/jballerina-debugger-integration-test/src/test/resources/testng.xml
+++ b/tests/jballerina-debugger-integration-test/src/test/resources/testng.xml
@@ -30,9 +30,9 @@ under the License.
             </run>
         </groups>
         <classes>
-            <!--<class name="org.ballerinalang.debugger.test.remote.BallerinaRunRemoteDebugTest"/>-->
-            <!--<class name="org.ballerinalang.debugger.test.remote.BallerinaTestRemoteDebugTest"/>-->
-            <!--<class name="org.ballerinalang.debugger.test.remote.BallerinaBuildRemoteDebugTest"/>-->
+            <class name="org.ballerinalang.debugger.test.remote.BallerinaRunRemoteDebugTest"/>
+            <class name="org.ballerinalang.debugger.test.remote.BallerinaTestRemoteDebugTest"/>
+            <class name="org.ballerinalang.debugger.test.remote.BallerinaBuildRemoteDebugTest"/>
             <class name="org.ballerinalang.debugger.test.adapter.ModuleBreakpointTest"/>
             <class name="org.ballerinalang.debugger.test.adapter.run.SingleBalFileRunDebugTest"/>
             <class name="org.ballerinalang.debugger.test.adapter.run.MultiModuleRunDebugTest"/>


### PR DESCRIPTION
This PR will re-enable remote debugging tests on the 1.2.x branch.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/24697
