### PR TITLE
Remove project loading in BallerinaPackageService

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/packages/BallerinaPackageServiceImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/packages/BallerinaPackageServiceImpl.java
@@ -28,7 +28,6 @@ import io.ballerina.projects.Module;
 import io.ballerina.projects.Package;
 import io.ballerina.projects.Project;
 import io.ballerina.projects.ProjectKind;
-import io.ballerina.projects.directory.ProjectLoader;
 import io.ballerina.tools.diagnostics.Location;
 import io.ballerina.tools.text.LineRange;
 import org.ballerinalang.langserver.LSClientLogger;
@@ -96,8 +95,8 @@ public class BallerinaPackageServiceImpl implements BallerinaPackageService {
             try {
                 Arrays.stream(documentIdentifiers).iterator().forEachRemaining(documentIdentifier -> {
                     CommonUtil.getPathFromURI(documentIdentifier.getUri()).ifPresent(path -> {
-                        Project project = ProjectLoader.loadProject(path);
-                        jsonPackages.add(getPackageComponents(project));
+                        Optional<Project> project = this.workspaceManager.project(path);
+                        project.ifPresent(value -> jsonPackages.add(getPackageComponents(value)));
                     });
                 });
                 response.setProjectPackages(jsonPackages);


### PR DESCRIPTION

## Purpose
Replace loadProject() with workspaceManager.project() to avoid project loading for each request.


## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
