### PR TITLE
Fix field symbol position issue in intersected record types

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ImmutableTypeCloner.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ImmutableTypeCloner.java
@@ -560,7 +560,7 @@ public class ImmutableTypeCloner {
             if (immutableFieldType.tag == TypeTags.INVOKABLE && immutableFieldType.tsymbol != null) {
                 immutableFieldSymbol = new BInvokableSymbol(origField.symbol.tag, origField.symbol.flags | flag,
                                                             origFieldName, pkgID, immutableFieldType,
-                                                            immutableStructureSymbol, origField.pos, SOURCE);
+                                                            immutableStructureSymbol, origField.symbol.pos, SOURCE);
                 BInvokableTypeSymbol tsymbol = (BInvokableTypeSymbol) immutableFieldType.tsymbol;
                 BInvokableSymbol invokableSymbol = (BInvokableSymbol) immutableFieldSymbol;
                 invokableSymbol.params = tsymbol.params == null ? null : new ArrayList<>(tsymbol.params);
@@ -569,8 +569,8 @@ public class ImmutableTypeCloner {
                 invokableSymbol.flags = tsymbol.flags;
             } else {
                 immutableFieldSymbol = new BVarSymbol(origField.symbol.flags | flag, origFieldName, pkgID,
-                                                      immutableFieldType, immutableStructureSymbol, origField.pos,
-                                                      SOURCE);
+                                                      immutableFieldType, immutableStructureSymbol,
+                                                      origField.symbol.pos, SOURCE);
             }
             String nameString = origFieldName.value;
             fields.put(nameString, new BField(origFieldName, null, immutableFieldSymbol));

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/FieldSymbolTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/FieldSymbolTest.java
@@ -27,6 +27,7 @@ import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.projects.Document;
 import io.ballerina.projects.Project;
+import io.ballerina.tools.diagnostics.Location;
 import org.ballerinalang.test.BCompileUtil;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
@@ -38,6 +39,7 @@ import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDefaul
 import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDocumentForSingleSource;
 import static io.ballerina.tools.text.LinePosition.from;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 /**
  * Test cases for record/object/class field symbols.
@@ -118,6 +120,21 @@ public class FieldSymbolTest {
                 {31, 19, "lName", STRING, false, "private string lName"},
                 {32, 8, "age", INT, true, "int age"},
         };
+    }
+
+    @Test
+    public void testRecordFieldSymbolPos() {
+        Symbol symbol = getSymbol(51, 14);
+        assertEquals(symbol.kind(), SymbolKind.RECORD_FIELD);
+
+        RecordFieldSymbol fieldSymbol = (RecordFieldSymbol) symbol;
+        assertTrue(fieldSymbol.getLocation().isPresent());
+
+        Location symbolPos = fieldSymbol.getLocation().get();
+        assertEquals(symbolPos.lineRange().startLine().line(), 45);
+        assertEquals(symbolPos.lineRange().startLine().offset(), 12);
+        assertEquals(symbolPos.lineRange().endLine().line(), 45);
+        assertEquals(symbolPos.lineRange().endLine().offset(), 17);
     }
 
     private Symbol getSymbol(int line, int col) {

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/field_symbols_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/field_symbols_test.bal
@@ -41,3 +41,13 @@ public class PersonClass {
         return self.fname + " " + self.lname;
     }
 }
+
+type BooleanSubtype readonly & record {|
+    boolean value;
+|};
+
+function booleanSubtypeUnion(anydata d1, anydata d2) returns BooleanSubtype {
+    BooleanSubtype v1 = <BooleanSubtype>d1;
+    BooleanSubtype v2 = <BooleanSubtype>d2;
+    return v1.value == v2.value ? v1 : true;
+}


### PR DESCRIPTION
## Purpose
This PR fixes the incorrect position given for record fields of an intersected record type.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
