### PR TITLE
Add locations of wrapped error causes to stack trace

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ErrorValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ErrorValue.java
@@ -37,12 +37,10 @@ import io.ballerina.runtime.internal.types.BTypeIdSet;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.StringJoiner;
 
 import static io.ballerina.runtime.api.PredefinedTypes.TYPE_MAP;

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ErrorValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ErrorValue.java
@@ -37,10 +37,12 @@ import io.ballerina.runtime.internal.types.BTypeIdSet;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.StringJoiner;
 
 import static io.ballerina.runtime.api.PredefinedTypes.TYPE_MAP;
@@ -302,17 +304,21 @@ public class ErrorValue extends BError implements RefValue {
         for (int i = 1; i < stackTrace.length; i++) {
             printStackElement(sb, stackTrace[i], "\n\t   ");
         }
-        addErrorCauseWithLocation(sb, this.cause);
+        addErrorCauseWithLocation(sb, this.cause, stackTrace.length);
         return sb.toString();
     }
 
-    public void addErrorCauseWithLocation(StringBuilder sb, BError cause) {
+    public void addErrorCauseWithLocation(StringBuilder sb, BError cause, int offset) {
         if (cause != null) {
+            StackTraceElement[] stackTrace = cause.getStackTrace();
             sb.append("\ncause: ")
                     .append(cause.getMessage())
                     .append("\n\tat ");
-            printStackElement(sb, cause.getStackTrace()[0], "");
-            addErrorCauseWithLocation(sb, cause.getCause());
+            printStackElement(sb, stackTrace[0], "");
+            for (int i = 1; i < stackTrace.length - offset; i++) {
+                printStackElement(sb, stackTrace[i], "\n\t   ");
+            }
+            addErrorCauseWithLocation(sb, cause.getCause(), stackTrace.length);
         }
     }
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ErrorValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ErrorValue.java
@@ -75,6 +75,7 @@ public class ErrorValue extends BError implements RefValue {
     private static final String INIT_FUNCTION_SUFFIX = "..<init>";
     private static final String START_FUNCTION_SUFFIX = ".<start>";
     private static final String STOP_FUNCTION_SUFFIX = ".<stop>";
+    private static final String ERROR_CAUSE_PREFIX = "cause: ";
 
     public ErrorValue(BString message) {
         this(new BErrorType(TypeConstants.ERROR, PredefinedTypes.TYPE_ERROR.getPackage(), TYPE_MAP),
@@ -302,7 +303,16 @@ public class ErrorValue extends BError implements RefValue {
         for (int i = 1; i < stackTrace.length; i++) {
             printStackElement(sb, stackTrace[i], "\n\t   ");
         }
+        addErrorCauseWithLocation(sb, this.cause);
         return sb.toString();
+    }
+
+    public void addErrorCauseWithLocation(StringBuilder sb, BError cause) {
+        if (cause != null) {
+            sb.append("\n" + ERROR_CAUSE_PREFIX + cause.getMessage() + "\n\tat ");
+            printStackElement(sb, cause.getStackTrace()[0], "");
+            addErrorCauseWithLocation(sb, cause.getCause());
+        }
     }
 
     @Override
@@ -347,9 +357,6 @@ public class ErrorValue extends BError implements RefValue {
         StringJoiner joiner = new StringJoiner(" ");
 
         joiner.add(this.message.getValue());
-        if (this.cause != null) {
-            joiner.add("cause: " + this.cause.getMessage());
-        }
         if (!isEmptyDetail()) {
             joiner.add(this.details.toString());
         }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ErrorValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ErrorValue.java
@@ -36,14 +36,11 @@ import io.ballerina.runtime.internal.types.BTypeIdSet;
 
 import java.io.PrintStream;
 import java.io.PrintWriter;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.StringJoiner;
 
 import static io.ballerina.runtime.api.PredefinedTypes.TYPE_MAP;
@@ -294,37 +291,29 @@ public class ErrorValue extends BError implements RefValue {
         String errorMsg = getPrintableError();
         StringBuilder sb = new StringBuilder();
         sb.append(errorMsg);
-        Set<StackTraceElement> printedStackElementsSet = new HashSet<>();
-        addPrintableStackTrace(sb, this, printedStackElementsSet);
+        addPrintableStackTrace(sb, this);
         BError cause = this.getCause();
         while (cause != null) {
             sb.append("\ncause: ")
                     .append(cause.getMessage());
-            addPrintableStackTrace(sb, cause, printedStackElementsSet);
+            addPrintableStackTrace(sb, cause);
             cause = cause.getCause();
         }
         return sb.toString();
     }
 
-    private void addPrintableStackTrace(StringBuilder sb, BError error,
-                                       Set<StackTraceElement> printedStackElementsSet) {
+    private void addPrintableStackTrace(StringBuilder sb, BError error) {
         // Append function/action/resource name with package path (if any)
         StackTraceElement[] stackTrace = error.getStackTrace();
         if (stackTrace.length == 0) {
             return;
         }
-        List<StackTraceElement> printedElements = new ArrayList<>();
         sb.append("\n\tat ");
         // print first element
         printStackElement(sb, stackTrace[0], "");
-        printedElements.add(stackTrace[0]);
         for (int i = 1; i < stackTrace.length; i++) {
-            if (!printedStackElementsSet.contains(stackTrace[i])) {
-                printStackElement(sb, stackTrace[i], "\n\t   ");
-                printedElements.add(stackTrace[i]);
-            }
+            printStackElement(sb, stackTrace[i], "\n\t   ");
         }
-        printedStackElementsSet.addAll(printedElements);
     }
 
     @Override

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ErrorValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ErrorValue.java
@@ -75,7 +75,6 @@ public class ErrorValue extends BError implements RefValue {
     private static final String INIT_FUNCTION_SUFFIX = "..<init>";
     private static final String START_FUNCTION_SUFFIX = ".<start>";
     private static final String STOP_FUNCTION_SUFFIX = ".<stop>";
-    private static final String ERROR_CAUSE_PREFIX = "cause: ";
 
     public ErrorValue(BString message) {
         this(new BErrorType(TypeConstants.ERROR, PredefinedTypes.TYPE_ERROR.getPackage(), TYPE_MAP),
@@ -309,7 +308,9 @@ public class ErrorValue extends BError implements RefValue {
 
     public void addErrorCauseWithLocation(StringBuilder sb, BError cause) {
         if (cause != null) {
-            sb.append("\n" + ERROR_CAUSE_PREFIX + cause.getMessage() + "\n\tat ");
+            sb.append("\ncause: ")
+                    .append(cause.getMessage())
+                    .append("\n\tat ");
             printStackElement(sb, cause.getStackTrace()[0], "");
             addErrorCauseWithLocation(sb, cause.getCause());
         }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
@@ -399,13 +399,14 @@ public class ErrorTest {
 
         Assert.assertNotNull(expectedException);
         String message = expectedException.getMessage();
-        Assert.assertEquals(message, "error: error1\n\t" +
-                "at error_test:foo(error_test.bal:470)\n\t" +
-                "   error_test:testStackTraceWithErrorCauseLocation(error_test.bal:466)\n" +
-                "cause: error2\n\t" +
-                "at error_test:baz(error_test.bal:475)\n" +
-                "cause: error3\n\t" +
-                "at error_test:foobar(error_test.bal:480)");
+        Assert.assertEquals(message, "error: error1\n" +
+                "\tat error_test:foo(error_test.bal:470)\n" +
+                "\t   error_test:testStackTraceWithErrorCauseLocation(error_test.bal:466)\n" +
+                "cause: error2\n" +
+                "\tat error_test:baz(error_test.bal:479)\n" +
+                "\t   error_test:x(error_test.bal:475)\n" +
+                "cause: error3\n" +
+                "\tat error_test:foobar(error_test.bal:484)");
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
@@ -405,8 +405,14 @@ public class ErrorTest {
                 "cause: error2\n" +
                 "\tat error_test:baz(error_test.bal:479)\n" +
                 "\t   error_test:x(error_test.bal:475)\n" +
+                "\t   error_test:foo(error_test.bal:470)\n" +
+                "\t   error_test:testStackTraceWithErrorCauseLocation(error_test.bal:466)\n" +
                 "cause: error3\n" +
-                "\tat error_test:foobar(error_test.bal:484)");
+                "\tat error_test:foobar(error_test.bal:484)\n" +
+                "\t   error_test:baz(error_test.bal:479)\n" +
+                "\t   error_test:x(error_test.bal:475)\n" +
+                "\t   error_test:foo(error_test.bal:470)\n" +
+                "\t   error_test:testStackTraceWithErrorCauseLocation(error_test.bal:466)");
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
@@ -388,6 +388,26 @@ public class ErrorTest {
         BRunUtil.invoke(errorTestResult, "testErrorBindingPattern");
     }
 
+    @Test
+    public void testStackTraceWithErrorCauseLocation() {
+        Exception expectedException = null;
+        try {
+            BRunUtil.invoke(errorTestResult, "testStackTraceWithErrorCauseLocation");
+        } catch (Exception e) {
+            expectedException = e;
+        }
+
+        Assert.assertNotNull(expectedException);
+        String message = expectedException.getMessage();
+        Assert.assertEquals(message, "error: error1\n\t" +
+                "at error_test:foo(error_test.bal:470)\n\t" +
+                "   error_test:testStackTraceWithErrorCauseLocation(error_test.bal:466)\n" +
+                "cause: error2\n\t" +
+                "at error_test:baz(error_test.bal:475)\n" +
+                "cause: error3\n\t" +
+                "at error_test:foobar(error_test.bal:480)");
+    }
+
     @AfterClass
     public void cleanup() {
         errorTestResult = null;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/PrintableStackTraceTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/PrintableStackTraceTest.java
@@ -56,7 +56,9 @@ public class PrintableStackTraceTest {
                 "\t   test_org.project.0_1_0:main(main.bal:20)\n" +
                 "cause: error1\n" +
                 "\tat test_org.project.foo.0_1_0:errorFunc(foo.bal:22)\n" +
-                "\t   test_org.project.foo.0_1_0:testFunc(foo.bal:18)");
+                "\t   test_org.project.foo.0_1_0:testFunc(foo.bal:18)\n" +
+                "\t   test_org.project.0_1_0:testFunc(main.bal:24)\n" +
+                "\t   test_org.project.0_1_0:main(main.bal:20)");
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/PrintableStackTraceTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/PrintableStackTraceTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.test.error;
+
+import org.ballerinalang.test.BCompileUtil;
+import org.ballerinalang.test.BRunUtil;
+import org.ballerinalang.test.CompileResult;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * Test case for Error StackTrace.
+ *
+ * @since 2.0.0
+ */
+
+public class PrintableStackTraceTest {
+
+    private CompileResult compileResult;
+
+    @BeforeClass
+    public void setup() {
+        compileResult = BCompileUtil.compile("test-src/error/project");
+    }
+
+    @Test
+    public void testPrintableStackTrace() {
+        Exception expectedException = null;
+        try {
+            BRunUtil.invoke(compileResult, "main");
+        } catch (Exception e) {
+            expectedException = e;
+        }
+
+        Assert.assertNotNull(expectedException);
+        String message = expectedException.getMessage();
+        Assert.assertEquals(message, "error: error2\n" +
+                "\tat test_org.project.0_1_0:testFunc(main.bal:24)\n" +
+                "\t   test_org.project.0_1_0:main(main.bal:20)\n" +
+                "cause: error1\n" +
+                "\tat test_org.project.foo.0_1_0:errorFunc(foo.bal:22)\n" +
+                "\t   test_org.project.foo.0_1_0:testFunc(foo.bal:18)");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
+    }
+
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/error/error_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/error/error_test.bal
@@ -467,8 +467,12 @@ function testStackTraceWithErrorCauseLocation() {
 }
 
 function foo() returns error {
-    error err = error("error1", baz());
+    error err = error("error1", x());
     return err;
+}
+
+function x() returns error {
+    return baz();
 }
 
 function baz() returns error {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/error/error_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/error/error_test.bal
@@ -462,6 +462,25 @@ function testLocalErrorTypeWithClosure() {
 //    assertEquality(err.detail()["i"], k);
 //}
 
+function testStackTraceWithErrorCauseLocation() {
+    panic foo();
+}
+
+function foo() returns error {
+    error err = error("error1", baz());
+    return err;
+}
+
+function baz() returns error {
+    error err = error("error2", foobar());
+    return err;
+}
+
+function foobar() returns error {
+    error err = error("error3");
+    return err;
+}
+
 const ASSERTION_ERROR_REASON = "AssertionError";
 
 function assertEquality(any|error actual, any|error expected) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/error/project/Ballerina.toml
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/error/project/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "test_org"
+name = "project"
+version= "0.1.0"

--- a/tests/jballerina-unit-test/src/test/resources/test-src/error/project/main.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/error/project/main.bal
@@ -1,0 +1,26 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import project.foo as foo;
+
+public function main() {
+    panic testFunc();
+}
+
+public function testFunc() returns error {
+    error err = error("error2", foo:testFunc());
+    return err;
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/error/project/main.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/error/project/main.bal
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import project.foo as foo;
+import project.foo;
 
 public function main() {
     panic testFunc();

--- a/tests/jballerina-unit-test/src/test/resources/test-src/error/project/modules/foo/foo.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/error/project/modules/foo/foo.bal
@@ -1,0 +1,24 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+public function testFunc() returns error {
+    return errorFunc();
+}
+
+function errorFunc() returns error {
+    error err = error("error1");
+    return err;
+}


### PR DESCRIPTION
## Purpose
This PR will introduce an improvement to add the wrapped error's cause locations to the stack trace. 
e.g: For the following code snippet
```
public function main() {
    panic bar();
}

function bar() returns error {
    error b = error("b", foo());
    return b;
}

function foo() returns error {
    error a = error("a", foobar());
    return a;
}

function foobar() returns error {
    error c = error("c");
    return c;
}
```
the printed error message will be,
```
error: b
        at main:bar(main.bal:6)
           main:main(main.bal:2)
cause: a
        at main:foo(main.bal:11)
cause: c
        at main:foobar(main.bal:16)
```


Fixes #31554

## Approach

## Samples

## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
