### PR TITLE
Fix record type inclusion with finite type field

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -617,7 +617,8 @@ public class TypeChecker {
         }
 
         if (sourceTypeTag == TypeTags.FINITE_TYPE_TAG &&
-                (targetTypeTag <= TypeTags.NULL_TAG || targetTypeTag == TypeTags.XML_TEXT_TAG)) {
+                (targetTypeTag == TypeTags.FINITE_TYPE_TAG || targetTypeTag <= TypeTags.NULL_TAG ||
+                        targetTypeTag == TypeTags.XML_TEXT_TAG)) {
             return isFiniteTypeMatch((BFiniteType) sourceType, targetType);
         }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/record/ClosedRecordTypeInclusionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/record/ClosedRecordTypeInclusionTest.java
@@ -185,7 +185,7 @@ public class ClosedRecordTypeInclusionTest {
     }
 
     @Test(dataProvider = "FunctionList")
-    public void testSimpleSyncSendFunctions(String funcName) {
+    public void testSimpleFunctions(String funcName) {
         BRunUtil.invoke(compileResult, funcName);
     }
 
@@ -194,6 +194,7 @@ public class ClosedRecordTypeInclusionTest {
         return new Object[]{
                 "testRestTypeOverriding",
                 "testOutOfOrderFieldOverridingFieldFromTypeInclusion",
+                "testTypeInclusionWithFiniteField",
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/record/closed_record_type_inclusion.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/record/closed_record_type_inclusion.bal
@@ -275,6 +275,22 @@ function testRestTypeOverriding() {
      assertEquality(4, barRecord.body.id);
  }
 
+type UnaryExprOp "-"|"~"|"!";
+
+type UnaryExpr record {|
+    UnaryExprOp op;
+|};
+
+type SimpleConstNegateExpr record {|
+    *UnaryExpr;
+    "-" op = "-";
+|};
+
+function testTypeInclusionWithFiniteField() {
+    SimpleConstNegateExpr expr = {};
+    assertEquality(true, expr is UnaryExpr);
+}
+
 const ASSERTION_ERROR_REASON = "AssertionError";
 
 function assertEquality(any|error expected, any|error actual) {


### PR DESCRIPTION
## Purpose
Fixes #32099 

## Approach
The runtime typechecker returns wrong value for the following code.
```ballerina
type UnaryExprOp "-"|"~"|"!";

type UnaryExpr record {|
    UnaryExprOp op;
|};

type SimpleConstNegateExpr record {|
    *UnaryExpr;
    "-" op = "-";
|};

function testTypeInclusionWithFiniteField() {
    SimpleConstNegateExpr expr = {};
    io:println(expr is UnaryExpr);  // should be true
}
```
This is due to a branch of Typechecker `checkIsType()` implementation does not consider the target & source type with finite type.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
