### PR TITLE
Add spec conformance tests for type descriptors

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
@@ -1157,7 +1157,7 @@ class SymbolFinder extends BaseVisitor {
         lookupNode(streamType.error);
 
         if (symbolAtCursor == null) {
-            this.symbolAtCursor = streamType.type.getBType().tsymbol;
+            this.symbolAtCursor = streamType.getBType().tsymbol;
         }
     }
 
@@ -1168,7 +1168,7 @@ class SymbolFinder extends BaseVisitor {
         lookupNode(tableType.tableKeyTypeConstraint);
 
         if (this.symbolAtCursor == null) {
-            this.symbolAtCursor = tableType.type.getBType().tsymbol;
+            this.symbolAtCursor = tableType.tableType.tsymbol;
         }
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -1289,8 +1289,8 @@ public class SymbolResolver extends BLangNodeVisitor {
         BTableType tableType = new BTableType(TypeTags.TABLE, constraintType, null);
         BTypeSymbol typeSymbol = type.tsymbol;
         tableType.tsymbol = Symbols.createTypeSymbol(SymTag.TYPE, Flags.asMask(EnumSet.noneOf(Flag.class)),
-                typeSymbol.name, typeSymbol.originalName, env.enclPkg.symbol.pkgID, tableType,
-                env.scope.owner, tableTypeNode.pos, SOURCE);
+                                                     typeSymbol.name, typeSymbol.originalName, typeSymbol.pkgID, tableType,
+                                                     env.scope.owner, tableTypeNode.pos, SOURCE);
         tableType.tsymbol.flags = typeSymbol.flags;
         tableType.constraintPos = tableTypeNode.constraint.pos;
         tableType.isTypeInlineDefined = tableTypeNode.isTypeInlineDefined;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -1289,8 +1289,8 @@ public class SymbolResolver extends BLangNodeVisitor {
         BTableType tableType = new BTableType(TypeTags.TABLE, constraintType, null);
         BTypeSymbol typeSymbol = type.tsymbol;
         tableType.tsymbol = Symbols.createTypeSymbol(SymTag.TYPE, Flags.asMask(EnumSet.noneOf(Flag.class)),
-                                                     typeSymbol.name, typeSymbol.originalName, typeSymbol.pkgID, tableType,
-                                                     env.scope.owner, tableTypeNode.pos, SOURCE);
+                                                     typeSymbol.name, typeSymbol.originalName, typeSymbol.pkgID,
+                                                     tableType, env.scope.owner, tableTypeNode.pos, SOURCE);
         tableType.tsymbol.flags = typeSymbol.flags;
         tableType.constraintPos = tableTypeNode.constraint.pos;
         tableType.isTypeInlineDefined = tableTypeNode.isTypeInlineDefined;

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/FunctionTypeSymbolTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/FunctionTypeSymbolTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.semantic.api.test.symbols;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.AnnotationSymbol;
+import io.ballerina.compiler.api.symbols.FunctionSymbol;
+import io.ballerina.compiler.api.symbols.FunctionTypeSymbol;
+import io.ballerina.compiler.api.symbols.ParameterKind;
+import io.ballerina.compiler.api.symbols.ParameterSymbol;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.projects.Document;
+import io.ballerina.projects.Project;
+import io.ballerina.tools.text.LinePosition;
+import org.ballerinalang.test.BCompileUtil;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDefaultModulesSemanticModel;
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDocumentForSingleSource;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Test cases for function type symbols.
+ *
+ * @since 2.0.0
+ */
+public class FunctionTypeSymbolTest {
+
+    private SemanticModel model;
+    private Document srcFile;
+
+    @BeforeClass
+    public void setup() {
+        Project project = BCompileUtil.loadProject("test-src/symbols/function_type_symbol_test.bal");
+        model = getDefaultModulesSemanticModel(project);
+        srcFile = getDocumentForSingleSource(project);
+    }
+
+    @Test
+    public void testFunctionType() {
+        Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(17, 100));
+        assertTrue(symbol.isPresent());
+//        assertEquals(symbol.get().kind(), SymbolKind.VARIABLE);
+
+        TypeSymbol typeSymbol = ((FunctionSymbol) symbol.get()).typeDescriptor();
+        assertEquals(typeSymbol.typeKind(), TypeDescKind.FUNCTION);
+
+        FunctionTypeSymbol fnType = (FunctionTypeSymbol) typeSymbol;
+        Optional<List<ParameterSymbol>> params = fnType.params();
+
+        assertTrue(params.isPresent());
+        List<ParameterSymbol> paramSymbols = params.get();
+        ParameterSymbol rp = paramSymbols.get(0);
+        assertTrue(rp.getName().isEmpty());
+        assertEquals(rp.paramKind(), ParameterKind.REQUIRED);
+        assertEquals(rp.typeDescriptor().typeKind(), TypeDescKind.INT);
+
+        List<AnnotationSymbol> rpAnnots = rp.annotations();
+//        assertEquals(rpAnnots.size(), 1);
+//        assertEquals(rpAnnots.get(0).getName().get(), "v1");
+
+        ParameterSymbol dp = paramSymbols.get(1);
+        assertTrue(dp.getName().isPresent());
+        assertEquals(dp.getName().get(), "dp");
+        assertEquals(dp.paramKind(), ParameterKind.DEFAULTABLE);
+        assertEquals(dp.typeDescriptor().typeKind(), TypeDescKind.STRING);
+        assertTrue(dp.annotations().isEmpty());
+
+        Optional<ParameterSymbol> rest = fnType.restParam();
+        assertTrue(rest.isPresent());
+        assertTrue(rest.get().getName().isPresent());
+        assertEquals(rest.get().getName().get(), "rp");
+        assertEquals(rest.get().paramKind(), ParameterKind.REST);
+        assertEquals(rest.get().typeDescriptor().typeKind(), TypeDescKind.ARRAY);
+        assertTrue(rest.get().annotations().isEmpty());
+
+        assertTrue(fnType.returnTypeDescriptor().isPresent());
+        assertEquals(fnType.returnTypeDescriptor().get().typeKind(), TypeDescKind.ANYDATA);
+//        assertTrue(fnType.returnTypeAnnotations().isPresent());
+//        assertEquals(fnType.returnTypeAnnotations().get().annotations().size(), 1);
+//        assertEquals(fnType.returnTypeAnnotations().get().annotations().get(0).getName().get(), "v1");
+    }
+
+    @Test
+    public void testAnyFunctionType() {
+        Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(18, 13));
+        assertTrue(symbol.isPresent());
+//        assertEquals(symbol.get().kind(), SymbolKind.VARIABLE);
+
+        FunctionTypeSymbol fnType = ((FunctionSymbol) symbol.get()).typeDescriptor();
+        assertTrue(fnType.params().isEmpty());
+        assertTrue(fnType.restParam().isEmpty());
+        assertTrue(fnType.returnTypeDescriptor().isEmpty());
+        assertTrue(fnType.returnTypeAnnotations().isEmpty());
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/ObjectTypeSymbolTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/ObjectTypeSymbolTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.semantic.api.test.symbols;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.AnnotationSymbol;
+import io.ballerina.compiler.api.symbols.Documentation;
+import io.ballerina.compiler.api.symbols.MethodSymbol;
+import io.ballerina.compiler.api.symbols.ObjectFieldSymbol;
+import io.ballerina.compiler.api.symbols.ObjectTypeSymbol;
+import io.ballerina.compiler.api.symbols.Qualifier;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.SymbolKind;
+import io.ballerina.compiler.api.symbols.TypeDefinitionSymbol;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.projects.Document;
+import io.ballerina.projects.Project;
+import io.ballerina.tools.text.LinePosition;
+import org.ballerinalang.test.BCompileUtil;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDefaultModulesSemanticModel;
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDocumentForSingleSource;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Test cases for object type symbols.
+ *
+ * @since 2.0.0
+ */
+public class ObjectTypeSymbolTest {
+
+    private SemanticModel model;
+    private Document srcFile;
+
+    @BeforeClass
+    public void setup() {
+        Project project = BCompileUtil.loadProject("test-src/symbols/object_type_symbol_test.bal");
+        model = getDefaultModulesSemanticModel(project);
+        srcFile = getDocumentForSingleSource(project);
+    }
+
+    @Test
+    public void testObjectTypeQualifiers() {
+        ObjectTypeSymbol object = getObjectType(42, 5);
+        List<Qualifier> qualifiers = object.qualifiers();
+        assertEquals(qualifiers.size(), 2);
+        assertTrue(qualifiers.contains(Qualifier.CLIENT));
+        assertTrue(qualifiers.contains(Qualifier.ISOLATED));
+    }
+
+    @Test
+    public void testFields() {
+        assertField(20, 22);
+        assertField(45, 18);
+    }
+
+    @Test
+    public void testMethods() {
+        assertMethod(24, 54);
+        assertMethod(49, 50);
+    }
+
+    @Test
+    public void testTypeInclusion() {
+        Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(38, 5));
+        assertTrue(symbol.isPresent());
+        assertEquals(symbol.get().kind(), SymbolKind.TYPE);
+        assertEquals(((TypeSymbol) symbol.get()).typeKind(), TypeDescKind.TYPE_REFERENCE);
+
+        TypeReferenceTypeSymbol typeRef = (TypeReferenceTypeSymbol) symbol.get();
+        assertEquals(typeRef.getName().get(), "Person");
+        assertEquals(typeRef.typeDescriptor().typeKind(), TypeDescKind.OBJECT);
+    }
+
+    // private utils
+    private ObjectTypeSymbol getObjectType(int line, int col) {
+        Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, col));
+
+        assertTrue(symbol.isPresent());
+        assertEquals(symbol.get().kind(), SymbolKind.TYPE_DEFINITION);
+
+        TypeDefinitionSymbol typeDef = (TypeDefinitionSymbol) symbol.get();
+        TypeSymbol type = typeDef.typeDescriptor();
+        assertEquals(type.typeKind(), TypeDescKind.OBJECT);
+        return (ObjectTypeSymbol) type;
+    }
+
+    private void assertField(int line, int col) {
+        Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, col));
+        assertTrue(symbol.isPresent());
+        assertEquals(symbol.get().kind(), SymbolKind.OBJECT_FIELD);
+
+        ObjectFieldSymbol nameField = (ObjectFieldSymbol) symbol.get();
+
+        // check name
+        assertEquals(nameField.getName().get(), "name");
+
+        // check docs (metadata)
+        Optional<Documentation> fieldDocs = nameField.documentation();
+        assertTrue(fieldDocs.isPresent());
+        assertTrue(fieldDocs.get().description().isPresent());
+        assertEquals(fieldDocs.get().description().get(), "An object field");
+
+        // check annotations (metadata)
+        List<AnnotationSymbol> fieldAnnots = nameField.annotations();
+        assertEquals(fieldAnnots.size(), 1);
+        assertEquals(fieldAnnots.get(0).getName().get(), "v1");
+
+        // check qualifiers
+        assertEquals(nameField.qualifiers().size(), 1);
+        assertEquals(nameField.qualifiers().get(0), Qualifier.PUBLIC);
+
+        // check type
+        assertEquals(nameField.typeDescriptor().typeKind(), TypeDescKind.STRING);
+    }
+
+    private void assertMethod(int line, int col) {
+        Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, col));
+        assertTrue(symbol.isPresent());
+        assertEquals(symbol.get().kind(), SymbolKind.METHOD);
+
+        MethodSymbol barMethod = (MethodSymbol) symbol.get();
+
+        // check name
+        assertEquals(barMethod.getName().get(), "bar");
+
+        // check docs (metadata)
+        Optional<Documentation> methodDocs = barMethod.documentation();
+        assertTrue(methodDocs.isPresent());
+        assertTrue(methodDocs.get().description().isPresent());
+        assertEquals(methodDocs.get().description().get(), "An object method");
+
+        // check annotations (metadata)
+        List<AnnotationSymbol> methodAnnots = barMethod.annotations();
+        assertEquals(methodAnnots.size(), 1);
+        assertEquals(methodAnnots.get(0).getName().get(), "v1");
+
+        // check qualifiers
+        assertEquals(barMethod.qualifiers().size(), 3);
+        assertTrue(barMethod.qualifiers().contains(Qualifier.ISOLATED));
+        assertTrue(barMethod.qualifiers().contains(Qualifier.REMOTE));
+        assertTrue(barMethod.qualifiers().contains(Qualifier.TRANSACTIONAL));
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/ObjectTypeSymbolTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/ObjectTypeSymbolTest.java
@@ -65,8 +65,17 @@ public class ObjectTypeSymbolTest {
 
     @Test
     public void testObjectTypeQualifiers() {
-        ObjectTypeSymbol object = getObjectType(42, 5);
+        Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(42, 5));
+        assertTrue(symbol.isPresent());
+        assertEquals(symbol.get().kind(), SymbolKind.TYPE_DEFINITION);
+
+        TypeDefinitionSymbol typeDef = (TypeDefinitionSymbol) symbol.get();
+        TypeSymbol type = typeDef.typeDescriptor();
+        assertEquals(type.typeKind(), TypeDescKind.OBJECT);
+
+        ObjectTypeSymbol object = (ObjectTypeSymbol) type;
         List<Qualifier> qualifiers = object.qualifiers();
+
         assertEquals(qualifiers.size(), 2);
         assertTrue(qualifiers.contains(Qualifier.CLIENT));
         assertTrue(qualifiers.contains(Qualifier.ISOLATED));
@@ -96,19 +105,7 @@ public class ObjectTypeSymbolTest {
         assertEquals(typeRef.typeDescriptor().typeKind(), TypeDescKind.OBJECT);
     }
 
-    // private utils
-    private ObjectTypeSymbol getObjectType(int line, int col) {
-        Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, col));
-
-        assertTrue(symbol.isPresent());
-        assertEquals(symbol.get().kind(), SymbolKind.TYPE_DEFINITION);
-
-        TypeDefinitionSymbol typeDef = (TypeDefinitionSymbol) symbol.get();
-        TypeSymbol type = typeDef.typeDescriptor();
-        assertEquals(type.typeKind(), TypeDescKind.OBJECT);
-        return (ObjectTypeSymbol) type;
-    }
-
+    // utils
     private void assertField(int line, int col) {
         Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, col));
         assertTrue(symbol.isPresent());

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/ParameterSymbolTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/ParameterSymbolTest.java
@@ -11,12 +11,12 @@
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
+ * KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */
 
