### PR TITLE
Fix string:char iterator for large codepoints

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/values/BString.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/values/BString.java
@@ -17,6 +17,8 @@
 */
 package io.ballerina.runtime.api.values;
 
+import io.ballerina.runtime.internal.values.IteratorValue;
+
 /**
  * Interface representing ballerina strings.
  *
@@ -37,4 +39,7 @@ public interface BString {
     Long lastIndexOf(BString str, int fromIndex);
 
     BString substring(int beginIndex, int endIndex);
+
+    IteratorValue getIterator();
+
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/BmpStringValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/BmpStringValue.java
@@ -28,7 +28,7 @@ import io.ballerina.runtime.api.values.BString;
  public class BmpStringValue extends StringValue {
 
      public BmpStringValue(String value) {
-         super(value, 0);
+         super(value, false);
      }
 
      @Override
@@ -44,7 +44,7 @@ import io.ballerina.runtime.api.values.BString;
      @Override
      public BString concat(BString str) {
          StringValue stringValue = (StringValue) str;
-         if (stringValue.nonBmpFlag == 1) {
+         if (stringValue.isNonBmp) {
              int[] otherSurrogates = ((NonBmpStringValue) str).getSurrogates();
              int[] newSurrogates = new int[otherSurrogates.length];
              int length = length();

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/BmpStringValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/BmpStringValue.java
@@ -18,7 +18,6 @@
 
 package io.ballerina.runtime.internal.values;
 
-import io.ballerina.runtime.api.values.BLink;
 import io.ballerina.runtime.api.values.BString;
 
  /**
@@ -26,17 +25,10 @@ import io.ballerina.runtime.api.values.BString;
   *
   * @since 1.0.5
   */
