### PR TITLE
[LS] Update pull module to use new compilation API

### DIFF
--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/capability/InitializationOptions.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/capability/InitializationOptions.java
@@ -23,21 +23,9 @@ package org.ballerinalang.langserver.commons.capability;
 public interface InitializationOptions {
 
     /**
-     * Initialization option key for pull module support.
-     */
-    String KEY_PULL_MODULE_SUPPORT = "pullModuleSupport";
-
-    /**
      * Semantic tokens initialization option key.
      */
     String KEY_ENABLE_SEMANTIC_TOKENS = "enableSemanticHighlighting";
-
-    /**
-     * Whether pull module command is supported by the client.
-     *
-     * @return True if supported
-     */
-    boolean isPullModuleSupported();
 
     /**
      * Returns if Ballerina semantic tokens is enabled.

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSClientCapabilitiesImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSClientCapabilitiesImpl.java
@@ -110,10 +110,7 @@ public class LSClientCapabilitiesImpl implements LSClientCapabilities {
      * @return Initialization options.
      */
     private InitializationOptions parseInitializationOptions(Map<String, Object> initOptions) {
-        Object pullModuleSupport = initOptions.get(InitializationOptions.KEY_PULL_MODULE_SUPPORT);
-        boolean pullModuleSupported = Boolean.parseBoolean(String.valueOf(pullModuleSupport));
         InitializationOptionsImpl initializationOptions = new InitializationOptionsImpl();
-        initializationOptions.setPullModuleSupported(pullModuleSupported);
 
         Object semanticTokensSupport = initOptions.get(InitializationOptions.KEY_ENABLE_SEMANTIC_TOKENS);
         boolean enableSemanticTokens = semanticTokensSupport == null ||
@@ -163,18 +160,8 @@ public class LSClientCapabilitiesImpl implements LSClientCapabilities {
      * Represents the initialization options the LS client will be sending.
      */
     public static class InitializationOptionsImpl implements InitializationOptions {
-        private boolean isPullModuleSupported = false;
         private boolean enableSemanticTokens = false;
         
-        @Override
-        public boolean isPullModuleSupported() {
-            return isPullModuleSupported;
-        }
-
-        public void setPullModuleSupported(boolean pullModuleSupported) {
-            isPullModuleSupported = pullModuleSupported;
-        }
-
         public boolean isEnableSemanticTokens() {
             return enableSemanticTokens;
         }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/imports/PullModuleCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/imports/PullModuleCodeAction.java
@@ -16,6 +16,7 @@
 package org.ballerinalang.langserver.codeaction.providers.imports;
 
 import io.ballerina.tools.diagnostics.Diagnostic;
+import io.ballerina.tools.diagnostics.DiagnosticProperty;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.codeaction.CodeActionUtil;
 import org.ballerinalang.langserver.codeaction.providers.AbstractCodeActionProvider;
@@ -50,11 +51,7 @@ public class PullModuleCodeAction extends AbstractCodeActionProvider {
     public List<CodeAction> getDiagBasedCodeActions(Diagnostic diagnostic,
                                                     DiagBasedPositionDetails positionDetails,
                                                     CodeActionContext context) {
-        if (!DiagnosticErrorCode.MODULE_NOT_FOUND.diagnosticId().equals(diagnostic.diagnosticInfo().code())) {
-            return Collections.emptyList();
-        }
-
-        Optional<String> moduleName = positionDetails.diagnosticProperty(MISSING_MODULE_NAME_INDEX);
+        Optional<String> moduleName = getMissingModuleNameFromDiagnostic(diagnostic);
         if (moduleName.isEmpty()) {
             return Collections.emptyList();
         }
@@ -77,5 +74,25 @@ public class PullModuleCodeAction extends AbstractCodeActionProvider {
     @Override
     public String getName() {
         return NAME;
+    }
+
+    /**
+     * Returns the missing module's name taken from diagnostic properties.
+     *
+     * @param diagnostic Diagnostic
+     * @return Optional module name
+     */
+    public static Optional<String> getMissingModuleNameFromDiagnostic(Diagnostic diagnostic) {
+        if (!DiagnosticErrorCode.MODULE_NOT_FOUND.diagnosticId().equals(diagnostic.diagnosticInfo().code())) {
+            return Optional.empty();
+        }
+
+        List<DiagnosticProperty<?>> properties = diagnostic.properties();
+        if (properties.size() <= MISSING_MODULE_NAME_INDEX) {
+            return Optional.empty();
+        }
+
+        DiagnosticProperty<?> diagnosticProperty = properties.get(MISSING_MODULE_NAME_INDEX);
+        return Optional.of((String) diagnosticProperty.value());
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/imports/PullModuleCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/imports/PullModuleCodeAction.java
@@ -19,10 +19,9 @@ import io.ballerina.tools.diagnostics.Diagnostic;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.codeaction.CodeActionUtil;
 import org.ballerinalang.langserver.codeaction.providers.AbstractCodeActionProvider;
+import org.ballerinalang.langserver.command.executors.PullModuleExecutor;
 import org.ballerinalang.langserver.common.constants.CommandConstants;
 import org.ballerinalang.langserver.commons.CodeActionContext;
-import org.ballerinalang.langserver.commons.LanguageServerContext;
-import org.ballerinalang.langserver.commons.capability.LSClientCapabilities;
 import org.ballerinalang.langserver.commons.codeaction.spi.DiagBasedPositionDetails;
 import org.ballerinalang.langserver.commons.command.CommandArgument;
 import org.ballerinalang.util.diagnostic.DiagnosticErrorCode;
@@ -45,15 +44,7 @@ public class PullModuleCodeAction extends AbstractCodeActionProvider {
 
     public static final String NAME = "Pull Module";
 
-    /** Command used at the LS client side to trigger pull module code command. */
-    private static final String PULL_MODULE_COMMAND = "ballerina.packages.pull";
     private static final int MISSING_MODULE_NAME_INDEX = 0;
-
-    @Override
-    public boolean isEnabled(LanguageServerContext serverContext) {
-        LSClientCapabilities clientCapabilities = serverContext.get(LSClientCapabilities.class);
-        return clientCapabilities != null && clientCapabilities.getInitializationOptions().isPullModuleSupported();
-    }
 
     @Override
     public List<CodeAction> getDiagBasedCodeActions(Diagnostic diagnostic,
@@ -78,7 +69,7 @@ public class PullModuleCodeAction extends AbstractCodeActionProvider {
         String commandTitle = CommandConstants.PULL_MOD_TITLE;
         CodeAction action = new CodeAction(commandTitle);
         action.setKind(CodeActionKind.QuickFix);
-        action.setCommand(new Command(commandTitle, PULL_MODULE_COMMAND, args));
+        action.setCommand(new Command(commandTitle, PullModuleExecutor.COMMAND, args));
         action.setDiagnostics(CodeActionUtil.toDiagnostics(diagnostics));
         return Collections.singletonList(action);
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/PullModuleExecutor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/PullModuleExecutor.java
@@ -183,7 +183,7 @@ public class PullModuleExecutor implements LSCommandExecutor {
                             .collect(Collectors.toList())
                     );
             if (missingModules.isEmpty()) {
-                throw new UserErrorException("Unable to pull modules");
+                throw new UserErrorException("Failed to pull modules");
             } else if (!missingModules.get().isEmpty()) {
                 String moduleNames = String.join(", ", missingModules.get());
                 throw new UserErrorException(String.format("Failed to pull modules: %s", moduleNames));
@@ -207,7 +207,7 @@ public class PullModuleExecutor implements LSCommandExecutor {
         @Override
         public void onFail(Throwable t) {
             WorkDoneProgressEnd endNotification = new WorkDoneProgressEnd();
-            endNotification.setMessage("Failed to pull modules!");
+            endNotification.setMessage("Failed to pull unresolved modules!");
             context.getLanguageClient().notifyProgress(new ProgressParams(Either.forLeft(getTaskId()),
                     Either.forLeft(endNotification)));
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/PullModuleExecutor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/PullModuleExecutor.java
@@ -16,7 +16,10 @@
 package org.ballerinalang.langserver.command.executors;
 
 import io.ballerina.projects.CompilationOptionsBuilder;
+import io.ballerina.projects.JBallerinaBackend;
+import io.ballerina.projects.JvmTarget;
 import io.ballerina.projects.Package;
+import io.ballerina.projects.PackageCompilation;
 import io.ballerina.projects.Project;
 import io.ballerina.projects.ProjectException;
 import org.ballerinalang.annotation.JavaSPIService;
@@ -153,7 +156,10 @@ public class PullModuleExecutor implements LSCommandExecutor {
         public void execute() throws Exception {
             Package currentPackage = project.currentPackage();
             // Compile in online mode so missing modules are pulled
-            currentPackage.getCompilation(new CompilationOptionsBuilder().buildOffline(false).build());
+            PackageCompilation compilation = currentPackage.getCompilation(
+                    new CompilationOptionsBuilder().buildOffline(false).build());
+            // Generate jar and BIR caches. To improve subsequent compilations
+            JBallerinaBackend.from(compilation, JvmTarget.JAVA_11);
 
             Path filePath = CommonUtil.getPathFromURI(fileUri)
                     .orElseThrow(() -> new ProjectException("Couldn't determine the project path"));

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/task/BackgroundTaskService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/task/BackgroundTaskService.java
@@ -21,6 +21,7 @@ import org.ballerinalang.langserver.commons.LanguageServerContext;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -76,6 +77,10 @@ public class BackgroundTaskService {
         future.thenAccept(v -> {
             task.onSuccess();
         }).exceptionally(t -> {
+            if (t instanceof CompletionException) {
+                t = t.getCause();
+            }
+            
             if (t instanceof TaskExecutionException) {
                 task.onFail(t.getCause());
             } else {

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/util/TestUtil.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/util/TestUtil.java
@@ -643,7 +643,7 @@ public class TestUtil {
         capabilities.setWorkspace(workspaceCapabilities);
 
         Map<String, Object> initializationOptions = new HashMap<>();
-        initializationOptions.put(InitializationOptions.KEY_PULL_MODULE_SUPPORT, true);
+        initializationOptions.put(InitializationOptions.KEY_ENABLE_SEMANTIC_TOKENS, true);
 
         params.setCapabilities(capabilities);
         params.setInitializationOptions(GSON.toJsonTree(initializationOptions));

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/pull-module/config/packagePull1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/pull-module/config/packagePull1.json
@@ -6,7 +6,7 @@
       "title": "Pull unresolved modules",
       "command": {
         "title": "Pull unresolved modules",
-        "command": "ballerina.packages.pull",
+        "command": "PULL_MODULE",
         "arguments": [
           {
             "key": "module",

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/pull-module/config/packagePull2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/pull-module/config/packagePull2.json
@@ -6,7 +6,7 @@
       "title": "Pull unresolved modules",
       "command": {
         "title": "Pull unresolved modules",
-        "command": "ballerina.packages.pull",
+        "command": "PULL_MODULE",
         "arguments": [
           {
             "key": "module",

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/pull-module/config/packagePull3.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/pull-module/config/packagePull3.json
@@ -6,7 +6,7 @@
       "title": "Pull unresolved modules",
       "command": {
         "title": "Pull unresolved modules",
-        "command": "ballerina.packages.pull",
+        "command": "PULL_MODULE",
         "arguments": [
           {
             "key": "module",

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/pull-module/config/packagePull4.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/pull-module/config/packagePull4.json
@@ -6,7 +6,7 @@
       "title": "Pull unresolved modules",
       "command": {
         "title": "Pull unresolved modules",
-        "command": "ballerina.packages.pull",
+        "command": "PULL_MODULE",
         "arguments": [
           {
             "key": "module",


### PR DESCRIPTION
## Purpose
$subject
Pull module code action is updated to use `package.getCompilation(CompilationOptions)` API to pull missing modules.

Fixes #32236

This is the current behavior if a module couldn't be pulled:
![pull_module2](https://user-images.githubusercontent.com/11285165/131090641-4341b3ad-161b-4b94-a165-382556683fdc.gif)

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
