### PR TITLE
Update OpenAPI help text file with new command line improvements

### DIFF
--- a/cli/ballerina-cli/src/main/resources/cli-help/ballerina-openapi.help
+++ b/cli/ballerina-cli/src/main/resources/cli-help/ballerina-openapi.help
@@ -46,7 +46,7 @@ OPTIONS
              `nullable:false` in openAPI schema property as nillable to reduce the type conversion errors.
 
         (--license) <license-file-path>
-            This option is to generate all ballerina files including given copyright or license header.
+            This option is to generate all ballerina files including the given copyright or license header.
 
         (-s| --service ) <current-service-name>
             This service name is used to identify the service that need to documented as openApi 

--- a/cli/ballerina-cli/src/main/resources/cli-help/ballerina-openapi.help
+++ b/cli/ballerina-cli/src/main/resources/cli-help/ballerina-openapi.help
@@ -42,11 +42,12 @@ OPTIONS
             will be generated according to the mode. 
 
         (-n| --nullable)
-            This option is to generate all the record fields that are not specifically mentioned as
-             `nullable:false` in the openAPI schema property as nullable to reduce the type conversion errors.
+            Optional. JSON schema properties that are not marked as `nullable:true` may return as null in
+            some responses. It will result in JSON schema to Ballerina record data binding error. This is a
+            safe option to generate all data types in the record with Ballerina nil support.
 
         (--license) <license-file-path>
-            This option is to generate all Ballerina files including the given copyright or license header.
+            Optional. The `.bal` files will generate with the given copyright or license header.
 
         (-s| --service ) <current-service-name>
             This service name is used to identify the service that need to documented as openApi 
@@ -54,7 +55,7 @@ OPTIONS
             generation.
 
         (--json)
-            This option is used to generate the JSON file in the Ballerina to OpenAPI command.
+            Optional. Ballerina service to OpenAPI output as JSON. The default is YAML.
 
         (--tags) <tag-names>
             This tags use to filter the operations tag need to generate services. This option uses 

--- a/cli/ballerina-cli/src/main/resources/cli-help/ballerina-openapi.help
+++ b/cli/ballerina-cli/src/main/resources/cli-help/ballerina-openapi.help
@@ -62,8 +62,7 @@ OPTIONS
             with command of OpenAPI to Ballerina file generation.
 
         (--operations) <operation-names>
-            These operations are used to filter the operations that are needed to generate services.
-            This option is used with the command of the OpenAPI to Ballerina file generation.
+            Optional. List of operations to generate the Ballerina service or client.
 
 DEFAULT BEHAVIOR
        If no options are provided, the help text for the OpenAPI Tool is shown.

--- a/cli/ballerina-cli/src/main/resources/cli-help/ballerina-openapi.help
+++ b/cli/ballerina-cli/src/main/resources/cli-help/ballerina-openapi.help
@@ -89,7 +89,7 @@ EXAMPLES
           $ bal openapi -i hello.yaml --nullable
 
        Generate both the Ballerina client and service files including given license or copyright header
-          $ bal openapi -i hello.yaml --license
+          $ bal openapi -i hello.yaml --license license.txt
 
        Export an OpenAPI definition for the `/hello` service of the `hello_service.bal` file.
           $ bal openapi -i hello_service.bal --service-name /hello

--- a/cli/ballerina-cli/src/main/resources/cli-help/ballerina-openapi.help
+++ b/cli/ballerina-cli/src/main/resources/cli-help/ballerina-openapi.help
@@ -7,9 +7,10 @@ SYNOPSIS
        bal openapi [-i | --input] <openapi-contract-file-path> [-o | --output] <output-location> 
        bal openapi [-i | --input] <ballerina-service-file-path> [-o | --output] <output-location> 
        bal openapi [-i | --input] <openapi-contract-file-path> [--mode <mode-type>] 
