### PR TITLE
Fix scope finding logic in `EnvironmentResolver`

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/EnvironmentResolver.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/EnvironmentResolver.java
@@ -435,8 +435,7 @@ public class EnvironmentResolver extends BaseVisitor {
 
     @Override
     public void visit(BLangQueryAction queryAction) {
-        if (!PositionUtil.withinRightInclusive(this.linePosition, queryAction.getPosition())
-                || !isNarrowerEnclosure(queryAction.getPosition())) {
+        if (!PositionUtil.withinRightInclusive(this.linePosition, queryAction.getPosition())) {
             return;
         }
         for (BLangNode clause : queryAction.queryClauseList) {
@@ -447,8 +446,7 @@ public class EnvironmentResolver extends BaseVisitor {
 
     @Override
     public void visit(BLangDoClause doClause) {
-        if (PositionUtil.withinBlock(this.linePosition, doClause.getPosition())
-                && isNarrowerEnclosure(doClause.getPosition())) {
+        if (PositionUtil.withinBlock(this.linePosition, doClause.getPosition())) {
             this.scope = doClause.env;
             this.acceptNode(doClause.body, doClause.env);
         }
@@ -456,8 +454,7 @@ public class EnvironmentResolver extends BaseVisitor {
 
     @Override
     public void visit(BLangFromClause fromClause) {
-        if (!PositionUtil.withinRightInclusive(this.linePosition, fromClause.getPosition())
-                || !isNarrowerEnclosure(fromClause.getPosition())) {
+        if (!PositionUtil.withinRightInclusive(this.linePosition, fromClause.getPosition())) {
             return;
         }
         this.scope = fromClause.env;
@@ -467,8 +464,7 @@ public class EnvironmentResolver extends BaseVisitor {
 
     @Override
     public void visit(BLangLetClause letClause) {
-        if (!PositionUtil.withinRightInclusive(this.linePosition, letClause.getPosition())
-                || !isNarrowerEnclosure(letClause.getPosition())) {
+        if (!PositionUtil.withinRightInclusive(this.linePosition, letClause.getPosition())) {
             return;
         }
         this.scope = letClause.env;
@@ -479,8 +475,7 @@ public class EnvironmentResolver extends BaseVisitor {
 
     @Override
     public void visit(BLangSelectClause selectClause) {
-        if (!PositionUtil.withinRightInclusive(this.linePosition, selectClause.getPosition())
-                || !isNarrowerEnclosure(selectClause.getPosition())) {
+        if (!PositionUtil.withinRightInclusive(this.linePosition, selectClause.getPosition())) {
             return;
         }
         this.scope = selectClause.env;
@@ -489,8 +484,7 @@ public class EnvironmentResolver extends BaseVisitor {
 
     @Override
     public void visit(BLangWhereClause whereClause) {
-        if (!PositionUtil.withinRightInclusive(this.linePosition, whereClause.getPosition())
-                || !isNarrowerEnclosure(whereClause.getPosition())) {
+        if (!PositionUtil.withinRightInclusive(this.linePosition, whereClause.getPosition())) {
             return;
         }
         this.scope = whereClause.env;
@@ -519,8 +513,7 @@ public class EnvironmentResolver extends BaseVisitor {
 
     @Override
     public void visit(BLangQueryExpr queryExpr) {
-        if (!PositionUtil.withinRightInclusive(this.linePosition, queryExpr.getPosition())
-                || !isNarrowerEnclosure(queryExpr.getPosition())) {
+        if (!PositionUtil.withinRightInclusive(this.linePosition, queryExpr.getPosition())) {
             return;
         }
         for (BLangNode clause : queryExpr.queryClauseList) {
@@ -570,8 +563,7 @@ public class EnvironmentResolver extends BaseVisitor {
 
     @Override
     public void visit(BLangJoinClause joinClause) {
-        if (!PositionUtil.withinRightInclusive(this.linePosition, joinClause.getPosition())
-                || !isNarrowerEnclosure(joinClause.getPosition())) {
+        if (!PositionUtil.withinRightInclusive(this.linePosition, joinClause.getPosition())) {
             return;
         }
         this.scope = joinClause.env;
@@ -581,8 +573,7 @@ public class EnvironmentResolver extends BaseVisitor {
 
     @Override
     public void visit(BLangOnClause onClause) {
-        if (!PositionUtil.withinRightInclusive(this.linePosition, onClause.getPosition())
-                || !isNarrowerEnclosure(onClause.getPosition())) {
+        if (!PositionUtil.withinRightInclusive(this.linePosition, onClause.getPosition())) {
             return;
         }
         if (onClause.equalsKeywordPos == null ||
@@ -600,8 +591,7 @@ public class EnvironmentResolver extends BaseVisitor {
 
     @Override
     public void visit(BLangOrderByClause orderByClause) {
-        if (!PositionUtil.withinRightInclusive(this.linePosition, orderByClause.getPosition())
-                || !isNarrowerEnclosure(orderByClause.getPosition())) {
+        if (!PositionUtil.withinRightInclusive(this.linePosition, orderByClause.getPosition())) {
             return;
         }
         this.scope = orderByClause.env;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/EnvironmentResolver.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/EnvironmentResolver.java
@@ -31,164 +31,61 @@ import org.wso2.ballerinalang.compiler.tree.BLangAnnotationAttachment;
 import org.wso2.ballerinalang.compiler.tree.BLangBlockFunctionBody;
 import org.wso2.ballerinalang.compiler.tree.BLangClassDefinition;
 import org.wso2.ballerinalang.compiler.tree.BLangCompilationUnit;
-import org.wso2.ballerinalang.compiler.tree.BLangErrorVariable;
 import org.wso2.ballerinalang.compiler.tree.BLangExprFunctionBody;
 import org.wso2.ballerinalang.compiler.tree.BLangExternalFunctionBody;
 import org.wso2.ballerinalang.compiler.tree.BLangFunction;
-import org.wso2.ballerinalang.compiler.tree.BLangIdentifier;
-import org.wso2.ballerinalang.compiler.tree.BLangImportPackage;
-import org.wso2.ballerinalang.compiler.tree.BLangMarkdownDocumentation;
-import org.wso2.ballerinalang.compiler.tree.BLangMarkdownReferenceDocumentation;
 import org.wso2.ballerinalang.compiler.tree.BLangNode;
-import org.wso2.ballerinalang.compiler.tree.BLangNodeVisitor;
-import org.wso2.ballerinalang.compiler.tree.BLangPackage;
-import org.wso2.ballerinalang.compiler.tree.BLangRecordVariable;
 import org.wso2.ballerinalang.compiler.tree.BLangResourceFunction;
-import org.wso2.ballerinalang.compiler.tree.BLangRetrySpec;
 import org.wso2.ballerinalang.compiler.tree.BLangService;
 import org.wso2.ballerinalang.compiler.tree.BLangSimpleVariable;
-import org.wso2.ballerinalang.compiler.tree.BLangTableKeySpecifier;
-import org.wso2.ballerinalang.compiler.tree.BLangTableKeyTypeConstraint;
-import org.wso2.ballerinalang.compiler.tree.BLangTestablePackage;
-import org.wso2.ballerinalang.compiler.tree.BLangTupleVariable;
 import org.wso2.ballerinalang.compiler.tree.BLangTypeDefinition;
-import org.wso2.ballerinalang.compiler.tree.BLangXMLNS;
-import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangCaptureBindingPattern;
-import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangListBindingPattern;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangDoClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangFromClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangJoinClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangLetClause;
-import org.wso2.ballerinalang.compiler.tree.clauses.BLangLimitClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangMatchClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangOnClause;
-import org.wso2.ballerinalang.compiler.tree.clauses.BLangOnConflictClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangOnFailClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangOrderByClause;
-import org.wso2.ballerinalang.compiler.tree.clauses.BLangOrderKey;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangSelectClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangWhereClause;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangAnnotAccessExpr;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangArrowFunction;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangBinaryExpr;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangCheckPanickedExpr;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangCheckedExpr;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangCommitExpr;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangConstRef;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangConstant;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangElvisExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangErrorConstructorExpr;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangErrorVarRef;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangFieldBasedAccess;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangGroupExpr;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangIgnoreExpr;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangIndexBasedAccess;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangInferredTypedescDefaultNode;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangIntRangeExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangInvocation;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangIsAssignableExpr;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangIsLikeExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangLambdaFunction;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangLetExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangListConstructorExpr;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangLiteral;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangMarkDownDeprecatedParametersDocumentation;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangMarkDownDeprecationDocumentation;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangMarkdownDocumentationLine;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangMarkdownParameterDocumentation;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangMarkdownReturnParameterDocumentation;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangMatchGuard;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangNamedArgsExpression;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangNumericLiteral;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangObjectConstructorExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangQueryAction;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangQueryExpr;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangRawTemplateLiteral;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordVarRef;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangRestArgsExpression;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangServiceConstructorExpr;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangSimpleVarRef;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangStatementExpression;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangStringTemplateLiteral;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangTableConstructorExpr;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangTableMultiKeyExpr;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangTernaryExpr;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangTransactionalExpr;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangTrapExpr;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangTupleVarRef;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangTypeConversionExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangTypeInit;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangTypeTestExpr;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangTypedescExpr;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangUnaryExpr;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangWaitExpr;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangWaitForAllExpr;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangWorkerFlushExpr;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangWorkerReceive;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangWorkerSyncSendExpr;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLAttribute;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLCommentLiteral;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLElementAccess;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLElementFilter;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLElementLiteral;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLNavigationAccess;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLProcInsLiteral;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLQName;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLQuotedString;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLSequenceLiteral;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLTextLiteral;
-import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangConstPattern;
-import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangVarBindingPatternMatchPattern;
-import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangWildCardMatchPattern;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangAssignment;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangBlockStmt;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangBreak;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangCompoundAssignment;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangContinue;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangDo;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangErrorDestructure;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangErrorVariableDef;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangExpressionStmt;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangFail;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangForeach;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangForkJoin;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangIf;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangLock;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangMatchStatement;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangPanic;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangRecordDestructure;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangRecordVariableDef;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangRetry;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangRetryTransaction;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangReturn;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangRollback;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangSimpleVariableDef;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangStatement;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangTransaction;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangTryCatchFinally;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangTupleDestructure;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangTupleVariableDef;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangWhile;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangWorkerSend;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangXMLNSStatement;
-import org.wso2.ballerinalang.compiler.tree.types.BLangArrayType;
-import org.wso2.ballerinalang.compiler.tree.types.BLangBuiltInRefTypeNode;
-import org.wso2.ballerinalang.compiler.tree.types.BLangConstrainedType;
-import org.wso2.ballerinalang.compiler.tree.types.BLangErrorType;
-import org.wso2.ballerinalang.compiler.tree.types.BLangFiniteTypeNode;
-import org.wso2.ballerinalang.compiler.tree.types.BLangFunctionTypeNode;
-import org.wso2.ballerinalang.compiler.tree.types.BLangIntersectionTypeNode;
 import org.wso2.ballerinalang.compiler.tree.types.BLangLetVariable;
 import org.wso2.ballerinalang.compiler.tree.types.BLangObjectTypeNode;
 import org.wso2.ballerinalang.compiler.tree.types.BLangRecordTypeNode;
-import org.wso2.ballerinalang.compiler.tree.types.BLangStreamType;
-import org.wso2.ballerinalang.compiler.tree.types.BLangTableTypeNode;
-import org.wso2.ballerinalang.compiler.tree.types.BLangTupleTypeNode;
-import org.wso2.ballerinalang.compiler.tree.types.BLangUnionTypeNode;
-import org.wso2.ballerinalang.compiler.tree.types.BLangUserDefinedType;
-import org.wso2.ballerinalang.compiler.tree.types.BLangValueType;
 
 import java.util.List;
 
@@ -197,7 +94,7 @@ import java.util.List;
  *
  * @since 2.0.0
  */
-public class EnvironmentResolver extends BLangNodeVisitor {
+public class EnvironmentResolver extends BaseVisitor {
     LinePosition linePosition = null;
     private SymbolEnv symbolEnv;
     private SymbolEnv scope;
@@ -440,24 +337,8 @@ public class EnvironmentResolver extends BLangNodeVisitor {
     }
 
     @Override
-    public void visit(BLangWorkerSend workerSendNode) {
-    }
-
-    @Override
-    public void visit(BLangWorkerReceive workerReceiveNode) {
-    }
-
-    @Override
     public void visit(BLangReturn returnNode) {
         this.acceptNode(returnNode.expr, symbolEnv);
-    }
-
-    @Override
-    public void visit(BLangContinue continueNode) {
-    }
-
-    @Override
-    public void visit(BLangBreak breakNode) {
     }
 
     @Override
@@ -498,10 +379,6 @@ public class EnvironmentResolver extends BLangNodeVisitor {
     }
 
     @Override
-    public void visit(BLangSimpleVarRef simpleVarRef) {
-    }
-
-    @Override
     public void visit(BLangRecordLiteral recordLiteral) {
         if (!PositionUtil.withinBlock(this.linePosition, recordLiteral.getPosition())) {
             return;
@@ -534,16 +411,8 @@ public class EnvironmentResolver extends BLangNodeVisitor {
     }
 
     @Override
-    public void visit(BLangTupleVariableDef bLangTupleVariableDef) {
-    }
-
-    @Override
     public void visit(BLangCompoundAssignment compoundAssignNode) {
         this.acceptNode(compoundAssignNode.expr, symbolEnv);
-    }
-
-    @Override
-    public void visit(BLangErrorVariableDef bLangErrorVariableDef) {
     }
 
     @Override
@@ -563,37 +432,6 @@ public class EnvironmentResolver extends BLangNodeVisitor {
             this.scope = doClause.env;
             this.acceptNode(doClause.body, doClause.env);
         }
-    }
-
-    @Override
-    public void visit(BLangPackage pkgNode) {
-    }
-
-    @Override
-    public void visit(BLangTestablePackage testablePkgNode) {
-    }
-
-    @Override
-    public void visit(BLangImportPackage importPkgNode) {
-    }
-
-    @Override
-    public void visit(BLangXMLNS xmlnsNode) {
-    }
-
-    @Override
-    public void visit(BLangIdentifier identifierNode) {
-
-    }
-
-    @Override
-    public void visit(BLangLock.BLangLockStmt lockStmtNode) {
-
-    }
-
-    @Override
-    public void visit(BLangLock.BLangUnLockStmt unLockNode) {
-
     }
 
     @Override
@@ -636,91 +474,6 @@ public class EnvironmentResolver extends BLangNodeVisitor {
     }
 
     @Override
-    public void visit(BLangTryCatchFinally tryNode) {
-
-    }
-
-    @Override
-    public void visit(BLangTupleDestructure stmt) {
-
-    }
-
-    @Override
-    public void visit(BLangRecordDestructure stmt) {
-
-    }
-
-    @Override
-    public void visit(BLangErrorDestructure stmt) {
-
-    }
-
-    @Override
-    public void visit(BLangLiteral literalExpr) {
-
-    }
-
-    @Override
-    public void visit(BLangConstRef constRef) {
-
-    }
-
-    @Override
-    public void visit(BLangNumericLiteral literalExpr) {
-
-    }
-
-    @Override
-    public void visit(BLangTupleVarRef varRefExpr) {
-
-    }
-
-    @Override
-    public void visit(BLangRecordVarRef varRefExpr) {
-
-    }
-
-    @Override
-    public void visit(BLangErrorVarRef varRefExpr) {
-
-    }
-
-    @Override
-    public void visit(BLangFieldBasedAccess fieldAccessExpr) {
-
-    }
-
-    @Override
-    public void visit(BLangIndexBasedAccess indexAccessExpr) {
-
-    }
-
-    @Override
-    public void visit(BLangInvocation.BLangActionInvocation actionInvocationExpr) {
-
-    }
-
-    @Override
-    public void visit(BLangTernaryExpr ternaryExpr) {
-
-    }
-
-    @Override
-    public void visit(BLangWaitExpr awaitExpr) {
-
-    }
-
-    @Override
-    public void visit(BLangTrapExpr trapExpr) {
-
-    }
-
-    @Override
-    public void visit(BLangElvisExpr elvisExpr) {
-
-    }
-
-    @Override
     public void visit(BLangLetExpression letExpr) {
         if (PositionUtil.withinBlock(this.linePosition, letExpr.getPosition())) {
             SymbolEnv letExprEnv = letExpr.env.createClone();
@@ -735,128 +488,8 @@ public class EnvironmentResolver extends BLangNodeVisitor {
     }
 
     @Override
-    public void visit(BLangLetVariable letVariable) {
-
-    }
-
-    @Override
-    public void visit(BLangListConstructorExpr.BLangTupleLiteral tupleLiteral) {
-
-    }
-
-    @Override
-    public void visit(BLangListConstructorExpr.BLangArrayLiteral arrayLiteral) {
-
-    }
-
-    @Override
-    public void visit(BLangUnaryExpr unaryExpr) {
-
-    }
-
-    @Override
-    public void visit(BLangTypedescExpr accessExpr) {
-
-    }
-
-    @Override
-    public void visit(BLangXMLQName xmlQName) {
-
-    }
-
-    @Override
-    public void visit(BLangXMLAttribute xmlAttribute) {
-
-    }
-
-    @Override
-    public void visit(BLangXMLElementLiteral xmlElementLiteral) {
-
-    }
-
-    @Override
-    public void visit(BLangXMLTextLiteral xmlTextLiteral) {
-
-    }
-
-    @Override
-    public void visit(BLangXMLCommentLiteral xmlCommentLiteral) {
-
-    }
-
-    @Override
-    public void visit(BLangXMLProcInsLiteral xmlProcInsLiteral) {
-
-    }
-
-    @Override
-    public void visit(BLangXMLQuotedString xmlQuotedString) {
-
-    }
-
-    @Override
-    public void visit(BLangStringTemplateLiteral stringTemplateLiteral) {
-
-    }
-
-    @Override
     public void visit(BLangLambdaFunction bLangLambdaFunction) {
         this.acceptNode(bLangLambdaFunction.function, this.symbolEnv);
-    }
-
-    @Override
-    public void visit(BLangArrowFunction bLangArrowFunction) {
-
-    }
-
-    @Override
-    public void visit(BLangIntRangeExpression intRangeExpression) {
-
-    }
-
-    @Override
-    public void visit(BLangRestArgsExpression bLangVarArgsExpression) {
-
-    }
-
-    @Override
-    public void visit(BLangIsAssignableExpr assignableExpr) {
-
-    }
-
-    @Override
-    public void visit(BLangCheckedExpr checkedExpr) {
-
-    }
-
-    @Override
-    public void visit(BLangCheckPanickedExpr checkPanickedExpr) {
-
-    }
-
-    @Override
-    public void visit(BLangServiceConstructorExpr serviceConstructorExpr) {
-
-    }
-
-    @Override
-    public void visit(BLangTypeTestExpr typeTestExpr) {
-
-    }
-
-    @Override
-    public void visit(BLangIsLikeExpr typeTestExpr) {
-
-    }
-
-    @Override
-    public void visit(BLangIgnoreExpr ignoreExpr) {
-
-    }
-
-    @Override
-    public void visit(BLangAnnotAccessExpr annotAccessExpr) {
-
     }
 
     @Override
@@ -870,278 +503,8 @@ public class EnvironmentResolver extends BLangNodeVisitor {
     }
 
     @Override
-    public void visit(BLangValueType valueType) {
-
-    }
-
-    @Override
-    public void visit(BLangArrayType arrayType) {
-
-    }
-
-    @Override
-    public void visit(BLangBuiltInRefTypeNode builtInRefType) {
-
-    }
-
-    @Override
-    public void visit(BLangConstrainedType constrainedType) {
-
-    }
-
-    @Override
-    public void visit(BLangStreamType streamType) {
-
-    }
-
-    @Override
-    public void visit(BLangUserDefinedType userDefinedType) {
-
-    }
-
-    @Override
-    public void visit(BLangFunctionTypeNode functionTypeNode) {
-
-    }
-
-    @Override
-    public void visit(BLangUnionTypeNode unionTypeNode) {
-
-    }
-
-    @Override
-    public void visit(BLangFiniteTypeNode finiteTypeNode) {
-
-    }
-
-    @Override
-    public void visit(BLangTupleTypeNode tupleTypeNode) {
-
-    }
-
-    @Override
-    public void visit(BLangErrorType errorType) {
-
-    }
-
-    @Override
-    public void visit(BLangSimpleVarRef.BLangLocalVarRef localVarRef) {
-
-    }
-
-    @Override
-    public void visit(BLangSimpleVarRef.BLangFieldVarRef fieldVarRef) {
-
-    }
-
-    @Override
-    public void visit(BLangSimpleVarRef.BLangPackageVarRef packageVarRef) {
-
-    }
-
-    @Override
-    public void visit(BLangSimpleVarRef.BLangFunctionVarRef functionVarRef) {
-
-    }
-
-    @Override
-    public void visit(BLangSimpleVarRef.BLangTypeLoad typeLoad) {
-
-    }
-
-    @Override
-    public void visit(BLangIndexBasedAccess.BLangStructFieldAccessExpr fieldAccessExpr) {
-
-    }
-
-    @Override
-    public void visit(BLangFieldBasedAccess.BLangStructFunctionVarRef functionVarRef) {
-
-    }
-
-    @Override
-    public void visit(BLangIndexBasedAccess.BLangMapAccessExpr mapKeyAccessExpr) {
-
-    }
-
-    @Override
-    public void visit(BLangIndexBasedAccess.BLangArrayAccessExpr arrayIndexAccessExpr) {
-
-    }
-
-    @Override
-    public void visit(BLangIndexBasedAccess.BLangTupleAccessExpr arrayIndexAccessExpr) {
-
-    }
-
-    @Override
-    public void visit(BLangIndexBasedAccess.BLangXMLAccessExpr xmlAccessExpr) {
-
-    }
-
-    @Override
-    public void visit(BLangRecordLiteral.BLangMapLiteral mapLiteral) {
-
-    }
-
-    @Override
-    public void visit(BLangRecordLiteral.BLangStructLiteral structLiteral) {
-
-    }
-
-    @Override
-    public void visit(BLangRecordLiteral.BLangChannelLiteral channelLiteral) {
-
-    }
-
-    @Override
-    public void visit(BLangInvocation.BFunctionPointerInvocation bFunctionPointerInvocation) {
-
-    }
-
-    @Override
-    public void visit(BLangInvocation.BLangAttachedFunctionInvocation iExpr) {
-
-    }
-
-    @Override
-    public void visit(BLangListConstructorExpr.BLangJSONArrayLiteral jsonArrayLiteral) {
-
-    }
-
-    @Override
-    public void visit(BLangIndexBasedAccess.BLangJSONAccessExpr jsonAccessExpr) {
-
-    }
-
-    @Override
-    public void visit(BLangIndexBasedAccess.BLangStringAccessExpr stringAccessExpr) {
-
-    }
-
-    @Override
-    public void visit(BLangXMLNS.BLangLocalXMLNS xmlnsNode) {
-
-    }
-
-    @Override
-    public void visit(BLangXMLNS.BLangPackageXMLNS xmlnsNode) {
-
-    }
-
-    @Override
-    public void visit(BLangXMLSequenceLiteral bLangXMLSequenceLiteral) {
-
-    }
-
-    @Override
     public void visit(BLangStatementExpression bLangStatementExpression) {
         this.acceptNode(bLangStatementExpression.stmt, this.symbolEnv);
-    }
-
-    @Override
-    public void visit(BLangMarkdownDocumentationLine bLangMarkdownDocumentationLine) {
-
-    }
-
-    @Override
-    public void visit(BLangMarkdownParameterDocumentation bLangDocumentationParameter) {
-
-    }
-
-    @Override
-    public void visit(BLangMarkdownReturnParameterDocumentation bLangMarkdownReturnParameterDocumentation) {
-
-    }
-
-    @Override
-    public void visit(BLangMarkDownDeprecationDocumentation bLangMarkDownDeprecationDocumentation) {
-
-    }
-
-    @Override
-    public void visit(BLangMarkdownDocumentation bLangMarkdownDocumentation) {
-
-    }
-
-    @Override
-    public void visit(BLangTupleVariable bLangTupleVariable) {
-
-    }
-
-    @Override
-    public void visit(BLangRecordVariable bLangRecordVariable) {
-
-    }
-
-    @Override
-    public void visit(BLangRecordVariableDef bLangRecordVariableDef) {
-
-    }
-
-    @Override
-    public void visit(BLangErrorVariable bLangErrorVariable) {
-
-    }
-
-    @Override
-    public void visit(BLangWorkerFlushExpr workerFlushExpr) {
-
-    }
-
-    @Override
-    public void visit(BLangWorkerSyncSendExpr syncSendExpr) {
-
-    }
-
-    @Override
-    public void visit(BLangWaitForAllExpr waitForAllExpr) {
-
-    }
-
-    @Override
-    public void visit(BLangWaitForAllExpr.BLangWaitLiteral waitLiteral) {
-
-    }
-
-    @Override
-    public void visit(BLangRecordLiteral.BLangRecordSpreadOperatorField spreadOperatorField) {
-
-    }
-
-    @Override
-    public void visit(BLangMarkdownReferenceDocumentation bLangMarkdownReferenceDocumentation) {
-
-    }
-
-    @Override
-    public void visit(BLangWaitForAllExpr.BLangWaitKeyValue waitKeyValue) {
-
-    }
-
-    @Override
-    public void visit(BLangXMLElementFilter xmlElementFilter) {
-
-    }
-
-    @Override
-    public void visit(BLangXMLElementAccess xmlElementAccess) {
-
-    }
-
-    @Override
-    public void visit(BLangXMLNavigationAccess xmlNavigation) {
-
-    }
-
-    @Override
-    public void visit(BLangXMLNSStatement xmlnsStmtNode) {
-
-    }
-
-    @Override
-    public void visit(BLangFail failNode) {
-
     }
 
     @Override
@@ -1161,14 +524,6 @@ public class EnvironmentResolver extends BLangNodeVisitor {
     }
 
     @Override
-    public void visit(BLangTableKeySpecifier tableKeySpecifierNode) {
-    }
-
-    @Override
-    public void visit(BLangTableKeyTypeConstraint tableKeyTypeConstraint) {
-    }
-
-    @Override
     public void visit(BLangRetry retryNode) {
         if (PositionUtil.withinBlock(this.linePosition, retryNode.getPosition())) {
             this.acceptNode(retryNode.retryBody, symbolEnv);
@@ -1181,34 +536,6 @@ public class EnvironmentResolver extends BLangNodeVisitor {
         if (PositionUtil.withinBlock(this.linePosition, retryTransaction.getPosition())) {
             this.acceptNode(retryTransaction.transaction, symbolEnv);
         }
-    }
-
-    @Override
-    public void visit(BLangRetrySpec retrySpec) {
-    }
-
-    @Override
-    public void visit(BLangMatchGuard matchGuard) {
-    }
-
-    @Override
-    public void visit(BLangConstPattern constMatchPattern) {
-    }
-
-    @Override
-    public void visit(BLangWildCardMatchPattern wildCardMatchPattern) {
-    }
-
-    @Override
-    public void visit(BLangVarBindingPatternMatchPattern varBindingPattern) {
-    }
-
-    @Override
-    public void visit(BLangCaptureBindingPattern captureBindingPattern) {
-    }
-
-    @Override
-    public void visit(BLangListBindingPattern listBindingPattern) {
     }
 
     @Override
@@ -1240,10 +567,6 @@ public class EnvironmentResolver extends BLangNodeVisitor {
     }
 
     @Override
-    public void visit(BLangOrderKey orderKeyClause) {
-    }
-
-    @Override
     public void visit(BLangOrderByClause orderByClause) {
         if (!PositionUtil.withinRightInclusive(this.linePosition, orderByClause.getPosition())) {
             return;
@@ -1260,68 +583,12 @@ public class EnvironmentResolver extends BLangNodeVisitor {
     }
 
     @Override
-    public void visit(BLangOnConflictClause onConflictClause) {
-    }
-
-    @Override
-    public void visit(BLangLimitClause limitClause) {
-    }
-
-    @Override
     public void visit(BLangMatchClause matchClause) {
         if (PositionUtil.withinBlock(this.linePosition, matchClause.getPosition())) {
             SymbolEnv blockEnv = SymbolEnv.createBlockEnv(matchClause.blockStmt, this.symbolEnv);
             this.scope = blockEnv;
             this.acceptNode(matchClause.blockStmt, blockEnv);
         }
-    }
-
-    @Override
-    public void visit(BLangRollback rollbackNode) {
-    }
-
-    @Override
-    public void visit(BLangTableConstructorExpr tableConstructorExpr) {
-    }
-
-    @Override
-    public void visit(BLangRawTemplateLiteral rawTemplateLiteral) {
-    }
-
-    @Override
-    public void visit(BLangTableMultiKeyExpr tableMultiKeyExpr) {
-    }
-
-    @Override
-    public void visit(BLangTransactionalExpr transactionalExpr) {
-    }
-
-    @Override
-    public void visit(BLangCommitExpr commitExpr) {
-    }
-
-    @Override
-    public void visit(BLangObjectConstructorExpression bLangObjectConstructorExpression) {
-    }
-
-    @Override
-    public void visit(BLangInferredTypedescDefaultNode inferTypedescExpr) {
-    }
-
-    @Override
-    public void visit(BLangTableTypeNode tableType) {
-    }
-
-    @Override
-    public void visit(BLangIntersectionTypeNode intersectionTypeNode) {
-    }
-
-    @Override
-    public void visit(BLangIndexBasedAccess.BLangTableAccessExpr tableKeyAccessExpr) {
-    }
-
-    @Override
-    public void visit(BLangMarkDownDeprecatedParametersDocumentation bLangMarkDownDeprecatedParametersDocumentation) {
     }
 
     private void acceptNode(BLangNode node, SymbolEnv env) {

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/anon_func_expr_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/anon_func_expr_ctx_config1.json
@@ -394,6 +394,29 @@
       "sortText": "G",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "CE",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/anon_func_expr_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/anon_func_expr_ctx_config1.json
@@ -238,29 +238,6 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "CE",
-      "insertText": "value3",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.value as value3 ;\n"
-        }
-      ]
-    },
-    {
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/anon_func_expr_ctx_config10.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/anon_func_expr_ctx_config10.json
@@ -481,29 +481,6 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "insertText": "value3",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.value as value3 ;\n"
-        }
-      ]
-    },
-    {
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
@@ -689,41 +666,6 @@
       }
     },
     {
-      "label": "value2",
-      "kind": "Variable",
-      "detail": "int",
-      "sortText": "B",
-      "insertText": "value2",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "lambda(int a, int b)",
-      "kind": "Function",
-      "detail": "int",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n**Params**  \n- `int` a  \n- `int` b  \n  \n**Return** `int`   \n  \n"
-        }
-      },
-      "sortText": "C",
-      "filterText": "lambda",
-      "insertText": "lambda(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "value1",
-      "kind": "Variable",
-      "detail": "int",
-      "sortText": "B",
-      "insertText": "value1",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "b",
       "kind": "Variable",
       "detail": "int",
@@ -739,6 +681,29 @@
       "filterText": "worker",
       "insertText": "worker ${1:name} {\n\t${2}\n}",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "insertText": "value5",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value as value5 ;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/anon_func_expr_ctx_config11.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/anon_func_expr_ctx_config11.json
@@ -529,25 +529,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "x(int, int, string, float)",
-      "kind": "Function",
-      "detail": "R1",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n**Params**  \n- `int`  \n- `int`  \n- `string`  \n- `float[]`  \n  \n**Return** `R1`   \n  \n"
-        }
-      },
-      "sortText": "AC",
-      "filterText": "x",
-      "insertText": "x(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
       "label": "rec",
       "kind": "Variable",
       "detail": "R1",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/anon_func_expr_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/anon_func_expr_ctx_config2.json
@@ -238,29 +238,6 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "CE",
-      "insertText": "value3",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.value as value3 ;\n"
-        }
-      ]
-    },
-    {
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
@@ -394,6 +371,29 @@
       "sortText": "G",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "CE",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/anon_func_expr_ctx_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/anon_func_expr_ctx_config5.json
@@ -238,29 +238,6 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "CE",
-      "insertText": "value3",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.value as value3 ;\n"
-        }
-      ]
-    },
-    {
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
@@ -394,6 +371,29 @@
       "sortText": "G",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "CE",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/anon_func_expr_ctx_config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/anon_func_expr_ctx_config7.json
@@ -119,29 +119,6 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "insertText": "value3",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.value as value3 ;\n"
-        }
-      ]
-    },
-    {
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
@@ -490,37 +467,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "value2",
-      "kind": "Variable",
-      "detail": "int",
-      "sortText": "AB",
-      "insertText": "value2",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "value1",
-      "kind": "Variable",
-      "detail": "int",
-      "sortText": "AB",
-      "insertText": "value1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "lambda()",
-      "kind": "Function",
-      "detail": "int",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n  \n**Return** `int`   \n  \n"
-        }
-      },
-      "sortText": "AC",
-      "filterText": "lambda",
-      "insertText": "lambda()",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "StrandData",
       "kind": "Struct",
       "detail": "Record",
@@ -586,6 +532,29 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/anon_func_expr_ctx_config8.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/anon_func_expr_ctx_config8.json
@@ -119,29 +119,6 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "insertText": "value3",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.value as value3 ;\n"
-        }
-      ]
-    },
-    {
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
@@ -490,41 +467,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "value2",
-      "kind": "Variable",
-      "detail": "int",
-      "sortText": "AB",
-      "insertText": "value2",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "value1",
-      "kind": "Variable",
-      "detail": "int",
-      "sortText": "AB",
-      "insertText": "value1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "lambda(int a, int b)",
-      "kind": "Function",
-      "detail": "int",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n**Params**  \n- `int` a  \n- `int` b  \n  \n**Return** `int`   \n  \n"
-        }
-      },
-      "sortText": "AC",
-      "filterText": "lambda",
-      "insertText": "lambda(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
       "label": "StrandData",
       "kind": "Struct",
       "detail": "Record",
@@ -606,6 +548,29 @@
       "sortText": "AB",
       "insertText": "a",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/object_constructor_expr_ctx_config10.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/object_constructor_expr_ctx_config10.json
@@ -29,7 +29,7 @@
           "value": ""
         }
       },
-      "sortText": "D",
+      "sortText": "AB",
       "insertText": "TEST_INT_CONST1",
       "insertTextFormat": "Snippet"
     },
@@ -159,7 +159,7 @@
       "label": "TestClass1",
       "kind": "Interface",
       "detail": "Class",
-      "sortText": "AK",
+      "sortText": "M",
       "insertText": "TestClass1",
       "insertTextFormat": "Snippet"
     },
@@ -219,7 +219,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function3 with input parameters\n  \n**Params**  \n- `int` param1: param1 Parameter Description   \n- `int` param2: param2 Parameter Description  \n- `float[]` param3: param3 Parameter Description  \n  \n**Return** `int`   \n- Return Value Description  \n  \n"
         }
       },
-      "sortText": "E",
+      "sortText": "AC",
       "filterText": "function3",
       "insertText": "function3(${1})",
       "insertTextFormat": "Snippet",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/object_constructor_expr_ctx_config13.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/object_constructor_expr_ctx_config13.json
@@ -238,29 +238,6 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "CE",
-      "insertText": "value2",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.value as value2 ;\n"
-        }
-      ]
-    },
-    {
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
@@ -394,6 +371,29 @@
       "sortText": "G",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "CE",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/object_constructor_expr_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/object_constructor_expr_ctx_config2.json
@@ -9,7 +9,7 @@
       "label": "module1",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "BO",
+      "sortText": "O",
       "insertText": "module1",
       "insertTextFormat": "Snippet"
     },
@@ -17,7 +17,7 @@
       "label": "ballerina/lang.test",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "CE",
+      "sortText": "R",
       "insertText": "test",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -40,7 +40,7 @@
       "label": "ballerina/lang.array",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "CE",
+      "sortText": "R",
       "insertText": "array",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -63,7 +63,7 @@
       "label": "ballerina/jballerina.java",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "CF",
+      "sortText": "R",
       "insertText": "java",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -83,33 +83,10 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "CE",
-      "insertText": "value2",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.value as value2 ;\n"
-        }
-      ]
-    },
-    {
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "CE",
+      "sortText": "R",
       "insertText": "runtime",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -132,7 +109,7 @@
       "label": "boolean",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "G",
+      "sortText": "R",
       "insertText": "boolean",
       "insertTextFormat": "Snippet"
     },
@@ -140,7 +117,7 @@
       "label": "decimal",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "G",
+      "sortText": "R",
       "insertText": "decimal",
       "insertTextFormat": "Snippet"
     },
@@ -148,7 +125,7 @@
       "label": "error",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "G",
+      "sortText": "R",
       "insertText": "error",
       "insertTextFormat": "Snippet"
     },
@@ -156,7 +133,7 @@
       "label": "float",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "G",
+      "sortText": "R",
       "insertText": "float",
       "insertTextFormat": "Snippet"
     },
@@ -164,7 +141,7 @@
       "label": "future",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "G",
+      "sortText": "R",
       "insertText": "future",
       "insertTextFormat": "Snippet"
     },
@@ -172,7 +149,7 @@
       "label": "int",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "G",
+      "sortText": "R",
       "insertText": "int",
       "insertTextFormat": "Snippet"
     },
@@ -180,7 +157,7 @@
       "label": "map",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "G",
+      "sortText": "R",
       "insertText": "map",
       "insertTextFormat": "Snippet"
     },
@@ -188,7 +165,7 @@
       "label": "object",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "G",
+      "sortText": "R",
       "insertText": "object",
       "insertTextFormat": "Snippet"
     },
@@ -196,7 +173,7 @@
       "label": "stream",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "G",
+      "sortText": "R",
       "insertText": "stream",
       "insertTextFormat": "Snippet"
     },
@@ -204,7 +181,7 @@
       "label": "string",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "G",
+      "sortText": "R",
       "insertText": "string",
       "insertTextFormat": "Snippet"
     },
@@ -212,7 +189,7 @@
       "label": "table",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "G",
+      "sortText": "R",
       "insertText": "table",
       "insertTextFormat": "Snippet"
     },
