### PR TITLE
Fix failing debugger expression evaluation test

### DIFF
--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/validator/impl/TopLevelDeclarationValidator.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/validator/impl/TopLevelDeclarationValidator.java
@@ -61,7 +61,7 @@ public class TopLevelDeclarationValidator extends Validator {
         // Needs to filter out module variable declarations, since variable assignment statements can be parsed into
         // module-level variable declaration during this validation phase.
         List<ModuleMemberDeclarationNode> members = memberNodes.stream()
-                .filter(node -> node.kind() != SyntaxKind.MODULE_VAR_DECL)
+                .filter(node -> node.kind() != SyntaxKind.MODULE_VAR_DECL && !node.hasDiagnostics())
                 .collect(Collectors.toList());
         failIf(members.size() > 0, UNSUPPORTED_INPUT_TOPLEVEL_DCLN);
     }

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/evaluation/ExpressionEvaluationNegativeTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/evaluation/ExpressionEvaluationNegativeTest.java
@@ -148,7 +148,7 @@ public class ExpressionEvaluationNegativeTest extends ExpressionEvaluationBaseTe
     }
 
     @Override
-    @Test(enabled = false) // issue: #31871
+    @Test
     public void functionCallEvaluationTest() throws BallerinaTestException {
 
         debugTestRunner.assertEvaluationError(context, "calculate(5, 6)", EvaluationExceptionKind.PREFIX +


### PR DESCRIPTION
## Purpose
This PR fixes debugger expression evaluation test failures due to parser lookahead limit change.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/31871.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [x] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
