### PR TITLE
[WIP] Fix `typeof` expression providing wrong outputs

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/values/BMap.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/values/BMap.java
@@ -192,7 +192,5 @@ public interface BMap<K, V> extends BRefValue, BCollection {
 
     Object merge(BMap v2, boolean checkMergeability);
 
-    BTypedesc getTypedesc();
-
     void populateInitialValue(K key, V value);
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/values/BRefValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/values/BRefValue.java
@@ -94,4 +94,6 @@ public interface BRefValue extends BValue {
             throw new BallerinaException("error occurred while serializing data", e);
         }
     }
+
+    BTypedesc getTypedesc();
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -519,6 +519,9 @@ public class TypeChecker {
         if (type == null) {
             return null;
         }
+        if (isSimpleBasicType(type)) {
+            type = new BFiniteType(value.toString(), Set.of(value), 0);
+        }
         if (value instanceof MapValue) {
             TypedescValue typedesc = (TypedescValue) ((MapValue) value).getTypedesc();
             if (typedesc != null) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -520,13 +520,10 @@ public class TypeChecker {
             return null;
         }
         if (isSimpleBasicType(type)) {
-            type = new BFiniteType(value.toString(), Set.of(value), 0);
+            return new TypedescValueImpl(new BFiniteType(value.toString(), Set.of(value), 0));
         }
-        if (value instanceof MapValue) {
-            TypedescValue typedesc = (TypedescValue) ((MapValue) value).getTypedesc();
-            if (typedesc != null) {
-                return typedesc;
-            }
+        if (value instanceof RefValue) {
+            return (TypedescValue) ((RefValue) value).getTypedesc();
         }
         return new TypedescValueImpl(type);
     }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/AbstractObjectValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/AbstractObjectValue.java
@@ -29,6 +29,7 @@ import io.ballerina.runtime.api.values.BLink;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
+import io.ballerina.runtime.api.values.BTypedesc;
 import io.ballerina.runtime.internal.TypeChecker;
 import io.ballerina.runtime.internal.types.BObjectType;
 import io.ballerina.runtime.internal.util.exceptions.BLangExceptionHelper;
@@ -56,13 +57,14 @@ import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReason
  * @since 0.995.0
  */
 public abstract class AbstractObjectValue implements ObjectValue {
-
+    private BTypedesc typedesc;
     private BObjectType type;
 
     private final HashMap<String, Object> nativeData = new HashMap<>();
 
     public AbstractObjectValue(BObjectType type) {
         this.type = type;
+        this.typedesc = new TypedescValueImpl(type);
     }
 
     @Override
@@ -175,6 +177,11 @@ public abstract class AbstractObjectValue implements ObjectValue {
         }
 
         return sj.toString();
+    }
+
+    @Override
+    public BTypedesc getTypedesc() {
+        return typedesc;
     }
 
     private String getStringValue(Object value) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ArrayValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ArrayValueImpl.java
@@ -28,6 +28,7 @@ import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.values.BLink;
 import io.ballerina.runtime.api.values.BListInitialValueEntry;
 import io.ballerina.runtime.api.values.BString;
+import io.ballerina.runtime.api.values.BTypedesc;
 import io.ballerina.runtime.api.values.BValue;
 import io.ballerina.runtime.internal.CycleUtils;
 import io.ballerina.runtime.internal.TypeChecker;
@@ -74,6 +75,7 @@ public class ArrayValueImpl extends AbstractArrayValue {
     private byte[] byteValues;
     private double[] floatValues;
     private BString[] bStringValues;
+    private BTypedesc typedesc;
     // ------------------------ Constructors -------------------------------------------------------------------
 
     public ArrayValueImpl(Object[] values, ArrayType type) {
@@ -83,30 +85,35 @@ public class ArrayValueImpl extends AbstractArrayValue {
         if (type.getTag() == TypeTags.ARRAY_TAG) {
             this.elementType = type.getElementType();
         }
+        setTypedescValue();
     }
 
     public ArrayValueImpl(long[] values, boolean readonly) {
         this.intValues = values;
         this.size = values.length;
         setArrayType(PredefinedTypes.TYPE_INT, readonly);
+        setTypedescValue();
     }
 
     public ArrayValueImpl(boolean[] values, boolean readonly) {
         this.booleanValues = values;
         this.size = values.length;
         setArrayType(PredefinedTypes.TYPE_BOOLEAN, readonly);
+        setTypedescValue();
     }
 
     public ArrayValueImpl(byte[] values, boolean readonly) {
         this.byteValues = values;
         this.size = values.length;
         setArrayType(PredefinedTypes.TYPE_BYTE, readonly);
+        setTypedescValue();
     }
 
     public ArrayValueImpl(double[] values, boolean readonly) {
         this.floatValues = values;
         this.size = values.length;
         setArrayType(PredefinedTypes.TYPE_FLOAT, readonly);
+        setTypedescValue();
     }
 
     public ArrayValueImpl(String[] values, boolean readonly) {
@@ -116,12 +123,18 @@ public class ArrayValueImpl extends AbstractArrayValue {
             bStringValues[i] = StringUtils.fromString(values[i]);
         }
         setArrayType(PredefinedTypes.TYPE_STRING, readonly);
+        setTypedescValue();
+    }
+
+    private void setTypedescValue() {
+        this.typedesc = new TypedescValueImpl(this.arrayType);
     }
 
     public ArrayValueImpl(BString[] values, boolean readonly) {
         this.bStringValues = values;
         this.size = values.length;
         setArrayType(PredefinedTypes.TYPE_STRING, readonly);
+        setTypedescValue();
     }
 
     public ArrayValueImpl(ArrayType type) {
@@ -131,6 +144,7 @@ public class ArrayValueImpl extends AbstractArrayValue {
         if (type.getState() == ArrayState.CLOSED) {
             this.size = maxSize = type.getSize();
         }
+        setTypedescValue();
     }
 
     private void initArrayValues(Type elementType) {
@@ -165,6 +179,11 @@ public class ArrayValueImpl extends AbstractArrayValue {
                     fillValues(initialArraySize);
                 }
         }
+    }
+
+    @Override
+    public BTypedesc getTypedesc() {
+        return typedesc;
     }
 
     @Override
@@ -229,6 +248,7 @@ public class ArrayValueImpl extends AbstractArrayValue {
         if (size != -1) {
             this.size = this.maxSize = (int) size;
         }
+        setTypedescValue();
     }
 
     public ArrayValueImpl(ArrayType type, long size, BListInitialValueEntry[] initialValues) {
@@ -244,7 +264,7 @@ public class ArrayValueImpl extends AbstractArrayValue {
         if (size != -1) {
             this.size = this.maxSize = (int) size;
         }
-
+        setTypedescValue();
         for (int index = 0; index < initialValues.length; index++) {
             addRefValue(index, ((ListInitialValueEntry.ExpressionEntry) initialValues[index]).value);
         }
@@ -933,6 +953,7 @@ public class ArrayValueImpl extends AbstractArrayValue {
         }
 
         this.arrayType = (ArrayType) ReadOnlyUtils.setImmutableTypeAndGetEffectiveType(this.arrayType);
+//        this.typedesc = new TypedescValueImpl(new BFiniteType(toString(), Set.of(this), 0));
         if (this.elementType == null || this.elementType.getTag() > TypeTags.BOOLEAN_TAG) {
             for (int i = 0; i < this.size; i++) {
                 Object value = this.getRefValue(i);

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ErrorValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ErrorValue.java
@@ -28,6 +28,7 @@ import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.api.values.BLink;
 import io.ballerina.runtime.api.values.BString;
+import io.ballerina.runtime.api.values.BTypedesc;
 import io.ballerina.runtime.api.values.BValue;
 import io.ballerina.runtime.internal.CycleUtils;
 import io.ballerina.runtime.internal.TypeChecker;
@@ -64,6 +65,7 @@ public class ErrorValue extends BError implements RefValue {
     private static final PrintStream outStream = System.err;
 
     private final Type type;
+    private final BTypedesc typedesc;
     private final BString message;
     private final BError cause;
     private final Object details;
@@ -92,6 +94,7 @@ public class ErrorValue extends BError implements RefValue {
         this.message = message;
         this.cause = cause;
         this.details = details;
+        this.typedesc = new TypedescValueImpl(type);
     }
 
     public ErrorValue(Type type, BString message, BError cause, Object details,
@@ -104,6 +107,7 @@ public class ErrorValue extends BError implements RefValue {
         BTypeIdSet typeIdSet = new BTypeIdSet();
         typeIdSet.add(typeIdPkg, typeIdName, true);
         ((BErrorType) type).setTypeIdSet(typeIdSet);
+        this.typedesc = new TypedescValueImpl(type);
     }
 
     @Override
@@ -215,6 +219,10 @@ public class ErrorValue extends BError implements RefValue {
     public Object frozenCopy(Map<Object, Object> refs) {
         // Error values are immutable and frozen, copy give same value.
         return this;
+    }
+
+    public BTypedesc getTypedesc() {
+        return typedesc;
     }
 
     /**

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/FPValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/FPValue.java
@@ -23,6 +23,7 @@ import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.values.BFunctionPointer;
 import io.ballerina.runtime.api.values.BFuture;
 import io.ballerina.runtime.api.values.BLink;
+import io.ballerina.runtime.api.values.BTypedesc;
 import io.ballerina.runtime.internal.scheduling.AsyncUtils;
 import io.ballerina.runtime.internal.scheduling.Scheduler;
 
@@ -46,6 +47,7 @@ import java.util.function.Function;
 public class FPValue<T, R> implements BFunctionPointer<T, R>, RefValue {
 
     final Type type;
+    private final BTypedesc typedesc;
     Function<T, R> function;
     public boolean isConcurrent;
     public String strandName;
@@ -56,6 +58,7 @@ public class FPValue<T, R> implements BFunctionPointer<T, R>, RefValue {
         this.type = type;
         this.strandName = strandName;
         this.isConcurrent = isConcurrent;
+        this.typedesc = new TypedescValueImpl(type);
     }
 
     public R call(T t) {
@@ -109,6 +112,11 @@ public class FPValue<T, R> implements BFunctionPointer<T, R>, RefValue {
     @Override
     public void freezeDirect() {
         return;
+    }
+
+    @Override
+    public BTypedesc getTypedesc() {
+        return typedesc;
     }
 
     @Override

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/FutureValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/FutureValue.java
@@ -21,6 +21,7 @@ package io.ballerina.runtime.internal.values;
  import io.ballerina.runtime.api.types.Type;
  import io.ballerina.runtime.api.values.BFuture;
  import io.ballerina.runtime.api.values.BLink;
+ import io.ballerina.runtime.api.values.BTypedesc;
  import io.ballerina.runtime.internal.scheduling.Strand;
  import io.ballerina.runtime.internal.types.BFutureType;
 
@@ -39,7 +40,9 @@ package io.ballerina.runtime.internal.values;
  */
  public class FutureValue implements BFuture, RefValue {
 
-     public Strand strand;
+    private final BTypedesc typedesc;
+
+    public Strand strand;
 
      public Object result;
 
@@ -58,7 +61,8 @@ package io.ballerina.runtime.internal.values;
          this.strand = strand;
          this.callback = callback;
          this.type = new BFutureType(constraint);
-     }
+        this.typedesc = new TypedescValueImpl(this.type);
+    }
 
      @Override
      public String stringValue(BLink parent) {
@@ -93,7 +97,12 @@ package io.ballerina.runtime.internal.values;
          throw new UnsupportedOperationException();
      }
 
-     public void cancel() {
+    @Override
+    public BTypedesc getTypedesc() {
+        return typedesc;
+    }
+
+    public void cancel() {
          this.strand.cancel = true;
      }
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/HandleValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/HandleValue.java
@@ -21,6 +21,7 @@ import io.ballerina.runtime.api.PredefinedTypes;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.values.BHandle;
 import io.ballerina.runtime.api.values.BLink;
+import io.ballerina.runtime.api.values.BTypedesc;
 
 import java.util.Map;
 
@@ -37,6 +38,7 @@ import java.util.Map;
 public class HandleValue implements BHandle, RefValue {
 
     private Object value;
+    private final BTypedesc typedesc = new TypedescValueImpl(PredefinedTypes.TYPE_HANDLE);
 
     @Deprecated
     public HandleValue(Object value) {
@@ -79,6 +81,11 @@ public class HandleValue implements BHandle, RefValue {
     @Override
     public void freezeDirect() {
         return;
+    }
+
+    @Override
+    public BTypedesc getTypedesc() {
+        return typedesc;
     }
 
     @Override

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/IteratorValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/IteratorValue.java
@@ -21,6 +21,7 @@ import io.ballerina.runtime.api.PredefinedTypes;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.values.BIterator;
 import io.ballerina.runtime.api.values.BLink;
+import io.ballerina.runtime.api.values.BTypedesc;
 
 import java.util.Map;
 
@@ -35,6 +36,8 @@ import java.util.Map;
  * @since 0.995.0
  */
 public interface IteratorValue extends RefValue, BIterator {
+
+    final BTypedesc TYPEDESC = new TypedescValueImpl(PredefinedTypes.TYPE_ITERATOR);
 
     /* Default implementation */
 
@@ -61,5 +64,10 @@ public interface IteratorValue extends RefValue, BIterator {
     @Override
     default Object frozenCopy(Map<Object, Object> refs) {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    default BTypedesc getTypedesc() {
+        return TYPEDESC;
     }
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValueImpl.java
@@ -101,17 +101,24 @@ public class MapValueImpl<K, V> extends LinkedHashMap<K, V> implements RefValue,
     public MapValueImpl(Type type) {
         super();
         this.type = type;
+        setTypedescValue();
     }
 
     public MapValueImpl(Type type, BMapInitialValueEntry[] initialValues) {
         super();
         this.type = type;
+        setTypedescValue();
         populateInitialValues(initialValues);
     }
 
     public MapValueImpl() {
         super();
         type = PredefinedTypes.TYPE_MAP;
+        setTypedescValue();
+    }
+
+    private void setTypedescValue() {
+        this.typedesc = new TypedescValueImpl(this.type);
     }
 
     public Long getIntValue(BString key) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/StreamValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/StreamValue.java
@@ -22,6 +22,7 @@ import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.values.BLink;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BStream;
+import io.ballerina.runtime.api.values.BTypedesc;
 import io.ballerina.runtime.internal.IteratorUtils;
 import io.ballerina.runtime.internal.types.BStreamType;
 
@@ -40,6 +41,7 @@ import java.util.UUID;
  */
 public class StreamValue implements RefValue, BStream {
 
+    private final BTypedesc typedesc;
     private Type type;
     private Type constraintType;
     private Type completionType;
@@ -59,6 +61,7 @@ public class StreamValue implements RefValue, BStream {
         this.type = new BStreamType(constraintType, completionType);
         this.streamId = UUID.randomUUID().toString();
         this.iteratorObj = null;
+        this.typedesc = new TypedescValueImpl(type);
     }
 
     public StreamValue(Type type, BObject iteratorObj) {
@@ -67,6 +70,7 @@ public class StreamValue implements RefValue, BStream {
         this.type = new BStreamType(constraintType, completionType);
         this.streamId = UUID.randomUUID().toString();
         this.iteratorObj = iteratorObj;
+        this.typedesc = new TypedescValueImpl(type);
     }
 
     public String getStreamId() {
@@ -116,6 +120,11 @@ public class StreamValue implements RefValue, BStream {
      */
     public Object frozenCopy(Map<Object, Object> refs) {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BTypedesc getTypedesc() {
+        return typedesc;
     }
 
     public Type getConstraintType() {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TableValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TableValueImpl.java
@@ -30,6 +30,7 @@ import io.ballerina.runtime.api.values.BLink;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
+import io.ballerina.runtime.api.values.BTypedesc;
 import io.ballerina.runtime.internal.CycleUtils;
 import io.ballerina.runtime.internal.IteratorUtils;
 import io.ballerina.runtime.internal.TableUtils;
@@ -92,6 +93,7 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
     private boolean nextKeySupported;
 
     private final Map<String, Object> nativeData = new HashMap<>();
+    private BTypedesc typedesc;
 
     public TableValueImpl(TableType type) {
         this.type = type;
@@ -102,6 +104,7 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
         this.keyToIndexMap = new LinkedHashMap<>();
         this.indexToKeyMap = new LinkedHashMap<>();
         this.fieldNames = type.getFieldNames();
+        setTypedescValue();
         if (type.getFieldNames() != null) {
             this.valueHolder = new KeyHashValueHolder();
         } else {
@@ -177,6 +180,15 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
                                                StringUtils.fromString(e.getDetail()));
             }
         }
+    }
+
+    @Override
+    public BTypedesc getTypedesc() {
+        return typedesc;
+    }
+
+    private void setTypedescValue() {
+        this.typedesc = new TypedescValueImpl(this.type);
     }
 
     @Override

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TupleValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TupleValueImpl.java
@@ -25,6 +25,7 @@ import io.ballerina.runtime.api.values.BArray;
 import io.ballerina.runtime.api.values.BLink;
 import io.ballerina.runtime.api.values.BListInitialValueEntry;
 import io.ballerina.runtime.api.values.BString;
+import io.ballerina.runtime.api.values.BTypedesc;
 import io.ballerina.runtime.internal.CycleUtils;
 import io.ballerina.runtime.internal.TypeChecker;
 import io.ballerina.runtime.internal.util.exceptions.BLangExceptionHelper;
@@ -63,6 +64,7 @@ public class TupleValueImpl extends AbstractArrayValue {
     Object[] refValues;
     private int minSize;
     private boolean hasRestElement; // cached value for ease of access
+    private BTypedesc typedesc;
     // ------------------------ Constructors -------------------------------------------------------------------
 
     @Override
@@ -105,6 +107,7 @@ public class TupleValueImpl extends AbstractArrayValue {
         }
         this.minSize = memTypes.size();
         this.size = refValues.length;
+        setTypedescValue();
     }
 
     public TupleValueImpl(TupleType type) {
@@ -130,6 +133,7 @@ public class TupleValueImpl extends AbstractArrayValue {
             }
             this.refValues[i] = memType.getZeroValue();
         }
+        setTypedescValue();
     }
 
     public TupleValueImpl(TupleType type, long size, BListInitialValueEntry[] initialValues) {
@@ -141,6 +145,7 @@ public class TupleValueImpl extends AbstractArrayValue {
         this.size = size < memCount ? memCount : (int) size;
         this.minSize = memCount;
         this.hasRestElement = this.tupleType.getRestType() != null;
+        setTypedescValue();
 
         if (type.getRestType() == null) {
             this.maxSize = this.size;
@@ -165,6 +170,15 @@ public class TupleValueImpl extends AbstractArrayValue {
 
             this.refValues[i] = memType.getZeroValue();
         }
+    }
+
+    private void setTypedescValue() {
+        this.typedesc = new TypedescValueImpl(tupleType);
+    }
+
+    @Override
+    public BTypedesc getTypedesc() {
+        return typedesc;
     }
 
     // ----------------------- get methods ----------------------------------------------------

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TypedescValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TypedescValueImpl.java
@@ -22,6 +22,7 @@ import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.values.BInitialValueEntry;
 import io.ballerina.runtime.api.values.BLink;
 import io.ballerina.runtime.api.values.BMapInitialValueEntry;
+import io.ballerina.runtime.api.values.BTypedesc;
 import io.ballerina.runtime.internal.scheduling.Strand;
 import io.ballerina.runtime.internal.types.BTypedescType;
 import io.ballerina.runtime.internal.util.exceptions.BallerinaException;
@@ -117,6 +118,11 @@ public class TypedescValueImpl implements  TypedescValue {
     @Override
     public void freezeDirect() {
         return;
+    }
+
+    @Override
+    public BTypedesc getTypedesc() {
+        return new TypedescValueImpl(this.type);
     }
 
     /**

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlComment.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlComment.java
@@ -39,11 +39,13 @@ public class XmlComment extends XmlNonElementItem {
     public XmlComment(String data) {
         this.data = data;
         this.type = PredefinedTypes.TYPE_COMMENT;
+        setTypedescValue(type);
     }
 
     public XmlComment(String data, boolean readonly) {
         this.data = data;
         this.type = readonly ? PredefinedTypes.TYPE_READONLY_COMMENT : PredefinedTypes.TYPE_COMMENT;
+        setTypedescValue(type);
     }
 
     @Override

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlItem.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlItem.java
@@ -82,6 +82,7 @@ public final class XmlItem extends XmlValue implements BXmlItem {
         probableParents = new ArrayList<>();
         this.type = PredefinedTypes.TYPE_ELEMENT;
         this.type = readonly ? PredefinedTypes.TYPE_READONLY_ELEMENT : PredefinedTypes.TYPE_ELEMENT;
+        setTypedescValue(type);
     }
 
     public XmlItem(QName name, XmlSequence children) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlPi.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlPi.java
@@ -41,6 +41,7 @@ public class XmlPi extends XmlNonElementItem {
         this.data = data;
         this.target = target;
         this.type = PredefinedTypes.TYPE_PROCESSING_INSTRUCTION;
+        setTypedescValue(type);
     }
 
     public XmlPi(String data, String target, boolean readonly) {
@@ -48,6 +49,7 @@ public class XmlPi extends XmlNonElementItem {
         this.target = target;
         this.type = readonly ? PredefinedTypes.TYPE_READONLY_PROCESSING_INSTRUCTION :
                 PredefinedTypes.TYPE_PROCESSING_INSTRUCTION;
+        setTypedescValue(type);
     }
 
     @Override

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlQName.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlQName.java
@@ -21,6 +21,7 @@ import io.ballerina.runtime.api.PredefinedTypes;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.values.BLink;
 import io.ballerina.runtime.api.values.BString;
+import io.ballerina.runtime.api.values.BTypedesc;
 import io.ballerina.runtime.api.values.BXmlQName;
 
 import java.util.Map;
@@ -41,6 +42,7 @@ public final class XmlQName implements RefValue, BXmlQName {
     private String localName;
     private String uri;
     private String prefix;
+    private final BTypedesc typedesc = new TypedescValueImpl(PredefinedTypes.TYPE_XML_ATTRIBUTES);
 
     /**
      * Create attribute map with an XML.
@@ -130,6 +132,11 @@ public final class XmlQName implements RefValue, BXmlQName {
         }
 
         return new XmlQName(localName, uri, prefix);
+    }
+
+    @Override
+    public BTypedesc getTypedesc() {
+        return typedesc;
     }
 
     /**

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlSequence.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlSequence.java
@@ -63,6 +63,7 @@ public final class XmlSequence extends XmlValue implements BXmlSequence {
     public XmlSequence() {
         children = new ArrayList<>();
         this.type = PredefinedTypes.TYPE_XML_NEVER;
+        setTypedescValue(type);
     }
 
     public XmlSequence(List<BXml> children) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlValue.java
@@ -22,6 +22,7 @@ import io.ballerina.runtime.api.types.XmlNodeType;
 import io.ballerina.runtime.api.values.BLink;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BString;
+import io.ballerina.runtime.api.values.BTypedesc;
 import io.ballerina.runtime.api.values.BXml;
 import io.ballerina.runtime.api.values.BXmlQName;
 import io.ballerina.runtime.internal.BallerinaXmlSerializer;
@@ -51,6 +52,7 @@ import javax.xml.namespace.QName;
 public abstract class XmlValue implements RefValue, BXml, CollectionValue {
 
     Type type = PredefinedTypes.TYPE_XML;
+    protected TypedescValue typedesc = new TypedescValueImpl(type);
 
     public abstract int size();
 
@@ -238,4 +240,14 @@ public abstract class XmlValue implements RefValue, BXml, CollectionValue {
             handleXmlException("error occurred during writing the message to the output stream: ", t);
         }
     }
+
+    @Override
+    public BTypedesc getTypedesc() {
+        return typedesc;
+    }
+
+    protected void setTypedescValue(Type type) {
+        this.typedesc = new TypedescValueImpl(type);
+    }
+
 }

--- a/langlib/lang.error/src/main/java/org/ballerinalang/langlib/error/StackTrace.java
+++ b/langlib/lang.error/src/main/java/org/ballerinalang/langlib/error/StackTrace.java
@@ -34,6 +34,7 @@ import io.ballerina.runtime.api.values.BLink;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
+import io.ballerina.runtime.api.values.BTypedesc;
 import io.ballerina.runtime.internal.scheduling.Strand;
 
 import java.util.Collections;
@@ -111,9 +112,11 @@ public class StackTrace {
         BArray callStack;
 
         private ObjectType type;
+        private BTypedesc typedesc;
 
         public CallStack(ObjectType type) {
             this.type = type;
+            this.typedesc = ValueCreator.createTypedescValue(type);
         }
 
         @Override
@@ -213,5 +216,11 @@ public class StackTrace {
         public Object frozenCopy(Map<Object, Object> refs) {
             return null;
         }
+
+        @Override
+        public BTypedesc getTypedesc() {
+            return typedesc;
+        }
+
     }
 }

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/mock/GenericMockObjectValue.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/mock/GenericMockObjectValue.java
@@ -27,8 +27,10 @@ import io.ballerina.runtime.api.values.BLink;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
+import io.ballerina.runtime.api.values.BTypedesc;
 import io.ballerina.runtime.internal.scheduling.Strand;
 import io.ballerina.runtime.internal.util.exceptions.BallerinaException;
+import io.ballerina.runtime.internal.values.TypedescValueImpl;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -44,10 +46,12 @@ public class GenericMockObjectValue implements BObject {
     private BObject mockObj;
 
     private ObjectType type;
+    private BTypedesc typedesc;
 
     public GenericMockObjectValue(ObjectType type, BObject mockObj) {
         this.type = type;
         this.mockObj = mockObj;
+        this.typedesc = new TypedescValueImpl(type);
     }
 
     @Override
@@ -245,4 +249,10 @@ public class GenericMockObjectValue implements BObject {
     public Object frozenCopy(Map<Object, Object> refs) {
         return null;
     }
+
+    @Override
+    public BTypedesc getTypedesc() {
+        return typedesc;
+    }
+
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typeof/TypeofOverLiteralExpressionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typeof/TypeofOverLiteralExpressionTest.java
@@ -51,7 +51,7 @@ public class TypeofOverLiteralExpressionTest {
     }
 
     @DataProvider(name = "simple-value-provider")
-    public Object[][] provideSimpleTypValuese() {
+    public Object[][] provideSimpleTypValues() {
         return new Object[][]{
                 {new BInteger(1L), "1"},
                 {new BDecimal("2.0"), "2.0"},

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typeof/TypeofOverLiteralExpressionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typeof/TypeofOverLiteralExpressionTest.java
@@ -17,13 +17,18 @@
  */
 package org.ballerinalang.test.expressions.typeof;
 
+import org.ballerinalang.core.model.values.BBoolean;
+import org.ballerinalang.core.model.values.BDecimal;
+import org.ballerinalang.core.model.values.BFloat;
+import org.ballerinalang.core.model.values.BInteger;
+import org.ballerinalang.core.model.values.BString;
 import org.ballerinalang.core.model.values.BValue;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
-import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 /**
@@ -31,7 +36,6 @@ import org.testng.annotations.Test;
  *
  * @since 0.995
  */
-@Test(groups = "no-bvm-support")
 public class TypeofOverLiteralExpressionTest {
 
     private CompileResult result;
@@ -41,49 +45,33 @@ public class TypeofOverLiteralExpressionTest {
         result = BCompileUtil.compile("test-src/expressions/typeof/typeof.bal");
     }
 
-    @Test
-    public void testTypeDescOperatorOnLiterals() {
-        BValue[] res = BRunUtil.invoke(result, "typeDescOfLiterals");
-        Assert.assertEquals(res[0].stringValue(), "int");
-        Assert.assertEquals(res[1].stringValue(), "float");
-        Assert.assertEquals(res[2].stringValue(), "float");
-        Assert.assertEquals(res[3].stringValue(), "string");
-        Assert.assertEquals(res[4].stringValue(), "boolean");
-        Assert.assertEquals(res[5].stringValue(), "boolean");
-        Assert.assertEquals(res[6].stringValue(), "null");
+    @Test (dataProvider = "simple-value-provider")
+    public void testTypeDescOperatorOnLiterals(BValue value, String expected) {
+        BRunUtil.invoke(result, "typeDescOfLiterals", new BValue[] {value, new BString(expected)});
     }
 
-    @Test
-    public void testTypeDescOperatorOnExpressionsOfLiterals() {
-        BValue[] res = BRunUtil.invoke(result, "typeDescOfExpressionsOfLiterals");
-        Assert.assertEquals(res[0].stringValue(), "int");
-        Assert.assertEquals(res[1].stringValue(), "float");
+    @DataProvider(name = "simple-value-provider")
+    public Object[][] provideSimpleTypValuese() {
+        return new Object[][]{
+                {new BInteger(1L), "1"},
+                {new BDecimal("2.0"), "2.0"},
+                {new BFloat(2.1), "2.1"},
+                {new BString("str-literal"), "str-literal"},
+                {new BBoolean(true), "true"},
+                {new BBoolean(false), "false"},
+                {null, "()"},
+        };
     }
 
-    @Test
-    public void testUsingTypeofOperatorAtFunctionInvocationSite() {
-        BValue[] res = BRunUtil.invoke(result, "passTypeofToAFunction");
-        Assert.assertEquals(res[0].stringValue(), "int");
+    @Test (dataProvider = "function-provider")
+    public void testTypeOfExpression(String functionName) {
+        BRunUtil.invoke(result, functionName);
     }
 
-    @Test
-    public void getTypeDescOfASimpleRecordType() {
-        BValue[] res = BRunUtil.invoke(result, "typeDescOfARecord");
-        Assert.assertEquals(res[0].stringValue(), "RecType0");
-    }
-
-    @Test
-    public void getTypeDescOfASimpleObjectType() {
-        BValue[] res = BRunUtil.invoke(result, "typeDescOrAObject");
-        Assert.assertEquals(res[0].stringValue(), "Obj0");
-    }
-
-    @Test
-    public void testUsingTypeofOperatorAsRestArgs() {
-        BValue[] res = BRunUtil.invoke(result, "passTypeofAsRestParams");
-        Assert.assertEquals(res[0].stringValue(), "int");
-        Assert.assertEquals(res[1].stringValue(), "int");
-        Assert.assertEquals(res[2].stringValue(), "float");
+    @DataProvider(name = "function-provider")
+    public Object[] provideFunctionNames() {
+        return new String[]{"typeDescOfExpressionsOfLiterals", "passTypeofToAFunction", "typeDescOfARecord",
+                "typeDescOrAObject", "passTypeofAsRestParams", "compareTypeOfValues"};
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/access/access.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/access/access.bal
@@ -264,7 +264,7 @@ public function testAccessOnGroupedExpressions() returns error|boolean {
     result = result && s == "msg";
 
     s = (typeof (12.5f)).toString();
-    result = result && s == "typedesc float";
+    result = result && s == "typedesc 12.5";
     return result;
 }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/mapping_constructor_infer_record.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/mapping_constructor_infer_record.bal
@@ -164,7 +164,7 @@ function testMappingConstrExprWithNoACET() {
     assertEquality(s, r2.s);
     assertEquality(i, r2.i);
     assertEquality(s, r2.s2);
-    assertEquality("typedesc string", r2.t.toString());
+    assertEquality("typedesc global s", r2.t.toString());
 }
 
 public type ExpInferredType2 record {|

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typeof/typeof.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typeof/typeof.bal
@@ -13,16 +13,16 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-
+import ballerina/test;
 
 type RecType0 record {
     string name;
 };
 
-function typeDescOfARecord() returns typedesc<any> {
+function typeDescOfARecord() {
     RecType0 i = { name: "theName"};
     typedesc<any> td0 = typeof i;
-    return td0;
+    test:assertEquals(td0.toString(), "typedesc RecType0");
 }
 
 class Obj0 {
@@ -35,52 +35,58 @@ class Obj0 {
     }
 }
 
-function typeDescOrAObject() returns typedesc<any> {
+function typeDescOrAObject() {
     Obj0 o = new("name", 42);
-    return typeof o;
+    test:assertEquals((typeof o).toString(), "typedesc Obj0");
 }
 
-function typeDescOfLiterals() returns
-    [typedesc<any>, typedesc<any>, typedesc<any>, typedesc<any>, typedesc<any>, typedesc<any>, typedesc<any>] {
-    var a = typeof 1;
-    var b = typeof 2.0;
-    var c = typeof 2.1f;
-    var d = typeof "str-literal";
-    var e = typeof true;
-    var f = typeof false;
-    var g = typeof ();
-    return [a, b, c, d, e, f, g];
+function typeDescOfLiterals(any value, string expected) {
+    var a = typeof value;
+    test:assertEquals(a.toString(), "typedesc " + expected);
 }
 
-function typeDescOfExpressionsOfLiterals() returns
-    [typedesc<any>, typedesc<any>] {
+function typeDescOfExpressionsOfLiterals() {
     int i = 0;
     int j = 4;
     int k = 4;
     float f = 0.0;
     float ff = 22.0;
-    return [typeof (i+j*k), typeof (f*ff)];
+    var r1 = typeof (i + j * k);
+    test:assertEquals(r1.toString(), "typedesc 16");
+    var r2 = typeof (f * ff);
+    test:assertEquals(r2.toString(), "typedesc 0.0");
 }
 
 function takesATypedescParam(typedesc<any> param) returns typedesc<any> {
     return param;
 }
 
-function passTypeofToAFunction() returns typedesc<any> {
+function passTypeofToAFunction() {
     typedesc<any> t = typeof 22;
     var t1 = takesATypedescParam(t);
     var t2 = takesATypedescParam(typeof 33);
-    return t1;
+    test:assertEquals(t1.toString(), "typedesc 22");
+    test:assertEquals(t2.toString(), "typedesc 33");
 }
 
 function takeTypeofAsRestParams(typedesc<any>... xs) returns typedesc<any>[] {
     return xs;
 }
 
-function passTypeofAsRestParams() returns typedesc<any>[] {
-    return takeTypeofAsRestParams(typeof 22, typeof 33, typeof 33.33);
+function passTypeofAsRestParams() {
+    typedesc<any>[] result = takeTypeofAsRestParams(typeof 22, typeof 33, typeof 33.33);
+    test:assertEquals(result[0].toString(), "typedesc 22");
+    test:assertEquals(result[1].toString(), "typedesc 33");
+    test:assertEquals(result[2].toString(), "typedesc 33.33");
 }
 
 function returnTypeOfInt() returns typedesc<any> {
     return typeof (5 + 1);
+}
+
+function compareTypeOfValues() {
+    int i = 34;
+    var t1 = typeof i;
+    var t2 = typeof i;
+    test:assertFalse(t1 === t2);    
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typeof/typeof.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typeof/typeof.bal
@@ -85,8 +85,35 @@ function returnTypeOfInt() returns typedesc<any> {
 }
 
 function compareTypeOfValues() {
+
+    // Basic Simple Type 
     int i = 34;
-    var t1 = typeof i;
-    var t2 = typeof i;
-    test:assertFalse(t1 === t2);    
+    test:assertFalse(typeof i === typeof i); 
+
+    // Structural types - Array, Tuple
+    int[] arr = [1, 2, 3];
+    test:assertTrue(typeof arr === typeof arr); 
+
+    [string, int] tuple = ["ballerina", 123];
+    test:assertTrue(typeof tuple === typeof tuple); 
+
+    // Structural types - Records, Maps
+    RecType0 rec = {name: "test"};
+    test:assertTrue(typeof rec === typeof rec); 
+    test:assertTrue(typeof rec === RecType0); 
+
+    map<string> mapVal = {s: "test"};
+    test:assertTrue(typeof mapVal === typeof mapVal); 
+
+    // Structural types -tables 
+    table<map<string>> tableVal = table [{s: "test"}];
+    test:assertTrue(typeof tableVal === typeof tableVal); 
+
+    // Behavioral types - Object
+    Obj0 obj = new ("abc", 123);
+    test:assertTrue(typeof obj === typeof obj); 
+
+    // Behavioral types - Error
+    error err = error("This is an error!");
+    test:assertTrue(typeof obj === typeof obj); 
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/varref/tuple-variable-reference.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/varref/tuple-variable-reference.bal
@@ -216,7 +216,7 @@ function testRestVarRefType1() {
     [string, int, float...] t1 = ["A", 100, 200.5, 300.5];
 
     var [a1, ...a2] = t1;
-    assertEqual("typedesc string", (typeof a1).toString());
+    assertEqual("typedesc A", (typeof a1).toString());
     assertEqual("typedesc [int,float...]", (typeof a2).toString());
 
     [int, float...] x1;
@@ -227,8 +227,8 @@ function testRestVarRefType1() {
     assertEqual(300.5, x1[2]);
 
     var [b1, b2, ...b3] = t1;
-    assertEqual("typedesc string", (typeof b1).toString());
-    assertEqual("typedesc int", (typeof b2).toString());
+    assertEqual("typedesc A", (typeof b1).toString());
+    assertEqual("typedesc 100", (typeof b2).toString());
     assertEqual("typedesc float[]", (typeof b3).toString());
 
     float[] x2;
@@ -307,7 +307,7 @@ function testRestVarRefType6() {
                 {firstName: "John", lastName: "Damon"}, 12, fooObj1, barObj1], {id: 34, flag: true}, 10.5, 20], "A",
                 true, false];
     var [[g1, [g2, ...g3], ...g4], ...g5] = t5;
-    assertEqual("typedesc string", (typeof g1).toString());
+    assertEqual("typedesc Ballerina", (typeof g1).toString());
     assertEqual("typedesc error", (typeof g2).toString());
     assertEqual("typedesc [map<string>,int,(FooObj|BarObj)...]", (typeof g3).toString());
     assertEqual("typedesc [Bar,(byte|float)...]", (typeof g4).toString());
@@ -372,8 +372,8 @@ function testRestVarRefType6() {
 function testRestVarRefType7() {
     int[5] t6 = [10, 20, 30, 40, 50];
     var [h1, h2, ...h3] = t6;
-    assertEqual("typedesc int", (typeof h1).toString());
-    assertEqual("typedesc int", (typeof h2).toString());
+    assertEqual("typedesc 10", (typeof h1).toString());
+    assertEqual("typedesc 20", (typeof h2).toString());
     assertEqual("typedesc [int,int,int]", (typeof h3).toString());
     assertEqual(10, h1);
     assertEqual(20, h2);
@@ -404,7 +404,7 @@ function testRestVarRefType9() {
     [[string, [FooObj, Bar...], int, float...], boolean[3], string...] [[i1, [...i2], ...i3], ...i4] =
                 [["Ballerina", [fooObj1, {id: 34, flag: true}, {id: 35, flag: false}], 453, 10.5, 20.5],
                 [false, true, true], "Ballerina", "Hello"];
-    assertEqual("typedesc string", (typeof i1).toString());
+    assertEqual("typedesc Ballerina", (typeof i1).toString());
     assertEqual("typedesc [FooObj,Bar...]", (typeof i2).toString());
     assertEqual("typedesc [int,float...]", (typeof i3).toString());
     assertEqual("typedesc [boolean[3],string...]", (typeof i4).toString());

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/vardeclr/module_tuple_var_decl.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/vardeclr/module_tuple_var_decl.bal
@@ -170,7 +170,7 @@ BarObj barObj1 = new (true, 56);
 var [[g1, [g2, ...g3], ...g4], ...g5] = t2;
 
 function testModuleLevelTupleRest2() {
-    assertEquality("typedesc string", (typeof g1).toString());
+    assertEquality("typedesc Ballerina", (typeof g1).toString());
     assertEquality("typedesc error", (typeof g2).toString());
     assertEquality("typedesc [map<string>,int,(FooObj|BarObj)...]", (typeof g3).toString());
     assertEquality("typedesc [Bar,(byte|float)...]", (typeof g4).toString());
@@ -200,8 +200,8 @@ int[5] t3 = [10, 20, 30, 40, 50];
 var [h1, h2, ...h3] = t3;
 
 function testModuleLevelTupleRest3() {
-    assertEquality("typedesc int", (typeof h1).toString());
-    assertEquality("typedesc int", (typeof h2).toString());
+    assertEquality("typedesc 10", (typeof h1).toString());
+    assertEquality("typedesc 20", (typeof h2).toString());
     assertEquality("typedesc [int,int,int]", (typeof h3).toString());
     assertEquality(10, h1);
     assertEquality(20, h2);
@@ -216,7 +216,7 @@ function testModuleLevelTupleRest3() {
             [false, true, true], "Ballerina", "Hello"];
 
 function testModuleLevelTupleRest4() {
-    assertEquality("typedesc string", (typeof i1).toString());
+    assertEquality("typedesc Ballerina", (typeof i1).toString());
     assertEquality("typedesc [FooObj,Bar...]", (typeof i2).toString());
     assertEquality("typedesc [int,float...]", (typeof i3).toString());
     assertEquality("typedesc [boolean[3],string...]", (typeof i4).toString());


### PR DESCRIPTION
## Purpose
As per the spec, the `typeof` expression must return the type as the following,
- For basic simple value, 
       - provide a type with single shape
       - For each `typeof` call, produce a new typedesc value.
       
- For reference value, 
       - provide a type with single shape - if the value is immutable
       - Or else provide the typedesc that is used to construct the value
       - For each `typeof` call, provide identical typedesc values.

Fixes #15278

## Approach
- Create and return new singleton typedesc values for simple basic type values.
- Store the typedesc information of the reference values which can be returned at the `typeof` call.
- Store the singleton type as the value type when creating an immutable value
 
## Samples
```ballerina

    // Basic Simple Type 
    int i = 34;
    test:assertFalse(typeof i === typeof i); 

    // Structural types 
    int[] arr = [1, 2, 3];
    test:assertTrue(typeof arr === typeof arr); 

    map<string> mapVal = {s: "test"};
    test:assertTrue(typeof mapVal === typeof mapVal); 

    // Behavioral types - Object
    Obj0 obj = new ("abc", 123);
    test:assertTrue(typeof obj === typeof obj); 

    // Behavioral types - Error
    error err = error("This is an error!");
    test:assertTrue(typeof err === typeof err); 
```

## Remarks
- TODO: Fix immutable values

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