@@ -220,7 +197,7 @@
       "label": "transaction",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "G",
+      "sortText": "R",
       "insertText": "transaction",
       "insertTextFormat": "Snippet"
     },
@@ -228,7 +205,7 @@
       "label": "typedesc",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "G",
+      "sortText": "R",
       "insertText": "typedesc",
       "insertTextFormat": "Snippet"
     },
@@ -236,9 +213,32 @@
       "label": "xml",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "G",
+      "sortText": "R",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/object_constructor_expr_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/object_constructor_expr_ctx_config2.json
@@ -9,7 +9,7 @@
       "label": "module1",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "O",
+      "sortText": "BO",
       "insertText": "module1",
       "insertTextFormat": "Snippet"
     },
@@ -17,7 +17,7 @@
       "label": "ballerina/lang.test",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "R",
+      "sortText": "CE",
       "insertText": "test",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -40,7 +40,7 @@
       "label": "ballerina/lang.array",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "R",
+      "sortText": "CE",
       "insertText": "array",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -63,7 +63,7 @@
       "label": "ballerina/jballerina.java",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "R",
+      "sortText": "CF",
       "insertText": "java",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -86,7 +86,7 @@
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "R",
+      "sortText": "CE",
       "insertText": "runtime",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -109,7 +109,7 @@
       "label": "boolean",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "G",
       "insertText": "boolean",
       "insertTextFormat": "Snippet"
     },
