### PR TITLE
Fix incorrect results for the equality of floating points with non-simple types

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -2708,7 +2708,6 @@ public class TypeChecker {
 
         switch (lhsValTypeTag) {
             case TypeTags.STRING_TAG:
-            case TypeTags.FLOAT_TAG:
             case TypeTags.DECIMAL_TAG:
             case TypeTags.BOOLEAN_TAG:
                 return lhsValue.equals(rhsValue);
@@ -2722,6 +2721,14 @@ public class TypeChecker {
                     return false;
                 }
                 return ((Number) lhsValue).byteValue() == ((Number) rhsValue).byteValue();
+            case TypeTags.FLOAT_TAG:
+                if (rhsValTypeTag != TypeTags.FLOAT_TAG) {
+                    return false;
+                }
+                if (Double.isNaN((Double) lhsValue) && Double.isNaN((Double) rhsValue)) {
+                    return true;
+                }
+                return ((Number) lhsValue).doubleValue() == ((Number) rhsValue).doubleValue();
             case TypeTags.XML_TAG:
                 // Instance of xml never
                 if (lhsValue instanceof XmlText) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -467,8 +467,30 @@ public class TypeChecker {
         Type lhsType = getType(lhsValue);
         Type rhsType = getType(rhsValue);
 
-        if (isSimpleBasicType(lhsType) && isSimpleBasicType(rhsType)) {
-            return isEqual(lhsValue, rhsValue);
+        switch(lhsType.getTag()) {
+            case TypeTags.INT_TAG:
+                if (rhsType.getTag() != TypeTags.BYTE_TAG || rhsType.getTag() != TypeTags.INT_TAG) {
+                    return false;
+                }
+                return lhsValue.equals(((Number) rhsValue).longValue());
+            case TypeTags.BYTE_TAG:
+                if (rhsType.getTag() != TypeTags.BYTE_TAG || rhsType.getTag() != TypeTags.INT_TAG) {
+                    return false;
+                }
+                return lhsValue.equals(((Number) rhsValue).byteValue());
+            case TypeTags.FLOAT_TAG:
+                if (rhsType.getTag() != TypeTags.FLOAT_TAG) {
+                    return false;
+                }
+                return lhsValue.equals(((Number) rhsValue).doubleValue());
+            case TypeTags.DECIMAL_TAG:
+                if (rhsType.getTag() != TypeTags.DECIMAL_TAG) {
+                    return false;
+                }
+                return checkDecimalExactEqual((DecimalValue) lhsValue, (DecimalValue) rhsValue);
+            case TypeTags.BOOLEAN_TAG:
+            case TypeTags.STRING_TAG:
+                return lhsValue.equals(rhsValue);
         }
 
         if (TypeTags.isXMLTypeTag(lhsType.getTag()) && TypeTags.isXMLTypeTag(rhsType.getTag())) {
@@ -2708,7 +2730,6 @@ public class TypeChecker {
 
         switch (lhsValTypeTag) {
             case TypeTags.STRING_TAG:
-            case TypeTags.DECIMAL_TAG:
             case TypeTags.BOOLEAN_TAG:
                 return lhsValue.equals(rhsValue);
             case TypeTags.INT_TAG:
@@ -2729,6 +2750,11 @@ public class TypeChecker {
                     return true;
                 }
                 return ((Number) lhsValue).doubleValue() == ((Number) rhsValue).doubleValue();
+            case TypeTags.DECIMAL_TAG:
+                if (rhsValTypeTag != TypeTags.DECIMAL_TAG) {
+                    return false;
+                }
+                return checkDecimalEqual((DecimalValue) lhsValue, (DecimalValue) rhsValue);
             case TypeTags.XML_TAG:
                 // Instance of xml never
                 if (lhsValue instanceof XmlText) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -467,17 +467,7 @@ public class TypeChecker {
         Type lhsType = getType(lhsValue);
         Type rhsType = getType(rhsValue);
 
-        switch(lhsType.getTag()) {
-            case TypeTags.INT_TAG:
-                if (rhsType.getTag() != TypeTags.BYTE_TAG && rhsType.getTag() != TypeTags.INT_TAG) {
-                    return false;
-                }
-                return lhsValue.equals(((Number) rhsValue).longValue());
-            case TypeTags.BYTE_TAG:
-                if (rhsType.getTag() != TypeTags.BYTE_TAG && rhsType.getTag() != TypeTags.INT_TAG) {
-                    return false;
-                }
-                return lhsValue.equals(((Number) rhsValue).byteValue());
+        switch (lhsType.getTag()) {
             case TypeTags.FLOAT_TAG:
                 if (rhsType.getTag() != TypeTags.FLOAT_TAG) {
                     return false;
@@ -488,17 +478,25 @@ public class TypeChecker {
                     return false;
                 }
                 return checkDecimalExactEqual((DecimalValue) lhsValue, (DecimalValue) rhsValue);
+            case TypeTags.INT_TAG:
+            case TypeTags.BYTE_TAG:
             case TypeTags.BOOLEAN_TAG:
             case TypeTags.STRING_TAG:
-                return lhsValue.equals(rhsValue);
-        }
-
-        if (TypeTags.isXMLTypeTag(lhsType.getTag()) && TypeTags.isXMLTypeTag(rhsType.getTag())) {
-            return isXMLValueRefEqual((XmlValue) lhsValue, (XmlValue) rhsValue);
-        }
-
-        if (isHandleType(lhsType) && isHandleType(rhsType)) {
-            return isHandleValueRefEqual(lhsValue, rhsValue);
+                return isEqual(lhsValue, rhsValue);
+            case TypeTags.XML_TAG:
+            case TypeTags.XML_COMMENT_TAG:
+            case TypeTags.XML_ELEMENT_TAG:
+            case TypeTags.XML_PI_TAG:
+            case TypeTags.XML_TEXT_TAG:
+                if (!TypeTags.isXMLTypeTag(rhsType.getTag())) {
+                    return false;
+                }
+                return isXMLValueRefEqual((XmlValue) lhsValue, (XmlValue) rhsValue);
+            case TypeTags.HANDLE_TAG:
+                if (rhsType.getTag() != TypeTags.HANDLE_TAG) {
+                    return false;
+                }
+                return isHandleValueRefEqual(lhsValue, rhsValue);
         }
 
         return false;

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -469,12 +469,12 @@ public class TypeChecker {
 
         switch(lhsType.getTag()) {
             case TypeTags.INT_TAG:
-                if (rhsType.getTag() != TypeTags.BYTE_TAG || rhsType.getTag() != TypeTags.INT_TAG) {
+                if (rhsType.getTag() != TypeTags.BYTE_TAG && rhsType.getTag() != TypeTags.INT_TAG) {
                     return false;
                 }
                 return lhsValue.equals(((Number) rhsValue).longValue());
             case TypeTags.BYTE_TAG:
-                if (rhsType.getTag() != TypeTags.BYTE_TAG || rhsType.getTag() != TypeTags.INT_TAG) {
+                if (rhsType.getTag() != TypeTags.BYTE_TAG && rhsType.getTag() != TypeTags.INT_TAG) {
                     return false;
                 }
                 return lhsValue.equals(((Number) rhsValue).byteValue());

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/EqualAndNotEqualOperationsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/EqualAndNotEqualOperationsTest.java
@@ -1146,7 +1146,8 @@ public class EqualAndNotEqualOperationsTest {
                 "testNotEqualityWithDecimalUnion",
                 "testExactEqualityWithDecimalUnion",
                 "testNotExactEqualityWithDecimalUnion",
-                "testEqualityWithUnionType"
+                "testEqualityWithUnionOfSimpleTypes",
+                "testExactEqualityWithUnionOfNonSimpleTypes"
         };
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/EqualAndNotEqualOperationsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/EqualAndNotEqualOperationsTest.java
@@ -1149,5 +1149,4 @@ public class EqualAndNotEqualOperationsTest {
                 "testEqualityWithUnionType"
         };
     }
-
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/EqualAndNotEqualOperationsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/EqualAndNotEqualOperationsTest.java
@@ -1130,4 +1130,17 @@ public class EqualAndNotEqualOperationsTest {
         BRunUtil.invoke(result, "testTableEquality");
     }
 
+    @Test(dataProvider = "functionsWithFloatUnionEqualityChecks")
+    public void testFunctionsWithFloatUnionEqualityChecks(String function) {
+        BRunUtil.invoke(result, function);
+    }
+
+    @DataProvider
+    public  Object[] functionsWithFloatUnionEqualityChecks() {
+        return new String[] {
+                "testEqualityWithFloatUnion",
+                "testNotEqualityWithFloatUnion"
+        };
+    }
+
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/EqualAndNotEqualOperationsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/EqualAndNotEqualOperationsTest.java
@@ -1130,16 +1130,23 @@ public class EqualAndNotEqualOperationsTest {
         BRunUtil.invoke(result, "testTableEquality");
     }
 
-    @Test(dataProvider = "functionsWithFloatUnionEqualityChecks")
-    public void testFunctionsWithFloatUnionEqualityChecks(String function) {
+    @Test(dataProvider = "functionsWithUnionEqualityChecks")
+    public void testFunctionsWithUnionEqualityChecks(String function) {
         BRunUtil.invoke(result, function);
     }
 
     @DataProvider
-    public  Object[] functionsWithFloatUnionEqualityChecks() {
+    public  Object[] functionsWithUnionEqualityChecks() {
         return new String[] {
                 "testEqualityWithFloatUnion",
-                "testNotEqualityWithFloatUnion"
+                "testNotEqualityWithFloatUnion",
+                "testExactEqualityWithFloatUnion",
+                "testNotExactEqualityWithFloatUnion",
+                "testEqualityWithDecimalUnion",
+                "testNotEqualityWithDecimalUnion",
+                "testExactEqualityWithDecimalUnion",
+                "testNotExactEqualityWithDecimalUnion",
+                "testEqualityWithUnionType"
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/equal_and_not_equal_operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/equal_and_not_equal_operation.bal
@@ -1458,15 +1458,15 @@ function testEqualityWithNonAnydataType() {
     assert(obj2 != (), true);
 }
 
-type Num float|int;
+type FloatOrInt float|int;
 
-Num n1 = 0.0;
-Num n2 = -0.0;
-Num n3 = 0.0/0.0;
-Num n4 = -0.0/0.0;
-Num n5 = 2.0;
-Num n6 = 2.00;
-Num n7 = 2;
+FloatOrInt n1 = 0.0;
+FloatOrInt n2 = -0.0;
+FloatOrInt n3 = 0.0/0.0;
+FloatOrInt n4 = -0.0/0.0;
+FloatOrInt n5 = 2.0;
+FloatOrInt n6 = 2.00;
+FloatOrInt n7 = 2;
 
 function testEqualityWithFloatUnion() {
     test:assertTrue(n1 == n2);
@@ -1480,6 +1480,90 @@ function testNotEqualityWithFloatUnion() {
     test:assertFalse(n3 != n4);
     test:assertFalse(n5 != n6);
     test:assertTrue(n5 != n7);
+}
+
+function testExactEqualityWithFloatUnion() {
+    test:assertFalse(n1 === n2);
+    test:assertTrue(n3 === n4);
+    test:assertTrue(n5 === n6);
+    test:assertFalse(n5 === n7);
+}
+
+function testNotExactEqualityWithFloatUnion() {
+    test:assertTrue(n1 !== n2);
+    test:assertFalse(n3 !== n4);
+    test:assertFalse(n5 !== n6);
+    test:assertTrue(n5 !== n7);
+}
+
+type DecimalOrInt decimal|int;
+
+DecimalOrInt m1 = 0.0;
+DecimalOrInt m2 = -0.0;
+DecimalOrInt m3 = 2.0;
+DecimalOrInt m4 = 2.00;
+DecimalOrInt m5 = 2;
+
+function testEqualityWithDecimalUnion() {
+    test:assertTrue(m1 == m2);
+    test:assertTrue(m3 == m4);
+    test:assertFalse(m3 == m5);
+}
+
+function testNotEqualityWithDecimalUnion() {
+    test:assertFalse(m1 != m2);
+    test:assertFalse(m3 != m4);
+    test:assertTrue(m3 != m5);
+}
+
+function testExactEqualityWithDecimalUnion() {
+    test:assertTrue(m1 === m2);
+    test:assertFalse(m3 === m4);
+    test:assertFalse(m3 === m5);
+}
+
+function testNotExactEqualityWithDecimalUnion() {
+    test:assertFalse(m1 !== m2);
+    test:assertTrue(m3 !== m4);
+    test:assertTrue(m3 !== m5);
+}
+
+type VALUE_TYPE int|byte|float|boolean|string;
+
+function testEqualityWithUnionType() {
+    VALUE_TYPE a = "abc";
+    VALUE_TYPE b = "abc";
+    VALUE_TYPE c = "bcd";
+    VALUE_TYPE d = true;
+    VALUE_TYPE e = true;
+    VALUE_TYPE f = false;
+
+    VALUE_TYPE g = <byte> 1;
+    VALUE_TYPE h = <byte> 1;
+    VALUE_TYPE i = <byte> 2;
+
+    VALUE_TYPE j = 2;
+    VALUE_TYPE k = 2.0;
+
+    test:assertTrue(a == b);
+    test:assertFalse(b == c);
+    test:assertTrue(a === b);
+    test:assertFalse(b === c);
+
+    test:assertTrue(d == e);
+    test:assertFalse(e == f);
+    test:assertTrue(d === e);
+    test:assertFalse(e === f);
+
+    test:assertTrue(g == h);
+    test:assertFalse(h == i);
+    test:assertTrue(g === h);
+    test:assertFalse(h === i);
+
+    test:assertTrue(j == i);
+    test:assertFalse(i == k);
+    test:assertFalse(j === i);
+    test:assertFalse(i === k);
 }
 
 function assert(anydata actual, anydata expected) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/equal_and_not_equal_operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/equal_and_not_equal_operation.bal
@@ -1543,7 +1543,9 @@ function testEqualityWithUnionType() {
     VALUE_TYPE i = <byte> 2;
 
     VALUE_TYPE j = 2;
-    VALUE_TYPE k = 2.0;
+    VALUE_TYPE k = 2;
+    VALUE_TYPE l = 1;
+    VALUE_TYPE m = 2.0;
 
     test:assertTrue(a == b);
     test:assertFalse(b == c);
@@ -1560,10 +1562,15 @@ function testEqualityWithUnionType() {
     test:assertTrue(g === h);
     test:assertFalse(h === i);
 
-    test:assertTrue(j == i);
-    test:assertFalse(i == k);
-    test:assertFalse(j === i);
-    test:assertFalse(i === k);
+    test:assertTrue(j == k);
+    test:assertFalse(j == l);
+    test:assertTrue(j === k);
+    test:assertFalse(j === l);
+
+    test:assertTrue(i == j);
+    test:assertFalse(i == m);
+    test:assertTrue(j === i);
+    test:assertFalse(i === m);
 }
 
 function assert(anydata actual, anydata expected) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/equal_and_not_equal_operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/equal_and_not_equal_operation.bal
@@ -14,6 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/jballerina.java;
 import ballerina/test;
 
 type OpenEmployee record {
@@ -1530,7 +1531,7 @@ function testNotExactEqualityWithDecimalUnion() {
 
 type VALUE_TYPE int|byte|float|boolean|string;
 
-function testEqualityWithUnionType() {
+function testEqualityWithUnionOfSimpleTypes() {
     VALUE_TYPE a = "abc";
     VALUE_TYPE b = "abc";
     VALUE_TYPE c = "bcd";
@@ -1571,6 +1572,22 @@ function testEqualityWithUnionType() {
     test:assertFalse(i == m);
     test:assertTrue(j === i);
     test:assertFalse(i === m);
+}
+
+type T xml|handle|string;
+
+function testExactEqualityWithUnionOfNonSimpleTypes() {
+    T h1 = java:fromString("abc");
+    T h2 = java:fromString("abc");
+    T h3 = java:fromString("bcd");
+    T x1 = xml `<book>Book One</book>`;
+    T x2 = xml`abc`;
+
+    test:assertTrue(h1 === h2);
+    test:assertFalse(h1 === h3);
+    test:assertFalse(h1 === x1);
+    test:assertFalse(x1 === x2);
+    test:assertFalse(x2 === h1);
 }
 
 function assert(anydata actual, anydata expected) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/equal_and_not_equal_operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/equal_and_not_equal_operation.bal
@@ -14,6 +14,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/test;
+
 type OpenEmployee record {
     string|json name = "";
     int id = 0;
@@ -1454,6 +1456,30 @@ function testEqualityWithNonAnydataType() {
     MyObj2? obj2 = new;
     assert(obj2 == (), false);
     assert(obj2 != (), true);
+}
+
+type Num float|int;
+
+Num n1 = 0.0;
+Num n2 = -0.0;
+Num n3 = 0.0/0.0;
+Num n4 = -0.0/0.0;
+Num n5 = 2.0;
+Num n6 = 2.00;
+Num n7 = 2;
+
+function testEqualityWithFloatUnion() {
+    test:assertTrue(n1 == n2);
+    test:assertTrue(n3 == n4);
+    test:assertTrue(n5 == n6);
+    test:assertFalse(n5 == n7);
+}
+
+function testNotEqualityWithFloatUnion() {
+    test:assertFalse(n1 != n2);
+    test:assertFalse(n3 != n4);
+    test:assertFalse(n5 != n6);
+    test:assertTrue(n5 != n7);
 }
 
 function assert(anydata actual, anydata expected) {


### PR DESCRIPTION
## Purpose
> $title

```
import ballerina/io;

type Num float|int;

public function main() {
    Num n1 = 0.0;
    Num n2 = -0.0;
    Num n3 = 0.0/0.0;
    Num n4 = -0.0/0.0;
    Num n5 = 2.0;
    Num n6 = 2;

    io:println(n1 == n2);  // true
    io:println(n3 == n4);  // true
    io:println(n5 == n6);  // false

    io:println(n1 === n2);  // false
    io:println(n3 === n4);  // true
    io:println(n5 === n6);  // false
}
```

Fixes #32173

## Approach

## Samples

## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
