### PR TITLE
Fix xml equals check in TypeChecker

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -2705,7 +2705,8 @@ public class TypeChecker {
             case TypeTags.XML_COMMENT_TAG:
             case TypeTags.XML_TEXT_TAG:
             case TypeTags.XML_PI_TAG:
-                return XmlFactory.isEqual((XmlValue) lhsValue, (XmlValue) rhsValue);
+                return TypeTags.isXMLTypeTag(rhsValTypeTag) && XmlFactory.isEqual((XmlValue) lhsValue,
+                        (XmlValue) rhsValue);
             case TypeTags.MAP_TAG:
             case TypeTags.JSON_TAG:
             case TypeTags.RECORD_TYPE_TAG:

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/EqualAndNotEqualOperationsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/EqualAndNotEqualOperationsTest.java
@@ -661,6 +661,11 @@ public class EqualAndNotEqualOperationsTest {
     }
 
     @Test
+    public void testXmlStringNegative() {
+        BRunUtil.invoke(result, "testXmlStringNegative");
+    }
+
+    @Test
     public void testReferenceEqualityXml() {
         BRunUtil.invoke(result, "testReferenceEqualityXml");
     }
@@ -1110,4 +1115,5 @@ public class EqualAndNotEqualOperationsTest {
     public void testTableEquality() {
         BRunUtil.invoke(result, "testTableEquality");
     }
+
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/equal_and_not_equal_operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/equal_and_not_equal_operation.bal
@@ -1034,6 +1034,20 @@ public function testXmlSequenceAndXmlItemEqualityNegative() returns boolean {
     return x1 == x3 || !(x1 != x3) || x3 == x1 || !(x3 != x1);
 }
 
+function testXmlStringNegative() {
+    anydata x1 = xml `<book>The Lost World</book>`;
+    anydata x2 = "<book>The Lost World</book>";
+    anydata x3 = xml `Hello, world!`;
+    anydata x4 = "Hello, world!";
+    anydata x5 = xml `<?target data?>`;
+    anydata x6 = "<?target data?>";
+    anydata x7 = xml `<!-- I'm comment -->`;
+    anydata x8 = "<!-- I'm comment -->";
+    boolean result =  x1 == x2 || !(x1 != x2) || x3 == x4 || !(x3 != x4) || x5 == x6 || !(x5 != x6) || x7 == x8 || !(x7
+     != x8) || x2 == x1 || !(x2 != x1) || x4 == x3 || !(x4 != x3) || x6 == x5 || !(x6 != x5) || x8 == x7 || !(x8 != x7);
+     assert(result, false);
+}
+
 public function testJsonRecordMapEqualityPositive() returns boolean {
     OpenEmployeeTwo e = { name: "Maryam", "id": 1000 };
 


### PR DESCRIPTION
## Purpose
$subject
Fixes #25709 

## Approach
Fix unchecked casting to `XmlValue`

## Samples
```ballerina 
anydata xmlValue = xml `<book>The Lost World</book>`;
anydata xmlString = "<book>The Lost World</book>";
if (xmlValue == xmlString) {
   io:println("xmlValue");
}
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
