### PR TITLE
Add connector form-fields cache version field to BallerinaConnectorInfo

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/connector/BallerinaConnectorInfo.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/connector/BallerinaConnectorInfo.java
@@ -34,8 +34,8 @@ public class BallerinaConnectorInfo {
     private Boolean beta;
     private String category;
 
-    public BallerinaConnectorInfo(String org, String module, String name,
-                                  String version, String cacheVersion, String displayName, Boolean beta, String category) {
+    public BallerinaConnectorInfo(String org, String module, String name, String version,
+                                    String cacheVersion, String displayName, Boolean beta, String category) {
         this.org = org;
         this.module = module;
         this.name = name;
@@ -46,8 +46,8 @@ public class BallerinaConnectorInfo {
         this.category = category;
     }
 
-    public BallerinaConnectorInfo(String org, String module, String name, String version, String cacheVersion, String displayName,
-                                  String logoBase64Encoded, Boolean beta, String category) {
+    public BallerinaConnectorInfo(String org, String module, String name, String version, String cacheVersion,
+                                    String displayName, String logoBase64Encoded, Boolean beta, String category) {
         this.org = org;
         this.module = module;
         this.name = name;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/connector/BallerinaConnectorInfo.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/connector/BallerinaConnectorInfo.java
@@ -28,28 +28,31 @@ public class BallerinaConnectorInfo {
     private String module;
     private String name;
     private String version;
+    private String cacheVersion;
     private String displayName;
     private String logoBase64Encoded;
     private Boolean beta;
     private String category;
 
     public BallerinaConnectorInfo(String org, String module, String name,
-                                  String version, String displayName, Boolean beta, String category) {
+                                  String version, String cacheVersion, String displayName, Boolean beta, String category) {
         this.org = org;
         this.module = module;
         this.name = name;
         this.version = version;
+        this.cacheVersion = cacheVersion;
         this.displayName = displayName;
         this.beta = beta;
         this.category = category;
     }
 
-    public BallerinaConnectorInfo(String org, String module, String name, String version, String displayName,
+    public BallerinaConnectorInfo(String org, String module, String name, String version, String cacheVersion, String displayName,
                                   String logoBase64Encoded, Boolean beta, String category) {
         this.org = org;
         this.module = module;
         this.name = name;
         this.version = version;
+        this.cacheVersion = cacheVersion;
         this.displayName = displayName;
         this.logoBase64Encoded = logoBase64Encoded;
         this.beta = beta;
@@ -70,6 +73,10 @@ public class BallerinaConnectorInfo {
 
     public String getVersion() {
         return version;
+    }
+
+    public String getCacheVersion() {
+        return cacheVersion;
     }
 
     public String getDisplayName() {

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/ballerina/connector/BallerinaConnectorInfoTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/ballerina/connector/BallerinaConnectorInfoTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.langserver.extensions.ballerina.connector;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class BallerinaConnectorInfoTest {
+
+    private BallerinaConnectorInfo connectorInfo;
+
+    @BeforeClass
+    public void initConnectorInfo() {
+        this.connectorInfo = new BallerinaConnectorInfo(
+                "ballerinax",
+                "slack",
+                "Client",
+                "0.1.1",
+                "1",
+                "Slack",
+                true,
+                "service-connectors"
+        );
+    }
+
+    @Test(description = "Test version from connector info object")
+    public void getVersionTest() {
+        String version = "1";
+        Assert.assertEquals(version, connectorInfo.getCacheVersion());
+    }
+
+    @Test(description = "Test overloaded constructor with logo")
+    public void createConnectorInfoWithLogo() {
+        String encodedLogo = "bm90aGluZwo=";
+        this.connectorInfo = new BallerinaConnectorInfo(
+                "ballerinax",
+                "slack",
+                "Client",
+                "0.1.1",
+                "1",
+                "Slack",
+                encodedLogo,
+                true,
+                "service-connectors"
+        );
+        Assert.assertEquals(encodedLogo, connectorInfo.getLogoBase64Encoded());
+    }
+}

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/ballerina/connector/BallerinaConnectorInfoTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/ballerina/connector/BallerinaConnectorInfoTest.java
@@ -22,13 +22,16 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+/**
+ * Test for connector info.
+ */
 public class BallerinaConnectorInfoTest {
 
     private BallerinaConnectorInfo connectorInfo;
 
     @BeforeClass
     public void initConnectorInfo() {
-        this.connectorInfo = new BallerinaConnectorInfo(
+        connectorInfo = new BallerinaConnectorInfo(
                 "ballerinax",
                 "slack",
                 "Client",
@@ -49,7 +52,7 @@ public class BallerinaConnectorInfoTest {
     @Test(description = "Test overloaded constructor with logo")
     public void createConnectorInfoWithLogo() {
         String encodedLogo = "bm90aGluZwo=";
-        this.connectorInfo = new BallerinaConnectorInfo(
+        connectorInfo = new BallerinaConnectorInfo(
                 "ballerinax",
                 "slack",
                 "Client",


### PR DESCRIPTION
## Purpose
Add connector `cache version` field to BallerinaConnectorInfo

Fixes https://github.com/wso2-enterprise/choreo/issues/7425

## Approach
Update **BallerinaConnectorInfo** class with `cacheVersion` property


## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