-package io.ballerina.semantic.api.test;
+package io.ballerina.semantic.api.test.symbols;
 
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.impl.BallerinaModuleID;

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/RecordTypeSymbolTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/RecordTypeSymbolTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.semantic.api.test.symbols;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.AnnotationSymbol;
+import io.ballerina.compiler.api.symbols.Documentation;
+import io.ballerina.compiler.api.symbols.Qualifier;
+import io.ballerina.compiler.api.symbols.RecordFieldSymbol;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.SymbolKind;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.projects.Document;
+import io.ballerina.projects.Project;
+import io.ballerina.tools.text.LinePosition;
+import org.ballerinalang.test.BCompileUtil;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDefaultModulesSemanticModel;
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDocumentForSingleSource;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Test cases for record type symbols.
+ *
+ * @since 2.0.0
+ */
+public class RecordTypeSymbolTest {
+
+    private SemanticModel model;
+    private Document srcFile;
+
+    @BeforeClass
+    public void setup() {
+        Project project = BCompileUtil.loadProject("test-src/symbols/record_type_symbol_test.bal");
+        model = getDefaultModulesSemanticModel(project);
+        srcFile = getDocumentForSingleSource(project);
+    }
+
+    @Test(dataProvider = "FieldProvider")
+    public void testFields(int line, int col, String expName, String expDoc, TypeDescKind expTypeKind,
+                           Qualifier expQual, boolean expDefVal, boolean expOptional) {
+        Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, col));
+        assertTrue(symbol.isPresent());
+        assertEquals(symbol.get().kind(), SymbolKind.RECORD_FIELD);
+
+        RecordFieldSymbol field = (RecordFieldSymbol) symbol.get();
+
+        // check name
+        assertEquals(field.getName().get(), expName);
+
+        // check docs (metadata)
+        Optional<Documentation> fieldDocs = field.documentation();
+        assertTrue(fieldDocs.isPresent());
+        assertTrue(fieldDocs.get().description().isPresent());
+        assertEquals(fieldDocs.get().description().get(), expDoc);
+
+        // check annotations (metadata)
+        List<AnnotationSymbol> fieldAnnots = field.annotations();
+        assertEquals(fieldAnnots.size(), 1);
+        assertEquals(fieldAnnots.get(0).getName().get(), "v1");
+
+        // check qualifiers
+        if (expQual != null) {
+            assertEquals(field.qualifiers().size(), 1);
+            assertEquals(field.qualifiers().get(0), expQual);
+        } else {
+            assertTrue(field.qualifiers().isEmpty());
+        }
+
+        // check type
+        assertEquals(field.typeDescriptor().typeKind(), expTypeKind);
+
+        // check misc info
+        assertEquals(field.hasDefaultValue(), expDefVal);
+        assertEquals(field.isOptional(), expOptional);
+    }
+
+    @DataProvider(name = "FieldProvider")
+    public Object[][] getFields() {
+        return new Object[][]{
+                {22, 15, "designation", "Designation field", TypeDescKind.STRING, null, false, false},
+                {29, 20, "name", "Name field", TypeDescKind.STRING, Qualifier.READONLY, false, false},
+                {32, 12, "age", "Age field", TypeDescKind.INT, null, false, true},
+                {43, 11, "designation", "Designation field", TypeDescKind.STRING, null, true, false},
+        };
+    }
+
+    @Test(dataProvider = "TypeInclusionProvider")
+    public void testTypeInclusion(int line, int col) {
+        Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, col));
+        assertTrue(symbol.isPresent());
+        assertEquals(symbol.get().kind(), SymbolKind.TYPE);
+        assertEquals(((TypeSymbol) symbol.get()).typeKind(), TypeDescKind.TYPE_REFERENCE);
+
+        TypeReferenceTypeSymbol typeRef = (TypeReferenceTypeSymbol) symbol.get();
+        assertEquals(typeRef.getName().get(), "Person");
+        assertEquals(typeRef.typeDescriptor().typeKind(), TypeDescKind.RECORD);
+    }
+
+    @DataProvider(name = "TypeInclusionProvider")
+    public Object[][] getTypeInclusions() {
+        return new Object[][]{
+                {18, 9},
+                {39, 5}
+        };
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/TypeSymbolTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/TypeSymbolTest.java
@@ -60,7 +60,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 /**
- * Test cases for function and function type symbols.
+ * Test cases for type symbols.
  *
  * @since 2.0.0
  */

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/TypeSymbolTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/TypeSymbolTest.java
@@ -19,6 +19,7 @@
 package io.ballerina.semantic.api.test.symbols;
 
 import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.ConstantSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
@@ -47,6 +48,7 @@ import static io.ballerina.compiler.api.symbols.TypeDescKind.MAP;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.NEVER;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.NIL;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.READONLY;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.SINGLETON;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.STREAM;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.STRING;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.TABLE;
@@ -107,8 +109,6 @@ public class TypeSymbolTest {
 //                {46, 4, ERROR, "error<ErrorData>"},
                 {47, 4, HANDLE, "handle"},
                 {48, 4, STREAM, "stream<Person, error>"},
-//                {52, 4, SINGLETON, "10"},
-//                {53, 4, SINGLETON, "FOO"},
                 {54, 4, ANY, "any"},
                 {55, 4, NEVER, "never"},
                 {56, 4, READONLY, "readonly"},
@@ -174,6 +174,20 @@ public class TypeSymbolTest {
                 {41, 8, "TEN"},
                 {53, 4, "FOO"},
         };
+    }
+
+    @Test
+    public void testConstAsAType() {
+        Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(53, 4));
+        assertTrue(symbol.isPresent());
+        assertEquals(symbol.get().kind(), SymbolKind.CONSTANT);
+
+        ConstantSymbol constant = (ConstantSymbol) symbol.get();
+        assertEquals(constant.getName().get(), "FOO");
+        assertEquals(constant.typeKind(), SINGLETON);
+        assertEquals(constant.typeDescriptor().typeKind(), SINGLETON);
+        assertEquals(constant.broaderTypeDescriptor().typeKind(), STRING);
+//        assertEquals(constant.signature(), expName);
     }
 
     // private utils

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/TypeSymbolTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/TypeSymbolTest.java
@@ -38,6 +38,7 @@ import static io.ballerina.compiler.api.symbols.TypeDescKind.ANYDATA;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.BOOLEAN;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.BYTE;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.DECIMAL;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.ERROR;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.FLOAT;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.FUTURE;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.HANDLE;
@@ -120,6 +121,7 @@ public class TypeSymbolTest {
                 {60, 4, ANYDATA, "anydata"},
                 {61, 4, JSON, "json"},
                 {62, 4, BYTE, "byte"},
+                {63, 13, ERROR, "error"},
         };
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/TypeSymbolTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/TypeSymbolTest.java
@@ -103,23 +103,23 @@ public class TypeSymbolTest {
                 {35, 4, FUTURE, "future<string>"},
                 {36, 4, FUTURE, "future<any|error>"},
                 {40, 4, INT, "int"},
-                {41, 5, INT, "int"},
-                {41, 10, STRING, "string"},
-//                {45, 4, ERROR, "error<ErrorData>"},
-                {46, 4, HANDLE, "handle"},
-                {47, 4, STREAM, "stream<Person, error>"},
-                {51, 4, SINGLETON, "10"},
-                {52, 4, SINGLETON, "FOO"},
-                {53, 4, ANY, "any"},
-                {54, 4, NEVER, "never"},
-                {55, 4, READONLY, "readonly"},
-                {56, 4, INT, "int"},
-                {56, 8, STRING, "string"},
-                {57, 13, READONLY, "readonly"},
-                {58, 4, INT, "int"},
-                {59, 4, ANYDATA, "anydata"},
-                {60, 4, JSON, "json"},
-                {61, 4, BYTE, "byte"},
+                {42, 5, INT, "int"},
+                {42, 10, STRING, "string"},
+//                {46, 4, ERROR, "error<ErrorData>"},
+                {47, 4, HANDLE, "handle"},
+                {48, 4, STREAM, "stream<Person, error>"},
+                {52, 4, SINGLETON, "10"},
+                {53, 4, SINGLETON, "FOO"},
+                {54, 4, ANY, "any"},
+                {55, 4, NEVER, "never"},
+                {56, 4, READONLY, "readonly"},
+                {57, 4, INT, "int"},
+                {57, 8, STRING, "string"},
+                {58, 13, READONLY, "readonly"},
+                {59, 4, INT, "int"},
+                {60, 4, ANYDATA, "anydata"},
+                {61, 4, JSON, "json"},
+                {62, 4, BYTE, "byte"},
         };
     }
 
