### PR TITLE
[Beta 3] Remove ballerina/observe getting injected when observability is enabled 

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageResolution.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageResolution.java
@@ -221,13 +221,6 @@ public class PackageResolution {
                         PackageDependencyScope.DEFAULT, DependencyResolutionType.PLATFORM_PROVIDED);
                 allModuleLoadRequests.add(observeModuleLoadReq);
             }
-            {
-                String moduleName = Names.OBSERVE.getValue();
-                ModuleLoadRequest observeModuleLoadReq = new ModuleLoadRequest(
-                        PackageOrg.from(Names.BALLERINA_ORG.value), moduleName,
-                        PackageDependencyScope.DEFAULT, DependencyResolutionType.PLATFORM_PROVIDED);
-                allModuleLoadRequests.add(observeModuleLoadReq);
-            }
         }
 
         // TODO Can we make this a builtin compiler plugin

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/elements/PackageID.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/elements/PackageID.java
@@ -40,7 +40,6 @@ import static org.wso2.ballerinalang.compiler.util.Names.JAVA_VERSION;
 import static org.wso2.ballerinalang.compiler.util.Names.MAP_VERSION;
 import static org.wso2.ballerinalang.compiler.util.Names.OBJECT_VERSION;
 import static org.wso2.ballerinalang.compiler.util.Names.OBSERVE_INTERNAL_VERSION;
-import static org.wso2.ballerinalang.compiler.util.Names.OBSERVE_VERSION;
 import static org.wso2.ballerinalang.compiler.util.Names.QUERY_VERSION;
 import static org.wso2.ballerinalang.compiler.util.Names.RUNTIME_VERSION;
 import static org.wso2.ballerinalang.compiler.util.Names.STREAM_VERSION;
@@ -114,8 +113,6 @@ public class PackageID {
                                                                        TRANSACTION_INTERNAL_VERSION);
     public static final PackageID OBSERVE_INTERNAL = new PackageID(Names.BALLERINA_INTERNAL_ORG,
             Lists.of(Names.OBSERVE), OBSERVE_INTERNAL_VERSION);
-    public static final PackageID OBSERVE = new PackageID(Names.BALLERINA_ORG,
-            Lists.of(Names.OBSERVE), OBSERVE_VERSION);
 
     public Name orgName;
     // A read-only variable is used to keep track of the Package Name.

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/BLangCompilerConstants.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/BLangCompilerConstants.java
@@ -57,7 +57,6 @@ public class BLangCompilerConstants {
     public static final String TRANSACTION_VERSION = "0.0.1";
     public static final String TRANSACTION_INTERNAL_VERSION = "1.0.15";
     public static final String OBSERVE_INTERNAL_VERSION = "0.9.0";
-    public static final String OBSERVE_VERSION = "0.9.0";
     public static final String C2C_VERSION = "1.0.0";
 
     private BLangCompilerConstants() {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -741,7 +741,6 @@ public class Desugar extends BLangNodeVisitor {
             return;
         }
         observabilityDesugar.addObserveInternalModuleImport(pkgNode);
-        observabilityDesugar.addObserveModuleImport(pkgNode);
 
         code2CloudDesugar.addCode2CloudModuleImport(pkgNode);
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ObservabilityDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ObservabilityDesugar.java
@@ -71,21 +71,4 @@ public class ObservabilityDesugar {
             pkgNode.symbol.imports.add(importDcl.symbol);
         }
     }
-
-    void addObserveModuleImport(BLangPackage pkgNode) {
-        if (observabilityIncluded && (pkgNode.moduleContextDataHolder != null
-                && !pkgNode.moduleContextDataHolder.projectKind().equals(ProjectKind.BALA_PROJECT))) {
-            BLangImportPackage importDcl = (BLangImportPackage) TreeBuilder.createImportPackageNode();
-            List<BLangIdentifier> pkgNameComps = new ArrayList<>();
-            pkgNameComps.add(ASTBuilderUtil.createIdentifier(pkgNode.pos, Names.OBSERVE.value));
-            importDcl.pkgNameComps = pkgNameComps;
-            importDcl.pos = pkgNode.symbol.pos;
-            importDcl.orgName = ASTBuilderUtil.createIdentifier(pkgNode.pos, Names.BALLERINA_ORG.value);
-            importDcl.alias = ASTBuilderUtil.createIdentifier(pkgNode.pos, "_");
-            importDcl.version = ASTBuilderUtil.createIdentifier(pkgNode.pos, "");
-            importDcl.symbol = packageCache.getSymbol(PackageID.OBSERVE);
-            pkgNode.imports.add(importDcl);
-            pkgNode.symbol.imports.add(importDcl.symbol);
-        }
-    }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/Names.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/Names.java
@@ -171,7 +171,6 @@ public class Names {
     public static final Name TRANSACTION_INTERNAL_VERSION =
             new Name(BLangCompilerConstants.TRANSACTION_INTERNAL_VERSION);
     public static final Name OBSERVE_INTERNAL_VERSION = new Name(BLangCompilerConstants.OBSERVE_INTERNAL_VERSION);
-    public static final Name OBSERVE_VERSION = new Name(BLangCompilerConstants.OBSERVE_VERSION);
 
     public CompilerContext context;
 


### PR DESCRIPTION
## Purpose
> Remove ballerina/observe getting injected when observability is enabled. This will still be picked up as a dependency of the ballerinai/observe module

Related to https://github.com/ballerina-platform/ballerina-lang/issues/32364