### PR TITLE
Use createTypeInstance instead of loadUnion

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BUnionType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BUnionType.java
@@ -77,6 +77,15 @@ public class BUnionType extends BType implements UnionType, SelectivelyImmutable
         this.isCyclic = isCyclic;
     }
 
+    public BUnionType(int typeFlags, boolean isCyclic, long flags) {
+        super(null, null, Object.class);
+        this.typeFlags = typeFlags;
+        this.readonly = isReadOnlyFlagOn(flags);
+        this.memberTypes = new ArrayList<>(0);
+        this.isCyclic = isCyclic;
+        this.flags = flags;
+    }
+
     public BUnionType(List<Type> memberTypes) {
         this(memberTypes, false);
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmPackageGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmPackageGen.java
@@ -799,6 +799,9 @@ public class JvmPackageGen {
         initMethodGen.enrichPkgWithInitializers(jvmClassMapping, moduleInitClass, module, flattenedModuleImports);
         JvmBStringConstantsGen stringConstantsGen = new JvmBStringConstantsGen(module.packageID);
         JvmUnionTypeConstantsGen unionTypeConstantsGen = new JvmUnionTypeConstantsGen(module.packageID);
+        JvmTypeGen jvmTypeGen = new JvmTypeGen(stringConstantsGen, unionTypeConstantsGen, module.packageID);
+        JvmCreateTypeGen jvmCreateTypeGen = new JvmCreateTypeGen(jvmTypeGen, module.packageID);
+        unionTypeConstantsGen.setJvmCreateTypeGen(jvmCreateTypeGen);
         configMethodGen.generateConfigMapper(flattenedModuleImports, module, moduleInitClass, stringConstantsGen,
                                              unionTypeConstantsGen, jarEntries);
 
@@ -811,8 +814,6 @@ public class JvmPackageGen {
         // generate object/record value classes
         JvmValueGen valueGen = new JvmValueGen(module, this, methodGen);
         valueGen.generateValueClasses(jarEntries, stringConstantsGen, unionTypeConstantsGen);
-        JvmTypeGen jvmTypeGen = new JvmTypeGen(stringConstantsGen, unionTypeConstantsGen, module.packageID);
-        JvmCreateTypeGen jvmCreateTypeGen = new JvmCreateTypeGen(jvmTypeGen, module.packageID);
         JvmAnnotationsGen jvmAnnotationsGen = new JvmAnnotationsGen(module, this, jvmTypeGen);
         valueGen.generateValueClasses(jarEntries, stringConstantsGen, unionTypeConstantsGen);
 


### PR DESCRIPTION
## Purpose
> Use createTypeInstance instead of loadUnion
Resolve https://github.com/ballerina-platform/ballerina-lang/issues/32562

## Approach
> Reuse the createType method by first creating the unions and then populating them.

## Samples
> N/A

## Remarks
> https://github.com/ballerina-platform/ballerina-lang/pull/32325
## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