@@ -117,7 +117,7 @@
       "label": "decimal",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "G",
       "insertText": "decimal",
       "insertTextFormat": "Snippet"
     },
@@ -125,7 +125,7 @@
       "label": "error",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "G",
       "insertText": "error",
       "insertTextFormat": "Snippet"
     },
@@ -133,7 +133,7 @@
       "label": "float",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "G",
       "insertText": "float",
       "insertTextFormat": "Snippet"
     },
@@ -141,7 +141,7 @@
       "label": "future",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "G",
       "insertText": "future",
       "insertTextFormat": "Snippet"
     },
@@ -149,7 +149,7 @@
       "label": "int",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "G",
       "insertText": "int",
       "insertTextFormat": "Snippet"
     },
@@ -157,7 +157,7 @@
       "label": "map",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "G",
       "insertText": "map",
       "insertTextFormat": "Snippet"
     },
@@ -165,7 +165,7 @@
       "label": "object",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "G",
       "insertText": "object",
       "insertTextFormat": "Snippet"
     },
@@ -173,7 +173,7 @@
       "label": "stream",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "G",
       "insertText": "stream",
       "insertTextFormat": "Snippet"
     },
@@ -181,7 +181,7 @@
       "label": "string",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "G",
       "insertText": "string",
       "insertTextFormat": "Snippet"
     },
