### PR TITLE
Fix debugger for typedesc changes on immutable values

### DIFF
--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/variable/types/BJson.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/variable/types/BJson.java
@@ -31,6 +31,6 @@ public class BJson extends BMap {
 
     @Override
     public String computeValue() {
-        return String.format("map<json> (size = %d)", getChildrenCount());
+        return String.format("json (size = %d)", getChildrenCount());
     }
 }

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/variable/types/BMap.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/variable/types/BMap.java
@@ -66,15 +66,9 @@ public class BMap extends IndexedCompoundVariable {
     @Override
     public String computeValue() {
         try {
-            Value valueAsObject = getValueAsObject(context, jvmValue);
-            List<String> methodArgTypeNames = Collections.singletonList(JAVA_OBJECT_CLASS);
-            RuntimeStaticMethod method = getRuntimeMethod(context, B_TYPE_CHECKER_CLASS, GET_TYPEDESC_METHOD,
-                    methodArgTypeNames);
-            method.setArgValues(Collections.singletonList(valueAsObject));
-            Value value = method.invokeSafely();
-            String typeDescValue = VariableFactory.getVariable(context, value).computeValue();
-            typeDescValue = typeDescValue.split(MAP_TYPEDESC_SEPARATOR)[0].trim();
-            return String.format("%s (size = %d)", typeDescValue, getChildrenCount());
+            // Todo - include constraint type (e.g. map<TYPE>), once we have language level support to get the simple
+            //  type
+            return String.format("map (size = %d)", getChildrenCount());
         } catch (Exception e) {
             return VariableUtils.getBType(jvmValue);
         }

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/evaluation/ExpressionEvaluationTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/evaluation/ExpressionEvaluationTest.java
@@ -127,7 +127,7 @@ public class ExpressionEvaluationTest extends ExpressionEvaluationBaseTest {
         // tuple variable test
         debugTestRunner.assertExpression(context, TUPLE_VAR, "tuple[int,string] (size = 2)", "tuple");
         // map variable test
-        debugTestRunner.assertExpression(context, MAP_VAR, "map<string> (size = 4)", "map");
+        debugTestRunner.assertExpression(context, MAP_VAR, "map (size = 4)", "map");
         // record variable test (Student record)
         debugTestRunner.assertExpression(context, RECORD_VAR, " /:@[`{~π_123_ƮέŞŢ_Student", "record");
         // anonymous record variable test
@@ -161,7 +161,7 @@ public class ExpressionEvaluationTest extends ExpressionEvaluationBaseTest {
         // never variable test
         debugTestRunner.assertExpression(context, NEVER_VAR, "XMLSequence (size = 0)", "xml");
         // json variable test
-        debugTestRunner.assertExpression(context, JSON_VAR, "map<json> (size = 3)", "json");
+        debugTestRunner.assertExpression(context, JSON_VAR, "json (size = 3)", "json");
         // anonymous object variable test (AnonPerson object)
         debugTestRunner.assertExpression(context, ANON_OBJECT_VAR, "Person_\\ /<>:@[`{~π_ƮέŞŢ", "object");
         // service object variable test
@@ -170,7 +170,7 @@ public class ExpressionEvaluationTest extends ExpressionEvaluationBaseTest {
         // Todo - Enable after fixing https://github.com/ballerina-platform/ballerina-lang/issues/26139
         // debugTestRunner.assertExpression(context, GL, "Ballerina", "string");
         // debugTestRunner.assertExpression(context, "gv02_nameWithType", "Ballerina", "string");
-        debugTestRunner.assertExpression(context, GLOBAL_VAR_03, "map<string> (size = 1)", "map");
+        debugTestRunner.assertExpression(context, GLOBAL_VAR_03, "map (size = 1)", "map");
         debugTestRunner.assertExpression(context, GLOBAL_VAR_04, "()", "nil");
         debugTestRunner.assertExpression(context, GLOBAL_VAR_05, "()", "nil");
         // global variables
@@ -178,7 +178,7 @@ public class ExpressionEvaluationTest extends ExpressionEvaluationBaseTest {
         debugTestRunner.assertExpression(context, GLOBAL_VAR_07, "100.0", "decimal");
         debugTestRunner.assertExpression(context, GLOBAL_VAR_08, "2", "int");
         debugTestRunner.assertExpression(context, GLOBAL_VAR_09, "2.0", "float");
-        debugTestRunner.assertExpression(context, GLOBAL_VAR_10, "map<json> (size = 3)", "json");
+        debugTestRunner.assertExpression(context, GLOBAL_VAR_10, "json (size = 3)", "json");
         debugTestRunner.assertExpression(context, GLOBAL_VAR_11, "\"IL with global var\"", "string");
 
         // Todo - add test for qualified name references, after adding support
@@ -216,7 +216,7 @@ public class ExpressionEvaluationTest extends ExpressionEvaluationBaseTest {
     @Override
     @Test
     public void annotationAccessEvaluationTest() throws BallerinaTestException {
-        debugTestRunner.assertExpression(context, "(typeof a).@v1", "variable_tests:Annot (size = 2)", "map");
+        debugTestRunner.assertExpression(context, "(typeof a).@v1", "map (size = 2)", "map");
         debugTestRunner.assertExpression(context, "(typeof a).@v2", "()", "nil");
         debugTestRunner.assertExpression(context, "(typeof a).@v1[\"foo\"]", "\"v1 value\"", "string");
         debugTestRunner.assertExpression(context, "(typeof a).@v1[\"bar\"]", "1", "int");

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/variables/VariableVisibilityTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/variables/VariableVisibilityTest.java
@@ -180,7 +180,7 @@ public class VariableVisibilityTest extends BaseTestCase {
         // global constants
         debugTestRunner.assertVariable(globalVariables, "nameWithoutType", "\"Ballerina\"", "string");
         debugTestRunner.assertVariable(globalVariables, "nameWithType", "\"Ballerina\"", "string");
-        debugTestRunner.assertVariable(globalVariables, "nameMap", "map<string> (size = 1)", "map");
+        debugTestRunner.assertVariable(globalVariables, "nameMap", "map (size = 1)", "map");
         debugTestRunner.assertVariable(globalVariables, "nilWithoutType", "()", "nil");
         debugTestRunner.assertVariable(globalVariables, "nilWithType", "()", "nil");
         debugTestRunner.assertVariable(globalVariables, "RED", "\"RED\"", "string");
@@ -191,7 +191,7 @@ public class VariableVisibilityTest extends BaseTestCase {
         debugTestRunner.assertVariable(globalVariables, "decimalValue", "100.0", "decimal");
         debugTestRunner.assertVariable(globalVariables, "byteValue", "2", "int");
         debugTestRunner.assertVariable(globalVariables, "floatValue", "2.0", "float");
-        debugTestRunner.assertVariable(globalVariables, "jsonValue", "map<json> (size = 2)", "json");
+        debugTestRunner.assertVariable(globalVariables, "jsonValue", "json (size = 2)", "json");
         debugTestRunner.assertVariable(globalVariables, " /:@[`{~π_IL", "\"IL with global var\"", "string");
         debugTestRunner.assertVariable(globalVariables, "port", "9090", "int");
     }
@@ -231,7 +231,7 @@ public class VariableVisibilityTest extends BaseTestCase {
         debugTestRunner.assertVariable(localVariables, "tupleVar", "tuple[int,string] (size = 2)", "tuple");
 
         // map variable visibility test
-        debugTestRunner.assertVariable(localVariables, "mapVar", "map<string> (size = 4)", "map");
+        debugTestRunner.assertVariable(localVariables, "mapVar", "map (size = 4)", "map");
 
         // record variable visibility test (Student record)
         debugTestRunner.assertVariable(localVariables, "recordVar", " /:@[`{~π_123_ƮέŞŢ_Student", "record");
@@ -274,7 +274,7 @@ public class VariableVisibilityTest extends BaseTestCase {
         debugTestRunner.assertVariable(localVariables, "byteVar", "128", "int");
 
         // json variable visibility test
-        debugTestRunner.assertVariable(localVariables, "jsonVar", "map<json> (size = 3)", "json");
+        debugTestRunner.assertVariable(localVariables, "jsonVar", "json (size = 3)", "json");
 
         // table with key variable visibility test
         debugTestRunner.assertVariable(localVariables, "tableWithKeyVar", "table<Employee> (entries = 3)", "table");
@@ -290,7 +290,7 @@ public class VariableVisibilityTest extends BaseTestCase {
                 "string");
         debugTestRunner.assertVariable(localVariables, "üňĩćőđę_var", "\"IL with unicode characters in var\"",
                 "string");
-        debugTestRunner.assertVariable(localVariables, "ĠĿŐΒȂɭ_ /:@[`{~π_json", "map<json> (size = 0)", "json");
+        debugTestRunner.assertVariable(localVariables, "ĠĿŐΒȂɭ_ /:@[`{~π_json", "json (size = 0)", "json");
 
         // service variable visibility test
         debugTestRunner.assertVariable(localVariables, "serviceVar", "service", "service");
@@ -369,8 +369,7 @@ public class VariableVisibilityTest extends BaseTestCase {
 
         // error child variable visibility test
         Map<String, Variable> errorChildVariables = debugTestRunner.fetchChildVariables(localVariables.get("errorVar"));
-        debugTestRunner.assertVariable(errorChildVariables, "details", "map<ballerina/lang.value:1.0.0:Cloneable> " +
-                "(size = 1)", "map");
+        debugTestRunner.assertVariable(errorChildVariables, "details", "map (size = 1)", "map");
         debugTestRunner.assertVariable(errorChildVariables, "message", "\"SimpleErrorType\"", "string");
 
         // error details child variable visibility test


### PR DESCRIPTION
## Purpose
This PR fixes debugger integration test failures related to recent typedesc changes on Ballerina immutable types.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [x] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [x] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
