### PR TITLE
Fix `typeof` expression providing wrong outputs

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/values/BMap.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/values/BMap.java
@@ -192,7 +192,5 @@ public interface BMap<K, V> extends BRefValue, BCollection {
 
     Object merge(BMap v2, boolean checkMergeability);
 
-    BTypedesc getTypedesc();
-
     void populateInitialValue(K key, V value);
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/values/BRefValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/values/BRefValue.java
@@ -94,4 +94,6 @@ public interface BRefValue extends BValue {
             throw new BallerinaException("error occurred while serializing data", e);
         }
     }
+
+    BTypedesc getTypedesc();
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -524,6 +524,9 @@ public class TypeChecker {
         if (type == null) {
             return null;
         }
+        if (isSimpleBasicType(type)) {
+            type = new BFiniteType(value.toString(), Set.of(value), 0);
+        }
         if (value instanceof MapValue) {
             TypedescValue typedesc = (TypedescValue) ((MapValue) value).getTypedesc();
             if (typedesc != null) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -525,13 +525,10 @@ public class TypeChecker {
             return null;
         }
         if (isSimpleBasicType(type)) {
-            type = new BFiniteType(value.toString(), Set.of(value), 0);
+            return new TypedescValueImpl(new BFiniteType(value.toString(), Set.of(value), 0));
         }
-        if (value instanceof MapValue) {
-            TypedescValue typedesc = (TypedescValue) ((MapValue) value).getTypedesc();
-            if (typedesc != null) {
-                return typedesc;
-            }
+        if (value instanceof RefValue) {
+            return (TypedescValue) ((RefValue) value).getTypedesc();
         }
         return new TypedescValueImpl(type);
     }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/ValueUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/ValueUtils.java
@@ -18,12 +18,16 @@
 package io.ballerina.runtime.internal;
 
 import io.ballerina.runtime.api.Module;
+import io.ballerina.runtime.api.creators.TypeCreator;
 import io.ballerina.runtime.api.flags.SymbolFlags;
 import io.ballerina.runtime.api.types.Field;
+import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
+import io.ballerina.runtime.api.values.BTypedesc;
+import io.ballerina.runtime.api.values.BValue;
 import io.ballerina.runtime.api.values.BXml;
 import io.ballerina.runtime.internal.scheduling.Scheduler;
 import io.ballerina.runtime.internal.scheduling.State;
@@ -31,9 +35,11 @@ import io.ballerina.runtime.internal.scheduling.Strand;
 import io.ballerina.runtime.internal.types.BRecordType;
 import io.ballerina.runtime.internal.values.MapValue;
 import io.ballerina.runtime.internal.values.MapValueImpl;
+import io.ballerina.runtime.internal.values.TypedescValueImpl;
 import io.ballerina.runtime.internal.values.ValueCreator;
 
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Class @{@link ValueUtils} provides utils to create Ballerina Values.
@@ -162,5 +168,28 @@ public class ValueUtils {
         BXml xml = TypeConverter.stringToXml(value);
         xml.freezeDirect();
         return xml;
+    }
+
+
+    /**
+     * Provide the Typedesc Value with the singleton type with a value.
+     * @param value Ballerina value
+     * @return typedesc with singleton type
+     */
+    public static BTypedesc createSingletonTypedesc(BValue value) {
+        return io.ballerina.runtime.api.creators.ValueCreator
+                .createTypedescValue(TypeCreator.createFiniteType(value.toString(), Set.of(value), 0));
+    }
+
+    /**
+     * Provide the Typedesc Value depending on the immutability of a value.
+     * @param type Ballerina value
+     * @return typedesc with the suitable type
+     */
+    public static BTypedesc getTypedescValue(Type type, BValue value) {
+        if (type.isReadOnly()) {
+            return createSingletonTypedesc(value);
+        }
+        return new TypedescValueImpl(type);
     }
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/AbstractObjectValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/AbstractObjectValue.java
@@ -29,6 +29,7 @@ import io.ballerina.runtime.api.values.BLink;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
+import io.ballerina.runtime.api.values.BTypedesc;
 import io.ballerina.runtime.internal.TypeChecker;
 import io.ballerina.runtime.internal.types.BObjectType;
 import io.ballerina.runtime.internal.util.exceptions.BLangExceptionHelper;
@@ -56,13 +57,14 @@ import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReason
  * @since 0.995.0
  */
 public abstract class AbstractObjectValue implements ObjectValue {
-
+    private BTypedesc typedesc;
     private BObjectType type;
 
     private final HashMap<String, Object> nativeData = new HashMap<>();
 
     public AbstractObjectValue(BObjectType type) {
         this.type = type;
+        this.typedesc = new TypedescValueImpl(type);
     }
 
     @Override
@@ -175,6 +177,11 @@ public abstract class AbstractObjectValue implements ObjectValue {
         }
 
         return sj.toString();
+    }
+
+    @Override
+    public BTypedesc getTypedesc() {
+        return typedesc;
     }
 
     private String getStringValue(Object value) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ArrayValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ArrayValueImpl.java
@@ -49,6 +49,8 @@ import java.util.StringJoiner;
 import java.util.stream.IntStream;
 
 import static io.ballerina.runtime.api.constants.RuntimeConstants.ARRAY_LANG_LIB;
+import static io.ballerina.runtime.internal.ValueUtils.createSingletonTypedesc;
+import static io.ballerina.runtime.internal.ValueUtils.getTypedescValue;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.INDEX_OUT_OF_RANGE_ERROR_IDENTIFIER;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.INHERENT_TYPE_VIOLATION_ERROR_IDENTIFIER;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.getModulePrefixedReason;
@@ -85,35 +87,35 @@ public class ArrayValueImpl extends AbstractArrayValue {
         if (type.getTag() == TypeTags.ARRAY_TAG) {
             this.elementType = type.getElementType();
         }
-        setTypedescValue();
+        this.typedesc = getTypedescValue(arrayType, this);
     }
 
     public ArrayValueImpl(long[] values, boolean readonly) {
         this.intValues = values;
         this.size = values.length;
         setArrayType(PredefinedTypes.TYPE_INT, readonly);
-        setTypedescValue();
+        this.typedesc = getTypedescValue(arrayType, this);
     }
 
     public ArrayValueImpl(boolean[] values, boolean readonly) {
         this.booleanValues = values;
         this.size = values.length;
         setArrayType(PredefinedTypes.TYPE_BOOLEAN, readonly);
-        setTypedescValue();
+        this.typedesc = getTypedescValue(arrayType, this);
     }
 
     public ArrayValueImpl(byte[] values, boolean readonly) {
         this.byteValues = values;
         this.size = values.length;
         setArrayType(PredefinedTypes.TYPE_BYTE, readonly);
-        setTypedescValue();
+        this.typedesc = getTypedescValue(arrayType, this);
     }
 
     public ArrayValueImpl(double[] values, boolean readonly) {
         this.floatValues = values;
         this.size = values.length;
         setArrayType(PredefinedTypes.TYPE_FLOAT, readonly);
-        setTypedescValue();
+        this.typedesc = getTypedescValue(arrayType, this);
     }
 
     public ArrayValueImpl(String[] values, boolean readonly) {
@@ -123,18 +125,14 @@ public class ArrayValueImpl extends AbstractArrayValue {
             bStringValues[i] = StringUtils.fromString(values[i]);
         }
         setArrayType(PredefinedTypes.TYPE_STRING, readonly);
-        setTypedescValue();
-    }
-
-    private void setTypedescValue() {
-        this.typedesc = new TypedescValueImpl(this.arrayType);
+        this.typedesc = getTypedescValue(arrayType, this);
     }
 
     public ArrayValueImpl(BString[] values, boolean readonly) {
         this.bStringValues = values;
         this.size = values.length;
         setArrayType(PredefinedTypes.TYPE_STRING, readonly);
-        setTypedescValue();
+        this.typedesc = getTypedescValue(arrayType, this);
     }
 
     public ArrayValueImpl(ArrayType type) {
@@ -144,7 +142,7 @@ public class ArrayValueImpl extends AbstractArrayValue {
         if (type.getState() == ArrayState.CLOSED) {
             this.size = maxSize = type.getSize();
         }
-        setTypedescValue();
+        this.typedesc = getTypedescValue(arrayType, this);
     }
 
     private void initArrayValues(Type elementType) {
@@ -248,7 +246,7 @@ public class ArrayValueImpl extends AbstractArrayValue {
         if (size != -1) {
             this.size = this.maxSize = (int) size;
         }
-        setTypedescValue();
+        this.typedesc = getTypedescValue(arrayType, this);
     }
 
     public ArrayValueImpl(ArrayType type, long size, BListInitialValueEntry[] initialValues) {
@@ -264,10 +262,10 @@ public class ArrayValueImpl extends AbstractArrayValue {
         if (size != -1) {
             this.size = this.maxSize = (int) size;
         }
-        setTypedescValue();
         for (int index = 0; index < initialValues.length; index++) {
             addRefValue(index, ((ListInitialValueEntry.ExpressionEntry) initialValues[index]).value);
         }
+        this.typedesc = getTypedescValue(arrayType, this);
     }
 
     // ----------------------- get methods ----------------------------------------------------
@@ -683,7 +681,7 @@ public class ArrayValueImpl extends AbstractArrayValue {
                 }
                 break;
         }
-        return "[" + sj.toString() + "]";
+        return "[" + sj + "]";
     }
 
     @Override
@@ -733,7 +731,7 @@ public class ArrayValueImpl extends AbstractArrayValue {
                 }
                 break;
         }
-        return "[" + sj.toString() + "]";
+        return "[" + sj + "]";
     }
 
     @Override
@@ -953,7 +951,6 @@ public class ArrayValueImpl extends AbstractArrayValue {
         }
 
         this.arrayType = (ArrayType) ReadOnlyUtils.setImmutableTypeAndGetEffectiveType(this.arrayType);
-//        this.typedesc = new TypedescValueImpl(new BFiniteType(toString(), Set.of(this), 0));
         if (this.elementType == null || this.elementType.getTag() > TypeTags.BOOLEAN_TAG) {
             for (int i = 0; i < this.size; i++) {
                 Object value = this.getRefValue(i);
@@ -962,6 +959,7 @@ public class ArrayValueImpl extends AbstractArrayValue {
                 }
             }
         }
+        this.typedesc = createSingletonTypedesc(this);
     }
 
     /**

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ArrayValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ArrayValueImpl.java
@@ -28,6 +28,7 @@ import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.values.BLink;
 import io.ballerina.runtime.api.values.BListInitialValueEntry;
 import io.ballerina.runtime.api.values.BString;
+import io.ballerina.runtime.api.values.BTypedesc;
 import io.ballerina.runtime.api.values.BValue;
 import io.ballerina.runtime.internal.CycleUtils;
 import io.ballerina.runtime.internal.TypeChecker;
@@ -74,6 +75,7 @@ public class ArrayValueImpl extends AbstractArrayValue {
     private byte[] byteValues;
     private double[] floatValues;
     private BString[] bStringValues;
+    private BTypedesc typedesc;
     // ------------------------ Constructors -------------------------------------------------------------------
 
     public ArrayValueImpl(Object[] values, ArrayType type) {
@@ -83,30 +85,35 @@ public class ArrayValueImpl extends AbstractArrayValue {
         if (type.getTag() == TypeTags.ARRAY_TAG) {
             this.elementType = type.getElementType();
         }
+        setTypedescValue();
     }
 
     public ArrayValueImpl(long[] values, boolean readonly) {
         this.intValues = values;
         this.size = values.length;
         setArrayType(PredefinedTypes.TYPE_INT, readonly);
+        setTypedescValue();
     }
 
     public ArrayValueImpl(boolean[] values, boolean readonly) {
         this.booleanValues = values;
         this.size = values.length;
         setArrayType(PredefinedTypes.TYPE_BOOLEAN, readonly);
+        setTypedescValue();
     }
 
     public ArrayValueImpl(byte[] values, boolean readonly) {
         this.byteValues = values;
         this.size = values.length;
         setArrayType(PredefinedTypes.TYPE_BYTE, readonly);
+        setTypedescValue();
     }
 
     public ArrayValueImpl(double[] values, boolean readonly) {
         this.floatValues = values;
         this.size = values.length;
         setArrayType(PredefinedTypes.TYPE_FLOAT, readonly);
+        setTypedescValue();
     }
 
     public ArrayValueImpl(String[] values, boolean readonly) {
@@ -116,12 +123,18 @@ public class ArrayValueImpl extends AbstractArrayValue {
             bStringValues[i] = StringUtils.fromString(values[i]);
         }
         setArrayType(PredefinedTypes.TYPE_STRING, readonly);
+        setTypedescValue();
+    }
+
+    private void setTypedescValue() {
+        this.typedesc = new TypedescValueImpl(this.arrayType);
     }
 
     public ArrayValueImpl(BString[] values, boolean readonly) {
         this.bStringValues = values;
         this.size = values.length;
         setArrayType(PredefinedTypes.TYPE_STRING, readonly);
+        setTypedescValue();
     }
 
     public ArrayValueImpl(ArrayType type) {
@@ -131,6 +144,7 @@ public class ArrayValueImpl extends AbstractArrayValue {
         if (type.getState() == ArrayState.CLOSED) {
             this.size = maxSize = type.getSize();
         }
+        setTypedescValue();
     }
 
     private void initArrayValues(Type elementType) {
@@ -165,6 +179,11 @@ public class ArrayValueImpl extends AbstractArrayValue {
                     fillValues(initialArraySize);
                 }
         }
+    }
+
+    @Override
+    public BTypedesc getTypedesc() {
+        return typedesc;
     }
 
     @Override
@@ -229,6 +248,7 @@ public class ArrayValueImpl extends AbstractArrayValue {
         if (size != -1) {
             this.size = this.maxSize = (int) size;
         }
+        setTypedescValue();
     }
 
     public ArrayValueImpl(ArrayType type, long size, BListInitialValueEntry[] initialValues) {
@@ -244,7 +264,7 @@ public class ArrayValueImpl extends AbstractArrayValue {
         if (size != -1) {
             this.size = this.maxSize = (int) size;
         }
-
+        setTypedescValue();
         for (int index = 0; index < initialValues.length; index++) {
             addRefValue(index, ((ListInitialValueEntry.ExpressionEntry) initialValues[index]).value);
         }
@@ -933,6 +953,7 @@ public class ArrayValueImpl extends AbstractArrayValue {
         }
 
         this.arrayType = (ArrayType) ReadOnlyUtils.setImmutableTypeAndGetEffectiveType(this.arrayType);
+//        this.typedesc = new TypedescValueImpl(new BFiniteType(toString(), Set.of(this), 0));
         if (this.elementType == null || this.elementType.getTag() > TypeTags.BOOLEAN_TAG) {
             for (int i = 0; i < this.size; i++) {
                 Object value = this.getRefValue(i);

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ErrorValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ErrorValue.java
@@ -28,6 +28,7 @@ import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.api.values.BLink;
 import io.ballerina.runtime.api.values.BString;
+import io.ballerina.runtime.api.values.BTypedesc;
 import io.ballerina.runtime.api.values.BValue;
 import io.ballerina.runtime.internal.CycleUtils;
 import io.ballerina.runtime.internal.TypeChecker;
@@ -64,6 +65,7 @@ public class ErrorValue extends BError implements RefValue {
     private static final PrintStream outStream = System.err;
 
     private final Type type;
+    private final BTypedesc typedesc;
     private final BString message;
     private final BError cause;
     private final Object details;
@@ -92,6 +94,7 @@ public class ErrorValue extends BError implements RefValue {
         this.message = message;
         this.cause = cause;
         this.details = details;
+        this.typedesc = new TypedescValueImpl(type);
     }
 
     public ErrorValue(Type type, BString message, BError cause, Object details,
@@ -104,6 +107,7 @@ public class ErrorValue extends BError implements RefValue {
         BTypeIdSet typeIdSet = new BTypeIdSet();
         typeIdSet.add(typeIdPkg, typeIdName, true);
         ((BErrorType) type).setTypeIdSet(typeIdSet);
+        this.typedesc = new TypedescValueImpl(type);
     }
 
     @Override
@@ -215,6 +219,10 @@ public class ErrorValue extends BError implements RefValue {
     public Object frozenCopy(Map<Object, Object> refs) {
         // Error values are immutable and frozen, copy give same value.
         return this;
+    }
+
+    public BTypedesc getTypedesc() {
+        return typedesc;
     }
 
     /**

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/FPValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/FPValue.java
@@ -23,6 +23,7 @@ import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.values.BFunctionPointer;
 import io.ballerina.runtime.api.values.BFuture;
 import io.ballerina.runtime.api.values.BLink;
+import io.ballerina.runtime.api.values.BTypedesc;
 import io.ballerina.runtime.internal.scheduling.AsyncUtils;
 import io.ballerina.runtime.internal.scheduling.Scheduler;
 
@@ -46,6 +47,7 @@ import java.util.function.Function;
 public class FPValue<T, R> implements BFunctionPointer<T, R>, RefValue {
 
     final Type type;
+    private final BTypedesc typedesc;
     Function<T, R> function;
     public boolean isConcurrent;
     public String strandName;
@@ -56,6 +58,7 @@ public class FPValue<T, R> implements BFunctionPointer<T, R>, RefValue {
         this.type = type;
         this.strandName = strandName;
         this.isConcurrent = isConcurrent;
+        this.typedesc = new TypedescValueImpl(type);
     }
 
     public R call(T t) {
@@ -109,6 +112,11 @@ public class FPValue<T, R> implements BFunctionPointer<T, R>, RefValue {
     @Override
     public void freezeDirect() {
         return;
+    }
+
+    @Override
+    public BTypedesc getTypedesc() {
+        return typedesc;
     }
 
     @Override

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/FutureValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/FutureValue.java
@@ -21,6 +21,7 @@ package io.ballerina.runtime.internal.values;
  import io.ballerina.runtime.api.types.Type;
  import io.ballerina.runtime.api.values.BFuture;
  import io.ballerina.runtime.api.values.BLink;
+ import io.ballerina.runtime.api.values.BTypedesc;
  import io.ballerina.runtime.internal.scheduling.Strand;
  import io.ballerina.runtime.internal.types.BFutureType;
 
@@ -39,7 +40,9 @@ package io.ballerina.runtime.internal.values;
  */
  public class FutureValue implements BFuture, RefValue {
 
-     public Strand strand;
+    private final BTypedesc typedesc;
+
+    public Strand strand;
 
      public Object result;
 
@@ -58,7 +61,8 @@ package io.ballerina.runtime.internal.values;
          this.strand = strand;
          this.callback = callback;
          this.type = new BFutureType(constraint);
-     }
+        this.typedesc = new TypedescValueImpl(this.type);
+    }
 
      @Override
      public String stringValue(BLink parent) {
@@ -93,7 +97,12 @@ package io.ballerina.runtime.internal.values;
          throw new UnsupportedOperationException();
      }
 
