### PR TITLE
Implement length formatting for Testerina diff

### DIFF
--- a/misc/testerina/modules/testerina-core/src/main/ballerina/assert.bal
+++ b/misc/testerina/modules/testerina-core/src/main/ballerina/assert.bal
@@ -273,12 +273,9 @@ isolated function getInequalityErrorMsg(any|error actual, any|error expected, st
 }
 
 isolated function getFormattedString(string str) returns string {
-
     string formattedString = "";
-
     // Number of iterations in the loop
     int itr = (str.length() / maxArgLength) + 1;
-
     foreach int i in 0 ..< itr {
         // If the calculated substring index is less than string length
         if ((i + 1) * maxArgLength < str.length()) {
@@ -293,7 +290,6 @@ isolated function getFormattedString(string str) returns string {
             formattedString += subString;
         }
     }
-
     return formattedString;
 }
 

--- a/misc/testerina/modules/testerina-core/src/main/ballerina/assert.bal
+++ b/misc/testerina/modules/testerina-core/src/main/ballerina/assert.bal
@@ -249,10 +249,10 @@ isolated function getInequalityErrorMsg(any|error actual, any|error expected, st
         string expectedStr = sprintf("%s", expected);
         string actualStr = sprintf("%s", actual);
         if (expectedStr.length() > maxArgLength) {
-            expectedStr = expectedStr.substring(0, maxArgLength) + "...";
+            expectedStr = getFormattedString(expectedStr);
         }
         if (actualStr.length() > maxArgLength) {
-            actualStr = actualStr.substring(0, maxArgLength) + "...";
+            actualStr = getFormattedString(actualStr);
         }
         if (expectedType != actualType) {
             errorMsg = string `${msg}` + "\n \nexpected: " + string `<${expectedType}> '${expectedStr}'` + "\nactual\t: "
@@ -270,6 +270,31 @@ isolated function getInequalityErrorMsg(any|error actual, any|error expected, st
                                                  + string `'${actualStr}'`;
         }
         return errorMsg;
+}
+
+isolated function getFormattedString(string str) returns string {
+
+    string formattedString = "";
+
+    // Number of iterations in the loop
+    int itr = (str.length() / maxArgLength) + 1;
+
+    foreach int i in 0 ..< itr {
+        // If the calculated substring index is less than string length
+        if ((i + 1) * maxArgLength < str.length()) {
+            // Formulate the substring
+            string subString = str.substring((i * maxArgLength), ((i + 1) * maxArgLength));
+            // Append substring with newline
+            formattedString += subString + "\n";
+        } else {
+            // If the calculated substring is equal to or greater than the string length
+            // Modify the substring to include only the string length
+            string subString = str.substring((i * maxArgLength), str.length());
+            formattedString += subString;
+        }
+    }
+
+    return formattedString;
 }
 
 isolated function getKeyArray(map<anydata> valueMap) returns @tainted string[] {

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/assertions-diff-error/tests/assertions-diff-error-messages.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/assertions-diff-error/tests/assertions-diff-error-messages.bal
@@ -94,7 +94,7 @@ function testAssertJsonValues() {
     error result = <error>err;
     test:assertEquals(result.message().toString(), "Assertion Failed!\n " +
     "\nexpected: '{\"name\":\"John Doe New\",\"age\":25,\"address\":" +
-    "{\"city\":\"Colombo\"," + "\"country\":\"Sri Lanka...'\nactual\t: '" +
+    "{\"city\":\"Colombo\"," + "\"country\":\"Sri Lanka\n\"}}'\nactual\t: '" +
     "{\"name\":\"John Doe\",\"age\":25,\"address\":{\"city\":\"Colombo\"," +
     "\"country\":\"Sri Lanka\"}}'\n \nDiff\t:\n\nkey: name\n \nexpected " +
     "value\t: John Doe New\nactual value\t: John Doe");
@@ -108,9 +108,9 @@ function testAssertJsonInJson() {
     error result = <error>err;
     test:assertEquals(result.message().toString(), "Assertion Failed!\n " +
     "\nexpected: '{\"name\":\"Anne\",\"age\":21,\"marks\":{\"maths\":100," +
-    "\"physics\":90,\"status\":{\"pass\":false...'\nactual\t: '" +
+    "\"physics\":90,\"status\":{\"pass\":false\n}}}'\nactual\t: '" +
     "{\"name\":\"Anne\",\"age\":\"21\",\"marks\":{\"maths\":100,\"physics\":90," +
-    "\"status\":{\"pass\":tru...'\n \nDiff\t:\n\nkey: age\n \nexpected " +
+    "\"status\":{\"pass\":tru\ne}}}'\n \nDiff\t:\n\nkey: age\n \nexpected " +
     "value\t: <int> 21\nactual value\t: <string> 21\n\nkey: marks.status." +
     "pass\n \nexpected value\t: false\nactual value\t: true");
 }
@@ -121,11 +121,20 @@ function testAssertLongJsonValues() {
     json bioData2 = {name:"John Doe New", age:25, designation: "SSE", address:{city:"Colombo", country:"Sri Lanka"}};
     error? err = trap test:assertEquals(bioData, bioData2);
     error result = <error>err;
-    test:assertEquals(result.message().toString(), "Assertion Failed!\n \nexpected: '{\"name\":\"John Doe New\"," +
-    "\"age\":25,\"designation\":\"SSE\",\"address\":{\"city\":\"Colombo\",...'\nactual\t: '{\"name\":" +
-    "\"John Doe Old\",\"age\":25,\"designation\":\"SSE\",\"address\":{\"city\":\"Colombo\",...'\n \n" +
-    "Diff\t:\n\nkey: name\n \nexpected value\t: John Doe New\nactual value\t: John Doe Old\n\n" +
-    "key: address.country\n \nexpected value\t: Sri Lanka\nactual value\t: Sri Lankaa");
+    test:assertEquals(result.message().toString(), "Assertion Failed!\n " +
+    "\nexpected: " +
+    "'{\"name\":\"John Doe New\",\"age\":25,\"designation\":\"SSE\",\"address\":{\"city\":\"Colombo\",\n" +
+    "\"country\":\"Sri Lanka\"}}'" +
+    "\nactual\t: " +
+    "'{\"name\":\"John Doe Old\",\"age\":25,\"designation\":\"SSE\",\"address\":{\"city\":\"Colombo\",\n" +
+    "\"country\":\"Sri Lankaa\"}}'" +
+    "\n \nDiff\t:" +
+    "\n\nkey: name\n " +
+    "\nexpected value\t: John Doe New" +
+    "\nactual value\t: John Doe Old" +
+    "\n\nkey: address.country\n " +
+    "\nexpected value\t: Sri Lanka" +
+    "\nactual value\t: Sri Lankaa");
 }
 
 @test:Config {}
@@ -135,12 +144,17 @@ function testAssertJsonWithKeyDiff() {
     error? err = trap test:assertEquals(j1, j2);
     error result = <error>err;
     test:assertEquals(result.message().toString(), "Assertion Failed!\n " +
-    "\nexpected: '{\"name2\":\"Anne\",\"age\":21,\"marks\":{\"maths\":100," +
-    "\"physics\":90,\"status\":{\"pass2\":fal...'\nactual\t: '" +
-    "{\"name\":\"Anne\",\"age\":\"21\",\"marks\":{\"maths\":100,\"physics\":90," +
-    "\"status\":{\"pass\":tru...'\n \nDiff\t:\n\nexpected keys\t: name2, " +
-    "marks.status.pass2\nactual keys\t: name, marks.status.pass\n\n" +
-    "key: age\n \nexpected value\t: <int> 21\nactual value\t: <string> 21\n");
+    "\nexpected: " +
+    "'{\"name2\":\"Anne\",\"age\":21,\"marks\":{\"maths\":100," +
+    "\"physics\":90,\"status\":{\"pass2\":fal\nse}}}'" +
+    "\nactual\t: " +
+    "'{\"name\":\"Anne\",\"age\":\"21\",\"marks\":{\"maths\":100,\"physics\":90," +
+    "\"status\":{\"pass\":tru\ne}}}'" +
+    "\n \nDiff\t:" +
+    "\n\nexpected keys\t: name2, marks.status.pass2" +
+    "\nactual keys\t: name, marks.status.pass" +
+    "\n\nkey: age\n " +
+    "\nexpected value\t: <int> 21\nactual value\t: <string> 21\n");
 }
 
 @test:Config {}
@@ -151,14 +165,18 @@ function testAssertJsonWithCount() {
     marks: {maths: 10, physics: 40, chemistry: 50, english: 55, status: {pass:false}}};
     error? err = trap test:assertEquals(j1, j2);
     error result = <error>err;
-    test:assertEquals(result.message().toString(), "Assertion Failed!\n \nexpected: '{\"name2\":\"Anne\",\"age\":21," +
-    "\"marks\":{\"maths\":10,\"physics\":40,\"chemistry\":50,\"englis...'\nactual\t: '{\"name\":\"Anne\",\"age\":" +
-    "\"21\",\"marks\":{\"maths\":99,\"physics\":80,\"chemistry\":70,\"engli...'\n \nDiff\t:\n\nexpected keys\t: " +
+    test:assertEquals(result.message().toString(), "Assertion Failed!\n " +
+    "\nexpected: '{\"name2\":\"Anne\",\"age\":21," +
+    "\"marks\":{\"maths\":10,\"physics\":40,\"chemistry\":50,\"englis\n" +
+    "h\":55,\"status\":{\"pass\":false}}}'" +
+    "\nactual\t: '{\"name\":\"Anne\",\"age\":\"21\"," +
+    "\"marks\":{\"maths\":99,\"physics\":80,\"chemistry\":70,\"engli\n" +
+    "sh\":95,\"status\":{\"pass\":true}}}'" +
+    "\n \nDiff\t:\n\nexpected keys\t: " +
     "name2\nactual keys\t: name\n\nkey: age\n \nexpected value\t: <int> 21\nactual value\t: <string> 21\n\n" +
     "key: marks.maths\n \nexpected value\t: 10\nactual value\t: 99\n\nkey: marks.physics\n \nexpected value\t: 40\n" +
     "actual value\t: 80\n\nkey: marks.chemistry\n \nexpected value\t: 50\nactual value\t: 70\n\nkey: " +
-    "marks.english\n \nexpected value\t: 55\nactual value\t: 95\n\nkey: marks.status.pass\n \nexpected value\t: false\n" +
-    "actual value\t: true\n \nTotal value mismatches: 6\n");
+    "marks.english\n \nexpected value\t: 55\nactual value\t: 95\n\nkey: marks.status.pass\n \nexpected value\t: false\nactual value\t: true\n \nTotal value mismatches: 6\n");
 }
 
 @test:Config {}
@@ -218,9 +236,11 @@ function testAssertRecords() {
     error? err = trap test:assertEquals(theRevenant, theRevenantNew);
     error result = <error>err;
     test:assertEquals(result.message().toString(), "Assertion Failed!\n \n" +
-    "expected: '{\"title\":\"The Revenant\",\"year\":\"2020\",\"released\":\"08 Jan 2020\",\"writer\":{\"fname\"...'" +
-    "\nactual\t: '{\"title\":\"The Revenant\",\"year\":\"2015\",\"released\":\"08 Jan 2016\",\"writer\":{\"fname\"" +
-    "...'\n \nDiff\t:\n\nkey: year\n \nexpected value\t: 2020\nactual value\t: 2015\n\nkey: released\n \n" +
+    "expected: '{\"title\":\"The Revenant\",\"year\":\"2020\",\"released\":\"08 Jan 2020\",\"writer\":{\"fname\"\n" +
+    ":\"Michael\",\"lname\":\"Punke\",\"age\":35}}'" +
+    "\nactual\t: '{\"title\":\"The Revenant\",\"year\":\"2015\",\"released\":\"08 Jan 2016\",\"writer\":{\"fname\"\n" +
+    ":\"Michael\",\"lname\":\"Punke\",\"age\":30}}'" +
+    "\n \nDiff\t:\n\nkey: year\n \nexpected value\t: 2020\nactual value\t: 2015\n\nkey: released\n \n" +
     "expected value\t: 08 Jan 2020\nactual value\t: 08 Jan 2016\n\nkey: writer.age\n \nexpected value\t: 35\n" +
     "actual value\t: 30");
 }

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/assertions-error-messages/tests/assertions-error-messages.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/assertions-error-messages/tests/assertions-error-messages.bal
@@ -91,8 +91,10 @@ function testAssertTableAndString() {
     string customerTabString = "table [{id: 1, name: \"John\", salary: 300.50},{id: 2, name: \"Bella\", salary: 500.50}]";
     error? err = trap test:assertEquals(customerTab, customerTabString);
     error result = <error>err;
-    test:assertEquals(result.message().toString(), 
-    "Assertion Failed!\n \nexpected: <string> 'table [{id: 1, name: \"John\", salary: 300.50},{id: 2, name: \"Bella\", " + "salary: 500....'\nactual\t: <table> '[{\"id\":1,\"name\":\"John\",\"salary\":300.5},{\"id\":2,\"name\":\"Bella\"," + "\"salary\":500.5}]'");
+    test:assertEquals(result.message().toString(), "Assertion Failed!\n \n" +
+    "expected: <string> 'table [{id: 1, name: \"John\", salary: 300.50}," +
+    "{id: 2, name: \"Bella\", salary: 500.\n50}]'" +
+    "\nactual\t: <table> '[{\"id\":1,\"name\":\"John\",\"salary\":300.5},{\"id\":2,\"name\":\"Bella\",\"salary\":500.5}]'");
 }
 
 @test:Config {}
@@ -129,6 +131,10 @@ function testAssertLongValues() {
 
     error? err = trap test:assertEquals(value1, value2);
     error result = <error>err;
-    test:assertEquals(result.message().toString(), "Assertion Failed!\n \nexpected: <map> '{\"description\":\"Ballerina" + " is an open source programming language and platform fo...'\nactual\t: <string> 'Ballerina is an open source" + 
-    " programming language and platform for cloud-era appl...'");
+    test:assertEquals(result.message().toString(), "Assertion Failed!\n \nexpected: <map> '{\"description\":\"Ballerina" +
+    " is an open source programming language and platform fo\n" +
+    "r cloud-era application programmers.\"}'" +
+    "\nactual\t: <string> 'Ballerina is an open source" +
+    " programming language and platform for cloud-era appl\n" +
+    "ication programmers.'");
 }


### PR DESCRIPTION
## Purpose
Implements a similar diff print that `AssertionDiffEvaluator` uses buy printing each substring of the actual value and expected value with size `maxArgLength` and appending a `\n` to the end. 

Should see outputs similar to this 

<img width="736" alt="Screenshot 2021-08-20 at 16 04 26" src="https://user-images.githubusercontent.com/43578935/130220899-5225d15a-8d98-4bd0-9ce3-76df484a1c8e.png">

Fixes #32081 

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
