### PR TITLE
Fix type resolving issue with both Elvis and Ternary operators

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -4116,7 +4116,7 @@ public class TypeChecker extends BLangNodeVisitor {
                 resultType = symTable.semanticError;
             }
         } else {
-            resultType = types.mergeTypes(rhsReturnType, lhsReturnType);
+            resultType = expType;
         }
     }
 
@@ -6175,6 +6175,8 @@ public class TypeChecker extends BLangNodeVisitor {
             case LIST_CONSTRUCTOR_EXPR:
             case RECORD_LITERAL_EXPR:
                 return true;
+            case ELVIS_EXPR:
+            case TERNARY_EXPR:
             case NUMERIC_LITERAL:
                 return inferTypeForNumericLiteral;
             default:

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -4116,7 +4116,7 @@ public class TypeChecker extends BLangNodeVisitor {
                 resultType = symTable.semanticError;
             }
         } else {
-            resultType = expType;
+            resultType = types.mergeTypes(rhsReturnType, lhsReturnType);
         }
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/elvis/ElvisExpressionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/elvis/ElvisExpressionTest.java
@@ -195,11 +195,18 @@ public class ElvisExpressionTest {
         Assert.assertEquals(((BInteger) results[1]).intValue(), 0);
     }
 
+    @Test(description = "Test Elvis as an function argument.")
+    public void testElvisAsArgumentPositive() {
+        Assert.assertEquals(BRunUtil.invoke(compileResult, "testElvisAsArgumentPositive").length, 1);
+    }
+
     @Test(description = "Negative test cases.")
     public void testElvisOperatorNegative() {
-        Assert.assertEquals(negativeResult.getErrorCount(), 3);
+        Assert.assertEquals(negativeResult.getErrorCount(), 4);
         BAssertUtil.validateError(negativeResult, 0, "incompatible types: expected 'int', found 'int?'", 5, 14);
         BAssertUtil.validateError(negativeResult, 1, "incompatible types: expected 'int', found 'string'", 12, 14);
         BAssertUtil.validateError(negativeResult, 2, "incompatible types: expected 'int', found 'string'", 19, 9);
+        BAssertUtil.validateError(negativeResult, 3, "incompatible types: expected 'int', found '(string|int)'", 26,
+                18);
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/elvis/ElvisExpressionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/elvis/ElvisExpressionTest.java
@@ -197,16 +197,16 @@ public class ElvisExpressionTest {
 
     @Test(description = "Test Elvis as an function argument.")
     public void testElvisAsArgumentPositive() {
-        Assert.assertEquals(BRunUtil.invoke(compileResult, "testElvisAsArgumentPositive").length, 1);
+        BRunUtil.invoke(compileResult, "testElvisAsArgumentPositive");
     }
 
     @Test(description = "Negative test cases.")
     public void testElvisOperatorNegative() {
-        Assert.assertEquals(negativeResult.getErrorCount(), 4);
+        Assert.assertEquals(negativeResult.getErrorCount(), 5);
         BAssertUtil.validateError(negativeResult, 0, "incompatible types: expected 'int', found 'int?'", 5, 14);
         BAssertUtil.validateError(negativeResult, 1, "incompatible types: expected 'int', found 'string'", 12, 14);
         BAssertUtil.validateError(negativeResult, 2, "incompatible types: expected 'int', found 'string'", 19, 9);
-        BAssertUtil.validateError(negativeResult, 3, "incompatible types: expected 'int', found '(string|int)'", 26,
-                18);
+        BAssertUtil.validateError(negativeResult, 3, "incompatible types: expected 'int', found 'string'", 26, 17);
+        BAssertUtil.validateError(negativeResult, 4, "incompatible types: expected 'byte', found 'int'", 30, 17);
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/ternary/TernaryExpressionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/ternary/TernaryExpressionTest.java
@@ -339,8 +339,8 @@ public class TernaryExpressionTest {
         BAssertUtil.validateError(compileResult, 0, "incompatible types: expected 'string', found 'int'", 6, 29);
         BAssertUtil.validateError(compileResult, 1, "incompatible types: expected 'boolean', found 'int'", 7, 13);
         BAssertUtil.validateError(compileResult, 2, "incompatible types: expected 'string', found 'boolean'", 13, 30);
-        BAssertUtil.validateError(compileResult, 3, "incompatible types: expected 'int', found 'string'", 21, 23);
-        BAssertUtil.validateError(compileResult, 4, "incompatible types: expected 'byte', found 'int'", 24, 24);
+        BAssertUtil.validateError(compileResult, 3, "incompatible types: expected 'int', found 'string'", 21, 26);
+        BAssertUtil.validateError(compileResult, 4, "incompatible types: expected 'byte', found 'int'", 24, 27);
     }
 
     @Test

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/ternary/TernaryExpressionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/ternary/TernaryExpressionTest.java
@@ -339,8 +339,8 @@ public class TernaryExpressionTest {
         BAssertUtil.validateError(compileResult, 0, "incompatible types: expected 'string', found 'int'", 6, 29);
         BAssertUtil.validateError(compileResult, 1, "incompatible types: expected 'boolean', found 'int'", 7, 13);
         BAssertUtil.validateError(compileResult, 2, "incompatible types: expected 'string', found 'boolean'", 13, 30);
-        BAssertUtil.validateError(compileResult, 3, "incompatible types: expected 'int', found 'string'", 18, 21);
-        BAssertUtil.validateError(compileResult, 4, "incompatible types: expected 'byte', found 'int'", 21, 22);
+        BAssertUtil.validateError(compileResult, 3, "incompatible types: expected 'int', found 'string'", 21, 23);
+        BAssertUtil.validateError(compileResult, 4, "incompatible types: expected 'byte', found 'int'", 24, 24);
     }
 
     @Test

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/ternary/TernaryExpressionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/ternary/TernaryExpressionTest.java
@@ -335,10 +335,12 @@ public class TernaryExpressionTest {
     @Test
     public void testNegative() {
         CompileResult compileResult = BCompileUtil.compile("test-src/expressions/ternary/ternary-expr-negative.bal");
-        Assert.assertEquals(compileResult.getErrorCount(), 3);
+        Assert.assertEquals(compileResult.getErrorCount(), 5);
         BAssertUtil.validateError(compileResult, 0, "incompatible types: expected 'string', found 'int'", 6, 29);
         BAssertUtil.validateError(compileResult, 1, "incompatible types: expected 'boolean', found 'int'", 7, 13);
         BAssertUtil.validateError(compileResult, 2, "incompatible types: expected 'string', found 'boolean'", 13, 30);
+        BAssertUtil.validateError(compileResult, 3, "incompatible types: expected 'int', found 'string'", 18, 21);
+        BAssertUtil.validateError(compileResult, 4, "incompatible types: expected 'byte', found 'int'", 21, 22);
     }
 
     @Test
@@ -351,6 +353,11 @@ public class TernaryExpressionTest {
     public void testPredeclPrefixInTernary() {
         BValue[] results = BRunUtil.invoke(compileResult, "testPredeclPrefixInTernary");
         Assert.assertEquals(((BInteger) results[0]).intValue(), 11);
+    }
+
+    @Test
+    public void testTernaryAsArgument() {
+        BRunUtil.invoke(compileResult, "testTernaryAsArgument");
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/elvis/elvis-expr-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/elvis/elvis-expr-negative.bal
@@ -19,3 +19,9 @@ function testElvisValueTypeNotMatchingTypeWithLHS () returns (int) {
     b = x ?: 3;
     return b;
 }
+
+function testElvisAsArgumentPositive() {
+    int[] filters = [];
+    int? x = 1;
+    filters.push(x ?: "");
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/elvis/elvis-expr-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/elvis/elvis-expr-negative.bal
@@ -20,8 +20,12 @@ function testElvisValueTypeNotMatchingTypeWithLHS () returns (int) {
     return b;
 }
 
-function testElvisAsArgumentPositive() {
-    int[] filters = [];
-    int? x = 1;
-    filters.push(x ?: "");
+function testElvisAsArgumentNegative() {
+    int[] a = [];
+    int? b = 1;
+    a.push(b ?: "");
+
+    byte[] c = [];
+    byte? d = ();
+    c.push(d ?: 256);
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/elvis/elvis-expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/elvis/elvis-expr.bal
@@ -135,7 +135,7 @@ function testElvisNestedTupleTypeCaseThree() returns [string, int] {
     return rT;
 }
 
-function testElvisAsArgumentPositive() returns string|error {
+function testElvisAsArgumentPositive() {
     string[] filters = [];
     string? mergable1 = ();
     string s1 = mergable1 ?: "";
@@ -158,8 +158,6 @@ function testElvisAsArgumentPositive() returns string|error {
     assertEquals(filters[2], filters[3]);
     assertEquals(a[0], 255);
     assertEquals(a[1], 0);
-
-    return "";
 }
 
 const ASSERTION_ERROR_REASON = "AssertionError";

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/elvis/elvis-expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/elvis/elvis-expr.bal
@@ -137,20 +137,35 @@ function testElvisNestedTupleTypeCaseThree() returns [string, int] {
 
 function testElvisAsArgumentPositive() returns string|error {
     string[] filters = [];
-    json j = {};
-    string? mergable = check j.mergeable;
-    string s = mergable ?: "";
-    filters.push(s);
-    filters.push(mergable ?: "");
+    string? mergable1 = ();
+    string s1 = mergable1 ?: "";
+    filters.push(s1);
+    filters.push(mergable1 ?: "");
 
+    string? mergable2 = "str";
+    string s2 = mergable2 ?: "";
+    filters.push(s2);
+    filters.push(mergable2 ?: "");
+
+    byte[] a = [];
+    byte? b = ();
+    a.push(b ?: 255);
+    a.push(b ?: 0);
+
+    assertEquals(filters[0], "");
+    assertEquals(filters[2], "str");
     assertEquals(filters[0], filters[1]);
-    return filters[0];
+    assertEquals(filters[2], filters[3]);
+    assertEquals(a[0], 255);
+    assertEquals(a[1], 0);
+
+    return "";
 }
 
 const ASSERTION_ERROR_REASON = "AssertionError";
 
 function assertEquals(anydata expected, anydata actual) {
-    if (expected == actual) {
+    if expected == actual {
         return;
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/elvis/elvis-expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/elvis/elvis-expr.bal
@@ -134,3 +134,29 @@ function testElvisNestedTupleTypeCaseThree() returns [string, int] {
     var rT = xT ?: (x2T ?: dT);
     return rT;
 }
+
+function testElvisAsArgumentPositive() returns string|error {
+    string[] filters = [];
+    json j = {};
+    string? mergable = check j.mergeable;
+    string s = mergable ?: "";
+    filters.push(s);
+    filters.push(mergable ?: "");
+
+    assertEquals(filters[0], filters[1]);
+    return filters[0];
+}
+
+const ASSERTION_ERROR_REASON = "AssertionError";
+
+function assertEquals(anydata expected, anydata actual) {
+    if (expected == actual) {
+        return;
+    }
+
+    typedesc<anydata> expT = typeof expected;
+    typedesc<anydata> actT = typeof actual;
+    string msg = "expected [" + expected.toString() + "] of type [" + expT.toString()
+                            + "], but found [" + actual.toString() + "] of type [" + actT.toString() + "]";
+    panic error(ASSERTION_ERROR_REASON, message = msg);
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/ternary/ternary-expr-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/ternary/ternary-expr-negative.bal
@@ -15,11 +15,11 @@ function test1 (int value) {
 
 function test2() {
     int[] a = [];
-    boolean True = true;
-    boolean False = false;
+    boolean trueVal = true;
+    boolean falseVal = false;
 
-    a.push(True ? 1 : "");
+    a.push(trueVal ? 1 : "");
 
     byte[] b = [];
-    b.push(False ? 0 : 256);
+    b.push(falseVal ? 0 : 256);
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/ternary/ternary-expr-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/ternary/ternary-expr-negative.bal
@@ -15,8 +15,11 @@ function test1 (int value) {
 
 function test2() {
     int[] a = [];
-    a.push(true? 1: "");
+    boolean True = true;
+    boolean False = false;
+
+    a.push(True ? 1 : "");
 
     byte[] b = [];
-    b.push(false? 0: 256);
+    b.push(False ? 0 : 256);
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/ternary/ternary-expr-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/ternary/ternary-expr-negative.bal
@@ -12,3 +12,11 @@ public function main(string... args){
 function test1 (int value) {
     string s1 = value > 40 ? true : false ? "morethan40" : "lessthan20";
 }
+
+function test2() {
+    int[] a = [];
+    a.push(true? 1: "");
+
+    byte[] b = [];
+    b.push(false? 0: 256);
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/ternary/ternary-expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/ternary/ternary-expr.bal
@@ -115,3 +115,39 @@ function testPredeclPrefixInTernary() returns int {
     int a = true? int:sum(5, 6) : 5;
     return a;
 }
+
+function testTernaryAsArgument() {
+    string[] filters = [];
+    string s1 = true? "str": "";
+    filters.push(s1);
+    filters.push(true? "str": "");
+
+    string s2 = false? "str": "";
+    filters.push(s2);
+    filters.push(false? "str": "");
+
+    byte[] a = [];
+    a.push(true? 0: 255);
+    a.push(false? 0: 255);
+
+    assertEquals(filters[0], "str");
+    assertEquals(filters[2], "");
+    assertEquals(filters[0], filters[1]);
+    assertEquals(filters[2], filters[3]);
+    assertEquals(a[0], 0);
+    assertEquals(a[1], 255);
+}
+
+const ASSERTION_ERROR_REASON = "AssertionError";
+
+function assertEquals(anydata expected, anydata actual) {
+    if expected == actual {
+        return;
+    }
+
+    typedesc<anydata> expT = typeof expected;
+    typedesc<anydata> actT = typeof actual;
+    string msg = "expected [" + expected.toString() + "] of type [" + expT.toString()
+                            + "], but found [" + actual.toString() + "] of type [" + actT.toString() + "]";
+    panic error(ASSERTION_ERROR_REASON, message = msg);
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/ternary/ternary-expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/ternary/ternary-expr.bal
@@ -118,17 +118,20 @@ function testPredeclPrefixInTernary() returns int {
 
 function testTernaryAsArgument() {
     string[] filters = [];
-    string s1 = true? "str": "";
-    filters.push(s1);
-    filters.push(true? "str": "");
+    boolean True = true;
+    boolean False = false;
 
-    string s2 = false? "str": "";
+    string s1 = True ? "str" : "";
+    filters.push(s1);
+    filters.push(True ? "str" : "");
+
+    string s2 = False ? "str" : "";
     filters.push(s2);
-    filters.push(false? "str": "");
+    filters.push(False ? "str" : "");
 
     byte[] a = [];
-    a.push(true? 0: 255);
-    a.push(false? 0: 255);
+    a.push(True ? 0 : 255);
+    a.push(False ? 0 : 255);
 
     assertEquals(filters[0], "str");
     assertEquals(filters[2], "");

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/ternary/ternary-expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/ternary/ternary-expr.bal
@@ -118,20 +118,20 @@ function testPredeclPrefixInTernary() returns int {
 
 function testTernaryAsArgument() {
     string[] filters = [];
-    boolean True = true;
-    boolean False = false;
+    boolean trueVal = true;
+    boolean falseVal = false;
 
-    string s1 = True ? "str" : "";
+    string s1 = trueVal ? "str" : "";
     filters.push(s1);
-    filters.push(True ? "str" : "");
+    filters.push(trueVal ? "str" : "");
 
-    string s2 = False ? "str" : "";
+    string s2 = falseVal ? "str" : "";
     filters.push(s2);
-    filters.push(False ? "str" : "");
+    filters.push(falseVal ? "str" : "");
 
     byte[] a = [];
-    a.push(True ? 0 : 255);
-    a.push(False ? 0 : 255);
+    a.push(trueVal ? 0 : 255);
+    a.push(falseVal ? 0 : 255);
 
     assertEquals(filters[0], "str");
     assertEquals(filters[2], "");


### PR DESCRIPTION
## Purpose
> Fix the resultant type of the Elvis operator 

Fixes #32055

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
