### PR TITLE
Limit update call to once a day

### DIFF
--- a/compiler/ballerina-lang/spotbugs-exclude.xml
+++ b/compiler/ballerina-lang/spotbugs-exclude.xml
@@ -347,4 +347,9 @@
         <Class name="io.ballerina.projects.internal.ResolutionEngine"/>
         <Bug pattern="URF_UNREAD_FIELD"/>
     </Match>
+    <Match>
+        <Class name="io.ballerina.projects.directory.BuildProject"/>
+        <Method name="createBuildFile"/>
+        <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"/>
+    </Match>
 </FindBugsFilter>

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageResolution.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageResolution.java
@@ -29,6 +29,7 @@ import io.ballerina.projects.internal.ImportModuleResponse;
 import io.ballerina.projects.internal.PackageContainer;
 import io.ballerina.projects.internal.PackageDiagnostic;
 import io.ballerina.projects.internal.ResolutionEngine;
+import io.ballerina.projects.internal.model.BuildJson;
 import io.ballerina.projects.internal.repositories.LocalPackageRepository;
 import io.ballerina.projects.util.ProjectConstants;
 import io.ballerina.projects.util.ProjectUtils;
@@ -39,6 +40,7 @@ import io.ballerina.tools.diagnostics.DiagnosticSeverity;
 import io.ballerina.tools.diagnostics.Location;
 import org.wso2.ballerinalang.compiler.util.Names;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -48,6 +50,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