-     public void cancel() {
+    @Override
+    public BTypedesc getTypedesc() {
+        return typedesc;
+    }
+
+    public void cancel() {
          this.strand.cancel = true;
      }
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/FutureValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/FutureValue.java
@@ -15,7 +15,7 @@
   *  specific language governing permissions and limitations
   *  under the License.
   */
-package io.ballerina.runtime.internal.values;
+ package io.ballerina.runtime.internal.values;
 
  import io.ballerina.runtime.api.async.Callback;
  import io.ballerina.runtime.api.types.Type;
@@ -28,21 +28,21 @@ package io.ballerina.runtime.internal.values;
  import java.util.Map;
  import java.util.StringJoiner;
 
-/**
- * <p>
- * Represent a Ballerina future in Java.
- * </p>
- * <p>
- * <i>Note: This is an internal API and may change in future versions.</i>
- * </p>
- * 
- * @since 0.995.0
- */
+ /**
+  * <p>
+  * Represent a Ballerina future in Java.
+  * </p>
+  * <p>
+  * <i>Note: This is an internal API and may change in future versions.</i>
+  * </p>
+  *
+  * @since 0.995.0
+  */
  public class FutureValue implements BFuture, RefValue {
 
-    private final BTypedesc typedesc;
+     private final BTypedesc typedesc;
 
-    public Strand strand;
+     public Strand strand;
 
      public Object result;
 
@@ -61,8 +61,8 @@ package io.ballerina.runtime.internal.values;
          this.strand = strand;
          this.callback = callback;
          this.type = new BFutureType(constraint);
-        this.typedesc = new TypedescValueImpl(this.type);
-    }
+         this.typedesc = new TypedescValueImpl(this.type);
+     }
 
      @Override
      public String stringValue(BLink parent) {
@@ -77,12 +77,12 @@ package io.ballerina.runtime.internal.values;
          return "future " + sj;
      }
 
-    @Override
-    public String expressionStringValue(BLink parent) {
-        return stringValue(parent);
-    }
+     @Override
+     public String expressionStringValue(BLink parent) {
+         return stringValue(parent);
+     }
 
-    @Override
+     @Override
      public Type getType() {
          return this.type;
      }
@@ -97,65 +97,65 @@ package io.ballerina.runtime.internal.values;
          throw new UnsupportedOperationException();
      }
 
-    @Override
-    public BTypedesc getTypedesc() {
-        return typedesc;
-    }
+     @Override
+     public BTypedesc getTypedesc() {
+         return typedesc;
+     }
 
-    public void cancel() {
+     public void cancel() {
          this.strand.cancel = true;
      }
 
-    /**
-     * Returns the strand that the future is attached to.
-     * @return {@code Strand}
-     */
-    public Strand getStrand() {
-        return this.strand;
-    }
+     /**
+      * Returns the strand that the future is attached to.
+      * @return {@code Strand}
+      */
+     public Strand getStrand() {
+         return this.strand;
+     }
 
-    /**
-     * Returns the result value of the future.
-     * @return result value
-     */
-    public Object getResult() {
-       return this.result;
-    }
+     /**
+      * Returns the result value of the future.
+      * @return result value
+      */
+     public Object getResult() {
+         return this.result;
+     }
 
-    /**
-     * Returns completion status of the {@code Strand} that the future is attached.
-     * @return true if future is completed
-     */
-    public boolean isDone() {
-        return this.isDone;
-    }
+     /**
+      * Returns completion status of the {@code Strand} that the future is attached.
+      * @return true if future is completed
+      */
+     public boolean isDone() {
+         return this.isDone;
+     }
 
-    /**
-     * Returns {@code Throwable} if the attached strand panic.
-     * @return panic error or null if not panic occurred
-     */
-    public Throwable getPanic() {
-        return this.panic;
-    }
+     /**
+      * Returns {@code Throwable} if the attached strand panic.
+      * @return panic error or null if not panic occurred
+      */
+     public Throwable getPanic() {
+         return this.panic;
+     }
 
-    /**
-     * {@code CallableUnitCallback} listening on the completion of this future.
-     * @return registered {@code CallableUnitCallback}
-     */
-    public Callback getCallback() {
-        return this.callback;
-    }
+     /**
+      * {@code CallableUnitCallback} listening on the completion of this future.
+      * @return registered {@code CallableUnitCallback}
+      */
+     public Callback getCallback() {
+         return this.callback;
+     }
 
-    @Override
-    public String toString() {
-        return stringValue(null);
-    }
+     @Override
+     public String toString() {
+         return stringValue(null);
+     }
 
-    public boolean hasWaited() {
-        return waited;
-    }
+     public boolean hasWaited() {
+         return waited;
+     }
 
-    public void setWaited(boolean waited) {
-        this.waited = waited;
-    }
-}
+     public void setWaited(boolean waited) {
+         this.waited = waited;
+     }
+ }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/HandleValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/HandleValue.java
@@ -21,6 +21,7 @@ import io.ballerina.runtime.api.PredefinedTypes;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.values.BHandle;
 import io.ballerina.runtime.api.values.BLink;
+import io.ballerina.runtime.api.values.BTypedesc;
 
 import java.util.Map;
 
