### PR TITLE
Remove return statement from LVT

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/MethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/MethodGen.java
@@ -501,7 +501,9 @@ public class MethodGen {
 
     private void processTerminator(MethodVisitor mv, BIRFunction func, BIRPackage module, String funcName,
                                    BIRTerminator terminator, JvmTypeGen jvmTypeGen, int localVarOffset) {
-        JvmCodeGenUtil.generateDiagnosticPos(terminator.pos, mv);
+        if (terminator.kind != InstructionKind.RETURN) {
+            JvmCodeGenUtil.generateDiagnosticPos(terminator.pos, mv);
+        }
         if ((MethodGenUtils.isModuleInitFunction(func) || isModuleTestInitFunction(func)) &&
                 terminator instanceof Return) {
             generateAnnotLoad(mv, module.typeDefs, JvmCodeGenUtil.getPackageName(module.packageID),


### PR DESCRIPTION
## Purpose
> Resolve https://github.com/ballerina-platform/ballerina-lang/issues/31061

## Approach
> The return statement is in a separate Basic Block(BB). When the program has multiple return statements they all go to the same BB. In this case the position of the actual return statement in the bal code is unclear. The actual return statements are indicated by the GOTO statements to the BB with the return statement. So only the GOTO statements are included in the LVT and the return statements are ignored.

## Samples
> N/A

## Remarks
> N/A

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
