### PR TITLE
Improve create function code action

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/CreateFunctionExecutor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/CreateFunctionExecutor.java
@@ -17,11 +17,13 @@ package org.ballerinalang.langserver.command.executors;
 
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.syntax.tree.FunctionArgumentNode;
 import io.ballerina.compiler.syntax.tree.FunctionCallExpressionNode;
 import io.ballerina.compiler.syntax.tree.NonTerminalNode;
+import io.ballerina.compiler.syntax.tree.PositionalArgumentNode;
 import io.ballerina.compiler.syntax.tree.SimpleNameReferenceNode;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.compiler.syntax.tree.SyntaxTree;
@@ -51,6 +53,7 @@ import org.eclipse.lsp4j.services.LanguageClient;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -134,16 +137,28 @@ public class CreateFunctionExecutor implements LSCommandExecutor {
 
         List<String> args = new ArrayList<>();
         int argIndex = 1;
+        List<SymbolKind> argumentKindList = Arrays.asList(SymbolKind.VARIABLE, SymbolKind.CONSTANT);
         for (FunctionArgumentNode fnArgNode : fnCallExprNode.get().arguments()) {
-            Optional<TypeSymbol> type = semanticModel.type(fnArgNode);
-
-            String varName = CommonUtil.generateName(argIndex, visibleSymbolNames);
-            if (type.isPresent() && type.get().typeKind() != TypeDescKind.COMPILATION_ERROR) {
-                args.add(FunctionGenerator.getParameterTypeAsString(codeActionContext, type.get()) + " " + varName);
+            Optional<TypeSymbol> type = semanticModel.typeOf(fnArgNode);
+            Optional<Symbol> symbol;
+            if (fnArgNode.kind() == SyntaxKind.POSITIONAL_ARG) {
+                symbol = semanticModel.symbol(((PositionalArgumentNode) fnArgNode).expression());
             } else {
-                args.add(FunctionGenerator.getParameterTypeAsString(codeActionContext, null) + " " + varName);
+                symbol = semanticModel.symbol(fnArgNode);
+            }
+            String varName = "";
+            if (symbol.isPresent() && argumentKindList.contains(symbol.get().kind())) {
+                varName = symbol.get().getName().orElse("");
             }
 
+            if (type.isPresent() && type.get().typeKind() != TypeDescKind.COMPILATION_ERROR) {
+                varName = CommonUtil.generateParameterName(varName, argIndex,
+                        CommonUtil.getRawType(type.get()), visibleSymbolNames);
+                args.add(FunctionGenerator.getParameterTypeAsString(codeActionContext, type.get()) + " " + varName);
+            } else {
+                varName = CommonUtil.generateParameterName(varName, argIndex, null, visibleSymbolNames);
+                args.add(FunctionGenerator.getParameterTypeAsString(codeActionContext, null) + " " + varName);
+            }
             visibleSymbolNames.add(varName);
             argIndex++;
         }
@@ -157,13 +172,24 @@ public class CreateFunctionExecutor implements LSCommandExecutor {
             return Collections.emptyList();
         }
 
+        LanguageClient client = context.getLanguageClient();
+        List<TextEdit> edits = new ArrayList<>();
+        Optional<NonTerminalNode> enclosingNode = findEnclosingModulePartNode(fnCallExprNode.get());
+        Range insertRange;
+        if (enclosingNode.isPresent()) {
+            LineRange endLineRange = enclosingNode.get().lineRange();
+            newLineAtEnd = false;
+            insertRange = new Range(new Position(endLineRange.endLine().line(), endLineRange.endLine().offset()),
+                    new Position(endLineRange.endLine().line(), endLineRange.endLine().offset()));
+
+        } else {
+            insertRange = new Range(new Position(endLine, endCol), new Position(endLine, endCol));
+        }
+
         // Generate function
         String function = FunctionGenerator.generateFunction(codeActionContext, !newLineAtEnd, functionName,
                 args, returnTypeSymbol.get());
 
-        LanguageClient client = context.getLanguageClient();
-        List<TextEdit> edits = new ArrayList<>();
-        Range insertRange = new Range(new Position(endLine, endCol), new Position(endLine, endCol));
         edits.add(new TextEdit(insertRange, function));
         TextDocumentEdit textDocumentEdit = new TextDocumentEdit(new VersionedTextDocumentIdentifier(uri, null), edits);
         return CommandUtil.applyWorkspaceEdit(Collections.singletonList(Either.forLeft(textDocumentEdit)), client);
@@ -175,5 +201,16 @@ public class CreateFunctionExecutor implements LSCommandExecutor {
     @Override
     public String getCommand() {
         return COMMAND;
+    }
+
+    private Optional<NonTerminalNode> findEnclosingModulePartNode(NonTerminalNode node) {
+        NonTerminalNode reference = node;
+        while (reference != null && reference.parent() != null) {
+            if (reference.parent().kind() == SyntaxKind.MODULE_PART) {
+                return Optional.of(reference);
+            }
+            reference = reference.parent();
+        }
+        return Optional.empty();
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -631,6 +631,26 @@ public class CommonUtil {
     }
 
     /**
+     * Generates a variable name.
+     *
+     * @param name {@link BLangNode}
+     * @return random argument name
+     */
+    public static String generateVariableName(String name, Set<String> names) {
+        return generateVariableName(1, name, names);
+    }
+
+    /**
+     * Generates a variable name.
+     *
+     * @param symbol {@link Symbol}
+     * @return random argument name
+     */
+    public static String generateVariableName(Symbol symbol, Set<String> names) {
+        return generateVariableName(1, symbol.kind().name(), names);
+    }
+
+    /**
      * Generates a random name.
      *
      * @param value    index of the argument
@@ -662,26 +682,6 @@ public class CommonUtil {
             return generateVariableName(1, ((BLangInvocation) bLangNode).name.value, names);
         }
         return newName;
-    }
-
-    /**
-     * Generates a variable name.
-     *
-     * @param name {@link BLangNode}
-     * @return random argument name
-     */
-    public static String generateVariableName(String name, Set<String> names) {
-        return generateVariableName(1, name, names);
-    }
-
-    /**
-     * Generates a variable name.
-     *
-     * @param symbol {@link Symbol}
-     * @return random argument name
-     */
-    public static String generateVariableName(Symbol symbol, Set<String> names) {
-        return generateVariableName(1, symbol.kind().name(), names);
     }
 
     /**
@@ -720,20 +720,6 @@ public class CommonUtil {
         } else {
             return generateName(1, names);
         }
-    }
-
-    /**
-     * Whether the given module is a langlib module.
-     *
-     * @param moduleID Module ID to evaluate
-     * @return {@link Boolean} whether langlib or not
-     */
-    public static boolean isLangLib(ModuleID moduleID) {
-        return isLangLib(moduleID.orgName(), moduleID.moduleName());
-    }
-
-    public static boolean isLangLib(String orgName, String moduleName) {
-        return orgName.equals("ballerina") && moduleName.startsWith("lang.");
     }
 
     private static String generateVariableName(int suffix, String name, Set<String> names) {
@@ -810,6 +796,137 @@ public class CommonUtil {
             newName = generateName(++suffix, names);
         }
         return newName;
+    }
+
+    /**
+     * Generates a parameter name.
+     *
+     * @param arg          Argument name.
+     * @param position     Argument position.
+     * @param type         Type symbol of the argument.
+     * @param visibleNames Visible symbol names.
+     * @return
+     */
+    public static String generateParameterName(String arg, int position, TypeSymbol type, Set<String> visibleNames) {
+        String newName;
+        if (arg.isEmpty() || !isValidIdentifier(arg)) {
+            String typeName = type != null ? type.typeKind().getName() : "";
+            if (!typeName.isEmpty()) {
+                newName = typeName.substring(0, 1).toLowerCase(Locale.getDefault());
+                return toCamelCase(getValidatedSymbolName(visibleNames, newName));
+            } else {
+                return generateName(position, visibleNames);
+            }
+        } else {
+            return toCamelCase(getValidatedSymbolName(visibleNames, arg));
+        }
+    }
+
+    /**
+     * Get a validated symbol name against the visible symbols.
+     * This method can be used to auto generate the symbol names without conflicting with the existing symbol names
+     *
+     * @param visibleNames visible symbol names in the context.
+     * @param symbolName   raw symbol name to modify with the numbered suffix
+     * @return {@link String} modified symbol name
+     */
+    public static String getValidatedSymbolName(Set<String> visibleNames, String symbolName) {
+        if (!visibleNames.contains(symbolName)) {
+            return symbolName;
+        }
+        List<Integer> suffixList = visibleNames.parallelStream().map(sName -> {
+            if (sName == null) {
+                return -2;
+            }
+            if (sName.equals(symbolName)) {
+                return 0;
+            }
+            String modifiedName = sName.replaceFirst(symbolName, "");
+
+            if (!modifiedName.isEmpty() && modifiedName.chars().allMatch(Character::isDigit)) {
+                return Integer.parseInt(modifiedName);
+            }
+
+            return -3;
+        }).filter(integer -> integer >= 0).sorted().collect(Collectors.toList());
+
+        for (int i = 0; i < suffixList.size(); i++) {
+            Integer suffix = suffixList.get(i);
+            if (i == suffixList.size() - 1 || (suffix + 1) != suffixList.get(i + 1)) {
+                return symbolName + (suffix + 1);
+            }
+        }
+        return symbolName;
+    }
+
+    /**
+     * Get the validated symbol name against the visible symbols.
+     * This method can be used to auto generate the symbol names without conflicting with the existing symbol names
+     *
+     * @param context    completion context
+     * @param symbolName raw symbol name to modify with the numbered suffix
+     * @return {@link String} modified symbol name
+     */
+    public static String getValidatedSymbolName(PositionedOperationContext context, String symbolName) {
+        List<Symbol> symbols = context.visibleSymbols(context.getCursorPosition());
+        Set<String> visibleSymbolNames = symbols.stream()
+                .map(Symbol::getName)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toSet());
+        return getValidatedSymbolName(visibleSymbolNames, symbolName);
+    }
+
+    /**
+     * Coverts a given text to camel case.
+     *
+     * @param text text to be converted.
+     * @return {@link String} converted string.
+     */
+    private static String toCamelCase(String text) {
+        String[] words = text.split("[\\W_]+");
+        StringBuilder result = new StringBuilder();
+        if (words.length == 1) {
+            if (!StringUtils.isAllUpperCase(words[0])) {
+                String word = words[0];
+                word = Character.toLowerCase(word.charAt(0)) + word.substring(1);
+                return word;
+            }
+            return words[0];
+        }
+        for (int i = 0; i < words.length; i++) {
+            String word = words[i];
+            if (word.isEmpty()) {
+                continue;
+            }
+            if (i == 0) {
+                word = word.toLowerCase();
+            } else {
+                word = Character.toUpperCase(word.charAt(0)) + word.substring(1).toLowerCase();
+            }
+            result.append(word);
+        }
+        return result.toString();
+    }
+
+    /**
+     * Whether the given module is a langlib module.
+     * public static String generateParameterName(String arg, Set<String> visibleNames) {
+     * visibleNames.addAll(BALLERINA_KEYWORDS);
+     * String newName = arg.replaceAll(".+[\\:\\.]", "");
+     * <p>
+     * <p>
+     * }
+     *
+     * @param moduleID Module ID to evaluate
+     * @return {@link Boolean} whether langlib or not
+     */
+    public static boolean isLangLib(ModuleID moduleID) {
+        return isLangLib(moduleID.orgName(), moduleID.moduleName());
+    }
+
+    public static boolean isLangLib(String orgName, String moduleName) {
+        return orgName.equals("ballerina") && moduleName.startsWith("lang.");
     }
 
     /**
@@ -1121,43 +1238,6 @@ public class CommonUtil {
         return modNameComponents[modNameComponents.length - 1];
     }
 
-    /**
-     * Get the validated symbol name against the visible symbols.
-     * This method can be used to auto generate the symbol names without conflicting with the existing symbol names
-     *
-     * @param context    completion context
-     * @param symbolName raw symbol name to modify with the numbered suffix
-     * @return {@link String} modified symbol name
-     */
-    public static String getValidatedSymbolName(PositionedOperationContext context, String symbolName) {
-        List<Symbol> symbols = context.visibleSymbols(context.getCursorPosition());
-        List<Integer> variableNumbers = symbols.parallelStream().map(symbol -> {
-            if (symbol.getName().isEmpty()) {
-                return -2;
-            }
-            String sName = symbol.getName().get();
-            if (sName.equals(symbolName)) {
-                return 0;
-            }
-            String modifiedName = sName.replaceFirst(symbolName, "");
-
-            if (!modifiedName.isEmpty() && modifiedName.chars().allMatch(Character::isDigit)) {
-                return Integer.parseInt(modifiedName);
-            }
-
-            return -3;
-        }).filter(integer -> integer >= 0).sorted().collect(Collectors.toList());
-
-        for (int i = 0; i < variableNumbers.size(); i++) {
-            Integer intVal = variableNumbers.get(i);
-            if (i == variableNumbers.size() - 1 || (intVal + 1) != variableNumbers.get(i + 1)) {
-                return symbolName + (intVal + 1);
-            }
-        }
-
-        return symbolName;
-    }
-
     public static boolean isKeyword(String token) {
         return CommonUtil.BALLERINA_KEYWORDS.contains(token);
     }
@@ -1182,7 +1262,7 @@ public class CommonUtil {
      * (1) any variable defined
      * (2) Function Parameters
      * (3) Service/ resource path parameters
-     * 
+     *
      * @return {@link Predicate<Symbol>}
      */
     public static Predicate<Symbol> getVariableFilterPredicate() {

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/command/CreateFunctionCommandExecTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/command/CreateFunctionCommandExecTest.java
@@ -78,6 +78,8 @@ public class CreateFunctionCommandExecTest extends AbstractCommandExecutionTest 
                 {"projectCreateUndefinedFunction3.json", "testproject/main.bal"},
                 {"projectCreateUndefinedFunction4.json", "testproject/main.bal"},
                 {"projectCreateUndefinedFunction5.json", "testproject/school.bal"},
+                {"projectCreateUndefinedFunction6.json", "testproject/main.bal"},
+
                 // Let Expression
                 {"projectCreateUndefinedFunctionInLet.json", "testproject/school.bal"},
                 {"projectCreateUndefinedFunctionInLet2.json", "testproject/school.bal"},

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction1.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction1.json
@@ -20,15 +20,15 @@
               {
                 "range": {
                   "start": {
-                    "line": 8,
-                    "character": 0
+                    "line": 7,
+                    "character": 1
                   },
                   "end": {
-                    "line": 8,
-                    "character": 0
+                    "line": 7,
+                    "character": 1
                   }
                 },
-                "newText": "\n\nfunction addTwoIntegers(int a, float b, boolean c) {\n    \n}\n"
+                "newText": "\n\nfunction addTwoIntegers(int a, float c, boolean b) {\n    \n}\n"
               }
             ]
           }

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction10.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction10.json
@@ -1,40 +1,40 @@
 {
-    "arguments": {
-        "node.range": {
-            "start": {
-                "line": 20,
-                "character": 29
-            },
-            "end": {
-                "line": 20,
-                "character": 50
-            }
-        }
-    },
-    "expected": {
-        "result": {
-            "edit": {
-                "documentChanges": [
-                    {
-                        "edits": [
-                            {
-                                "range": {
-                                    "start": {
-                                        "line": 34,
-                                        "character": 0
-                                    },
-                                    "end": {
-                                        "line": 34,
-                                        "character": 0
-                                    }
-                                },
-                                "newText": "\n\nfunction callEndpoint(int a, int b, module1:Listener c) returns module1:TestClass1 {\n    return new (0, 0);\n}\n"
-                            }
-                        ]
-                    }
-                ]
-            }
-        },
-        "jsonrpc": "2.0"
+  "arguments": {
+    "node.range": {
+      "start": {
+        "line": 20,
+        "character": 29
+      },
+      "end": {
+        "line": 20,
+        "character": 50
+      }
     }
+  },
+  "expected": {
+    "result": {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "range": {
+                  "start": {
+                    "line": 33,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 33,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction callEndpoint(int a, int b, module1:Listener c) returns module1:TestClass1 {\n    return new (0, 0);\n}\n"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "jsonrpc": "2.0"
+  }
 }

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction11.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction11.json
@@ -1,40 +1,40 @@
 {
-    "arguments": {
-        "node.range": {
-            "start": {
-                "line": 23,
-                "character": 4
-            },
-            "end": {
-                "line": 23,
-                "character": 29
-            }
-        }
-    },
-    "expected": {
-        "result": {
-            "edit": {
-                "documentChanges": [
-                    {
-                        "edits": [
-                            {
-                                "range": {
-                                    "start": {
-                                        "line": 34,
-                                        "character": 0
-                                    },
-                                    "end": {
-                                        "line": 34,
-                                        "character": 0
-                                    }
-                                },
-                                "newText": "\n\nfunction printThis(boolean a) {\n    \n}\n"
-                            }
-                        ]
-                    }
-                ]
-            }
-        },
-        "jsonrpc": "2.0"
+  "arguments": {
+    "node.range": {
+      "start": {
+        "line": 23,
+        "character": 4
+      },
+      "end": {
+        "line": 23,
+        "character": 29
+      }
     }
+  },
+  "expected": {
+    "result": {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "range": {
+                  "start": {
+                    "line": 33,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 33,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction printThis(boolean b) {\n    \n}\n"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "jsonrpc": "2.0"
+  }
 }

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction12.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction12.json
@@ -1,40 +1,40 @@
 {
-    "arguments": {
-        "node.range": {
-            "start": {
-                "line": 25,
-                "character": 4
-            },
-            "end": {
-                "line": 25,
-                "character": 28
-            }
-        }
-    },
-    "expected": {
-        "result": {
-            "edit": {
-                "documentChanges": [
-                    {
-                        "edits": [
-                            {
-                                "range": {
-                                    "start": {
-                                        "line": 34,
-                                        "character": 0
-                                    },
-                                    "end": {
-                                        "line": 34,
-                                        "character": 0
-                                    }
-                                },
-                                "newText": "\n\nfunction printField(int a) {\n    \n}\n"
-                            }
-                        ]
-                    }
-                ]
-            }
-        },
-        "jsonrpc": "2.0"
+  "arguments": {
+    "node.range": {
+      "start": {
+        "line": 25,
+        "character": 4
+      },
+      "end": {
+        "line": 25,
+        "character": 28
+      }
     }
+  },
+  "expected": {
+    "result": {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "range": {
+                  "start": {
+                    "line": 33,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 33,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction printField(int i) {\n    \n}\n"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "jsonrpc": "2.0"
+  }
 }

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction14.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction14.json
@@ -1,40 +1,40 @@
 {
-    "arguments": {
-        "node.range": {
-            "start": {
-                "line": 10,
-                "character": 16
-            },
-            "end": {
-                "line": 10,
-                "character": 31
-            }
-        }
-    },
-    "expected": {
-        "result": {
-            "edit": {
-                "documentChanges": [
-                    {
-                        "edits": [
-                            {
-                                "range": {
-                                    "start": {
-                                        "line": 34,
-                                        "character": 0
-                                    },
-                                    "end": {
-                                        "line": 34,
-                                        "character": 0
-                                    }
-                                },
-                                "newText": "\n\nfunction createStudent() returns Student {\n    return new (\"\");\n}\n"
-                            }
-                        ]
-                    }
-                ]
-            }
-        },
-        "jsonrpc": "2.0"
+  "arguments": {
+    "node.range": {
+      "start": {
+        "line": 10,
+        "character": 16
+      },
+      "end": {
+        "line": 10,
+        "character": 31
+      }
     }
+  },
+  "expected": {
+    "result": {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "range": {
+                  "start": {
+                    "line": 15,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 15,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction createStudent() returns Student {\n    return new (\"\");\n}\n"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "jsonrpc": "2.0"
+  }
 }

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction15.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction15.json
@@ -1,40 +1,40 @@
 {
-    "arguments": {
-        "node.range": {
-            "start": {
-                "line": 12,
-                "character": 26
-            },
-            "end": {
-                "line": 12,
-                "character": 51
-            }
-        }
-    },
-    "expected": {
-        "result": {
-            "edit": {
-                "documentChanges": [
-                    {
-                        "edits": [
-                            {
-                                "range": {
-                                    "start": {
-                                        "line": 34,
-                                        "character": 0
-                                    },
-                                    "end": {
-                                        "line": 34,
-                                        "character": 0
-                                    }
-                                },
-                                "newText": "\n\nfunction createClassRoom(Student[] a) returns ClassRoom {\n    return new (\"\", 0, []);\n}\n"
-                            }
-                        ]
-                    }
-                ]
-            }
-        },
-        "jsonrpc": "2.0"
+  "arguments": {
+    "node.range": {
+      "start": {
+        "line": 12,
+        "character": 26
+      },
+      "end": {
+        "line": 12,
+        "character": 51
+      }
     }
+  },
+  "expected": {
+    "result": {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "range": {
+                  "start": {
+                    "line": 15,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 15,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction createClassRoom(Student[] students) returns ClassRoom {\n    return new (\"\", 0, []);\n}\n"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "jsonrpc": "2.0"
+  }
 }

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction16.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction16.json
@@ -1,40 +1,40 @@
 {
-    "arguments": {
-        "node.range": {
-            "start": {
-                "line": 14,
-                "character": 22
-            },
-            "end": {
-                "line": 14,
-                "character": 48
-            }
-        }
-    },
-    "expected": {
-        "result": {
-            "edit": {
-                "documentChanges": [
-                    {
-                        "edits": [
-                            {
-                                "range": {
-                                    "start": {
-                                        "line": 34,
-                                        "character": 0
-                                    },
-                                    "end": {
-                                        "line": 34,
-                                        "character": 0
-                                    }
-                                },
-                                "newText": "\n\nfunction createAddress(string a) returns Address {\n    return object {};\n}\n"
-                            }
-                        ]
-                    }
-                ]
-            }
-        },
-        "jsonrpc": "2.0"
+  "arguments": {
+    "node.range": {
+      "start": {
+        "line": 14,
+        "character": 22
+      },
+      "end": {
+        "line": 14,
+        "character": 48
+      }
     }
+  },
+  "expected": {
+    "result": {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "range": {
+                  "start": {
+                    "line": 15,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 15,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction createAddress(string s) returns Address {\n    return object {};\n}\n"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "jsonrpc": "2.0"
+  }
 }

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction2.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction2.json
@@ -20,12 +20,12 @@
               {
                 "range": {
                   "start": {
-                    "line": 8,
-                    "character": 0
+                    "line": 7,
+                    "character": 1
                   },
                   "end": {
-                    "line": 8,
-                    "character": 0
+                    "line": 7,
+                    "character": 1
                   }
                 },
                 "newText": "\n\nfunction addTwoIntegers2(int a, int b) returns int {\n    return 0;\n}\n"

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction3.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction3.json
@@ -20,15 +20,15 @@
               {
                 "range": {
                   "start": {
-                    "line": 8,
-                    "character": 0
+                    "line": 7,
+                    "character": 1
                   },
                   "end": {
-                    "line": 8,
-                    "character": 0
+                    "line": 7,
+                    "character": 1
                   }
                 },
-                "newText": "\n\nfunction assignInteger(string a, int b, boolean c) returns int {\n    return 0;\n}\n"
+                "newText": "\n\nfunction assignInteger(string s, int b, boolean b1) returns int {\n    return 0;\n}\n"
               }
             ]
           }

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction7.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction7.json
@@ -20,15 +20,15 @@
               {
                 "range": {
                   "start": {
-                    "line": 34,
-                    "character": 0
+                    "line": 33,
+                    "character": 1
                   },
                   "end": {
-                    "line": 34,
-                    "character": 0
+                    "line": 33,
+                    "character": 1
                   }
                 },
-                "newText": "\n\nfunction partition(string a, string b, function (string) returns boolean c) returns string[][][] {\n    return [[[]]];\n}\n"
+                "newText": "\n\nfunction partition(string recs, string s, function (string) returns boolean f) returns string[][][] {\n    return [[[]]];\n}\n"
               }
             ]
           }

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction8.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction8.json
@@ -20,12 +20,12 @@
               {
                 "range": {
                   "start": {
-                    "line": 34,
-                    "character": 0
+                    "line": 33,
+                    "character": 1
                   },
                   "end": {
-                    "line": 34,
-                    "character": 0
+                    "line": 33,
+                    "character": 1
                   }
                 },
                 "newText": "\n\nfunction addAndPrintTwoIntegers(int a, int b) returns [int, string[][]] {\n    return [0, [[]]];\n}\n"

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction9.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction9.json
@@ -20,12 +20,12 @@
               {
                 "range": {
                   "start": {
-                    "line": 34,
-                    "character": 0
+                    "line": 33,
+                    "character": 1
                   },
                   "end": {
-                    "line": 34,
-                    "character": 0
+                    "line": 33,
+                    "character": 1
                   }
                 },
                 "newText": "\n\nfunction addAndGetResultOfTwoIntegers(int a, int b) returns int {\n    return 0;\n}\n"

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunctionInRecord.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunctionInRecord.json
@@ -1,40 +1,40 @@
 {
-    "arguments": {
-        "node.range": {
-            "start": {
-                "line": 18,
-                "character": 22
-            },
-            "end": {
-                "line": 18,
-                "character": 39
-            }
-        }
-    },
-    "expected": {
-        "result": {
-            "edit": {
-                "documentChanges": [
-                    {
-                        "edits": [
-                            {
-                                "range": {
-                                    "start": {
-                                        "line": 25,
-                                        "character": 0
-                                    },
-                                    "end": {
-                                        "line": 25,
-                                        "character": 0
-                                    }
-                                },
-                                "newText": "\n\nfunction getManufacturer() returns Manufacturer {\n    return {name: \"\"};\n}\n"
-                            }
-                        ]
-                    }
-                ]
-            }
-        },
-        "jsonrpc": "2.0"
+  "arguments": {
+    "node.range": {
+      "start": {
+        "line": 18,
+        "character": 22
+      },
+      "end": {
+        "line": 18,
+        "character": 39
+      }
     }
+  },
+  "expected": {
+    "result": {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "range": {
+                  "start": {
+                    "line": 24,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 24,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction getManufacturer() returns Manufacturer {\n    return {name: \"\"};\n}\n"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "jsonrpc": "2.0"
+  }
 }

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunctionInRecord2.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunctionInRecord2.json
@@ -1,40 +1,40 @@
 {
-    "arguments": {
-        "node.range": {
-            "start": {
-                "line": 22,
-                "character": 20
-            },
-            "end": {
-                "line": 22,
-                "character": 41
-            }
-        }
-    },
-    "expected": {
-        "result": {
-            "edit": {
-                "documentChanges": [
-                    {
-                        "edits": [
-                            {
-                                "range": {
-                                    "start": {
-                                        "line": 25,
-                                        "character": 0
-                                    },
-                                    "end": {
-                                        "line": 25,
-                                        "character": 0
-                                    }
-                                },
-                                "newText": "\n\nfunction createListener(Car a) returns module1:Listener {\n    return new (0);\n}\n"
-                            }
-                        ]
-                    }
-                ]
-            }
-        },
-        "jsonrpc": "2.0"
+  "arguments": {
+    "node.range": {
+      "start": {
+        "line": 22,
+        "character": 20
+      },
+      "end": {
+        "line": 22,
+        "character": 41
+      }
     }
+  },
+  "expected": {
+    "result": {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "range": {
+                  "start": {
+                    "line": 24,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 24,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction createListener(Car myCar) returns module1:Listener {\n    return new (0);\n}\n"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "jsonrpc": "2.0"
+  }
 }

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/create_function_which_returns_record1.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/create_function_which_returns_record1.json
@@ -20,12 +20,12 @@
               {
                 "range": {
                   "start": {
-                    "line": 9,
-                    "character": 0
+                    "line": 8,
+                    "character": 1
                   },
                   "end": {
-                    "line": 9,
-                    "character": 0
+                    "line": 8,
+                    "character": 1
                   }
                 },
                 "newText": "\n\nfunction createData() returns Data {\n    return {id: \"\", value: \"\", count: 0};\n}\n"

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/create_function_which_returns_record2.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/create_function_which_returns_record2.json
@@ -20,12 +20,12 @@
               {
                 "range": {
                   "start": {
-                    "line": 16,
-                    "character": 0
+                    "line": 15,
+                    "character": 1
                   },
                   "end": {
-                    "line": 16,
-                    "character": 0
+                    "line": 15,
+                    "character": 1
                   }
                 },
                 "newText": "\n\nfunction createData() returns Data {\n    return {id: \"\", value: \"\", count: 0, summary: {total: 0, rejected: 0, reference: \"\"}};\n}\n"

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/create_function_with_strands1.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/create_function_with_strands1.json
@@ -20,12 +20,12 @@
               {
                 "range": {
                   "start": {
-                    "line": 12,
-                    "character": 0
+                    "line": 11,
+                    "character": 1
                   },
                   "end": {
-                    "line": 12,
-                    "character": 0
+                    "line": 11,
+                    "character": 1
                   }
                 },
                 "newText": "\n\nfunction testAsync() returns int {\n    return 0;\n}\n"

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/create_function_with_strands2.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/create_function_with_strands2.json
@@ -20,15 +20,15 @@
               {
                 "range": {
                   "start": {
-                    "line": 12,
-                    "character": 0
+                    "line": 11,
+                    "character": 1
                   },
                   "end": {
-                    "line": 12,
-                    "character": 0
+                    "line": 11,
+                    "character": 1
                   }
                 },
-                "newText": "\n\nfunction createVal(int a) returns (Foo & readonly)|int {\n    return {};\n}\n"
+                "newText": "\n\nfunction createVal(int i) returns (Foo & readonly)|int {\n    return {};\n}\n"
               }
             ]
           }

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/create_function_with_strands3.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/create_function_with_strands3.json
@@ -20,15 +20,15 @@
               {
                 "range": {
                   "start": {
-                    "line": 12,
-                    "character": 0
+                    "line": 11,
+                    "character": 1
                   },
                   "end": {
-                    "line": 12,
-                    "character": 0
+                    "line": 11,
+                    "character": 1
                   }
                 },
-                "newText": "\n\nfunction createAnotherVal(Foo & readonly a) returns Foo & readonly {\n    return {};\n}\n"
+                "newText": "\n\nfunction createAnotherVal(Foo & readonly r) returns Foo & readonly {\n    return {};\n}\n"
               }
             ]
           }

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/create_function_with_strands4.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/create_function_with_strands4.json
@@ -20,12 +20,12 @@
               {
                 "range": {
                   "start": {
-                    "line": 12,
-                    "character": 0
+                    "line": 11,
+                    "character": 1
                   },
                   "end": {
-                    "line": 12,
-                    "character": 0
+                    "line": 11,
+                    "character": 1
                   }
                 },
                 "newText": "\n\nfunction funcWithNoType() {\n    \n}\n"

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/projectCreateUndefinedFunction1.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/projectCreateUndefinedFunction1.json
@@ -1,40 +1,40 @@
 {
-    "arguments": {
-        "node.range": {
-            "start": {
-                "line": 8,
-                "character": 30
-            },
-            "end": {
-                "line": 8,
-                "character": 54
-            }
-        }
-    },
-    "expected": {
-        "result": {
-            "edit": {
-                "documentChanges": [
-                    {
-                        "edits": [
-                            {
-                                "range": {
-                                    "start": {
-                                        "line": 17,
-                                        "character": 0
-                                    },
-                                    "end": {
-                                        "line": 17,
-                                        "character": 0
-                                    }
-                                },
-                                "newText": "\n\nfunction createStudent(string a, any b) returns module1:Student {\n    return {name: \"\", age: 0};\n}\n"
-                            }
-                        ]
-                    }
-                ]
-            }
-        },
-        "jsonrpc": "2.0"
+  "arguments": {
+    "node.range": {
+      "start": {
+        "line": 8,
+        "character": 30
+      },
+      "end": {
+        "line": 8,
+        "character": 54
+      }
     }
+  },
+  "expected": {
+    "result": {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "range": {
+                  "start": {
+                    "line": 18,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 18,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction createStudent(string name, any b) returns module1:Student {\n    return {name: \"\", age: 0};\n}\n"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "jsonrpc": "2.0"
+  }
 }

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/projectCreateUndefinedFunction2.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/projectCreateUndefinedFunction2.json
@@ -1,40 +1,40 @@
 {
-    "arguments": {
-        "node.range": {
-            "start": {
-                "line": 9,
-                "character": 4
-            },
-            "end": {
-                "line": 9,
-                "character": 23
-            }
-        }
-    },
-    "expected": {
-        "result": {
-            "edit": {
-                "documentChanges": [
-                    {
-                        "edits": [
-                            {
-                                "range": {
-                                    "start": {
-                                        "line": 17,
-                                        "character": 0
-                                    },
-                                    "end": {
-                                        "line": 17,
-                                        "character": 0
-                                    }
-                                },
-                                "newText": "\n\nfunction addStudent(module1:Student a) {\n    \n}\n"
-                            }
-                        ]
-                    }
-                ]
-            }
-        },
-        "jsonrpc": "2.0"
+  "arguments": {
+    "node.range": {
+      "start": {
+        "line": 9,
+        "character": 4
+      },
+      "end": {
+        "line": 9,
+        "character": 23
+      }
     }
+  },
+  "expected": {
+    "result": {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "range": {
+                  "start": {
+                    "line": 18,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 18,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction addStudent(module1:Student student) {\n    \n}\n"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "jsonrpc": "2.0"
+  }
 }

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/projectCreateUndefinedFunction3.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/projectCreateUndefinedFunction3.json
@@ -1,40 +1,40 @@
 {
-    "arguments": {
-        "node.range": {
-            "start": {
-                "line": 10,
-                "character": 32
-            },
-            "end": {
-                "line": 10,
-                "character": 55
-            }
-        }
-    },
-    "expected": {
-        "result": {
-            "edit": {
-                "documentChanges": [
-                    {
-                        "edits": [
-                            {
-                                "range": {
-                                    "start": {
-                                        "line": 17,
-                                        "character": 0
-                                    },
-                                    "end": {
-                                        "line": 17,
-                                        "character": 0
-                                    }
-                                },
-                                "newText": "\n\nfunction convertStudent(module1:Student a) returns module1:Student {\n    return {name: \"\", age: 0};\n}\n"
-                            }
-                        ]
-                    }
-                ]
-            }
-        },
-        "jsonrpc": "2.0"
+  "arguments": {
+    "node.range": {
+      "start": {
+        "line": 10,
+        "character": 32
+      },
+      "end": {
+        "line": 10,
+        "character": 55
+      }
     }
+  },
+  "expected": {
+    "result": {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "range": {
+                  "start": {
+                    "line": 18,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 18,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction convertStudent(module1:Student student) returns module1:Student {\n    return {name: \"\", age: 0};\n}\n"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "jsonrpc": "2.0"
+  }
 }

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/projectCreateUndefinedFunction4.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/projectCreateUndefinedFunction4.json
@@ -1,40 +1,40 @@
 {
-    "arguments": {
-        "node.range": {
-            "start": {
-                "line": 14,
-                "character": 13
-            },
-            "end": {
-                "line": 14,
-                "character": 28
-            }
-        }
-    },
-    "expected": {
-        "result": {
-            "edit": {
-                "documentChanges": [
-                    {
-                        "edits": [
-                            {
-                                "range": {
-                                    "start": {
-                                        "line": 17,
-                                        "character": 0
-                                    },
-                                    "end": {
-                                        "line": 17,
-                                        "character": 0
-                                    }
-                                },
-                                "newText": "\n\nfunction getAge(module1:Student a) returns int {\n    return 0;\n}\n"
-                            }
-                        ]
-                    }
-                ]
-            }
-        },
-        "jsonrpc": "2.0"
+  "arguments": {
+    "node.range": {
+      "start": {
+        "line": 14,
+        "character": 13
+      },
+      "end": {
+        "line": 14,
+        "character": 28
+      }
     }
+  },
+  "expected": {
+    "result": {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "range": {
+                  "start": {
+                    "line": 18,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 18,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction getAge(module1:Student student) returns int {\n    return 0;\n}\n"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "jsonrpc": "2.0"
+  }
 }

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/projectCreateUndefinedFunction5.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/projectCreateUndefinedFunction5.json
@@ -1,40 +1,40 @@
 {
-    "arguments": {
-        "node.range": {
-            "start": {
-                "line": 4,
-                "character": 16
-            },
-            "end": {
-                "line": 4,
-                "character": 27
-            }
-        }
-    },
-    "expected": {
-        "result": {
-            "edit": {
-                "documentChanges": [
-                    {
-                        "edits": [
-                            {
-                                "range": {
-                                    "start": {
-                                        "line": 11,
-                                        "character": 0
-                                    },
-                                    "end": {
-                                        "line": 11,
-                                        "character": 0
-                                    }
-                                },
-                                "newText": "\n\nfunction getSchool() returns School {\n    return {students: []};\n}\n"
-                            }
-                        ]
-                    }
-                ]
-            }
-        },
-        "jsonrpc": "2.0"
+  "arguments": {
+    "node.range": {
+      "start": {
+        "line": 4,
+        "character": 16
+      },
+      "end": {
+        "line": 4,
+        "character": 27
+      }
     }
+  },
+  "expected": {
+    "result": {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "range": {
+                  "start": {
+                    "line": 4,
+                    "character": 28
+                  },
+                  "end": {
+                    "line": 4,
+                    "character": 28
+                  }
+                },
+                "newText": "\n\nfunction getSchool() returns School {\n    return {students: []};\n}\n"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "jsonrpc": "2.0"
+  }
 }

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/projectCreateUndefinedFunction6.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/projectCreateUndefinedFunction6.json
@@ -2,12 +2,12 @@
   "arguments": {
     "node.range": {
       "start": {
-        "line": 5,
-        "character": 34
+        "line": 17,
+        "character": 4
       },
       "end": {
-        "line": 5,
-        "character": 51
+        "line": 17,
+        "character": 39
       }
     }
   },
@@ -20,15 +20,15 @@
               {
                 "range": {
                   "start": {
-                    "line": 6,
+                    "line": 18,
                     "character": 1
                   },
                   "end": {
-                    "line": 6,
+                    "line": 18,
                     "character": 1
                   }
                 },
-                "newText": "\n\nfunction getResponse(int a, int b) returns module1:TestRecord2 {\n    return {};\n}\n"
+                "newText": "\n\nfunction generateIndex(int intake, string name) {\n    \n}\n"
               }
             ]
           }

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/projectCreateUndefinedFunctionInLet.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/projectCreateUndefinedFunctionInLet.json
@@ -1,40 +1,40 @@
 {
-    "arguments": {
-        "node.range": {
-            "start": {
-                "line": 7,
-                "character": 59
-            },
-            "end": {
-                "line": 7,
-                "character": 80
-            }
-        }
-    },
-    "expected": {
-        "result": {
-            "edit": {
-                "documentChanges": [
-                    {
-                        "edits": [
-                            {
-                                "range": {
-                                    "start": {
-                                        "line": 11,
-                                        "character": 0
-                                    },
-                                    "end": {
-                                        "line": 11,
-                                        "character": 0
-                                    }
-                                },
-                                "newText": "\n\nfunction createSchool([Grade] a) returns School {\n    return {students: []};\n}\n"
-                            }
-                        ]
-                    }
-                ]
-            }
-        },
-        "jsonrpc": "2.0"
+  "arguments": {
+    "node.range": {
+      "start": {
+        "line": 7,
+        "character": 59
+      },
+      "end": {
+        "line": 7,
+        "character": 80
+      }
     }
+  },
+  "expected": {
+    "result": {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "range": {
+                  "start": {
+                    "line": 10,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 10,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction createSchool([Grade] t) returns School {\n    return {students: []};\n}\n"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "jsonrpc": "2.0"
+  }
 }

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/projectCreateUndefinedFunctionInLet2.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/projectCreateUndefinedFunctionInLet2.json
@@ -1,40 +1,40 @@
 {
-    "arguments": {
-        "node.range": {
-            "start": {
-                "line": 8,
-                "character": 38
-            },
-            "end": {
-                "line": 8,
-                "character": 46
-            }
-        }
-    },
-    "expected": {
-        "result": {
-            "edit": {
-                "documentChanges": [
-                    {
-                        "edits": [
-                            {
-                                "range": {
-                                    "start": {
-                                        "line": 11,
-                                        "character": 0
-                                    },
-                                    "end": {
-                                        "line": 11,
-                                        "character": 0
-                                    }
-                                },
-                                "newText": "\n\nfunction getStr() returns string {\n    return \"\";\n}\n"
-                            }
-                        ]
-                    }
-                ]
-            }
-        },
-        "jsonrpc": "2.0"
+  "arguments": {
+    "node.range": {
+      "start": {
+        "line": 8,
+        "character": 38
+      },
+      "end": {
+        "line": 8,
+        "character": 46
+      }
     }
+  },
+  "expected": {
+    "result": {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "range": {
+                  "start": {
+                    "line": 10,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 10,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction getStr() returns string {\n    return \"\";\n}\n"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "jsonrpc": "2.0"
+  }
 }

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/projectCreateUndefinedFunctionInLet3.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/projectCreateUndefinedFunctionInLet3.json
@@ -1,40 +1,40 @@
 {
-    "arguments": {
-        "node.range": {
-            "start": {
-                "line": 9,
-                "character": 22
-            },
-            "end": {
-                "line": 9,
-                "character": 35
-            }
-        }
-    },
-    "expected": {
-        "result": {
-            "edit": {
-                "documentChanges": [
-                    {
-                        "edits": [
-                            {
-                                "range": {
-                                    "start": {
-                                        "line": 11,
-                                        "character": 0
-                                    },
-                                    "end": {
-                                        "line": 11,
-                                        "character": 0
-                                    }
-                                },
-                                "newText": "\n\nfunction getSchool(int a) {\n    \n}\n"
-                            }
-                        ]
-                    }
-                ]
-            }
-        },
-        "jsonrpc": "2.0"
+  "arguments": {
+    "node.range": {
+      "start": {
+        "line": 9,
+        "character": 22
+      },
+      "end": {
+        "line": 9,
+        "character": 35
+      }
     }
+  },
+  "expected": {
+    "result": {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "range": {
+                  "start": {
+                    "line": 10,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 10,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction getSchool(int id) {\n    \n}\n"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "jsonrpc": "2.0"
+  }
 }

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/projectCreateUndefinedFunctionWithLangLib.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/projectCreateUndefinedFunctionWithLangLib.json
@@ -1,40 +1,40 @@
 {
-    "arguments": {
-        "node.range": {
-            "start": {
-                "line": 8,
-                "character": 25
-            },
-            "end": {
-                "line": 8,
-                "character": 45
-            }
-        }
-    },
-    "expected": {
-        "result": {
-            "edit": {
-                "documentChanges": [
-                    {
-                        "edits": [
-                            {
-                                "range": {
-                                    "start": {
-                                        "line": 10,
-                                        "character": 0
-                                    },
-                                    "end": {
-                                        "line": 10,
-                                        "character": 0
-                                    }
-                                },
-                                "newText": "\n\nfunction createListener(int a) returns module1:Listener {\n    return new (0);\n}\n"
-                            }
-                        ]
-                    }
-                ]
-            }
-        },
-        "jsonrpc": "2.0"
+  "arguments": {
+    "node.range": {
+      "start": {
+        "line": 8,
+        "character": 25
+      },
+      "end": {
+        "line": 8,
+        "character": 45
+      }
     }
+  },
+  "expected": {
+    "result": {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "range": {
+                  "start": {
+                    "line": 9,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 9,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction createListener(int port) returns module1:Listener {\n    return new (0);\n}\n"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "jsonrpc": "2.0"
+  }
 }

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/projectCreateUndefinedFunctionWithModAlias.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/projectCreateUndefinedFunctionWithModAlias.json
@@ -1,40 +1,40 @@
 {
-    "arguments": {
-        "node.range": {
-            "start": {
-                "line": 3,
-                "character": 27
-            },
-            "end": {
-                "line": 3,
-                "character": 53
-            }
-        }
-    },
-    "expected": {
-        "result": {
-            "edit": {
-                "documentChanges": [
-                    {
-                        "edits": [
-                            {
-                                "range": {
-                                    "start": {
-                                        "line": 6,
-                                        "character": 0
-                                    },
-                                    "end": {
-                                        "line": 6,
-                                        "character": 0
-                                    }
-                                },
-                                "newText": "\n\nfunction createTeacher(string a) returns mod2:Teacher {\n    return {name: \"\"};\n}\n"
-                            }
-                        ]
-                    }
-                ]
-            }
-        },
-        "jsonrpc": "2.0"
+  "arguments": {
+    "node.range": {
+      "start": {
+        "line": 3,
+        "character": 27
+      },
+      "end": {
+        "line": 3,
+        "character": 53
+      }
     }
+  },
+  "expected": {
+    "result": {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "range": {
+                  "start": {
+                    "line": 5,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 5,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction createTeacher(string s) returns mod2:Teacher {\n    return {name: \"\"};\n}\n"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "jsonrpc": "2.0"
+  }
 }

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/projectCreateUndefinedFunctionWithModAlias2.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/projectCreateUndefinedFunctionWithModAlias2.json
@@ -1,40 +1,40 @@
 {
-    "arguments": {
-        "node.range": {
-            "start": {
-                "line": 4,
-                "character": 16
-            },
-            "end": {
-                "line": 4,
-                "character": 45
-            }
-        }
-    },
-    "expected": {
-        "result": {
-            "edit": {
-                "documentChanges": [
-                    {
-                        "edits": [
-                            {
-                                "range": {
-                                    "start": {
-                                        "line": 6,
-                                        "character": 0
-                                    },
-                                    "end": {
-                                        "line": 6,
-                                        "character": 0
-                                    }
-                                },
-                                "newText": "\n\nfunction addTeacher(mod2:Teacher a, string b) returns int {\n    return 0;\n}\n"
-                            }
-                        ]
-                    }
-                ]
-            }
-        },
-        "jsonrpc": "2.0"
+  "arguments": {
+    "node.range": {
+      "start": {
+        "line": 4,
+        "character": 16
+      },
+      "end": {
+        "line": 4,
+        "character": 45
+      }
     }
+  },
+  "expected": {
+    "result": {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "range": {
+                  "start": {
+                    "line": 5,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 5,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction addTeacher(mod2:Teacher teacher, string s) returns int {\n    return 0;\n}\n"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "jsonrpc": "2.0"
+  }
 }

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/source/testproject/main.bal
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/source/testproject/main.bal
@@ -14,4 +14,6 @@ public function main() {
         name: name,
         age: getAge(student)
     };
+
+    generateIndex(module1:intake, name);
 }

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/source/testproject/modules/module1/module1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/source/testproject/modules/module1/module1.bal
@@ -2,3 +2,5 @@ public type Student record {
     string name;
     int age;
 };
+
+public int intake = 16;

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/anon_func_expr_ctx_config10.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/anon_func_expr_ctx_config10.json
@@ -687,7 +687,7 @@
       "kind": "Module",
       "detail": "Module",
       "sortText": "R",
-      "insertText": "value5",
+      "insertText": "value",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -701,7 +701,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.value as value5 ;\n"
+          "newText": "import ballerina/lang.value;\n"
         }
       ]
     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/check_expression_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/check_expression_ctx_config1.json
@@ -119,29 +119,6 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "insertText": "value3",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.value as value3 ;\n"
-        }
-      ]
-    },
-    {
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
@@ -575,6 +552,29 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/check_expression_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/check_expression_ctx_config2.json
@@ -119,29 +119,6 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "insertText": "value3",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.value as value3 ;\n"
-        }
-      ]
-    },
-    {
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
@@ -575,6 +552,29 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/list_constructor_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/list_constructor_ctx_config1.json
@@ -75,29 +75,6 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "ARR",
-      "insertText": "value3",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.value as value3 ;\n"
-        }
-      ]
-    },
-    {
       "label": "ballerina/module1",
       "kind": "Module",
       "detail": "Module",
@@ -569,6 +546,29 @@
       "sortText": "ARR",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "ARR",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/list_constructor_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/list_constructor_ctx_config2.json
@@ -75,29 +75,6 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "ARR",
-      "insertText": "value3",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.value as value3 ;\n"
-        }
-      ]
-    },
-    {
       "label": "ballerina/module1",
       "kind": "Module",
       "detail": "Module",
@@ -569,6 +546,29 @@
       "sortText": "ARR",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "ARR",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/list_constructor_ctx_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/list_constructor_ctx_config3.json
@@ -75,29 +75,6 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "ARR",
-      "insertText": "value3",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.value as value3 ;\n"
-        }
-      ]
-    },
-    {
       "label": "ballerina/module1",
       "kind": "Module",
       "detail": "Module",
@@ -569,6 +546,29 @@
       "sortText": "ARR",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "ARR",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config1.json
@@ -83,29 +83,6 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "insertText": "value3",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.value as value3 ;\n"
-        }
-      ]
-    },
-    {
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
@@ -569,6 +546,29 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config2.json
@@ -83,29 +83,6 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "insertText": "value3",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.value as value3 ;\n"
-        }
-      ]
-    },
-    {
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
@@ -569,6 +546,29 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config5.json
@@ -167,29 +167,6 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "insertText": "value3",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.value as value3 ;\n"
-        }
-      ]
-    },
-    {
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
@@ -323,6 +300,29 @@
       "sortText": "R",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config6.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config6.json
@@ -167,29 +167,6 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "insertText": "value3",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.value as value3 ;\n"
-        }
-      ]
-    },
-    {
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
@@ -323,6 +300,29 @@
       "sortText": "R",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config7.json
@@ -167,29 +167,6 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "insertText": "value3",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.value as value3 ;\n"
-        }
-      ]
-    },
-    {
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
@@ -323,6 +300,29 @@
       "sortText": "R",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/trap_expression_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/trap_expression_ctx_config1.json
@@ -119,29 +119,6 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "insertText": "value3",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.value as value3 ;\n"
-        }
-      ]
-    },
-    {
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
@@ -575,6 +552,29 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/trap_expression_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/trap_expression_ctx_config2.json
@@ -119,29 +119,6 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "insertText": "value3",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.value as value3 ;\n"
-        }
-      ]
-    },
-    {
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
@@ -575,6 +552,29 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/typecast_expr_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/typecast_expr_ctx_config1.json
@@ -277,29 +277,6 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "insertText": "value3",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.value as value3 ;\n"
-        }
-      ]
-    },
-    {
       "label": "boolean",
       "kind": "Unit",
       "detail": "type",
@@ -410,6 +387,29 @@
       "sortText": "R",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/typecast_expr_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/typecast_expr_ctx_config2.json
@@ -277,29 +277,6 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "insertText": "value3",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.value as value3 ;\n"
-        }
-      ]
-    },
-    {
       "label": "boolean",
       "kind": "Unit",
       "detail": "type",
@@ -410,6 +387,29 @@
       "sortText": "R",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/typecast_expr_ctx_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/typecast_expr_ctx_config4.json
@@ -277,29 +277,6 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "insertText": "value3",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.value as value3 ;\n"
-        }
-      ]
-    },
-    {
       "label": "boolean",
       "kind": "Unit",
       "detail": "type",
@@ -410,6 +387,29 @@
       "sortText": "R",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/typecast_expr_ctx_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/typecast_expr_ctx_config5.json
@@ -277,29 +277,6 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "insertText": "value3",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.value as value3 ;\n"
-        }
-      ]
-    },
-    {
       "label": "boolean",
       "kind": "Unit",
       "detail": "type",
@@ -410,6 +387,29 @@
       "sortText": "R",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/typecast_expr_ctx_config6.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/typecast_expr_ctx_config6.json
@@ -119,29 +119,6 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "insertText": "value3",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.value as value3 ;\n"
-        }
-      ]
-    },
-    {
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
@@ -568,6 +545,29 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/function_body/config/config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function_body/config/config5.json
@@ -481,29 +481,6 @@
       ]
     },
     {
-      "label": "ballerina/module1",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "insertText": "module11",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/module1 as module11 ;\n"
-        }
-      ]
-    },
-    {
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
@@ -681,6 +658,29 @@
       "filterText": "worker",
       "insertText": "worker ${1:name} {\n\t${2}\n}",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/module1",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "insertText": "module11",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/module1 as module11 ;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/function_body/config/config6.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function_body/config/config6.json
@@ -481,29 +481,6 @@
       ]
     },
     {
-      "label": "ballerina/module1",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "insertText": "module12",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 1,
-              "character": 0
-            },
-            "end": {
-              "line": 1,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/module1 as module12 ;\n"
-        }
-      ]
-    },
-    {
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
@@ -681,6 +658,29 @@
       "filterText": "worker",
       "insertText": "worker ${1:name} {\n\t${2}\n}",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/module1",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "insertText": "module1",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 0
+            },
+            "end": {
+              "line": 1,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/module1;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/import_decl/config/config11.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/import_decl/config/config11.json
@@ -504,29 +504,6 @@
       ]
     },
     {
-      "label": "ballerina/module1",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "insertText": "module11",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/module1 as module11 ;\n"
-        }
-      ]
-    },
-    {
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
@@ -662,29 +639,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "lsproject.hierarchy.module4",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "insertText": "module4",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import lsproject.hierarchy.module4;\n"
-        }
-      ]
-    },
-    {
       "label": "lsproject.module2",
       "kind": "Module",
       "detail": "Module",
@@ -760,6 +714,52 @@
       "filterText": "worker",
       "insertText": "worker ${1:name} {\n\t${2}\n}",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/module1",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "insertText": "module11",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/module1 as module11 ;\n"
+        }
+      ]
+    },
+    {
+      "label": "lsproject.hierarchy.module4",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "insertText": "module4",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import lsproject.hierarchy.module4;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/import_decl/config/config11.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/import_decl/config/config11.json
@@ -504,6 +504,29 @@
       ]
     },
     {
+      "label": "ballerina/module1",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "insertText": "module11",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/module1 as module11 ;\n"
+        }
+      ]
+    },
+    {
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
@@ -639,6 +662,29 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "lsproject.hierarchy.module4",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "insertText": "module4",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import lsproject.hierarchy.module4;\n"
+        }
+      ]
+    },
+    {
       "label": "lsproject.module2",
       "kind": "Module",
       "detail": "Module",
@@ -714,52 +760,6 @@
       "filterText": "worker",
       "insertText": "worker ${1:name} {\n\t${2}\n}",
       "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ballerina/module1",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "insertText": "module11",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/module1 as module11 ;\n"
-        }
-      ]
-    },
-    {
-      "label": "lsproject.hierarchy.module4",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "insertText": "module4",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import lsproject.hierarchy.module4;\n"
-        }
-      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/import_decl/config/config12.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/import_decl/config/config12.json
@@ -504,29 +504,6 @@
       ]
     },
     {
-      "label": "ballerina/module1",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "insertText": "module11",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/module1 as module11 ;\n"
-        }
-      ]
-    },
-    {
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
@@ -662,29 +639,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "lsproject.hierarchy.module4",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "insertText": "module4",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import lsproject.hierarchy.module4;\n"
-        }
-      ]
-    },
-    {
       "label": "lsproject.module2",
       "kind": "Module",
       "detail": "Module",
@@ -760,6 +714,52 @@
       "filterText": "worker",
       "insertText": "worker ${1:name} {\n\t${2}\n}",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/module1",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "insertText": "module11",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/module1 as module11 ;\n"
+        }
+      ]
+    },
+    {
+      "label": "lsproject.hierarchy.module4",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "insertText": "module4",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import lsproject.hierarchy.module4;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/import_decl/config/config12.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/import_decl/config/config12.json
@@ -504,6 +504,29 @@
       ]
     },
     {
+      "label": "ballerina/module1",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "insertText": "module11",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/module1 as module11 ;\n"
+        }
+      ]
+    },
+    {
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
@@ -639,6 +662,29 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "lsproject.hierarchy.module4",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "insertText": "module4",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import lsproject.hierarchy.module4;\n"
+        }
+      ]
+    },
+    {
       "label": "lsproject.module2",
       "kind": "Module",
       "detail": "Module",
@@ -714,52 +760,6 @@
       "filterText": "worker",
       "insertText": "worker ${1:name} {\n\t${2}\n}",
       "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ballerina/module1",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "insertText": "module11",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/module1 as module11 ;\n"
-        }
-      ]
-    },
-    {
-      "label": "lsproject.hierarchy.module4",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "insertText": "module4",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import lsproject.hierarchy.module4;\n"
-        }
-      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/import_decl/config/config21.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/import_decl/config/config21.json
@@ -639,29 +639,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "lsproject.hierarchy.module4",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "insertText": "module4",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 2,
-              "character": 0
-            },
-            "end": {
-              "line": 2,
-              "character": 0
-            }
-          },
-          "newText": "import lsproject.hierarchy.module4;\n"
-        }
-      ]
-    },
-    {
       "label": "lsproject.module2",
       "kind": "Module",
       "detail": "Module",
@@ -681,29 +658,6 @@
             }
           },
           "newText": "import lsproject.module2;\n"
-        }
-      ]
-    },
-    {
-      "label": "lsproject.module1",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "insertText": "module11",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 2,
-              "character": 0
-            },
-            "end": {
-              "line": 2,
-              "character": 0
-            }
-          },
-          "newText": "import lsproject.module1 as module11 ;\n"
         }
       ]
     },
@@ -760,6 +714,52 @@
       "filterText": "worker",
       "insertText": "worker ${1:name} {\n\t${2}\n}",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "lsproject.module1",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "insertText": "module11",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 2,
+              "character": 0
+            },
+            "end": {
+              "line": 2,
+              "character": 0
+            }
+          },
+          "newText": "import lsproject.module1 as module11 ;\n"
+        }
+      ]
+    },
+    {
+      "label": "lsproject.hierarchy.module4",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "insertText": "module4",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 2,
+              "character": 0
+            },
+            "end": {
+              "line": 2,
+              "character": 0
+            }
+          },
+          "newText": "import lsproject.hierarchy.module4;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/import_decl/config/config21.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/import_decl/config/config21.json
@@ -639,6 +639,29 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "lsproject.hierarchy.module4",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "insertText": "module4",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 2,
+              "character": 0
+            },
+            "end": {
+              "line": 2,
+              "character": 0
+            }
+          },
+          "newText": "import lsproject.hierarchy.module4;\n"
+        }
+      ]
+    },
+    {
       "label": "lsproject.module2",
       "kind": "Module",
       "detail": "Module",
@@ -658,6 +681,29 @@
             }
           },
           "newText": "import lsproject.module2;\n"
