### PR TITLE
Add configurable property for client http.url metric in observability

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/observability/ObservabilityConstants.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/observability/ObservabilityConstants.java
@@ -72,4 +72,8 @@ public class ObservabilityConstants {
 
     // Tracing Configs
     public static final String CONFIG_TRACING_ENABLED = CONFIG_TABLE_TRACING + ".enabled";
+
+    // Client http.url Metrics Config
+    public static final String CONFIG_CLIENT_HTTP_URL_DISABLED =
+            CONFIG_TABLE_METRICS + ".client." + TAG_KEY_HTTP_URL + ".disabled";
 }

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/HttpUtil.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/HttpUtil.java
@@ -107,6 +107,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static io.netty.handler.codec.http.HttpHeaderNames.CACHE_CONTROL;
+import static org.ballerinalang.jvm.observability.ObservabilityConstants.CONFIG_CLIENT_HTTP_URL_DISABLED;
 import static org.ballerinalang.jvm.observability.ObservabilityConstants.PROPERTY_HTTP_HOST;
 import static org.ballerinalang.jvm.observability.ObservabilityConstants.PROPERTY_HTTP_PORT;
 import static org.ballerinalang.jvm.observability.ObservabilityConstants.TAG_KEY_HTTP_METHOD;
@@ -1132,7 +1133,9 @@ public class HttpUtil {
         observerContext.ifPresent(ctx -> {
             HttpUtil.injectHeaders(message, ObserveUtils.getContextProperties(strand.observerContext));
             strand.observerContext.addTag(TAG_KEY_HTTP_METHOD, message.getHttpMethod());
-            strand.observerContext.addTag(TAG_KEY_HTTP_URL, String.valueOf(message.getProperty(HttpConstants.TO)));
+            if (!ConfigRegistry.getInstance().getAsBoolean(CONFIG_CLIENT_HTTP_URL_DISABLED)) {
+                strand.observerContext.addTag(TAG_KEY_HTTP_URL, String.valueOf(message.getProperty(HttpConstants.TO)));
+            }
             strand.observerContext.addTag(TAG_KEY_PEER_ADDRESS,
                        message.getProperty(PROPERTY_HTTP_HOST) + ":" + message.getProperty(PROPERTY_HTTP_PORT));
             // Add HTTP Status Code tag. The HTTP status code will be set using the response message.


### PR DESCRIPTION
## Purpose
> Related to https://github.com/ballerina-platform/ballerina-standard-library/issues/1630
> By default, metric is enabled.

## Samples
> To disable client http_url metric : `--b7a.observability.metrics.client.http.url.disabled=true`

Default metric:
```json
ballerina_http_HttpClient_response_time_seconds{http_url="/hello/",peer_address="localhost:9092",http_method="POST",action="forward",http_status_code="0",timeWindow="300000",quantile="0.5",} 0.10107421875
```
Disabled metric:
```json
ballerina_http_HttpClient_response_time_seconds{peer_address="localhost:9092",http_method="POST",action="forward",http_status_code="0",timeWindow="300000",quantile="0.5",} 0.10302734375

```


## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
