### PR TITLE
Support int subtypes & avoid duplication in BIR text

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/emit/BIREmitter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/emit/BIREmitter.java
@@ -29,7 +29,6 @@ import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
-import java.util.Map;
 
 import static org.wso2.ballerinalang.compiler.bir.emit.EmitterUtils.emitBasicBlockRef;
 import static org.wso2.ballerinalang.compiler.bir.emit.EmitterUtils.emitFlags;
@@ -223,9 +222,6 @@ public class BIREmitter {
         funcString += emitSpaces(1);
         funcString += "{";
         funcString += emitLBreaks(1);
-        funcString += emitLocalVar(func.returnVariable, tabs + 1);
-        funcString += emitLBreaks(1);
-        funcString += emitArguments(func.parameters, tabs + 1);
         funcString += emitLocalVars(func.localVars, tabs + 1);
         funcString += emitLBreaks(1);
         funcString += emitBasicBlocks(func.basicBlocks, tabs + 1);
@@ -259,16 +255,6 @@ public class BIREmitter {
         str += emitTypeRef(lVar.type, 0);
         str += ";";
         return str;
-    }
-
-    private String emitArguments(Map<BIRNode.BIRFunctionParameter, List<BIRNode.BIRBasicBlock>> localVars, int tabs) {
-
-        StringBuilder varStr = new StringBuilder();
-        for (BIRNode.BIRFunctionParameter parameter : localVars.keySet()) {
-            varStr.append(emitLocalVar(parameter, tabs));
-            varStr.append(emitLBreaks(1));
-        }
-        return varStr.toString();
     }
 
     private String emitBasicBlocks(List<BIRNode.BIRBasicBlock> basicBlocks, int tabs) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/emit/TypeEmitter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/emit/TypeEmitter.java
@@ -67,6 +67,18 @@ class TypeEmitter {
         switch (bType.tag) {
             case TypeTags.INT:
                 return "int";
+            case TypeTags.SIGNED32_INT:
+                return "int:Signed32";
+            case TypeTags.SIGNED16_INT:
+                return "int:Signed16";
+            case TypeTags.SIGNED8_INT:
+                return "int:Signed8";
+            case TypeTags.UNSIGNED32_INT:
+                return "int:Unsigned32";
+            case TypeTags.UNSIGNED16_INT:
+                return "int:Unsigned16";
+            case TypeTags.UNSIGNED8_INT:
+                return "int:Unsigned8";
             case TypeTags.BOOLEAN:
                 return "boolean";
             case TypeTags.ANY:

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bir/bir-dump/$lambda$_0
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bir/bir-dump/$lambda$_0
@@ -2,9 +2,6 @@ $lambda$_0 function(map<...>, int) -> int {
     %0(RETURN) int;
     %1(ARG) ...;
     %2(ARG) int;
-    %0(RETURN) int;
-    %1(ARG) ...;
-    %2(ARG) int;
     %3(LOCAL) int;
     %6(TEMP) int;
     %7(TEMP) boolean;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bir/bir-dump/cacheInserts
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bir/bir-dump/cacheInserts
@@ -1,6 +1,5 @@
 public cacheInserts function() -> () {
     %0(RETURN) ();
-    %0(RETURN) ();
     %1(LOCAL) ballerina/cache:2.0.0:CacheConfig;
     %2(TEMP) typeDesc<any | error>;
     %4(TEMP) string;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bir/bir-dump/complexAddition
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bir/bir-dump/complexAddition
@@ -1,6 +1,5 @@
 public complexAddition function() -> () {
     %0(RETURN) ();
-    %0(RETURN) ();
     %1(LOCAL) int;
     %3(LOCAL) int;
     %5(TEMP) int;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bir/bir-dump/globalVarsAndAnonFunctions
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bir/bir-dump/globalVarsAndAnonFunctions
@@ -1,6 +1,5 @@
 public globalVarsAndAnonFunctions function() -> () {
     %0(RETURN) ();
-    %0(RETURN) ();
     %1(SYNTHETIC) ...;
     %2(TEMP) typeDesc<...>;
     %4(TEMP) ...;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bir/bir-dump/mapInits
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bir/bir-dump/mapInits
@@ -1,6 +1,5 @@
 mapInits function() -> (string|(), int|()) {
     %0(RETURN) (string|(), int|());
-    %0(RETURN) (string|(), int|());
     %1(LOCAL) map<Employee>;
     %2(TEMP) typeDesc<any|error{map<Cloneable>}>;
     %4(LOCAL) Person;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bir/bir-dump/sayHello
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bir/bir-dump/sayHello
@@ -1,8 +1,6 @@
 sayHello function(string) -> error{map<anydata | readonly>} | () {
     %1(RETURN) error | ();
     %2(ARG) string;
-    %1(RETURN) error | ();
-    %2(ARG) string;
     %3(LOCAL) ballerina/lang.test:1.0.0:Caller;
     %4(SYNTHETIC) ballerina/lang.test:1.0.0:Caller;
     %7(TEMP) ();

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bir/bir-dump/simpleAddition
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bir/bir-dump/simpleAddition
@@ -1,6 +1,5 @@
 public simpleAddition function() -> () {
     %0(RETURN) ();
-    %0(RETURN) ();
     %1(LOCAL) int;
     %3(LOCAL) int;
     %5(TEMP) int;


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues.

$title

Fixes #31912
Fixes #31667

## Approach
> Describe how you are implementing the solutions along with the design details.

* Add cases for int subtyptes in TypeEmitter class
* Do not write separately function args and return types in BIR text as local variables include them  

## Samples
> Provide high-level details about the samples related to this feature.
```ballerina
function add(int:Signed8 a, int:Unsigned16 b) returns int:Signed32{
    byte c = 0x2;
    int ans = a + b + c;
    int:Signed32 return_val = <int:Signed32> ans;
    return return_val;
}
```
Above Ballerina code snippet will now produce the following BIR text.
```llvm
add function(int:Signed8, int:Unsigned16) -> int:Signed32 {
    %0(RETURN) int:Signed32;
    %1(ARG) int:Signed8;
    %2(ARG) int:Unsigned16;
    %3(LOCAL) byte;
    %5(LOCAL) int;
    %8(TEMP) int;
    %9(TEMP) int;
    %12(LOCAL) int:Signed32;

    bb0 {
        %3 = ConstLoad 2;
        %8 = %1 + %2;
        %9 = <int> %3;
        %5 = %8 + %9;
        %12 = <int:Signed32> %5;
        %0 = %12;
        GOTO bb2;
    }
    bb1 {
        GOTO bb2;
    }
    bb2 {
        return;
    }


}
```
## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
