### PR TITLE
Return singleton type symbol for symbol() when used on singleton types

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
@@ -1252,6 +1252,11 @@ class SymbolFinder extends BaseVisitor {
 
     @Override
     public void visit(BLangFiniteTypeNode finiteTypeNode) {
+        // Special case handling for singleton types.
+        if (finiteTypeNode.valueSpace.size() == 1 && this.symbolAtCursor == null) {
+            this.symbolAtCursor = finiteTypeNode.getBType().tsymbol;
+        }
+
         lookupNodes(finiteTypeNode.valueSpace);
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/TypeSymbolTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/TypeSymbolTest.java
@@ -109,6 +109,7 @@ public class TypeSymbolTest {
 //                {46, 4, ERROR, "error<ErrorData>"},
                 {47, 4, HANDLE, "handle"},
                 {48, 4, STREAM, "stream<Person, error>"},
+                {52, 4, SINGLETON, "10"},
                 {54, 4, ANY, "any"},
                 {55, 4, NEVER, "never"},
                 {56, 4, READONLY, "readonly"},


### PR DESCRIPTION
## Purpose
> Previously `symbol()` returned empty when the cursor was placed at a singleton type. This PR fixes it to return a `SingletonTypeSymbol` for such cases.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