-                   [--tags <tag-names>] [--operations <operation-names>]
-       bal openapi [-i | --input] <ballerina-service-file-path> 
-                   [-s | --service] <current-service-name>           
+                   [--tags <tag-names>] [--operations <operation-names>] [-n | --nullable]
+                   [--license] <license-file-path>
+       bal openapi [-i | --input] <ballerina-service-file-path> [--json]
+                   [-s | --service] <current-service-name>
 
 DESCRIPTION
        Generate a Ballerina source (either a mock
@@ -40,10 +41,20 @@ OPTIONS
             Mode type is optional and can be service or client. The Ballerina service and client 
             will be generated according to the mode. 
 
+        (-n| --nullable)
+            This option is to generate all the record fields that are not specifically mentioned as
+             `nullable:false` in openAPI schema property as nillable to reduce the type conversion errors.
+
+        (--license) <license-file-path>
+            This option is to generate all ballerina files including given copyright or license header.
+
         (-s| --service ) <current-service-name>
             This service name is used to identify the service that need to documented as openApi 
             specification. This option uses with the command of Ballerina to OpenAPI specification 
             generation.
+
+        (--json)
+            This option is used to generate JSON file in ballerina to openapi command.
 
         (--tags) <tag-names>
             This tags use to filter the operations tag need to generate services. This option uses 
@@ -51,7 +62,7 @@ OPTIONS
 
         (--operations) <operation-names>
             These operations are used to filter the operations that are needed to generate services.
-            This option is used with the commandof the OpenAPI to Ballerina file generation.
+            This option is used with the command of the OpenAPI to Ballerina file generation.
 
 DEFAULT BEHAVIOR
        If no options are provided, the help text for the OpenAPI Tool is shown.
@@ -73,5 +84,15 @@ EXAMPLES
        Generate services for the operations given in the `hello.yaml` OpenAPI contract.
           $ bal openapi -i hello.yaml --mode service --operations operation_ID
 
+       Generate all the record fields that are not specifically mentioned as `nullable:false` in
+       OpenAPI schema property as nillable.
+          $ bal openapi -i hello.yaml --nullable
+
+       Generate both the Ballerina client and service files including given license or copyright header
+          $ bal openapi -i hello.yaml --license
+
        Export an OpenAPI definition for the `/hello` service of the `hello_service.bal` file.
-          $ bal openapi -i hello_service.bal --service-name /hello 
+          $ bal openapi -i hello_service.bal --service-name /hello
+
+       Generate OpenAPI specification with JSON format.
+          $ bal openapi -i hello_service.bal --json

--- a/cli/ballerina-cli/src/main/resources/cli-help/ballerina-openapi.help
+++ b/cli/ballerina-cli/src/main/resources/cli-help/ballerina-openapi.help
@@ -88,7 +88,7 @@ EXAMPLES
        OpenAPI schema property as nillable.
           $ bal openapi -i hello.yaml --nullable
 
-       Generate both the Ballerina client and service files including given license or copyright header
+       Generate both the Ballerina client and service files including given license or copyright header.
           $ bal openapi -i hello.yaml --license license.txt
 
        Export an OpenAPI definition for the `/hello` service of the `hello_service.bal` file.

--- a/cli/ballerina-cli/src/main/resources/cli-help/ballerina-openapi.help
+++ b/cli/ballerina-cli/src/main/resources/cli-help/ballerina-openapi.help
@@ -43,10 +43,10 @@ OPTIONS
 
         (-n| --nullable)
             This option is to generate all the record fields that are not specifically mentioned as
-             `nullable:false` in openAPI schema property as nillable to reduce the type conversion errors.
+             `nullable:false` in the openAPI schema property as nullable to reduce the type conversion errors.
 
         (--license) <license-file-path>
-            This option is to generate all ballerina files including the given copyright or license header.
+            This option is to generate all Ballerina files including the given copyright or license header.
 
         (-s| --service ) <current-service-name>
             This service name is used to identify the service that need to documented as openApi 
@@ -54,7 +54,7 @@ OPTIONS
             generation.
 
         (--json)
-            This option is used to generate JSON file in ballerina to openapi command.
+            This option is used to generate the JSON file in the Ballerina to OpenAPI command.
 
         (--tags) <tag-names>
             This tags use to filter the operations tag need to generate services. This option uses 
@@ -85,14 +85,14 @@ EXAMPLES
           $ bal openapi -i hello.yaml --mode service --operations operation_ID
 
        Generate all the record fields that are not specifically mentioned as `nullable:false` in
-       OpenAPI schema property as nillable.
+       the OpenAPI schema property as nullable.
           $ bal openapi -i hello.yaml --nullable
 
-       Generate both the Ballerina client and service files including given license or copyright header.
+       Generate both the Ballerina client and service files including the given license or copyright header.
           $ bal openapi -i hello.yaml --license license.txt
 
        Export an OpenAPI definition for the `/hello` service of the `hello_service.bal` file.
           $ bal openapi -i hello_service.bal --service-name /hello
 
-       Generate OpenAPI specification with JSON format.
+       Generate an OpenAPI specification in the JSON format.
           $ bal openapi -i hello_service.bal --json


### PR DESCRIPTION
## Purpose
> Update openapi help text with new command line options

 This option is to generate all the record fields that are not specifically mentioned as  `nullable:false` in openAPI schema property as nillable to reduce the type conversion errors.
- bal openapi -i \<yaml-file\> --nullable

This option is to generate all ballerina files including the given copyright or license header.
- bal openapi -i \<yaml-file\> --license \<license-file-path\>

This option is used to generate JSON file in ballerina to openapi command.
- bal openapi -i \<service-file\> --json

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