+import static io.ballerina.projects.util.ProjectConstants.BUILD_FILE;
+import static io.ballerina.projects.util.ProjectConstants.TARGET_DIR_NAME;
+import static io.ballerina.projects.util.ProjectUtils.readBuildJson;
 
 /**
  * Resolves dependencies and handles version conflicts in the dependency graph.
@@ -63,6 +69,7 @@ public class PackageResolution {
     private final ModuleResolver moduleResolver;
     private final List<Diagnostic> diagnosticList;
     private DiagnosticResult diagnosticResult;
+    private boolean autoUpdate;
 
     private List<ModuleContext> topologicallySortedModuleList;
     private Collection<ResolvedPackageDependency> dependenciesWithTransitives;
@@ -79,8 +86,7 @@ public class PackageResolution {
 
         this.moduleResolver = new ModuleResolver(projectEnvContext.getService(PackageResolver.class));
 
-        boolean sticky = rootPackageContext.project().buildOptions().sticky();
-        dependencyGraph = buildDependencyGraph(sticky);
+        dependencyGraph = buildDependencyGraph(getSticky(rootPackageContext));
         DependencyResolution dependencyResolution = new DependencyResolution(
                 projectEnvContext.getService(PackageCache.class), moduleResolver, dependencyGraph);
         resolveDependencies(dependencyResolution);
@@ -139,6 +145,34 @@ public class PackageResolution {
         var packageDiagnostic = new PackageDiagnostic(diagnostic, moduleDescriptor, rootPackageContext.project());
         this.diagnosticList.add(packageDiagnostic);
         this.diagnosticResult = new DefaultDiagnosticResult(this.diagnosticList);
+    }
+
+    public boolean autoUpdate() {
+        return autoUpdate;
+    }
+
+    private boolean getSticky(PackageContext rootPackageContext) {
+        boolean sticky = rootPackageContext.project().buildOptions().sticky();
+        if (sticky) {
+            this.autoUpdate = false;
+            return true;
+        }
+        // set sticky if `build` file exists and `last_update_time` not passed 24 hours
+        if (rootPackageContext.project().kind() == ProjectKind.BUILD_PROJECT) {
+            Path buildFilePath = this.rootPackageContext.project().sourceRoot().resolve(TARGET_DIR_NAME)
+                    .resolve(BUILD_FILE);
+            if (buildFilePath.toFile().exists()) {
+                BuildJson buildJson = readBuildJson(buildFilePath);
+                if (!buildJson.isExpiredLastUpdateTime()) {
+                    this.autoUpdate = false;
+                    return true;
+                }
+            }
+            this.autoUpdate = true;
+            return false;
+        }
+        this.autoUpdate = true;
+        return false;
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/directory/BuildProject.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/directory/BuildProject.java
@@ -36,9 +36,11 @@ import io.ballerina.projects.ResolvedPackageDependency;
 import io.ballerina.projects.internal.BalaFiles;
 import io.ballerina.projects.internal.PackageConfigCreator;
 import io.ballerina.projects.internal.ProjectFiles;
+import io.ballerina.projects.internal.model.BuildJson;
 import io.ballerina.projects.internal.model.Dependency;
 import io.ballerina.projects.util.ProjectConstants;
 import io.ballerina.projects.util.ProjectPaths;
+import io.ballerina.projects.util.ProjectUtils;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -51,8 +53,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import static io.ballerina.projects.util.ProjectConstants.BUILD_FILE;
 import static io.ballerina.projects.util.ProjectConstants.DEPENDENCIES_TOML;
+import static io.ballerina.projects.util.ProjectConstants.TARGET_DIR_NAME;
 import static io.ballerina.projects.util.ProjectUtils.getDependenciesTomlContent;
+import static io.ballerina.projects.util.ProjectUtils.readBuildJson;
 
 /**
  * {@code BuildProject} represents Ballerina project instance created from the project directory.
@@ -193,7 +198,29 @@ public class BuildProject extends Project {
     }
 
     public void save() {
-        writeDependencies();
+        boolean shouldUpdate = this.currentPackage().getResolution().autoUpdate();
+        Path buildFilePath = this.sourceRoot.resolve(TARGET_DIR_NAME).resolve(BUILD_FILE);
+        // if build file does not exists
+        if (!buildFilePath.toFile().exists()) {
+            // set both last build time and lat updated time as current timestamp
+            createBuildFile(buildFilePath);
+            writeBuildFile(buildFilePath);
+            writeDependencies();
+        } else {
+            // build file exists
+            BuildJson buildJson = readBuildJson(buildFilePath);
+            // check whether last updated time is expired
+            if (shouldUpdate) {
+                // need to update Dependencies toml
+                writeDependencies();
+                // update build json file
+                writeBuildFile(buildFilePath);
+            } else {
+                // only update build time
+                buildJson.setLastBuildTime(System.currentTimeMillis());
+                ProjectUtils.writeBuildFile(buildFilePath, buildJson);
+            }
+        }
     }
 
     private void writeDependencies() {
@@ -318,6 +345,22 @@ public class BuildProject extends Project {
         } catch (IOException e) {
             throw new ProjectException("Failed to write dependencies to the 'Dependencies.toml' file");
         }
+    }
 
+    private static void createBuildFile(Path buildFilePath) {
+        try {
+            if (!buildFilePath.getParent().toFile().exists()) {
+                // create target directory if not exists
+                Files.createDirectory(buildFilePath.getParent());
+            }
+            Files.createFile(buildFilePath);
+        } catch (IOException e) {
+            throw new ProjectException("Failed to create '" + BUILD_FILE + "' file");
+        }
+    }
+
+    private static void writeBuildFile(Path buildFilePath) {
+        BuildJson buildJson = new BuildJson(System.currentTimeMillis(), System.currentTimeMillis());
+        ProjectUtils.writeBuildFile(buildFilePath, buildJson);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/model/BuildJson.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/model/BuildJson.java
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.projects.internal.model;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * {@code PackageJson} Model for build file.
+ *
+ * @since 2.0.0
+ */
+public class BuildJson {
+
+    public static final String SERIALIZED_NAME_LAST_BUILD_TIME = "last_build_time";
+    @SerializedName(SERIALIZED_NAME_LAST_BUILD_TIME)
+    private long lastBuildTime;
+
+    public static final String SERIALIZED_NAME_LAST_UPDATE_TIME = "last_update_time";
+    @SerializedName(SERIALIZED_NAME_LAST_UPDATE_TIME)
+    private long lastUpdateTime;
+
+    private static final long ONE_DAY = 24 * 60 * 60 * 1000;
+
+    public BuildJson(long lastBuildTime, long lastUpdateTime) {
+        this.lastBuildTime = lastBuildTime;
+        this.lastUpdateTime = lastUpdateTime;
+    }
+
+    public long lastBuildTime() {
+        return lastBuildTime;
+    }
+
+    public void setLastBuildTime(long lastBuildTime) {
+        this.lastBuildTime = lastBuildTime;
+    }
+
+    public long lastUpdateTime() {
+        return lastUpdateTime;
+    }
+
+    public void setLastUpdateTime(long lastUpdateTime) {
+        this.lastUpdateTime = lastUpdateTime;
+    }
+
+    public boolean isExpiredLastUpdateTime() {
+        long oneDayAgo = System.currentTimeMillis() - ONE_DAY;
+        return lastUpdateTime() < oneDayAgo;
+    }
+}

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/ProjectConstants.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/ProjectConstants.java
@@ -41,6 +41,7 @@ public class ProjectConstants {
     public static final String BALA_JSON = "bala.json";
     public static final String COMPILER_PLUGIN_JSON = "compiler-plugin.json";
     public static final String DEPENDENCY_GRAPH_JSON = "dependency-graph.json";
+    public static final String BUILD_FILE = "build";
 
     public static final String SOURCE_DIR_NAME = "src";
     public static final String BIN_DIR_NAME = "bin";

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/ProjectUtilsTests.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/ProjectUtilsTests.java
@@ -1,0 +1,95 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.projects;
+
+import io.ballerina.projects.internal.model.BuildJson;
+import io.ballerina.projects.util.ProjectConstants;
+import io.ballerina.projects.util.ProjectUtils;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Test {@code ProjectUtils}.
+ *
+ * @since 2.0.0
+ */
+public class ProjectUtilsTests {
+
+    private static final Path RESOURCE_DIRECTORY = Paths.get("src", "test", "resources");
+    private static final Path PROJECT_UTILS_RESOURCES = RESOURCE_DIRECTORY.resolve("project-utils");
+    private static Path tempDirectory;
+    private static BuildJson buildJson;
+
+    @BeforeClass
+    public void setUp() throws IOException {
+        tempDirectory = Files.createTempDirectory("b7a-project-utils-test-" + System.nanoTime());
+        buildJson = new BuildJson(1629359520, 1629259520);
+    }
+
+    @Test
+    public void testReadBuildJson() {
+        Path buildFilePath = PROJECT_UTILS_RESOURCES.resolve(ProjectConstants.BUILD_FILE);
+        BuildJson buildJson = ProjectUtils.readBuildJson(buildFilePath);
+        Assert.assertEquals(buildJson.lastBuildTime(), 1629359520);
+        Assert.assertEquals(buildJson.lastUpdateTime(), 1629259520);
+    }
+
+    @Test(expectedExceptions = ProjectException.class,
+            expectedExceptionsMessageRegExp = "Failed to read the 'build' file")
+    public void testReadBuildJsonForNonExistingBuildFile() {
+        Path buildFilePath = PROJECT_UTILS_RESOURCES.resolve("xyz").resolve(ProjectConstants.BUILD_FILE);
+        ProjectUtils.readBuildJson(buildFilePath);
+    }
+
+    @Test(expectedExceptions = ProjectException.class,
+            expectedExceptionsMessageRegExp = "Invalid 'build' file format")
+    public void testReadBuildJsonForInvalidBuildFile() {
+        Path buildFilePath = PROJECT_UTILS_RESOURCES.resolve("invalid-build");
+        ProjectUtils.readBuildJson(buildFilePath);
+    }
+
+    @Test
+    public void testWriteBuildFile() throws IOException {
+        Path buildFilePath = tempDirectory.resolve(ProjectConstants.BUILD_FILE);
+        Files.createFile(buildFilePath);
+        ProjectUtils.writeBuildFile(buildFilePath, buildJson);
+        // check file exists
+        Assert.assertTrue(buildFilePath.toFile().exists());
+        // check created build file content
+        BuildJson resBuildJson = ProjectUtils.readBuildJson(buildFilePath);
+        Assert.assertEquals(resBuildJson.lastBuildTime(), 1629359520);
+        Assert.assertEquals(resBuildJson.lastUpdateTime(), 1629259520);
+    }
+
+    @Test(dependsOnMethods = "testWriteBuildFile",
+            expectedExceptions = ProjectException.class,
+            expectedExceptionsMessageRegExp = "'build' file does not have write permissions")
+    public void testWriteBuildFileForNonExistingPath() throws IOException {
+        Path buildFilePath = tempDirectory.resolve(ProjectConstants.BUILD_FILE);
+        new File(String.valueOf(buildFilePath)).setWritable(false);
+        ProjectUtils.writeBuildFile(buildFilePath, buildJson);
+    }
+}

--- a/compiler/ballerina-lang/src/test/resources/project-utils/build
+++ b/compiler/ballerina-lang/src/test/resources/project-utils/build
@@ -1,0 +1,4 @@
+{
+  "last_build_time": 1629359520,
+  "last_update_time": 1629259520
+}

--- a/compiler/ballerina-lang/src/test/resources/project-utils/invalid-build
+++ b/compiler/ballerina-lang/src/test/resources/project-utils/invalid-build
@@ -1,0 +1,4 @@
+{
+  "last_build_time": "Hello",
+  "last_update_time": 1629259520
+}

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProject.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProject.java
@@ -51,6 +51,7 @@ import io.ballerina.projects.ProjectException;
 import io.ballerina.projects.ResolvedPackageDependency;
 import io.ballerina.projects.directory.BuildProject;
 import io.ballerina.projects.directory.ProjectLoader;
+import io.ballerina.projects.internal.model.BuildJson;
 import io.ballerina.projects.util.ProjectConstants;
 import io.ballerina.projects.util.ProjectUtils;
 import io.ballerina.toml.semantic.ast.TomlTableArrayNode;
@@ -73,6 +74,9 @@ import java.util.stream.Collectors;
 
 import static io.ballerina.projects.test.TestUtils.isWindows;
 import static io.ballerina.projects.test.TestUtils.resetPermissions;
+import static io.ballerina.projects.util.ProjectConstants.BUILD_FILE;
+import static io.ballerina.projects.util.ProjectConstants.TARGET_DIR_NAME;
+import static io.ballerina.projects.util.ProjectUtils.readBuildJson;
 import static org.testng.Assert.assertEquals;
 
 /**
@@ -1389,6 +1393,58 @@ public class TestBuildProject extends BaseTest {
         Assert.assertFalse(project.currentPackage().compilationOptions().offlineBuild());
     }
 
+    @Test(description = "test auto updating dependencies using build file")
+    public void testAutoUpdateWithBuildFile() {
+        Path projectPath = RESOURCE_DIRECTORY.resolve("myproject");
+
+        // 1) Initialize the project instance
+        BuildProject project = null;
+        try {
+            project = BuildProject.load(projectPath);
+            project.save();
+        } catch (Exception e) {
+            Assert.fail(e.getMessage());
+        }
+        Assert.assertEquals(project.currentPackage().packageName().toString(), "myproject");
+        Path buildFile = project.sourceRoot().resolve(TARGET_DIR_NAME).resolve(BUILD_FILE);
+        Assert.assertTrue(buildFile.toFile().exists());
+        BuildJson initialBuildJson = readBuildJson(buildFile);
+        Assert.assertTrue(initialBuildJson.lastBuildTime() > 0);
+        Assert.assertTrue(initialBuildJson.lastUpdateTime() > 0);
+        Assert.assertFalse(initialBuildJson.isExpiredLastUpdateTime());
+
+        // 2) Build project again with build file
+        BuildProject projectSecondBuild = null;
+        try {
+            projectSecondBuild = BuildProject.load(projectPath);
+            projectSecondBuild.save();
+        } catch (Exception e) {
+            Assert.fail(e.getMessage());
+        }
+        Assert.assertTrue(buildFile.toFile().exists());
+        BuildJson secondBuildJson = readBuildJson(buildFile);
+        Assert.assertTrue(secondBuildJson.lastBuildTime() > initialBuildJson.lastBuildTime());
+        assertEquals(initialBuildJson.lastUpdateTime(), secondBuildJson.lastUpdateTime());
+        Assert.assertFalse(secondBuildJson.isExpiredLastUpdateTime());
+        Assert.assertFalse(projectSecondBuild.currentPackage().getResolution().autoUpdate());
+
+        // 3) Change `last_update-time` in `build` file to a timestamp older than one day and build the project again
+        secondBuildJson.setLastUpdateTime(secondBuildJson.lastUpdateTime() - (24 * 60 * 60 * 1000 + 1));
+        ProjectUtils.writeBuildFile(buildFile, secondBuildJson);
+        BuildProject projectThirdBuild = null;
+        try {
+            projectThirdBuild = BuildProject.load(projectPath);
+            Assert.assertTrue(projectThirdBuild.currentPackage().getResolution().autoUpdate());
+            projectThirdBuild.save();
+        } catch (Exception e) {
+            Assert.fail(e.getMessage());
+        }
+        Assert.assertTrue(buildFile.toFile().exists());
+        BuildJson thirdBuildJson = readBuildJson(buildFile);
+        Assert.assertTrue(thirdBuildJson.lastBuildTime() > initialBuildJson.lastBuildTime());
+        Assert.assertTrue(thirdBuildJson.lastUpdateTime() > initialBuildJson.lastUpdateTime());
+        Assert.assertFalse(thirdBuildJson.isExpiredLastUpdateTime());
+    }
 
     @AfterClass (alwaysRun = true)
     public void reset() {


### PR DESCRIPTION
## Purpose
> Limiting update dependencies for a given project to once a day. Introduced a file called `build` inside the target directory to store the last build time and last update time. Dependencies will be updated if the last update time is older than one day.

- Fixes https://github.com/ballerina-platform/ballerina-lang/issues/32191

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> `target/build` file:
```json
{
  "last_build_time": 1629359520431,
  "last_update_time": 1629359520431
}
```

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