+        }
+      ]
+    },
+    {
+      "label": "lsproject.module1",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "insertText": "module11",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 2,
+              "character": 0
+            },
+            "end": {
+              "line": 2,
+              "character": 0
+            }
+          },
+          "newText": "import lsproject.module1 as module11 ;\n"
         }
       ]
     },
@@ -714,52 +760,6 @@
       "filterText": "worker",
       "insertText": "worker ${1:name} {\n\t${2}\n}",
       "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "lsproject.module1",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "insertText": "module11",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 2,
-              "character": 0
-            },
-            "end": {
-              "line": 2,
-              "character": 0
-            }
-          },
-          "newText": "import lsproject.module1 as module11 ;\n"
-        }
-      ]
-    },
-    {
-      "label": "lsproject.hierarchy.module4",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "insertText": "module4",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 2,
-              "character": 0
-            },
-            "end": {
-              "line": 2,
-              "character": 0
-            }
-          },
-          "newText": "import lsproject.hierarchy.module4;\n"
-        }
-      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config14.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config14.json
@@ -83,29 +83,6 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "insertText": "value3",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.value as value3 ;\n"
-        }
-      ]
-    },
-    {
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
@@ -551,6 +528,29 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config7.json
@@ -261,29 +261,6 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "insertText": "value3",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.value as value3 ;\n"
-        }
-      ]
-    },
-    {
       "label": "boolean",
       "kind": "Unit",
       "detail": "type",
@@ -403,6 +380,29 @@
       "filterText": "var",
       "insertText": "var ",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config8.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config8.json
@@ -261,29 +261,6 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "insertText": "value3",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.value as value3 ;\n"
-        }
-      ]
-    },
-    {
       "label": "boolean",
       "kind": "Unit",
       "detail": "type",
@@ -403,6 +380,29 @@
       "filterText": "var",
       "insertText": "var ",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/do_stmt_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/do_stmt_ctx_config1.json
@@ -481,29 +481,6 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "insertText": "value3",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.value as value3 ;\n"
-        }
-      ]
-    },
-    {
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
@@ -683,6 +660,29 @@
       "sortText": "B",
       "insertText": "value2",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Purpose
1. Render the text edit immediately after the enclosing top-level node of the call expression. 
2. Add the following logic to generate a parameter name 

`functionCall(functionArgumentNode)`

1. If `functionArgumentNode`'s symbol has a valid name (not empty), it to camel case and use as the parameter name
2. If the `functionArgumentNode`'s symbol does not have a valid name, use the first letter of the type symbol of the `functionArgumentNode` as the parameter name.
3. If the `funcionArgumentNode` does not have both the symbol and the type symbol generate a single letter name based on the argument position. (argPosition1-> a, argPosition2->b)

Name generate by each of the above steps are validated to ensure that the name has not been already used with in the scope. If a particular name is already used. A suffix is added to the end of the generated name. (refer the samples below)

Fixes #31981 

## Samples
![ezgif com-gif-maker(4)](https://user-images.githubusercontent.com/35211477/128677505-8a3634af-bc3a-4986-895d-d901bf638993.gif)




## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
