### PR TITLE
Cleanup both PackageResolver and PackageRepository APIs to reduce potential API usages related bugs

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Bootstrap.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Bootstrap.java
@@ -205,7 +205,7 @@ public class Bootstrap {
         PackageName pkgName = PackageName.from(packageID.name.getValue());
         PackageVersion pkgVersion = PackageVersion.from(packageID.getPackageVersion().toString());
         PackageDescriptor pkgDesc = PackageDescriptor.from(pkgOrg, pkgName, pkgVersion);
-        return ResolutionRequest.from(pkgDesc, false);
+        return ResolutionRequest.from(pkgDesc);
     }
 
     private BPackageSymbol getSymbolFromCache(CompilerContext context, PackageID packageID) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Bootstrap.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Bootstrap.java
@@ -18,6 +18,7 @@
 package io.ballerina.projects;
 
 import io.ballerina.projects.environment.PackageResolver;
+import io.ballerina.projects.environment.ResolutionOptions;
 import io.ballerina.projects.environment.ResolutionRequest;
 import io.ballerina.projects.environment.ResolutionResponse;
 import org.ballerinalang.model.elements.PackageID;
@@ -187,7 +188,8 @@ public class Bootstrap {
 
     private void loadLangLibFromBala(ResolutionRequest resolutionRequest) {
         Collection<ResolutionResponse> resolutionResponses = packageResolver.resolvePackages(
-                Collections.singletonList(resolutionRequest), true);
+                Collections.singletonList(resolutionRequest),
+                ResolutionOptions.builder().setOffline(true).build());
         resolutionResponses.forEach(resolutionResponse -> {
             Package pkg = resolutionResponse.resolvedPackage();
             PackageCompilation compilation = pkg.getCompilation();

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageResolution.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageResolution.java
@@ -80,12 +80,13 @@ public class PackageResolution {
         this.diagnosticList = new ArrayList<>();
         this.compilationOptions = compilationOptions;
 
+        ResolutionOptions resolutionOptions = getResolutionOptions(rootPackageContext, compilationOptions);
         ProjectEnvironment projectEnvContext = rootPackageContext.project().projectEnvironmentContext();
         this.packageResolver = projectEnvContext.getService(PackageResolver.class);
         this.blendedManifest = createBlendedManifest(rootPackageContext, projectEnvContext);
-        this.moduleResolver = createModuleResolver(rootPackageContext, projectEnvContext);
+        this.moduleResolver = createModuleResolver(rootPackageContext, projectEnvContext, resolutionOptions);
 
-        dependencyGraph = buildDependencyGraph(getSticky(rootPackageContext), compilationOptions.offlineBuild());
+        this.dependencyGraph = buildDependencyGraph(resolutionOptions);
         DependencyResolution dependencyResolution = new DependencyResolution(
                 projectEnvContext.getService(PackageCache.class), moduleResolver, dependencyGraph);
         resolveDependencies(dependencyResolution);
@@ -188,12 +189,12 @@ public class PackageResolution {
      *
      * @return package dependency graph of this package
      */
-    private DependencyGraph<ResolvedPackageDependency> buildDependencyGraph(boolean sticky, boolean offline) {
+    private DependencyGraph<ResolvedPackageDependency> buildDependencyGraph(ResolutionOptions resolutionOptions) {
         // TODO We should get diagnostics as well. Need to design that contract
         if (rootPackageContext.project().kind() == ProjectKind.BALA_PROJECT) {
-            return resolveBALADependencies(offline);
+            return resolveBALADependencies(resolutionOptions);
         } else {
-            return resolveSourceDependencies(sticky, offline);
+            return resolveSourceDependencies(resolutionOptions);
         }
     }
 
@@ -232,30 +233,29 @@ public class PackageResolution {
         return allModuleLoadRequests;
     }
 
-    private DependencyGraph<ResolvedPackageDependency> resolveBALADependencies(boolean offline) {
+    private DependencyGraph<ResolvedPackageDependency> resolveBALADependencies(ResolutionOptions resolutionOptions) {
         // 1) Convert package descriptor graph to DependencyNode graph
         DependencyGraph<DependencyNode> dependencyNodeGraph = createDependencyNodeGraph(
                 rootPackageContext.dependencyGraph());
 
         //2 ) Create the package dependency graph by downloading packages if necessary.
         return buildPackageGraph(dependencyNodeGraph, rootPackageContext.project().currentPackage(),
-                packageResolver, offline);
+                packageResolver, resolutionOptions);
     }
 
-    private DependencyGraph<ResolvedPackageDependency> resolveSourceDependencies(boolean sticky, boolean offline) {
+    private DependencyGraph<ResolvedPackageDependency> resolveSourceDependencies(ResolutionOptions resolutionOptions) {
         // 1) Get PackageLoadRequests for all the direct dependencies of this package
         LinkedHashSet<ModuleLoadRequest> moduleLoadRequests = getModuleLoadRequestsOfDirectDependencies();
 
         // 2) Resolve imports to packages and create the complete dependency graph with package metadata
-        ResolutionOptions options = ResolutionOptions.builder().setOffline(offline).setSticky(sticky).build();
         ResolutionEngine resolutionEngine = new ResolutionEngine(rootPackageContext.descriptor(),
-                blendedManifest, packageResolver, moduleResolver, options);
+                blendedManifest, packageResolver, moduleResolver, resolutionOptions);
         DependencyGraph<DependencyNode> dependencyNodeGraph =
                 resolutionEngine.resolveDependencies(moduleLoadRequests);
 
         //3 ) Create the package dependency graph by downloading packages if necessary.
         return buildPackageGraph(dependencyNodeGraph, rootPackageContext.project().currentPackage(),
-                packageResolver, offline);
+                packageResolver, resolutionOptions);
     }
 
     static Optional<ModuleContext> findModuleInPackage(PackageContext resolvedPackage, String moduleNameStr) {
@@ -282,7 +282,7 @@ public class PackageResolution {
     private DependencyGraph<ResolvedPackageDependency> buildPackageGraph(DependencyGraph<DependencyNode> depGraph,
                                                                          Package rootPackage,
                                                                          PackageResolver packageResolver,
-                                                                         boolean offline) {
+                                                                         ResolutionOptions resolutionOptions) {
         PackageContainer<ResolvedPackageDependency> resolvedPkgContainer = new PackageContainer<>();
 
         // Add root node to the container
@@ -294,10 +294,10 @@ public class PackageResolution {
         // Resolve rest of the packages in the graph
         List<ResolutionRequest> resolutionRequests = depGraph.getNodes().stream()
                 .filter(depNode -> !depNode.equals(rootNode)) // Remove root node from the requests
-                .map(depNode -> createFromDepNode(depNode, offline))
+                .map(depNode -> createFromDepNode(depNode, resolutionOptions.offline()))
                 .collect(Collectors.toList());
         Collection<ResolutionResponse> resolutionResponses =
-                packageResolver.resolvePackages(resolutionRequests, offline);
+                packageResolver.resolvePackages(resolutionRequests, resolutionOptions.offline());
 
         // Add resolved packages to the container
         for (ResolutionResponse resolutionResp : resolutionResponses) {
@@ -388,13 +388,14 @@ public class PackageResolution {
     }
 
     private ModuleResolver createModuleResolver(PackageContext rootPackageContext,
-                                                ProjectEnvironment projectEnvContext) {
+                                                ProjectEnvironment projectEnvContext,
+                                                ResolutionOptions resolutionOptions) {
         List<ModuleName> moduleNames = rootPackageContext.moduleIds().stream()
                 .map(rootPackageContext::moduleContext)
                 .map(ModuleContext::moduleName)
                 .collect(Collectors.toList());
         return new ModuleResolver(rootPackageContext.descriptor(), moduleNames, blendedManifest,
-                projectEnvContext.getService(PackageResolver.class));
+                projectEnvContext.getService(PackageResolver.class), resolutionOptions);
     }
 
     private BlendedManifest createBlendedManifest(PackageContext rootPackageContext,
@@ -402,6 +403,14 @@ public class PackageResolution {
         return BlendedManifest.from(rootPackageContext.dependencyManifest(),
                 rootPackageContext.packageManifest(),
                 projectEnvContext.getService(LocalPackageRepository.class));
+    }
+
+    private ResolutionOptions getResolutionOptions(PackageContext rootPackageContext,
+                                                   CompilationOptions compilationOptions) {
+        return ResolutionOptions.builder()
+                .setOffline(compilationOptions.offlineBuild())
+                .setSticky(getSticky(rootPackageContext))
+                .build();
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageResolution.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageResolution.java
@@ -297,7 +297,7 @@ public class PackageResolution {
                 .map(depNode -> createFromDepNode(depNode, resolutionOptions.offline()))
                 .collect(Collectors.toList());
         Collection<ResolutionResponse> resolutionResponses =
-                packageResolver.resolvePackages(resolutionRequests, resolutionOptions.offline());
+                packageResolver.resolvePackages(resolutionRequests, resolutionOptions);
 
         // Add resolved packages to the container
         for (ResolutionResponse resolutionResp : resolutionResponses) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageResolution.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageResolution.java
@@ -22,6 +22,7 @@ import io.ballerina.projects.environment.ModuleLoadRequest;
 import io.ballerina.projects.environment.PackageCache;
 import io.ballerina.projects.environment.PackageResolver;
 import io.ballerina.projects.environment.ProjectEnvironment;
+import io.ballerina.projects.environment.ResolutionOptions;
 import io.ballerina.projects.environment.ResolutionRequest;
 import io.ballerina.projects.environment.ResolutionResponse;
 import io.ballerina.projects.internal.BlendedManifest;
@@ -246,8 +247,9 @@ public class PackageResolution {
         LinkedHashSet<ModuleLoadRequest> moduleLoadRequests = getModuleLoadRequestsOfDirectDependencies();
 
         // 2) Resolve imports to packages and create the complete dependency graph with package metadata
+        ResolutionOptions options = ResolutionOptions.builder().setOffline(offline).setSticky(sticky).build();
         ResolutionEngine resolutionEngine = new ResolutionEngine(rootPackageContext.descriptor(),
-                blendedManifest, packageResolver, moduleResolver, offline, sticky);
+                blendedManifest, packageResolver, moduleResolver, options);
         DependencyGraph<DependencyNode> dependencyNodeGraph =
                 resolutionEngine.resolveDependencies(moduleLoadRequests);
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageResolution.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageResolution.java
@@ -294,7 +294,7 @@ public class PackageResolution {
         // Resolve rest of the packages in the graph
         List<ResolutionRequest> resolutionRequests = depGraph.getNodes().stream()
                 .filter(depNode -> !depNode.equals(rootNode)) // Remove root node from the requests
-                .map(depNode -> createFromDepNode(depNode, resolutionOptions.offline()))
+                .map(this::createFromDepNode)
                 .collect(Collectors.toList());
         Collection<ResolutionResponse> resolutionResponses =
                 packageResolver.resolvePackages(resolutionRequests, resolutionOptions);
@@ -335,8 +335,8 @@ public class PackageResolution {
         return depGraphBuilder.build();
     }
 
-    private ResolutionRequest createFromDepNode(DependencyNode depNode, boolean offline) {
-        return ResolutionRequest.from(depNode.pkgDesc(), depNode.scope(), depNode.resolutionType(), offline);
+    private ResolutionRequest createFromDepNode(DependencyNode depNode) {
+        return ResolutionRequest.from(depNode.pkgDesc(), depNode.scope(), depNode.resolutionType());
     }
 
     private DependencyGraph<DependencyNode> createDependencyNodeGraph(

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/environment/PackageRepository.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/environment/PackageRepository.java
@@ -41,8 +41,18 @@ public interface PackageRepository {
 
     Map<String, List<String>> getPackages();
 
-    Collection<PackageMetadataResponse> resolvePackageMetadata(Collection<ResolutionRequest> requests,
-                                                               ResolutionOptions options);
+    /**
+     * Returns requested packages metadata such as the availability, dependency graph.
+     * <p>
+     * Metadata requests provide an efficient way to complete the dependency graph without
+     * downloading physical packages from Ballerina central.
+     *
+     * @param requests requested package collection
+     * @param options  resolution options
+     * @return a collection of {@code PackageMetadataResponse} instances
+     */
+    Collection<PackageMetadataResponse> getPackageMetadata(Collection<ResolutionRequest> requests,
+                                                           ResolutionOptions options);
 
     List<ImportModuleResponse> resolvePackageNames(List<ImportModuleRequest> importModuleRequests);
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/environment/PackageRepository.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/environment/PackageRepository.java
@@ -23,6 +23,7 @@ import io.ballerina.projects.PackageVersion;
 import io.ballerina.projects.internal.ImportModuleRequest;
 import io.ballerina.projects.internal.ImportModuleResponse;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -40,7 +41,8 @@ public interface PackageRepository {
 
     Map<String, List<String>> getPackages();
 
-    List<PackageMetadataResponse> resolvePackageMetadata(List<ResolutionRequest> resolutionRequests);
+    Collection<PackageMetadataResponse> resolvePackageMetadata(Collection<ResolutionRequest> requests,
+                                                               ResolutionOptions options);
 
     List<ImportModuleResponse> resolvePackageNames(List<ImportModuleRequest> importModuleRequests);
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/environment/PackageRepository.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/environment/PackageRepository.java
@@ -54,5 +54,13 @@ public interface PackageRepository {
     Collection<PackageMetadataResponse> getPackageMetadata(Collection<ResolutionRequest> requests,
                                                            ResolutionOptions options);
 
-    List<ImportModuleResponse> resolvePackageNames(List<ImportModuleRequest> importModuleRequests);
+    /**
+     * Resolve requested import declaration with hierarchical module name to packages.
+     *
+     * @param requests import declaration collection
+     * @param options  resolution options
+     * @return a collection of resolved package metadata
+     */
+    Collection<ImportModuleResponse> getPackageNames(Collection<ImportModuleRequest> requests,
+                                                     ResolutionOptions options);
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/environment/PackageRepository.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/environment/PackageRepository.java
@@ -35,9 +35,25 @@ import java.util.Optional;
  */
 public interface PackageRepository {
 
-    Optional<Package> getPackage(ResolutionRequest resolutionRequest);
+    /**
+     * Return the package specified in {@code ResolutionRequest}.
+     * <p>
+     * if the package is not found, this method returns an empty response.
+     *
+     * @param request package request
+     * @param options resolution options
+     * @return The loaded package or else an empty container
+     */
+    Optional<Package> getPackage(ResolutionRequest request, ResolutionOptions options);
 
-    List<PackageVersion> getPackageVersions(ResolutionRequest resolutionRequest);
+    /**
+     * Returns the available package versions in the repository.
+     *
+     * @param request package request
+     * @param options resolution options
+     * @return the available package versions in the repository
+     */
+    Collection<PackageVersion> getPackageVersions(ResolutionRequest request, ResolutionOptions options);
 
     Map<String, List<String>> getPackages();
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/environment/PackageResolver.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/environment/PackageResolver.java
@@ -33,7 +33,8 @@ public interface PackageResolver {
 
     List<ImportModuleResponse> resolvePackageNames(List<ImportModuleRequest> importModuleRequests);
 
-    List<PackageMetadataResponse> resolvePackageMetadata(List<ResolutionRequest> resolutionRequests);
+    Collection<PackageMetadataResponse> resolvePackageMetadata(Collection<ResolutionRequest> requests,
+                                                               ResolutionOptions options);
 
     Collection<ResolutionResponse> resolvePackages(Collection<ResolutionRequest> resolutionRequests, boolean offline);
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/environment/PackageResolver.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/environment/PackageResolver.java
@@ -56,5 +56,13 @@ public interface PackageResolver {
     Collection<PackageMetadataResponse> resolvePackageMetadata(Collection<ResolutionRequest> requests,
                                                                ResolutionOptions options);
 
-    Collection<ResolutionResponse> resolvePackages(Collection<ResolutionRequest> resolutionRequests, boolean offline);
+    /**
+     * Loads the packages specified in {@code ResolutionRequest} collection.
+     *
+     * @param requests package requests
+     * @param options  resolution options
+     * @return a collection of loaded packages
+     */
+    Collection<ResolutionResponse> resolvePackages(Collection<ResolutionRequest> requests,
+                                                   ResolutionOptions options);
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/environment/PackageResolver.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/environment/PackageResolver.java
@@ -21,7 +21,6 @@ import io.ballerina.projects.internal.ImportModuleRequest;
 import io.ballerina.projects.internal.ImportModuleResponse;
 
 import java.util.Collection;
-import java.util.List;
 
 /**
  * Defines the interface that will be used by the resolution logic to resolve
@@ -31,7 +30,15 @@ import java.util.List;
  */
 public interface PackageResolver {
 
-    List<ImportModuleResponse> resolvePackageNames(List<ImportModuleRequest> importModuleRequests);
+    /**
+     * Resolve requested import declaration with hierarchical module name to packages.
+     *
+     * @param requests import declaration collection
+     * @param options  resolution options
+     * @return a collection of resolved package metadata
+     */
+    Collection<ImportModuleResponse> resolvePackageNames(Collection<ImportModuleRequest> requests,
+                                                         ResolutionOptions options);
 
     /**
      * Loads requested packages metadata such as the availability, dependency graph.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/environment/PackageResolver.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/environment/PackageResolver.java
@@ -33,6 +33,19 @@ public interface PackageResolver {
 
     List<ImportModuleResponse> resolvePackageNames(List<ImportModuleRequest> importModuleRequests);
 
+    /**
+     * Loads requested packages metadata such as the availability, dependency graph.
+     * <p>
+     * Metadata requests provide an efficient way to complete the dependency graph without
+     * downloading physical packages from Ballerina central.
+     * <p>
+     * An implementation of the {@code PackageResolver} should issue separate requests
+     * to local, dist and central repositories and aggregate their responses.
+     *
+     * @param requests requested package collection
+     * @param options  resolution options
+     * @return a collection of {@code PackageMetadataResponse} instances
+     */
     Collection<PackageMetadataResponse> resolvePackageMetadata(Collection<ResolutionRequest> requests,
                                                                ResolutionOptions options);
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/environment/ResolutionOptions.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/environment/ResolutionOptions.java
@@ -1,0 +1,86 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package io.ballerina.projects.environment;
+
+/**
+ * Holds the options used by the package resolution components.
+ *
+ * @since 2.0.0
+ */
+public class ResolutionOptions {
+    private final boolean offline;
+    private final boolean sticky;
+
+    private ResolutionOptions(boolean offline, boolean sticky) {
+        this.offline = offline;
+        this.sticky = sticky;
+    }
+
+    /**
+     * Offline mode indicates whether the resolution system makes network calls to Ballerina central API or not.
+     * <p>
+     * A `false` value indicates that the system will make connections to Ballerina central.
+     * <p>
+     * The default value is 'false'.
+     *
+     * @return true if offline mode is enabled, otherwise false
+     */
+    public boolean offline() {
+        return offline;
+    }
+
+    /**
+     * If the sticky mode is enabled, the resolution system attempts use the dependency versions
+     * recorded in Ballerina.toml as much as possible.
+     * <p>
+     * The default value is 'true'.
+     *
+     * @return true if sticky model is enabled, otherwise false
+     */
+    public boolean sticky() {
+        return sticky;
+    }
+
+    public static ResolutionOptionBuilder builder() {
+        return new ResolutionOptionBuilder();
+    }
+
+    /**
+     * A builder for the {@code ResolutionOptions}.
+     *
+     * @since 2.0.0
+     */
+    public static class ResolutionOptionBuilder {
+        private boolean offline = false;
+        private boolean sticky = true;
+
+        public ResolutionOptionBuilder setOffline(boolean value) {
+            offline = value;
+            return this;
+        }
+
+        public ResolutionOptionBuilder setSticky(boolean value) {
+            sticky = value;
+            return this;
+        }
+
+        public ResolutionOptions build() {
+            return new ResolutionOptions(offline, sticky);
+        }
+    }
+}

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/environment/ResolutionRequest.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/environment/ResolutionRequest.java
@@ -36,10 +36,7 @@ import java.util.Optional;
 public final class ResolutionRequest {
     private final PackageDescriptor packageDesc;
     private final PackageDependencyScope scope;
-
-    // TODO Why did we introduce the offline flag here.
     private final DependencyResolutionType dependencyResolutionType;
-    private final boolean offline;
 
     // TODO rethink about this
     private final PackageLockingMode packageLockingMode;
@@ -47,41 +44,37 @@ public final class ResolutionRequest {
     private ResolutionRequest(PackageDescriptor packageDescriptor,
                               PackageDependencyScope scope,
                               DependencyResolutionType dependencyResolutionType,
-                              boolean offline,
                               PackageLockingMode packageLockingMode) {
         this.packageDesc = packageDescriptor;
         this.scope = scope;
         this.dependencyResolutionType = dependencyResolutionType;
-        this.offline = offline;
         this.packageLockingMode = packageLockingMode;
     }
 
-    public static ResolutionRequest from(PackageDescriptor packageDescriptor, boolean offline) {
+    public static ResolutionRequest from(PackageDescriptor packageDescriptor) {
         return new ResolutionRequest(packageDescriptor, PackageDependencyScope.DEFAULT,
-                DependencyResolutionType.SOURCE, offline, PackageLockingMode.MEDIUM);
+                DependencyResolutionType.SOURCE, PackageLockingMode.MEDIUM);
+    }
+
+    public static ResolutionRequest from(PackageDescriptor packageDescriptor,
+                                         PackageDependencyScope scope) {
+        return new ResolutionRequest(packageDescriptor, scope,
+                DependencyResolutionType.SOURCE, PackageLockingMode.MEDIUM);
     }
 
     public static ResolutionRequest from(PackageDescriptor packageDescriptor,
                                          PackageDependencyScope scope,
-                                         boolean offline) {
-        return new ResolutionRequest(packageDescriptor, scope, DependencyResolutionType.SOURCE,
-                offline, PackageLockingMode.MEDIUM);
-    }
-
-    public static ResolutionRequest from(PackageDescriptor packageDescriptor,
-                                         PackageDependencyScope scope,
-                                         DependencyResolutionType resolutionType,
-                                         boolean offline) {
-        return new ResolutionRequest(packageDescriptor, scope, resolutionType, offline,
-                PackageLockingMode.MEDIUM);
+                                         DependencyResolutionType resolutionType) {
+        return new ResolutionRequest(packageDescriptor, scope,
+                resolutionType, PackageLockingMode.MEDIUM);
     }
 
     public static ResolutionRequest from(PackageDescriptor packageDescriptor,
                                          PackageDependencyScope scope,
                                          DependencyResolutionType dependencyResolutionType,
-                                         boolean offline,
                                          PackageLockingMode packageLockingMode) {
-        return new ResolutionRequest(packageDescriptor, scope, dependencyResolutionType, offline,
+        return new ResolutionRequest(packageDescriptor, scope,
+                dependencyResolutionType,
                 packageLockingMode);
     }
 
@@ -107,10 +100,6 @@ public final class ResolutionRequest {
 
     public Optional<String> repositoryName() {
         return packageDesc.repository();
-    }
-
-    public boolean offline() {
-        return offline;
     }
 
     public PackageLockingMode packageLockingMode() {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ImportModuleRequest.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ImportModuleRequest.java
@@ -33,7 +33,6 @@ public class ImportModuleRequest {
     private final PackageOrg packageOrg;
     private final String moduleName;
     private final List<PackageDescriptor> possiblePackages;
-    // TODO need to have an offline flag
 
     private ModuleLoadRequest moduleLoadRequest;
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ModuleResolver.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ModuleResolver.java
@@ -26,6 +26,7 @@ import io.ballerina.projects.PackageName;
 import io.ballerina.projects.PackageOrg;
 import io.ballerina.projects.environment.ModuleLoadRequest;
 import io.ballerina.projects.environment.PackageResolver;
+import io.ballerina.projects.environment.ResolutionOptions;
 import io.ballerina.projects.environment.ResolutionResponse;
 import io.ballerina.projects.util.ProjectConstants;
 import io.ballerina.projects.util.ProjectUtils;
@@ -50,16 +51,19 @@ public class ModuleResolver {
     private final BlendedManifest blendedManifest;
     private final DependencyManifest dependencyManifest;
     private final PackageResolver packageResolver;
+    private final ResolutionOptions resolutionOptions;
 
     public ModuleResolver(PackageDescriptor rootPkgDesc,
                           Collection<ModuleName> moduleNames,
                           BlendedManifest blendedManifest,
-                          PackageResolver packageResolver) {
+                          PackageResolver packageResolver,
+                          ResolutionOptions resolutionOptions) {
         this.rootPkgDesc = rootPkgDesc;
         this.moduleNames = moduleNames;
         this.blendedManifest = blendedManifest;
         this.dependencyManifest = blendedManifest.dependencyManifest();
         this.packageResolver = packageResolver;
+        this.resolutionOptions = resolutionOptions;
     }
 
     public ImportModuleResponse getImportModuleResponse(ImportModuleRequest importModuleRequest) {
@@ -80,8 +84,8 @@ public class ModuleResolver {
         }
 
         // Resolve unresolved import module declarations
-        List<ImportModuleResponse> importModResponses =
-                packageResolver.resolvePackageNames(unresolvedModuleRequests);
+        Collection<ImportModuleResponse> importModResponses =
+                packageResolver.resolvePackageNames(unresolvedModuleRequests, resolutionOptions);
         for (ImportModuleResponse importModResp : importModResponses) {
             if (importModResp.resolutionStatus() == ResolutionResponse.ResolutionStatus.UNRESOLVED) {
                 // TODO Report diagnostics

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ResolutionEngine.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ResolutionEngine.java
@@ -182,7 +182,7 @@ public class ResolutionEngine {
             }
 
             resolutionRequests.add(ResolutionRequest.from(pkgDesc, directDependency.scope(),
-                    directDependency.resolutionType(), resolutionOptions.offline(), lockingMode));
+                    directDependency.resolutionType(), lockingMode));
         }
 
         return packageResolver.resolvePackageMetadata(resolutionRequests, resolutionOptions);
@@ -220,8 +220,7 @@ public class ResolutionEngine {
             List<ResolutionRequest> resRequests = new ArrayList<>(unresolvedNodes.size());
             for (DependencyNode unresolvedNode : unresolvedNodes) {
                 resRequests.add(ResolutionRequest.from(unresolvedNode.pkgDesc(),
-                        unresolvedNode.scope(), unresolvedNode.resolutionType(),
-                        resolutionOptions.offline(), lockingMode));
+                        unresolvedNode.scope(), unresolvedNode.resolutionType(), lockingMode));
             }
 
             Collection<PackageMetadataResponse> pkgMetadataResponses =

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/environment/DefaultPackageResolver.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/environment/DefaultPackageResolver.java
@@ -67,14 +67,15 @@ public class DefaultPackageResolver implements PackageResolver {
     }
 
     @Override
-    public List<ImportModuleResponse> resolvePackageNames(List<ImportModuleRequest> importModuleRequests) {
-        // We will only receive hierarchical imports in importModuleRequests
-        List<ImportModuleResponse> responseListInDist = distributionRepo.resolvePackageNames(importModuleRequests);
-        List<ImportModuleResponse> responseListInCentral =
-                centralRepo.resolvePackageNames(importModuleRequests);
+    public Collection<ImportModuleResponse> resolvePackageNames(Collection<ImportModuleRequest> requests,
+                                                                ResolutionOptions options) {
+        // We will only receive hierarchical imports in requests
+        Collection<ImportModuleResponse> responseListInDist = distributionRepo.getPackageNames(requests, options);
+        Collection<ImportModuleResponse> responseListInCentral = centralRepo.getPackageNames(requests, options);
 
         return new ArrayList<>(
-                Stream.of(responseListInDist, responseListInCentral).flatMap(List::stream).collect(Collectors.toMap(
+                Stream.of(responseListInDist, responseListInCentral)
+                        .flatMap(Collection::stream).collect(Collectors.toMap(
                         ImportModuleResponse::importModuleRequest, Function.identity(),
                         (ImportModuleResponse x, ImportModuleResponse y) -> {
                             if (y.resolutionStatus().equals(ResolutionStatus.UNRESOLVED)) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/environment/DefaultPackageResolver.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/environment/DefaultPackageResolver.java
@@ -113,20 +113,20 @@ public class DefaultPackageResolver implements PackageResolver {
             }
         }
 
-        Collection<PackageMetadataResponse> localRepoPackages =
-                localRepoRequests.isEmpty() ?
-                        Collections.emptyList() : localRepo.resolvePackageMetadata(localRepoRequests, options);
+        Collection<PackageMetadataResponse> localRepoPackages = localRepoRequests.isEmpty() ?
+                Collections.emptyList() :
+                localRepo.getPackageMetadata(localRepoRequests, options);
 
         // TODO Send ballerina* org names to dist repo
         Collection<PackageMetadataResponse> latestVersionsInDist =
-                distributionRepo.resolvePackageMetadata(requests, options);
+                distributionRepo.getPackageMetadata(requests, options);
 
         // Send non built in packages to central
         Collection<ResolutionRequest> centralLoadRequests = requests.stream()
                 .filter(r -> !ProjectUtils.isBuiltInPackage(r.orgName(), r.packageName().value()))
                 .collect(Collectors.toList());
         Collection<PackageMetadataResponse> latestVersionsInCentral =
-                centralRepo.resolvePackageMetadata(centralLoadRequests, options);
+                centralRepo.getPackageMetadata(centralLoadRequests, options);
 
         // TODO Local package should get priority over the same version in central or dist repo
         // TODO Unit test following merge

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/environment/DefaultPackageResolver.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/environment/DefaultPackageResolver.java
@@ -86,7 +86,7 @@ public class DefaultPackageResolver implements PackageResolver {
                             }
                             if (!x.packageDescriptor().name().equals(y.packageDescriptor().name())) {
                                 ResolutionRequest resolutionRequest = ResolutionRequest
-                                        .from(y.packageDescriptor(), PackageDependencyScope.DEFAULT, true);
+                                        .from(y.packageDescriptor(), PackageDependencyScope.DEFAULT);
                                 Collection<PackageVersion> packageVersions =
                                         distributionRepo.getPackageVersions(resolutionRequest, options);
                                 // If module exists in both repos, then we check if a newer version of

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/AbstractPackageRepository.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/AbstractPackageRepository.java
@@ -27,6 +27,7 @@ import io.ballerina.projects.SemanticVersion;
 import io.ballerina.projects.environment.PackageLockingMode;
 import io.ballerina.projects.environment.PackageMetadataResponse;
 import io.ballerina.projects.environment.PackageRepository;
+import io.ballerina.projects.environment.ResolutionOptions;
 import io.ballerina.projects.environment.ResolutionRequest;
 import io.ballerina.projects.internal.ImportModuleRequest;
 import io.ballerina.projects.internal.ImportModuleResponse;
@@ -47,16 +48,17 @@ import java.util.stream.Collectors;
 public abstract class AbstractPackageRepository implements PackageRepository {
 
     @Override
-    public List<PackageMetadataResponse> resolvePackageMetadata(List<ResolutionRequest> resolutionRequests) {
+    public Collection<PackageMetadataResponse> resolvePackageMetadata(Collection<ResolutionRequest> requests,
+                                                                      ResolutionOptions options) {
         List<PackageMetadataResponse> descriptorSet = new ArrayList<>();
-        for (ResolutionRequest resolutionRequest : resolutionRequests) {
+        for (ResolutionRequest request : requests) {
             List<PackageVersion> versions = getCompatiblePackageVersions(
-                    resolutionRequest.packageDescriptor(), resolutionRequest.packageLockingMode());
+                    request.packageDescriptor(), request.packageLockingMode());
             PackageVersion latest = findLatest(versions);
             if (latest != null) {
-                descriptorSet.add(createMetadataResponse(resolutionRequest, latest));
+                descriptorSet.add(createMetadataResponse(request, latest));
             } else {
-                descriptorSet.add(PackageMetadataResponse.createUnresolvedResponse(resolutionRequest));
+                descriptorSet.add(PackageMetadataResponse.createUnresolvedResponse(request));
             }
         }
         return descriptorSet;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/AbstractPackageRepository.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/AbstractPackageRepository.java
@@ -65,9 +65,10 @@ public abstract class AbstractPackageRepository implements PackageRepository {
     }
 
     @Override
-    public List<ImportModuleResponse> resolvePackageNames(List<ImportModuleRequest> importModuleRequests) {
+    public Collection<ImportModuleResponse> getPackageNames(Collection<ImportModuleRequest> requests,
+                                                            ResolutionOptions options) {
         List<ImportModuleResponse> importModuleResponseList = new ArrayList<>();
-        for (ImportModuleRequest importModuleRequest : importModuleRequests) {
+        for (ImportModuleRequest importModuleRequest : requests) {
             ImportModuleResponse importModuleLoadResponse = getImportModuleLoadResponse(importModuleRequest);
             importModuleResponseList.add(importModuleLoadResponse);
         }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/AbstractPackageRepository.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/AbstractPackageRepository.java
@@ -48,8 +48,8 @@ import java.util.stream.Collectors;
 public abstract class AbstractPackageRepository implements PackageRepository {
 
     @Override
-    public Collection<PackageMetadataResponse> resolvePackageMetadata(Collection<ResolutionRequest> requests,
-                                                                      ResolutionOptions options) {
+    public Collection<PackageMetadataResponse> getPackageMetadata(Collection<ResolutionRequest> requests,
+                                                                  ResolutionOptions options) {
         List<PackageMetadataResponse> descriptorSet = new ArrayList<>();
         for (ResolutionRequest request : requests) {
             List<PackageVersion> versions = getCompatiblePackageVersions(

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/FileSystemRepository.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/FileSystemRepository.java
@@ -30,6 +30,7 @@ import io.ballerina.projects.ProjectEnvironmentBuilder;
 import io.ballerina.projects.ProjectException;
 import io.ballerina.projects.bala.BalaProject;
 import io.ballerina.projects.environment.Environment;
+import io.ballerina.projects.environment.ResolutionOptions;
 import io.ballerina.projects.environment.ResolutionRequest;
 import io.ballerina.projects.internal.BalaFiles;
 import io.ballerina.projects.repos.FileSystemCache;
@@ -89,12 +90,12 @@ public class FileSystemRepository extends AbstractPackageRepository {
     }
 
     @Override
-    public Optional<Package> getPackage(ResolutionRequest resolutionRequest) {
+    public Optional<Package> getPackage(ResolutionRequest request, ResolutionOptions options) {
         // if version and org name is empty we add empty string so we return empty package anyway
-        String packageName = resolutionRequest.packageName().value();
-        String orgName = resolutionRequest.orgName().value();
-        String version = resolutionRequest.version().isPresent() ?
-                resolutionRequest.version().get().toString() : "0.0.0";
+        String packageName = request.packageName().value();
+        String orgName = request.orgName().value();
+        String version = request.version().isPresent() ?
+                request.version().get().toString() : "0.0.0";
 
         Path balaPath = getPackagePath(orgName, packageName, version);
         if (!Files.exists(balaPath)) {
@@ -109,10 +110,10 @@ public class FileSystemRepository extends AbstractPackageRepository {
     }
 
     @Override
-    public List<PackageVersion> getPackageVersions(ResolutionRequest resolutionRequest) {
+    public Collection<PackageVersion> getPackageVersions(ResolutionRequest request, ResolutionOptions options) {
         // if version and org name is empty we add empty string so we return empty package anyway
-        return getPackageVersions(resolutionRequest.orgName(), resolutionRequest.packageName(),
-                resolutionRequest.version().orElse(null));
+        return getPackageVersions(request.orgName(), request.packageName(),
+                request.version().orElse(null));
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/RemotePackageRepository.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/RemotePackageRepository.java
@@ -230,16 +230,14 @@ public class RemotePackageRepository implements PackageRepository {
         return request;
     }
 
-    public Collection<PackageMetadataResponse> resolvePackageMetadata(Collection<ResolutionRequest> requests,
-                                                                      ResolutionOptions options) {
-
+    public Collection<PackageMetadataResponse> getPackageMetadata(Collection<ResolutionRequest> requests,
+                                                                  ResolutionOptions options) {
         if (requests.isEmpty()) {
             return Collections.emptyList();
         }
 
         // Resolve all the requests locally
-        Collection<PackageMetadataResponse> cachedPackages =
-                fileSystemRepo.resolvePackageMetadata(requests, options);
+        Collection<PackageMetadataResponse> cachedPackages = fileSystemRepo.getPackageMetadata(requests, options);
         if (options.offline()) {
             return cachedPackages;
         }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/RemotePackageRepository.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/RemotePackageRepository.java
@@ -156,8 +156,9 @@ public class RemotePackageRepository implements PackageRepository {
     }
 
     @Override
-    public List<ImportModuleResponse> resolvePackageNames(List<ImportModuleRequest> importModuleRequests) {
-        List<ImportModuleResponse> filesystem = fileSystemRepo.resolvePackageNames(importModuleRequests);
+    public Collection<ImportModuleResponse> getPackageNames(Collection<ImportModuleRequest> requests,
+                                                            ResolutionOptions options) {
+        Collection<ImportModuleResponse> filesystem = fileSystemRepo.getPackageNames(requests, options);
         List<ImportModuleResponse> unresolved = filesystem.stream()
                 .filter(r -> r.resolutionStatus().equals(ResolutionResponse.ResolutionStatus.UNRESOLVED))
                 .collect(Collectors.toList());
@@ -179,8 +180,8 @@ public class RemotePackageRepository implements PackageRepository {
         return filesystem;
     }
 
-    private List<ImportModuleResponse> mergeNameResolution(List<ImportModuleResponse> filesystem,
-                                                           List<ImportModuleResponse> remote) {
+    private List<ImportModuleResponse> mergeNameResolution(Collection<ImportModuleResponse> filesystem,
+                                                           Collection<ImportModuleResponse> remote) {
         List<ImportModuleResponse> all = new ArrayList<>();
         // We assume file system responses will have all module requests
         for (ImportModuleResponse fileResponse : filesystem) {

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/FileSystemRepositoryTests.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/FileSystemRepositoryTests.java
@@ -29,7 +29,6 @@ import org.testng.annotations.Test;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
-import java.util.List;
 
 /**
  * Test file system repository.
@@ -55,10 +54,9 @@ public class FileSystemRepositoryTests {
     public void testGetPackageVersions() {
         ResolutionRequest resolutionRequest = ResolutionRequest.from(
                 PackageDescriptor.from(PackageOrg.from("hevayo"), PackageName.from("package_a"), null),
-                PackageDependencyScope.DEFAULT, true
-        );
+                PackageDependencyScope.DEFAULT);
         Collection<PackageVersion> versions = fileSystemRepository.getPackageVersions(resolutionRequest,
-                ResolutionOptions.builder().build());
+                ResolutionOptions.builder().setOffline(true).build());
         Assert.assertEquals(versions.size(), 2);
         Assert.assertTrue(versions.contains(PackageVersion.from("0.1.2")));
         Assert.assertTrue(versions.contains(PackageVersion.from("0.1.5")));

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/FileSystemRepositoryTests.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/FileSystemRepositoryTests.java
@@ -19,6 +19,7 @@
 package io.ballerina.projects;
 
 import io.ballerina.projects.environment.Environment;
+import io.ballerina.projects.environment.ResolutionOptions;
 import io.ballerina.projects.environment.ResolutionRequest;
 import io.ballerina.projects.internal.repositories.FileSystemRepository;
 import org.testng.Assert;
@@ -27,6 +28,7 @@ import org.testng.annotations.Test;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -51,12 +53,12 @@ public class FileSystemRepositoryTests {
 
     @Test
     public void testGetPackageVersions() {
-
         ResolutionRequest resolutionRequest = ResolutionRequest.from(
                 PackageDescriptor.from(PackageOrg.from("hevayo"), PackageName.from("package_a"), null),
                 PackageDependencyScope.DEFAULT, true
         );
-        List<PackageVersion> versions = fileSystemRepository.getPackageVersions(resolutionRequest);
+        Collection<PackageVersion> versions = fileSystemRepository.getPackageVersions(resolutionRequest,
+                ResolutionOptions.builder().build());
         Assert.assertEquals(versions.size(), 2);
         Assert.assertTrue(versions.contains(PackageVersion.from("0.1.2")));
         Assert.assertTrue(versions.contains(PackageVersion.from("0.1.5")));

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/RemotePackageRepositoryTests.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/RemotePackageRepositoryTests.java
@@ -246,12 +246,11 @@ public class RemotePackageRepositoryTests {
                 anyString(), anyString(), anyBoolean())).thenReturn(centralResponse);
 
         // Mock response from file system
-        when(fileSystemRepository.resolvePackageNames(anyList()))
+        when(fileSystemRepository.getPackageNames(anyList(), any(ResolutionOptions.class)))
                 .thenReturn(Arrays.asList(fileJavaArray, fileCovid, fileUnresolved));
 
-
-        List<ImportModuleResponse> response = this.remotePackageRepository
-                .resolvePackageNames(Arrays.asList(javaArrayReq, covidReq, unknownReq));
+        List<ImportModuleResponse> response = new ArrayList<>(this.remotePackageRepository
+                .getPackageNames(Arrays.asList(javaArrayReq, covidReq, unknownReq), offlineFalseOption));
 
         Assert.assertEquals(response.size(), 3);
         ImportModuleResponse javaArray = response.get(0);

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/RemotePackageRepositoryTests.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/RemotePackageRepositoryTests.java
@@ -55,9 +55,9 @@ public class RemotePackageRepositoryTests {
     PackageDescriptor smtp130 = PackageDescriptor.from(
             PackageOrg.from("ballerinax"), PackageName.from("smtp"), PackageVersion.from("1.3.0"));
     // - Resolution requests
-    ResolutionRequest resHttp120 = ResolutionRequest.from(http120, PackageDependencyScope.DEFAULT, false);
-    ResolutionRequest resCovid156 = ResolutionRequest.from(covid156, PackageDependencyScope.DEFAULT, false);
-    ResolutionRequest resSmtp130 = ResolutionRequest.from(smtp130, PackageDependencyScope.DEFAULT, false);
+    ResolutionRequest resHttp120 = ResolutionRequest.from(http120, PackageDependencyScope.DEFAULT);
+    ResolutionRequest resCovid156 = ResolutionRequest.from(covid156, PackageDependencyScope.DEFAULT);
+    ResolutionRequest resSmtp130 = ResolutionRequest.from(smtp130, PackageDependencyScope.DEFAULT);
 
     ResolutionOptions offlineTrueOption = ResolutionOptions.builder().setOffline(true).build();
     ResolutionOptions offlineFalseOption = ResolutionOptions.builder().setOffline(false).build();
@@ -169,8 +169,8 @@ public class RemotePackageRepositoryTests {
                 .thenReturn(Arrays.asList(fileHttp120, fileCovid159));
 
         // Test call to remote repository
-        ResolutionRequest resHttp120Offline = ResolutionRequest.from(http120, PackageDependencyScope.DEFAULT, true);
-        ResolutionRequest resCovid156Offline = ResolutionRequest.from(covid156, PackageDependencyScope.DEFAULT, true);
+        ResolutionRequest resHttp120Offline = ResolutionRequest.from(http120, PackageDependencyScope.DEFAULT);
+        ResolutionRequest resCovid156Offline = ResolutionRequest.from(covid156, PackageDependencyScope.DEFAULT);
         List<PackageMetadataResponse> resolutionResponseDescriptors = new ArrayList<>(
                 remotePackageRepository.getPackageMetadata(
                         Arrays.asList(resHttp120Offline, resCovid156Offline), offlineTrueOption));

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/RemotePackageRepositoryTests.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/RemotePackageRepositoryTests.java
@@ -92,12 +92,12 @@ public class RemotePackageRepositoryTests {
         when(centralAPIClient.resolveDependencies(any(PackageResolutionRequest.class),
                 anyString(), anyString(), anyBoolean())).thenReturn(response);
         // Mock response from file system
-        when(fileSystemRepository.resolvePackageMetadata(anyList(), offlineFalseOption))
+        when(fileSystemRepository.getPackageMetadata(anyList(), any(ResolutionOptions.class)))
                 .thenReturn(Arrays.asList(fileHttp120, fileCovid159));
 
         // Test call to remote repository
         List<PackageMetadataResponse> resolutionResponseDescriptors = new ArrayList<>(
-                remotePackageRepository.resolvePackageMetadata(
+                remotePackageRepository.getPackageMetadata(
                         Arrays.asList(resHttp120, resCovid156), offlineFalseOption));
 
         // response should return resolution for same number of requests
@@ -127,13 +127,13 @@ public class RemotePackageRepositoryTests {
         when(centralAPIClient.resolveDependencies(any(PackageResolutionRequest.class),
                 anyString(), anyString(), anyBoolean())).thenReturn(response);
         // Mock response from file system
-        when(fileSystemRepository.resolvePackageMetadata(anyList(), offlineFalseOption))
+        when(fileSystemRepository.getPackageMetadata(anyList(), any(ResolutionOptions.class)))
                 .thenReturn(Arrays.asList(PackageMetadataResponse.createUnresolvedResponse(resHttp120),
                         fileCovid159, fileSmtp130));
 
         // Test call to remote repository
         List<PackageMetadataResponse> resolutionResponseDescriptors = new ArrayList<>(
-                remotePackageRepository.resolvePackageMetadata(
+                remotePackageRepository.getPackageMetadata(
                         Arrays.asList(resHttp120, resCovid156, resSmtp130), offlineFalseOption));
 
         // response should return resolution for same number of requests
@@ -165,14 +165,14 @@ public class RemotePackageRepositoryTests {
                 anyString(), anyString(), anyBoolean()))
                 .thenThrow(new AssertionError("Client get called in offline mode"));
         // Mock response from file system
-        when(fileSystemRepository.resolvePackageMetadata(anyList(), offlineTrueOption))
+        when(fileSystemRepository.getPackageMetadata(anyList(), any(ResolutionOptions.class)))
                 .thenReturn(Arrays.asList(fileHttp120, fileCovid159));
 
         // Test call to remote repository
         ResolutionRequest resHttp120Offline = ResolutionRequest.from(http120, PackageDependencyScope.DEFAULT, true);
         ResolutionRequest resCovid156Offline = ResolutionRequest.from(covid156, PackageDependencyScope.DEFAULT, true);
         List<PackageMetadataResponse> resolutionResponseDescriptors = new ArrayList<>(
-                remotePackageRepository.resolvePackageMetadata(
+                remotePackageRepository.getPackageMetadata(
                         Arrays.asList(resHttp120Offline, resCovid156Offline), offlineTrueOption));
 
         // response should return resolution for same number of requests
@@ -198,12 +198,12 @@ public class RemotePackageRepositoryTests {
         when(centralAPIClient.resolveDependencies(any(PackageResolutionRequest.class),
                 anyString(), anyString(), anyBoolean())).thenThrow(new ConnectionErrorException("500 Error"));
         // Mock response from file system
-        when(fileSystemRepository.resolvePackageMetadata(anyList(), offlineFalseOption))
+        when(fileSystemRepository.getPackageMetadata(anyList(), any(ResolutionOptions.class)))
                 .thenReturn(Arrays.asList(fileHttp120, fileCovid159));
 
         // Test call to remote repository
         List<PackageMetadataResponse> resolutionResponseDescriptors = new ArrayList<>(
-                remotePackageRepository.resolvePackageMetadata(
+                remotePackageRepository.getPackageMetadata(
                         Arrays.asList(resHttp120, resCovid156), offlineFalseOption));
 
         // response should return resolution for same number of requests

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/RemotePackageRepositoryTests.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/RemotePackageRepositoryTests.java
@@ -1,6 +1,7 @@
 package io.ballerina.projects;
 
 import io.ballerina.projects.environment.PackageMetadataResponse;
+import io.ballerina.projects.environment.ResolutionOptions;
 import io.ballerina.projects.environment.ResolutionRequest;
 import io.ballerina.projects.environment.ResolutionResponse;
 import io.ballerina.projects.internal.ImportModuleRequest;
@@ -20,6 +21,7 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -53,9 +55,12 @@ public class RemotePackageRepositoryTests {
     PackageDescriptor smtp130 = PackageDescriptor.from(
             PackageOrg.from("ballerinax"), PackageName.from("smtp"), PackageVersion.from("1.3.0"));
     // - Resolution requests
-    ResolutionRequest resHttp120 = ResolutionRequest.from(http120 , PackageDependencyScope.DEFAULT, false);
-    ResolutionRequest resCovid156 = ResolutionRequest.from(covid156 , PackageDependencyScope.DEFAULT, false);
-    ResolutionRequest resSmtp130 = ResolutionRequest.from(smtp130 , PackageDependencyScope.DEFAULT, false);
+    ResolutionRequest resHttp120 = ResolutionRequest.from(http120, PackageDependencyScope.DEFAULT, false);
+    ResolutionRequest resCovid156 = ResolutionRequest.from(covid156, PackageDependencyScope.DEFAULT, false);
+    ResolutionRequest resSmtp130 = ResolutionRequest.from(smtp130, PackageDependencyScope.DEFAULT, false);
+
+    ResolutionOptions offlineTrueOption = ResolutionOptions.builder().setOffline(true).build();
+    ResolutionOptions offlineFalseOption = ResolutionOptions.builder().setOffline(false).build();
 
     // - Data returned from central client
     // -- dependency package
@@ -87,18 +92,19 @@ public class RemotePackageRepositoryTests {
         when(centralAPIClient.resolveDependencies(any(PackageResolutionRequest.class),
                 anyString(), anyString(), anyBoolean())).thenReturn(response);
         // Mock response from file system
-        when(fileSystemRepository.resolvePackageMetadata(anyList()))
+        when(fileSystemRepository.resolvePackageMetadata(anyList(), offlineFalseOption))
                 .thenReturn(Arrays.asList(fileHttp120, fileCovid159));
 
         // Test call to remote repository
-        List<PackageMetadataResponse> resolutionResponseDescriptors =
-                remotePackageRepository.resolvePackageMetadata(Arrays.asList(resHttp120, resCovid156));
+        List<PackageMetadataResponse> resolutionResponseDescriptors = new ArrayList<>(
+                remotePackageRepository.resolvePackageMetadata(
+                        Arrays.asList(resHttp120, resCovid156), offlineFalseOption));
 
         // response should return resolution for same number of requests
         Assert.assertEquals(resolutionResponseDescriptors.size(), 2);
 
         // If the remote repository version is higher than filesystem it should return remote version
-        PackageMetadataResponse httpResult =  resolutionResponseDescriptors.get(0);
+        PackageMetadataResponse httpResult = resolutionResponseDescriptors.get(0);
         Assert.assertEquals(httpResult.resolvedDescriptor().version().toString(), "1.2.2");
         Assert.assertEquals(httpResult.resolutionStatus(), ResolutionResponse.ResolutionStatus.RESOLVED);
 
@@ -121,19 +127,20 @@ public class RemotePackageRepositoryTests {
         when(centralAPIClient.resolveDependencies(any(PackageResolutionRequest.class),
                 anyString(), anyString(), anyBoolean())).thenReturn(response);
         // Mock response from file system
-        when(fileSystemRepository.resolvePackageMetadata(anyList()))
+        when(fileSystemRepository.resolvePackageMetadata(anyList(), offlineFalseOption))
                 .thenReturn(Arrays.asList(PackageMetadataResponse.createUnresolvedResponse(resHttp120),
                         fileCovid159, fileSmtp130));
 
         // Test call to remote repository
-        List<PackageMetadataResponse> resolutionResponseDescriptors =
-                remotePackageRepository.resolvePackageMetadata(Arrays.asList(resHttp120, resCovid156, resSmtp130));
+        List<PackageMetadataResponse> resolutionResponseDescriptors = new ArrayList<>(
+                remotePackageRepository.resolvePackageMetadata(
+                        Arrays.asList(resHttp120, resCovid156, resSmtp130), offlineFalseOption));
 
         // response should return resolution for same number of requests
         Assert.assertEquals(resolutionResponseDescriptors.size(), 3);
 
         // if local is unresolved it should return remote
-        PackageMetadataResponse httpResult =  resolutionResponseDescriptors.get(0);
+        PackageMetadataResponse httpResult = resolutionResponseDescriptors.get(0);
         Assert.assertEquals(httpResult.resolvedDescriptor().version().toString(), "1.2.2");
         Assert.assertEquals(httpResult.resolutionStatus(), ResolutionResponse.ResolutionStatus.RESOLVED);
 
@@ -158,20 +165,21 @@ public class RemotePackageRepositoryTests {
                 anyString(), anyString(), anyBoolean()))
                 .thenThrow(new AssertionError("Client get called in offline mode"));
         // Mock response from file system
-        when(fileSystemRepository.resolvePackageMetadata(anyList()))
+        when(fileSystemRepository.resolvePackageMetadata(anyList(), offlineTrueOption))
                 .thenReturn(Arrays.asList(fileHttp120, fileCovid159));
 
         // Test call to remote repository
-        ResolutionRequest resHttp120Offline = ResolutionRequest.from(http120 , PackageDependencyScope.DEFAULT, true);
-        ResolutionRequest resCovid156Offline = ResolutionRequest.from(covid156 , PackageDependencyScope.DEFAULT, true);
-        List<PackageMetadataResponse> resolutionResponseDescriptors =
-                remotePackageRepository.resolvePackageMetadata(Arrays.asList(resHttp120Offline, resCovid156Offline));
+        ResolutionRequest resHttp120Offline = ResolutionRequest.from(http120, PackageDependencyScope.DEFAULT, true);
+        ResolutionRequest resCovid156Offline = ResolutionRequest.from(covid156, PackageDependencyScope.DEFAULT, true);
+        List<PackageMetadataResponse> resolutionResponseDescriptors = new ArrayList<>(
+                remotePackageRepository.resolvePackageMetadata(
+                        Arrays.asList(resHttp120Offline, resCovid156Offline), offlineTrueOption));
 
         // response should return resolution for same number of requests
         Assert.assertEquals(resolutionResponseDescriptors.size(), 2);
 
         // If the remote repository version is higher than filesystem it should return remote version
-        PackageMetadataResponse httpResult =  resolutionResponseDescriptors.get(0);
+        PackageMetadataResponse httpResult = resolutionResponseDescriptors.get(0);
         Assert.assertEquals(httpResult.resolvedDescriptor().version().toString(), "1.2.1");
         Assert.assertEquals(httpResult.resolutionStatus(), ResolutionResponse.ResolutionStatus.RESOLVED);
 
@@ -190,18 +198,19 @@ public class RemotePackageRepositoryTests {
         when(centralAPIClient.resolveDependencies(any(PackageResolutionRequest.class),
                 anyString(), anyString(), anyBoolean())).thenThrow(new ConnectionErrorException("500 Error"));
         // Mock response from file system
-        when(fileSystemRepository.resolvePackageMetadata(anyList()))
+        when(fileSystemRepository.resolvePackageMetadata(anyList(), offlineFalseOption))
                 .thenReturn(Arrays.asList(fileHttp120, fileCovid159));
 
         // Test call to remote repository
-        List<PackageMetadataResponse> resolutionResponseDescriptors =
-                remotePackageRepository.resolvePackageMetadata(Arrays.asList(resHttp120, resCovid156));
+        List<PackageMetadataResponse> resolutionResponseDescriptors = new ArrayList<>(
+                remotePackageRepository.resolvePackageMetadata(
+                        Arrays.asList(resHttp120, resCovid156), offlineFalseOption));
 
         // response should return resolution for same number of requests
         Assert.assertEquals(resolutionResponseDescriptors.size(), 2);
 
         // If the remote repository version is higher than filesystem it should return remote version
-        PackageMetadataResponse httpResult =  resolutionResponseDescriptors.get(0);
+        PackageMetadataResponse httpResult = resolutionResponseDescriptors.get(0);
         Assert.assertEquals(httpResult.resolvedDescriptor().version().toString(), "1.2.1");
         Assert.assertEquals(httpResult.resolutionStatus(), ResolutionResponse.ResolutionStatus.RESOLVED);
 

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/test/resolution/packages/AbstractPackageResolutionTest.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/test/resolution/packages/AbstractPackageResolutionTest.java
@@ -48,7 +48,7 @@ public abstract class AbstractPackageResolutionTest {
         Path testSuitePath = RESOURCE_DIRECTORY.resolve(testSuiteDirName);
         TestCaseFilePaths filePaths = TestCaseFilePathsBuilder.build(testSuitePath,
                 testSuitePath.resolve(testCaseDirName));
-        PackageResolutionTestCase resolutionTestCase = PackageResolutionTestCaseBuilder.build(filePaths);
+        PackageResolutionTestCase resolutionTestCase = PackageResolutionTestCaseBuilder.build(filePaths, sticky);
         DependencyGraph<DependencyNode> actualGraph = resolutionTestCase.execute(sticky);
         DependencyGraph<DependencyNode> expectedGraph = resolutionTestCase.getExpectedGraph(sticky);
         GraphComparisonResult compResult = GraphUtils.compareGraph(actualGraph, expectedGraph);

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/test/resolution/packages/internal/DefaultPackageRepository.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/test/resolution/packages/internal/DefaultPackageRepository.java
@@ -24,6 +24,7 @@ import io.ballerina.projects.PackageDescriptor;
 import io.ballerina.projects.PackageName;
 import io.ballerina.projects.PackageOrg;
 import io.ballerina.projects.PackageVersion;
+import io.ballerina.projects.environment.ResolutionOptions;
 import io.ballerina.projects.environment.ResolutionRequest;
 import io.ballerina.projects.internal.repositories.AbstractPackageRepository;
 
@@ -91,12 +92,12 @@ public class  DefaultPackageRepository extends AbstractPackageRepository {
     }
 
     @Override
-    public Optional<Package> getPackage(ResolutionRequest resolutionRequest) {
+    public Optional<Package> getPackage(ResolutionRequest request, ResolutionOptions options) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public List<PackageVersion> getPackageVersions(ResolutionRequest resolutionRequest) {
+    public Collection<PackageVersion> getPackageVersions(ResolutionRequest request, ResolutionOptions options) {
         throw new UnsupportedOperationException();
     }
 

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/test/resolution/packages/internal/PackageResolutionTestCase.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/test/resolution/packages/internal/PackageResolutionTestCase.java
@@ -21,6 +21,7 @@ import io.ballerina.projects.DependencyGraph;
 import io.ballerina.projects.PackageDescriptor;
 import io.ballerina.projects.environment.ModuleLoadRequest;
 import io.ballerina.projects.environment.PackageResolver;
+import io.ballerina.projects.environment.ResolutionOptions;
 import io.ballerina.projects.internal.BlendedManifest;
 import io.ballerina.projects.internal.ModuleResolver;
 import io.ballerina.projects.internal.ResolutionEngine;
@@ -60,8 +61,9 @@ public class PackageResolutionTestCase {
     }
 
     public DependencyGraph<DependencyNode> execute(boolean sticky) {
+        ResolutionOptions options = ResolutionOptions.builder().setOffline(true).setSticky(sticky).build();
         ResolutionEngine resolutionEngine = new ResolutionEngine(rootPkgDesc, blendedManifest,
-                packageResolver, moduleResolver, true, sticky);
+                packageResolver, moduleResolver, options);
         return resolutionEngine.resolveDependencies(moduleLoadRequests);
     }
 

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/test/resolution/packages/internal/PackageResolutionTestCaseBuilder.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/test/resolution/packages/internal/PackageResolutionTestCaseBuilder.java
@@ -30,6 +30,7 @@ import io.ballerina.projects.PackageDescriptor;
 import io.ballerina.projects.PackageManifest;
 import io.ballerina.projects.environment.ModuleLoadRequest;
 import io.ballerina.projects.environment.PackageCache;
+import io.ballerina.projects.environment.ResolutionOptions;
 import io.ballerina.projects.internal.BlendedManifest;
 import io.ballerina.projects.internal.ModuleResolver;
 import io.ballerina.projects.internal.ResolutionEngine.DependencyNode;
@@ -55,7 +56,7 @@ public class PackageResolutionTestCaseBuilder {
     private PackageResolutionTestCaseBuilder() {
     }
 
-    public static PackageResolutionTestCase build(TestCaseFilePaths filePaths) {
+    public static PackageResolutionTestCase build(TestCaseFilePaths filePaths, boolean sticky) {
         // Create PackageResolver
         DotGraphBasedPackageResolver packageResolver = buildPackageResolver(filePaths);
 
@@ -86,7 +87,7 @@ public class PackageResolutionTestCaseBuilder {
                 packageManifest, packageResolver.localRepo());
         ModuleResolver moduleResolver = new ModuleResolver(rootPkgDes,
                 getModulesInRootPackage(rootPkgDescWrapper, rootPkgDes),
-                blendedManifest, packageResolver);
+                blendedManifest, packageResolver, ResolutionOptions.builder().setSticky(sticky).build());
         return new PackageResolutionTestCase(rootPkgDes, blendedManifest,
                 packageResolver, moduleResolver, moduleLoadRequests,
                 expectedGraphSticky, expectedGraphNoSticky);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSPackageLoader.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSPackageLoader.java
@@ -22,6 +22,7 @@ import io.ballerina.projects.PackageName;
 import io.ballerina.projects.PackageOrg;
 import io.ballerina.projects.PackageVersion;
 import io.ballerina.projects.environment.PackageRepository;
+import io.ballerina.projects.environment.ResolutionOptions;
 import io.ballerina.projects.environment.ResolutionRequest;
 import io.ballerina.projects.internal.environment.BallerinaDistribution;
 import io.ballerina.projects.internal.environment.DefaultEnvironment;
@@ -82,9 +83,10 @@ public class LSPackageLoader {
                 PackageName packageName = PackageName.from(nameComponent);
                 PackageVersion pkgVersion = PackageVersion.from(version);
                 PackageDescriptor pkdDesc = PackageDescriptor.from(packageOrg, packageName, pkgVersion);
-                ResolutionRequest request = ResolutionRequest.from(pkdDesc, PackageDependencyScope.DEFAULT, true);
+                ResolutionRequest request = ResolutionRequest.from(pkdDesc, PackageDependencyScope.DEFAULT);
 
-                Optional<Package> repoPackage = packageRepository.getPackage(request);
+                Optional<Package> repoPackage = packageRepository.getPackage(request,
+                        ResolutionOptions.builder().setOffline(true).build());
                 repoPackage.ifPresent(packages::add);
             });
         });

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/connector/BallerinaConnectorServiceImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/connector/BallerinaConnectorServiceImpl.java
@@ -52,6 +52,7 @@ import io.ballerina.projects.directory.ProjectLoader;
 import io.ballerina.projects.environment.Environment;
 import io.ballerina.projects.environment.EnvironmentBuilder;
 import io.ballerina.projects.environment.PackageResolver;
+import io.ballerina.projects.environment.ResolutionOptions;
 import io.ballerina.projects.environment.ResolutionRequest;
 import io.ballerina.projects.environment.ResolutionResponse;
 import io.ballerina.projects.repos.TempDirCompilationCache;
@@ -146,14 +147,15 @@ public class BallerinaConnectorServiceImpl implements BallerinaConnectorService 
 
         PackageDescriptor packageDescriptor = PackageDescriptor.from(
                 PackageOrg.from(org), PackageName.from(pkgName), PackageVersion.from(version));
-        ResolutionRequest resolutionRequest = ResolutionRequest.from(packageDescriptor, false);
+        ResolutionRequest resolutionRequest = ResolutionRequest.from(packageDescriptor);
 
         PackageResolver packageResolver = environment.getService(PackageResolver.class);
         Collection<ResolutionResponse> resolutionResponses = packageResolver.resolvePackages(
-                Collections.singletonList(resolutionRequest), false);
-        ResolutionResponse resolutionResponse = resolutionResponses.stream().findFirst().get();
+                Collections.singletonList(resolutionRequest), ResolutionOptions.builder().setOffline(false).build());
+        ResolutionResponse resolutionResponse = resolutionResponses.stream().findFirst().orElse(null);
 
-        if (resolutionResponse.resolutionStatus().equals(ResolutionResponse.ResolutionStatus.RESOLVED)) {
+        if (resolutionResponse != null && resolutionResponse.resolutionStatus().equals(
+                ResolutionResponse.ResolutionStatus.RESOLVED)) {
             Package resolvedPackage = resolutionResponse.resolvedPackage();
             if (resolvedPackage != null) {
                 return resolvedPackage.project().sourceRoot();

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/DependencyGraphTests.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/DependencyGraphTests.java
@@ -302,14 +302,14 @@ public class DependencyGraphTests extends BaseTest {
 
         ResolutionRequest resolutionRequest = ResolutionRequest.from(
                 PackageDescriptor.from(PackageOrg.from("samjs"), PackageName.from("io"), null),
-                PackageDependencyScope.DEFAULT, DependencyResolutionType.SOURCE, true, PackageLockingMode.SOFT);
+                PackageDependencyScope.DEFAULT, DependencyResolutionType.SOURCE, PackageLockingMode.SOFT);
         ResolutionRequest resolutionRequest2 = ResolutionRequest.from(
                 PackageDescriptor.from(PackageOrg.from("samjs"), PackageName.from("cache"), null),
-                PackageDependencyScope.DEFAULT, DependencyResolutionType.SOURCE, true, PackageLockingMode.SOFT);
+                PackageDependencyScope.DEFAULT, DependencyResolutionType.SOURCE, PackageLockingMode.SOFT);
         // Adding an unrelated package to test the unresolved packages
         ResolutionRequest resolutionRequest3 = ResolutionRequest.from(
                 PackageDescriptor.from(PackageOrg.from("samjs"), PackageName.from("dummy"), null),
-                PackageDependencyScope.DEFAULT, DependencyResolutionType.SOURCE, true, PackageLockingMode.SOFT);
+                PackageDependencyScope.DEFAULT, DependencyResolutionType.SOURCE, PackageLockingMode.SOFT);
 
         List<ResolutionRequest> resolutionRequestList = new ArrayList<>();
         resolutionRequestList.add(resolutionRequest);
@@ -341,7 +341,7 @@ public class DependencyGraphTests extends BaseTest {
         // Test passing the request with a version
         resolutionRequest = ResolutionRequest.from(
                 PackageDescriptor.from(PackageOrg.from("samjs"), PackageName.from("io"), PackageVersion.from("1.4.2")),
-                PackageDependencyScope.DEFAULT, DependencyResolutionType.SOURCE, true, PackageLockingMode.SOFT);
+                PackageDependencyScope.DEFAULT, DependencyResolutionType.SOURCE, PackageLockingMode.SOFT);
         responseDescriptors = packageResolver.resolvePackageMetadata(
                 Collections.singletonList(resolutionRequest), resolutionOptions);
 
@@ -361,14 +361,14 @@ public class DependencyGraphTests extends BaseTest {
 
         ResolutionRequest resolutionRequest = ResolutionRequest.from(
                 PackageDescriptor.from(PackageOrg.from("samjs"), PackageName.from("io"), PackageVersion.from("1.4.2")),
-                PackageDependencyScope.DEFAULT, DependencyResolutionType.SOURCE, true, PackageLockingMode.MEDIUM);
+                PackageDependencyScope.DEFAULT, DependencyResolutionType.SOURCE, PackageLockingMode.MEDIUM);
         ResolutionRequest resolutionRequest2 = ResolutionRequest.from(
                 PackageDescriptor.from(PackageOrg.from("samjs"), PackageName.from("cache"), null),
-                PackageDependencyScope.DEFAULT, DependencyResolutionType.SOURCE, true, PackageLockingMode.MEDIUM);
+                PackageDependencyScope.DEFAULT, DependencyResolutionType.SOURCE, PackageLockingMode.MEDIUM);
         // Adding an unrelated package to test the unresolved packages
         ResolutionRequest resolutionRequest3 = ResolutionRequest.from(
                 PackageDescriptor.from(PackageOrg.from("samjs"), PackageName.from("dummy"), null),
-                PackageDependencyScope.DEFAULT, DependencyResolutionType.SOURCE, true, PackageLockingMode.MEDIUM);
+                PackageDependencyScope.DEFAULT, DependencyResolutionType.SOURCE, PackageLockingMode.MEDIUM);
 
         List<ResolutionRequest> resolutionRequestList = new ArrayList<>();
         resolutionRequestList.add(resolutionRequest);
@@ -400,7 +400,7 @@ public class DependencyGraphTests extends BaseTest {
         // Test passing an unavailable version but compatible with an existing version (1.4.2)
         resolutionRequest = ResolutionRequest.from(
                 PackageDescriptor.from(PackageOrg.from("samjs"), PackageName.from("io"), PackageVersion.from("1.4.0")),
-                PackageDependencyScope.DEFAULT, DependencyResolutionType.SOURCE, true, PackageLockingMode.MEDIUM);
+                PackageDependencyScope.DEFAULT, DependencyResolutionType.SOURCE, PackageLockingMode.MEDIUM);
         responseDescriptors = packageResolver.resolvePackageMetadata(
                 Collections.singletonList(resolutionRequest), resolutionOptions);
         PackageMetadataResponse packageMetadataResponse = responseDescriptors.iterator().next();
@@ -411,7 +411,7 @@ public class DependencyGraphTests extends BaseTest {
         // Test passing an unavailable version that is not compatible with any existing versions (1.3.2)
         resolutionRequest = ResolutionRequest.from(
                 PackageDescriptor.from(PackageOrg.from("samjs"), PackageName.from("io"), PackageVersion.from("1.3.2")),
-                PackageDependencyScope.DEFAULT, DependencyResolutionType.SOURCE, true, PackageLockingMode.MEDIUM);
+                PackageDependencyScope.DEFAULT, DependencyResolutionType.SOURCE, PackageLockingMode.MEDIUM);
         responseDescriptors = packageResolver.resolvePackageMetadata(
                 Collections.singletonList(resolutionRequest), resolutionOptions);
         packageMetadataResponse = responseDescriptors.iterator().next();
@@ -422,7 +422,7 @@ public class DependencyGraphTests extends BaseTest {
         // Test passing the request without the version
         resolutionRequest = ResolutionRequest.from(
                 PackageDescriptor.from(PackageOrg.from("samjs"), PackageName.from("io"), null),
-                PackageDependencyScope.DEFAULT, DependencyResolutionType.SOURCE, true, PackageLockingMode.MEDIUM);
+                PackageDependencyScope.DEFAULT, DependencyResolutionType.SOURCE, PackageLockingMode.MEDIUM);
         responseDescriptors = packageResolver.resolvePackageMetadata(
                 Collections.singletonList(resolutionRequest), resolutionOptions);
         packageMetadataResponse = responseDescriptors.iterator().next();
@@ -441,14 +441,14 @@ public class DependencyGraphTests extends BaseTest {
 
         ResolutionRequest resolutionRequest = ResolutionRequest.from(
                 PackageDescriptor.from(PackageOrg.from("samjs"), PackageName.from("io"), PackageVersion.from("1.4.2")),
-                PackageDependencyScope.DEFAULT, DependencyResolutionType.SOURCE, true, PackageLockingMode.HARD);
+                PackageDependencyScope.DEFAULT, DependencyResolutionType.SOURCE, PackageLockingMode.HARD);
         ResolutionRequest resolutionRequest2 = ResolutionRequest.from(
                 PackageDescriptor.from(PackageOrg.from("samjs"), PackageName.from("cache"), null),
-                PackageDependencyScope.DEFAULT, DependencyResolutionType.SOURCE, true, PackageLockingMode.HARD);
+                PackageDependencyScope.DEFAULT, DependencyResolutionType.SOURCE, PackageLockingMode.HARD);
         // Adding an unrelated package to test the unresolved packages
         ResolutionRequest resolutionRequest3 = ResolutionRequest.from(
                 PackageDescriptor.from(PackageOrg.from("samjs"), PackageName.from("dummy"), null),
-                PackageDependencyScope.DEFAULT, DependencyResolutionType.SOURCE, true, PackageLockingMode.HARD);
+                PackageDependencyScope.DEFAULT, DependencyResolutionType.SOURCE, PackageLockingMode.HARD);
 
         List<ResolutionRequest> resolutionRequestList = new ArrayList<>();
         resolutionRequestList.add(resolutionRequest);
@@ -480,7 +480,7 @@ public class DependencyGraphTests extends BaseTest {
         // Test passing an unavailable version
         resolutionRequest = ResolutionRequest.from(
                 PackageDescriptor.from(PackageOrg.from("samjs"), PackageName.from("io"), PackageVersion.from("1.4.0")),
-                PackageDependencyScope.DEFAULT, DependencyResolutionType.SOURCE, true, PackageLockingMode.HARD);
+                PackageDependencyScope.DEFAULT, DependencyResolutionType.SOURCE, PackageLockingMode.HARD);
         responseDescriptors = packageResolver.resolvePackageMetadata(
                 Collections.singletonList(resolutionRequest), resolutionOptions);
         PackageMetadataResponse packageMetadataResponse = responseDescriptors.iterator().next();
@@ -491,7 +491,7 @@ public class DependencyGraphTests extends BaseTest {
         // Test passing with no version
         resolutionRequest = ResolutionRequest.from(
                 PackageDescriptor.from(PackageOrg.from("samjs"), PackageName.from("io"), null),
-                PackageDependencyScope.DEFAULT, DependencyResolutionType.SOURCE, true, PackageLockingMode.HARD);
+                PackageDependencyScope.DEFAULT, DependencyResolutionType.SOURCE, PackageLockingMode.HARD);
         responseDescriptors = packageResolver.resolvePackageMetadata(
                 Collections.singletonList(resolutionRequest), resolutionOptions);
         packageMetadataResponse = responseDescriptors.iterator().next();

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/HierarchicalPackageNameTests.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/HierarchicalPackageNameTests.java
@@ -28,6 +28,7 @@ import io.ballerina.projects.directory.BuildProject;
 import io.ballerina.projects.environment.Environment;
 import io.ballerina.projects.environment.EnvironmentBuilder;
 import io.ballerina.projects.environment.PackageResolver;
+import io.ballerina.projects.environment.ResolutionOptions;
 import io.ballerina.projects.environment.ResolutionResponse;
 import io.ballerina.projects.internal.ImportModuleRequest;
 import io.ballerina.projects.internal.ImportModuleResponse;
@@ -40,6 +41,7 @@ import java.io.PrintStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -122,7 +124,8 @@ public class HierarchicalPackageNameTests {
         importModuleRequests.add(request2);
         importModuleRequests.add(request3);
         importModuleRequests.add(request4);
-        List<ImportModuleResponse> importModuleResponseList = packageResolver.resolvePackageNames(importModuleRequests);
+        Collection<ImportModuleResponse> importModuleResponseList =
+                packageResolver.resolvePackageNames(importModuleRequests, ResolutionOptions.builder().build());
         Assert.assertEquals(importModuleResponseList.size(), 4);
 
         for (ImportModuleResponse importModuleResponse : importModuleResponseList) {
@@ -158,7 +161,8 @@ public class HierarchicalPackageNameTests {
         importModuleRequests.add(request1);
         importModuleRequests.add(request2);
 
-        List<ImportModuleResponse> importModuleResponseList = packageResolver.resolvePackageNames(importModuleRequests);
+        Collection<ImportModuleResponse> importModuleResponseList =
+                packageResolver.resolvePackageNames(importModuleRequests, ResolutionOptions.builder().build());
         Assert.assertEquals(importModuleResponseList.size(), 2);
         for (ImportModuleResponse importModuleResponse : importModuleResponseList) {
             if (importModuleResponse.importModuleRequest().moduleName().equals("a.c")) {

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/PackageResolutionTests.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/PackageResolutionTests.java
@@ -38,6 +38,7 @@ import io.ballerina.projects.bala.BalaProject;
 import io.ballerina.projects.directory.BuildProject;
 import io.ballerina.projects.environment.Environment;
 import io.ballerina.projects.environment.EnvironmentBuilder;
+import io.ballerina.projects.environment.ResolutionOptions;
 import io.ballerina.projects.internal.ImportModuleRequest;
 import io.ballerina.projects.internal.ImportModuleResponse;
 import io.ballerina.projects.internal.environment.DefaultPackageResolver;
@@ -405,15 +406,16 @@ public class PackageResolutionTests extends BaseTest {
         moduleRequests.add(new ImportModuleRequest(PackageOrg.from("ballerina"), "sample.module"));
 
         //dummyResponse
-        List<ImportModuleResponse>  moduleResponse = new ArrayList<>();
-        for (ImportModuleRequest request: moduleRequests) {
+        List<ImportModuleResponse> moduleResponse = new ArrayList<>();
+        for (ImportModuleRequest request : moduleRequests) {
             String[] parts = request.moduleName().split("[.]");
             moduleResponse.add(new ImportModuleResponse(
                     PackageDescriptor.from(request.packageOrg(), PackageName.from(parts[0])), request));
         }
 
-        when(mockResolver.resolvePackageNames(any())).thenReturn(moduleResponse);
+        when(mockResolver.resolvePackageNames(any(), any(ResolutionOptions.class))).thenReturn(moduleResponse);
 
-        Assert.assertEquals(mockResolver.resolvePackageNames(moduleRequests).size(), 2);
+        Assert.assertEquals(mockResolver.resolvePackageNames(moduleRequests,
+                ResolutionOptions.builder().build()).size(), 2);
     }
 }


### PR DESCRIPTION
## Purpose
As explained in the following issue, the current APIs are not well designed. There are two different ways to provide the `offline` flag. 
Fixes #32500

## Approach
Introduced `ResolutionOptions` to unify above mentioned approaches. It provides a simple way to pass resolution-related options to the resolution engine. 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
