### PR TITLE
Revamp `Update documentation` code action

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/docs/AddDocumentationCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/docs/AddDocumentationCodeAction.java
@@ -33,6 +33,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static org.ballerinalang.langserver.command.docs.DocumentationGenerator.hasDocs;
+
 /**
  * Code Action for adding single documentation.
  *
@@ -67,10 +69,10 @@ public class AddDocumentationCodeAction extends AbstractCodeActionProvider {
                                                     NodeBasedPositionDetails posDetails) {
         String docUri = context.fileUri();
         NonTerminalNode matchedNode = posDetails.matchedTopLevelNode();
-        // TODO: disabled `hasDocs` check since update-doc code-action is fragile with compiler-phase-runner issue
-//        if (hasDocs(matchedNode)) {
-//            return Collections.emptyList();
-//        }
+        
+        if (hasDocs(matchedNode)) {
+            return Collections.emptyList();
+        }
 
         CommandArgument docUriArg = CommandArgument.from(CommandConstants.ARG_KEY_DOC_URI, docUri);
         CommandArgument lineStart = CommandArgument.from(CommandConstants.ARG_KEY_NODE_RANGE,

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/docs/NodeBasedUpdateDocumentationCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/docs/NodeBasedUpdateDocumentationCodeAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 Inc. (http://wso2.com) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -95,30 +95,29 @@ public class NodeBasedUpdateDocumentationCodeAction extends AbstractCodeActionPr
         Optional<Symbol> documentableSymbol = getDocumentableSymbol(node, semanticModel);
         SyntaxTree syntaxTree = context.workspace().syntaxTree(context.filePath()).orElseThrow();
         Optional<DocAttachmentInfo> docAttachmentInfo = getDocumentationEditForNode(node, syntaxTree);
-        DocAttachmentInfo docs = docAttachmentInfo.get();
+
+        if (docAttachmentInfo.isEmpty()) {
+            return false;
+        }
         
-        if (documentableSymbol.isPresent()) {
-            Optional<Documentation> symbolDocumentation = ((Documentable) documentableSymbol.get()).documentation();
-            if (symbolDocumentation.isPresent()) {
-                Documentation documentation = symbolDocumentation.get();
-                docs = docs.mergeDocAttachment(documentation);
-                // Description mismatch
-                if (!documentation.description().equals(docs.description())) {
-                    return true;
-                }
-                // Parameter mismatch
-                if (!documentation.parameterMap().equals(docs.parameterMap())) {
-                    return true;
-                }
-                // Return description mismatch
-                if (!documentation.returnDescription().equals(docs.returnDescription())) {
-                    return true;
-                }
-                // Deprecated description mismatch
-                if (!documentation.deprecatedDescription().equals(docs.deprecatedDescription())) {
-                    return true;
-                }
-            }
+        DocAttachmentInfo docs = docAttachmentInfo.get();
+        if (documentableSymbol.isEmpty()) {
+            return false;
+        }
+        
+        Optional<Documentation> symbolDocumentation = ((Documentable) documentableSymbol.get()).documentation();
+        if (symbolDocumentation.isEmpty()) {
+            return false;
+        }
+        
+        Documentation documentation = symbolDocumentation.get();
+        docs = docs.mergeDocAttachment(documentation);
+        
+        if (!documentation.description().equals(docs.description()) || 
+                !documentation.parameterMap().equals(docs.parameterMap()) || 
+                !documentation.returnDescription().equals(docs.returnDescription()) || 
+                !documentation.deprecatedDescription().equals(docs.deprecatedDescription())) {
+            return true;
         }
         return false;
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/docs/NodeBasedUpdateDocumentationCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/docs/NodeBasedUpdateDocumentationCodeAction.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.langserver.codeaction.providers.docs;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.Documentable;
+import io.ballerina.compiler.api.symbols.Documentation;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.syntax.tree.NonTerminalNode;
+import io.ballerina.compiler.syntax.tree.SyntaxTree;
+import org.ballerinalang.annotation.JavaSPIService;
+import org.ballerinalang.langserver.codeaction.providers.AbstractCodeActionProvider;
+import org.ballerinalang.langserver.command.docs.DocAttachmentInfo;
+import org.ballerinalang.langserver.command.executors.UpdateDocumentationExecutor;
+import org.ballerinalang.langserver.common.constants.CommandConstants;
+import org.ballerinalang.langserver.common.utils.CommonUtil;
+import org.ballerinalang.langserver.commons.CodeActionContext;
+import org.ballerinalang.langserver.commons.codeaction.CodeActionNodeType;
+import org.ballerinalang.langserver.commons.codeaction.spi.NodeBasedPositionDetails;
+import org.ballerinalang.langserver.commons.command.CommandArgument;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Command;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.ballerinalang.langserver.command.docs.DocumentationGenerator.getDocumentableSymbol;
+import static org.ballerinalang.langserver.command.docs.DocumentationGenerator.getDocumentationEditForNode;
+import static org.ballerinalang.langserver.command.docs.DocumentationGenerator.hasDocs;
+
+/**
+ * Code Action for updating single documentation.
+ *
+ * @since 2.0.0
+ */
+@JavaSPIService("org.ballerinalang.langserver.commons.codeaction.spi.LSCodeActionProvider")
+public class NodeBasedUpdateDocumentationCodeAction extends AbstractCodeActionProvider {
+
+    public static final String NAME = "Update Documentation";
+
+    public NodeBasedUpdateDocumentationCodeAction() {
+        super(Arrays.asList(CodeActionNodeType.FUNCTION,
+                CodeActionNodeType.OBJECT,
+                CodeActionNodeType.CLASS,
+                CodeActionNodeType.SERVICE,
+                CodeActionNodeType.RESOURCE,
+                CodeActionNodeType.RECORD,
+                CodeActionNodeType.OBJECT_FUNCTION,
+                CodeActionNodeType.CLASS_FUNCTION));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<CodeAction> getNodeBasedCodeActions(CodeActionContext context,
+                                                    NodeBasedPositionDetails posDetails) {
+        String docUri = context.fileUri();
+        NonTerminalNode matchedNode = posDetails.matchedTopLevelNode();
+
+        if (!hasDocs(matchedNode) || !hasMismatch(context, matchedNode)) {
+            return Collections.emptyList();
+        }
+
+        CommandArgument docUriArg = CommandArgument.from(CommandConstants.ARG_KEY_DOC_URI, docUri);
+        CommandArgument lineStart = CommandArgument.from(CommandConstants.ARG_KEY_NODE_RANGE,
+                                                         CommonUtil.toRange(matchedNode.lineRange()));
+        List<Object> args = new ArrayList<>(Arrays.asList(docUriArg, lineStart));
+
+        CodeAction action = new CodeAction(CommandConstants.UPDATE_DOCUMENTATION_TITLE);        
+        Command command = new Command(CommandConstants.UPDATE_DOCUMENTATION_TITLE, UpdateDocumentationExecutor.COMMAND, 
+                args);
+        action.setCommand(command);
+        return Collections.singletonList(action);
+    }
+
+    private boolean hasMismatch(CodeActionContext context, NonTerminalNode node) {
+        SemanticModel semanticModel = context.workspace().semanticModel(context.filePath()).orElseThrow();
+        Optional<Symbol> documentableSymbol = getDocumentableSymbol(node, semanticModel);
+        SyntaxTree syntaxTree = context.workspace().syntaxTree(context.filePath()).orElseThrow();
+        Optional<DocAttachmentInfo> docAttachmentInfo = getDocumentationEditForNode(node, syntaxTree);
+        DocAttachmentInfo docs = docAttachmentInfo.get();
+        
+        if (documentableSymbol.isPresent()) {
+            Optional<Documentation> symbolDocumentation = ((Documentable) documentableSymbol.get()).documentation();
+            if (symbolDocumentation.isPresent()) {
+                Documentation documentation = symbolDocumentation.get();
+                docs = docs.mergeDocAttachment(documentation);
+                // Description mismatch
+                if (!documentation.description().equals(docs.description())) {
+                    return true;
+                }
+                // Parameter mismatch
+                if (!documentation.parameterMap().equals(docs.parameterMap())) {
+                    return true;
+                }
+                // Return description mismatch
+                if (!documentation.returnDescription().equals(docs.returnDescription())) {
+                    return true;
+                }
+                // Deprecated description mismatch
+                if (!documentation.deprecatedDescription().equals(docs.deprecatedDescription())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+}

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/docs/UpdateDocumentationCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/docs/UpdateDocumentationCodeAction.java
@@ -26,6 +26,7 @@ import org.ballerinalang.langserver.command.executors.UpdateDocumentationExecuto
 import org.ballerinalang.langserver.common.constants.CommandConstants;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.commons.CodeActionContext;
+import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.commons.codeaction.spi.DiagBasedPositionDetails;
 import org.ballerinalang.langserver.commons.command.CommandArgument;
 import org.ballerinalang.util.diagnostic.DiagnosticErrorCode;
@@ -49,6 +50,11 @@ import java.util.Optional;
 public class UpdateDocumentationCodeAction extends AbstractCodeActionProvider {
 
     public static final String NAME = "Update Documentation";
+
+    @Override
+    public boolean isEnabled(LanguageServerContext serverContext) {
+        return false;
+    }
 
     @Override
     public int priority() {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/docs/DocAttachmentInfo.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/docs/DocAttachmentInfo.java
@@ -120,7 +120,7 @@ public class DocAttachmentInfo implements Documentation {
         StringBuilder result = new StringBuilder();
         String[] descriptionLines = this.description.trim().split("(\r)?\n");
         for (String descriptionLine : descriptionLines) {
-            result.append(String.format("# %s%n", descriptionLine.trim()));
+            result.append(String.format("%s# %s%n", padding, descriptionLine.trim()));
         }
 
         if (!parameters.isEmpty()) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/docs/DocAttachmentInfo.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/docs/DocAttachmentInfo.java
@@ -19,6 +19,7 @@ import io.ballerina.compiler.api.symbols.Documentation;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.eclipse.lsp4j.Position;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -126,13 +127,22 @@ public class DocAttachmentInfo implements Documentation {
         if (!parameters.isEmpty()) {
             StringJoiner paramJoiner = new StringJoiner(CommonUtil.MD_LINE_SEPARATOR);
             for (Map.Entry<String, String> parameter : this.parameters.entrySet()) {
-                paramJoiner.add(String.format("%s# + %s - %s", padding, parameter.getKey(), parameter.getValue()));
+                String[] parameterLines = parameter.getValue().trim().split("(\r)?\n");
+                paramJoiner.add(String.format("%s# + %s - %s", padding, parameter.getKey(), parameterLines[0].trim()));
+                for (String parameterLine : Arrays.copyOfRange(parameterLines, 1, parameterLines.length)) {
+                    paramJoiner.add(String.format("%s# %s", padding, parameterLine.trim()));
+                }
+                
             }
             result.append(String.format("%s#%n%s%n", padding, paramJoiner.toString()));
         }
 
         if (returnDesc != null) {
-            result.append(String.format("%s# + return - %s%n", padding, this.returnDesc.trim()));
+            String[] returnDescLines = this.returnDesc.trim().split("(\r)?\n");
+            result.append(String.format("%s# + return - %s%n", padding, returnDescLines[0].trim()));
+            for (String returnDescLine : Arrays.copyOfRange(returnDescLines, 1, returnDescLines.length)) {
+                result.append(String.format("%s# %s%n", padding, returnDescLine.trim()));
+            }
         }
 
         if (deprecatedDesc != null) {

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/UpdateDocumentationTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/UpdateDocumentationTest.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 
 /**
  * Tests the functionality of
- * {@link org.ballerinalang.langserver.codeaction.providers.docs.UpdateDocumentationCodeAction}.
+ * {@link org.ballerinalang.langserver.codeaction.providers.docs.NodeBasedUpdateDocumentationCodeAction}.
  */
 public class UpdateDocumentationTest extends AbstractCodeActionTest {
 
@@ -40,6 +40,7 @@ public class UpdateDocumentationTest extends AbstractCodeActionTest {
                 {"updateDocumentationConfig1.json", "updateDocumentation1.bal"},
                 {"updateDocumentationConfig2.json", "updateDocumentation2.bal"},
                 {"updateDocumentationConfig3.json", "updateDocumentation3.bal"},
+                {"updateDocumentationConfig4.json", "updateDocumentation4.bal"},
                 {"updateDocCodeActionWithDeprecatedConfig1.json", "updateDocCodeActionWithDeprecated1.bal"},
         };
     }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/command/UpdateDocumentationExecutorTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/command/UpdateDocumentationExecutorTest.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 import java.util.List;
 
 /**
- * Tests the functinality of {@link UpdateDocumentationExecutor}.
+ * Tests the functionality of {@link UpdateDocumentationExecutor}.
  */
 public class UpdateDocumentationExecutorTest extends AbstractCommandExecutionTest {
 
@@ -41,6 +41,8 @@ public class UpdateDocumentationExecutorTest extends AbstractCommandExecutionTes
                 {"updateDocumentationConfig1.json", "updateDocumentationSource1.bal"},
                 {"updateDocumentationConfig2.json", "updateDocumentationSource2.bal"},
                 {"updateDocumentationConfig3.json", "updateDocumentationSource3.bal"},
+                {"updateDocumentationConfig4.json", "updateDocumentationSource4.bal"},
+                {"updateDocumentationConfig5.json", "updateDocumentationSource5.bal"},
                 {"updateDocumentationWithDeprecatedConfig1.json", "updateDocumentationWithDeprecatedSource1.bal"},
                 {"updateDocumentationWithDeprecatedConfig2.json", "updateDocumentationWithDeprecatedSource2.bal"},
                 {"updateDocumentationWithDeprecatedConfig3.json", "updateDocumentationWithDeprecatedSource3.bal"},

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/add-documentation/config/documentAlreadyDocumentedConfig1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/add-documentation/config/documentAlreadyDocumentedConfig1.json
@@ -3,28 +3,6 @@
   "character": 19,
   "expected": [
     {
-      "title": "Document this",
-      "command": {
-        "title": "Document this",
-        "command": "ADD_DOC",
-        "arguments": [
-          {
-            "key": "node.range",
-            "value": {
-              "start": {
-                "line": 1,
-                "character": 0
-              },
-              "end": {
-                "line": 7,
-                "character": 1
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
       "title": "Document all",
       "command": {
         "title": "Document all",

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/update-documentation/config/updateDocumentationConfig4.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/update-documentation/config/updateDocumentationConfig4.json
@@ -1,6 +1,6 @@
 {
-  "line": 8,
-  "character": 16,
+  "line": 3,
+  "character": 9,
   "expected": [
     {
       "title": "Update documentation",
@@ -13,12 +13,12 @@
             "key": "node.range",
             "value": {
               "start": {
-                "line": 2,
-                "character": 4
+                "line": 1,
+                "character": 0
               },
               "end": {
-                "line": 9,
-                "character": 5
+                "line": 5,
+                "character": 1
               }
             }
           }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/update-documentation/config/updateDocumentationConfig4.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/update-documentation/config/updateDocumentationConfig4.json
@@ -1,0 +1,29 @@
+{
+  "line": 8,
+  "character": 16,
+  "expected": [
+    {
+      "title": "Update documentation",
+      "kind": "quickfix",
+      "command": {
+        "title": "Update documentation",
+        "command": "UPDATE_DOC",
+        "arguments": [
+          {
+            "key": "node.range",
+            "value": {
+              "start": {
+                "line": 2,
+                "character": 4
+              },
+              "end": {
+                "line": 9,
+                "character": 5
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/update-documentation/source/updateDocumentation4.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/update-documentation/source/updateDocumentation4.bal
@@ -1,0 +1,11 @@
+service / on new http:Listener(8080) {
+
+    # This function has a doc with multiple lines. Once updated, it should
+    # preserve these lines
+    #
+    # + path - Resource path parameter    
+    # + caller - Parameter Description    
+    # + req - Parameter Description
+    resource function get getResource/[int id]/[string...path](http:Caller caller, http:Request req) {
+    }
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/update-documentation/source/updateDocumentation4.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/update-documentation/source/updateDocumentation4.bal
@@ -1,11 +1,6 @@
-service / on new http:Listener(8080) {
 
-    # This function has a doc with multiple lines. Once updated, it should
-    # preserve these lines
-    #
-    # + path - Resource path parameter    
-    # + caller - Parameter Description    
-    # + req - Parameter Description
-    resource function get getResource/[int id]/[string...path](http:Caller caller, http:Request req) {
-    }
+# Description
+#
+public function getInt() returns int {
+    return 0;
 }

--- a/language-server/modules/langserver-core/src/test/resources/command/update-documentation/config/updateDocumentationConfig2.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/update-documentation/config/updateDocumentationConfig2.json
@@ -28,7 +28,7 @@
                     "character": 28
                   }
                 },
-                "newText": "# Description\n#\n# + name - Name of the student    \n# + id - Field Description    \n# + vals - Field Description"
+                "newText": "# Description\n#\n# + name - Name of the student  \n# + id - Field Description  \n# + vals - Field Description"
               }
             ]
           }

--- a/language-server/modules/langserver-core/src/test/resources/command/update-documentation/config/updateDocumentationConfig4.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/update-documentation/config/updateDocumentationConfig4.json
@@ -1,0 +1,40 @@
+{
+  "arguments": {
+    "node.range": {
+      "start": {
+        "line": 3,
+        "character": 4
+      },
+      "end": {
+        "line": 9,
+        "character": 5
+      }
+    }
+  },
+  "expected": {
+    "result": {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "range": {
+                  "start": {
+                    "line": 3,
+                    "character": 4
+                  },
+                  "end": {
+                    "line": 7,
+                    "character": 35
+                  }
+                },
+                "newText": "# Description\n    #\n    # + id - Parameter Description  \n    # + path - Resource path parameter  \n    # + caller - Parameter Description  \n    # + req - Parameter Description"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "jsonrpc": "2.0"
+  }
+}

--- a/language-server/modules/langserver-core/src/test/resources/command/update-documentation/config/updateDocumentationConfig4.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/update-documentation/config/updateDocumentationConfig4.json
@@ -6,7 +6,7 @@
         "character": 4
       },
       "end": {
-        "line": 9,
+        "line": 8,
         "character": 5
       }
     }
@@ -20,11 +20,11 @@
               {
                 "range": {
                   "start": {
-                    "line": 3,
+                    "line": 2,
                     "character": 4
                   },
                   "end": {
-                    "line": 7,
+                    "line": 6,
                     "character": 35
                   }
                 },

--- a/language-server/modules/langserver-core/src/test/resources/command/update-documentation/config/updateDocumentationConfig5.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/update-documentation/config/updateDocumentationConfig5.json
@@ -1,0 +1,40 @@
+{
+  "arguments": {
+    "node.range": {
+      "start": {
+        "line": 1,
+        "character": 0
+      },
+      "end": {
+        "line": 11,
+        "character": 1
+      }
+    }
+  },
+  "expected": {
+    "result": {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "range": {
+                  "start": {
+                    "line": 1,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 32
+                  }
+                },
+                "newText": "# This function has a doc with multiple lines. Once updated, it should\n# preserve these lines\n#\n# + a - Parameter Description spans across multiple lines. Once updated,  \n# it should preserve these lines\n# + return - Return Value Description spans across multiple lines. Once updated,\n# it should preserve these lines"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "jsonrpc": "2.0"
+  }
+}

--- a/language-server/modules/langserver-core/src/test/resources/command/update-documentation/source/updateDocumentationSource4.bal
+++ b/language-server/modules/langserver-core/src/test/resources/command/update-documentation/source/updateDocumentationSource4.bal
@@ -1,0 +1,11 @@
+
+service / on new http:Listener(8080) {
+
+    # Description
+    #
+    # + path - Resource path parameter    
+    # + caller - Parameter Description    
+    # + req - Parameter Description
+    resource function get getResource/[int id]/[string...path](http:Caller caller, http:Request req) {
+    }
+}

--- a/language-server/modules/langserver-core/src/test/resources/command/update-documentation/source/updateDocumentationSource4.bal
+++ b/language-server/modules/langserver-core/src/test/resources/command/update-documentation/source/updateDocumentationSource4.bal
@@ -1,4 +1,3 @@
-
 service / on new http:Listener(8080) {
 
     # Description

--- a/language-server/modules/langserver-core/src/test/resources/command/update-documentation/source/updateDocumentationSource5.bal
+++ b/language-server/modules/langserver-core/src/test/resources/command/update-documentation/source/updateDocumentationSource5.bal
@@ -1,0 +1,12 @@
+
+# This function has a doc with multiple lines. Once updated, it should
+# preserve these lines
+#
+# + a - Parameter Description spans across multiple lines. Once updated, 
+# it should preserve these lines
+# + b - Parameter Description
+# + return - Return Value Description spans across multiple lines. Once updated, 
+# it should preserve these lines
+function doSomething(int a) returns int {
+    return 0;
+}


### PR DESCRIPTION
## Purpose
This PR adds a `node based Update documentation` code action and disables the existing `diagnostic based Update documentation` code action to ensure `Update documentation` code action is shown only if there is a mismatch in the documentation.
![update documentation](https://user-images.githubusercontent.com/27485094/127311516-30d933fe-7a78-453d-a6c5-1237bf05f742.gif)

Also adds support for `parameter descriptions` and `return value descriptions` that span across several lines.
![parameter description (2)](https://user-images.githubusercontent.com/27485094/127312003-03aa0d1d-ddf6-4f4d-a2db-c054fc7b45c1.gif)

Fixes #31678
Fixes #31881

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
