### PR TITLE
[LS] Refactor default value handling of optional types

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/AbstractImplementMethodCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/AbstractImplementMethodCodeAction.java
@@ -162,7 +162,7 @@ public abstract class AbstractImplementMethodCodeAction extends AbstractCodeActi
                 Optional<String> defaultReturnValueForType = CommonUtil.getDefaultValueForType(returnTypeSymbol);
                 if (defaultReturnValueForType.isPresent()) {
                     String defaultReturnValue = defaultReturnValueForType.get();
-                    if (defaultReturnValue.equals(CommonKeys.PARANTHESIS_KEY)) {
+                    if (defaultReturnValue.equals(CommonKeys.PARANTHESES_KEY)) {
                         returnStmt = "return;";
                     } else {
                         returnStmt = "return " + defaultReturnValue + CommonKeys.SEMI_COLON_SYMBOL_KEY;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/AbstractImplementMethodCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/AbstractImplementMethodCodeAction.java
@@ -159,11 +159,14 @@ public abstract class AbstractImplementMethodCodeAction extends AbstractCodeActi
         if (unimplMethod.typeDescriptor().returnTypeDescriptor().isPresent()) {
             TypeSymbol returnTypeSymbol = unimplMethod.typeDescriptor().returnTypeDescriptor().get();
             if (returnTypeSymbol.typeKind() != TypeDescKind.COMPILATION_ERROR) {
-                String defaultReturnValue = CommonUtil.getDefaultValueForType(returnTypeSymbol);
-                if (defaultReturnValue.equals(CommonKeys.PARANTHESIS_KEY)) {
-                    returnStmt = "return;";
-                } else {
-                    returnStmt = "return " + defaultReturnValue + CommonKeys.SEMI_COLON_SYMBOL_KEY;
+                Optional<String> defaultReturnValueForType = CommonUtil.getDefaultValueForType(returnTypeSymbol);
+                if (defaultReturnValueForType.isPresent()) {
+                    String defaultReturnValue = defaultReturnValueForType.get();
+                    if (defaultReturnValue.equals(CommonKeys.PARANTHESIS_KEY)) {
+                        returnStmt = "return;";
+                    } else {
+                        returnStmt = "return " + defaultReturnValue + CommonKeys.SEMI_COLON_SYMBOL_KEY;
+                    }
                 }
             }
         }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonKeys.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonKeys.java
@@ -47,7 +47,7 @@ public class CommonKeys {
 
     public static final String DOLLAR_SYMBOL_KEY = "$";
 
-    public static final String PARANTHESIS_KEY = "()";
+    public static final String PARANTHESES_KEY = "()";
     // End non letter symbol keys
 
     public static final String FUNCTION_KEYWORD_KEY = "function";

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -248,15 +248,15 @@ public class CommonUtil {
      * @param bType Type descriptor to get the default value
      * @return {@link String}   Default value as a String
      */
-    public static String getDefaultValueForType(TypeSymbol bType) {
+    public static Optional<String> getDefaultValueForType(TypeSymbol bType) {
         return getDefaultValueForType(bType, 1);
     }
     
-    private static String getDefaultValueForType(TypeSymbol bType, int depth) {
+    private static Optional<String> getDefaultValueForType(TypeSymbol bType, int depth) {
         String typeString;
         
         if (bType == null) {
-            return "";
+            return Optional.empty();
         }
 
         TypeSymbol rawType = getRawType(bType);
@@ -271,7 +271,7 @@ public class CommonUtil {
             case TUPLE:
                 TupleTypeSymbol tupleType = (TupleTypeSymbol) rawType;
                 String memberTypes = tupleType.memberTypeDescriptors().stream()
-                        .map(bType1 -> getDefaultValueForType(bType1, depth + 1))
+                        .map(member -> getDefaultValueForType(member, depth + 1).orElse(""))
                         .collect(Collectors.joining(", "));
                 typeString = "[" + memberTypes + "]";
                 break;
@@ -279,14 +279,15 @@ public class CommonUtil {
                 // Filler value of an array is []
                 ArrayTypeSymbol arrayType = (ArrayTypeSymbol) rawType;
                 if (arrayType.memberTypeDescriptor().typeKind() == TypeDescKind.ARRAY) {
-                    typeString = "[" + getDefaultValueForType(arrayType.memberTypeDescriptor(), depth + 1) + "]";
+                    typeString = "[" + getDefaultValueForType(arrayType.memberTypeDescriptor(), depth + 1).orElse("") 
+                            + "]";
                 } else {
                     typeString = "[]";
                 }
                 break;
             case RECORD:
                 if (depth > MAX_DEPTH) {
-                    return "{}";
+                    return Optional.ofNullable("{}");
                 }
                 // TODO: Here we have disregarded the formatting of the record fields. Need to consider that in future
                 RecordTypeSymbol recordTypeSymbol = (RecordTypeSymbol) rawType;
@@ -294,7 +295,7 @@ public class CommonUtil {
                 typeString += getMandatoryRecordFields(recordTypeSymbol).stream()
                         .filter(recordFieldSymbol -> recordFieldSymbol.getName().isPresent())
                         .map(recordFieldSymbol -> recordFieldSymbol.getName().get() + ": " +
-                                getDefaultValueForType(recordFieldSymbol.typeDescriptor(), depth + 1))
+                                getDefaultValueForType(recordFieldSymbol.typeDescriptor(), depth + 1).orElse("()"))
                         .collect(Collectors.joining(", "));
                 typeString += "}";
                 break;
@@ -303,7 +304,7 @@ public class CommonUtil {
                 break;
             case OBJECT:
                 if (depth > MAX_DEPTH) {
-                    return "";
+                    return Optional.ofNullable("");
                 }
                 ObjectTypeSymbol objectTypeSymbol = (ObjectTypeSymbol) rawType;
                 if (objectTypeSymbol.kind() == SymbolKind.CLASS) {
@@ -311,7 +312,7 @@ public class CommonUtil {
                     if (classSymbol.initMethod().isPresent()) {
                         List<ParameterSymbol> params = classSymbol.initMethod().get().typeDescriptor().params().get();
                         String text = params.stream()
-                                .map(param -> getDefaultValueForType(param.typeDescriptor(), depth + 1))
+                                .map(param -> getDefaultValueForType(param.typeDescriptor(), depth + 1).orElse(""))
                                 .collect(Collectors.joining(", "));
                         typeString = "new (" + text + ")";
                     } else {
@@ -323,16 +324,16 @@ public class CommonUtil {
                 break;
             case UNION:
                 if (depth > MAX_DEPTH) {
-                    return "";
+                    return Optional.ofNullable("");
                 }
                 List<TypeSymbol> members =
                         new ArrayList<>(((UnionTypeSymbol) rawType).memberTypeDescriptors());
                 List<TypeSymbol> nilMembers = members.stream()
                         .filter(member -> member.typeKind() == TypeDescKind.NIL).collect(Collectors.toList());
                 if (nilMembers.isEmpty()) {
-                    typeString = getDefaultValueForType(members.get(0), depth + 1);
+                    typeString = getDefaultValueForType(members.get(0), depth + 1).orElse("()");
                 } else {
-                    return "()";
+                    return Optional.ofNullable("()");
                 }
                 break;
             case INTERSECTION:
@@ -348,15 +349,15 @@ public class CommonUtil {
                             .filter(typeSymbol -> typeSymbol.typeKind() != TypeDescKind.READONLY)
                             .findAny();
                     if (memberType.isPresent()) {
-                        typeString = getDefaultValueForType(memberType.get(), depth + 1);
+                        typeString = getDefaultValueForType(memberType.get(), depth + 1).orElse("");
                     }
                 } else {
-                    typeString = getDefaultValueForType(effectiveType, depth + 1);
+                    typeString = getDefaultValueForType(effectiveType, depth + 1).orElse("");
                 }
                 break;
             case TABLE:
                 TypeSymbol rowType = ((TableTypeSymbol) rawType).rowTypeParameter();
-                typeString = "table [" + getDefaultValueForType(rowType, depth + 1) + "]";
+                typeString = "table [" + getDefaultValueForType(rowType, depth + 1).orElse("") + "]";
                 break;
             case ERROR:
                 TypeSymbol errorType = CommonUtil.getRawType(((ErrorTypeSymbol) rawType).detailTypeDescriptor());
@@ -365,7 +366,8 @@ public class CommonUtil {
                     errorString.append(", ");
                     errorString.append(getMandatoryRecordFields((RecordTypeSymbol) errorType).stream()
                             .map(recordFieldSymbol -> recordFieldSymbol.getName().get()
-                                    + " = " + getDefaultValueForType(recordFieldSymbol.typeDescriptor(), depth + 1))
+                                    + " = " + getDefaultValueForType(recordFieldSymbol.typeDescriptor(), depth + 1)
+                                    .orElse(""))
                             .collect(Collectors.joining(", ")));
                 }
                 errorString.append(")");
@@ -380,9 +382,6 @@ public class CommonUtil {
             case DECIMAL:
                 typeString = Integer.toString(0);
                 break;
-            case NIL:
-                typeString = "()";
-                break;
             default:
                 if (typeKind.isIntegerType()) {
                     typeString = Integer.toString(0);
@@ -394,10 +393,9 @@ public class CommonUtil {
                     break;
                 }
 
-                typeString = "";
-                break;
+                return Optional.empty();
         }
-        return typeString;
+        return Optional.ofNullable(typeString);
     }
 
     /**
@@ -473,7 +471,7 @@ public class CommonUtil {
             for (Map.Entry<String, RecordFieldSymbol> entry : requiredFields.entrySet()) {
                 String fieldEntry = entry.getKey()
                         + PKG_DELIMITER_KEYWORD + " "
-                        + getDefaultValueForType(entry.getValue().typeDescriptor());
+                        + getDefaultValueForType(entry.getValue().typeDescriptor()).orElse("()");
                 fieldEntries.add(fieldEntry);
             }
         } else {
@@ -481,7 +479,7 @@ public class CommonUtil {
             for (Map.Entry<String, RecordFieldSymbol> entry : fields.entrySet()) {
                 String fieldEntry = entry.getKey()
                         + PKG_DELIMITER_KEYWORD + " "
-                        + getDefaultValueForType(entry.getValue().typeDescriptor());
+                        + getDefaultValueForType(entry.getValue().typeDescriptor()).orElse("()");
                 fieldEntries.add(fieldEntry);
             }
         }
@@ -638,7 +636,7 @@ public class CommonUtil {
             insertText.append("\"").append("${").append(fieldId).append("}").append("\"");
         } else {
             insertText.append("${").append(fieldId).append(":")
-                    .append(getDefaultValueForType(bField.typeDescriptor())).append("}");
+                    .append(getDefaultValueForType(bField.typeDescriptor()).orElse("()")).append("}");
         }
 
         return insertText.toString();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -287,7 +287,7 @@ public class CommonUtil {
                 break;
             case RECORD:
                 if (depth > MAX_DEPTH) {
-                    return Optional.ofNullable("{}");
+                    return Optional.of("{}");
                 }
                 // TODO: Here we have disregarded the formatting of the record fields. Need to consider that in future
                 RecordTypeSymbol recordTypeSymbol = (RecordTypeSymbol) rawType;
@@ -295,7 +295,7 @@ public class CommonUtil {
                 typeString += getMandatoryRecordFields(recordTypeSymbol).stream()
                         .filter(recordFieldSymbol -> recordFieldSymbol.getName().isPresent())
                         .map(recordFieldSymbol -> recordFieldSymbol.getName().get() + ": " +
-                                getDefaultValueForType(recordFieldSymbol.typeDescriptor(), depth + 1).orElse("()"))
+                                getDefaultValueForType(recordFieldSymbol.typeDescriptor(), depth + 1).orElse(""))
                         .collect(Collectors.joining(", "));
                 typeString += "}";
                 break;
@@ -304,7 +304,7 @@ public class CommonUtil {
                 break;
             case OBJECT:
                 if (depth > MAX_DEPTH) {
-                    return Optional.ofNullable("");
+                    return Optional.of("");
                 }
                 ObjectTypeSymbol objectTypeSymbol = (ObjectTypeSymbol) rawType;
                 if (objectTypeSymbol.kind() == SymbolKind.CLASS) {
@@ -324,16 +324,16 @@ public class CommonUtil {
                 break;
             case UNION:
                 if (depth > MAX_DEPTH) {
-                    return Optional.ofNullable("");
+                    return Optional.of("");
                 }
                 List<TypeSymbol> members =
                         new ArrayList<>(((UnionTypeSymbol) rawType).memberTypeDescriptors());
                 List<TypeSymbol> nilMembers = members.stream()
                         .filter(member -> member.typeKind() == TypeDescKind.NIL).collect(Collectors.toList());
                 if (nilMembers.isEmpty()) {
-                    typeString = getDefaultValueForType(members.get(0), depth + 1).orElse("()");
+                    typeString = getDefaultValueForType(members.get(0), depth + 1).orElse("");
                 } else {
-                    return Optional.ofNullable("()");
+                    return Optional.of("()");
                 }
                 break;
             case INTERSECTION:
@@ -471,7 +471,7 @@ public class CommonUtil {
             for (Map.Entry<String, RecordFieldSymbol> entry : requiredFields.entrySet()) {
                 String fieldEntry = entry.getKey()
                         + PKG_DELIMITER_KEYWORD + " "
-                        + getDefaultValueForType(entry.getValue().typeDescriptor()).orElse("()");
+                        + getDefaultValueForType(entry.getValue().typeDescriptor()).orElse(" ");
                 fieldEntries.add(fieldEntry);
             }
         } else {
@@ -479,7 +479,7 @@ public class CommonUtil {
             for (Map.Entry<String, RecordFieldSymbol> entry : fields.entrySet()) {
                 String fieldEntry = entry.getKey()
                         + PKG_DELIMITER_KEYWORD + " "
-                        + getDefaultValueForType(entry.getValue().typeDescriptor()).orElse("()");
+                        + getDefaultValueForType(entry.getValue().typeDescriptor()).orElse(" ");
                 fieldEntries.add(fieldEntry);
             }
         }
@@ -636,7 +636,7 @@ public class CommonUtil {
             insertText.append("\"").append("${").append(fieldId).append("}").append("\"");
         } else {
             insertText.append("${").append(fieldId).append(":")
-                    .append(getDefaultValueForType(bField.typeDescriptor()).orElse("()")).append("}");
+                    .append(getDefaultValueForType(bField.typeDescriptor()).orElse(" ")).append("}");
         }
 
         return insertText.toString();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/FunctionGenerator.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/FunctionGenerator.java
@@ -199,11 +199,9 @@ public class FunctionGenerator {
             // returns clause
             returnsClause = "returns " + returnType.get();
             // return statement
-            String defaultReturnValue = CommonUtil.getDefaultValueForType(returnTypeSymbol);
-            if (defaultReturnValue.equals(CommonKeys.PARANTHESIS_KEY)) {
-                returnStmt = "return;";
-            } else {
-                returnStmt = "return " + defaultReturnValue + CommonKeys.SEMI_COLON_SYMBOL_KEY;
+            Optional<String> defaultReturnValue = CommonUtil.getDefaultValueForType(returnTypeSymbol);
+            if (defaultReturnValue.isPresent()) {
+                    returnStmt = "return " + defaultReturnValue.get() + CommonKeys.SEMI_COLON_SYMBOL_KEY;
             }
         }
 

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/implement-functions/config/implementFuncObj3.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/implement-functions/config/implementFuncObj3.json
@@ -3,7 +3,7 @@
     "character": 4,
     "expected": [
         {
-            "title": "Implement method \u0027pushText2\u0027",
+            "title": "Implement method \u0027pushText3\u0027",
             "edits": [
                 {
                     "range": {
@@ -16,7 +16,7 @@
                             "character": 0
                         }
                     },
-                    "newText": "\n    public function pushText2(string text) returns error? {\n        return;\n    }\n"
+                    "newText": "\n    public function pushText3(string text) {\n        \n    }\n"
                 }
             ]
         }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/implement-functions/source/implementFuncObj.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/implement-functions/source/implementFuncObj.bal
@@ -1,7 +1,7 @@
 public type BaseConnector object {
     public function pushText1(string text) returns error?;
     public function pushText2(string text) returns error?;
-    public function pushText3(string text) returns error?;
+    public function pushText3(string text);
 };
 
 public class Connector {

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction18.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction18.json
@@ -28,7 +28,7 @@
                                         "character": 1
                                     }
                                 },
-                                "newText": "\n\nfunction getValue() returns () {\n    return;\n}\n"
+                                "newText": "\n\nfunction getValue() returns () {\n    \n}\n"
                             }
                         ]
                     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config46.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config46.json
@@ -19,7 +19,7 @@
       "kind": "Field",
       "detail": "LinkedList.next",
       "sortText": "G",
-      "insertText": "next: {\n\tvalue: \"${1}\",\n\tnext: {}\n}",
+      "insertText": "next: {\n\tvalue: ${1:()},\n\tnext: {}\n}",
       "insertTextFormat": "Snippet"
     },
     {
@@ -27,7 +27,7 @@
       "kind": "Field",
       "detail": "LinkedList.value",
       "sortText": "G",
-      "insertText": "value: \"${2}\"",
+      "insertText": "value: ${2:()}",
       "insertTextFormat": "Snippet"
     },
     {
@@ -36,7 +36,7 @@
       "detail": "LinkedList",
       "sortText": "R",
       "filterText": "fill",
-      "insertText": "next: {value: \"\", next: {}},\nvalue: \"\"",
+      "insertText": "next: {value: (), next: {}},\nvalue: ()",
       "insertTextFormat": "Snippet"
     }
   ]

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config46.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config46.json
@@ -19,7 +19,7 @@
       "kind": "Field",
       "detail": "LinkedList.next",
       "sortText": "G",
-      "insertText": "next: {\n\tvalue: ${1:()},\n\tnext: {}\n}",
+      "insertText": "next: {\n\tvalue: ${1: },\n\tnext: {}\n}",
       "insertTextFormat": "Snippet"
     },
     {
@@ -27,7 +27,7 @@
       "kind": "Field",
       "detail": "LinkedList.value",
       "sortText": "G",
-      "insertText": "value: ${2:()}",
+      "insertText": "value: ${2: }",
       "insertTextFormat": "Snippet"
     },
     {
@@ -36,7 +36,7 @@
       "detail": "LinkedList",
       "sortText": "R",
       "filterText": "fill",
-      "insertText": "next: {value: (), next: {}},\nvalue: ()",
+      "insertText": "next: {value: , next: {}},\nvalue:  ",
       "insertTextFormat": "Snippet"
     }
   ]

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/mapping_expr_ctx_source46.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/mapping_expr_ctx_source46.bal
@@ -1,5 +1,5 @@
 type LinkedList record {|
-    string value;
+    () value;
     LinkedList next;
 |};
 


### PR DESCRIPTION
## Purpose

Fixes #31790

## Approach
Modify `CommonUtil.getDefaultValueForType()` method to return an `Optional<String>`.

## Samples
![23](https://user-images.githubusercontent.com/27485094/130913750-9b7a80dc-19c0-40d3-a1b6-453660469218.gif)
As a result, it adds no return statement when generating a function with `Implement method` code action where the default return value is `()`. But for record fields where the default value is `()`, it adds `fieldName : ()`.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