- public class BmpStringValue implements StringValue {
-
-     private final String value;
+ public class BmpStringValue extends StringValue {
 
      public BmpStringValue(String value) {
-         this.value = value;
-     }
-
-     @Override
-     public String getValue() {
-         return value;
+         super(value, 0);
      }
 
      @Override
@@ -51,55 +43,17 @@ import io.ballerina.runtime.api.values.BString;
 
      @Override
      public BString concat(BString str) {
-         if (str instanceof BmpStringValue) {
-             return new BmpStringValue(this.value + ((BmpStringValue) str).value);
-         } else if (str instanceof NonBmpStringValue) {
+         StringValue stringValue = (StringValue) str;
+         if (stringValue.nonBmpFlag == 1) {
              int[] otherSurrogates = ((NonBmpStringValue) str).getSurrogates();
              int[] newSurrogates = new int[otherSurrogates.length];
              int length = length();
              for (int i = 0; i < otherSurrogates.length; i++) {
                  newSurrogates[i] = otherSurrogates[i] + length;
              }
-             return new NonBmpStringValue(this.value + str.getValue(), ((NonBmpStringValue) str).getSurrogates());
-         } else {
-             throw new RuntimeException("not impl yet");
+             return new NonBmpStringValue(this.value + str.getValue(), newSurrogates);
          }
-     }
-
-     @Override
-     public String stringValue(BLink parent) {
-         return value;
-     }
-
-     @Override
-     public String informalStringValue(BLink parent) {
-         return "\"" + toString() + "\"";
-     }
-
-     @Override
-     public String expressionStringValue(BLink parent) {
-         return informalStringValue(parent);
-     }
-
-     @Override
-     public int hashCode() {
-         return value.hashCode();
-     }
-
-     @Override
-     public boolean equals(Object str) {
-         if (str == this) {
-             return true;
-         }
-         if (str instanceof BString) {
-             return ((BString) str).getValue().equals(value);
-         }
-         return false;
-     }
-
-     @Override
-     public String toString() {
-         return value;
+         return new BmpStringValue(this.value + str.getValue());
      }
 
      @Override

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/BmpStringValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/BmpStringValue.java
@@ -18,8 +18,8 @@
 
 package io.ballerina.runtime.internal.values;
 
- import io.ballerina.runtime.api.values.BLink;
- import io.ballerina.runtime.api.values.BString;
+import io.ballerina.runtime.api.values.BLink;
+import io.ballerina.runtime.api.values.BString;
 
  /**
   * Represent ballerina strings containing only unicode basic multilingual plane characters.
@@ -54,6 +54,12 @@ package io.ballerina.runtime.internal.values;
          if (str instanceof BmpStringValue) {
              return new BmpStringValue(this.value + ((BmpStringValue) str).value);
          } else if (str instanceof NonBmpStringValue) {
+             int[] otherSurrogates = ((NonBmpStringValue) str).getSurrogates();
+             int[] newSurrogates = new int[otherSurrogates.length];
+             int length = length();
+             for (int i = 0; i < otherSurrogates.length; i++) {
+                 newSurrogates[i] = otherSurrogates[i] + length;
+             }
              return new NonBmpStringValue(this.value + str.getValue(), ((NonBmpStringValue) str).getSurrogates());
          } else {
              throw new RuntimeException("not impl yet");

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/CharIterator.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/CharIterator.java
@@ -1,0 +1,70 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.runtime.internal.values;
+
+import io.ballerina.runtime.api.values.BString;
+
+/**
+ * {@code {@link CharIterator }} provides iterator implementation for Ballerina string values.
+ *
+ * @since 2.0
+ */
+public class CharIterator implements IteratorValue {
+
+    BString value;
+    boolean isNonBmp;
+    long cursor = 0;
+    long length;
+    String stringValue;
+
+    CharIterator(BString value) {
+        this.value = value;
+        this.length = value.length();
+        this.isNonBmp = value instanceof NonBmpStringValue;
+        this.stringValue = value.getValue();
+    }
+
+    @Override
+    public Object next() {
+        long cursor = this.cursor++;
+        if (cursor == length) {
+            return null;
+        }
+        if (isNonBmp) {
+            int offset = (int) cursor;
+            for (int surrogate : ((NonBmpStringValue) value).getSurrogates()) {
+                if (surrogate < cursor) {
+                    offset++;
+                } else if (surrogate > cursor) {
+                    break;
+                } else {
+                    return new String(new char[]{stringValue.charAt(offset), stringValue.charAt(offset + 1)});
+                }
+            }
+            return String.valueOf(stringValue.charAt(offset));
+        }
+        return String.valueOf(stringValue.charAt((int) cursor));
+    }
+
+    @Override
+    public boolean hasNext() {
+        return cursor < length;
+    }
+
+}

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/NonBmpStringValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/NonBmpStringValue.java
@@ -32,7 +32,7 @@ import java.util.Arrays;
      private final int[] surrogates;
 
      public NonBmpStringValue(String value, int[] surrogatePairLocations) {
-         super(value, 1);
+         super(value, true);
          surrogates = surrogatePairLocations;
      }
 
@@ -63,7 +63,7 @@ import java.util.Arrays;
     @Override
     public BString concat(BString str) {
         StringValue stringValue = (StringValue) str;
-        if (stringValue.nonBmpFlag == 1) {
+        if (stringValue.isNonBmp) {
             NonBmpStringValue other = (NonBmpStringValue) str;
             int[] both = Arrays.copyOf(surrogates, surrogates.length + other.surrogates.length);
             int length = length();

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/NonBmpStringValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/NonBmpStringValue.java
@@ -18,31 +18,23 @@
  package io.ballerina.runtime.internal.values;
 
  import io.ballerina.runtime.api.utils.StringUtils;
- import io.ballerina.runtime.api.values.BLink;
- import io.ballerina.runtime.api.values.BString;
+import io.ballerina.runtime.api.values.BString;
 
- import java.util.Arrays;
+import java.util.Arrays;
 
  /**
   * Represent ballerina strings containing at least one non basic multilingual plane unicode character.
   *
   * @since 1.0.5
   */
- public class NonBmpStringValue implements StringValue {
+ public class NonBmpStringValue extends StringValue {
 
-     private final String value;
      private final int[] surrogates;
 
-
      public NonBmpStringValue(String value, int[] surrogatePairLocations) {
-         this.value = value;
+         super(value, 1);
          surrogates = surrogatePairLocations;
      }
-
-    @Override
-    public String getValue() {
-        return value;
-    }
 
     @Override
     public int getCodePoint(int index) {
@@ -70,7 +62,8 @@
 
     @Override
     public BString concat(BString str) {
-        if (str instanceof NonBmpStringValue) {
+        StringValue stringValue = (StringValue) str;
+        if (stringValue.nonBmpFlag == 1) {
             NonBmpStringValue other = (NonBmpStringValue) str;
             int[] both = Arrays.copyOf(surrogates, surrogates.length + other.surrogates.length);
             int length = length();
@@ -78,52 +71,12 @@
                 both[i + surrogates.length] = other.surrogates[i] + length;
             }
             return new NonBmpStringValue(this.value + other.value, both);
-        } else if (str instanceof BmpStringValue) {
-            BmpStringValue other = (BmpStringValue) str;
-            return new NonBmpStringValue(this.value + other.getValue(), surrogates);
-        } else {
-            throw new RuntimeException("not impl yet");
         }
+        return new NonBmpStringValue(this.value + str.getValue(), surrogates);
     }
-
-     @Override
-     public String stringValue(BLink parent) {
-         return value;
-     }
-
-     @Override
-     public String informalStringValue(BLink parent) {
-         return "\"" + toString() + "\"";
-     }
-
-     @Override
-     public String expressionStringValue(BLink parent) {
-         return informalStringValue(parent);
-     }
 
      public int[] getSurrogates() {
          return surrogates.clone();
-     }
-
-     @Override
-     public String toString() {
-         return value;
-     }
-
-     @Override
-     public boolean equals(Object str) {
-         if (str == this) {
-             return true;
-         }
-         if (str instanceof BString) {
-             return ((BString) str).getValue().equals(value);
-         }
-         return false;
-     }
-
-     @Override
-     public int hashCode() {
-         return value.hashCode();
      }
 
      @Override

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/NonBmpStringValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/NonBmpStringValue.java
@@ -73,7 +73,10 @@
         if (str instanceof NonBmpStringValue) {
             NonBmpStringValue other = (NonBmpStringValue) str;
             int[] both = Arrays.copyOf(surrogates, surrogates.length + other.surrogates.length);
-            System.arraycopy(other.surrogates, 0, both, surrogates.length, other.surrogates.length);
+            int length = length();
+            for (int i = 0; i < other.surrogates.length; i++) {
+                both[i + surrogates.length] = other.surrogates[i] + length;
+            }
             return new NonBmpStringValue(this.value + other.value, both);
         } else if (str instanceof BmpStringValue) {
             BmpStringValue other = (BmpStringValue) str;

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/StringValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/StringValue.java
@@ -44,4 +44,9 @@ public interface StringValue extends BString, SimpleValue {
     default Object frozenCopy(Map<Object, Object> refs) {
         return this;
     }
+
+    @Override
+    default IteratorValue getIterator() {
+        return new CharIterator(this);
+    }
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/StringValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/StringValue.java
@@ -19,6 +19,7 @@ package io.ballerina.runtime.internal.values;
 
 import io.ballerina.runtime.api.PredefinedTypes;
 import io.ballerina.runtime.api.types.Type;
+import io.ballerina.runtime.api.values.BLink;
 import io.ballerina.runtime.api.values.BString;
 
 import java.util.Map;
@@ -28,25 +29,75 @@ import java.util.Map;
  *
  * @since 1.0.5
  */
-public interface StringValue extends BString, SimpleValue {
+public abstract class StringValue implements BString, SimpleValue {
+
+    final String value;
+    final int nonBmpFlag;
+
+    protected StringValue(String value, int nonBmpFlag) {
+        this.value = value;
+        this.nonBmpFlag = nonBmpFlag;
+    }
 
     @Override
-    default Type getType() {
+    public Type getType() {
         return PredefinedTypes.TYPE_STRING;
     }
 
     @Override
-    default Object copy(Map<Object, Object> refs) {
+    public Object copy(Map<Object, Object> refs) {
         return this;
     }
 
     @Override
-    default Object frozenCopy(Map<Object, Object> refs) {
+    public Object frozenCopy(Map<Object, Object> refs) {
         return this;
     }
 
     @Override
-    default IteratorValue getIterator() {
+    public IteratorValue getIterator() {
         return new CharIterator(this);
     }
+
+    @Override
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String stringValue(BLink parent) {
+        return value;
+    }
+
+    @Override
+    public String informalStringValue(BLink parent) {
+        return "\"" + this + "\"";
+    }
+
+    @Override
+    public String expressionStringValue(BLink parent) {
+        return informalStringValue(parent);
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object str) {
+        if (str == this) {
+            return true;
+        }
+        if (str instanceof BString) {
+            return ((BString) str).getValue().equals(value);
+        }
+        return false;
+    }
+
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/StringValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/StringValue.java
@@ -32,11 +32,11 @@ import java.util.Map;
 public abstract class StringValue implements BString, SimpleValue {
 
     final String value;
-    final int nonBmpFlag;
+    final boolean isNonBmp;
 
-    protected StringValue(String value, int nonBmpFlag) {
+    protected StringValue(String value, boolean isNonBmp) {
         this.value = value;
-        this.nonBmpFlag = nonBmpFlag;
+        this.isNonBmp = isNonBmp;
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/emit/TypeEmitter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/emit/TypeEmitter.java
@@ -107,6 +107,8 @@ class TypeEmitter {
                 return "xml:Text";
             case TypeTags.DECIMAL:
                 return "decimal";
+            case TypeTags.CHAR_STRING:
+                return "string:Char";
             case TypeTags.UNION:
                 return emitBUnionType((BUnionType) bType, tabs);
             case TypeTags.INTERSECTION:

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibStringTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibStringTest.java
@@ -20,7 +20,6 @@ package org.ballerinalang.langlib.test;
 
 
 import org.ballerinalang.core.model.values.BBoolean;
-import org.ballerinalang.core.model.values.BError;
 import org.ballerinalang.core.model.values.BInteger;
 import org.ballerinalang.core.model.values.BString;
 import org.ballerinalang.core.model.values.BValue;
@@ -147,7 +146,7 @@ public class LangLibStringTest {
     public void testToCodepointInts(String st1, int[] expected) {
         BValue[] args = {new BString(st1)};
         BValue[] returns = BRunUtil.invoke(compileResult, "testToCodepointInts", args);
-        assertEquals(((BValueArray) returns[0]).size(), expected.length);
+        assertEquals((returns[0]).size(), expected.length);
         int[] codePoints = toIntArray((BValueArray) returns[0]);
         assertEquals(codePoints, expected);
     }
@@ -156,14 +155,14 @@ public class LangLibStringTest {
     public void testFromCodePointInts(long[] array, String expected) {
         BValue[] args = {new BValueArray(array)};
         BValue[] returns = BRunUtil.invoke(compileResult, "testFromCodePointInts", args);
-        assertEquals(((BString) returns[0]).stringValue(), expected);
+        assertEquals((returns[0]).stringValue(), expected);
     }
 
     @Test
     public void testFromCodePointIntsNegative() {
         BValue[] args = {new BValueArray(new long[]{0x10FFFF, 0x10FFFF + 1})};
         BValue[] returns = BRunUtil.invoke(compileResult, "testFromCodePointInts", args);
-        assertEquals(((BError) returns[0]).stringValue(), "Invalid codepoint: 1114112 {}");
+        assertEquals((returns[0]).stringValue(), "Invalid codepoint: 1114112 {}");
     }
 
     private int[] toIntArray(BValueArray array) {
@@ -280,5 +279,30 @@ public class LangLibStringTest {
     @Test
     public void testLangLibCallOnFiniteType() {
         BRunUtil.invoke(compileResult, "testLangLibCallOnFiniteType");
+    }
+
+    @Test(dataProvider = "unicodeCharProvider")
+    public void testIteratorWithUnicodeChar(long codePoint, long[] expected) {
+        BValue[] args = {new BInteger(codePoint), new BValueArray(expected)};
+        BRunUtil.invoke(compileResult, "testIteratorWithUnicodeChar", args);
+    }
+
+    @DataProvider(name = "unicodeCharProvider")
+    public Object[][] testUnicodeCharIteratorProvider() {
+        long asciiValue = Long.parseLong("7E", 16);
+        long nonAsciiLatinValue = Long.parseLong("DF", 16);
+        long twoByteValue = Long.parseLong("03BB", 16);
+        long threeByteValue = Long.parseLong("0BF8", 16);
+        long emojiValue = Long.parseLong("1F4A9", 16);
+        long encodedValue = Long.parseLong("DFFFF", 16);
+
+        return new Object[][]{
+                {asciiValue, new long[]{asciiValue}},
+                {nonAsciiLatinValue, new long[]{nonAsciiLatinValue}},
+                {twoByteValue, new long[]{twoByteValue}},
+                {threeByteValue, new long[]{threeByteValue}},
+                {emojiValue, new long[]{emojiValue}},
+                {encodedValue, new long[]{encodedValue}},
+        };
     }
 }

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibStringTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibStringTest.java
@@ -146,7 +146,7 @@ public class LangLibStringTest {
     public void testToCodepointInts(String st1, int[] expected) {
         BValue[] args = {new BString(st1)};
         BValue[] returns = BRunUtil.invoke(compileResult, "testToCodepointInts", args);
-        assertEquals((returns[0]).size(), expected.length);
+        assertEquals(returns[0].size(), expected.length);
         int[] codePoints = toIntArray((BValueArray) returns[0]);
         assertEquals(codePoints, expected);
     }
@@ -155,14 +155,14 @@ public class LangLibStringTest {
     public void testFromCodePointInts(long[] array, String expected) {
         BValue[] args = {new BValueArray(array)};
         BValue[] returns = BRunUtil.invoke(compileResult, "testFromCodePointInts", args);
-        assertEquals((returns[0]).stringValue(), expected);
+        assertEquals(returns[0].stringValue(), expected);
     }
 
     @Test
     public void testFromCodePointIntsNegative() {
         BValue[] args = {new BValueArray(new long[]{0x10FFFF, 0x10FFFF + 1})};
         BValue[] returns = BRunUtil.invoke(compileResult, "testFromCodePointInts", args);
-        assertEquals((returns[0]).stringValue(), "Invalid codepoint: 1114112 {}");
+        assertEquals(returns[0].stringValue(), "Invalid codepoint: 1114112 {}");
     }
 
     private int[] toIntArray(BValueArray array) {
@@ -304,5 +304,23 @@ public class LangLibStringTest {
                 {emojiValue, new long[]{emojiValue}},
                 {encodedValue, new long[]{encodedValue}},
         };
+    }
+
+    @Test(dataProvider = "StringPrefixProvider")
+    public void testConcatNonBMPStrings(String prefix) {
+        BString bString = new BString(prefix);
+        BString resultString = new BString(prefix + "👋world🤷!");
+        BRunUtil.invoke(compileResult, "concatNonBMP", new BValue[]{bString, resultString});
+    }
+
+    @Test(dataProvider = "StringPrefixProvider")
+    public void testCharIterator(String prefix) {
+        BString bString = new BString(prefix + "👋world🤷!");
+        BRunUtil.invoke(compileResult, "testCharIterator", new BValue[]{bString});
+    }
+
+    @DataProvider(name = "StringPrefixProvider")
+    public Object[] testBMPStringProvider() {
+        return new String[]{"ascii~?", "£ßóµ¥", "ęЯλĢŃ", "☃✈௸ऴᛤ", "😀🄰🍺" };
     }
 }

--- a/langlib/langlib-test/src/test/resources/test-src/stringlib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/stringlib_test.bal
@@ -206,6 +206,19 @@ function testIteratorWithUnicodeChar(int codePoint, int[] expected) returns erro
     }
 }
 
+function testCharIterator(string stringValue) {
+    string result = "";
+    foreach var ch in stringValue {
+        result = result + ch;
+    }
+    assertEquals(stringValue, result);
+}
+
+function concatNonBMP(string prefix, string expected) {
+    string s = "👋world🤷!";
+    assertEquals(expected, prefix + s);
+}
+
 const ASSERTION_ERROR_REASON = "AssertionError";
 
 function assertEquals(anydata expected, anydata actual) {

--- a/langlib/langlib-test/src/test/resources/test-src/stringlib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/stringlib_test.bal
@@ -198,6 +198,13 @@ function testLangLibCallOnFiniteType() {
     assertEquals(false, x.startsWith("a"));
 }
 
+function testIteratorWithUnicodeChar(int codePoint, int[] expected) returns error? {
+    string str = check string:fromCodePointInt(codePoint);
+    int i = 0;
+    foreach var ch in str {
+        assertEquals(expected, ch.toCodePointInts());
+    }
+}
 
 const ASSERTION_ERROR_REASON = "AssertionError";
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/StringUtilsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/StringUtilsTest.java
@@ -19,6 +19,7 @@ package org.ballerinalang.test.types.string;
 
 import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.values.BString;
+import io.ballerina.runtime.api.values.BValue;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
@@ -50,6 +51,15 @@ public class StringUtilsTest {
             }
         }
         return StringUtils.fromString(content.toString());
+    }
+
+    @Test
+    public void testStringValue() {
+        BRunUtil.invoke(result, "testStringValue");
+    }
+
+    public static BString invokeStringValue(BValue value) {
+        return StringUtils.fromString(value.stringValue(null));
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/string/string-utils.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/string/string-utils.bal
@@ -38,3 +38,14 @@ function baz() {
 function getStringVal(any... values) returns string = @java:Method {
     'class:"org/ballerinalang/test/types/string/StringUtilsTest"
 } external;
+
+public function testStringValue() {
+    string expected = "ascii~?£ßóµ¥ęЯλĢŃ☃✈௸ऴᛤ😀🄰🍺";
+    string val = "ascii~?" + "£ßóµ¥" + "ęЯλĢŃ" + "☃✈௸ऴᛤ" + "😀🄰🍺";
+    val = invokeStringValue(val);
+    test:assertEquals(val, expected);
+}
+
+function invokeStringValue(any values) returns string = @java:Method {
+    'class:"org/ballerinalang/test/types/string/StringUtilsTest"
+} external;


### PR DESCRIPTION
## Purpose
$subject

Fixes #31775
Fixes #31767
Fixes #31917

## Approach
Use a natively implemnted character iterator instead of `StringCharacterIterator` which does not consider the 4 byte encoded unicode values.

## Samples
```ballerina
public function main() returns error? {
    string str  = check string:fromCodePointInt(0x10FFFF);
    foreach var ch in str {
        io:println(ch.toCodePointInts());
    }
}
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
