### PR TITLE
Fix floating point numerical comparisons

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -407,22 +407,6 @@ public class TypeChecker {
     }
 
     /**
-     * Equality check for float values.
-     *
-     * @param lhsValue The value on the left-hand side
-     * @param rhsValue The value of the right-hand side
-     * @return True if values are equal, else false.
-     */
-
-    public static boolean checkFloatEqual(double lhsValue, double rhsValue) {
-        if (Double.isNaN(lhsValue) && Double.isNaN(rhsValue)) {
-            return true;
-        } else {
-            return lhsValue == rhsValue;
-        }
-    }
-
-    /**
      * Check if two decimal values are equal in value.
      *
      * @param lhsValue The value on the left hand side
@@ -430,12 +414,29 @@ public class TypeChecker {
      * @return True if values are equal, else false.
      */
     public static boolean checkDecimalEqual(DecimalValue lhsValue, DecimalValue rhsValue) {
-        if (lhsValue.valueKind == DecimalValueKind.NOT_A_NUMBER &&
-                rhsValue.valueKind == DecimalValueKind.NOT_A_NUMBER) {
+        if (lhsValue.getValueKind() == DecimalValueKind.NOT_A_NUMBER &&
+                rhsValue.getValueKind() == DecimalValueKind.NOT_A_NUMBER) {
             return true;
         }
         return isDecimalRealNumber(lhsValue) && isDecimalRealNumber(rhsValue) &&
                lhsValue.decimalValue().compareTo(rhsValue.decimalValue()) == 0;
+    }
+
+    /**
+     * Check if two decimal values are exactly equal.
+     *
+     * @param lhsValue The value on the left-hand side
+     * @param rhsValue The value of the right-hand side
+     * @return True if values are exactly equal, else false.
+     */
+
+    public static boolean checkDecimalExactEqual(DecimalValue lhsValue, DecimalValue rhsValue) {
+        if ((lhsValue.getValueKind() == DecimalValueKind.NOT_A_NUMBER &&
+                rhsValue.getValueKind() == DecimalValueKind.NOT_A_NUMBER)) {
+            return true;
+        }
+        return isDecimalRealNumber(lhsValue) && isDecimalRealNumber(rhsValue)
+                && lhsValue.decimalValue().equals(rhsValue.decimalValue());
     }
 
     /**

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -407,15 +407,19 @@ public class TypeChecker {
     }
 
     /**
-     * Reference equality check for float values.
+     * Equality check for float values.
      *
      * @param lhsValue The value on the left-hand side
      * @param rhsValue The value of the right-hand side
-     * @return True if values are reference equal, else false.
+     * @return True if values are equal, else false.
      */
 
-    public static boolean checkFloatExactEqual(double lhsValue, double rhsValue) {
-        return Double.valueOf(lhsValue).equals(rhsValue);
+    public static boolean checkFloatEqual(double lhsValue, double rhsValue) {
+        if (Double.isNaN(lhsValue) && Double.isNaN(rhsValue)) {
+            return true;
+        } else {
+            return lhsValue == rhsValue;
+        }
     }
 
     /**
@@ -426,6 +430,10 @@ public class TypeChecker {
      * @return True if values are equal, else false.
      */
     public static boolean checkDecimalEqual(DecimalValue lhsValue, DecimalValue rhsValue) {
+        if (lhsValue.valueKind == DecimalValueKind.NOT_A_NUMBER &&
+                rhsValue.valueKind == DecimalValueKind.NOT_A_NUMBER) {
+            return true;
+        }
         return isDecimalRealNumber(lhsValue) && isDecimalRealNumber(rhsValue) &&
                lhsValue.decimalValue().compareTo(rhsValue.decimalValue()) == 0;
     }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -414,10 +414,6 @@ public class TypeChecker {
      * @return True if values are equal, else false.
      */
     public static boolean checkDecimalEqual(DecimalValue lhsValue, DecimalValue rhsValue) {
-        if (lhsValue.getValueKind() == DecimalValueKind.NOT_A_NUMBER &&
-                rhsValue.getValueKind() == DecimalValueKind.NOT_A_NUMBER) {
-            return true;
-        }
         return isDecimalRealNumber(lhsValue) && isDecimalRealNumber(rhsValue) &&
                lhsValue.decimalValue().compareTo(rhsValue.decimalValue()) == 0;
     }
@@ -431,10 +427,6 @@ public class TypeChecker {
      */
 
     public static boolean checkDecimalExactEqual(DecimalValue lhsValue, DecimalValue rhsValue) {
-        if ((lhsValue.getValueKind() == DecimalValueKind.NOT_A_NUMBER &&
-                rhsValue.getValueKind() == DecimalValueKind.NOT_A_NUMBER)) {
-            return true;
-        }
         return isDecimalRealNumber(lhsValue) && isDecimalRealNumber(rhsValue)
                 && lhsValue.decimalValue().equals(rhsValue.decimalValue());
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
@@ -292,8 +292,8 @@ public class JvmConstants {
     public static final String ANY_TO_BOOLEAN_METHOD = "anyToBoolean";
     public static final String DECIMAL_VALUE_OF_J_METHOD = "valueOfJ";
     public static final String VALUE_OF_METHOD = "valueOf";
+    public static final String EQUALS_METHOD = "equals";
     public static final String POPULATE_INITIAL_VALUES_METHOD = "populateInitialValues";
-    public static final String CHECK_FLOAT_EXACT_EQUAL = "checkFloatExactEqual";
     public static final String CREATE_TYPES_METHOD = "$createTypes";
     public static final String CREATE_TYPE_INSTANCES_METHOD = "$createTypeInstances";
     public static final String GLOBAL_LOCK_NAME = "lock";

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
@@ -130,8 +130,9 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.B_MAP;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.B_MAPPING_INITIAL_VALUE_ENTRY;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.B_OBJECT;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.B_XML_QNAME;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.CHECK_FLOAT_EXACT_EQUAL;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.DECIMAL_VALUE;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.DOUBLE_VALUE;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.EQUALS_METHOD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.ERROR_VALUE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.FUNCTION;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.FUNCTION_POINTER;
@@ -164,6 +165,7 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.TYPEDESC_
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.TYPEDESC_VALUE_IMPL;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.TYPE_CHECKER;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.VALUE_COMPARISON_UTILS;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.VALUE_OF_METHOD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.XML_FACTORY;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.XML_QNAME;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.XML_SEQUENCE;
@@ -715,30 +717,47 @@ public class JvmInstructionGen {
 
     private void generateEqualIns(BIRNonTerminator.BinaryOp binaryIns) {
 
-        this.generateBinaryRhsAndLhsLoad(binaryIns);
-
         Label label1 = new Label();
         Label label2 = new Label();
+        Label label3 = new Label();
 
         BType lhsOpType = binaryIns.rhsOp1.variableDcl.type;
         BType rhsOpType = binaryIns.rhsOp2.variableDcl.type;
 
         if (TypeTags.isIntegerTypeTag(lhsOpType.tag) && TypeTags.isIntegerTypeTag(rhsOpType.tag)) {
+            this.generateBinaryRhsAndLhsLoad(binaryIns);
             this.mv.visitInsn(LCMP);
             this.mv.visitJumpInsn(IFNE, label1);
         } else if (lhsOpType.tag == TypeTags.BYTE && rhsOpType.tag == TypeTags.BYTE) {
+            this.generateBinaryRhsAndLhsLoad(binaryIns);
             this.mv.visitJumpInsn(IF_ICMPNE, label1);
         } else if (lhsOpType.tag == TypeTags.FLOAT && rhsOpType.tag == TypeTags.FLOAT) {
+            this.loadVar(binaryIns.rhsOp1.variableDcl);
+            this.mv.visitMethodInsn(INVOKESTATIC, "java/lang/Double", "isNaN", "(D)Z", false);
+            this.mv.visitJumpInsn(IFEQ, label3);
+            this.loadVar(binaryIns.rhsOp2.variableDcl);
+            this.mv.visitMethodInsn(INVOKESTATIC, "java/lang/Double", "isNaN", "(D)Z", false);
+            this.mv.visitJumpInsn(IFEQ, label3);
+
+            this.mv.visitInsn(ICONST_1);
+            this.mv.visitJumpInsn(GOTO, label2);
+
+            this.mv.visitLabel(label3);
+            this.generateBinaryRhsAndLhsLoad(binaryIns);
             this.mv.visitInsn(DCMPL);
             this.mv.visitJumpInsn(IFNE, label1);
+
         } else if (lhsOpType.tag == TypeTags.BOOLEAN && rhsOpType.tag == TypeTags.BOOLEAN) {
+            this.generateBinaryRhsAndLhsLoad(binaryIns);
             this.mv.visitJumpInsn(IF_ICMPNE, label1);
         } else if (lhsOpType.tag == TypeTags.DECIMAL && rhsOpType.tag == TypeTags.DECIMAL) {
+            this.generateBinaryRhsAndLhsLoad(binaryIns);
             this.mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "checkDecimalEqual",
                     String.format("(L%s;L%s;)Z", DECIMAL_VALUE, DECIMAL_VALUE), false);
             this.storeToVar(binaryIns.lhsOp.variableDcl);
             return;
         } else {
+            this.generateBinaryRhsAndLhsLoad(binaryIns);
             this.mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "isEqual",
                     String.format("(L%s;L%s;)Z", OBJECT, OBJECT), false);
             this.storeToVar(binaryIns.lhsOp.variableDcl);
@@ -771,8 +790,8 @@ public class JvmInstructionGen {
         } else if (lhsOpType.tag == TypeTags.BYTE && rhsOpType.tag == TypeTags.BYTE) {
             this.mv.visitJumpInsn(IF_ICMPEQ, label1);
         } else if (lhsOpType.tag == TypeTags.FLOAT && rhsOpType.tag == TypeTags.FLOAT) {
-            this.mv.visitInsn(DCMPL);
-            this.mv.visitJumpInsn(IFEQ, label1);
+            this.mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "checkFloatEqual", "(DD)Z", false);
+            this.mv.visitJumpInsn(IFNE, label1);
         } else if (lhsOpType.tag == TypeTags.BOOLEAN && rhsOpType.tag == TypeTags.BOOLEAN) {
             this.mv.visitJumpInsn(IF_ICMPEQ, label1);
         } else if (lhsOpType.tag == TypeTags.DECIMAL && rhsOpType.tag == TypeTags.DECIMAL) {
@@ -797,25 +816,34 @@ public class JvmInstructionGen {
 
     private void generateRefEqualIns(BIRNonTerminator.BinaryOp binaryIns) {
 
-        this.generateBinaryRhsAndLhsLoad(binaryIns);
-
         Label label1 = new Label();
         Label label2 = new Label();
 
         BType lhsOpType = binaryIns.rhsOp1.variableDcl.type;
         BType rhsOpType = binaryIns.rhsOp2.variableDcl.type;
         if (TypeTags.isIntegerTypeTag(lhsOpType.tag) && TypeTags.isIntegerTypeTag(rhsOpType.tag)) {
+            this.generateBinaryRhsAndLhsLoad(binaryIns);
             this.mv.visitInsn(LCMP);
             this.mv.visitJumpInsn(IFNE, label1);
         } else if (lhsOpType.tag == TypeTags.BYTE && rhsOpType.tag == TypeTags.BYTE) {
+            this.generateBinaryRhsAndLhsLoad(binaryIns);
             this.mv.visitJumpInsn(IF_ICMPNE, label1);
         } else if (lhsOpType.tag == TypeTags.FLOAT && rhsOpType.tag == TypeTags.FLOAT) {
-            this.mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, CHECK_FLOAT_EXACT_EQUAL, "(DD)Z", false);
+            this.loadVar(binaryIns.rhsOp1.variableDcl);
+            this.mv.visitMethodInsn(INVOKESTATIC, DOUBLE_VALUE, VALUE_OF_METHOD,
+                    String.format("(D)L%s;", DOUBLE_VALUE), false);
+            this.loadVar(binaryIns.rhsOp2.variableDcl);
+            this.mv.visitMethodInsn(INVOKESTATIC, DOUBLE_VALUE, VALUE_OF_METHOD,
+                    String.format("(D)L%s;", DOUBLE_VALUE), false);
+            this.mv.visitMethodInsn(INVOKEVIRTUAL, DOUBLE_VALUE, EQUALS_METHOD,
+                    String.format("(L%s;)Z", OBJECT), false);
             this.storeToVar(binaryIns.lhsOp.variableDcl);
             return;
         } else if (lhsOpType.tag == TypeTags.BOOLEAN && rhsOpType.tag == TypeTags.BOOLEAN) {
+            this.generateBinaryRhsAndLhsLoad(binaryIns);
             this.mv.visitJumpInsn(IF_ICMPNE, label1);
         } else {
+            this.generateBinaryRhsAndLhsLoad(binaryIns);
             this.mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "isReferenceEqual",
                     String.format("(L%s;L%s;)Z", OBJECT, OBJECT), false);
             this.storeToVar(binaryIns.lhsOp.variableDcl);
@@ -834,8 +862,6 @@ public class JvmInstructionGen {
 
     private void generateRefNotEqualIns(BIRNonTerminator.BinaryOp binaryIns) {
 
-        this.generateBinaryRhsAndLhsLoad(binaryIns);
-
         Label label1 = new Label();
         Label label2 = new Label();
 
@@ -843,16 +869,27 @@ public class JvmInstructionGen {
         BType lhsOpType = binaryIns.rhsOp1.variableDcl.type;
         BType rhsOpType = binaryIns.rhsOp2.variableDcl.type;
         if (TypeTags.isIntegerTypeTag(lhsOpType.tag) && TypeTags.isIntegerTypeTag(rhsOpType.tag)) {
+            this.generateBinaryRhsAndLhsLoad(binaryIns);
             this.mv.visitInsn(LCMP);
             this.mv.visitJumpInsn(IFEQ, label1);
         } else if (lhsOpType.tag == TypeTags.BYTE && rhsOpType.tag == TypeTags.BYTE) {
+            this.generateBinaryRhsAndLhsLoad(binaryIns);
             this.mv.visitJumpInsn(IF_ICMPEQ, label1);
         } else if (lhsOpType.tag == TypeTags.FLOAT && rhsOpType.tag == TypeTags.FLOAT) {
-            this.mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, CHECK_FLOAT_EXACT_EQUAL, "(DD)Z", false);
+            this.loadVar(binaryIns.rhsOp1.variableDcl);
+            this.mv.visitMethodInsn(INVOKESTATIC, DOUBLE_VALUE, VALUE_OF_METHOD,
+                    String.format("(D)L%s;", DOUBLE_VALUE), false);
+            this.loadVar(binaryIns.rhsOp2.variableDcl);
+            this.mv.visitMethodInsn(INVOKESTATIC, DOUBLE_VALUE, VALUE_OF_METHOD,
+                    String.format("(D)L%s;", DOUBLE_VALUE), false);
+            this.mv.visitMethodInsn(INVOKEVIRTUAL, DOUBLE_VALUE, EQUALS_METHOD,
+                    String.format("(L%s;)Z", OBJECT), false);
             this.mv.visitJumpInsn(IFNE, label1);
         } else if (lhsOpType.tag == TypeTags.BOOLEAN && rhsOpType.tag == TypeTags.BOOLEAN) {
+            this.generateBinaryRhsAndLhsLoad(binaryIns);
             this.mv.visitJumpInsn(IF_ICMPEQ, label1);
         } else {
+            this.generateBinaryRhsAndLhsLoad(binaryIns);
             this.mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "isReferenceEqual",
                     String.format("(L%s;L%s;)Z", OBJECT, OBJECT), false);
             this.mv.visitJumpInsn(IFNE, label1);

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibDecimalTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibDecimalTest.java
@@ -306,4 +306,19 @@ public class LangLibDecimalTest {
     public void testLangLibCallOnFiniteType() {
         BRunUtil.invoke(compileResult, "testLangLibCallOnFiniteType");
     }
+
+    @Test(dataProvider = "functionsWithDecimalEqualityChecks")
+    public void testFunctionsWithDecimalEqualityChecks(String function) {
+        BRunUtil.invoke(compileResult, function);
+    }
+
+    @DataProvider
+    public  Object[] functionsWithDecimalEqualityChecks() {
+        return new String[] {
+                "testDecimalEquality",
+                "testDecimalNotEquality",
+                "testDecimalExactEquality",
+                "testDecimalNotExactEquality"
+        };
+    }
 }

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibFloatTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibFloatTest.java
@@ -81,14 +81,16 @@ public class LangLibFloatTest {
         BRunUtil.invoke(compileResult, "testLangLibCallOnFiniteType");
     }
 
-    @Test(dataProvider = "functionsWithFloatExactEqualityChecks")
-    public void testFunctionsWithFloatExactEqualityChecks(String function) {
+    @Test(dataProvider = "functionsWithFloatEqualityChecks")
+    public void testFunctionsWithFloatEqualityChecks(String function) {
         BRunUtil.invoke(compileResult, function);
     }
 
     @DataProvider
-    public  Object[] functionsWithFloatExactEqualityChecks() {
+    public  Object[] functionsWithFloatEqualityChecks() {
         return new String[] {
+                "testFloatEquality",
+                "testFloatNotEquality",
                 "testFloatExactEquality",
                 "testFloatNotExactEquality"
         };

--- a/langlib/langlib-test/src/test/resources/test-src/decimallib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/decimallib_test.bal
@@ -15,6 +15,7 @@
 // under the License.
 
 import ballerina/lang.'decimal as decimals;
+import ballerina/lang.test;
 
 function testSum(decimal p1, decimal p2) returns decimal {
     return decimals:sum(p1, p2);
@@ -98,6 +99,40 @@ function testLangLibCallOnFiniteType() {
     Decimals x = 12;
     decimal y = x.sum(1, 2, 3);
     assertEquality(18d, y);
+}
+
+decimal d1 = -0.0;
+decimal d2 = 0.0;
+decimal d3 = 1.0;
+decimal d4 = 2.0;
+decimal d5 = 2.00;
+
+function testDecimalEquality() {
+    test:assertTrue(d3 == d3);
+    test:assertFalse(d3 == d4);
+    test:assertTrue(d1/d2 == d2/d2);
+    test:assertTrue(d1 == d2);
+}
+
+function testDecimalNotEquality() {
+    test:assertFalse(d3 != d3);
+    test:assertTrue(d3 != d4);
+    test:assertFalse(d1/d2 != d2/d2);
+    test:assertFalse(d1 != d2);
+}
+
+function testDecimalExactEquality() {
+    test:assertTrue(d5 === d5);
+    test:assertFalse(d3 === d4);
+    test:assertTrue(d1/d2 === d2/d2);
+    test:assertTrue(d1 === d2);
+}
+
+function testDecimalNotExactEquality() {
+    test:assertFalse(d5 !== d5);
+    test:assertTrue(d3 !== d4);
+    test:assertFalse(d1/d2 !== d2/d2);
+    test:assertFalse(d1 !== d2);
 }
 
 function assertEquality(any|error expected, any|error actual) {

--- a/langlib/langlib-test/src/test/resources/test-src/decimallib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/decimallib_test.bal
@@ -110,28 +110,28 @@ decimal d5 = 2.00;
 function testDecimalEquality() {
     test:assertTrue(d3 == d3);
     test:assertFalse(d3 == d4);
-    test:assertTrue(d1/d2 == d2/d2);
+    test:assertTrue(d4 == d5);
     test:assertTrue(d1 == d2);
 }
 
 function testDecimalNotEquality() {
     test:assertFalse(d3 != d3);
     test:assertTrue(d3 != d4);
-    test:assertFalse(d1/d2 != d2/d2);
+    test:assertFalse(d4 != d5);
     test:assertFalse(d1 != d2);
 }
 
 function testDecimalExactEquality() {
     test:assertTrue(d5 === d5);
     test:assertFalse(d3 === d4);
-    test:assertTrue(d1/d2 === d2/d2);
+    test:assertFalse(d4 === d5);
     test:assertTrue(d1 === d2);
 }
 
 function testDecimalNotExactEquality() {
     test:assertFalse(d5 !== d5);
     test:assertTrue(d3 !== d4);
-    test:assertFalse(d1/d2 !== d2/d2);
+    test:assertTrue(d4 !== d5);
     test:assertFalse(d1 !== d2);
 }
 

--- a/langlib/langlib-test/src/test/resources/test-src/floatlib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/floatlib_test.bal
@@ -45,6 +45,20 @@ function testLangLibCallOnFiniteType() {
     test:assertValueEqual(24.3, y);
 }
 
+function testFloatEquality() {
+    test:assertTrue(42.0 == 42.0);
+    test:assertFalse(1.0 == 12.0);
+    test:assertTrue(float:NaN == float:NaN);
+    test:assertTrue(-0.0 == 0.0);
+}
+
+function testFloatNotEquality() {
+    test:assertFalse(42.0 != 42.0);
+    test:assertTrue(1.0 != 12.0);
+    test:assertFalse(float:NaN != float:NaN);
+    test:assertFalse(-0.0 != 0.0);
+}
+
 function testFloatExactEquality() {
     test:assertTrue(42.0 === 42.0);
     test:assertFalse(1.0 === 12.0);


### PR DESCRIPTION
## Purpose
> Fixes the incorrect results given for floating point numerical comparisons.
```
float nan = 0.0/0.0;

nan == nan  // true
nan != nan  // false
nan === nan  // true
nan !== nan  // false

-0.0 === 0.0 // false
-0.0 == +0.0  // true

decimal d1 = +0.0;
decimal d2 = -0.0;
d1 == d2  // true
d1 === d2 // true
```


Fixes #17977

## Approach

## Samples

## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
