### PR TITLE
Fix toml diagnostics zero based issue

### DIFF
--- a/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/diagnostics/TomlDiagnostic.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/diagnostics/TomlDiagnostic.java
@@ -22,6 +22,8 @@ import io.ballerina.tools.diagnostics.Diagnostic;
 import io.ballerina.tools.diagnostics.DiagnosticInfo;
 import io.ballerina.tools.diagnostics.DiagnosticProperty;
 import io.ballerina.tools.diagnostics.Location;
+import io.ballerina.tools.text.LinePosition;
+import io.ballerina.tools.text.LineRange;
 
 import java.util.List;
 import java.util.Objects;
@@ -80,5 +82,19 @@ public class TomlDiagnostic extends Diagnostic {
     @Override
     public int hashCode() {
         return Objects.hash(location, diagnosticInfo, message);
+    }
+
+    @Override
+    public String toString() {
+        String filePath = this.location().lineRange().filePath();
+
+        LineRange lineRange = this.location().lineRange();
+        LineRange oneBasedLineRange = LineRange.from(
+                filePath,
+                LinePosition.from(lineRange.startLine().line() + 1, lineRange.startLine().offset() + 1),
+                LinePosition.from(lineRange.endLine().line() + 1, lineRange.endLine().offset() + 1));
+
+        return this.diagnosticInfo().severity().toString() + " ["
+                + filePath + ":" + oneBasedLineRange + "] " + message();
     }
 }

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProject.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProject.java
@@ -147,7 +147,7 @@ public class TestBuildProject extends BaseTest {
         PackageCompilation packageCompilation = project.currentPackage().getCompilation();
         Assert.assertEquals(packageCompilation.diagnosticResult().diagnosticCount(), 1);
         Assert.assertEquals(packageCompilation.diagnosticResult().diagnostics().stream().findFirst().get().toString(),
-                "ERROR [Ballerina.toml:(3:0,3:43)] " +
+                "ERROR [Ballerina.toml:(4:1,4:44)] " +
                         "could not locate dependency path './libs/ballerina-io-1.0.0-java.txt'");
         JBallerinaBackend jBallerinaBackend = JBallerinaBackend.from(packageCompilation, JvmTarget.JAVA_11);
         Assert.assertEquals(jBallerinaBackend.diagnosticResult().diagnosticCount(), 1);

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/plugins/CompilerPluginTests.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/plugins/CompilerPluginTests.java
@@ -154,11 +154,11 @@ public class CompilerPluginTests {
         DiagnosticResult diagnosticResult = currentPackage.getCompilation().diagnosticResult();
         Assert.assertEquals(diagnosticResult.diagnosticCount(), 3, "Unexpected number of compilation diagnostics");
         Iterator<Diagnostic> diagnosticIterator = diagnosticResult.diagnostics().iterator();
-        Assert.assertEquals(diagnosticIterator.next().toString(), "ERROR [Ballerina.toml:(7:0,7:64)] "
+        Assert.assertEquals(diagnosticIterator.next().toString(), "ERROR [Ballerina.toml:(8:1,8:65)] "
                 + "could not locate dependency path '../libs/ballerina-runtime-api-2.0.0-beta.2-SNAPSHOT.jar'");
-        Assert.assertEquals(diagnosticIterator.next().toString(), "ERROR [Ballerina.toml:(4:10,4:15)] "
+        Assert.assertEquals(diagnosticIterator.next().toString(), "ERROR [Ballerina.toml:(5:11,5:16)] "
                 + "exported module 'abc' is not a module of the package");
-        Assert.assertEquals(diagnosticIterator.next().toString(), "ERROR [Ballerina.toml:(4:17,4:22)] "
+        Assert.assertEquals(diagnosticIterator.next().toString(), "ERROR [Ballerina.toml:(5:18,5:23)] "
                 + "exported module 'xyz' is not a module of the package");
     }
 


### PR DESCRIPTION
## Purpose
This issue was working as intend on LS Side. In PackageDiagnostic class, it appends +1 to line ranges in toString method. This PR follows the same approach for fixing the zero based issue on CLI.

Resolves #30501
## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
