### PR TITLE
[Formatter] Remove trailing whitespaces at user defined new lines

### DIFF
--- a/compiler/ballerina-parser/src/test/resources/declarations/annot-decl/annot_decl_assert_10.json
+++ b/compiler/ballerina-parser/src/test/resources/declarations/annot-decl/annot_decl_assert_10.json
@@ -241,10 +241,6 @@
                   "kind": "COMMA_TOKEN",
                   "trailingMinutiae": [
                     {
-                      "kind": "WHITESPACE_MINUTIAE",
-                      "value": " "
-                    },
-                    {
                       "kind": "END_OF_LINE_MINUTIAE",
                       "value": "\n"
                     }

--- a/compiler/ballerina-parser/src/test/resources/declarations/annot-decl/annot_decl_assert_12.json
+++ b/compiler/ballerina-parser/src/test/resources/declarations/annot-decl/annot_decl_assert_12.json
@@ -67,10 +67,6 @@
                           "kind": "OBJECT_KEYWORD",
                           "trailingMinutiae": [
                             {
-                              "kind": "WHITESPACE_MINUTIAE",
-                              "value": " "
-                            },
-                            {
                               "kind": "END_OF_LINE_MINUTIAE",
                               "value": "\n"
                             }

--- a/compiler/ballerina-parser/src/test/resources/declarations/annot-decl/annot_decl_source_10.bal
+++ b/compiler/ballerina-parser/src/test/resources/declarations/annot-decl/annot_decl_source_10.bal
@@ -2,5 +2,5 @@ annotation Foo on source bar
 
 , ;
 
-const annotation name on source object function, 
+const annotation name on source object function,
 // Intentionally left with EOF as next token

--- a/compiler/ballerina-parser/src/test/resources/declarations/annot-decl/annot_decl_source_12.bal
+++ b/compiler/ballerina-parser/src/test/resources/declarations/annot-decl/annot_decl_source_12.bal
@@ -1,4 +1,4 @@
-const annotation name on object 
+const annotation name on object
 
 Animal a = new Animal();
 

--- a/compiler/ballerina-parser/src/test/resources/declarations/class-def/class_def_assert_35.json
+++ b/compiler/ballerina-parser/src/test/resources/declarations/class-def/class_def_assert_35.json
@@ -22,10 +22,6 @@
               "kind": "CLASS_KEYWORD",
               "trailingMinutiae": [
                 {
-                  "kind": "WHITESPACE_MINUTIAE",
-                  "value": " "
-                },
-                {
                   "kind": "END_OF_LINE_MINUTIAE",
                   "value": "\n"
                 }

--- a/compiler/ballerina-parser/src/test/resources/declarations/class-def/class_def_source_35.bal
+++ b/compiler/ballerina-parser/src/test/resources/declarations/class-def/class_def_source_35.bal
@@ -1,4 +1,4 @@
-class 
+class
 client client client Foo {
 string name;
 }

--- a/compiler/ballerina-parser/src/test/resources/declarations/func-definition/func_params_assert_25.json
+++ b/compiler/ballerina-parser/src/test/resources/declarations/func-definition/func_params_assert_25.json
@@ -145,10 +145,6 @@
                   "kind": "CLOSE_PAREN_TOKEN",
                   "trailingMinutiae": [
                     {
-                      "kind": "WHITESPACE_MINUTIAE",
-                      "value": " "
-                    },
-                    {
                       "kind": "END_OF_LINE_MINUTIAE",
                       "value": "\n"
                     }

--- a/compiler/ballerina-parser/src/test/resources/declarations/func-definition/func_params_source_25.bal
+++ b/compiler/ballerina-parser/src/test/resources/declarations/func-definition/func_params_source_25.bal
@@ -1,4 +1,4 @@
-function testFunction1(int testParam1, int testParam2 = ) 
+function testFunction1(int testParam1, int testParam2 = )
 
 function testFunction() {
 }

--- a/compiler/ballerina-parser/src/test/resources/declarations/object-type-def/object_type_def_assert_45.json
+++ b/compiler/ballerina-parser/src/test/resources/declarations/object-type-def/object_type_def_assert_45.json
@@ -640,10 +640,6 @@
                               ],
                               "trailingMinutiae": [
                                 {
-                                  "kind": "WHITESPACE_MINUTIAE",
-                                  "value": " "
-                                },
-                                {
                                   "kind": "END_OF_LINE_MINUTIAE",
                                   "value": "\n"
                                 }
@@ -1249,10 +1245,6 @@
                                 }
                               ],
                               "trailingMinutiae": [
-                                {
-                                  "kind": "WHITESPACE_MINUTIAE",
-                                  "value": " "
-                                },
                                 {
                                   "kind": "END_OF_LINE_MINUTIAE",
                                   "value": "\n"

--- a/compiler/ballerina-parser/src/test/resources/declarations/object-type-def/object_type_def_assert_46.json
+++ b/compiler/ballerina-parser/src/test/resources/declarations/object-type-def/object_type_def_assert_46.json
@@ -85,10 +85,6 @@
                               ],
                               "trailingMinutiae": [
                                 {
-                                  "kind": "WHITESPACE_MINUTIAE",
-                                  "value": " "
-                                },
-                                {
                                   "kind": "END_OF_LINE_MINUTIAE",
                                   "value": "\n"
                                 }

--- a/compiler/ballerina-parser/src/test/resources/declarations/object-type-def/object_type_def_source_45.bal
+++ b/compiler/ballerina-parser/src/test/resources/declarations/object-type-def/object_type_def_source_45.bal
@@ -8,7 +8,7 @@ type Calculator object {
         b = y;
         c = a
         + b;
-    } 
+    }
 
     function add(int x, int y)
      {
@@ -19,5 +19,5 @@ type Calculator object {
         b = y;
         c = a
         + b;
-    } 
+    }
 };

--- a/compiler/ballerina-parser/src/test/resources/declarations/object-type-def/object_type_def_source_46.bal
+++ b/compiler/ballerina-parser/src/test/resources/declarations/object-type-def/object_type_def_source_46.bal
@@ -1,5 +1,5 @@
 type MYOBJECT object {
-    p 
+    p
 };
 
 type MYOBJECT object {

--- a/compiler/ballerina-parser/src/test/resources/declarations/record-type-def/record_type_def_assert_28.json
+++ b/compiler/ballerina-parser/src/test/resources/declarations/record-type-def/record_type_def_assert_28.json
@@ -39,10 +39,6 @@
                       "value": "l",
                       "trailingMinutiae": [
                         {
-                          "kind": "WHITESPACE_MINUTIAE",
-                          "value": " "
-                        },
-                        {
                           "kind": "END_OF_LINE_MINUTIAE",
                           "value": "\n"
                         }

--- a/compiler/ballerina-parser/src/test/resources/declarations/record-type-def/record_type_def_source_28.bal
+++ b/compiler/ballerina-parser/src/test/resources/declarations/record-type-def/record_type_def_source_28.bal
@@ -1,4 +1,4 @@
-public l 
+public l
 
 # Description
 public type NodeCredential record {|

--- a/compiler/ballerina-parser/src/test/resources/declarations/service-decl/service_decl_assert_13.json
+++ b/compiler/ballerina-parser/src/test/resources/declarations/service-decl/service_decl_assert_13.json
@@ -109,10 +109,6 @@
                       "kind": "CLOSE_BRACE_TOKEN",
                       "trailingMinutiae": [
                         {
-                          "kind": "WHITESPACE_MINUTIAE",
-                          "value": " "
-                        },
-                        {
                           "kind": "END_OF_LINE_MINUTIAE",
                           "value": "\n"
                         }

--- a/compiler/ballerina-parser/src/test/resources/declarations/service-decl/service_decl_assert_21.json
+++ b/compiler/ballerina-parser/src/test/resources/declarations/service-decl/service_decl_assert_21.json
@@ -94,10 +94,6 @@
                       ],
                       "trailingMinutiae": [
                         {
-                          "kind": "WHITESPACE_MINUTIAE",
-                          "value": " "
-                        },
-                        {
                           "kind": "END_OF_LINE_MINUTIAE",
                           "value": "\n"
                         }

--- a/compiler/ballerina-parser/src/test/resources/declarations/service-decl/service_decl_source_13.bal
+++ b/compiler/ballerina-parser/src/test/resources/declarations/service-decl/service_decl_source_13.bal
@@ -1,6 +1,6 @@
 
 service someListner2 on listener {
-} 
+}
 
 service someListner2 on listener {
     resource function get greeting() returns string {

--- a/compiler/ballerina-parser/src/test/resources/declarations/service-decl/service_decl_source_21.bal
+++ b/compiler/ballerina-parser/src/test/resources/declarations/service-decl/service_decl_source_21.bal
@@ -1,3 +1,3 @@
 service on module1:listener1 {
-    public 
+    public
 }

--- a/compiler/ballerina-parser/src/test/resources/expressions/query-expr/query_expr_assert_65.json
+++ b/compiler/ballerina-parser/src/test/resources/expressions/query-expr/query_expr_assert_65.json
@@ -219,10 +219,6 @@
                                   ],
                                   "trailingMinutiae": [
                                     {
-                                      "kind": "WHITESPACE_MINUTIAE",
-                                      "value": " "
-                                    },
-                                    {
                                       "kind": "END_OF_LINE_MINUTIAE",
                                       "value": "\n"
                                     }

--- a/compiler/ballerina-parser/src/test/resources/expressions/query-expr/query_expr_assert_66.json
+++ b/compiler/ballerina-parser/src/test/resources/expressions/query-expr/query_expr_assert_66.json
@@ -293,10 +293,6 @@
                                       "kind": "COMMA_TOKEN",
                                       "trailingMinutiae": [
                                         {
-                                          "kind": "WHITESPACE_MINUTIAE",
-                                          "value": " "
-                                        },
-                                        {
                                           "kind": "END_OF_LINE_MINUTIAE",
                                           "value": "\n"
                                         }

--- a/compiler/ballerina-parser/src/test/resources/expressions/query-expr/query_expr_assert_67.json
+++ b/compiler/ballerina-parser/src/test/resources/expressions/query-expr/query_expr_assert_67.json
@@ -131,10 +131,6 @@
                   "kind": "EQUAL_TOKEN",
                   "trailingMinutiae": [
                     {
-                      "kind": "WHITESPACE_MINUTIAE",
-                      "value": " "
-                    },
-                    {
                       "kind": "END_OF_LINE_MINUTIAE",
                       "value": "\n"
                     }

--- a/compiler/ballerina-parser/src/test/resources/expressions/query-expr/query_expr_assert_68.json
+++ b/compiler/ballerina-parser/src/test/resources/expressions/query-expr/query_expr_assert_68.json
@@ -469,10 +469,6 @@
                   "kind": "EQUAL_TOKEN",
                   "trailingMinutiae": [
                     {
-                      "kind": "WHITESPACE_MINUTIAE",
-                      "value": " "
-                    },
-                    {
                       "kind": "END_OF_LINE_MINUTIAE",
                       "value": "\n"
                     }
@@ -716,10 +712,6 @@
                                       "kind": "IDENTIFIER_TOKEN",
                                       "value": "deptList",
                                       "trailingMinutiae": [
-                                        {
-                                          "kind": "WHITESPACE_MINUTIAE",
-                                          "value": " "
-                                        },
                                         {
                                           "kind": "END_OF_LINE_MINUTIAE",
                                           "value": "\n"

--- a/compiler/ballerina-parser/src/test/resources/expressions/query-expr/query_expr_source_65.bal
+++ b/compiler/ballerina-parser/src/test/resources/expressions/query-expr/query_expr_source_65.bal
@@ -1,6 +1,6 @@
 function testIterableOperation() {
     string outputNameString = from var person in personList
-        join 
+        join
          
 }
 

--- a/compiler/ballerina-parser/src/test/resources/expressions/query-expr/query_expr_source_66.bal
+++ b/compiler/ballerina-parser/src/test/resources/expressions/query-expr/query_expr_source_66.bal
@@ -1,6 +1,6 @@
 function testIterableOperation() {
     string outputNameString = from var person in personList
-        let var test = 12, 
+        let var test = 12,
          
 }
 

--- a/compiler/ballerina-parser/src/test/resources/expressions/query-expr/query_expr_source_67.bal
+++ b/compiler/ballerina-parser/src/test/resources/expressions/query-expr/query_expr_source_67.bal
@@ -1,5 +1,5 @@
 public function main() {
-    Employee[] empList = 
+    Employee[] empList =
         from var person in personList
     let stream<Department> dS = stream from var dep in deptList
         where dep.name != "HR"

--- a/compiler/ballerina-parser/src/test/resources/expressions/query-expr/query_expr_source_68.bal
+++ b/compiler/ballerina-parser/src/test/resources/expressions/query-expr/query_expr_source_68.bal
@@ -4,9 +4,9 @@ public function main() {
         w //<cursor>
         select pet;
 
-    DeptPerson[] deptPersonList = 
+    DeptPerson[] deptPersonList =
             from var person in personList
-    join var {id: deptId, name: deptName} in deptList 
+    join var {id: deptId, name: deptName} in deptList
             on person.id equals deptId
     w //<cursor>
     select {

--- a/compiler/ballerina-parser/src/test/resources/misc/completion/completion_assert_01.json
+++ b/compiler/ballerina-parser/src/test/resources/misc/completion/completion_assert_01.json
@@ -92,10 +92,6 @@
                       ],
                       "trailingMinutiae": [
                         {
-                          "kind": "WHITESPACE_MINUTIAE",
-                          "value": " "
-                        },
-                        {
                           "kind": "END_OF_LINE_MINUTIAE",
                           "value": "\n"
                         }
@@ -255,10 +251,6 @@
                           ],
                           "trailingMinutiae": [
                             {
-                              "kind": "WHITESPACE_MINUTIAE",
-                              "value": " "
-                            },
-                            {
                               "kind": "END_OF_LINE_MINUTIAE",
                               "value": "\n"
                             }
@@ -390,10 +382,6 @@
                             }
                           ],
                           "trailingMinutiae": [
-                            {
-                              "kind": "WHITESPACE_MINUTIAE",
-                              "value": " "
-                            },
                             {
                               "kind": "END_OF_LINE_MINUTIAE",
                               "value": "\n"

--- a/compiler/ballerina-parser/src/test/resources/misc/completion/completion_assert_02.json
+++ b/compiler/ballerina-parser/src/test/resources/misc/completion/completion_assert_02.json
@@ -97,10 +97,6 @@
                           ],
                           "trailingMinutiae": [
                             {
-                              "kind": "WHITESPACE_MINUTIAE",
-                              "value": " "
-                            },
-                            {
                               "kind": "END_OF_LINE_MINUTIAE",
                               "value": "\n"
                             }
@@ -310,10 +306,6 @@
                                             }
                                           ],
                                           "trailingMinutiae": [
-                                            {
-                                              "kind": "WHITESPACE_MINUTIAE",
-                                              "value": " "
-                                            },
                                             {
                                               "kind": "END_OF_LINE_MINUTIAE",
                                               "value": "\n"

--- a/compiler/ballerina-parser/src/test/resources/misc/completion/completion_assert_03.json
+++ b/compiler/ballerina-parser/src/test/resources/misc/completion/completion_assert_03.json
@@ -169,10 +169,6 @@
                       "kind": "EQUAL_TOKEN",
                       "trailingMinutiae": [
                         {
-                          "kind": "WHITESPACE_MINUTIAE",
-                          "value": " "
-                        },
-                        {
                           "kind": "END_OF_LINE_MINUTIAE",
                           "value": "\n"
                         }

--- a/compiler/ballerina-parser/src/test/resources/misc/completion/completion_assert_04.json
+++ b/compiler/ballerina-parser/src/test/resources/misc/completion/completion_assert_04.json
@@ -124,10 +124,6 @@
                                   ],
                                   "trailingMinutiae": [
                                     {
-                                      "kind": "WHITESPACE_MINUTIAE",
-                                      "value": " "
-                                    },
-                                    {
                                       "kind": "END_OF_LINE_MINUTIAE",
                                       "value": "\n"
                                     }

--- a/compiler/ballerina-parser/src/test/resources/misc/completion/completion_assert_06.json
+++ b/compiler/ballerina-parser/src/test/resources/misc/completion/completion_assert_06.json
@@ -133,10 +133,6 @@
                                   ],
                                   "trailingMinutiae": [
                                     {
-                                      "kind": "WHITESPACE_MINUTIAE",
-                                      "value": " "
-                                    },
-                                    {
                                       "kind": "END_OF_LINE_MINUTIAE",
                                       "value": "\n"
                                     }

--- a/compiler/ballerina-parser/src/test/resources/misc/completion/completion_assert_07.json
+++ b/compiler/ballerina-parser/src/test/resources/misc/completion/completion_assert_07.json
@@ -91,10 +91,6 @@
                           ],
                           "trailingMinutiae": [
                             {
-                              "kind": "WHITESPACE_MINUTIAE",
-                              "value": " "
-                            },
-                            {
                               "kind": "END_OF_LINE_MINUTIAE",
                               "value": "\n"
                             }
@@ -241,10 +237,6 @@
                             }
                           ],
                           "trailingMinutiae": [
-                            {
-                              "kind": "WHITESPACE_MINUTIAE",
-                              "value": " "
-                            },
                             {
                               "kind": "END_OF_LINE_MINUTIAE",
                               "value": "\n"
@@ -396,10 +388,6 @@
                             }
                           ],
                           "trailingMinutiae": [
-                            {
-                              "kind": "WHITESPACE_MINUTIAE",
-                              "value": " "
-                            },
                             {
                               "kind": "END_OF_LINE_MINUTIAE",
                               "value": "\n"
@@ -588,10 +576,6 @@
                               "kind": "ON_KEYWORD",
                               "trailingMinutiae": [
                                 {
-                                  "kind": "WHITESPACE_MINUTIAE",
-                                  "value": " "
-                                },
-                                {
                                   "kind": "END_OF_LINE_MINUTIAE",
                                   "value": "\n"
                                 }
@@ -772,10 +756,6 @@
                                   ],
                                   "trailingMinutiae": [
                                     {
-                                      "kind": "WHITESPACE_MINUTIAE",
-                                      "value": " "
-                                    },
-                                    {
                                       "kind": "END_OF_LINE_MINUTIAE",
                                       "value": "\n"
                                     }
@@ -906,10 +886,6 @@
                             }
                           ],
                           "trailingMinutiae": [
-                            {
-                              "kind": "WHITESPACE_MINUTIAE",
-                              "value": " "
-                            },
                             {
                               "kind": "END_OF_LINE_MINUTIAE",
                               "value": "\n"
@@ -1104,10 +1080,6 @@
                           ],
                           "trailingMinutiae": [
                             {
-                              "kind": "WHITESPACE_MINUTIAE",
-                              "value": " "
-                            },
-                            {
                               "kind": "END_OF_LINE_MINUTIAE",
                               "value": "\n"
                             }
@@ -1259,10 +1231,6 @@
                           ],
                           "trailingMinutiae": [
                             {
-                              "kind": "WHITESPACE_MINUTIAE",
-                              "value": " "
-                            },
-                            {
                               "kind": "END_OF_LINE_MINUTIAE",
                               "value": "\n"
                             }
@@ -1399,10 +1367,6 @@
                             }
                           ],
                           "trailingMinutiae": [
-                            {
-                              "kind": "WHITESPACE_MINUTIAE",
-                              "value": " "
-                            },
                             {
                               "kind": "END_OF_LINE_MINUTIAE",
                               "value": "\n"
@@ -1699,10 +1663,6 @@
                           ],
                           "trailingMinutiae": [
                             {
-                              "kind": "WHITESPACE_MINUTIAE",
-                              "value": " "
-                            },
-                            {
                               "kind": "END_OF_LINE_MINUTIAE",
                               "value": "\n"
                             }
@@ -1840,10 +1800,6 @@
                           ],
                           "trailingMinutiae": [
                             {
-                              "kind": "WHITESPACE_MINUTIAE",
-                              "value": " "
-                            },
-                            {
                               "kind": "END_OF_LINE_MINUTIAE",
                               "value": "\n"
                             }
@@ -1971,10 +1927,6 @@
                           ],
                           "trailingMinutiae": [
                             {
-                              "kind": "WHITESPACE_MINUTIAE",
-                              "value": " "
-                            },
-                            {
                               "kind": "END_OF_LINE_MINUTIAE",
                               "value": "\n"
                             }
@@ -2101,10 +2053,6 @@
                             }
                           ],
                           "trailingMinutiae": [
-                            {
-                              "kind": "WHITESPACE_MINUTIAE",
-                              "value": " "
-                            },
                             {
                               "kind": "END_OF_LINE_MINUTIAE",
                               "value": "\n"

--- a/compiler/ballerina-parser/src/test/resources/misc/completion/completion_assert_08.json
+++ b/compiler/ballerina-parser/src/test/resources/misc/completion/completion_assert_08.json
@@ -91,10 +91,6 @@
                               ],
                               "trailingMinutiae": [
                                 {
-                                  "kind": "WHITESPACE_MINUTIAE",
-                                  "value": " "
-                                },
-                                {
                                   "kind": "END_OF_LINE_MINUTIAE",
                                   "value": "\n"
                                 }
@@ -443,10 +439,6 @@
                                   "kind": "PIPE_TOKEN",
                                   "trailingMinutiae": [
                                     {
-                                      "kind": "WHITESPACE_MINUTIAE",
-                                      "value": " "
-                                    },
-                                    {
                                       "kind": "END_OF_LINE_MINUTIAE",
                                       "value": "\n"
                                     }
@@ -585,10 +577,6 @@
                                 }
                               ],
                               "trailingMinutiae": [
-                                {
-                                  "kind": "WHITESPACE_MINUTIAE",
-                                  "value": " "
-                                },
                                 {
                                   "kind": "END_OF_LINE_MINUTIAE",
                                   "value": "\n"
@@ -764,10 +752,6 @@
                               "kind": "RIGHT_ARROW_TOKEN",
                               "trailingMinutiae": [
                                 {
-                                  "kind": "WHITESPACE_MINUTIAE",
-                                  "value": " "
-                                },
-                                {
                                   "kind": "END_OF_LINE_MINUTIAE",
                                   "value": "\n"
                                 }
@@ -916,10 +900,6 @@
                               "kind": "SYNC_SEND_TOKEN",
                               "trailingMinutiae": [
                                 {
-                                  "kind": "WHITESPACE_MINUTIAE",
-                                  "value": " "
-                                },
-                                {
                                   "kind": "END_OF_LINE_MINUTIAE",
                                   "value": "\n"
                                 }
@@ -1052,10 +1032,6 @@
                                 }
                               ],
                               "trailingMinutiae": [
-                                {
-                                  "kind": "WHITESPACE_MINUTIAE",
-                                  "value": " "
-                                },
                                 {
                                   "kind": "END_OF_LINE_MINUTIAE",
                                   "value": "\n"
@@ -1503,10 +1479,6 @@
                                         }
                                       ],
                                       "trailingMinutiae": [
-                                        {
-                                          "kind": "WHITESPACE_MINUTIAE",
-                                          "value": " "
-                                        },
                                         {
                                           "kind": "END_OF_LINE_MINUTIAE",
                                           "value": "\n"

--- a/compiler/ballerina-parser/src/test/resources/misc/completion/completion_assert_09.json
+++ b/compiler/ballerina-parser/src/test/resources/misc/completion/completion_assert_09.json
@@ -701,10 +701,6 @@
                                   "kind": "COMMA_TOKEN",
                                   "trailingMinutiae": [
                                     {
-                                      "kind": "WHITESPACE_MINUTIAE",
-                                      "value": " "
-                                    },
-                                    {
                                       "kind": "END_OF_LINE_MINUTIAE",
                                       "value": "\n"
                                     }
@@ -894,10 +890,6 @@
                             {
                               "kind": "TABLE_KEYWORD",
                               "trailingMinutiae": [
-                                {
-                                  "kind": "WHITESPACE_MINUTIAE",
-                                  "value": " "
-                                },
                                 {
                                   "kind": "END_OF_LINE_MINUTIAE",
                                   "value": "\n"
@@ -1320,10 +1312,6 @@
                               "kind": "OBJECT_KEYWORD",
                               "trailingMinutiae": [
                                 {
-                                  "kind": "WHITESPACE_MINUTIAE",
-                                  "value": " "
-                                },
-                                {
                                   "kind": "END_OF_LINE_MINUTIAE",
                                   "value": "\n"
                                 }
@@ -1513,10 +1501,6 @@
                                 "ERROR_MISSING_LET_VARIABLE_DECLARATION"
                               ],
                               "trailingMinutiae": [
-                                {
-                                  "kind": "WHITESPACE_MINUTIAE",
-                                  "value": " "
-                                },
                                 {
                                   "kind": "END_OF_LINE_MINUTIAE",
                                   "value": "\n"
@@ -1937,10 +1921,6 @@
                               "kind": "IS_KEYWORD",
                               "trailingMinutiae": [
                                 {
-                                  "kind": "WHITESPACE_MINUTIAE",
-                                  "value": " "
-                                },
-                                {
                                   "kind": "END_OF_LINE_MINUTIAE",
                                   "value": "\n"
                                 }
@@ -2123,10 +2103,6 @@
                                 {
                                   "kind": "STREAM_KEYWORD",
                                   "trailingMinutiae": [
-                                    {
-                                      "kind": "WHITESPACE_MINUTIAE",
-                                      "value": " "
-                                    },
                                     {
                                       "kind": "END_OF_LINE_MINUTIAE",
                                       "value": "\n"
@@ -2413,10 +2389,6 @@
                                     {
                                       "kind": "FROM_KEYWORD",
                                       "trailingMinutiae": [
-                                        {
-                                          "kind": "WHITESPACE_MINUTIAE",
-                                          "value": " "
-                                        },
                                         {
                                           "kind": "END_OF_LINE_MINUTIAE",
                                           "value": "\n"

--- a/compiler/ballerina-parser/src/test/resources/misc/completion/completion_assert_10.json
+++ b/compiler/ballerina-parser/src/test/resources/misc/completion/completion_assert_10.json
@@ -266,10 +266,6 @@
                                   ],
                                   "trailingMinutiae": [
                                     {
-                                      "kind": "WHITESPACE_MINUTIAE",
-                                      "value": " "
-                                    },
-                                    {
                                       "kind": "END_OF_LINE_MINUTIAE",
                                       "value": "\n"
                                     }
@@ -431,10 +427,6 @@
                                     {
                                       "kind": "COMMA_TOKEN",
                                       "trailingMinutiae": [
-                                        {
-                                          "kind": "WHITESPACE_MINUTIAE",
-                                          "value": " "
-                                        },
                                         {
                                           "kind": "END_OF_LINE_MINUTIAE",
                                           "value": "\n"
@@ -1477,10 +1469,6 @@
                                       "kind": "COMMA_TOKEN",
                                       "trailingMinutiae": [
                                         {
-                                          "kind": "WHITESPACE_MINUTIAE",
-                                          "value": " "
-                                        },
-                                        {
                                           "kind": "END_OF_LINE_MINUTIAE",
                                           "value": "\n"
                                         }
@@ -1860,10 +1848,6 @@
                                   "kind": "CLOSE_BRACE_TOKEN",
                                   "trailingMinutiae": [
                                     {
-                                      "kind": "WHITESPACE_MINUTIAE",
-                                      "value": " "
-                                    },
-                                    {
                                       "kind": "END_OF_LINE_MINUTIAE",
                                       "value": "\n"
                                     }
@@ -2042,10 +2026,6 @@
                                               ],
                                               "trailingMinutiae": [
                                                 {
-                                                  "kind": "WHITESPACE_MINUTIAE",
-                                                  "value": " "
-                                                },
-                                                {
                                                   "kind": "END_OF_LINE_MINUTIAE",
                                                   "value": "\n"
                                                 }
@@ -2082,10 +2062,6 @@
                                     }
                                   ],
                                   "trailingMinutiae": [
-                                    {
-                                      "kind": "WHITESPACE_MINUTIAE",
-                                      "value": " "
-                                    },
                                     {
                                       "kind": "END_OF_LINE_MINUTIAE",
                                       "value": "\n"
@@ -2302,10 +2278,6 @@
                                     }
                                   ],
                                   "trailingMinutiae": [
-                                    {
-                                      "kind": "WHITESPACE_MINUTIAE",
-                                      "value": " "
-                                    },
                                     {
                                       "kind": "END_OF_LINE_MINUTIAE",
                                       "value": "\n"
@@ -2886,10 +2858,6 @@
                                           "kind": "COMMA_TOKEN",
                                           "trailingMinutiae": [
                                             {
-                                              "kind": "WHITESPACE_MINUTIAE",
-                                              "value": " "
-                                            },
-                                            {
                                               "kind": "END_OF_LINE_MINUTIAE",
                                               "value": "\n"
                                             }
@@ -3272,10 +3240,6 @@
                                     }
                                   ],
                                   "trailingMinutiae": [
-                                    {
-                                      "kind": "WHITESPACE_MINUTIAE",
-                                      "value": " "
-                                    },
                                     {
                                       "kind": "END_OF_LINE_MINUTIAE",
                                       "value": "\n"

--- a/compiler/ballerina-parser/src/test/resources/misc/completion/completion_source_01.bal
+++ b/compiler/ballerina-parser/src/test/resources/misc/completion/completion_source_01.bal
@@ -1,13 +1,13 @@
 public isolated service class testClass {
-    public 
+    public
 }
 
 var a = object {
-    public 
+    public
 };
 
 type obj object {
-    public 
+    public
 };
 
 function foo() returns int {

--- a/compiler/ballerina-parser/src/test/resources/misc/completion/completion_source_02.bal
+++ b/compiler/ballerina-parser/src/test/resources/misc/completion/completion_source_02.bal
@@ -1,10 +1,10 @@
 public function foo() {
-    match 
+    match
     }
 
 public function bar() {
     match v {
-        a 
+        a
         }
     }
 

--- a/compiler/ballerina-parser/src/test/resources/misc/completion/completion_source_03.bal
+++ b/compiler/ballerina-parser/src/test/resources/misc/completion/completion_source_03.bal
@@ -3,7 +3,7 @@ enum Language1 {
     }
 
 enum Language2 {
-    ENG = 
+    ENG =
 }
 
 enum Language3 {

--- a/compiler/ballerina-parser/src/test/resources/misc/completion/completion_source_04.bal
+++ b/compiler/ballerina-parser/src/test/resources/misc/completion/completion_source_04.bal
@@ -1,6 +1,6 @@
 public function foobar() {
     {
-        final 
+        final
     }
 }
 

--- a/compiler/ballerina-parser/src/test/resources/misc/completion/completion_source_06.bal
+++ b/compiler/ballerina-parser/src/test/resources/misc/completion/completion_source_06.bal
@@ -1,6 +1,6 @@
 public function foo() {
     fork {
-        worker 
+        worker
         }
     }
 

--- a/compiler/ballerina-parser/src/test/resources/misc/completion/completion_source_07.bal
+++ b/compiler/ballerina-parser/src/test/resources/misc/completion/completion_source_07.bal
@@ -1,39 +1,39 @@
 function foo1() {
-    final 
+    final
 }
 
 function foo2() {
-    if 
+    if
     }
 
 function foo3() {
-    do 
+    do
     }
 
 function foo4() {
     do {
 
-    } on 
+    } on
     }
 
 function foo5() {
-    var 
+    var
 }
 
 function foo6() {
-    foreach 
+    foreach
     }
 
 function foo7() {
-    while 
+    while
     }
 
 function foo8() {
-    lock 
+    lock
     }
 
 function foo9() {
-    retry 
+    retry
     }
 
 function foo10() {
@@ -41,19 +41,19 @@ function foo10() {
     }
 
 function foo11() {
-    transaction 
+    transaction
     }
 
 function foo12() {
-    rollback 
+    rollback
 }
 
 function foo13() {
-    return 
+    return
 }
 
 function foo14() {
-    xmlns 
+    xmlns
 }
 
 function foo14() {

--- a/compiler/ballerina-parser/src/test/resources/misc/completion/completion_source_08.bal
+++ b/compiler/ballerina-parser/src/test/resources/misc/completion/completion_source_08.bal
@@ -1,27 +1,27 @@
 function foo1() {
-    wait 
+    wait
 }
 
 function foo2() {
     wait {a: }
     wait {a, }
-    wait b | 
+    wait b |
 }
 
 function foo3() {
-    start 
+    start
 }
 
 function foo4() {
-    a -> 
+    a ->
 }
 
 function foo5() {
-    a ->> 
+    a ->>
 }
 
 function foo6() {
-    <- 
+    <-
 }
 
 function foo7() {
@@ -34,7 +34,7 @@ function foo8() {
 }
 
 function foo9() {
-    from 
+    from
      }
 
 function bar() returns int {

--- a/compiler/ballerina-parser/src/test/resources/misc/completion/completion_source_09.bal
+++ b/compiler/ballerina-parser/src/test/resources/misc/completion/completion_source_09.bal
@@ -11,11 +11,11 @@ function foo3() {
 }
 
 function foo4() {
-    var a = [b, 
+    var a = [b,
 }
 
 function foo5() {
-    var a = table 
+    var a = table
 }
 
 function foo6() {
@@ -23,11 +23,11 @@ function foo6() {
  }
 
 function foo7() {
-    var a = object 
+    var a = object
 }
 
 function foo8() {
-    var a = let 
+    var a = let
 }
 
 function foo9() {
@@ -35,15 +35,15 @@ function foo9() {
 }
 
 function foo10() {
-    var a = b is 
+    var a = b is
 }
 
 function foo11() {
-    var a = stream 
+    var a = stream
          }
 
 function foo12() {
-    var a = from 
+    var a = from
          }
 
 function bar() returns int {

--- a/compiler/ballerina-parser/src/test/resources/misc/completion/completion_source_10.bal
+++ b/compiler/ballerina-parser/src/test/resources/misc/completion/completion_source_10.bal
@@ -3,11 +3,11 @@ function foo1() {
 }
 
 function foo2() {
-    stream 
+    stream
 }
 
 function foo3() {
-    stream<a, 
+    stream<a,
  }
 
 function foo4() {
@@ -31,7 +31,7 @@ function foo8() {
 }
 
 function foo9() {
-    [a, 
+    [a,
  }
 
 function foo10() {
@@ -39,19 +39,19 @@ function foo10() {
  }
 
 function foo11() {
-    record } 
+    record }
 }
 
 function foo12() {
     record {
-        readonly 
-    } 
+        readonly
+    }
 }
 
 function foo13() {
     record {
         *
-    } 
+    }
 }
 
 function foo14() {
@@ -63,7 +63,7 @@ function foo15() {
  }
 
 function foo16() {
-    table<baz> key(a, 
+    table<baz> key(a,
  }
 
 function foo17() {
@@ -71,7 +71,7 @@ function foo17() {
  }
 
 function foo18() {
-    error 
+    error
 }
 
 function foo19() {

--- a/compiler/ballerina-parser/src/test/resources/statements/fork-stmt/fork_stmt_assert_07.json
+++ b/compiler/ballerina-parser/src/test/resources/statements/fork-stmt/fork_stmt_assert_07.json
@@ -85,10 +85,6 @@
                   ],
                   "trailingMinutiae": [
                     {
-                      "kind": "WHITESPACE_MINUTIAE",
-                      "value": " "
-                    },
-                    {
                       "kind": "END_OF_LINE_MINUTIAE",
                       "value": "\n"
                     }

--- a/compiler/ballerina-parser/src/test/resources/statements/fork-stmt/fork_stmt_source_07.bal
+++ b/compiler/ballerina-parser/src/test/resources/statements/fork-stmt/fork_stmt_source_07.bal
@@ -1,5 +1,5 @@
 public function foo() {
-    fork 
+    fork
         worker w1 returns int {
             int i = 23;
 

--- a/compiler/ballerina-parser/src/test/resources/statements/transaction-stmt/retry_stmt_assert_03.json
+++ b/compiler/ballerina-parser/src/test/resources/statements/transaction-stmt/retry_stmt_assert_03.json
@@ -75,10 +75,6 @@
                   ],
                   "trailingMinutiae": [
                     {
-                      "kind": "WHITESPACE_MINUTIAE",
-                      "value": " "
-                    },
-                    {
                       "kind": "END_OF_LINE_MINUTIAE",
                       "value": "\n"
                     }

--- a/compiler/ballerina-parser/src/test/resources/statements/transaction-stmt/retry_stmt_assert_04.json
+++ b/compiler/ballerina-parser/src/test/resources/statements/transaction-stmt/retry_stmt_assert_04.json
@@ -88,10 +88,6 @@
                       "kind": "TRANSACTION_KEYWORD",
                       "trailingMinutiae": [
                         {
-                          "kind": "WHITESPACE_MINUTIAE",
-                          "value": " "
-                        },
-                        {
                           "kind": "END_OF_LINE_MINUTIAE",
                           "value": "\n"
                         }

--- a/compiler/ballerina-parser/src/test/resources/statements/transaction-stmt/retry_stmt_source_03.bal
+++ b/compiler/ballerina-parser/src/test/resources/statements/transaction-stmt/retry_stmt_source_03.bal
@@ -1,5 +1,5 @@
 function foo() {
-    retry 
+    retry
     }
 
     retry<T {

--- a/compiler/ballerina-parser/src/test/resources/statements/transaction-stmt/retry_stmt_source_04.bal
+++ b/compiler/ballerina-parser/src/test/resources/statements/transaction-stmt/retry_stmt_source_04.bal
@@ -1,5 +1,5 @@
 function foo() {
-    retry transaction 
+    retry transaction
     }
 
     retry<T transaction {

--- a/compiler/ballerina-parser/src/test/resources/statements/while-stmt/while_stmt_assert_03.json
+++ b/compiler/ballerina-parser/src/test/resources/statements/while-stmt/while_stmt_assert_03.json
@@ -227,10 +227,6 @@
                                   "kind": "FALSE_KEYWORD",
                                   "trailingMinutiae": [
                                     {
-                                      "kind": "WHITESPACE_MINUTIAE",
-                                      "value": " "
-                                    },
-                                    {
                                       "kind": "END_OF_LINE_MINUTIAE",
                                       "value": "\n"
                                     }

--- a/compiler/ballerina-parser/src/test/resources/statements/while-stmt/while_stmt_source_03.bal
+++ b/compiler/ballerina-parser/src/test/resources/statements/while-stmt/while_stmt_source_03.bal
@@ -2,7 +2,7 @@ public function foo() {
     while true {
         int x = 4;
 
-        while false 
+        while false
             int x = 4;
         }
     }

--- a/compiler/ballerina-parser/src/test/resources/types/type-precedence/type-precedence_assert_04.json
+++ b/compiler/ballerina-parser/src/test/resources/types/type-precedence/type-precedence_assert_04.json
@@ -400,10 +400,6 @@
                                       "kind": "BITWISE_AND_TOKEN",
                                       "trailingMinutiae": [
                                         {
-                                          "kind": "WHITESPACE_MINUTIAE",
-                                          "value": " "
-                                        },
-                                        {
                                           "kind": "END_OF_LINE_MINUTIAE",
                                           "value": "\n"
                                         }

--- a/compiler/ballerina-parser/src/test/resources/types/type-precedence/type-precedence_source_04.bal
+++ b/compiler/ballerina-parser/src/test/resources/types/type-precedence/type-precedence_source_04.bal
@@ -1,3 +1,3 @@
 type customType readonly & int|Baz[] & Qux[mod1:app] & boolean|distinct float|
-function () returns Foo & distinct Bar|Baz & Qux[0] & 
+function () returns Foo & distinct Bar|Baz & Qux[0] &
 function () returns int[] & distinct distinct Bar[]|string[];

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
@@ -3903,6 +3903,7 @@ public class FormattingTreeModifier extends TreeModifier {
             switch (minutiae.kind()) {
                 case END_OF_LINE_MINUTIAE:
                     preserveIndentation(true);
+                    removeTrailingWS(trailingMinutiae);
                     trailingMinutiae.add(getNewline());
                     consecutiveNewlines++;
                     break;
@@ -3942,6 +3943,18 @@ public class FormattingTreeModifier extends TreeModifier {
         // reset the line length
         env.lineLength = 0;
         return NodeFactory.createEndOfLineMinutiae(FormatterUtils.NEWLINE_SYMBOL);
+    }
+
+    private List<Minutiae> removeTrailingWS(List<Minutiae> trailingMinutiae) {
+        int minutiaeCount = trailingMinutiae.size();
+        for (int i = minutiaeCount - 1; i > -1; i--) {
+            if (trailingMinutiae.get(i).kind() == SyntaxKind.WHITESPACE_MINUTIAE) {
+                trailingMinutiae.remove(i);
+            } else {
+                return trailingMinutiae;
+            }
+        }
+        return trailingMinutiae;
     }
 
     /**

--- a/misc/formatter/modules/formatter-core/src/test/resources/actions/query/assert/query_action_3.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/actions/query/assert/query_action_3.bal
@@ -2,7 +2,7 @@ public function main() {
     Report[] reportList = from var student in studentList
         // An inner equijoin is performed here.
         // The `join` clause iterates any iterable value similarly to the `from` clause.
-        join var department in departmentList 
+        join var department in departmentList
         // The `on` condition is used to match the `student` with the `department` based on the `deptId`.
         // The iteration is skipped when the condition is not satisfied.
         on student.deptId equals department.deptId

--- a/misc/formatter/modules/formatter-core/src/test/resources/misc/linebreaks/assert/line_breaks_1.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/misc/linebreaks/assert/line_breaks_1.bal
@@ -19,3 +19,10 @@ class Foo {
 
 const x = 5;
 listener T y = 6;
+
+function foo() {
+    if true {
+    }
+    else {
+    }
+}

--- a/misc/formatter/modules/formatter-core/src/test/resources/misc/linebreaks/assert/line_breaks_2.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/misc/linebreaks/assert/line_breaks_2.bal
@@ -23,5 +23,5 @@ class Foo {
 
 const x = 5;
 
-listener T y = 
+listener T y =
 6;

--- a/misc/formatter/modules/formatter-core/src/test/resources/misc/linebreaks/assert/line_breaks_3.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/misc/linebreaks/assert/line_breaks_3.bal
@@ -4,34 +4,34 @@ public function foo() {
 ;
     var x = ();
 
-    int 
+    int
 
     a = 12;
 
-    string s3 = string 
+    string s3 = string
     `${string `hello ${string `${s1}${s2}`
     } world`
     }`
     ;
 
-    foreach var i in 1 ..< endValue 
+    foreach var i in 1 ..< endValue
     {
         sum = sum + i;
     }
 
-    foreach 
-    [country, capital] book in books/<*> 
+    foreach
+    [country, capital] book in books/<*>
         {
     }
 
     xmlns "http://ballerinalang.com/ns1";
-    xmlns "http://ballerinalang.com/ns1" 
-    as 
+    xmlns "http://ballerinalang.com/ns1"
+    as
     ns1;
 
     while (true) {
         i = 6;
-    } 
+    }
 
     on fail var e {
     }
@@ -39,15 +39,15 @@ public function foo() {
     'object
     :RawTemplate template = `Hello ${name}!!!`;
 
-    future<()> f2 = 
+    future<()> f2 =
     start printSum(40, 50);
 
-    future<int> 
-    f1 = 
-    @strand 
+    future<int>
+    f1 =
+    @strand
     {
         thread: "any"
-    } start 
+    } start
     multiply(1, 2)
     ;
 }

--- a/misc/formatter/modules/formatter-core/src/test/resources/misc/linebreaks/assert/line_breaks_4.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/misc/linebreaks/assert/line_breaks_4.bal
@@ -1,15 +1,15 @@
 public function foo() {
     foreach string animal in animals {
-        match 
-    animal 
+        match
+    animal
             {
-            "Mouse" => 
+            "Mouse" =>
             {
             }
             "Dog"|"Canine" => {
             }
 
-            "Cat"|"Feline" => 
+            "Cat"|"Feline" =>
             {
             }
             _ => {
@@ -18,19 +18,19 @@ public function foo() {
     }
 
     int i = <
-                @qwe 
+                @qwe
                 @abc>test();
 
     Person person = <Person>
     employee;
 
     if (true
-    ) 
+    )
     {
     }
 
-    error? flushResult = 
-    flush 
+    error? flushResult =
+    flush
     w2
     ;
 
@@ -40,20 +40,20 @@ public function foo() {
                             } Arthur Conan Doyle</author>
                          </book>`;
 
-    fork 
+    fork
     {
         worker w1 returns int {
             return 20;
         }
     }
 
-    return 
+    return
         20
     ;
 }
 
 function foo(string
-|int id) returns int|error 
+|int id) returns int|error
 {
 }
 

--- a/misc/formatter/modules/formatter-core/src/test/resources/misc/linebreaks/source/line_breaks_1.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/misc/linebreaks/source/line_breaks_1.bal
@@ -13,3 +13,10 @@ class Foo {
 }
 const x = 5;
 listener T y = 6;
+
+function foo() {
+    if true {
+    }
+    else {
+    }
+}


### PR DESCRIPTION
## Purpose
When formatting user-defined new lines or incomplete code snippets, the formatter adds a whitespace at the end expecting the next token to be in the same line. This PR fixes this issue.

Fixes #32112

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
