### PR TITLE
Improve runtime function parameter API 

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/types/FunctionType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/types/FunctionType.java
@@ -24,6 +24,9 @@ package io.ballerina.runtime.api.types;
  */
 public interface FunctionType extends AnnotatableType {
 
+    /*
+     * @deprecated use {@link #getParameters()} instead.
+     */
     @Deprecated
     Type[] getParameterTypes();
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/types/FunctionType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/types/FunctionType.java
@@ -24,7 +24,7 @@ package io.ballerina.runtime.api.types;
  */
 public interface FunctionType extends AnnotatableType {
 
-
+    @Deprecated
     Type[] getParameterTypes();
 
     Type getReturnType();
@@ -34,4 +34,6 @@ public interface FunctionType extends AnnotatableType {
     Type getReturnParameterType();
 
     Type getRestType();
+
+    Parameter[] getParameters();
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/types/Parameter.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/types/Parameter.java
@@ -26,9 +26,11 @@ package io.ballerina.runtime.api.types;
 public class Parameter {
     public final String name;
     public final boolean isDefault;
+    public Type type;
 
-    public Parameter(String name, Boolean isDefault) {
+    public Parameter(String name, Boolean isDefault, Type type) {
         this.name = name;
         this.isDefault = isDefault;
+        this.type = type;
     }
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/types/Parameter.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/types/Parameter.java
@@ -16,7 +16,7 @@
  *  under the License.
  */
 
-package io.ballerina.runtime.api;
+package io.ballerina.runtime.api.types;
 
 /**
  * {@code {@link Parameter } represents the parameter of a function in ballerina.

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/types/RemoteMethodType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/types/RemoteMethodType.java
@@ -17,8 +17,6 @@
  */
 package io.ballerina.runtime.api.types;
 
-import io.ballerina.runtime.api.Parameter;
-
 /**
  * {@code {@link RemoteMethodType }} represents remote function type in ballerina.
  *
@@ -30,5 +28,4 @@ public interface RemoteMethodType extends MethodType {
 
     FunctionType getType();
 
-    Parameter[] getParameters();
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/types/ResourceMethodType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/types/ResourceMethodType.java
@@ -17,8 +17,6 @@
  */
 package io.ballerina.runtime.api.types;
 
-import io.ballerina.runtime.api.Parameter;
-
 /**
  * {@code ResourceFunctionType} represents a resource function in Ballerina.
  *
@@ -31,5 +29,4 @@ public interface ResourceMethodType extends MethodType {
     String[] getResourcePath();
     @Deprecated
     Boolean[] getParamDefaultability();
-    Parameter[] getParameters();
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/types/ResourceMethodType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/types/ResourceMethodType.java
@@ -23,10 +23,16 @@ package io.ballerina.runtime.api.types;
  * @since 2.0
  */
 public interface ResourceMethodType extends MethodType {
+    /*
+     * @deprecated use {@link #getParameters()} instead.
+     */
     @Deprecated
     String[] getParamNames();
     String getAccessor();
     String[] getResourcePath();
+    /*
+     * @deprecated use {@link #getParameters()} instead.
+     */
     @Deprecated
     Boolean[] getParamDefaultability();
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/utils/StringUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/utils/StringUtils.java
@@ -203,7 +203,7 @@ public class StringUtils {
             BObject objectValue = (BObject) value;
             ObjectType objectType = objectValue.getType();
             for (MethodType func : objectType.getMethods()) {
-                if (func.getName().equals(TO_STRING) && func.getParameterTypes().length == 0 &&
+                if (func.getName().equals(TO_STRING) && func.getParameters().length == 0 &&
                         func.getType().getReturnType().getTag() == TypeTags.STRING_TAG) {
                     return objectValue.call(Scheduler.getStrand(), TO_STRING).toString();
                 }
@@ -274,7 +274,7 @@ public class StringUtils {
             AbstractObjectValue objectValue = (AbstractObjectValue) value;
             ObjectType objectType = objectValue.getType();
             for (MethodType func : objectType.getMethods()) {
-                if (func.getName().equals(TO_STRING) && func.getParameterTypes().length == 0 &&
+                if (func.getName().equals(TO_STRING) && func.getParameters().length == 0 &&
                         func.getType().getReturnType().getTag() == TypeTags.STRING_TAG) {
                     return "object " + objectValue.call(Scheduler.getStrand(), TO_STRING).toString();
                 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -1757,12 +1757,12 @@ public class TypeChecker {
             return false;
         }
 
-        if (source.getParameterTypes().length != target.getParameterTypes().length) {
+        if (source.getParameters().length != target.getParameters().length) {
             return false;
         }
 
-        for (int i = 0; i < source.getParameterTypes().length; i++) {
-            if (!checkIsType(target.getParameterTypes()[i], source.getParameterTypes()[i], unresolvedTypes)) {
+        for (int i = 0; i < source.getParameters().length; i++) {
+            if (!checkIsType(target.getParameters()[i].type, source.getParameters()[i].type, unresolvedTypes)) {
                 return false;
             }
         }
@@ -1790,12 +1790,12 @@ public class TypeChecker {
             return true;
         }
 
-        if (source.paramTypes.length != targetType.paramTypes.length) {
+        if (source.parameters.length != targetType.parameters.length) {
             return false;
         }
 
-        for (int i = 0; i < source.paramTypes.length; i++) {
-            if (!checkIsType(targetType.paramTypes[i], source.paramTypes[i], new ArrayList<>())) {
+        for (int i = 0; i < source.parameters.length; i++) {
+            if (!checkIsType(targetType.parameters[i].type, source.parameters[i].type, new ArrayList<>())) {
                 return false;
             }
         }
@@ -3170,7 +3170,7 @@ public class TypeChecker {
             }
             FunctionType initFuncType = generatedInitializer.getType();
             // Todo: check defaultable params of the init func as well
-            boolean noParams = initFuncType.getParameterTypes().length == 0;
+            boolean noParams = initFuncType.getParameters().length == 0;
             boolean nilReturn = initFuncType.getReturnType().getTag() == TypeTags.NULL_TAG;
             return noParams && nilReturn;
         }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BFunctionType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BFunctionType.java
@@ -21,6 +21,7 @@ import io.ballerina.runtime.api.PredefinedTypes;
 import io.ballerina.runtime.api.TypeTags;
 import io.ballerina.runtime.api.flags.SymbolFlags;
 import io.ballerina.runtime.api.types.FunctionType;
+import io.ballerina.runtime.api.types.Parameter;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.utils.IdentifierUtils;
 
@@ -37,6 +38,7 @@ public class BFunctionType extends BAnnotatableType implements FunctionType {
     public Type restType;
     public Type retType;
     public long flags;
+    public Parameter[] parameters;
 
     public BFunctionType() {
         super("function ()", null, Object.class);
@@ -60,6 +62,7 @@ public class BFunctionType extends BAnnotatableType implements FunctionType {
         this.flags = flags;
     }
 
+    @Deprecated
     public Type[] getParameterTypes() {
         return paramTypes;
     }
@@ -177,12 +180,13 @@ public class BFunctionType extends BAnnotatableType implements FunctionType {
         return true;
     }
 
-    public Type[] getParamTypes() {
-        return paramTypes;
-    }
-
     public Type getRestType() {
         return restType;
+    }
+
+    @Override
+    public Parameter[] getParameters() {
+        return parameters;
     }
 
     public Type getReturnType() {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BFunctionType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BFunctionType.java
@@ -34,7 +34,6 @@ import java.util.Arrays;
  */
 public class BFunctionType extends BAnnotatableType implements FunctionType {
 
-    public Type[] paramTypes;
     public Type restType;
     public Type retType;
     public long flags;
@@ -42,29 +41,42 @@ public class BFunctionType extends BAnnotatableType implements FunctionType {
 
     public BFunctionType() {
         super("function ()", null, Object.class);
-        this.paramTypes = new Type[0];
+        this.parameters = new Parameter[0];
         this.retType = PredefinedTypes.TYPE_NULL;
         this.flags = 0;
     }
 
     public BFunctionType(long flags) {
         super("function", null, Object.class);
-        this.paramTypes = null;
+        this.parameters = null;
         this.retType = null;
         this.flags = flags;
     }
 
+    @Deprecated
     public BFunctionType(Type[] paramTypes, Type restType, Type retType, long flags) {
         super("function ()", null, Object.class);
-        this.paramTypes = paramTypes;
+        this.restType = restType;
+        this.retType = retType;
+        this.flags = flags;
+    }
+
+    public BFunctionType(Parameter[] parameters, Type restType, Type retType, long flags) {
+        super("function ()", null, Object.class);
+        this.parameters = parameters;
         this.restType = restType;
         this.retType = retType;
         this.flags = flags;
     }
 
     @Deprecated
+    @Override
     public Type[] getParameterTypes() {
-        return paramTypes;
+        Type[] types = new Type[parameters.length];
+        for (int i = 0; i < parameters.length; i++) {
+            types[i] = parameters[i].type;
+        }
+        return types;
     }
 
     public Type getReturnParameterType() {
@@ -86,12 +98,12 @@ public class BFunctionType extends BAnnotatableType implements FunctionType {
         return TypeTags.FUNCTION_POINTER_TAG;
     }
 
-    private static String getTypeListAsString(Type[] typeNames) {
+    private static String getTypeListAsString(Parameter[] parameters) {
         StringBuffer br = new StringBuffer();
         int i = 0;
-        for (Type type : typeNames) {
-            br.append(type.getName());
-            if (++i < typeNames.length) {
+        for (Parameter parameter : parameters) {
+            br.append(parameter.type.getName());
+            if (++i < parameters.length) {
                 br.append(",");
             }
         }
@@ -133,7 +145,7 @@ public class BFunctionType extends BAnnotatableType implements FunctionType {
             return false;
         }
 
-        if (!Arrays.equals(paramTypes, that.paramTypes)) {
+        if (!Arrays.equals(parameters, that.parameters)) {
             return false;
         }
         return retType.equals(that.retType);
@@ -145,7 +157,7 @@ public class BFunctionType extends BAnnotatableType implements FunctionType {
         if (SymbolFlags.isFlagOn(this.flags, SymbolFlags.ANY_FUNCTION)) {
             return result;
         }
-        result = 31 * result + Arrays.hashCode(paramTypes);
+        result = 31 * result + Arrays.hashCode(parameters);
         result = 31 * result + retType.hashCode();
         return result;
     }
@@ -157,7 +169,7 @@ public class BFunctionType extends BAnnotatableType implements FunctionType {
         if (SymbolFlags.isFlagOn(this.flags, SymbolFlags.ANY_FUNCTION)) {
             stringRep = "function";
         } else {
-            stringRep = "function (" + (paramTypes != null ? getTypeListAsString(paramTypes) : "") + ")" +
+            stringRep = "function (" + (parameters != null ? getTypeListAsString(parameters) : "") + ")" +
                     (retType != null ? " returns (" + retType + ")" : "");
         }
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BMethodType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BMethodType.java
@@ -21,7 +21,6 @@ import io.ballerina.runtime.api.types.FunctionType;
 import io.ballerina.runtime.api.types.MethodType;
 import io.ballerina.runtime.api.types.ObjectType;
 import io.ballerina.runtime.api.types.Parameter;
-import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.utils.IdentifierUtils;
 
 import java.util.StringJoiner;
@@ -42,25 +41,16 @@ public class BMethodType extends BFunctionType implements MethodType {
         this.type = type;
         this.parentObjectType = parent;
         this.flags = flags;
-    }
-
-    public BMethodType(String funcName, BObjectType parent, BFunctionType type, long flags, Parameter[] parameters) {
-        this(funcName, parent, type, flags);
-        this.parameters = parameters;
+        this.parameters = type.parameters;
     }
 
     @Override
     public String toString() {
         StringJoiner sj = new StringJoiner(",", "function " + funcName + "(", ") returns (" + type.retType + ")");
-        for (Type type : type.paramTypes) {
-            sj.add(type.getName());
+        for (Parameter parameter : parameters) {
+            sj.add(parameter.type.getName());
         }
         return sj.toString();
-    }
-
-    @Override
-    public Type[] getParameterTypes() {
-        return type.paramTypes;
     }
 
     @Override
@@ -84,6 +74,6 @@ public class BMethodType extends BFunctionType implements MethodType {
     }
 
     public <T extends MethodType> MethodType duplicate() {
-        return new BMethodType(funcName, parentObjectType, type, flags, parameters);
+        return new BMethodType(funcName, parentObjectType, type, flags);
     }
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BMethodType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BMethodType.java
@@ -20,6 +20,7 @@ package io.ballerina.runtime.internal.types;
 import io.ballerina.runtime.api.types.FunctionType;
 import io.ballerina.runtime.api.types.MethodType;
 import io.ballerina.runtime.api.types.ObjectType;
+import io.ballerina.runtime.api.types.Parameter;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.utils.IdentifierUtils;
 
@@ -41,6 +42,11 @@ public class BMethodType extends BFunctionType implements MethodType {
         this.type = type;
         this.parentObjectType = parent;
         this.flags = flags;
+    }
+
+    public BMethodType(String funcName, BObjectType parent, BFunctionType type, long flags, Parameter[] parameters) {
+        this(funcName, parent, type, flags);
+        this.parameters = parameters;
     }
 
     @Override
@@ -78,6 +84,6 @@ public class BMethodType extends BFunctionType implements MethodType {
     }
 
     public <T extends MethodType> MethodType duplicate() {
-        return new BMethodType(funcName, parentObjectType, type, flags);
+        return new BMethodType(funcName, parentObjectType, type, flags, parameters);
     }
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BRemoteMethodType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BRemoteMethodType.java
@@ -20,7 +20,6 @@ package io.ballerina.runtime.internal.types;
 import io.ballerina.runtime.api.types.MethodType;
 import io.ballerina.runtime.api.types.Parameter;
 import io.ballerina.runtime.api.types.RemoteMethodType;
-import io.ballerina.runtime.api.types.Type;
 
 import java.util.StringJoiner;
 
@@ -31,23 +30,22 @@ import java.util.StringJoiner;
  */
 public class BRemoteMethodType extends BMethodType implements RemoteMethodType {
 
-    public BRemoteMethodType(String funcName, BObjectType parent, BFunctionType type, long flags,
-                             Parameter[] parameters) {
-        super(funcName, parent, type, flags, parameters);
+    public BRemoteMethodType(String funcName, BObjectType parent, BFunctionType type, long flags) {
+        super(funcName, parent, type, flags);
     }
 
     @Override
     public String toString() {
         StringJoiner sj = new StringJoiner(",", "remote function (", ") returns (" + type.retType + ")");
-        for (Type type : type.paramTypes) {
-            sj.add(type.getName());
+        for (Parameter parameter : parameters) {
+            sj.add(parameter.type.getName());
         }
         return sj.toString();
     }
 
     @Override
     public <T extends MethodType> MethodType duplicate() {
-        return new BRemoteMethodType(funcName, parentObjectType, type, flags, parameters);
+        return new BRemoteMethodType(funcName, parentObjectType, type, flags);
     }
 
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BRemoteMethodType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BRemoteMethodType.java
@@ -17,8 +17,8 @@
  */
 package io.ballerina.runtime.internal.types;
 
-import io.ballerina.runtime.api.Parameter;
 import io.ballerina.runtime.api.types.MethodType;
+import io.ballerina.runtime.api.types.Parameter;
 import io.ballerina.runtime.api.types.RemoteMethodType;
 import io.ballerina.runtime.api.types.Type;
 
@@ -30,12 +30,10 @@ import java.util.StringJoiner;
  * @since 2.0
  */
 public class BRemoteMethodType extends BMethodType implements RemoteMethodType {
-    public final Parameter[] parameters;
 
     public BRemoteMethodType(String funcName, BObjectType parent, BFunctionType type, long flags,
                              Parameter[] parameters) {
-        super(funcName, parent, type, flags);
-        this.parameters = parameters;
+        super(funcName, parent, type, flags, parameters);
     }
 
     @Override
@@ -52,8 +50,4 @@ public class BRemoteMethodType extends BMethodType implements RemoteMethodType {
         return new BRemoteMethodType(funcName, parentObjectType, type, flags, parameters);
     }
 
-    @Override
-    public Parameter[] getParameters() {
-        return parameters;
-    }
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BResourceMethodType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BResourceMethodType.java
@@ -18,7 +18,6 @@
 package io.ballerina.runtime.internal.types;
 
 import io.ballerina.runtime.api.types.MethodType;
-import io.ballerina.runtime.api.types.Parameter;
 import io.ballerina.runtime.api.types.ResourceMethodType;
 import io.ballerina.runtime.api.types.Type;
 
@@ -35,8 +34,8 @@ public class BResourceMethodType extends BMethodType implements ResourceMethodTy
     public final String[] resourcePath;
 
     public BResourceMethodType(String funcName, BObjectType parent, BFunctionType type, long flags, String accessor,
-                               String[] resourcePath, Parameter[] parameters) {
-        super(funcName, parent, type, flags, parameters);
+                               String[] resourcePath) {
+        super(funcName, parent, type, flags);
         this.type = type;
         this.flags = flags;
         this.accessor = accessor;
@@ -51,9 +50,8 @@ public class BResourceMethodType extends BMethodType implements ResourceMethodTy
         }
         StringJoiner sj = new StringJoiner(",", "resource function " + accessor + " " + rp.toString() +
                 "(", ") returns (" + type.retType + ")");
-        Type[] types = type.paramTypes;
-        for (int i = 0; i < types.length; i++) {
-            Type type = types[i];
+        for (int i = 0; i < parameters.length; i++) {
+            Type type = parameters[i].type;
             sj.add(type.getName() + " " + parameters[i].name);
         }
         return sj.toString();
@@ -81,7 +79,7 @@ public class BResourceMethodType extends BMethodType implements ResourceMethodTy
 
     @Override
     public <T extends MethodType> MethodType duplicate() {
-        return new BResourceMethodType(funcName, parentObjectType, type, flags, accessor, resourcePath, parameters);
+        return new BResourceMethodType(funcName, parentObjectType, type, flags, accessor, resourcePath);
     }
 
     @Deprecated

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BResourceMethodType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BResourceMethodType.java
@@ -17,8 +17,8 @@
  */
 package io.ballerina.runtime.internal.types;
 
-import io.ballerina.runtime.api.Parameter;
 import io.ballerina.runtime.api.types.MethodType;
+import io.ballerina.runtime.api.types.Parameter;
 import io.ballerina.runtime.api.types.ResourceMethodType;
 import io.ballerina.runtime.api.types.Type;
 
@@ -33,16 +33,14 @@ public class BResourceMethodType extends BMethodType implements ResourceMethodTy
 
     public final String accessor;
     public final String[] resourcePath;
-    public final Parameter[] parameters;
 
     public BResourceMethodType(String funcName, BObjectType parent, BFunctionType type, long flags, String accessor,
                                String[] resourcePath, Parameter[] parameters) {
-        super(funcName, parent, type, flags);
+        super(funcName, parent, type, flags, parameters);
         this.type = type;
         this.flags = flags;
         this.accessor = accessor;
         this.resourcePath = resourcePath;
-        this.parameters = parameters;
     }
 
     @Override
@@ -96,8 +94,4 @@ public class BResourceMethodType extends BMethodType implements ResourceMethodTy
         return paramDefaults;
     }
 
-    @Override
-    public Parameter[] getParameters() {
-        return parameters;
-    }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
@@ -49,7 +49,7 @@ public class JvmConstants {
     public static final String ERROR_VALUE = "io/ballerina/runtime/internal/values/ErrorValue";
     public static final String BERROR = "io/ballerina/runtime/api/values/BError";
     public static final String STRING_VALUE = "java/lang/String";
-    public static final String FUNCTION_PARAMETER = "io/ballerina/runtime/api/Parameter";
+    public static final String FUNCTION_PARAMETER = "io/ballerina/runtime/api/types/Parameter";
     public static final String B_STRING_VALUE = "io/ballerina/runtime/api/values/BString";
     public static final String NON_BMP_STRING_VALUE = "io/ballerina/runtime/internal/values/NonBmpStringValue";
     public static final String BMP_STRING_VALUE = "io/ballerina/runtime/internal/values/BmpStringValue";

--- a/langlib/lang.__internal/src/main/java/org/ballerinalang/langlib/internal/GetFilterFunc.java
+++ b/langlib/lang.__internal/src/main/java/org/ballerinalang/langlib/internal/GetFilterFunc.java
@@ -35,8 +35,8 @@ public class GetFilterFunc {
     public static BFunctionPointer getFilterFunc(Object obj) {
         BFunctionPointer bFunctionPointer = (BFunctionPointer) obj;
         FunctionType functionType = (FunctionType) bFunctionPointer.getType();
-        functionType.getParameterTypes()[0] = TypeCreator.createUnionType(List.of(PredefinedTypes.TYPE_ANY,
-                                                                                  PredefinedTypes.TYPE_ERROR), 0);
+        functionType.getParameters()[0].type = TypeCreator.createUnionType(List.of(PredefinedTypes.TYPE_ANY,
+                PredefinedTypes.TYPE_ERROR), 0);
         return bFunctionPointer;
     }
 }

--- a/langlib/lang.__internal/src/main/java/org/ballerinalang/langlib/internal/GetMapFunc.java
+++ b/langlib/lang.__internal/src/main/java/org/ballerinalang/langlib/internal/GetMapFunc.java
@@ -35,8 +35,8 @@ public class GetMapFunc {
     public static BFunctionPointer getMapFunc(Object obj) {
         BFunctionPointer functionPointer = (BFunctionPointer) obj;
         FunctionType functionType = (FunctionType) functionPointer.getType();
-        functionType.getParameterTypes()[0] = TypeCreator.createUnionType(List.of(PredefinedTypes.TYPE_ANY,
-                                                                                  PredefinedTypes.TYPE_ERROR), 0);
+        functionType.getParameters()[0].type = TypeCreator.createUnionType(List.of(PredefinedTypes.TYPE_ANY,
+                PredefinedTypes.TYPE_ERROR), 0);
         return functionPointer;
     }
 }

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/mock/ObjectMock.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/mock/ObjectMock.java
@@ -23,6 +23,7 @@ import io.ballerina.runtime.api.creators.ErrorCreator;
 import io.ballerina.runtime.api.types.Field;
 import io.ballerina.runtime.api.types.MethodType;
 import io.ballerina.runtime.api.types.ObjectType;
+import io.ballerina.runtime.api.types.Parameter;
 import io.ballerina.runtime.api.types.ParameterizedType;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.types.UnionType;
@@ -166,7 +167,7 @@ public class ObjectMock {
             if (attachedFunction.getName().equals(functionName)) {
 
                 // validate the number of arguments provided
-                if (argsList.size() > attachedFunction.getType().getParameterTypes().length) {
+                if (argsList.size() > attachedFunction.getType().getParameters().length) {
                     String detail = "too many argument provided to mock the function '" + functionName + "()'";
                     return ErrorCreator.createError(
                             MockConstants.TEST_PACKAGE_ID,
@@ -179,11 +180,11 @@ public class ObjectMock {
                 // validate if each argument is compatible with the type given in the function signature
                 int i = 0;
                 for (BIterator it = argsList.getIterator(); it.hasNext(); i++) {
-                    if (attachedFunction.getType().getParameterTypes()[i] instanceof UnionType) {
+                    if (attachedFunction.getType().getParameters()[i].type instanceof UnionType) {
                         Object arg = it.next();
                         boolean isTypeAvailable = false;
                         List<Type> memberTypes =
-                                ((UnionType) attachedFunction.getType().getParameterTypes()[i]).getMemberTypes();
+                                ((UnionType) attachedFunction.getType().getParameters()[i].type).getMemberTypes();
                         for (Type memberType : memberTypes) {
                             if (TypeChecker.checkIsType(arg, memberType)) {
                                 isTypeAvailable = true;
@@ -201,7 +202,8 @@ public class ObjectMock {
                                     null,
                                     new MapValueImpl<>(PredefinedTypes.TYPE_ERROR_DETAIL));
                         }
-                    } else if (!TypeChecker.checkIsType(it.next(), attachedFunction.getType().getParameterTypes()[i])) {
+                    } else if (!TypeChecker.checkIsType(it.next(),
+                            attachedFunction.getType().getParameters()[i].type)) {
                         String detail =
                                 "incorrect type of argument provided at position '" + (i + 1)
                                         + "' to mock the function '" + functionName + "()'";
@@ -402,14 +404,14 @@ public class ObjectMock {
     private static BError validateFunctionSignatures(MethodType func,
                                                      MethodType[] attachedFunctions) {
         String functionName = func.getName();
-        Type[] paramTypes = func.getParameterTypes();
+        Parameter[] parameters = func.getParameters();
         Type returnType = func.getType().getReturnParameterType();
 
         for (MethodType attachedFunction : attachedFunctions) {
             if (attachedFunction.getName().equals(functionName)) {
 
                 // validate that the number of parameters are equal
-                if (paramTypes.length != attachedFunction.getParameterTypes().length) {
+                if (parameters.length != attachedFunction.getParameters().length) {
                     String detail = "incorrect number of parameters provided for function '" + functionName + "()'";
                     return ErrorCreator.createError(
                             MockConstants.TEST_PACKAGE_ID,
@@ -419,9 +421,9 @@ public class ObjectMock {
                             new MapValueImpl<>(PredefinedTypes.TYPE_ERROR_DETAIL));
                 } else {
                     // validate the equivalence of the parameter types
-                    for (int i = 0; i < paramTypes.length; i++) {
-                        if (attachedFunction.getParameterTypes()[i] instanceof UnionType) {
-                            if (!(paramTypes[i] instanceof UnionType)) {
+                    for (int i = 0; i < parameters.length; i++) {
+                        if (attachedFunction.getParameters()[i].type instanceof UnionType) {
+                            if (!(parameters[i].type instanceof UnionType)) {
                                 String detail = "incompatible parameter type provided at position " + (i + 1) + " in" +
                                         " function '" + functionName + "()'. parameter should be of union type ";
                                 return ErrorCreator.createError(
@@ -431,9 +433,9 @@ public class ObjectMock {
                                         null,
                                         new MapValueImpl<>(PredefinedTypes.TYPE_ERROR_DETAIL));
                             } else {
-                                Type[] memberTypes = ((UnionType) attachedFunction.getParameterTypes()[i])
+                                Type[] memberTypes = ((UnionType) attachedFunction.getParameters()[i].type)
                                         .getMemberTypes().toArray(new Type[0]);
-                                Type[] providedTypes = ((UnionType) paramTypes[i])
+                                Type[] providedTypes = ((UnionType) parameters[i].type)
                                         .getMemberTypes().toArray(new Type[0]);
                                 for (int j = 0; j < memberTypes.length; j++) {
                                     if (!TypeChecker.checkIsType(providedTypes[j], memberTypes[j])) {
@@ -451,7 +453,7 @@ public class ObjectMock {
 
                             }
                         } else {
-                            if (!TypeChecker.checkIsType(paramTypes[i], attachedFunction.getParameterTypes()[i])) {
+                            if (!TypeChecker.checkIsType(parameters[i], attachedFunction.getParameters()[i].type)) {
                                 BString detail =
                                         StringUtils.fromString("incompatible parameter type provided at position "
                                                 + (i + 1) + " in function '" + functionName + "()'");

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/mock/ObjectMock.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/mock/ObjectMock.java
@@ -453,7 +453,8 @@ public class ObjectMock {
 
                             }
                         } else {
-                            if (!TypeChecker.checkIsType(parameters[i], attachedFunction.getParameters()[i].type)) {
+                            if (!TypeChecker.checkIsType(parameters[i].type,
+                                    attachedFunction.getParameters()[i].type)) {
                                 BString detail =
                                         StringUtils.fromString("incompatible parameter type provided at position "
                                                 + (i + 1) + " in function '" + functionName + "()'");

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/BRunUtil.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/BRunUtil.java
@@ -1211,9 +1211,9 @@ public class BRunUtil {
             case io.ballerina.runtime.api.TypeTags.FUNCTION_POINTER_TAG:
                 io.ballerina.runtime.api.types.FunctionType jvmBFunctionType =
                         (io.ballerina.runtime.api.types.FunctionType) jvmType;
-                BType[] bParamTypes = new BType[jvmBFunctionType.getParameterTypes().length];
-                for (int i = 0; i < jvmBFunctionType.getParameterTypes().length; i++) {
-                    bParamTypes[i] = getBVMType(jvmBFunctionType.getParameterTypes()[i], selfTypeStack, visitedTypes,
+                BType[] bParamTypes = new BType[jvmBFunctionType.getParameters().length];
+                for (int i = 0; i < jvmBFunctionType.getParameters().length; i++) {
+                    bParamTypes[i] = getBVMType(jvmBFunctionType.getParameters()[i].type, selfTypeStack, visitedTypes,
                             newBTypes);
                 }
                 BType bRetType = getBVMType(jvmBFunctionType.getReturnType(), selfTypeStack, visitedTypes,

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
@@ -19,12 +19,12 @@
 package org.ballerinalang.nativeimpl.jvm.runtime.api.tests;
 
 import io.ballerina.runtime.api.Module;
-import io.ballerina.runtime.api.Parameter;
 import io.ballerina.runtime.api.PredefinedTypes;
 import io.ballerina.runtime.api.creators.TypeCreator;
 import io.ballerina.runtime.api.creators.ValueCreator;
 import io.ballerina.runtime.api.types.MethodType;
 import io.ballerina.runtime.api.types.ObjectType;
+import io.ballerina.runtime.api.types.Parameter;
 import io.ballerina.runtime.api.types.RemoteMethodType;
 import io.ballerina.runtime.api.types.TupleType;
 import io.ballerina.runtime.api.utils.StringUtils;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
@@ -26,6 +26,8 @@ import io.ballerina.runtime.api.types.MethodType;
 import io.ballerina.runtime.api.types.ObjectType;
 import io.ballerina.runtime.api.types.Parameter;
 import io.ballerina.runtime.api.types.RemoteMethodType;
+import io.ballerina.runtime.api.types.ResourceMethodType;
+import io.ballerina.runtime.api.types.ServiceType;
 import io.ballerina.runtime.api.types.TupleType;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.utils.StringUtils;
@@ -91,8 +93,20 @@ public class Values {
         return ValueCreator.createArrayValue(TypeCreator.createArrayType(tupleType), len, elements);
     }
 
-    public static BString getFunctionString(BFunctionPointer func) {
-        return StringUtils.fromString(func.stringValue(null));
+    public static BString getFunctionString(BObject object, BString methodName) {
+        ObjectType objectType = object.getType();
+        Optional<MethodType> funcType = Arrays.stream(objectType.getMethods())
+                .filter(r -> r.getName().equals(methodName.getValue())).findAny();
+        if (funcType.isPresent()) {
+            return StringUtils.fromString(funcType.get().toString());
+        }
+        Optional<ResourceMethodType> resourceMethodType =
+                Arrays.stream(((ServiceType) objectType).getResourceMethods())
+                        .filter(r -> r.getResourcePath()[0].equals(methodName.getValue())).findAny();
+        if (resourceMethodType.isPresent()) {
+            return StringUtils.fromString(resourceMethodType.get().toString());
+        }
+        return StringUtils.fromString("");
     }
 
     public static BString getParamTypesString(BFunctionPointer func) {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
@@ -27,12 +27,15 @@ import io.ballerina.runtime.api.types.ObjectType;
 import io.ballerina.runtime.api.types.Parameter;
 import io.ballerina.runtime.api.types.RemoteMethodType;
 import io.ballerina.runtime.api.types.TupleType;
+import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.values.BArray;
+import io.ballerina.runtime.api.values.BFunctionPointer;
 import io.ballerina.runtime.api.values.BListInitialValueEntry;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
+import io.ballerina.runtime.internal.types.BFunctionType;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -68,7 +71,7 @@ public class Values {
         Optional<MethodType> funcType = Arrays.stream(objectType.getMethods())
                 .filter(r -> r.getName().equals(methodName.getValue())).findAny();
         TupleType tupleType = TypeCreator.createTupleType(List.of(PredefinedTypes.TYPE_STRING,
-                PredefinedTypes.TYPE_BOOLEAN));
+                PredefinedTypes.TYPE_BOOLEAN, PredefinedTypes.TYPE_STRING));
         if (funcType.isEmpty()) {
             return ValueCreator.createArrayValue(TypeCreator.createArrayType(tupleType, 0), 0);
         }
@@ -79,10 +82,25 @@ public class Values {
         for (int i = 0; i < len; i++) {
             BListInitialValueEntry[] initialTupleValues =
                     {ValueCreator.createListInitialValueEntry(StringUtils.fromString(parameters[i].name)),
-                            ValueCreator.createListInitialValueEntry(parameters[i].isDefault)};
+                            ValueCreator.createListInitialValueEntry(parameters[i].isDefault),
+                            ValueCreator.createListInitialValueEntry(
+                                    (StringUtils.fromString(parameters[i].type.toString())))};
             elements[i] = ValueCreator
-                    .createListInitialValueEntry(ValueCreator.createTupleValue(tupleType, 2, initialTupleValues));
+                    .createListInitialValueEntry(ValueCreator.createTupleValue(tupleType, 3, initialTupleValues));
         }
         return ValueCreator.createArrayValue(TypeCreator.createArrayType(tupleType), len, elements);
+    }
+
+    public static BString getFunctionString(BFunctionPointer func) {
+        return StringUtils.fromString(func.stringValue(null));
+    }
+
+    public static BString getParamTypesString(BFunctionPointer func) {
+        BFunctionType funcType = (BFunctionType) func.getType();
+        StringBuilder sb = new StringBuilder();
+        for (Type type : funcType.getParameterTypes()) {
+            sb.append(type.toString()).append(" ");
+        }
+        return StringUtils.fromString(sb.toString());
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/runtime/api/RuntimeAPITest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/runtime/api/RuntimeAPITest.java
@@ -42,7 +42,7 @@ public class RuntimeAPITest {
     }
 
     @Test
-    public void remoteMethodTypeTest() {
+    public void methodTypeTest() {
         CompileResult result = BCompileUtil.compile("test-src/runtime/api/types");
         BRunUtil.invoke(result, "main");
     }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/object/test_service_objects.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/object/test_service_objects.bal
@@ -120,17 +120,20 @@ function assertEquality(any|error actual, any|error expected) {
 }
 
 function testServiceRemoteMethod(serv:Service serviceVal) {
-    [string, boolean][] parameters = getRemoteParameters(serviceVal, "getRemoteCounter");
+    [string, boolean, string][] parameters = getRemoteParameters(serviceVal, "getRemoteCounter");
     assertEquality(parameters.length(), 3);
     assertEquality(parameters[0][0], "num");
     assertEquality(parameters[0][1], false);
+    assertEquality(parameters[0][2], "int");
     assertEquality(parameters[1][0], "value");
     assertEquality(parameters[1][1], false);
+    assertEquality(parameters[1][2], "decimal");
     assertEquality(parameters[2][0], "msg");
     assertEquality(parameters[2][1], true);
+    assertEquality(parameters[2][2], "string");
 }
 
-public function getRemoteParameters(service object {} s, string name) returns [string, boolean][] = @java:Method {
+public function getRemoteParameters(service object {} s, string name) returns [string, boolean, string][] = @java:Method {
     'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values",
     name: "getParameters"
 } external;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/types/main.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/types/main.bal
@@ -26,7 +26,12 @@ public function main() {
 }
 
 function testFunctionToString() {
-    test:assertEquals(objects:getFunctionString(obj.testFunction), "function function (int,decimal,string) returns (())");
+    test:assertEquals(objects:getFunctionString(obj, "testFunction"), "function testFunction(int,decimal,string) returns (())");
+    test:assertEquals(objects:getFunctionString(obj, "getRemoteCounter"), "remote function (int,decimal,string) returns (())");
+
+    objects:Service serviceVal = new ();
+    test:assertEquals(objects:getFunctionString(serviceVal, "remoteFunction"), "remote function (int,decimal,string) returns (())");
+    test:assertEquals(objects:getFunctionString(serviceVal, "resourceFunction"), "resource function get resourceFunction(string test) returns (string)");
 }
 
 function testRemoteFunctionParameters() {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/types/main.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/types/main.bal
@@ -17,11 +17,27 @@
 import ballerina/test;
 import testorg/runtime_api_types.objects;
 
+objects:PublicClientObject obj = new ();
+
 public function main() {
-    objects:PublicClientObject obj = new ();
-    [string,boolean] [] parameters = objects:getParameters(obj, "getRemoteCounter");
+    testRemoteFunctionParameters();
+    testFunctionToString();
+    testParamTypesString();
+}
+
+function testFunctionToString() {
+    test:assertEquals(objects:getFunctionString(obj.testFunction), "function function (int,decimal,string) returns (())");
+}
+
+function testRemoteFunctionParameters() {
+    [string, boolean, string][] parameters = objects:getParameters(obj, "getRemoteCounter");
     test:assertEquals(parameters.length(), 3);
-    test:assertEquals(parameters[0], ["num", false]);
-    test:assertEquals(parameters[1], ["value", false]);
-    test:assertEquals(parameters[2], ["msg", true]);
+    test:assertEquals(parameters[0], ["num", false, "int"]);
+    test:assertEquals(parameters[1], ["value", false, "decimal"]);
+    test:assertEquals(parameters[2], ["msg", true, "string"]);
+}
+
+function testParamTypesString() {
+    //Need to be removed after removing getParamTypes() API
+    test:assertEquals(objects:getParamTypesString(obj.testFunction), "int decimal string ");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/types/modules/objects/objects.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/types/modules/objects/objects.bal
@@ -25,11 +25,21 @@ public client class PublicClientObject {
     }
 }
 
+public isolated service class Service {
+
+    isolated resource function get resourceFunction(string test) returns string {
+        return "foo";
+    }
+
+    isolated remote function remoteFunction(int num, decimal value, string msg = "test message") {
+    }
+}
+
 public function getParameters(PublicClientObject obj, string name) returns [string, boolean, string][] = @java:Method {
     'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
 } external;
 
-public function getFunctionString(function func) returns string = @java:Method {
+public function getFunctionString(object {} obj, string name) returns string = @java:Method {
     'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
 } external;
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/types/modules/objects/objects.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/types/modules/objects/objects.bal
@@ -19,8 +19,20 @@ import ballerina/jballerina.java;
 public client class PublicClientObject {
     remote function getRemoteCounter(int num, decimal value, string msg = "test message") {
     }
+
+    public function testFunction(int num, decimal value, string msg = "test message") {
+    // do nothing
+    }
 }
 
-public function getParameters(PublicClientObject obj, string name) returns [string, boolean][] = @java:Method {
+public function getParameters(PublicClientObject obj, string name) returns [string, boolean, string][] = @java:Method {
+    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
+} external;
+
+public function getFunctionString(function func) returns string = @java:Method {
+    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
+} external;
+
+public function getParamTypesString(function func) returns string = @java:Method {
     'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
 } external;

--- a/tests/observability-test-utils/src/main/java/org/ballerina/testobserve/listenerendpoint/Resource.java
+++ b/tests/observability-test-utils/src/main/java/org/ballerina/testobserve/listenerendpoint/Resource.java
@@ -17,6 +17,7 @@
  */
 package org.ballerina.testobserve.listenerendpoint;
 
+import io.ballerina.runtime.api.types.Parameter;
 import io.ballerina.runtime.api.types.ResourceMethodType;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.values.BObject;
@@ -86,7 +87,12 @@ public class Resource {
     }
 
     public Type[] getParamTypes() {
-        return this.resourceMethodType.getParameterTypes();
+        Parameter[] parameters = this.resourceMethodType.getParameters();
+        Type[] types = new Type[parameters.length];
+        for (int i = 0; i < parameters.length; i++) {
+            types[i] = parameters[i].type;
+        }
+        return types;
     }
 
     public Type getReturnType() {


### PR DESCRIPTION
## Purpose
$subject
Fixes #31887

## Approach
- Moved `getParameters()` API to FunctionType from Resource & Remote method types.
- Deprecated `getParamTypes()` API as now we can improve `getParameter()`  for the same purpose

## Remarks
TODO: Add doc comments for deprecated annotations, add more tests for the moved API. 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
