### PR TITLE
Fix type alias support for classes

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
@@ -187,7 +187,7 @@ public class SymbolFactory {
             if (symbol instanceof BPackageSymbol) {
                 return createModuleSymbol((BPackageSymbol) symbol, name);
             }
-            if (symbol instanceof BClassSymbol) {
+            if (symbol instanceof BClassSymbol && !((BClassSymbol) symbol).isLabel) {
                 return createClassSymbol((BClassSymbol) symbol, name);
             }
             if (Symbols.isFlagOn(symbol.flags, Flags.ENUM)) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/TypesFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/TypesFactory.java
@@ -220,7 +220,8 @@ public class TypesFactory {
             case OBJECT:
                 ObjectTypeSymbol objType = new BallerinaObjectTypeSymbol(this.context, moduleID, (BObjectType) bType);
                 if (Symbols.isFlagOn(tSymbol.flags, Flags.CLASS)) {
-                    return symbolFactory.createClassSymbol((BClassSymbol) tSymbol, tSymbol.name.value, objType);
+                    BTypeSymbol classSymbol = tSymbol.isLabel ? tSymbol.type.tsymbol : tSymbol;
+                    return symbolFactory.createClassSymbol((BClassSymbol) classSymbol, classSymbol.name.value, objType);
                 }
                 return objType;
             case RECORD:

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/class_symbols_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/class_symbols_test.bal
@@ -69,3 +69,9 @@ function test() {
     p3.tempAddress;
     p3.age;
 }
+
+type PersonType Person1;
+
+function testTypeAliasForClass() {
+    PersonType pt = new PersonType("John", "Doe");
+}


### PR DESCRIPTION
## Purpose
This PR fixes support for type aliasing for classes in the Semantic API.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
