### PR TITLE
Remove the "this function can be marked as isolated" warning logged for ballerina/ballerinax modules

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticWarningCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticWarningCode.java
@@ -55,15 +55,13 @@ public enum DiagnosticWarningCode implements DiagnosticCode {
     MATCH_STMT_PATTERN_UNREACHABLE("BCE20250", "match.stmt.unreachable.pattern.available"),
     MATCH_STMT_UNMATCHED_PATTERN("BCE20251", "match.stmt.unmatched.pattern"),
 
-    FUNCTION_CAN_BE_MARKED_ISOLATED("BCE20300", "function.can.be.marked.isolated"),
+    COMPILER_PLUGIN_ERROR("BCE20300", "compiler.plugin.crashed"),
 
-    COMPILER_PLUGIN_ERROR("BCE20400", "compiler.plugin.crashed"),
-
-    CONCURRENT_CALLS_WILL_NOT_BE_MADE_TO_NON_ISOLATED_METHOD_IN_NON_ISOLATED_SERVICE("BCE20401",
+    CONCURRENT_CALLS_WILL_NOT_BE_MADE_TO_NON_ISOLATED_METHOD_IN_NON_ISOLATED_SERVICE("BCE20400",
             "concurrent.calls.will.not.be.made.to.non.isolated.method.in.non.isolated.service"),
-    CONCURRENT_CALLS_WILL_NOT_BE_MADE_TO_NON_ISOLATED_SERVICE("BCE20402",
+    CONCURRENT_CALLS_WILL_NOT_BE_MADE_TO_NON_ISOLATED_SERVICE("BCE20401",
             "concurrent.calls.will.not.be.made.to.non.isolated.service"),
-    CONCURRENT_CALLS_WILL_NOT_BE_MADE_TO_NON_ISOLATED_METHOD("BCE20403",
+    CONCURRENT_CALLS_WILL_NOT_BE_MADE_TO_NON_ISOLATED_METHOD("BCE20402",
             "concurrent.calls.will.not.be.made.to.non.isolated.method")
     ;
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/IsolationAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/IsolationAnalyzer.java
@@ -416,17 +416,14 @@ public class IsolationAnalyzer extends BLangNodeVisitor {
 
         analyzeNode(funcNode.body, funcEnv);
 
-        if (!isIsolated(symbol.flags) && this.inferredIsolated && !Symbols.isFlagOn(symbol.flags, Flags.WORKER)) {
-            if (isBallerinaModule(env.enclPkg)) {
-                dlog.warning(funcNode.pos, DiagnosticWarningCode.FUNCTION_CAN_BE_MARKED_ISOLATED, funcNode.name);
-            }
-
-            if (functionIsolationInferenceInfo != null &&
-                    functionIsolationInferenceInfo.dependsOnlyOnInferableConstructs &&
-                    // Init method isolation depends on the object field-initializers too, so we defer inference.
-                    !funcNode.objInitFunction) {
-                functionIsolationInferenceInfo.inferredIsolated = true;
-            }
+        if (this.inferredIsolated &&
+                !isIsolated(symbol.flags) &&
+                !Symbols.isFlagOn(symbol.flags, Flags.WORKER) &&
+                functionIsolationInferenceInfo != null &&
+                functionIsolationInferenceInfo.dependsOnlyOnInferableConstructs &&
+                // Init method isolation depends on the object field-initializers too, so we defer inference.
+                !funcNode.objInitFunction) {
+            functionIsolationInferenceInfo.inferredIsolated = true;
         }
 
         this.inferredIsolated = this.inferredIsolated && prevInferredIsolated;
@@ -2368,11 +2365,6 @@ public class IsolationAnalyzer extends BLangNodeVisitor {
         if (inLockStatement) {
             copyInLockInfoStack.peek().nonIsolatedInvocations.add(invocationExpr);
         }
-    }
-
-    private boolean isBallerinaModule(BLangPackage module) {
-        String orgName = module.packageID.orgName.value;
-        return orgName.equals("ballerina") || orgName.equals("ballerinax");
     }
 
     private boolean isInIsolatedFunction(BLangInvokableNode enclInvokable) {

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1655,9 +1655,6 @@ error.invalid.worker.declaration.in.isolated.function=\
 error.invalid.fork.statement.in.isolated.function=\
   fork statement not allowed in an ''isolated'' function
 
-warning.function.can.be.marked.isolated=\
-  function ''{0}'' can be marked as an ''isolated'' function
-
 error.invalid.non.private.mutable.field.in.isolated.object=\
   invalid non-private mutable field in an ''isolated'' object
 


### PR DESCRIPTION
## Purpose
$title. Since the migration is done by the stdlib team and this results in unnecessary warnings with inference now, when the org name used by a sample is ballerina or ballerinax.

Fixes #32084

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