@@ -37,6 +38,7 @@ import java.util.Map;
 public class HandleValue implements BHandle, RefValue {
 
     private Object value;
+    private final BTypedesc typedesc = new TypedescValueImpl(PredefinedTypes.TYPE_HANDLE);
 
     @Deprecated
     public HandleValue(Object value) {
@@ -79,6 +81,11 @@ public class HandleValue implements BHandle, RefValue {
     @Override
     public void freezeDirect() {
         return;
+    }
+
+    @Override
+    public BTypedesc getTypedesc() {
+        return typedesc;
     }
 
     @Override

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/IteratorValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/IteratorValue.java
@@ -21,6 +21,7 @@ import io.ballerina.runtime.api.PredefinedTypes;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.values.BIterator;
 import io.ballerina.runtime.api.values.BLink;
+import io.ballerina.runtime.api.values.BTypedesc;
 
 import java.util.Map;
 
@@ -35,6 +36,8 @@ import java.util.Map;
  * @since 0.995.0
  */
 public interface IteratorValue extends RefValue, BIterator {
+
+    final BTypedesc TYPEDESC = new TypedescValueImpl(PredefinedTypes.TYPE_ITERATOR);
 
     /* Default implementation */
 
@@ -61,5 +64,10 @@ public interface IteratorValue extends RefValue, BIterator {
     @Override
     default Object frozenCopy(Map<Object, Object> refs) {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    default BTypedesc getTypedesc() {
+        return TYPEDESC;
     }
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValueImpl.java
@@ -63,6 +63,8 @@ import java.util.stream.Collectors;
 
 import static io.ballerina.runtime.api.constants.RuntimeConstants.MAP_LANG_LIB;
 import static io.ballerina.runtime.internal.JsonUtils.mergeJson;
+import static io.ballerina.runtime.internal.ValueUtils.createSingletonTypedesc;
+import static io.ballerina.runtime.internal.ValueUtils.getTypedescValue;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.INVALID_UPDATE_ERROR_IDENTIFIER;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.MAP_KEY_NOT_FOUND_ERROR;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.getModulePrefixedReason;
@@ -88,37 +90,37 @@ public class MapValueImpl<K, V> extends LinkedHashMap<K, V> implements RefValue,
         BMap<K, V> {
 
     private static final long serialVersionUID = 1L;
-    private TypedescValue typedesc;
+    private BTypedesc typedesc;
     private Type type;
     private final Map<String, Object> nativeData = new HashMap<>();
     private Type iteratorNextReturnType;
 
     public MapValueImpl(TypedescValue typedesc) {
         this(typedesc.getDescribingType());
-        this.typedesc = typedesc;
+        if (!type.isReadOnly()) {
+            this.typedesc = typedesc;
+        }
     }
 
     public MapValueImpl(Type type) {
         super();
         this.type = type;
-        setTypedescValue();
+        this.typedesc = getTypedescValue(type, this);
     }
 
     public MapValueImpl(Type type, BMapInitialValueEntry[] initialValues) {
         super();
         this.type = type;
-        setTypedescValue();
         populateInitialValues(initialValues);
+        if (!type.isReadOnly()) {
+            this.typedesc = new TypedescValueImpl(type);
+        }
     }
 
     public MapValueImpl() {
         super();
         type = PredefinedTypes.TYPE_MAP;
-        setTypedescValue();
-    }
-
-    private void setTypedescValue() {
-        this.typedesc = new TypedescValueImpl(this.type);
+        this.typedesc = getTypedescValue(type, this);
     }
 
     public Long getIntValue(BString key) {
@@ -290,6 +292,9 @@ public class MapValueImpl<K, V> extends LinkedHashMap<K, V> implements RefValue,
             for (Map.Entry<K, V> entry : values.entrySet()) {
                 populateInitialValue(entry.getKey(), entry.getValue());
             }
+        }
+        if (this.type.isReadOnly()) {
+            this.typedesc = createSingletonTypedesc(this);
         }
     }
 
@@ -515,6 +520,7 @@ public class MapValueImpl<K, V> extends LinkedHashMap<K, V> implements RefValue,
                 ((RefValue) val).freezeDirect();
             }
         });
+        this.typedesc = createSingletonTypedesc(this);
     }
 
     public String getJSONString() {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValueImpl.java
@@ -101,17 +101,24 @@ public class MapValueImpl<K, V> extends LinkedHashMap<K, V> implements RefValue,
     public MapValueImpl(Type type) {
         super();
         this.type = type;
+        setTypedescValue();
     }
 
     public MapValueImpl(Type type, BMapInitialValueEntry[] initialValues) {
         super();
         this.type = type;
+        setTypedescValue();
         populateInitialValues(initialValues);
     }
 
     public MapValueImpl() {
         super();
         type = PredefinedTypes.TYPE_MAP;
+        setTypedescValue();
+    }
+
+    private void setTypedescValue() {
+        this.typedesc = new TypedescValueImpl(this.type);
     }
 
     public Long getIntValue(BString key) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/StreamValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/StreamValue.java
@@ -22,6 +22,7 @@ import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.values.BLink;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BStream;
+import io.ballerina.runtime.api.values.BTypedesc;
 import io.ballerina.runtime.internal.IteratorUtils;
 import io.ballerina.runtime.internal.types.BStreamType;
 
@@ -40,6 +41,7 @@ import java.util.UUID;
  */
 public class StreamValue implements RefValue, BStream {
 
+    private final BTypedesc typedesc;
     private Type type;
     private Type constraintType;
     private Type completionType;
@@ -59,6 +61,7 @@ public class StreamValue implements RefValue, BStream {
         this.type = new BStreamType(constraintType, completionType);
         this.streamId = UUID.randomUUID().toString();
         this.iteratorObj = null;
+        this.typedesc = new TypedescValueImpl(type);
     }
 
     public StreamValue(Type type, BObject iteratorObj) {
@@ -67,6 +70,7 @@ public class StreamValue implements RefValue, BStream {
         this.type = new BStreamType(constraintType, completionType);
         this.streamId = UUID.randomUUID().toString();
         this.iteratorObj = iteratorObj;
+        this.typedesc = new TypedescValueImpl(type);
     }
 
     public String getStreamId() {
@@ -116,6 +120,11 @@ public class StreamValue implements RefValue, BStream {
      */
     public Object frozenCopy(Map<Object, Object> refs) {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BTypedesc getTypedesc() {
+        return typedesc;
     }
 
     public Type getConstraintType() {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TableValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TableValueImpl.java
@@ -30,6 +30,7 @@ import io.ballerina.runtime.api.values.BLink;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
+import io.ballerina.runtime.api.values.BTypedesc;
 import io.ballerina.runtime.internal.CycleUtils;
 import io.ballerina.runtime.internal.IteratorUtils;
 import io.ballerina.runtime.internal.TableUtils;
@@ -92,6 +93,7 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
     private boolean nextKeySupported;
 
     private final Map<String, Object> nativeData = new HashMap<>();
+    private BTypedesc typedesc;
 
     public TableValueImpl(TableType type) {
         this.type = type;
@@ -102,6 +104,7 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
         this.keyToIndexMap = new LinkedHashMap<>();
         this.indexToKeyMap = new LinkedHashMap<>();
         this.fieldNames = type.getFieldNames();
+        setTypedescValue();
         if (type.getFieldNames() != null) {
             this.valueHolder = new KeyHashValueHolder();
         } else {
@@ -177,6 +180,15 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
                                                StringUtils.fromString(e.getDetail()));
             }
         }
+    }
+
+    @Override
+    public BTypedesc getTypedesc() {
+        return typedesc;
+    }
+
+    private void setTypedescValue() {
+        this.typedesc = new TypedescValueImpl(this.type);
     }
 
     @Override

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TupleValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TupleValueImpl.java
@@ -46,6 +46,8 @@ import java.util.StringJoiner;
 import java.util.stream.IntStream;
 
 import static io.ballerina.runtime.api.constants.RuntimeConstants.ARRAY_LANG_LIB;
+import static io.ballerina.runtime.internal.ValueUtils.createSingletonTypedesc;
+import static io.ballerina.runtime.internal.ValueUtils.getTypedescValue;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.INDEX_OUT_OF_RANGE_ERROR_IDENTIFIER;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.INHERENT_TYPE_VIOLATION_ERROR_IDENTIFIER;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.getModulePrefixedReason;
@@ -109,7 +111,7 @@ public class TupleValueImpl extends AbstractArrayValue {
         }
         this.minSize = memTypes.size();
         this.size = refValues.length;
-        setTypedescValue();
+        this.typedesc = getTypedescValue(tupleType, this);
     }
 
     public TupleValueImpl(TupleType type) {
@@ -135,7 +137,7 @@ public class TupleValueImpl extends AbstractArrayValue {
             }
             this.refValues[i] = memType.getZeroValue();
         }
-        setTypedescValue();
+        this.typedesc = getTypedescValue(tupleType, this);
     }
 
     public TupleValueImpl(TupleType type, long size, BListInitialValueEntry[] initialValues) {
@@ -147,7 +149,6 @@ public class TupleValueImpl extends AbstractArrayValue {
         this.size = size < memCount ? memCount : (int) size;
         this.minSize = memCount;
         this.hasRestElement = this.tupleType.getRestType() != null;
-        setTypedescValue();
 
         if (type.getRestType() == null) {
             this.maxSize = this.size;
@@ -161,6 +162,7 @@ public class TupleValueImpl extends AbstractArrayValue {
         }
 
         if (size >= memCount) {
+            this.typedesc = getTypedescValue(tupleType, this);
             return;
         }
 
@@ -172,10 +174,7 @@ public class TupleValueImpl extends AbstractArrayValue {
 
             this.refValues[i] = memType.getZeroValue();
         }
-    }
-
-    private void setTypedescValue() {
-        this.typedesc = new TypedescValueImpl(tupleType);
+        this.typedesc = getTypedescValue(tupleType, this);
     }
 
     @Override
@@ -567,6 +566,7 @@ public class TupleValueImpl extends AbstractArrayValue {
                 ((RefValue) value).freezeDirect();
             }
         }
+        this.typedesc = createSingletonTypedesc(this);
     }
 
     /**

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TupleValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TupleValueImpl.java
@@ -26,6 +26,7 @@ import io.ballerina.runtime.api.values.BArray;
 import io.ballerina.runtime.api.values.BLink;
 import io.ballerina.runtime.api.values.BListInitialValueEntry;
 import io.ballerina.runtime.api.values.BString;
+import io.ballerina.runtime.api.values.BTypedesc;
 import io.ballerina.runtime.api.values.BValue;
 import io.ballerina.runtime.internal.CycleUtils;
 import io.ballerina.runtime.internal.TypeChecker;
@@ -65,6 +66,7 @@ public class TupleValueImpl extends AbstractArrayValue {
     Object[] refValues;
     private int minSize;
     private boolean hasRestElement; // cached value for ease of access
+    private BTypedesc typedesc;
     // ------------------------ Constructors -------------------------------------------------------------------
 
     @Override
@@ -107,6 +109,7 @@ public class TupleValueImpl extends AbstractArrayValue {
         }
         this.minSize = memTypes.size();
         this.size = refValues.length;
+        setTypedescValue();
     }
 
     public TupleValueImpl(TupleType type) {
@@ -132,6 +135,7 @@ public class TupleValueImpl extends AbstractArrayValue {
             }
             this.refValues[i] = memType.getZeroValue();
         }
+        setTypedescValue();
     }
 
     public TupleValueImpl(TupleType type, long size, BListInitialValueEntry[] initialValues) {
@@ -143,6 +147,7 @@ public class TupleValueImpl extends AbstractArrayValue {
         this.size = size < memCount ? memCount : (int) size;
         this.minSize = memCount;
         this.hasRestElement = this.tupleType.getRestType() != null;
+        setTypedescValue();
 
         if (type.getRestType() == null) {
             this.maxSize = this.size;
@@ -167,6 +172,15 @@ public class TupleValueImpl extends AbstractArrayValue {
 
             this.refValues[i] = memType.getZeroValue();
         }
+    }
+
+    private void setTypedescValue() {
+        this.typedesc = new TypedescValueImpl(tupleType);
+    }
+
+    @Override
+    public BTypedesc getTypedesc() {
+        return typedesc;
     }
 
     // ----------------------- get methods ----------------------------------------------------

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TypedescValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TypedescValueImpl.java
@@ -22,6 +22,7 @@ import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.values.BInitialValueEntry;
 import io.ballerina.runtime.api.values.BLink;
 import io.ballerina.runtime.api.values.BMapInitialValueEntry;
+import io.ballerina.runtime.api.values.BTypedesc;
 import io.ballerina.runtime.internal.scheduling.Strand;
 import io.ballerina.runtime.internal.types.BTypedescType;
 import io.ballerina.runtime.internal.util.exceptions.BallerinaException;
@@ -117,6 +118,11 @@ public class TypedescValueImpl implements  TypedescValue {
     @Override
     public void freezeDirect() {
         return;
+    }
+
+    @Override
+    public BTypedesc getTypedesc() {
+        return new TypedescValueImpl(this.type);
     }
 
     /**

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlComment.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlComment.java
@@ -39,11 +39,13 @@ public class XmlComment extends XmlNonElementItem {
     public XmlComment(String data) {
         this.data = data;
         this.type = PredefinedTypes.TYPE_COMMENT;
+        setTypedescValue(type);
     }
 
     public XmlComment(String data, boolean readonly) {
         this.data = data;
         this.type = readonly ? PredefinedTypes.TYPE_READONLY_COMMENT : PredefinedTypes.TYPE_COMMENT;
+        setTypedescValue(type);
     }
 
     @Override

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlItem.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlItem.java
@@ -55,6 +55,7 @@ import static io.ballerina.runtime.api.constants.RuntimeConstants.STRING_NULL_VA
 import static io.ballerina.runtime.api.constants.RuntimeConstants.XML_LANG_LIB;
 import static io.ballerina.runtime.api.types.XmlNodeType.ELEMENT;
 import static io.ballerina.runtime.api.types.XmlNodeType.TEXT;
+import static io.ballerina.runtime.internal.ValueUtils.createSingletonTypedesc;
 
 /**
  * {@code XMLItem} represents a single XML element in Ballerina.
@@ -97,6 +98,7 @@ public final class XmlItem extends XmlValue implements BXmlItem {
     public XmlItem(QName name) {
         this(name, new XmlSequence(new ArrayList<>()));
         this.type = PredefinedTypes.TYPE_ELEMENT;
+        setTypedescValue(type);
     }
 
     public XmlItem(QName name, boolean readonly) {
@@ -111,6 +113,7 @@ public final class XmlItem extends XmlValue implements BXmlItem {
         probableParents = new ArrayList<>();
 
         this.type = readonly ? PredefinedTypes.TYPE_READONLY_ELEMENT : PredefinedTypes.TYPE_ELEMENT;
+        setTypedescValue(type);
     }
     private void addDefaultNamespaceAttribute(QName name, AttributeMapValueImpl attributes) {
         String namespace = name.getNamespaceURI();
@@ -627,6 +630,7 @@ public final class XmlItem extends XmlValue implements BXmlItem {
         this.type = ReadOnlyUtils.setImmutableTypeAndGetEffectiveType(this.type);
         this.children.freezeDirect();
         this.attributes.freezeDirect();
+        this.typedesc = createSingletonTypedesc(this);
     }
 
     private QName getQName(String localName, String namespaceUri, String prefix) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlItem.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlItem.java
@@ -82,6 +82,7 @@ public final class XmlItem extends XmlValue implements BXmlItem {
         probableParents = new ArrayList<>();
         this.type = PredefinedTypes.TYPE_ELEMENT;
         this.type = readonly ? PredefinedTypes.TYPE_READONLY_ELEMENT : PredefinedTypes.TYPE_ELEMENT;
+        setTypedescValue(type);
     }
 
     public XmlItem(QName name, XmlSequence children) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlNonElementItem.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlNonElementItem.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 import static io.ballerina.runtime.api.constants.RuntimeConstants.STRING_NULL_VALUE;
+import static io.ballerina.runtime.internal.ValueUtils.createSingletonTypedesc;
 
 /**
  * Functionality common to PI, COMMENT and TEXT nodes.
@@ -214,6 +215,7 @@ public abstract class XmlNonElementItem extends XmlValue implements BXmlNonEleme
     @Override
     public void freezeDirect() {
         this.type = ReadOnlyUtils.setImmutableTypeAndGetEffectiveType(this.type);
+        this.typedesc = createSingletonTypedesc(this);
     }
 
     @Override

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlPi.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlPi.java
@@ -41,6 +41,7 @@ public class XmlPi extends XmlNonElementItem {
         this.data = data;
         this.target = target;
         this.type = PredefinedTypes.TYPE_PROCESSING_INSTRUCTION;
+        setTypedescValue(type);
     }
 
     public XmlPi(String data, String target, boolean readonly) {
@@ -48,6 +49,7 @@ public class XmlPi extends XmlNonElementItem {
         this.target = target;
         this.type = readonly ? PredefinedTypes.TYPE_READONLY_PROCESSING_INSTRUCTION :
                 PredefinedTypes.TYPE_PROCESSING_INSTRUCTION;
+        setTypedescValue(type);
     }
 
     @Override

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlQName.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlQName.java
@@ -21,6 +21,7 @@ import io.ballerina.runtime.api.PredefinedTypes;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.values.BLink;
 import io.ballerina.runtime.api.values.BString;
+import io.ballerina.runtime.api.values.BTypedesc;
 import io.ballerina.runtime.api.values.BXmlQName;
 
 import java.util.Map;
@@ -41,6 +42,7 @@ public final class XmlQName implements RefValue, BXmlQName {
     private String localName;
     private String uri;
     private String prefix;
+    private final BTypedesc typedesc = new TypedescValueImpl(PredefinedTypes.TYPE_XML_ATTRIBUTES);
 
     /**
      * Create attribute map with an XML.
@@ -130,6 +132,11 @@ public final class XmlQName implements RefValue, BXmlQName {
         }
 
         return new XmlQName(localName, uri, prefix);
+    }
+
+    @Override
+    public BTypedesc getTypedesc() {
+        return typedesc;
     }
 
     /**

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlSequence.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlSequence.java
@@ -41,6 +41,7 @@ import java.util.Objects;
 
 import static io.ballerina.runtime.api.constants.RuntimeConstants.STRING_EMPTY_VALUE;
 import static io.ballerina.runtime.api.constants.RuntimeConstants.XML_LANG_LIB;
+import static io.ballerina.runtime.internal.ValueUtils.createSingletonTypedesc;
 
 /**
  * <p>
@@ -67,6 +68,7 @@ public final class XmlSequence extends XmlValue implements BXmlSequence {
 
     public XmlSequence(List<BXml> children) {
         this.children = children;
+        setTypedescValue(type);
     }
 
     public XmlSequence(BXml child) {
@@ -74,6 +76,7 @@ public final class XmlSequence extends XmlValue implements BXmlSequence {
         if (!child.isEmpty()) {
             this.children.add(child);
         }
+        setTypedescValue(type);
     }
 
     public List<BXml> getChildrenList() {
@@ -586,6 +589,7 @@ public final class XmlSequence extends XmlValue implements BXmlSequence {
         for (BXml elem : children) {
             elem.freezeDirect();
         }
+        this.typedesc = createSingletonTypedesc(this);
     }
 
     @Override

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlSequence.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlSequence.java
@@ -62,6 +62,7 @@ public final class XmlSequence extends XmlValue implements BXmlSequence {
     public XmlSequence() {
         children = new ArrayList<>();
         this.type = PredefinedTypes.TYPE_XML_NEVER;
+        setTypedescValue(type);
     }
 
     public XmlSequence(List<BXml> children) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlText.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlText.java
@@ -41,6 +41,7 @@ public class XmlText extends XmlNonElementItem {
         // data is the content of xml comment or text node
         this.data = data;
         this.type = data.isEmpty() ? PredefinedTypes.TYPE_XML_NEVER : PredefinedTypes.TYPE_TEXT;
+        setTypedescValue(type);
     }
 
     @Override

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlValue.java
@@ -34,6 +34,8 @@ import java.util.Map;
 
 import javax.xml.namespace.QName;
 
+import static io.ballerina.runtime.internal.ValueUtils.getTypedescValue;
+
 /**
  * {@code BXML} represents an XML in Ballerina. An XML could be one of:
  * <ul>
@@ -52,7 +54,7 @@ import javax.xml.namespace.QName;
 public abstract class XmlValue implements RefValue, BXml, CollectionValue {
 
     Type type = PredefinedTypes.TYPE_XML;
-    protected TypedescValue typedesc = new TypedescValueImpl(type);
+    protected BTypedesc typedesc = new TypedescValueImpl(type);
 
     public abstract int size();
 
@@ -247,7 +249,7 @@ public abstract class XmlValue implements RefValue, BXml, CollectionValue {
     }
 
     protected void setTypedescValue(Type type) {
-        this.typedesc = new TypedescValueImpl(type);
+        this.typedesc = getTypedescValue(type, this);
     }
 
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlValue.java
@@ -22,6 +22,7 @@ import io.ballerina.runtime.api.types.XmlNodeType;
 import io.ballerina.runtime.api.values.BLink;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BString;
+import io.ballerina.runtime.api.values.BTypedesc;
 import io.ballerina.runtime.api.values.BXml;
 import io.ballerina.runtime.api.values.BXmlQName;
 import io.ballerina.runtime.internal.BallerinaXmlSerializer;
@@ -51,6 +52,7 @@ import javax.xml.namespace.QName;
 public abstract class XmlValue implements RefValue, BXml, CollectionValue {
 
     Type type = PredefinedTypes.TYPE_XML;
+    protected TypedescValue typedesc = new TypedescValueImpl(type);
 
     public abstract int size();
 
@@ -238,4 +240,14 @@ public abstract class XmlValue implements RefValue, BXml, CollectionValue {
             handleXmlException("error occurred during writing the message to the output stream: ", t);
         }
     }
+
+    @Override
+    public BTypedesc getTypedesc() {
+        return typedesc;
+    }
+
+    protected void setTypedescValue(Type type) {
+        this.typedesc = new TypedescValueImpl(type);
+    }
+
 }

--- a/langlib/lang.error/src/main/java/org/ballerinalang/langlib/error/StackTrace.java
+++ b/langlib/lang.error/src/main/java/org/ballerinalang/langlib/error/StackTrace.java
@@ -34,6 +34,7 @@ import io.ballerina.runtime.api.values.BLink;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
+import io.ballerina.runtime.api.values.BTypedesc;
 import io.ballerina.runtime.internal.scheduling.Strand;
 
 import java.util.Collections;
@@ -111,9 +112,11 @@ public class StackTrace {
         BArray callStack;
 
         private ObjectType type;
+        private BTypedesc typedesc;
 
         public CallStack(ObjectType type) {
             this.type = type;
+            this.typedesc = ValueCreator.createTypedescValue(type);
         }
 
         @Override
@@ -213,5 +216,11 @@ public class StackTrace {
         public Object frozenCopy(Map<Object, Object> refs) {
             return null;
         }
+
+        @Override
+        public BTypedesc getTypedesc() {
+            return typedesc;
+        }
+
     }
 }

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/expression/MemberAccessExpressionEvaluator.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/expression/MemberAccessExpressionEvaluator.java
@@ -31,6 +31,7 @@ import org.ballerinalang.debugadapter.variable.BVariable;
 import org.ballerinalang.debugadapter.variable.BVariableType;
 import org.ballerinalang.debugadapter.variable.DebugVariableException;
 import org.ballerinalang.debugadapter.variable.IndexedCompoundVariable;
+import org.ballerinalang.debugadapter.variable.JVMValueType;
 import org.ballerinalang.debugadapter.variable.NamedCompoundVariable;
 import org.ballerinalang.debugadapter.variable.VariableFactory;
 import org.ballerinalang.debugadapter.variable.VariableUtils;
@@ -40,8 +41,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static org.ballerinalang.debugadapter.evaluation.utils.EvaluationUtils.B_STRING_CLASS;
+import static org.ballerinalang.debugadapter.evaluation.utils.EvaluationUtils.B_STRING_UTILS_CLASS;
 import static org.ballerinalang.debugadapter.evaluation.utils.EvaluationUtils.B_VALUE_CREATOR_CLASS;
 import static org.ballerinalang.debugadapter.evaluation.utils.EvaluationUtils.CREATE_XML_VALUE_METHOD;
+import static org.ballerinalang.debugadapter.evaluation.utils.EvaluationUtils.GET_STRING_AT_METHOD;
 import static org.ballerinalang.debugadapter.evaluation.utils.EvaluationUtils.getRuntimeMethod;
 
 /**
@@ -94,14 +98,17 @@ public class MemberAccessExpressionEvaluator extends Evaluator {
                                 syntaxNode.toSourceCode()));
                     }
                     int index = Integer.parseInt(keyVar.getDapVariable().getValue());
-                    int strLength = containerVar.getDapVariable().getValue().length();
-                    // Validates for IndexOutOfRange errors.
-                    if (index < 0 || index >= strLength) {
-                        throw new EvaluationException(String.format(EvaluationExceptionKind.INDEX_OUT_OF_RANGE_ERROR
-                                .getString(), containerVar.getBType().getString(), index, strLength));
-                    }
-                    String substring = containerVar.getDapVariable().getValue().substring(index, index + 1);
-                    return VMUtils.make(context, substring);
+                    List<String> argTypeNames = new ArrayList<>();
+                    argTypeNames.add(B_STRING_CLASS);
+                    argTypeNames.add(JVMValueType.LONG.getString());
+                    RuntimeStaticMethod getCodePointMethod = getRuntimeMethod(context, B_STRING_UTILS_CLASS,
+                            GET_STRING_AT_METHOD, argTypeNames);
+
+                    List<Value> argValues = new ArrayList<>();
+                    argValues.add(containerResult.getJdiValue());
+                    argValues.add(VMUtils.make(context, index).getJdiValue());
+                    getCodePointMethod.setArgValues(argValues);
+                    return new BExpressionValue(context, getCodePointMethod.invokeSafely());
                 }
                 // Index access of lists
                 // If it is list, and index is < 0 or ≥ the length of the list, then the evaluation completes abruptly

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/utils/EvaluationUtils.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/utils/EvaluationUtils.java
@@ -93,9 +93,9 @@ public class EvaluationUtils {
     public static final String JAVA_LANG_CLASSLOADER = "java.lang.ClassLoader";
     public static final String JAVA_OBJECT_ARRAY_CLASS = JAVA_OBJECT_CLASS + "[]";
     public static final String JAVA_STRING_CLASS = "java.lang.String";
+    public static final String JAVA_LONG_CLASS = "java.lang.Long";
     private static final String JAVA_BOOLEAN_CLASS = "java.lang.Boolean";
     private static final String JAVA_INT_CLASS = "java.lang.Integer";
-    private static final String JAVA_LONG_CLASS = "java.lang.Long";
     private static final String JAVA_FLOAT_CLASS = "java.lang.Float";
     private static final String JAVA_DOUBLE_CLASS = "java.lang.Double";
     private static final String JAVA_LANG_CLASS = "java.lang.Class";
@@ -146,6 +146,7 @@ public class EvaluationUtils {
     public static final String GET_REST_ARG_ARRAY_METHOD = "getRestArgArray";
     public static final String GET_XML_FILTER_RESULT_METHOD = "getXMLFilterResult";
     public static final String GET_XML_STEP_RESULT_METHOD = "getXMLStepResult";
+    public static final String GET_STRING_AT_METHOD = "getStringAt";
     static final String FROM_STRING_METHOD = "fromString";
     private static final String B_STRING_CONCAT_METHOD = "concat";
     private static final String FOR_NAME_METHOD = "forName";

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/variable/types/BJson.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/variable/types/BJson.java
@@ -31,6 +31,6 @@ public class BJson extends BMap {
 
     @Override
     public String computeValue() {
-        return String.format("map<json> (size = %d)", getChildrenCount());
+        return String.format("json (size = %d)", getChildrenCount());
     }
 }

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/variable/types/BMap.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/variable/types/BMap.java
@@ -22,10 +22,8 @@ import com.sun.jdi.Method;
 import com.sun.jdi.ObjectReference;
 import com.sun.jdi.Value;
 import org.ballerinalang.debugadapter.SuspendedContext;
-import org.ballerinalang.debugadapter.evaluation.engine.invokable.RuntimeStaticMethod;
 import org.ballerinalang.debugadapter.variable.BVariableType;
 import org.ballerinalang.debugadapter.variable.IndexedCompoundVariable;
-import org.ballerinalang.debugadapter.variable.VariableFactory;
 import org.ballerinalang.debugadapter.variable.VariableUtils;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
@@ -34,12 +32,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-
-import static org.ballerinalang.debugadapter.evaluation.utils.EvaluationUtils.B_TYPE_CHECKER_CLASS;
-import static org.ballerinalang.debugadapter.evaluation.utils.EvaluationUtils.GET_TYPEDESC_METHOD;
-import static org.ballerinalang.debugadapter.evaluation.utils.EvaluationUtils.JAVA_OBJECT_CLASS;
-import static org.ballerinalang.debugadapter.evaluation.utils.EvaluationUtils.getRuntimeMethod;
-import static org.ballerinalang.debugadapter.evaluation.utils.EvaluationUtils.getValueAsObject;
 
 /**
  * Ballerina map variable type.

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/variable/types/BMap.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/variable/types/BMap.java
@@ -66,15 +66,9 @@ public class BMap extends IndexedCompoundVariable {
     @Override
     public String computeValue() {
         try {
-            Value valueAsObject = getValueAsObject(context, jvmValue);
-            List<String> methodArgTypeNames = Collections.singletonList(JAVA_OBJECT_CLASS);
-            RuntimeStaticMethod method = getRuntimeMethod(context, B_TYPE_CHECKER_CLASS, GET_TYPEDESC_METHOD,
-                    methodArgTypeNames);
-            method.setArgValues(Collections.singletonList(valueAsObject));
-            Value value = method.invokeSafely();
-            String typeDescValue = VariableFactory.getVariable(context, value).computeValue();
-            typeDescValue = typeDescValue.split(MAP_TYPEDESC_SEPARATOR)[0].trim();
-            return String.format("%s (size = %d)", typeDescValue, getChildrenCount());
+            // Todo - include constraint type (e.g. map<TYPE>), once we have language level support to get the simple
+            //  type
+            return String.format("map (size = %d)", getChildrenCount());
         } catch (Exception e) {
             return VariableUtils.getBType(jvmValue);
         }

--- a/misc/debug-adapter/modules/debug-adapter-runtime/src/main/ballerina/utils.bal
+++ b/misc/debug-adapter/modules/debug-adapter-runtime/src/main/ballerina/utils.bal
@@ -16,12 +16,25 @@
 //
 
 function getType(any value) returns string|error {
-    var result = trap (typeof value);
-    if(result is typedesc) {
-        string typeString = result.toString();
-        return typeString.startsWith("typedesc ") ? typeString.substring(9) : typeString;
+    // Need to handle simple values separately, since `typeof` operation returns the singleton type for simple values.
+    if (value is int) {
+        return "int";
+    } else if (value is float) {
+        return "float";
+    } else if (value is boolean) {
+        return "boolean";
+    } else if (value is byte) {
+        return "byte";
+    } else if (value is string) {
+        return "string";
     } else {
-        return result;
+        var result = trap (typeof value);
+        if (result is typedesc) {
+            string typeString = result.toString();
+            return typeString.startsWith("typedesc ") ? typeString.substring(9) : typeString;
+        } else {
+            return result;
+        }
     }
 }
 

--- a/misc/debug-adapter/modules/debug-adapter-runtime/src/main/java/org/ballerinalang/debugadapter/runtime/DebuggerRuntime.java
+++ b/misc/debug-adapter/modules/debug-adapter-runtime/src/main/java/org/ballerinalang/debugadapter/runtime/DebuggerRuntime.java
@@ -29,6 +29,7 @@ import io.ballerina.runtime.api.types.ArrayType;
 import io.ballerina.runtime.api.types.ErrorType;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.utils.StringUtils;
+import io.ballerina.runtime.api.utils.TypeUtils;
 import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.api.values.BFuture;
 import io.ballerina.runtime.api.values.BMap;
@@ -240,8 +241,8 @@ public class DebuggerRuntime {
      */
     public static Object getAnnotationValue(Object typedescValue, String annotationName) {
         if (!(typedescValue instanceof TypedescValue)) {
-            return ErrorCreator.createError(StringUtils.fromString("Incompatible types: expected 'typedesc`, found '"
-                    + typedescValue.toString() + "'."));
+            return ErrorCreator.createError(StringUtils.fromString("Incompatible types: expected 'typedesc`, " +
+                    "found '" + typedescValue.toString() + "'."));
         }
         Type type = ((TypedescValue) typedescValue).getDescribingType();
         if (type instanceof BAnnotatableType) {
@@ -252,8 +253,9 @@ public class DebuggerRuntime {
                     .map(Map.Entry::getValue)
                     .orElse(null);
         }
-        return ErrorCreator.createError(StringUtils.fromString("type: '" + type.toString() + "' does not support " +
-                "annotation access."));
+
+        return ErrorCreator.createError(StringUtils.fromString("type: '" + TypeUtils.getType(type.getEmptyValue())
+                + "' does not support annotation access."));
     }
 
     private static Method getMethod(String functionName, Class<?> funcClass) throws NoSuchMethodException {

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/mock/GenericMockObjectValue.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/mock/GenericMockObjectValue.java
@@ -27,8 +27,10 @@ import io.ballerina.runtime.api.values.BLink;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
+import io.ballerina.runtime.api.values.BTypedesc;
 import io.ballerina.runtime.internal.scheduling.Strand;
 import io.ballerina.runtime.internal.util.exceptions.BallerinaException;
+import io.ballerina.runtime.internal.values.TypedescValueImpl;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -44,10 +46,12 @@ public class GenericMockObjectValue implements BObject {
     private BObject mockObj;
 
     private ObjectType type;
+    private BTypedesc typedesc;
 
     public GenericMockObjectValue(ObjectType type, BObject mockObj) {
         this.type = type;
         this.mockObj = mockObj;
+        this.typedesc = new TypedescValueImpl(type);
     }
 
     @Override
@@ -245,4 +249,10 @@ public class GenericMockObjectValue implements BObject {
     public Object frozenCopy(Map<Object, Object> refs) {
         return null;
     }
+
+    @Override
+    public BTypedesc getTypedesc() {
+        return typedesc;
+    }
+
 }

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/ControlFlowDebugTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/ControlFlowDebugTest.java
@@ -164,7 +164,7 @@ public class ControlFlowDebugTest extends BaseTestCase {
         // Variable visibility test inside 'match' statement
         debugTestRunner.assertVariable(variables, "v07_intVar", "7", "int");
         // Variable visibility test for lambda - iterable arrow operation
-        debugTestRunner.assertVariable(variables, "v09_animals", "map<string> (size = 1)", "map");
+        debugTestRunner.assertVariable(variables, "v09_animals", "map (size = 1)", "map");
 
         // Variable visibility test for lambda child variables
         Map<String, Variable> lamdaChildVariables = debugTestRunner.fetchChildVariables(variables.get("v09_animals"));

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/evaluation/ExpressionEvaluationNegativeTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/evaluation/ExpressionEvaluationNegativeTest.java
@@ -121,13 +121,9 @@ public class ExpressionEvaluationNegativeTest extends ExpressionEvaluationBaseTe
     @Test
     public void memberAccessEvaluationTest() throws BallerinaTestException {
         // strings
-        debugTestRunner.assertEvaluationError(context, STRING_VAR + "[-1]", EvaluationExceptionKind.PREFIX +
-                "string index out of range: index=-1, size=5");
-        debugTestRunner.assertEvaluationError(context, STRING_VAR + "[100]", EvaluationExceptionKind.PREFIX +
-                "string index out of range: index=100, size=5");
-        debugTestRunner.assertEvaluationError(context, STRING_VAR + "[\"undefined\"]",
-                EvaluationExceptionKind.PREFIX + "expected key type 'int'; found 'string' in " +
-                        "'stringVar[\"undefined\"]'");
+        debugTestRunner.assertEvaluationError(context, STRING_VAR + "[100]", "{ballerina/lang.string}IndexOutOfRange");
+        debugTestRunner.assertEvaluationError(context, STRING_VAR + "[\"undefined\"]", EvaluationExceptionKind.PREFIX +
+                "expected key type 'int'; found 'string' in 'stringVar[\"undefined\"]'");
         // lists
         debugTestRunner.assertEvaluationError(context, ARRAY_VAR + "[-1]", EvaluationExceptionKind.PREFIX +
                 "array index out of range: index=-1, size=4");

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/evaluation/ExpressionEvaluationTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/evaluation/ExpressionEvaluationTest.java
@@ -407,12 +407,13 @@ public class ExpressionEvaluationTest extends ExpressionEvaluationBaseTest {
     @Test
     public void typeOfExpressionEvaluationTest() throws BallerinaTestException {
         // primitive types
-        debugTestRunner.assertExpression(context, String.format("typeof %s", BOOLEAN_VAR), "boolean", "typedesc");
-        debugTestRunner.assertExpression(context, String.format("typeof %s", INT_VAR), "int", "typedesc");
-        debugTestRunner.assertExpression(context, String.format("typeof %s", FLOAT_VAR), "float", "typedesc");
+        debugTestRunner.assertExpression(context, String.format("typeof %s", BOOLEAN_VAR), "true", "typedesc");
+        debugTestRunner.assertExpression(context, String.format("typeof %s", INT_VAR), "20", "typedesc");
+        debugTestRunner.assertExpression(context, String.format("typeof %s", FLOAT_VAR), "-10.0", "typedesc");
         // reference types
         debugTestRunner.assertExpression(context, String.format("typeof %s", JSON_VAR), "map<json>", "typedesc");
-        debugTestRunner.assertExpression(context, String.format("typeof %s[0]", STRING_VAR), "string", "typedesc");
+        // Need to change this result to `o` after fixing issue #32102
+        debugTestRunner.assertExpression(context, String.format("typeof %s[1]", STRING_VAR), "f", "typedesc");
         debugTestRunner.assertExpression(context, String.format("typeof typeof %s", BOOLEAN_VAR), "typedesc",
                 "typedesc");
     }

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/evaluation/ExpressionEvaluationTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/evaluation/ExpressionEvaluationTest.java
@@ -226,7 +226,7 @@ public class ExpressionEvaluationTest extends ExpressionEvaluationBaseTest {
     @Test
     public void memberAccessEvaluationTest() throws BallerinaTestException {
         // strings
-        debugTestRunner.assertExpression(context, STRING_VAR + "[0]", "\"\"", "string");
+        debugTestRunner.assertExpression(context, STRING_VAR + "[0]", "\"f\"", "string");
         // lists
         debugTestRunner.assertExpression(context, ARRAY_VAR + "[0]", "1", "int");
         // maps
@@ -412,8 +412,7 @@ public class ExpressionEvaluationTest extends ExpressionEvaluationBaseTest {
         debugTestRunner.assertExpression(context, String.format("typeof %s", FLOAT_VAR), "-10.0", "typedesc");
         // reference types
         debugTestRunner.assertExpression(context, String.format("typeof %s", JSON_VAR), "map<json>", "typedesc");
-        // Need to change this result to `o` after fixing issue #32102
-        debugTestRunner.assertExpression(context, String.format("typeof %s[1]", STRING_VAR), "f", "typedesc");
+        debugTestRunner.assertExpression(context, String.format("typeof %s[0]", STRING_VAR), "f", "typedesc");
         debugTestRunner.assertExpression(context, String.format("typeof typeof %s", BOOLEAN_VAR), "typedesc",
                 "typedesc");
     }

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/evaluation/ExpressionEvaluationTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/evaluation/ExpressionEvaluationTest.java
@@ -127,7 +127,7 @@ public class ExpressionEvaluationTest extends ExpressionEvaluationBaseTest {
         // tuple variable test
         debugTestRunner.assertExpression(context, TUPLE_VAR, "tuple[int,string] (size = 2)", "tuple");
         // map variable test
-        debugTestRunner.assertExpression(context, MAP_VAR, "map<string> (size = 4)", "map");
+        debugTestRunner.assertExpression(context, MAP_VAR, "map (size = 4)", "map");
         // record variable test (Student record)
         debugTestRunner.assertExpression(context, RECORD_VAR, " /:@[`{~π_123_ƮέŞŢ_Student", "record");
         // anonymous record variable test
@@ -161,7 +161,7 @@ public class ExpressionEvaluationTest extends ExpressionEvaluationBaseTest {
         // never variable test
         debugTestRunner.assertExpression(context, NEVER_VAR, "XMLSequence (size = 0)", "xml");
         // json variable test
-        debugTestRunner.assertExpression(context, JSON_VAR, "map<json> (size = 3)", "json");
+        debugTestRunner.assertExpression(context, JSON_VAR, "json (size = 3)", "json");
         // anonymous object variable test (AnonPerson object)
         debugTestRunner.assertExpression(context, ANON_OBJECT_VAR, "Person_\\ /<>:@[`{~π_ƮέŞŢ", "object");
         // service object variable test
@@ -170,7 +170,7 @@ public class ExpressionEvaluationTest extends ExpressionEvaluationBaseTest {
         // Todo - Enable after fixing https://github.com/ballerina-platform/ballerina-lang/issues/26139
         // debugTestRunner.assertExpression(context, GL, "Ballerina", "string");
         // debugTestRunner.assertExpression(context, "gv02_nameWithType", "Ballerina", "string");
-        debugTestRunner.assertExpression(context, GLOBAL_VAR_03, "map<string> (size = 1)", "map");
+        debugTestRunner.assertExpression(context, GLOBAL_VAR_03, "map (size = 1)", "map");
         debugTestRunner.assertExpression(context, GLOBAL_VAR_04, "()", "nil");
         debugTestRunner.assertExpression(context, GLOBAL_VAR_05, "()", "nil");
         // global variables
@@ -178,7 +178,7 @@ public class ExpressionEvaluationTest extends ExpressionEvaluationBaseTest {
         debugTestRunner.assertExpression(context, GLOBAL_VAR_07, "100.0", "decimal");
         debugTestRunner.assertExpression(context, GLOBAL_VAR_08, "2", "int");
         debugTestRunner.assertExpression(context, GLOBAL_VAR_09, "2.0", "float");
-        debugTestRunner.assertExpression(context, GLOBAL_VAR_10, "map<json> (size = 3)", "json");
+        debugTestRunner.assertExpression(context, GLOBAL_VAR_10, "json (size = 3)", "json");
         debugTestRunner.assertExpression(context, GLOBAL_VAR_11, "\"IL with global var\"", "string");
 
         // Todo - add test for qualified name references, after adding support
@@ -216,7 +216,7 @@ public class ExpressionEvaluationTest extends ExpressionEvaluationBaseTest {
     @Override
     @Test
     public void annotationAccessEvaluationTest() throws BallerinaTestException {
-        debugTestRunner.assertExpression(context, "(typeof a).@v1", "variable_tests:Annot (size = 2)", "map");
+        debugTestRunner.assertExpression(context, "(typeof a).@v1", "map (size = 2)", "map");
         debugTestRunner.assertExpression(context, "(typeof a).@v2", "()", "nil");
         debugTestRunner.assertExpression(context, "(typeof a).@v1[\"foo\"]", "\"v1 value\"", "string");
         debugTestRunner.assertExpression(context, "(typeof a).@v1[\"bar\"]", "1", "int");

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/variables/VariableVisibilityTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/variables/VariableVisibilityTest.java
@@ -180,7 +180,7 @@ public class VariableVisibilityTest extends BaseTestCase {
         // global constants
         debugTestRunner.assertVariable(globalVariables, "nameWithoutType", "\"Ballerina\"", "string");
         debugTestRunner.assertVariable(globalVariables, "nameWithType", "\"Ballerina\"", "string");
-        debugTestRunner.assertVariable(globalVariables, "nameMap", "map<string> (size = 1)", "map");
+        debugTestRunner.assertVariable(globalVariables, "nameMap", "map (size = 1)", "map");
         debugTestRunner.assertVariable(globalVariables, "nilWithoutType", "()", "nil");
         debugTestRunner.assertVariable(globalVariables, "nilWithType", "()", "nil");
         debugTestRunner.assertVariable(globalVariables, "RED", "\"RED\"", "string");
@@ -191,7 +191,7 @@ public class VariableVisibilityTest extends BaseTestCase {
         debugTestRunner.assertVariable(globalVariables, "decimalValue", "100.0", "decimal");
         debugTestRunner.assertVariable(globalVariables, "byteValue", "2", "int");
         debugTestRunner.assertVariable(globalVariables, "floatValue", "2.0", "float");
-        debugTestRunner.assertVariable(globalVariables, "jsonValue", "map<json> (size = 2)", "json");
+        debugTestRunner.assertVariable(globalVariables, "jsonValue", "json (size = 2)", "json");
         debugTestRunner.assertVariable(globalVariables, " /:@[`{~π_IL", "\"IL with global var\"", "string");
         debugTestRunner.assertVariable(globalVariables, "port", "9090", "int");
     }
@@ -231,7 +231,7 @@ public class VariableVisibilityTest extends BaseTestCase {
         debugTestRunner.assertVariable(localVariables, "tupleVar", "tuple[int,string] (size = 2)", "tuple");
 
         // map variable visibility test
-        debugTestRunner.assertVariable(localVariables, "mapVar", "map<string> (size = 4)", "map");
+        debugTestRunner.assertVariable(localVariables, "mapVar", "map (size = 4)", "map");
 
         // record variable visibility test (Student record)
         debugTestRunner.assertVariable(localVariables, "recordVar", " /:@[`{~π_123_ƮέŞŢ_Student", "record");
@@ -274,7 +274,7 @@ public class VariableVisibilityTest extends BaseTestCase {
         debugTestRunner.assertVariable(localVariables, "byteVar", "128", "int");
 
         // json variable visibility test
-        debugTestRunner.assertVariable(localVariables, "jsonVar", "map<json> (size = 3)", "json");
+        debugTestRunner.assertVariable(localVariables, "jsonVar", "json (size = 3)", "json");
 
         // table with key variable visibility test
         debugTestRunner.assertVariable(localVariables, "tableWithKeyVar", "table<Employee> (entries = 3)", "table");
@@ -290,7 +290,7 @@ public class VariableVisibilityTest extends BaseTestCase {
                 "string");
         debugTestRunner.assertVariable(localVariables, "üňĩćőđę_var", "\"IL with unicode characters in var\"",
                 "string");
-        debugTestRunner.assertVariable(localVariables, "ĠĿŐΒȂɭ_ /:@[`{~π_json", "map<json> (size = 0)", "json");
+        debugTestRunner.assertVariable(localVariables, "ĠĿŐΒȂɭ_ /:@[`{~π_json", "json (size = 0)", "json");
 
         // service variable visibility test
         debugTestRunner.assertVariable(localVariables, "serviceVar", "service", "service");
@@ -369,8 +369,7 @@ public class VariableVisibilityTest extends BaseTestCase {
 
         // error child variable visibility test
         Map<String, Variable> errorChildVariables = debugTestRunner.fetchChildVariables(localVariables.get("errorVar"));
-        debugTestRunner.assertVariable(errorChildVariables, "details", "map<ballerina/lang.value:1.0.0:Cloneable> " +
-                "(size = 1)", "map");
+        debugTestRunner.assertVariable(errorChildVariables, "details", "map (size = 1)", "map");
         debugTestRunner.assertVariable(errorChildVariables, "message", "\"SimpleErrorType\"", "string");
 
         // error details child variable visibility test

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/variables/VariableVisibilityTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/variables/VariableVisibilityTest.java
@@ -369,7 +369,7 @@ public class VariableVisibilityTest extends BaseTestCase {
 
         // error child variable visibility test
         Map<String, Variable> errorChildVariables = debugTestRunner.fetchChildVariables(localVariables.get("errorVar"));
-        debugTestRunner.assertVariable(errorChildVariables, "details", "map<ballerina/lang.value:1.0.0:Cloneable " +
+        debugTestRunner.assertVariable(errorChildVariables, "details", "map<ballerina/lang.value:1.0.0:Cloneable> " +
                 "(size = 1)", "map");
         debugTestRunner.assertVariable(errorChildVariables, "message", "\"SimpleErrorType\"", "string");
 

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/variables/VariableVisibilityTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/variables/VariableVisibilityTest.java
@@ -369,7 +369,7 @@ public class VariableVisibilityTest extends BaseTestCase {
 
         // error child variable visibility test
         Map<String, Variable> errorChildVariables = debugTestRunner.fetchChildVariables(localVariables.get("errorVar"));
-        debugTestRunner.assertVariable(errorChildVariables, "details", "map<(ballerina/lang.value:1:Cloneable " +
+        debugTestRunner.assertVariable(errorChildVariables, "details", "map<ballerina/lang.value:1.0.0:Cloneable " +
                 "(size = 1)", "map");
         debugTestRunner.assertVariable(errorChildVariables, "message", "\"SimpleErrorType\"", "string");
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typeof/TypeofOverLiteralExpressionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typeof/TypeofOverLiteralExpressionTest.java
@@ -71,7 +71,8 @@ public class TypeofOverLiteralExpressionTest {
     @DataProvider(name = "function-provider")
     public Object[] provideFunctionNames() {
         return new String[]{"typeDescOfExpressionsOfLiterals", "passTypeofToAFunction", "typeDescOfARecord",
-                "typeDescOrAObject", "passTypeofAsRestParams", "compareTypeOfValues"};
+                "typeDescOrAObject", "passTypeofAsRestParams", "compareTypeOfValues",
+                "typeOfImmutableStructuralValues"};
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typeof/TypeofOverLiteralExpressionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typeof/TypeofOverLiteralExpressionTest.java
@@ -51,7 +51,7 @@ public class TypeofOverLiteralExpressionTest {
     }
 
     @DataProvider(name = "simple-value-provider")
-    public Object[][] provideSimpleTypValuese() {
+    public Object[][] provideSimpleTypValues() {
         return new Object[][]{
                 {new BInteger(1L), "1"},
                 {new BDecimal("2.0"), "2.0"},

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typeof/TypeofOverLiteralExpressionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typeof/TypeofOverLiteralExpressionTest.java
@@ -17,12 +17,6 @@
  */
 package org.ballerinalang.test.expressions.typeof;
 
-import org.ballerinalang.core.model.values.BBoolean;
-import org.ballerinalang.core.model.values.BDecimal;
-import org.ballerinalang.core.model.values.BFloat;
-import org.ballerinalang.core.model.values.BInteger;
-import org.ballerinalang.core.model.values.BString;
-import org.ballerinalang.core.model.values.BValue;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
@@ -45,24 +39,6 @@ public class TypeofOverLiteralExpressionTest {
         result = BCompileUtil.compile("test-src/expressions/typeof/typeof.bal");
     }
 
-    @Test (dataProvider = "simple-value-provider")
-    public void testTypeDescOperatorOnLiterals(BValue value, String expected) {
-        BRunUtil.invoke(result, "typeDescOfLiterals", new BValue[] {value, new BString(expected)});
-    }
-
-    @DataProvider(name = "simple-value-provider")
-    public Object[][] provideSimpleTypValues() {
-        return new Object[][]{
-                {new BInteger(1L), "1"},
-                {new BDecimal("2.0"), "2.0"},
-                {new BFloat(2.1), "2.1"},
-                {new BString("str-literal"), "str-literal"},
-                {new BBoolean(true), "true"},
-                {new BBoolean(false), "false"},
-                {null, "()"},
-        };
-    }
-
     @Test (dataProvider = "function-provider")
     public void testTypeOfExpression(String functionName) {
         BRunUtil.invoke(result, functionName);
@@ -71,7 +47,7 @@ public class TypeofOverLiteralExpressionTest {
     @DataProvider(name = "function-provider")
     public Object[] provideFunctionNames() {
         return new String[]{"typeDescOfExpressionsOfLiterals", "passTypeofToAFunction", "typeDescOfARecord",
-                "typeDescOrAObject", "passTypeofAsRestParams", "compareTypeOfValues",
+                "typeDescOrAObject", "passTypeofAsRestParams", "compareTypeOfValues", "typeDescOfLiterals",
                 "typeOfImmutableStructuralValues", "typeOfWithCloneReadOnly"};
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typeof/TypeofOverLiteralExpressionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typeof/TypeofOverLiteralExpressionTest.java
@@ -72,7 +72,7 @@ public class TypeofOverLiteralExpressionTest {
     public Object[] provideFunctionNames() {
         return new String[]{"typeDescOfExpressionsOfLiterals", "passTypeofToAFunction", "typeDescOfARecord",
                 "typeDescOrAObject", "passTypeofAsRestParams", "compareTypeOfValues",
-                "typeOfImmutableStructuralValues"};
+                "typeOfImmutableStructuralValues", "typeOfWithCloneReadOnly"};
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typeof/TypeofOverLiteralExpressionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typeof/TypeofOverLiteralExpressionTest.java
@@ -17,13 +17,18 @@
  */
 package org.ballerinalang.test.expressions.typeof;
 
+import org.ballerinalang.core.model.values.BBoolean;
+import org.ballerinalang.core.model.values.BDecimal;
+import org.ballerinalang.core.model.values.BFloat;
+import org.ballerinalang.core.model.values.BInteger;
+import org.ballerinalang.core.model.values.BString;
 import org.ballerinalang.core.model.values.BValue;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
-import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 /**
@@ -31,7 +36,6 @@ import org.testng.annotations.Test;
  *
  * @since 0.995
  */
-@Test(groups = "no-bvm-support")
 public class TypeofOverLiteralExpressionTest {
 
     private CompileResult result;
@@ -41,49 +45,33 @@ public class TypeofOverLiteralExpressionTest {
         result = BCompileUtil.compile("test-src/expressions/typeof/typeof.bal");
     }
 
-    @Test
-    public void testTypeDescOperatorOnLiterals() {
-        BValue[] res = BRunUtil.invoke(result, "typeDescOfLiterals");
-        Assert.assertEquals(res[0].stringValue(), "int");
-        Assert.assertEquals(res[1].stringValue(), "float");
-        Assert.assertEquals(res[2].stringValue(), "float");
-        Assert.assertEquals(res[3].stringValue(), "string");
-        Assert.assertEquals(res[4].stringValue(), "boolean");
-        Assert.assertEquals(res[5].stringValue(), "boolean");
-        Assert.assertEquals(res[6].stringValue(), "null");
+    @Test (dataProvider = "simple-value-provider")
+    public void testTypeDescOperatorOnLiterals(BValue value, String expected) {
+        BRunUtil.invoke(result, "typeDescOfLiterals", new BValue[] {value, new BString(expected)});
     }
 
-    @Test
-    public void testTypeDescOperatorOnExpressionsOfLiterals() {
-        BValue[] res = BRunUtil.invoke(result, "typeDescOfExpressionsOfLiterals");
-        Assert.assertEquals(res[0].stringValue(), "int");
-        Assert.assertEquals(res[1].stringValue(), "float");
+    @DataProvider(name = "simple-value-provider")
+    public Object[][] provideSimpleTypValuese() {
+        return new Object[][]{
+                {new BInteger(1L), "1"},
+                {new BDecimal("2.0"), "2.0"},
+                {new BFloat(2.1), "2.1"},
+                {new BString("str-literal"), "str-literal"},
+                {new BBoolean(true), "true"},
+                {new BBoolean(false), "false"},
+                {null, "()"},
+        };
     }
 
-    @Test
-    public void testUsingTypeofOperatorAtFunctionInvocationSite() {
-        BValue[] res = BRunUtil.invoke(result, "passTypeofToAFunction");
-        Assert.assertEquals(res[0].stringValue(), "int");
+    @Test (dataProvider = "function-provider")
+    public void testTypeOfExpression(String functionName) {
+        BRunUtil.invoke(result, functionName);
     }
 
-    @Test
-    public void getTypeDescOfASimpleRecordType() {
-        BValue[] res = BRunUtil.invoke(result, "typeDescOfARecord");
-        Assert.assertEquals(res[0].stringValue(), "RecType0");
-    }
-
-    @Test
-    public void getTypeDescOfASimpleObjectType() {
-        BValue[] res = BRunUtil.invoke(result, "typeDescOrAObject");
-        Assert.assertEquals(res[0].stringValue(), "Obj0");
-    }
-
-    @Test
-    public void testUsingTypeofOperatorAsRestArgs() {
-        BValue[] res = BRunUtil.invoke(result, "passTypeofAsRestParams");
-        Assert.assertEquals(res[0].stringValue(), "int");
-        Assert.assertEquals(res[1].stringValue(), "int");
-        Assert.assertEquals(res[2].stringValue(), "float");
+    @DataProvider(name = "function-provider")
+    public Object[] provideFunctionNames() {
+        return new String[]{"typeDescOfExpressionsOfLiterals", "passTypeofToAFunction", "typeDescOfARecord",
+                "typeDescOrAObject", "passTypeofAsRestParams", "compareTypeOfValues"};
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/access/access.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/access/access.bal
@@ -264,7 +264,7 @@ public function testAccessOnGroupedExpressions() returns error|boolean {
     result = result && s == "msg";
 
     s = (typeof (12.5f)).toString();
-    result = result && s == "typedesc float";
+    result = result && s == "typedesc 12.5";
     return result;
 }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/mapping_constructor_infer_record.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/mapping_constructor_infer_record.bal
@@ -164,7 +164,7 @@ function testMappingConstrExprWithNoACET() {
     assertEquality(s, r2.s);
     assertEquality(i, r2.i);
     assertEquality(s, r2.s2);
-    assertEquality("typedesc string", r2.t.toString());
+    assertEquality("typedesc global s", r2.t.toString());
 }
 
 public type ExpInferredType2 record {|

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typeof/typeof.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typeof/typeof.bal
@@ -40,9 +40,19 @@ function typeDescOrAObject() {
     test:assertEquals((typeof o).toString(), "typedesc Obj0");
 }
 
-function typeDescOfLiterals(any value, string expected) {
-    var a = typeof value;
-    test:assertEquals(a.toString(), "typedesc " + expected);
+function typeDescOfLiterals() {
+    checkTypeDescLiteral(1, "1");
+    checkTypeDescLiteral(2.0d, "2.0");
+    checkTypeDescLiteral(2.1, "2.1");
+    checkTypeDescLiteral("str-literal", "str-literal");
+    checkTypeDescLiteral(true, "true");
+    checkTypeDescLiteral(false, "false");
+    checkTypeDescLiteral((), "()");    
+}
+
+function checkTypeDescLiteral(any value, string expected) {
+    var valueType = typeof value;
+    test:assertEquals(valueType.toString(), "typedesc " + expected);
 }
 
 function typeDescOfExpressionsOfLiterals() {
@@ -90,6 +100,10 @@ function compareTypeOfValues() {
     int i = 34;
     test:assertFalse(typeof i === typeof i);
 
+    // xml Value
+    xml xmlValue = xml`<data>test</data>`;
+    test:assertTrue(typeof xmlValue === typeof xmlValue);
+
     // Structural types - Array, Tuple
     int[] arr = [1, 2, 3];
     test:assertTrue(typeof arr === typeof arr);
@@ -120,6 +134,11 @@ function compareTypeOfValues() {
 
 function typeOfImmutableStructuralValues() {
 
+    // xml Value
+    xml & readonly xmlValue = xml `<data>test</data>`;
+    test:assertTrue(typeof xmlValue === typeof xmlValue);
+    test:assertEquals((typeof xmlValue).toString(), "typedesc <data></data>");
+
     // Structural types - Array, Tuple
     int[] & readonly arr = [1, 2, 3];
     test:assertTrue(typeof arr === typeof arr);
@@ -127,7 +146,7 @@ function typeOfImmutableStructuralValues() {
 
     [string, int] & readonly tuple = ["ballerina", 123];
     test:assertTrue(typeof tuple === typeof tuple);
-    test:assertEquals((typeof tuple).toString(), "typedesc ballerina 123");
+    test:assertEquals((typeof tuple).toString(), "typedesc [\"ballerina\",123]");
 
     // Structural types - Records, Maps
     RecType0 & readonly rec = {name: "test"};
@@ -147,16 +166,23 @@ function typeOfImmutableStructuralValues() {
 
 function typeOfWithCloneReadOnly() {
 
+    // xml Value
+    xml & readonly xmlValue = xml `<?xml-stylesheet href="mystyle.css" type="text/css"?>`;
+    any val = xmlValue.cloneReadOnly();
+    test:assertTrue(typeof val === typeof val);
+    test:assertEquals((typeof val).toString(), "typedesc <?xml-stylesheet href=\"mystyle.css\" " + 
+    "type=\"text/css\"?>");
+
     // Structural types - Array, Tuple
     int[] arr = [1, 2, 3];
-    any val = arr.cloneReadOnly();
+    val = arr.cloneReadOnly();
     test:assertTrue(typeof val === typeof val);
     test:assertEquals((typeof val).toString(), "typedesc [1,2,3]");
 
     [string, int] tuple = ["ballerina", 123];
     val = tuple.cloneReadOnly();
     test:assertTrue(typeof val === typeof val);
-    test:assertEquals((typeof val).toString(), "typedesc ballerina 123");
+    test:assertEquals((typeof val).toString(), "typedesc [\"ballerina\",123]");
 
     // Structural types - Records, Maps
     RecType0 rec = {name: "test"};

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typeof/typeof.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typeof/typeof.bal
@@ -88,32 +88,59 @@ function compareTypeOfValues() {
 
     // Basic Simple Type 
     int i = 34;
-    test:assertFalse(typeof i === typeof i); 
+    test:assertFalse(typeof i === typeof i);
 
     // Structural types - Array, Tuple
     int[] arr = [1, 2, 3];
-    test:assertTrue(typeof arr === typeof arr); 
+    test:assertTrue(typeof arr === typeof arr);
 
     [string, int] tuple = ["ballerina", 123];
-    test:assertTrue(typeof tuple === typeof tuple); 
+    test:assertTrue(typeof tuple === typeof tuple);
 
     // Structural types - Records, Maps
     RecType0 rec = {name: "test"};
-    test:assertTrue(typeof rec === typeof rec); 
-    test:assertTrue(typeof rec === RecType0); 
+    test:assertTrue(typeof rec === typeof rec);
+    test:assertTrue(typeof rec === RecType0);
 
     map<string> mapVal = {s: "test"};
-    test:assertTrue(typeof mapVal === typeof mapVal); 
+    test:assertTrue(typeof mapVal === typeof mapVal);
 
     // Structural types -tables 
     table<map<string>> tableVal = table [{s: "test"}];
-    test:assertTrue(typeof tableVal === typeof tableVal); 
+    test:assertTrue(typeof tableVal === typeof tableVal);
 
     // Behavioral types - Object
     Obj0 obj = new ("abc", 123);
-    test:assertTrue(typeof obj === typeof obj); 
+    test:assertTrue(typeof obj === typeof obj);
 
     // Behavioral types - Error
     error err = error("This is an error!");
     test:assertTrue(typeof err === typeof err);
+}
+
+function typeOfImmutableStructuralValues() {
+
+    // Structural types - Array, Tuple
+    int[] & readonly arr = [1, 2, 3];
+    test:assertTrue(typeof arr === typeof arr);
+    test:assertEquals((typeof arr).toString(), "typedesc [1,2,3]");
+
+    [string, int] & readonly tuple = ["ballerina", 123];
+    test:assertTrue(typeof tuple === typeof tuple);
+    test:assertEquals((typeof tuple).toString(), "typedesc ballerina 123");
+
+    // Structural types - Records, Maps
+    RecType0 & readonly rec = {name: "test"};
+    test:assertTrue(typeof rec === typeof rec);
+    test:assertTrue(typeof rec !== RecType0);
+    test:assertEquals((typeof rec).toString(), "typedesc {\"name\":\"test\"}");
+
+    map<string> & readonly mapVal = {s: "test"};
+    test:assertTrue(typeof mapVal === typeof mapVal);
+    test:assertEquals((typeof mapVal).toString(), "typedesc {\"s\":\"test\"}");
+
+    // Structural types -tables 
+    table<map<string>> & readonly tableVal = table [{s: "test"}];
+    test:assertTrue(typeof tableVal === typeof tableVal);
+    test:assertEquals((typeof tableVal).toString(), "typedesc [{\"s\":\"test\"}]");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typeof/typeof.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typeof/typeof.bal
@@ -13,16 +13,16 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-
+import ballerina/test;
 
 type RecType0 record {
     string name;
 };
 
-function typeDescOfARecord() returns typedesc<any> {
+function typeDescOfARecord() {
     RecType0 i = { name: "theName"};
     typedesc<any> td0 = typeof i;
-    return td0;
+    test:assertEquals(td0.toString(), "typedesc RecType0");
 }
 
 class Obj0 {
@@ -35,52 +35,58 @@ class Obj0 {
     }
 }
 
-function typeDescOrAObject() returns typedesc<any> {
+function typeDescOrAObject() {
     Obj0 o = new("name", 42);
-    return typeof o;
+    test:assertEquals((typeof o).toString(), "typedesc Obj0");
 }
 
-function typeDescOfLiterals() returns
-    [typedesc<any>, typedesc<any>, typedesc<any>, typedesc<any>, typedesc<any>, typedesc<any>, typedesc<any>] {
-    var a = typeof 1;
-    var b = typeof 2.0;
-    var c = typeof 2.1f;
-    var d = typeof "str-literal";
-    var e = typeof true;
-    var f = typeof false;
-    var g = typeof ();
-    return [a, b, c, d, e, f, g];
+function typeDescOfLiterals(any value, string expected) {
+    var a = typeof value;
+    test:assertEquals(a.toString(), "typedesc " + expected);
 }
 
-function typeDescOfExpressionsOfLiterals() returns
-    [typedesc<any>, typedesc<any>] {
+function typeDescOfExpressionsOfLiterals() {
     int i = 0;
     int j = 4;
     int k = 4;
     float f = 0.0;
     float ff = 22.0;
-    return [typeof (i+j*k), typeof (f*ff)];
+    var r1 = typeof (i + j * k);
+    test:assertEquals(r1.toString(), "typedesc 16");
+    var r2 = typeof (f * ff);
+    test:assertEquals(r2.toString(), "typedesc 0.0");
 }
 
 function takesATypedescParam(typedesc<any> param) returns typedesc<any> {
     return param;
 }
 
-function passTypeofToAFunction() returns typedesc<any> {
+function passTypeofToAFunction() {
     typedesc<any> t = typeof 22;
     var t1 = takesATypedescParam(t);
     var t2 = takesATypedescParam(typeof 33);
-    return t1;
+    test:assertEquals(t1.toString(), "typedesc 22");
+    test:assertEquals(t2.toString(), "typedesc 33");
 }
 
 function takeTypeofAsRestParams(typedesc<any>... xs) returns typedesc<any>[] {
     return xs;
 }
 
-function passTypeofAsRestParams() returns typedesc<any>[] {
-    return takeTypeofAsRestParams(typeof 22, typeof 33, typeof 33.33);
+function passTypeofAsRestParams() {
+    typedesc<any>[] result = takeTypeofAsRestParams(typeof 22, typeof 33, typeof 33.33);
+    test:assertEquals(result[0].toString(), "typedesc 22");
+    test:assertEquals(result[1].toString(), "typedesc 33");
+    test:assertEquals(result[2].toString(), "typedesc 33.33");
 }
 
 function returnTypeOfInt() returns typedesc<any> {
     return typeof (5 + 1);
+}
+
+function compareTypeOfValues() {
+    int i = 34;
+    var t1 = typeof i;
+    var t2 = typeof i;
+    test:assertFalse(t1 === t2);    
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typeof/typeof.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typeof/typeof.bal
@@ -85,8 +85,35 @@ function returnTypeOfInt() returns typedesc<any> {
 }
 
 function compareTypeOfValues() {
+
+    // Basic Simple Type 
     int i = 34;
-    var t1 = typeof i;
-    var t2 = typeof i;
-    test:assertFalse(t1 === t2);    
+    test:assertFalse(typeof i === typeof i); 
+
+    // Structural types - Array, Tuple
+    int[] arr = [1, 2, 3];
+    test:assertTrue(typeof arr === typeof arr); 
+
+    [string, int] tuple = ["ballerina", 123];
+    test:assertTrue(typeof tuple === typeof tuple); 
+
+    // Structural types - Records, Maps
+    RecType0 rec = {name: "test"};
+    test:assertTrue(typeof rec === typeof rec); 
+    test:assertTrue(typeof rec === RecType0); 
+
+    map<string> mapVal = {s: "test"};
+    test:assertTrue(typeof mapVal === typeof mapVal); 
+
+    // Structural types -tables 
+    table<map<string>> tableVal = table [{s: "test"}];
+    test:assertTrue(typeof tableVal === typeof tableVal); 
+
+    // Behavioral types - Object
+    Obj0 obj = new ("abc", 123);
+    test:assertTrue(typeof obj === typeof obj); 
+
+    // Behavioral types - Error
+    error err = error("This is an error!");
+    test:assertTrue(typeof err === typeof err);
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typeof/typeof.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typeof/typeof.bal
@@ -144,3 +144,35 @@ function typeOfImmutableStructuralValues() {
     test:assertTrue(typeof tableVal === typeof tableVal);
     test:assertEquals((typeof tableVal).toString(), "typedesc [{\"s\":\"test\"}]");
 }
+
+function typeOfWithCloneReadOnly() {
+
+    // Structural types - Array, Tuple
+    int[] arr = [1, 2, 3];
+    any val = arr.cloneReadOnly();
+    test:assertTrue(typeof val === typeof val);
+    test:assertEquals((typeof val).toString(), "typedesc [1,2,3]");
+
+    [string, int] tuple = ["ballerina", 123];
+    val = tuple.cloneReadOnly();
+    test:assertTrue(typeof val === typeof val);
+    test:assertEquals((typeof val).toString(), "typedesc ballerina 123");
+
+    // Structural types - Records, Maps
+    RecType0 rec = {name: "test"};
+    val = rec.cloneReadOnly();
+    test:assertTrue(typeof val === typeof val);
+    test:assertTrue(typeof val !== RecType0);
+    test:assertEquals((typeof val).toString(), "typedesc {\"name\":\"test\"}");
+
+    map<string> mapVal = {s: "test"};
+    val = mapVal.cloneReadOnly();
+    test:assertTrue(typeof val === typeof val);
+    test:assertEquals((typeof val).toString(), "typedesc {\"s\":\"test\"}");
+
+    // Structural types -tables 
+    table<map<string>> tableVal = table [{s: "test"}];
+    val = tableVal.cloneReadOnly();
+    test:assertTrue(typeof val === typeof val);
+    test:assertEquals((typeof val).toString(), "typedesc [{\"s\":\"test\"}]");
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/varref/tuple-variable-reference.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/varref/tuple-variable-reference.bal
@@ -216,7 +216,7 @@ function testRestVarRefType1() {
     [string, int, float...] t1 = ["A", 100, 200.5, 300.5];
 
     var [a1, ...a2] = t1;
-    assertEqual("typedesc string", (typeof a1).toString());
+    assertEqual("typedesc A", (typeof a1).toString());
     assertEqual("typedesc [int,float...]", (typeof a2).toString());
 
     [int, float...] x1;
@@ -227,8 +227,8 @@ function testRestVarRefType1() {
     assertEqual(300.5, x1[2]);
 
     var [b1, b2, ...b3] = t1;
-    assertEqual("typedesc string", (typeof b1).toString());
-    assertEqual("typedesc int", (typeof b2).toString());
+    assertEqual("typedesc A", (typeof b1).toString());
+    assertEqual("typedesc 100", (typeof b2).toString());
     assertEqual("typedesc float[]", (typeof b3).toString());
 
     float[] x2;
@@ -307,7 +307,7 @@ function testRestVarRefType6() {
                 {firstName: "John", lastName: "Damon"}, 12, fooObj1, barObj1], {id: 34, flag: true}, 10.5, 20], "A",
                 true, false];
     var [[g1, [g2, ...g3], ...g4], ...g5] = t5;
-    assertEqual("typedesc string", (typeof g1).toString());
+    assertEqual("typedesc Ballerina", (typeof g1).toString());
     assertEqual("typedesc error", (typeof g2).toString());
     assertEqual("typedesc [map<string>,int,(FooObj|BarObj)...]", (typeof g3).toString());
     assertEqual("typedesc [Bar,(byte|float)...]", (typeof g4).toString());
@@ -372,8 +372,8 @@ function testRestVarRefType6() {
 function testRestVarRefType7() {
     int[5] t6 = [10, 20, 30, 40, 50];
     var [h1, h2, ...h3] = t6;
-    assertEqual("typedesc int", (typeof h1).toString());
-    assertEqual("typedesc int", (typeof h2).toString());
+    assertEqual("typedesc 10", (typeof h1).toString());
+    assertEqual("typedesc 20", (typeof h2).toString());
     assertEqual("typedesc [int,int,int]", (typeof h3).toString());
     assertEqual(10, h1);
     assertEqual(20, h2);
@@ -404,7 +404,7 @@ function testRestVarRefType9() {
     [[string, [FooObj, Bar...], int, float...], boolean[3], string...] [[i1, [...i2], ...i3], ...i4] =
                 [["Ballerina", [fooObj1, {id: 34, flag: true}, {id: 35, flag: false}], 453, 10.5, 20.5],
                 [false, true, true], "Ballerina", "Hello"];
-    assertEqual("typedesc string", (typeof i1).toString());
+    assertEqual("typedesc Ballerina", (typeof i1).toString());
     assertEqual("typedesc [FooObj,Bar...]", (typeof i2).toString());
     assertEqual("typedesc [int,float...]", (typeof i3).toString());
     assertEqual("typedesc [boolean[3],string...]", (typeof i4).toString());

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/vardeclr/module_tuple_var_decl.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/vardeclr/module_tuple_var_decl.bal
@@ -170,7 +170,7 @@ BarObj barObj1 = new (true, 56);
 var [[g1, [g2, ...g3], ...g4], ...g5] = t2;
 
 function testModuleLevelTupleRest2() {
-    assertEquality("typedesc string", (typeof g1).toString());
+    assertEquality("typedesc Ballerina", (typeof g1).toString());
     assertEquality("typedesc error", (typeof g2).toString());
     assertEquality("typedesc [map<string>,int,(FooObj|BarObj)...]", (typeof g3).toString());
     assertEquality("typedesc [Bar,(byte|float)...]", (typeof g4).toString());
@@ -200,8 +200,8 @@ int[5] t3 = [10, 20, 30, 40, 50];
 var [h1, h2, ...h3] = t3;
 
 function testModuleLevelTupleRest3() {
-    assertEquality("typedesc int", (typeof h1).toString());
-    assertEquality("typedesc int", (typeof h2).toString());
+    assertEquality("typedesc 10", (typeof h1).toString());
+    assertEquality("typedesc 20", (typeof h2).toString());
     assertEquality("typedesc [int,int,int]", (typeof h3).toString());
     assertEquality(10, h1);
     assertEquality(20, h2);
@@ -216,7 +216,7 @@ function testModuleLevelTupleRest3() {
             [false, true, true], "Ballerina", "Hello"];
 
 function testModuleLevelTupleRest4() {
-    assertEquality("typedesc string", (typeof i1).toString());
+    assertEquality("typedesc Ballerina", (typeof i1).toString());
     assertEquality("typedesc [FooObj,Bar...]", (typeof i2).toString());
     assertEquality("typedesc [int,float...]", (typeof i3).toString());
     assertEquality("typedesc [boolean[3],string...]", (typeof i4).toString());

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/typedesc/typedesc_positive.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/typedesc/typedesc_positive.bal
@@ -208,7 +208,7 @@ function testTypeDefWithIntersectionTypeDescAsTypedesc() {
     typedesc<anydata> a = ImmutableIntArray;
     (int|string)[] arr = [1, 2, 3];
     anydata|error b = arr.cloneWithType(a);
-    assertEquality("typedesc int[] & readonly", (typeof b).toString());
+    assertEquality("typedesc [1,2,3]", (typeof b).toString());
     assertEquality(true, b is int[]);
     assertEquality(true, (<int[]> checkpanic b).isReadOnly());
     assertEquality(<int[]> [1, 2, 3], b);


### PR DESCRIPTION
## Purpose
As per the spec, the `typeof` expression must return the type as the following,
- For basic simple value, 
       - provide a type with single shape
       - For each `typeof` call, produce a new typedesc value.
       
- For reference value, 
       -  if the value is immutable & a container (structural value),  provide a type with single shape
       - Or else provide the typedesc that is used to construct the value
       - For each `typeof` call, provide identical typedesc values.

Fixes #15278
Fixes #32101
Fixes #32102
Fixes #32130

## Approach
- Create and return new singleton typedesc values for simple basic type values.
- Store the typedesc information of the reference values which can be returned at the `typeof` call.
- Store the singleton type as the value type when creating an immutable value
 
## Samples
```ballerina

    // Basic Simple Type 
    int i = 34;
    io:println(typeof i); // typedesc 34
    test:assertFalse(typeof i === typeof i); 

    // Structural types 
    int[] arr = [1, 2, 3];
    test:assertTrue(typeof arr === typeof arr); 

    map<string> mapVal = {s: "test"};
    test:assertTrue(typeof mapVal === typeof mapVal); 

    // Behavioral types - Object
    Obj0 obj = new ("abc", 123);
    test:assertTrue(typeof obj === typeof obj); 

    // Behavioral types - Error
    error err = error("This is an error!");
    test:assertTrue(typeof err === typeof err); 

   // Immutable Values
    int[] & readonly arr = [1, 2, 3];
    test:assertTrue(typeof arr === typeof arr);
    io:println(typeof arr); // typedesc [1,2,3]
```

## Remarks
- Duplicate of PR #32080

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [x] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
