### PR TITLE
[Testerina] Add support for escaping special characters in data provider cases

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
@@ -216,11 +216,7 @@ public class RunTestsTask implements Task {
             if (isSingleTestExecution || isRerunTestExecution) {
                 // Update data driven tests with key
                 updatedSingleExecTests = filterKeyBasedTests(moduleName.moduleNamePart(), suite, singleExecTests);
-                if (!updatedSingleExecTests.isEmpty()) {
-                    suite.setTests(TesterinaUtils.getSingleExecutionTests(suite, updatedSingleExecTests));
-                } else {
-                    suite.setTests(TesterinaUtils.getSingleExecutionTests(suite, singleExecTests));
-                }
+                suite.setTests(TesterinaUtils.getSingleExecutionTests(suite, updatedSingleExecTests));
             }
             if (project.kind() == ProjectKind.SINGLE_FILE_PROJECT) {
                 suite.setSourceFileName(project.sourceRoot().getFileName().toString());
@@ -275,19 +271,39 @@ public class RunTestsTask implements Task {
     }
 
     /**
-     * Check whether this module is included in the provided test name.
+     * Contains module name as prefix to test name.
      *
      * @param testName String
-     * @param packageID String
-     * @param moduleName String
      * @return boolean
      */
-    private boolean includesModule(String testName, String packageID, String moduleName) {
-        boolean flag = false;
+    private boolean containsModulePrefix(String testName) {
+        boolean hasModPrefix = false;
         if (testName.contains(MODULE_SEPARATOR)) {
-            String[] functionDetail = testName.split(MODULE_SEPARATOR);
+            if (testName.contains(DATA_KEY_SEPARATOR)) {
+                if (testName.indexOf(MODULE_SEPARATOR) < testName.indexOf(DATA_KEY_SEPARATOR)) {
+                    hasModPrefix = true;
+                }
+            } else {
+                hasModPrefix = true;
+            }
+        }
+        return hasModPrefix;
+    }
+
+    /**
+     * Check whether module information is included in the provided test name.
+     *
+     * @param testName    String
+     * @param packageName String
+     * @param moduleName  String
+     * @return boolean
+     */
+    private boolean includesModule(String testName, String packageName, String moduleName) {
+        boolean flag = false;
+        if (containsModulePrefix(testName)) {
+            String prefix = testName.substring(0, testName.indexOf(MODULE_SEPARATOR));
             try {
-                if (functionDetail[0].equals(packageID) || functionDetail[0].equals(packageID + DOT + moduleName)) {
+                if (prefix.equals(packageName) || prefix.equals(packageName + DOT + moduleName)) {
                     flag = true;
                 }
             } catch (IndexOutOfBoundsException e) {
@@ -302,8 +318,8 @@ public class RunTestsTask implements Task {
     /**
      * Update test filters using the given data keys.
      *
-     * @param moduleName String
-     * @param suite TestSuite
+     * @param moduleName      String
+     * @param suite           TestSuite
      * @param singleExecTests List<String>
      * @return List of updated tests
      */
@@ -314,10 +330,11 @@ public class RunTestsTask implements Task {
             if (testName.contains(DATA_KEY_SEPARATOR) && includesModule(testName, suite.getPackageID(), moduleName)) {
                 try {
                     // Separate test name and the data set key
-                    String originalTestName = testName.substring(0, testName.indexOf(DATA_KEY_SEPARATOR));
+                    String testValue = testName.substring(0, testName.indexOf(DATA_KEY_SEPARATOR));
+                    String originalTestName = testValue;
                     String caseValue = testName.substring(testName.indexOf(DATA_KEY_SEPARATOR) + 1);
                     if (originalTestName.contains(MODULE_SEPARATOR)) {
-                        originalTestName = originalTestName.split(MODULE_SEPARATOR)[1];
+                        originalTestName = originalTestName.substring(originalTestName.indexOf(MODULE_SEPARATOR) + 1);
                     }
                     if (keyValues.containsKey(originalTestName)) {
                         keyValues.get(originalTestName).add(caseValue);
@@ -325,8 +342,8 @@ public class RunTestsTask implements Task {
                         keyValues.put(originalTestName, new ArrayList<>(Arrays.asList(caseValue)));
                     }
                     // Update the test name in the filtered test list
-                    if (!updatedSingleExecTests.contains(originalTestName)) {
-                        updatedSingleExecTests.add(originalTestName);
+                    if (!updatedSingleExecTests.contains(testValue)) {
+                        updatedSingleExecTests.add(testValue);
                     }
                 } catch (IndexOutOfBoundsException e) {
                     throw createLauncherException("error occurred while filtering tests based on provided key values",

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/DataProviderTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/DataProviderTest.java
@@ -24,7 +24,10 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 
 /**
  * Test class to test map based data provider implementation.
@@ -85,7 +88,7 @@ public class DataProviderTest extends BaseTestCase {
     public void testDataProviderWithMixedType() throws BallerinaTestException {
         String msg1 = "2 passing";
         String msg2 = "0 failing";
-        String[] args = mergeCoverageArgs(new String[]{"--tests", "testFunction1#CaseNew*",
+        String[] args = mergeCoverageArgs(new String[]{"--tests", "testFunction1#'CaseNew*'",
                 "data-providers"});
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
@@ -149,7 +152,7 @@ public class DataProviderTest extends BaseTestCase {
         }
     }
 
-    @Test
+    @Test (dependsOnMethods = "testArrayDataRerunFailedTest")
     public void testMultiModuleSingleTestExec() throws BallerinaTestException {
         String msg1 = "1 passing";
         String msg2 = "0 failing";
@@ -158,6 +161,24 @@ public class DataProviderTest extends BaseTestCase {
                 new HashMap<>(), projectPath, false);
         if (!output.contains(msg1) || !output.contains(msg2)) {
             Assert.fail("Test failed due to multi module single test exec failure with array based data provider.");
+        }
+    }
+
+    @Test
+    public void testCodeFragmentKeys() throws BallerinaTestException {
+        String msg1 = "1 passing";
+        String msg2 = "0 failing";
+        List<String> keys = new ArrayList<>(Arrays.asList("'%60'%22%5Ca%22%22'",
+                "'%22%5Cu{D7FF}%22%22%09%22'", "'a +%0A%0D b'",
+                "'(x * 1) %21= (y / 3) || (a ^ b) == (b & c) >> (1 % 2)'", "'%281'", "'a:x(c%2Cd)[]; ^(x|y).ok();'",
+                "'map<any> v = { %22x%22: 1 };'"));
+        for (String key:keys) {
+            String[] args = mergeCoverageArgs(new String[]{"--tests", "testFunction3#" + key, "data-providers"});
+            String output = balClient.runMainAndReadStdOut("test", args,
+                    new HashMap<>(), projectPath, false);
+            if (!output.contains(msg1) || !output.contains(msg2)) {
+                Assert.fail("Test failed due to data provider single case execution failure for the key " + key);
+            }
         }
     }
 }

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/data-providers/tests/new-data-provider-tests.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/data-providers/tests/new-data-provider-tests.bal
@@ -16,6 +16,8 @@
 
 import ballerina/test;
 
+type CodeFragment [string, string];
+
 @test:Config {
     dataProvider: dataGen
 }
@@ -78,6 +80,13 @@ function testFunction2(int value1, int value2, int result1) returns error? {
     test:assertEquals(value1 + value2, result1, msg = "The sum is not correct");
 }
 
+@test:Config {
+    dataProvider: dataGen9
+}
+function testFunction3(string value1, string value2) returns error? {
+   test:assertEquals("E", value1, msg = "The code fragment is not correct.");
+}
+
 function dataGen() returns map<[int, int, int]>|error {
     map<[int, int, int]> dataSet = {
         "Case1": [1, 2, 4],
@@ -131,4 +140,21 @@ function dataGen8() returns map<[int, int, int]>|error {
         "Case#3": [5, 6, 11]
     };
     return dataSet;
+}
+
+function dataGen9() returns map<CodeFragment>|error {
+    CodeFragment[] sources = [
+        ["E", "`'" +  string`"\a"` + string`"`],
+        ["E", "\"\\" + "u{D7FF}\"" + "\"\t\""],
+        ["E",  "a +\n\r b"],
+        ["E", "(x * 1) != (y / 3) || (a ^ b) == (b & c) >> (1 % 2)"],
+        ["E",  "(1"],
+        ["E", "a:x(c,d)[]; ^(x|y).ok();"],
+        ["E",  string`map<any> v = { "x": 1 };`]];
+
+    map<CodeFragment> tests = {};
+    foreach var s in sources {
+        tests[s[1]] = s;
+    }
+    return tests;
 }


### PR DESCRIPTION
## Purpose

Add support for escaping special characters in data provider cases in the test framework.
Fixes #31672

## Approach

The key for each data provider entry, will be shown in the following format.

testFunction#**'**case1**'**

Following special characters in the data provider keys will be encoded.

```
","
"\\n" 
"\\r"
"\\t"
"\n"
"\r"
"\t"
"\""
"\\"
"!"
"`"
```

Following is an example test output when the case value is **"map<any> v = { "x": 1 };"**

testFunction#**'map<any> v = { %22x%22: 1 };'**

## Samples

## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