@@ -189,7 +189,7 @@
       "label": "table",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "G",
       "insertText": "table",
       "insertTextFormat": "Snippet"
     },
@@ -197,7 +197,7 @@
       "label": "transaction",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "G",
       "insertText": "transaction",
       "insertTextFormat": "Snippet"
     },
@@ -205,7 +205,7 @@
       "label": "typedesc",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "G",
       "insertText": "typedesc",
       "insertTextFormat": "Snippet"
     },
@@ -213,7 +213,7 @@
       "label": "xml",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "G",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
     },
@@ -221,7 +221,7 @@
       "label": "ballerina/lang.value",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "R",
+      "sortText": "CE",
       "insertText": "value",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/object_constructor_expr_ctx_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/object_constructor_expr_ctx_config4.json
@@ -238,29 +238,6 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "insertText": "value2",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.value as value2 ;\n"
-        }
-      ]
-    },
-    {
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
@@ -448,6 +425,29 @@
       "filterText": "transactional",
       "insertText": "transactional",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/object_constructor_expr_ctx_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/object_constructor_expr_ctx_config5.json
@@ -238,29 +238,6 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "insertText": "value2",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.value as value2 ;\n"
-        }
-      ]
-    },
-    {
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
@@ -448,6 +425,29 @@
       "filterText": "transactional",
       "insertText": "transactional",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/object_constructor_expr_ctx_config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/object_constructor_expr_ctx_config7.json
@@ -238,29 +238,6 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "insertText": "value2",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.value as value2 ;\n"
-        }
-      ]
-    },
-    {
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
@@ -448,6 +425,29 @@
       "filterText": "transactional",
       "insertText": "transactional",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/object_constructor_expr_ctx_config9.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/object_constructor_expr_ctx_config9.json
@@ -83,29 +83,6 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "insertText": "value2",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.value as value2 ;\n"
-        }
-      ]
-    },
-    {
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
@@ -420,14 +397,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "constructor",
-      "kind": "Variable",
-      "detail": "object {public int field1;}",
-      "sortText": "AB",
-      "insertText": "constructor",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "testObjectConstructor()",
       "kind": "Function",
       "detail": "()",
@@ -458,14 +427,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "value1",
-      "kind": "Variable",
-      "detail": "int",
-      "sortText": "D",
-      "insertText": "value1",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "StrandData",
       "kind": "Struct",
       "detail": "Record",
@@ -486,7 +447,7 @@
           "value": "**Package:** _._  \n  \n  \n  \n  \n**Return** `int`   \n  \n"
         }
       },
