### PR TITLE
Fix reference equality checks for float

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -407,6 +407,18 @@ public class TypeChecker {
     }
 
     /**
+     * Reference equality check for float values.
+     *
+     * @param lhsValue The value on the left-hand side
+     * @param rhsValue The value of the right-hand side
+     * @return True if values are reference equal, else false.
+     */
+
+    public static boolean checkFloatRefEqual(double lhsValue, double rhsValue) {
+        return Objects.equals(lhsValue, rhsValue);
+    }
+
+    /**
      * Check if two decimal values are equal in value.
      *
      * @param lhsValue The value on the left hand side

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -414,8 +414,8 @@ public class TypeChecker {
      * @return True if values are reference equal, else false.
      */
 
-    public static boolean checkFloatRefEqual(double lhsValue, double rhsValue) {
-        return Objects.equals(lhsValue, rhsValue);
+    public static boolean checkFloatExactEqual(double lhsValue, double rhsValue) {
+        return Double.valueOf(lhsValue).equals(Double.valueOf(rhsValue));
     }
 
     /**

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -415,7 +415,7 @@ public class TypeChecker {
      */
 
     public static boolean checkFloatExactEqual(double lhsValue, double rhsValue) {
-        return Double.valueOf(lhsValue).equals(Double.valueOf(rhsValue));
+        return Double.valueOf(lhsValue).equals(rhsValue);
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
@@ -293,7 +293,7 @@ public class JvmConstants {
     public static final String DECIMAL_VALUE_OF_J_METHOD = "valueOfJ";
     public static final String VALUE_OF_METHOD = "valueOf";
     public static final String POPULATE_INITIAL_VALUES_METHOD = "populateInitialValues";
-    public static final String CHECK_FLOAT_REF_EQUAL = "checkFloatRefEqual";
+    public static final String CHECK_FLOAT_EXACT_EQUAL = "checkFloatExactEqual";
     public static final String CREATE_TYPES_METHOD = "$createTypes";
     public static final String CREATE_TYPE_INSTANCES_METHOD = "$createTypeInstances";
     public static final String GLOBAL_LOCK_NAME = "lock";

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
@@ -293,6 +293,7 @@ public class JvmConstants {
     public static final String DECIMAL_VALUE_OF_J_METHOD = "valueOfJ";
     public static final String VALUE_OF_METHOD = "valueOf";
     public static final String POPULATE_INITIAL_VALUES_METHOD = "populateInitialValues";
+    public static final String CHECK_FLOAT_REF_EQUAL = "checkFloatRefEqual";
     public static final String CREATE_TYPES_METHOD = "$createTypes";
     public static final String CREATE_TYPE_INSTANCES_METHOD = "$createTypeInstances";
     public static final String GLOBAL_LOCK_NAME = "lock";

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
@@ -848,8 +848,8 @@ public class JvmInstructionGen {
         } else if (lhsOpType.tag == TypeTags.BYTE && rhsOpType.tag == TypeTags.BYTE) {
             this.mv.visitJumpInsn(IF_ICMPEQ, label1);
         } else if (lhsOpType.tag == TypeTags.FLOAT && rhsOpType.tag == TypeTags.FLOAT) {
-            this.mv.visitInsn(DCMPL);
-            this.mv.visitJumpInsn(IFEQ, label1);
+            this.mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, CHECK_FLOAT_REF_EQUAL, "(DD)Z", false);
+            this.mv.visitJumpInsn(IFNE, label1);
         } else if (lhsOpType.tag == TypeTags.BOOLEAN && rhsOpType.tag == TypeTags.BOOLEAN) {
             this.mv.visitJumpInsn(IF_ICMPEQ, label1);
         } else {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
@@ -130,7 +130,7 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.B_MAP;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.B_MAPPING_INITIAL_VALUE_ENTRY;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.B_OBJECT;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.B_XML_QNAME;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.CHECK_FLOAT_REF_EQUAL;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.CHECK_FLOAT_EXACT_EQUAL;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.DECIMAL_VALUE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.ERROR_VALUE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.FUNCTION;
@@ -810,7 +810,7 @@ public class JvmInstructionGen {
         } else if (lhsOpType.tag == TypeTags.BYTE && rhsOpType.tag == TypeTags.BYTE) {
             this.mv.visitJumpInsn(IF_ICMPNE, label1);
         } else if (lhsOpType.tag == TypeTags.FLOAT && rhsOpType.tag == TypeTags.FLOAT) {
-            this.mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, CHECK_FLOAT_REF_EQUAL, "(DD)Z", false);
+            this.mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, CHECK_FLOAT_EXACT_EQUAL, "(DD)Z", false);
             this.storeToVar(binaryIns.lhsOp.variableDcl);
             return;
         } else if (lhsOpType.tag == TypeTags.BOOLEAN && rhsOpType.tag == TypeTags.BOOLEAN) {
@@ -848,7 +848,7 @@ public class JvmInstructionGen {
         } else if (lhsOpType.tag == TypeTags.BYTE && rhsOpType.tag == TypeTags.BYTE) {
             this.mv.visitJumpInsn(IF_ICMPEQ, label1);
         } else if (lhsOpType.tag == TypeTags.FLOAT && rhsOpType.tag == TypeTags.FLOAT) {
-            this.mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, CHECK_FLOAT_REF_EQUAL, "(DD)Z", false);
+            this.mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, CHECK_FLOAT_EXACT_EQUAL, "(DD)Z", false);
             this.mv.visitJumpInsn(IFNE, label1);
         } else if (lhsOpType.tag == TypeTags.BOOLEAN && rhsOpType.tag == TypeTags.BOOLEAN) {
             this.mv.visitJumpInsn(IF_ICMPEQ, label1);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
@@ -130,6 +130,7 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.B_MAP;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.B_MAPPING_INITIAL_VALUE_ENTRY;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.B_OBJECT;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.B_XML_QNAME;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.CHECK_FLOAT_REF_EQUAL;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.DECIMAL_VALUE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.ERROR_VALUE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.FUNCTION;
@@ -809,8 +810,9 @@ public class JvmInstructionGen {
         } else if (lhsOpType.tag == TypeTags.BYTE && rhsOpType.tag == TypeTags.BYTE) {
             this.mv.visitJumpInsn(IF_ICMPNE, label1);
         } else if (lhsOpType.tag == TypeTags.FLOAT && rhsOpType.tag == TypeTags.FLOAT) {
-            this.mv.visitInsn(DCMPL);
-            this.mv.visitJumpInsn(IFNE, label1);
+            this.mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, CHECK_FLOAT_REF_EQUAL, "(DD)Z", false);
+            this.storeToVar(binaryIns.lhsOp.variableDcl);
+            return;
         } else if (lhsOpType.tag == TypeTags.BOOLEAN && rhsOpType.tag == TypeTags.BOOLEAN) {
             this.mv.visitJumpInsn(IF_ICMPNE, label1);
         } else {

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibFloatTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibFloatTest.java
@@ -79,4 +79,9 @@ public class LangLibFloatTest {
     public void testLangLibCallOnFiniteType() {
         BRunUtil.invoke(compileResult, "testLangLibCallOnFiniteType");
     }
+
+    @Test
+    public void testFloatRefEquality() {
+        BRunUtil.invoke(compileResult, "testFloatRefEquality");
+    }
 }

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibFloatTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibFloatTest.java
@@ -26,6 +26,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -80,8 +81,16 @@ public class LangLibFloatTest {
         BRunUtil.invoke(compileResult, "testLangLibCallOnFiniteType");
     }
 
-    @Test
-    public void testFloatRefEquality() {
-        BRunUtil.invoke(compileResult, "testFloatRefEquality");
+    @Test(dataProvider = "functionsWithFloatRefEqualityChecks")
+    public void testFunctionsWithFloatRefEqualityChecks(String function) {
+        BRunUtil.invoke(compileResult, function);
+    }
+
+    @DataProvider
+    public  Object[] functionsWithFloatRefEqualityChecks() {
+        return new String[] {
+                "testFloatRefEquality",
+                "testFloatRefNotEquality"
+        };
     }
 }

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibFloatTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibFloatTest.java
@@ -81,16 +81,16 @@ public class LangLibFloatTest {
         BRunUtil.invoke(compileResult, "testLangLibCallOnFiniteType");
     }
 
-    @Test(dataProvider = "functionsWithFloatRefEqualityChecks")
-    public void testFunctionsWithFloatRefEqualityChecks(String function) {
+    @Test(dataProvider = "functionsWithFloatExactEqualityChecks")
+    public void testFunctionsWithFloatExactEqualityChecks(String function) {
         BRunUtil.invoke(compileResult, function);
     }
 
     @DataProvider
-    public  Object[] functionsWithFloatRefEqualityChecks() {
+    public  Object[] functionsWithFloatExactEqualityChecks() {
         return new String[] {
-                "testFloatRefEquality",
-                "testFloatRefNotEquality"
+                "testFloatExactEquality",
+                "testFloatNotExactEquality"
         };
     }
 }

--- a/langlib/langlib-test/src/test/resources/test-src/floatlib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/floatlib_test.bal
@@ -44,3 +44,10 @@ function testLangLibCallOnFiniteType() {
     float y = x.sum(1, 2.3);
     test:assertValueEqual(24.3, y);
 }
+
+function testFloatRefEquality() {
+    test:assertTrue(42.0 === 42.0);
+    test:assertFalse(1.0 === 12.0);
+    test:assertTrue(float:NaN === float:NaN);
+    test:assertFalse(-0.0 === 0.0);
+}

--- a/langlib/langlib-test/src/test/resources/test-src/floatlib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/floatlib_test.bal
@@ -45,14 +45,14 @@ function testLangLibCallOnFiniteType() {
     test:assertValueEqual(24.3, y);
 }
 
-function testFloatRefEquality() {
+function testFloatExactEquality() {
     test:assertTrue(42.0 === 42.0);
     test:assertFalse(1.0 === 12.0);
     test:assertTrue(float:NaN === float:NaN);
     test:assertFalse(-0.0 === 0.0);
 }
 
-function testFloatRefNotEquality() {
+function testFloatNotExactEquality() {
     test:assertFalse(42.0 !== 42.0);
     test:assertTrue(1.0 !== 12.0);
     test:assertFalse(float:NaN !== float:NaN);

--- a/langlib/langlib-test/src/test/resources/test-src/floatlib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/floatlib_test.bal
@@ -51,3 +51,10 @@ function testFloatRefEquality() {
     test:assertTrue(float:NaN === float:NaN);
     test:assertFalse(-0.0 === 0.0);
 }
+
+function testFloatRefNotEquality() {
+    test:assertFalse(42.0 !== 42.0);
+    test:assertTrue(1.0 !== 12.0);
+    test:assertFalse(float:NaN !== float:NaN);
+    test:assertTrue(-0.0 !== 0.0);
+}


### PR DESCRIPTION
## Purpose
> Fixes the incorrect results given for float reference equality checks. 
```
io:println(42.0 === 42.0);  // true
io:println(1.0 === 12.0);  // false
io:println(float:NaN === float:NaN);  // true
io:println(-0.0 === 0.0);  // false
```

Fixes #32054

## Approach

## Samples

## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
