### PR TITLE
Fix 'testAutoUpdateWithBuildFile' test & Changes to CompilationOptionsBuilder

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BuildOptionsBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BuildOptionsBuilder.java
@@ -66,7 +66,7 @@ public class BuildOptionsBuilder {
     }
 
     public BuildOptionsBuilder offline(Boolean value) {
-        compilationOptionsBuilder.buildOffline(value);
+        compilationOptionsBuilder.offline(value);
         return this;
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/CompilationOptionsBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/CompilationOptionsBuilder.java
@@ -25,7 +25,7 @@ package io.ballerina.projects;
  * @since 2.0.0
  */
 public class CompilationOptionsBuilder {
-    private Boolean buildOffline;
+    private Boolean offline;
     private Boolean experimental;
     private Boolean observabilityIncluded;
     private Boolean dumpBir;
@@ -37,8 +37,8 @@ public class CompilationOptionsBuilder {
     public CompilationOptionsBuilder() {
     }
 
-    public CompilationOptionsBuilder buildOffline(Boolean value) {
-        buildOffline = value;
+    public CompilationOptionsBuilder offline(Boolean value) {
+        offline = value;
         return this;
     }
 
@@ -73,11 +73,11 @@ public class CompilationOptionsBuilder {
     }
 
     public CompilationOptions build() {
-        return new CompilationOptions(buildOffline, experimental, observabilityIncluded, dumpBir,
-                dumpBirFile, cloud, listConflictedClasses, sticky);
+        return new CompilationOptions(offline, experimental, observabilityIncluded, dumpBir,
+                                      dumpBirFile, cloud, listConflictedClasses, sticky);
     }
 
-    void sticky(Boolean value) {
+    public void sticky(Boolean value) {
         sticky = value;
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageContext.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageContext.java
@@ -218,7 +218,7 @@ class PackageContext {
 
     PackageCompilation getPackageCompilation(CompilationOptions compilationOptions) {
         CompilationOptions options = new CompilationOptionsBuilder()
-                .buildOffline(this.compilationOptions.offlineBuild())
+                .offline(this.compilationOptions.offlineBuild())
                 .experimental(this.compilationOptions.experimental())
                 .observabilityIncluded(this.compilationOptions.observabilityIncluded())
                 .dumpBir(this.compilationOptions.dumpBir())

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProject.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProject.java
@@ -1375,7 +1375,7 @@ public class TestBuildProject extends BaseTest {
 
         // 2) Pass compilations option 'offline' to the package compilation
         CompilationOptionsBuilder compilationOptionsBuilder = new CompilationOptionsBuilder();
-        compilationOptionsBuilder.buildOffline(true);
+        compilationOptionsBuilder.offline(true);
         project.currentPackage().getCompilation(compilationOptionsBuilder.build());
         Assert.assertFalse(project.currentPackage().compilationOptions().offlineBuild());
 


### PR DESCRIPTION
## Purpose
> Fix and enabled 'testAutoUpdateWithBuildFile' test which was disbaled in https://github.com/ballerina-platform/ballerina-lang/pull/32383. Renamed buildOffline setter to offline and made sticky setter to public.

Fixes #<Issue Number>

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