-      "sortText": "E",
+      "sortText": "AC",
       "filterText": "testFunctionWithReturn2",
       "insertText": "testFunctionWithReturn2()",
       "insertTextFormat": "Snippet"
@@ -548,11 +509,27 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "new()",
-      "kind": "Function",
-      "sortText": "E",
-      "insertText": "new()",
-      "insertTextFormat": "Snippet"
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/return_stmt_ctx_config10.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/return_stmt_ctx_config10.json
@@ -404,29 +404,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "ballerina/lang.test",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "insertText": "test1",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.test as test1 ;\n"
-        }
-      ]
-    },
-    {
       "label": "ballerina/lang.array",
       "kind": "Module",
       "detail": "Module",
@@ -654,49 +631,27 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "test",
-      "kind": "Variable",
-      "detail": "()",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n"
-        }
-      },
-      "sortText": "B",
-      "filterText": "test",
+      "label": "ballerina/lang.test",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
       "insertText": "test",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "test()",
-      "kind": "Function",
-      "detail": "()",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n"
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.test;\n"
         }
-      },
-      "sortText": "C",
-      "filterText": "test",
-      "insertText": "test()",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "testFunction",
-      "kind": "Variable",
-      "detail": "()",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n"
-        }
-      },
-      "sortText": "B",
-      "filterText": "testFunction",
-      "insertText": "testFunction",
-      "insertTextFormat": "Snippet"
+      ]
     },
     {
       "label": "testFunction()",

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/return_stmt_ctx_config15.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/return_stmt_ctx_config15.json
@@ -404,29 +404,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "ballerina/lang.test",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "insertText": "test1",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.test as test1 ;\n"
-        }
-      ]
-    },
-    {
       "label": "ballerina/lang.array",
       "kind": "Module",
       "detail": "Module",
@@ -654,49 +631,27 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "test",
-      "kind": "Variable",
-      "detail": "()",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n"
-        }
-      },
-      "sortText": "B",
-      "filterText": "test",
+      "label": "ballerina/lang.test",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
       "insertText": "test",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "test()",
