### PR TITLE
Not creating `Dependencies.toml` when there is no dependencies

### DIFF
--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/BuildCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/BuildCommandTest.java
@@ -38,6 +38,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Objects;
 
 import static io.ballerina.cli.cmd.CommandOutputUtils.getOutput;
+import static io.ballerina.projects.util.ProjectConstants.DEPENDENCIES_TOML;
 import static io.ballerina.projects.util.ProjectConstants.USER_NAME;
 
 /**
@@ -599,7 +600,12 @@ public class BuildCommandTest extends BaseCommandTest {
         Assert.assertTrue(projectPath.resolve("target").resolve("bala").resolve("foo-winery-any-0.1.0.bala")
                                   .toFile().exists());
         // `Dependencies.toml` file should not get deleted
-        Assert.assertTrue(projectPath.resolve("Dependencies.toml").toFile().exists());
+        Assert.assertTrue(projectPath.resolve(DEPENDENCIES_TOML).toFile().exists());
+        // `dependencies-toml-version` should exists in `Dependencies.toml`
+        String expected = "[ballerina]\n"
+                + "dependencies-toml-version = \"2\"";
+        String actual = Files.readString(projectPath.resolve(DEPENDENCIES_TOML));
+        Assert.assertTrue(actual.contains(expected));
     }
 
     @Test(description = "Compile an empty package with compiler plugin")

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/directory/BuildProject.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/directory/BuildProject.java
@@ -208,12 +208,20 @@ public class BuildProject extends Project {
 
             List<Dependency> pkgDependencies = getPackageDependencies();
             pkgDependencies.sort(comparator);
-            String dependenciesContent = getDependenciesTomlContent(pkgDependencies);
 
-            if (!dependenciesContent.isEmpty()) {
+            Path dependenciesTomlFile = currentPackage.project().sourceRoot().resolve(DEPENDENCIES_TOML);
+            String dependenciesContent = getDependenciesTomlContent(pkgDependencies);
+            if (!pkgDependencies.isEmpty()) {
                 // write content to Dependencies.toml file
-                createIfNotExistsAndWrite(currentPackage.project().sourceRoot().resolve(DEPENDENCIES_TOML),
-                                          dependenciesContent);
+                createIfNotExists(dependenciesTomlFile);
+                writeContent(dependenciesTomlFile, dependenciesContent);
+            } else {
+                // when there are no package dependencies to write
+                // if Dependencies.toml does not exists ---> Dependencies.toml will not be created
+                // if Dependencies.toml exists          ---> content will be written to existing Dependencies.toml
+                if (dependenciesTomlFile.toFile().exists()) {
+                    writeContent(dependenciesTomlFile, dependenciesContent);
+                }
             }
         }
     }
@@ -304,7 +312,7 @@ public class BuildProject extends Project {
         return dependencyList;
     }
 
-    private static void createIfNotExistsAndWrite(Path filePath, String content) {
+    private static void createIfNotExists(Path filePath) {
         if (!filePath.toFile().exists()) {
             try {
                 Files.createFile(filePath);
@@ -312,12 +320,13 @@ public class BuildProject extends Project {
                 throw new ProjectException("Failed to create 'Dependencies.toml' file to write dependencies");
             }
         }
+    }
 
+    private static void writeContent(Path filePath, String content) {
         try {
             Files.write(filePath, Collections.singleton(content));
         } catch (IOException e) {
             throw new ProjectException("Failed to write dependencies to the 'Dependencies.toml' file");
         }
-
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/DependencyManifestBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/DependencyManifestBuilder.java
@@ -64,6 +64,8 @@ public class DependencyManifestBuilder {
     private final List<Diagnostic> diagnosticList;
     private final DependencyManifest dependencyManifest;
 
+    private static final String LATEST_DEPS_TOML_VERSION = "2";
+
     private DependencyManifestBuilder(TomlDocument dependenciesToml) {
         this.dependenciesToml = Optional.ofNullable(dependenciesToml);
         this.diagnosticList = new ArrayList<>();
@@ -142,7 +144,8 @@ public class DependencyManifestBuilder {
 
     private String getDependenciesTomlVersion() {
         if (dependenciesToml.isEmpty()) {
-            return null;
+            // When Dependencies.toml does not exists, we consider it is in the latest toml version
+            return LATEST_DEPS_TOML_VERSION;
         }
 
         TomlTableNode tomlTableNode = dependenciesToml.get().toml().rootNode();

--- a/compiler/ballerina-lang/src/main/resources/ballerina-toml-schema.json
+++ b/compiler/ballerina-lang/src/main/resources/ballerina-toml-schema.json
@@ -120,21 +120,21 @@
             "type": "string",
             "pattern": "^[a-zA-Z0-9_]*$",
             "message": {
-              "pattern": "invalid 'org' under [[package]]: 'org' can only contain alphanumerics, underscores and the maximum length is 256 characters"
+              "pattern": "invalid 'org' under [[dependency]]: 'org' can only contain alphanumerics, underscores and the maximum length is 256 characters"
             }
           },
           "name": {
             "type": "string",
             "pattern": "^[a-zA-Z0-9_.]*$",
             "message": {
-              "pattern": "invalid 'name' under [[package]]: 'name' can only contain alphanumerics, underscores and periods and the maximum length is 256 characters"
+              "pattern": "invalid 'name' under [[dependency]]: 'name' can only contain alphanumerics, underscores and periods and the maximum length is 256 characters"
             }
           },
           "version": {
             "type": "string",
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "message": {
-              "pattern": "invalid 'version' under [[package]]: 'version' should be compatible with semver"
+              "pattern": "invalid 'version' under [[dependency]]: 'version' should be compatible with semver"
             }
           },
           "repository": {

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProject.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProject.java
@@ -61,6 +61,8 @@ import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -73,6 +75,7 @@ import java.util.stream.Collectors;
 
 import static io.ballerina.projects.test.TestUtils.isWindows;
 import static io.ballerina.projects.test.TestUtils.resetPermissions;
+import static io.ballerina.projects.util.ProjectConstants.DEPENDENCIES_TOML;
 import static org.testng.Assert.assertEquals;
 
 /**
@@ -1389,6 +1392,43 @@ public class TestBuildProject extends BaseTest {
         Assert.assertFalse(project.currentPackage().compilationOptions().offlineBuild());
     }
 
+    @Test(description = "test build package without dependencies")
+    public void testPackageWithoutDependencies() throws IOException {
+        Path projectPath = RESOURCE_DIRECTORY.resolve("project_wo_deps");
+        // Delete Dependencies.toml if already exists
+        if (projectPath.resolve(DEPENDENCIES_TOML).toFile().exists()) {
+            Files.delete(projectPath.resolve(DEPENDENCIES_TOML));
+        }
+
+        // 1) Initialize the project instance
+        BuildProject project = null;
+        try {
+            project = BuildProject.load(projectPath);
+            project.save();
+        } catch (Exception e) {
+            Assert.fail(e.getMessage());
+        }
+        Assert.assertEquals(project.currentPackage().packageName().toString(), "project_wo_deps");
+        // Dependencies.toml should not be created when there is no package dependencies
+        Path dependenciesTomlPath = project.sourceRoot().resolve(DEPENDENCIES_TOML);
+        Assert.assertFalse(dependenciesTomlPath.toFile().exists());
+
+        // 2) Add an Dependencies.toml to the project load and save project again
+        Files.createFile(dependenciesTomlPath);
+        try {
+            project = BuildProject.load(projectPath);
+            project.save();
+        } catch (Exception e) {
+            Assert.fail(e.getMessage());
+        }
+        // Existing Dependencies.toml should not be deleted when there is no package dependencies
+        Assert.assertTrue(dependenciesTomlPath.toFile().exists());
+        // It should consist of the dependency toml version
+        String expected = "[ballerina]\n"
+                + "dependencies-toml-version = \"2\"";
+        String actual = Files.readString(projectPath.resolve(DEPENDENCIES_TOML));
+        Assert.assertTrue(actual.contains(expected));
+    }
 
     @AfterClass (alwaysRun = true)
     public void reset() {

--- a/project-api/project-api-test/src/test/resources/project_wo_deps/Ballerina.toml
+++ b/project-api/project-api-test/src/test/resources/project_wo_deps/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "pram"
+name = "project_wo_deps"
+version = "0.1.0"

--- a/project-api/project-api-test/src/test/resources/project_wo_deps/main.bal
+++ b/project-api/project-api-test/src/test/resources/project_wo_deps/main.bal
@@ -1,0 +1,4 @@
+
+public function main() {
+    int a = 1 + 2;
+}


### PR DESCRIPTION


## Purpose
> If there are no dependencies in the graph not creating Dependencies.toml. And there is a existing Dependencies.toml and no dependencies existing Dependencies.toml will be deleted. When Dependencies.toml does not exist, considering it's in the latest dependency toml version.

Fixes #32242

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