@@ -138,7 +138,7 @@ public class TypeSymbolTest {
                 {31, 13, ANYDATA, "anydata"},
                 {34, 22, INT, "int"},
                 {35, 11, STRING, "string"},
-//                {47, 19, ERROR, "error"},
+//                {48, 19, ERROR, "error"},
         };
     }
 
@@ -154,10 +154,19 @@ public class TypeSymbolTest {
         return new Object[][]{
                 {33, 10, TYPE_REFERENCE, "Person"},
                 {34, 10, TYPE_REFERENCE, "Person"},
-                {45, 10, TYPE_REFERENCE, "ErrorData"},
-                {47, 11, TYPE_REFERENCE, "Person"},
-                {57, 4, TYPE_REFERENCE, "Person"},
+                {46, 10, TYPE_REFERENCE, "ErrorData"},
+                {48, 11, TYPE_REFERENCE, "Person"},
+                {58, 4, TYPE_REFERENCE, "Person"},
         };
+    }
+
+    @Test
+    public void testConstRef() {
+        Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(41, 8));
+
+        assertTrue(symbol.isPresent());
+        assertEquals(symbol.get().kind(), SymbolKind.CONSTANT);
+        assertEquals(symbol.get().getName().get(), "TEN");
     }
 
     // private utils

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/TypeSymbolTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/TypeSymbolTest.java
@@ -38,7 +38,6 @@ import static io.ballerina.compiler.api.symbols.TypeDescKind.ANYDATA;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.BOOLEAN;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.BYTE;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.DECIMAL;
-import static io.ballerina.compiler.api.symbols.TypeDescKind.ERROR;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.FLOAT;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.FUTURE;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.HANDLE;
@@ -48,7 +47,6 @@ import static io.ballerina.compiler.api.symbols.TypeDescKind.MAP;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.NEVER;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.NIL;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.READONLY;
-import static io.ballerina.compiler.api.symbols.TypeDescKind.SINGLETON;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.STREAM;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.STRING;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.TABLE;
@@ -109,8 +107,8 @@ public class TypeSymbolTest {
 //                {46, 4, ERROR, "error<ErrorData>"},
                 {47, 4, HANDLE, "handle"},
                 {48, 4, STREAM, "stream<Person, error>"},
-                {52, 4, SINGLETON, "10"},
-                {53, 4, SINGLETON, "FOO"},
+//                {52, 4, SINGLETON, "10"},
+//                {53, 4, SINGLETON, "FOO"},
                 {54, 4, ANY, "any"},
                 {55, 4, NEVER, "never"},
                 {56, 4, READONLY, "readonly"},
@@ -121,7 +119,7 @@ public class TypeSymbolTest {
                 {60, 4, ANYDATA, "anydata"},
                 {61, 4, JSON, "json"},
                 {62, 4, BYTE, "byte"},
-                {63, 13, ERROR, "error"},
+//                {63, 13, ERROR, "error"},
         };
     }
 