-      "kind": "Function",
-      "detail": "()",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n"
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.test;\n"
         }
-      },
-      "sortText": "C",
-      "filterText": "test",
-      "insertText": "test()",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "testFunction",
-      "kind": "Variable",
-      "detail": "()",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n"
-        }
-      },
-      "sortText": "B",
-      "filterText": "testFunction",
-      "insertText": "testFunction",
-      "insertTextFormat": "Snippet"
+      ]
     },
     {
       "label": "testFunction()",

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolLookupTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolLookupTest.java
@@ -451,7 +451,7 @@ public class SymbolLookupTest {
     }
 
     @Test
-    public void test() {
+    public void testDestructureStmts() {
         Project project = BCompileUtil.loadProject("test-src/symbol_lookup_destructure_var_exclusion_test.bal");
         Package currentPackage = project.currentPackage();
         ModuleId defaultModuleId = currentPackage.getDefaultModule().moduleId();
@@ -465,6 +465,27 @@ public class SymbolLookupTest {
         ModuleID moduleID = new BallerinaModuleID(pkg.packageID);
 
         Map<String, Symbol> symbolsInFile = getSymbolsInFile(model, srcFile, 22, 4, moduleID);
+
+        assertEquals(symbolsInFile.size(), expSymbolNames.size());
+        for (String symName : expSymbolNames) {
+            assertTrue(symbolsInFile.containsKey(symName), "Symbol not found: " + symName);
+        }
+    }
+
+    @Test
+    public void testObjectConstructorExpr() {
+        Project project = BCompileUtil.loadProject("test-src/symbol_lookup_in_object_constructor.bal");
+        Package currentPackage = project.currentPackage();
+        ModuleId defaultModuleId = currentPackage.getDefaultModule().moduleId();
+        PackageCompilation packageCompilation = currentPackage.getCompilation();
+        SemanticModel model = packageCompilation.getSemanticModel(defaultModuleId);
+        Document srcFile = getDocumentForSingleSource(project);
+        List<String> expSymbolNames = List.of("test", "f1", "foo", "self", "a");
+
+        BLangPackage pkg = packageCompilation.defaultModuleBLangPackage();
+        ModuleID moduleID = new BallerinaModuleID(pkg.packageID);
+
+        Map<String, Symbol> symbolsInFile = getSymbolsInFile(model, srcFile, 21, 20, moduleID);
 
         assertEquals(symbolsInFile.size(), expSymbolNames.size());
         for (String symName : expSymbolNames) {

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol_lookup_in_object_constructor.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol_lookup_in_object_constructor.bal
@@ -1,0 +1,25 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+function test() {
+    var helloVar = object {
+        int f1 = 12;
+
+        public isolated transactional function foo() {
+            int a =
+        }
+    };
+}


### PR DESCRIPTION
## Purpose
This PR fixes an issue we had in the `EnvironmentResolver` which caused the correct scope found to be overwritten.

## Approach
Added an additional check before proceeding to create the symbol env and setting it. This check basically checks whether the current node is a narrow scope than the narrowest scope found so far. If not, we skip visiting it. 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
