### PR TITLE
Decode typename at compile time

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/creators/TypeCreator.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/creators/TypeCreator.java
@@ -502,4 +502,6 @@ public class TypeCreator {
         return new BFiniteType(typeName, values, typeFlags);
     }
 
+    private TypeCreator() {
+    }
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/ValueUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/ValueUtils.java
@@ -109,7 +109,7 @@ public class ValueUtils {
      * @return value of the object.
      */
     public static BObject createObjectValue(Module packageId, String objectTypeName, Object... fieldValues) {
-        Strand currentStrand = getStrand();
+        Strand currentStrand = Scheduler.getStrandNoException();
         // This method duplicates the createObjectValue with referencing the issue in runtime API getting strand
         io.ballerina.runtime.internal.values.ValueCreator
                 valueCreator = io.ballerina.runtime.internal.values.ValueCreator.getValueCreator(packageId.toString());
@@ -146,13 +146,7 @@ public class ValueUtils {
         return objectValue;
     }
 
-    private static Strand getStrand() {
-        try {
-            return Scheduler.getStrand();
-        } catch (Exception ex) {
-            // Ignore : issue #22871 is opened to fix this
-        }
-        return null;
+    private ValueUtils() {
     }
 
     /**

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/scheduling/Scheduler.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/scheduling/Scheduler.java
@@ -113,6 +113,11 @@ public class Scheduler {
         return strand;
     }
 
+    public static Strand getStrandNoException() {
+        // issue #22871 is opened to fix this
+        return strandHolder.get().strand;
+    }
+
     /**
      * Schedules given function by creating a new strand group.
      *
@@ -420,7 +425,7 @@ public class Scheduler {
                 int strandsLeft = totalStrands.decrementAndGet();
                 if (strandsLeft == 0) {
                     // (number of started stands - finished stands) = 0, all the work is done
-                    assert runnableList.size() == 0;
+                    assert runnableList.isEmpty();
 
                     if (!immortal) {
                         poison();

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BType.java
@@ -21,7 +21,6 @@ import io.ballerina.runtime.api.Module;
 import io.ballerina.runtime.api.TypeTags;
 import io.ballerina.runtime.api.types.IntersectionType;
 import io.ballerina.runtime.api.types.Type;
-import io.ballerina.runtime.api.utils.IdentifierUtils;
 import io.ballerina.runtime.internal.TypeChecker;
 import io.ballerina.runtime.internal.util.exceptions.BallerinaException;
 
@@ -44,7 +43,7 @@ public abstract class BType implements Type {
     private int hashCode;
 
     protected BType(String typeName, Module pkg, Class<? extends Object> valueClass) {
-        this.typeName = IdentifierUtils.decodeIdentifier(typeName);
+        this.typeName = typeName;
         this.pkg = pkg;
         this.valueClass = valueClass;
         if (pkg != null && typeName != null) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ReadOnlyUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ReadOnlyUtils.java
@@ -28,6 +28,7 @@ import io.ballerina.runtime.api.types.IntersectableReferenceType;
 import io.ballerina.runtime.api.types.IntersectionType;
 import io.ballerina.runtime.api.types.SelectivelyImmutableReferenceType;
 import io.ballerina.runtime.api.types.Type;
+import io.ballerina.runtime.api.utils.IdentifierUtils;
 import io.ballerina.runtime.internal.TypeChecker;
 import io.ballerina.runtime.internal.types.BArrayType;
 import io.ballerina.runtime.internal.types.BField;
@@ -215,11 +216,12 @@ public class ReadOnlyUtils {
                                           originalField.getFieldName(), originalField.getFlags()));
                 }
 
-                BRecordType immutableRecordType = new BRecordType(origRecordType.getName().concat(" & readonly"),
-                                                                  origRecordType.getPackage(),
-                                                                  origRecordType.flags |= SymbolFlags.READONLY, fields,
-                                                                  null, origRecordType.sealed,
-                                                                  origRecordType.typeFlags);
+                BRecordType immutableRecordType = new BRecordType(
+                        IdentifierUtils.decodeIdentifier(origRecordType.getName().concat(" & readonly")),
+                        origRecordType.getPackage(),
+                        origRecordType.flags |= SymbolFlags.READONLY, fields,
+                        null, origRecordType.sealed,
+                        origRecordType.typeFlags);
                 BIntersectionType intersectionType = createAndSetImmutableIntersectionType(origRecordType,
                                                                                            immutableRecordType);
 
@@ -241,7 +243,7 @@ public class ReadOnlyUtils {
                                                         getImmutableType(origKeyType, unresolvedTypes), true);
                 } else {
                     immutableTableType = new BTableType(getImmutableType(origTableType.getConstrainedType(),
-                                                                                     unresolvedTypes),
+                                                                         unresolvedTypes),
                                                         origTableType.getFieldNames(), true);
                 }
 
@@ -251,9 +253,9 @@ public class ReadOnlyUtils {
 
                 Map<String, Field> originalObjectFields = origObjectType.getFields();
                 Map<String, Field> immutableObjectFields = new HashMap<>(originalObjectFields.size());
-                BObjectType immutableObjectType = new BObjectType(origObjectType.getName().concat(" & readonly"),
-                                                                  origObjectType.getPackage(),
-                                                                  origObjectType.flags |= SymbolFlags.READONLY);
+                BObjectType immutableObjectType = new BObjectType(
+                        IdentifierUtils.decodeIdentifier(origObjectType.getName().concat(" & readonly")),
+                        origObjectType.getPackage(), origObjectType.flags |= SymbolFlags.READONLY);
                 immutableObjectType.setFields(immutableObjectFields);
                 immutableObjectType.generatedInitializer = origObjectType.generatedInitializer;
                 immutableObjectType.initializer = origObjectType.initializer;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
@@ -15,6 +15,7 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
+
 package org.wso2.ballerinalang.compiler.bir.codegen;
 
 import org.ballerinalang.model.elements.PackageID;
@@ -197,6 +198,7 @@ public class JvmConstants {
     public static final String LISTENER_REGISTRY_CLASS =
             "io/ballerina/runtime/internal/scheduling/Scheduler$ListenerRegistry";
     public static final String VALUE_COMPARISON_UTILS = "io/ballerina/runtime/internal/ValueComparisonUtils";
+    public static final String IDENTIFIER_UTILS = "io/ballerina/runtime/api/utils/IdentifierUtils";
 
     // other java classes
     public static final String OBJECT = "java/lang/Object";
@@ -351,9 +353,6 @@ public class JvmConstants {
     public static final int TYPE_FLAG_NILABLE = 1;
     public static final int TYPE_FLAG_ANYDATA = 2;
     public static final int TYPE_FLAG_PURETYPE = 4;
-
-    // ballerina error reasons for ASM operations.
-    public static final String CLASS_TOO_LARGE = "ClassTooLarge";
 
 
     public static final String TYPE_NOT_SUPPORTED_MESSAGE = "JVM generation is not supported for type ";


### PR DESCRIPTION
## Purpose
> This is to optimize performance at runtime. There's a lot of slowness if the typeNames are decoded at runtime.

## Approach
> The typename which was decoded at runtime in `BType` class is now decoded at compile time to improve performance

## Samples
> N/A
## Remarks
> 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
