### PR TITLE
Fix duplicate variables issue when an EE covers more than one BB

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
@@ -646,8 +646,10 @@ class JvmObservabilityGen {
                         BIRBasicBlock newTargetBB = insertBasicBlock(func, eeTargetIndex + 3);
                         swapBasicBlockContent(errorEntry.targetBB, newTargetBB);
 
+                        String uniqueId = String.format("%s$%s", INVOCATION_INSTRUMENTATION_TYPE,
+                                newCurrentBB.id.value); // Unique ID to work with EEs covering multiple BBs
                         injectCheckErrorCalls(errorEntry.targetBB, errorReportBB, newTargetBB, func.localVars,
-                                desugaredInsPos, errorEntry.errorOp, INVOCATION_INSTRUMENTATION_TYPE);
+                                desugaredInsPos, errorEntry.errorOp, uniqueId);
                         injectReportErrorCall(errorReportBB, func.localVars, desugaredInsPos, errorEntry.errorOp,
                                 INVOCATION_INSTRUMENTATION_TYPE);
                         injectStopObservationCall(observeEndBB, desugaredInsPos);


### PR DESCRIPTION
## Purpose
> Fix duplicate variables issue when an EE covers more than one BB

Fixes #32074

## Approach
> The Observability Instrumentation had been written assuming that an EE only covers a single BB (since a trap can only cover a single call instruction). However in places such as in transactions, EEs had been created which spans across multiple BBs. Therefore, a unique ID had been added to avoid duplicates in such scenarios.

## Samples
> N/A

## Remarks
> N/A

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [x] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
