### PR TITLE
Update dependencies with security vulnerabilities

### DIFF
--- a/bvm/ballerina-rt/build.gradle
+++ b/bvm/ballerina-rt/build.gradle
@@ -102,7 +102,7 @@ dependencies {
     dist project(':tracing-extensions:ballerina-jaeger-extension')
     dist 'io.jaegertracing:jaeger-core:0.31.0'
     dist 'io.jaegertracing:jaeger-thrift:0.31.0'
-    dist 'org.apache.thrift:libthrift:0.12.0'
+    dist 'org.apache.thrift:libthrift:0.14.1'
     dist 'com.squareup.okhttp3:okhttp:3.14.0'
     dist 'com.squareup.okio:okio:2.2.2'
 

--- a/cli/ballerina-cli-module/build.gradle
+++ b/cli/ballerina-cli-module/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     implementation project(':toml-parser')
     implementation 'com.moandjiezana.toml:toml4j'
     implementation 'info.picocli:picocli'
-    implementation 'org.apache.commons:commons-compress:1.18'
+    implementation 'org.apache.commons:commons-compress:1.19'
     implementation 'me.tongfei:progressbar:0.7.4'
     implementation 'org.jline:jline:3.11.0'
     implementation 'javax.ws.rs:javax.ws.rs-api'

--- a/cli/ballerina-packerina/build.gradle
+++ b/cli/ballerina-packerina/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     implementation project(':maven-resolver')
     implementation 'com.moandjiezana.toml:toml4j'
     implementation 'info.picocli:picocli'
-    implementation 'org.apache.commons:commons-compress:1.18'
+    implementation 'org.apache.commons:commons-compress:1.19'
 
     testCompile 'org.testng:testng'
     testCompile 'com.moandjiezana.toml:toml4j'

--- a/distribution/zip/jballerina-tools/build.gradle
+++ b/distribution/zip/jballerina-tools/build.gradle
@@ -76,7 +76,7 @@ dependencies {
     // dist 'org.ow2.asm:asm:6.2.1'
     dist 'org.codehaus.woodstox:woodstox-core-asl:4.2.0'
     dist 'org.codehaus.woodstox:stax2-api:3.1.1'
-    dist 'org.apache.commons:commons-compress:1.18'
+    dist 'org.apache.commons:commons-compress:1.19'
     dist 'me.tongfei:progressbar:0.7.4'
     dist 'org.jline:jline:3.11.0'
 

--- a/gradle/javaLibsProject.gradle
+++ b/gradle/javaLibsProject.gradle
@@ -39,7 +39,7 @@ dependencies {
     dist 'org.wso2.securevault:org.wso2.securevault:1.0.0-wso2v2'
     dist 'org.wso2.transport.file:org.wso2.transport.local-file-system:6.0.55'
     dist 'org.wso2.transport.http:org.wso2.transport.http.netty:6.3.25'
-    dist 'org.bouncycastle:bcprov-jdk15on:1.61'
+    dist 'org.bouncycastle:bcprov-jdk15on:1.69'
     dist 'org.bouncycastle:bcpkix-jdk15on:1.61'
 
     dist 'info.picocli:picocli:4.0.1'

--- a/gradle/javaLibsProject.gradle
+++ b/gradle/javaLibsProject.gradle
@@ -31,7 +31,7 @@ dependencies {
     dist 'com.zaxxer:HikariCP:3.3.1'
     dist 'io.dropwizard.metrics:metrics-core:3.1.0'
     dist 'javax.transaction:javax.transaction-api:1.2'
-    dist 'org.apache.thrift:libthrift:0.10.0'
+    dist 'org.apache.thrift:libthrift:0.14.1'
     dist 'org.jvnet.mimepull:mimepull:1.9.7'
     dist 'org.quartz-scheduler:quartz-jobs:2.3.0'
     dist 'org.quartz-scheduler:quartz:2.3.2'

--- a/gradle/javaProject.gradle
+++ b/gradle/javaProject.gradle
@@ -74,7 +74,7 @@ dependencies {
         implementation 'org.codehaus.woodstox:stax2-api:4.2'
         implementation 'org.awaitility:awaitility:3.1.6'
         implementation 'org.apache.thrift:libthrift:0.12.0'
-        implementation 'org.bouncycastle:bcprov-jdk15on:1.61'
+        implementation 'org.bouncycastle:bcprov-jdk15on:1.69'
         implementation 'org.bouncycastle:bcpkix-jdk15on:1.61'
         implementation 'org.bytedeco.javacpp-presets:llvm-platform:6.0.1-1.4.2'
         implementation 'org.codehaus.plexus:plexus-utils:3.0.8'

--- a/gradle/javaProject.gradle
+++ b/gradle/javaProject.gradle
@@ -73,7 +73,7 @@ dependencies {
         implementation 'org.codehaus.woodstox:woodstox-core-asl:4.4.1'
         implementation 'org.codehaus.woodstox:stax2-api:4.2'
         implementation 'org.awaitility:awaitility:3.1.6'
-        implementation 'org.apache.thrift:libthrift:0.12.0'
+        implementation 'org.apache.thrift:libthrift:0.14.1'
         implementation 'org.bouncycastle:bcprov-jdk15on:1.69'
         implementation 'org.bouncycastle:bcpkix-jdk15on:1.61'
         implementation 'org.bytedeco.javacpp-presets:llvm-platform:6.0.1-1.4.2'

--- a/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/LSCompilerUtil.java
+++ b/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/LSCompilerUtil.java
@@ -84,8 +84,12 @@ public class LSCompilerUtil {
         }
 
         // Here we will create a tmp directory as the untitled project repo.
-        File untitledDir = com.google.common.io.Files.createTempDir();
-        untitledProjectPath = untitledDir.toPath();
+        try {
+            untitledProjectPath = Files.createTempDirectory(System.currentTimeMillis() + "-");
+        } catch (IOException e) {
+            logger.error("Unable to create the temp directory.");
+        }
+
         // Now lets create a empty untitled.bal to fool compiler.
         File untitledBal = new File(Paths.get(untitledProjectPath.toString(), UNTITLED_BAL).toString());
         try {

--- a/misc/debug-adapter/modules/debug-adapter-core/build.gradle
+++ b/misc/debug-adapter/modules/debug-adapter-core/build.gradle
@@ -8,7 +8,7 @@ repositories {
 dependencies {
     implementation 'org.eclipse.lsp4j:org.eclipse.lsp4j.debug:0.7.1'
     implementation project(':ballerina-lang')
-    implementation 'org.apache.commons:commons-compress:1.18'
+    implementation 'org.apache.commons:commons-compress:1.19'
     implementation files(org.gradle.internal.jvm.Jvm.current().toolsJar)
 }
 

--- a/stdlib/grpc/src/main/ballerina/Ballerina.toml
+++ b/stdlib/grpc/src/main/ballerina/Ballerina.toml
@@ -105,8 +105,8 @@ target = "java8"
 
     [[platform.libraries]]
     artifactId = "bcprov-jdk15on"
-    version = "1.61"
-    path = "./lib/bcprov-jdk15on-1.61.jar"
+    version = "1.69"
+    path = "./lib/bcprov-jdk15on-1.69.jar"
     groupId = "org.bouncycastle"
     modules = ["grpc"]
 

--- a/stdlib/http/src/main/ballerina/Ballerina.toml
+++ b/stdlib/http/src/main/ballerina/Ballerina.toml
@@ -98,8 +98,8 @@ target = "java8"
 
     [[platform.libraries]]
     artifactId = "bcprov-jdk15on"
-    version = "1.61"
-    path = "./lib/bcprov-jdk15on-1.61.jar"
+    version = "1.69"
+    path = "./lib/bcprov-jdk15on-1.69.jar"
     groupId = "org.bouncycastle"
     modules = ["http"]
 

--- a/stdlib/mime/src/main/ballerina/Ballerina.toml
+++ b/stdlib/mime/src/main/ballerina/Ballerina.toml
@@ -105,8 +105,8 @@ target = "java8"
 
     [[platform.libraries]]
     artifactId = "bcprov-jdk15on"
-    version = "1.61"
-    path = "./lib/bcprov-jdk15on-1.61.jar"
+    version = "1.69"
+    path = "./lib/bcprov-jdk15on-1.69.jar"
     groupId = "org.bouncycastle"
     modules = ["mime"]
 

--- a/stdlib/websub/src/main/ballerina/Ballerina.toml
+++ b/stdlib/websub/src/main/ballerina/Ballerina.toml
@@ -98,8 +98,8 @@ target = "java8"
 
     [[platform.libraries]]
     artifactId = "bcprov-jdk15on"
-    version = "1.61"
-    path = "./lib/bcprov-jdk15on-1.61.jar"
+    version = "1.69"
+    path = "./lib/bcprov-jdk15on-1.69.jar"
     groupId = "org.bouncycastle"
     modules = ["web-sub"]
 


### PR DESCRIPTION
## Purpose
* Bump `org.apache.thrift:libthrift` from 0.12.0 to 0.14.1.
* Bump `org.apache.commons:commons-compress` from 1.18 to 1.19.
* Bump `org.bouncycastle:bcprov-jdk15on` from 1.61 to 1.69.
* Remove the `com.google.common.io.Files.createTempDir` method.

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