@@ -162,13 +160,20 @@ public class TypeSymbolTest {
         };
     }
 
-    @Test
-    public void testConstRef() {
-        Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(41, 8));
-
+    @Test(dataProvider = "ConstRefPosProvider")
+    public void testConstRef(int line, int col, String expName) {
+        Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, col));
         assertTrue(symbol.isPresent());
         assertEquals(symbol.get().kind(), SymbolKind.CONSTANT);
-        assertEquals(symbol.get().getName().get(), "TEN");
+        assertEquals(symbol.get().getName().get(), expName);
+    }
+
+    @DataProvider(name = "ConstRefPosProvider")
+    public Object[][] getConstRefPos() {
+        return new Object[][]{
+                {41, 8, "TEN"},
+                {53, 4, "FOO"},
+        };
     }
 
     // private utils

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/TypeSymbolTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/TypeSymbolTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.semantic.api.test.symbols;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.SymbolKind;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.projects.Document;
+import io.ballerina.projects.Project;
+import io.ballerina.tools.text.LinePosition;
+import org.ballerinalang.test.BCompileUtil;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.ballerina.compiler.api.symbols.TypeDescKind.ANY;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.ANYDATA;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.BOOLEAN;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.BYTE;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.DECIMAL;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.FLOAT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.FUTURE;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.HANDLE;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.INT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.JSON;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.MAP;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.NEVER;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.NIL;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.READONLY;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.SINGLETON;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.STREAM;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.STRING;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.TABLE;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.TYPEDESC;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.TYPE_REFERENCE;
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDefaultModulesSemanticModel;
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDocumentForSingleSource;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Test cases for function and function type symbols.
+ *
+ * @since 2.0.0
+ */
+public class TypeSymbolTest {
+
+    private SemanticModel model;
+    private Document srcFile;
+
+    @BeforeClass
+    public void setup() {
+        Project project = BCompileUtil.loadProject("test-src/symbols/type_symbol_test.bal");
+        model = getDefaultModulesSemanticModel(project);
+        srcFile = getDocumentForSingleSource(project);
+    }
+
+    @Test(dataProvider = "PosProvider")
+    public void testTypeSymbolLookup(int line, int col, TypeDescKind typeKind, String signature) {
+        TypeSymbol type = assertBasicsAndGetType(line, col, typeKind, signature);
+        assertTrue(type.getName().isEmpty());
+        assertTrue(type.getLocation().isEmpty());
+    }
+
+    @DataProvider(name = "PosProvider")
+    public Object[][] getTypePosition() {
+        return new Object[][]{
+                {17, 4, INT, "int"},
+                {18, 4, BOOLEAN, "boolean"},
+                {19, 4, FLOAT, "float"},
+                {20, 4, DECIMAL, "decimal"},
+                {21, 4, NIL, "()"},
+                {22, 4, STRING, "string"},
+                {23, 4, INT, "int"},
+//                {26, 4, TypeDescKind.XML, "xml"},
+//                {27, 4, TypeDescKind.XML, "xml<xml>"},
+//                {28, 4, TypeDescKind.XML, "xml<ballerina/lang.xml:0.8.0:Element>"},
+                {30, 4, MAP, "map<string>"},
+                {31, 4, TYPEDESC, "typedesc<anydata>"},
+                {32, 4, TYPEDESC, "typedesc<any|error>"},
+                {33, 4, TABLE, "table<Person>"},
+                {34, 4, TABLE, "table<Person> key<int>"},
+                {35, 4, FUTURE, "future<string>"},
+                {36, 4, FUTURE, "future<any|error>"},
+                {40, 4, INT, "int"},
+                {41, 5, INT, "int"},
+                {41, 10, STRING, "string"},
+//                {45, 4, ERROR, "error<ErrorData>"},
+                {46, 4, HANDLE, "handle"},
+                {47, 4, STREAM, "stream<Person, error>"},
+                {51, 4, SINGLETON, "10"},
+                {52, 4, SINGLETON, "FOO"},
+                {53, 4, ANY, "any"},
+                {54, 4, NEVER, "never"},
+                {55, 4, READONLY, "readonly"},
+                {56, 4, INT, "int"},
+                {56, 8, STRING, "string"},
+                {57, 13, READONLY, "readonly"},
+                {58, 4, INT, "int"},
+                {59, 4, ANYDATA, "anydata"},
+                {60, 4, JSON, "json"},
+                {61, 4, BYTE, "byte"},
+        };
+    }
+
+    @Test(dataProvider = "ConstrainedTypePosProvider")
+    public void testConstrainedTypes(int line, int col, TypeDescKind typeKind, String signature) {
+        assertBasicsAndGetType(line, col, typeKind, signature);
+    }
+
+    @DataProvider(name = "ConstrainedTypePosProvider")
+    public Object[][] getConstrainedTypePos() {
+        return new Object[][]{
+//                {26, 4, XML, "xml"},
+//                {27, 4, XML, "xml<xml>"},
+//                {28, 4, XML, "xml<ballerina/lang.xml:0.8.0:Element>"},
+                {30, 9, STRING, "string"},
+                {31, 13, ANYDATA, "anydata"},
+                {34, 22, INT, "int"},
+                {35, 11, STRING, "string"},
+//                {47, 19, ERROR, "error"},
+        };
+    }
+
+    @Test(dataProvider = "TypeRefPosProvider")
+    public void testTypeRefs(int line, int col, TypeDescKind typeKind, String name) {
+        TypeSymbol type = assertBasicsAndGetType(line, col, typeKind, name);
+        assertEquals(type.typeKind(), TYPE_REFERENCE);
+        assertEquals(type.getName().get(), name);
+    }
+
+    @DataProvider(name = "TypeRefPosProvider")
+    public Object[][] getTypeRefPos() {
+        return new Object[][]{
+                {33, 10, TYPE_REFERENCE, "Person"},
+                {34, 10, TYPE_REFERENCE, "Person"},
+                {45, 10, TYPE_REFERENCE, "ErrorData"},
+                {47, 11, TYPE_REFERENCE, "Person"},
+                {57, 4, TYPE_REFERENCE, "Person"},
+        };
+    }
+
+    // private utils
+    private TypeSymbol assertBasicsAndGetType(int line, int col, TypeDescKind typeKind, String signature) {
+        Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, col));
+
+        assertTrue(symbol.isPresent());
+        assertEquals(symbol.get().kind(), SymbolKind.TYPE);
+
+        TypeSymbol type = (TypeSymbol) symbol.get();
+        assertEquals(type.typeKind(), typeKind);
+        assertEquals(type.signature(), signature);
+        return (TypeSymbol) symbol.get();
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbols/function_type_symbol_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbols/function_type_symbol_test.bal
@@ -1,0 +1,23 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+function test() {
+    transactional isolated function (@v1 int, string dp = "foo", anydata... rp) returns @v1 anydata fn1;
+    function fn2;
+}
+
+// utils
+public const annotation v1 on source type, parameter;

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbols/object_type_symbol_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbols/object_type_symbol_test.bal
@@ -1,0 +1,60 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+function test() {
+    isolated client object {
+        # An object field
+        @v1 {tag: "f1"}
+        public string name;
+
+        # An object method
+        @v1 {tag: "m1"}
+        public remote transactional isolated function bar(@v2 string p1, @v2 int p2 = 10, @v2 string... p3);
+    } obj;
+}
+
+type Person object {
+    string name;
+    int age;
+
+    public function getName() returns string;
+
+    public function getAge() returns int;
+};
+
+type Employee object {
+    *Person;
+    string designation;
+};
+
+type Foo isolated client object {
+    # An object field
+    @v1 {tag: "f1"}
+    public string name;
+
+    # An object method
+    @v1 {tag: "m1"}
+    public remote transactional isolated function bar(@v2 string p1, @v2 int p2 = 10, @v2 string... p3);
+};
+
+// utils
+
+type Annot record {
+    string tag;
+};
+
+public const annotation Annot v1 on source type, field, var, parameter, function;
+public const annotation v2 on source parameter;

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbols/record_type_symbol_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbols/record_type_symbol_test.bal
@@ -1,0 +1,48 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+function test() {
+    record {
+        *Person;
+
+        # Designation field
+        @v1
+        string designation;
+    } rec;
+}
+
+type Person record {|
+    # Name field
+    @v1
+    readonly string name;
+
+    # Age field
+    @v1 int age?;
+
+    # rest field
+    string...;
+|};
+
+type Employee record {
+    *Person;
+
+    # Designation field
+    @v1
+    string designation = "unemployed";
+};
+
+// utils
+public const annotation v1 on source type, field;

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbols/type_symbol_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbols/type_symbol_test.bal
@@ -1,0 +1,77 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+function simpleTypes() {
+    int a;
+    boolean b;
+    float c;
+    decimal d;
+    () e;
+    string s;
+    int[] arr;
+}
+
+function constrainedTypes() {
+    xml x1;
+    xml<xml> x2;
+    xml<'xml:Element> x3;
+    map<string> m;
+    typedesc<anydata> td1;
+    typedesc td2;
+    table<Person> t1;
+    table<Person> key<int> t2;
+    future<string> f1;
+    future f2;
+}
+
+function structuredTypes() {
+    int[] ar;
+    [int, string] tup;
+}
+
+function behaviouralTypes() {
+    error<ErrorData> err;
+    handle h;
+    stream<Person, error> st;
+}
+
+function otherTypes() {
+    10 a;
+    FOO b;
+    any c;
+    never d;
+    readonly e;
+    int|string f;
+    Person & readonly g;
+    int? h;
+    anydata i;
+    json j;
+    byte k;
+}
+
+// utils
+const FOO = "foo";
+
+type Person record {|
+    int id;
+    string name;
+    int age;
+|};
+
+type ErrorData record {|
+    string message;
+    error cause?;
+|};

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbols/type_symbol_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbols/type_symbol_test.bal
@@ -38,7 +38,8 @@ function constrainedTypes() {
 }
 
 function structuredTypes() {
-    int[] ar;
+    int[] ar1;
+    int[TEN] ar2;
     [int, string] tup;
 }
 
