### PR TITLE
Fix symbol finding issue in object constructors

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
@@ -1206,7 +1206,7 @@ class SymbolFinder extends BaseVisitor {
 
     @Override
     public void visit(BLangClassDefinition classDefinition) {
-        if (!isClassDefForServiceDecl(classDefinition) &&
+        if (!isClassDefForServiceOrObjectCtr(classDefinition) &&
                 setEnclosingNode(classDefinition.symbol, classDefinition.name.pos)) {
             return;
         }
@@ -1567,8 +1567,9 @@ class SymbolFinder extends BaseVisitor {
         return false;
     }
 
-    private boolean isClassDefForServiceDecl(BLangClassDefinition clazz) {
-        return clazz.flagSet.contains(Flag.SERVICE) && clazz.flagSet.contains(Flag.ANONYMOUS);
+    private boolean isClassDefForServiceOrObjectCtr(BLangClassDefinition clazz) {
+        return clazz.flagSet.contains(Flag.SERVICE) && clazz.flagSet.contains(Flag.ANONYMOUS)
+                || clazz.flagSet.contains(Flag.OBJECT_CTOR);
     }
 
     private boolean isLambdaFunction(TopLevelNode node) {

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/SymbolsInObjectConstructorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/SymbolsInObjectConstructorTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.semantic.api.test.symbols;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.SymbolKind;
+import io.ballerina.projects.Document;
+import io.ballerina.projects.Project;
+import io.ballerina.tools.text.LinePosition;
+import org.ballerinalang.test.BCompileUtil;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.ballerina.compiler.api.symbols.SymbolKind.CLASS_FIELD;
+import static io.ballerina.compiler.api.symbols.SymbolKind.METHOD;
+import static io.ballerina.compiler.api.symbols.SymbolKind.VARIABLE;
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDefaultModulesSemanticModel;
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDocumentForSingleSource;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Test cases for use of symbol() with object constructors.
+ *
+ * @since 2.0.0
+ */
+public class SymbolsInObjectConstructorTest {
+
+    private SemanticModel model;
+    private Document srcFile;
+
+    @BeforeClass
+    public void setup() {
+        Project project = BCompileUtil.loadProject("test-src/symbols/symbols_in_object_constructor_test.bal");
+        model = getDefaultModulesSemanticModel(project);
+        srcFile = getDocumentForSingleSource(project);
+    }
+
+    @Test(dataProvider = "SymbolPosProvider")
+    public void testFields(int line, int col, SymbolKind kind, String name) {
+        Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, col));
+
+        if (kind == null) {
+            assertTrue(symbol.isEmpty());
+            return;
+        }
+
+        assertTrue(symbol.isPresent());
+        assertEquals(symbol.get().kind(), kind);
+        assertEquals(symbol.get().getName().get(), name);
+    }
+
+    @DataProvider(name = "SymbolPosProvider")
+    public Object[][] getSymbolPos() {
+        return new Object[][]{
+                {18, 12, CLASS_FIELD, "item2"},
+                {19, 23, CLASS_FIELD, "item1"},
+                {21, 24, METHOD, "init"},
+                {22, 17, CLASS_FIELD, "item1"},
+                {24, 5, null, null},
+                {26, 47, METHOD, "testFunction"},
+                {27, 16, VARIABLE, "x"},
+        };
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbols/symbols_in_object_constructor_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbols/symbols_in_object_constructor_test.bal
@@ -1,0 +1,31 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+function test() {
+    var helloVar = client object {
+        int item2 = 1;
+        private string item1 = "";
+
+        public function init() {
+            self.item1 = "Foo"
+            self.item2 = 10;
+        }
+
+        public isolated transactional function testFunction() returns int {
+            int x = self.item2;
+        }
+    };
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
+++ b/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
@@ -106,6 +106,7 @@
             <!--Symbols-->
             <class name="io.ballerina.semantic.api.test.symbols.FunctionSymbolTest" />
             <class name="io.ballerina.semantic.api.test.symbols.SymbolsInMappingConstructorTest" />
+            <class name="io.ballerina.semantic.api.test.symbols.SymbolsInObjectConstructorTest" />
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
## Purpose
This PR fixes an issue in looking up symbols contained within object constructors. 

Fixes #31834
Fixes #31833 
Fixes #31886

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
