### PR TITLE
Implement equals and hashCode functions in NodeLocation

### DIFF
--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/syntax/tree/NodeLocation.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/syntax/tree/NodeLocation.java
@@ -21,6 +21,8 @@ import io.ballerina.tools.diagnostics.Location;
 import io.ballerina.tools.text.LineRange;
 import io.ballerina.tools.text.TextRange;
 
+import java.util.Objects;
+
 /**
  * The {@code NodeLocation} represent the location of a {@code Node} in source code.
  * <p>
@@ -41,5 +43,25 @@ public class NodeLocation implements Location {
 
     public TextRange textRange() {
         return node.textRange();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        
+        NodeLocation that = (NodeLocation) o;
+        return Objects.equals(node.lineRange(), that.node.lineRange()) &&
+                Objects.equals(node.textRange(), that.node.textRange());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(node.textRange(), node.lineRange());
     }
 }


### PR DESCRIPTION
## Purpose
$subject
This is to avoid a memory leak inside `ModuleLoadRequest`s where it's keeping track of locations as `NodeLocation`s inside a set.

Fixes #32290 

## Approach
Implemented `equals()` and `hashCode()` methods in `NodeLocation` class

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