@@ -64,6 +65,7 @@ function otherTypes() {
 
 // utils
 const FOO = "foo";
+const TEN = 10;
 
 type Person record {|
     int id;

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbols/type_symbol_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbols/type_symbol_test.bal
@@ -61,6 +61,7 @@ function otherTypes() {
     anydata i;
     json j;
     byte k;
+    distinct error err;
 }
 
 // utils

--- a/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
+++ b/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
@@ -106,6 +106,7 @@
             <!--Symbols-->
             <class name="io.ballerina.semantic.api.test.symbols.FunctionSymbolTest" />
             <class name="io.ballerina.semantic.api.test.symbols.ObjectTypeSymbolTest" />
+            <class name="io.ballerina.semantic.api.test.symbols.RecordTypeSymbolTest" />
             <class name="io.ballerina.semantic.api.test.symbols.SymbolsInMappingConstructorTest" />
             <class name="io.ballerina.semantic.api.test.symbols.SymbolsInObjectConstructorTest" />
             <class name="io.ballerina.semantic.api.test.symbols.TypeSymbolTest" />

--- a/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
+++ b/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
@@ -107,6 +107,7 @@
             <class name="io.ballerina.semantic.api.test.symbols.FunctionSymbolTest" />
             <class name="io.ballerina.semantic.api.test.symbols.SymbolsInMappingConstructorTest" />
             <class name="io.ballerina.semantic.api.test.symbols.SymbolsInObjectConstructorTest" />
+            <class name="io.ballerina.semantic.api.test.symbols.TypeSymbolTest" />
         </classes>
     </test>
 </suite>

--- a/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
+++ b/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
@@ -30,7 +30,6 @@
             <class name="io.ballerina.semantic.api.test.ExpressionTypeTestNew" />
             <class name="io.ballerina.semantic.api.test.FieldSymbolTest" />
             <class name="io.ballerina.semantic.api.test.LangLibFunctionTest" />
-            <class name="io.ballerina.semantic.api.test.ParameterSymbolTest" />
             <class name="io.ballerina.semantic.api.test.SymbolAtCursorTest" />
             <class name="io.ballerina.semantic.api.test.SymbolBIRTest" />
             <class name="io.ballerina.semantic.api.test.SymbolEquivalenceTest" />
@@ -105,7 +104,9 @@
 
             <!--Symbols-->
             <class name="io.ballerina.semantic.api.test.symbols.FunctionSymbolTest" />
+            <class name="io.ballerina.semantic.api.test.symbols.FunctionTypeSymbolTest" />
             <class name="io.ballerina.semantic.api.test.symbols.ObjectTypeSymbolTest" />
+            <class name="io.ballerina.semantic.api.test.symbols.ParameterSymbolTest" />
             <class name="io.ballerina.semantic.api.test.symbols.RecordTypeSymbolTest" />
             <class name="io.ballerina.semantic.api.test.symbols.SymbolsInMappingConstructorTest" />
             <class name="io.ballerina.semantic.api.test.symbols.SymbolsInObjectConstructorTest" />

--- a/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
+++ b/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
@@ -105,6 +105,7 @@
 
             <!--Symbols-->
             <class name="io.ballerina.semantic.api.test.symbols.FunctionSymbolTest" />
+            <class name="io.ballerina.semantic.api.test.symbols.ObjectTypeSymbolTest" />
             <class name="io.ballerina.semantic.api.test.symbols.SymbolsInMappingConstructorTest" />
             <class name="io.ballerina.semantic.api.test.symbols.SymbolsInObjectConstructorTest" />
             <class name="io.ballerina.semantic.api.test.symbols.TypeSymbolTest" />


### PR DESCRIPTION
## Purpose
This PR adds tests to validate the behaviour of the `symbol()` method in the Semantic API against the spec. This also fixes a couple of minor bugs that was found while verifying the behaviour.

## Remarks
Some of the tests/checks in this PR are commented. Those are buggy areas in the compiler/Semantic API. Following issues are for tracking these issues.
- #32194 
- #32195 
- #32196 
- #32197
- #32198
- #18207 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
