### PR TITLE
Revert Observability module tag format to original version

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
@@ -99,7 +99,6 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.REPORT_ER
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.START_CALLABLE_OBSERVATION_METHOD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.START_RESOURCE_OBSERVATION_METHOD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.STOP_OBSERVATION_METHOD;
-import static org.wso2.ballerinalang.compiler.util.CompilerUtils.getMajorVersion;
 
 /**
  * BIR desugar to inject observations class.
@@ -1003,7 +1002,7 @@ class JvmObservabilityGen {
      * @return The generated ID
      */
     private String generatePackageId(PackageID pkg) {
-        return String.format("%s/%s:%s", pkg.orgName.value, pkg.name.value, getMajorVersion(pkg.version.value));
+        return String.format("%s/%s:%s", pkg.orgName.value, pkg.name.value, pkg.version.value);
     }
 
     /**

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/metrics/MetricsTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/metrics/MetricsTestCase.java
@@ -53,7 +53,7 @@ public class MetricsTestCase extends ObservabilityBaseTest {
     protected static final String TEST_SRC_PROJECT_NAME = "metrics_tests";
     private static final String TEST_SRC_ORG_NAME = "intg_tests";
     protected static final String TEST_SRC_PACKAGE_NAME = "metrics_tests";
-    private static final String MODULE_ID = TEST_SRC_ORG_NAME + "/" + TEST_SRC_PACKAGE_NAME + ":0";
+    private static final String TEST_SRC_MODULE_ID = TEST_SRC_ORG_NAME + "/" + TEST_SRC_PACKAGE_NAME + ":0.0.1";
 
     protected static final String MOCK_CLIENT_OBJECT_NAME = TEST_SRC_ORG_NAME + "/" + TEST_SRC_PACKAGE_NAME
             + "/MockClient";
@@ -151,7 +151,7 @@ public class MetricsTestCase extends ObservabilityBaseTest {
         Metrics functionMetrics = filterByTag(allMetrics, "src.position", invocationPosition);
 
         Set<Tag> startTags = new HashSet<>(Arrays.asList(startObservationTags));
-        startTags.add(Tag.of("src.module", MODULE_ID));
+        startTags.add(Tag.of("src.module", TEST_SRC_MODULE_ID));
         startTags.add(Tag.of("src.position", invocationPosition));
 
         Set<Tag> endTags = new HashSet<>(startTags);
@@ -268,7 +268,7 @@ public class MetricsTestCase extends ObservabilityBaseTest {
                 Duration.ofMinutes(5));
         Assert.assertTrue(durations.contains(snapshot.getTimeWindow()), "time window "
                 + snapshot.getTimeWindow() + " of snapshot not equal to either one of "
-                + durations.toString());
+                + durations);
 
         if (invocationCount > 0) {
             Assert.assertTrue(snapshot.getMax() > 0, "Expected max of "
@@ -307,7 +307,7 @@ public class MetricsTestCase extends ObservabilityBaseTest {
         List<Double> expectedPercentiles = Arrays.asList(0.33, 0.5, 0.66, 0.75, 0.95, 0.99, 0.999);
         Assert.assertTrue(expectedPercentiles.contains(percentileValue.getPercentile()),
                 "percentile " + percentileValue.getPercentile()
-                        + " is not one of the expected percentiles " + expectedPercentiles.toString());
+                        + " is not one of the expected percentiles " + expectedPercentiles);
         if (invocationCount > 0) {
             Assert.assertTrue(percentileValue.getValue() > 0, "percentile "
                     + percentileValue.getPercentile() + " expected to be greater than 0, but found "

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/metrics/MetricsTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/metrics/MetricsTestCase.java
@@ -325,18 +325,18 @@ public class MetricsTestCase extends ObservabilityBaseTest {
         testFunctionMetrics(metrics, fileName + ":19:1", 1,
                 Tag.of("src.function.name", "main"),
                 Tag.of("src.main", "true"),
-                Tag.of("entrypoint.function.module", "intg_tests/metrics_tests:0"),
+                Tag.of("entrypoint.function.module", TEST_SRC_MODULE_ID),
                 Tag.of("entrypoint.function.name", "main")
         );
         testFunctionMetrics(metrics, fileName + ":24:24", 1,
                 Tag.of("src.object.name", OBSERVABLE_ADDER_OBJECT_NAME),
                 Tag.of("src.function.name", "getSum"),
-                Tag.of("entrypoint.function.module", "intg_tests/metrics_tests:0"),
+                Tag.of("entrypoint.function.module", TEST_SRC_MODULE_ID),
                 Tag.of("entrypoint.function.name", "main")
         );
         testFunctionMetrics(metrics, fileName + ":38:12", 3,
                 Tag.of("src.function.name", "calculateSumWithObservability"),
-                Tag.of("entrypoint.function.module", "intg_tests/metrics_tests:0"),
+                Tag.of("entrypoint.function.module", TEST_SRC_MODULE_ID),
                 Tag.of("entrypoint.function.name", "main")
         );
     }

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/HttpTracingTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/HttpTracingTestCase.java
@@ -75,7 +75,7 @@ public class HttpTracingTestCase extends HttpTracingBaseTest {  // TODO: Move th
             Assert.assertEquals(span.getOperationName(), "resourceOne");
             Assert.assertEquals(span.getTags(), toMap(
                     new AbstractMap.SimpleEntry<>("span.kind", "server"),
-                    new AbstractMap.SimpleEntry<>("src.module", "ballerina-test/httptracing:0"),
+                    new AbstractMap.SimpleEntry<>("src.module", "ballerina-test/httptracing:0.0.0"),
                     new AbstractMap.SimpleEntry<>("src.position", span1Position),
                     new AbstractMap.SimpleEntry<>("src.service.resource", "true"),
                     new AbstractMap.SimpleEntry<>("http.url", "/test-service/resource-1"),
@@ -97,7 +97,7 @@ public class HttpTracingTestCase extends HttpTracingBaseTest {  // TODO: Move th
             Assert.assertEquals(span.getOperationName(), "ballerina/http/Client:get");
             Assert.assertEquals(span.getTags(), toMap(
                     new AbstractMap.SimpleEntry<>("span.kind", "client"),
-                    new AbstractMap.SimpleEntry<>("src.module", "ballerina-test/httptracing:0"),
+                    new AbstractMap.SimpleEntry<>("src.module", "ballerina-test/httptracing:0.0.0"),
                     new AbstractMap.SimpleEntry<>("src.position", span2Position),
                     new AbstractMap.SimpleEntry<>("src.client.remote", "true"),
                     new AbstractMap.SimpleEntry<>("http.base_url", "http://localhost:19091/test-service"),
@@ -146,7 +146,7 @@ public class HttpTracingTestCase extends HttpTracingBaseTest {  // TODO: Move th
             Assert.assertEquals(span.getOperationName(), "resourceTwo");
             Assert.assertEquals(span.getTags(), toMap(
                     new AbstractMap.SimpleEntry<>("span.kind", "server"),
-                    new AbstractMap.SimpleEntry<>("src.module", "ballerina-test/httptracing:0"),
+                    new AbstractMap.SimpleEntry<>("src.module", "ballerina-test/httptracing:0.0.0"),
                     new AbstractMap.SimpleEntry<>("src.position", span4Position),
                     new AbstractMap.SimpleEntry<>("src.service.resource", "true"),
                     new AbstractMap.SimpleEntry<>("http.url", "/test-service/resource-2"),
@@ -168,7 +168,7 @@ public class HttpTracingTestCase extends HttpTracingBaseTest {  // TODO: Move th
             Assert.assertEquals(span.getOperationName(), "ballerina/http/Caller:respond");
             Assert.assertEquals(span.getTags(), toMap(
                     new AbstractMap.SimpleEntry<>("span.kind", "client"),
-                    new AbstractMap.SimpleEntry<>("src.module", "ballerina-test/httptracing:0"),
+                    new AbstractMap.SimpleEntry<>("src.module", "ballerina-test/httptracing:0.0.0"),
                     new AbstractMap.SimpleEntry<>("src.position", span5Position),
                     new AbstractMap.SimpleEntry<>("src.client.remote", "true"),
                     new AbstractMap.SimpleEntry<>("http.status_code", "200"),
@@ -190,7 +190,7 @@ public class HttpTracingTestCase extends HttpTracingBaseTest {  // TODO: Move th
             Assert.assertEquals(span.getOperationName(), "ballerina/http/Caller:respond");
             Assert.assertEquals(span.getTags(), toMap(
                     new AbstractMap.SimpleEntry<>("span.kind", "client"),
-                    new AbstractMap.SimpleEntry<>("src.module", "ballerina-test/httptracing:0"),
+                    new AbstractMap.SimpleEntry<>("src.module", "ballerina-test/httptracing:0.0.0"),
                     new AbstractMap.SimpleEntry<>("src.position", span6Position),
                     new AbstractMap.SimpleEntry<>("src.client.remote", "true"),
                     new AbstractMap.SimpleEntry<>("http.status_code", "200"),
@@ -246,7 +246,7 @@ public class HttpTracingTestCase extends HttpTracingBaseTest {  // TODO: Move th
             Assert.assertEquals(span.getOperationName(), "resourceOne");
             Assert.assertEquals(span.getTags(), toMap(
                     new AbstractMap.SimpleEntry<>("span.kind", "server"),
-                    new AbstractMap.SimpleEntry<>("src.module", "ballerina-test/httptracing:0"),
+                    new AbstractMap.SimpleEntry<>("src.module", "ballerina-test/httptracing:0.0.0"),
                     new AbstractMap.SimpleEntry<>("src.position", span1Position),
                     new AbstractMap.SimpleEntry<>("src.service.resource", "true"),
                     new AbstractMap.SimpleEntry<>("http.url", "/test-service/resource-1"),
@@ -268,7 +268,7 @@ public class HttpTracingTestCase extends HttpTracingBaseTest {  // TODO: Move th
             Assert.assertEquals(span.getOperationName(), "ballerina/http/Client:get");
             Assert.assertEquals(span.getTags(), toMap(
                     new AbstractMap.SimpleEntry<>("span.kind", "client"),
-                    new AbstractMap.SimpleEntry<>("src.module", "ballerina-test/httptracing:0"),
+                    new AbstractMap.SimpleEntry<>("src.module", "ballerina-test/httptracing:0.0.0"),
                     new AbstractMap.SimpleEntry<>("src.position", span2Position),
                     new AbstractMap.SimpleEntry<>("src.client.remote", "true"),
                     new AbstractMap.SimpleEntry<>("http.base_url", "http://localhost:10011/echo-service"),
@@ -317,7 +317,7 @@ public class HttpTracingTestCase extends HttpTracingBaseTest {  // TODO: Move th
             Assert.assertEquals(span.getOperationName(), "resourceOne");
             Assert.assertEquals(span.getTags(), toMap(
                     new AbstractMap.SimpleEntry<>("span.kind", "server"),
-                    new AbstractMap.SimpleEntry<>("src.module", "ballerina-test/backend:0"),
+                    new AbstractMap.SimpleEntry<>("src.module", "ballerina-test/backend:0.0.0"),
                     new AbstractMap.SimpleEntry<>("src.position", span4Position),
                     new AbstractMap.SimpleEntry<>("src.service.resource", "true"),
                     new AbstractMap.SimpleEntry<>("http.url", "/echo-service/echo/Hello%20Echo%20!"),
@@ -339,7 +339,7 @@ public class HttpTracingTestCase extends HttpTracingBaseTest {  // TODO: Move th
             Assert.assertEquals(span.getOperationName(), "ballerina/http/Caller:respond");
             Assert.assertEquals(span.getTags(), toMap(
                     new AbstractMap.SimpleEntry<>("span.kind", "client"),
-                    new AbstractMap.SimpleEntry<>("src.module", "ballerina-test/backend:0"),
+                    new AbstractMap.SimpleEntry<>("src.module", "ballerina-test/backend:0.0.0"),
                     new AbstractMap.SimpleEntry<>("src.position", span5Position),
                     new AbstractMap.SimpleEntry<>("src.client.remote", "true"),
                     new AbstractMap.SimpleEntry<>("http.status_code", "200"),
@@ -361,7 +361,7 @@ public class HttpTracingTestCase extends HttpTracingBaseTest {  // TODO: Move th
             Assert.assertEquals(span.getOperationName(), "ballerina/http/Caller:respond");
             Assert.assertEquals(span.getTags(), toMap(
                     new AbstractMap.SimpleEntry<>("span.kind", "client"),
-                    new AbstractMap.SimpleEntry<>("src.module", "ballerina-test/httptracing:0"),
+                    new AbstractMap.SimpleEntry<>("src.module", "ballerina-test/httptracing:0.0.0"),
                     new AbstractMap.SimpleEntry<>("src.position", span6Position),
                     new AbstractMap.SimpleEntry<>("src.client.remote", "true"),
                     new AbstractMap.SimpleEntry<>("http.status_code", "200"),

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/MainFunctionTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/MainFunctionTestCase.java
@@ -50,7 +50,7 @@ public class MainFunctionTestCase extends TracingBaseTestCase {
         final String span4Position = FILE_NAME + ":24:15";
         final String span5Position = FILE_NAME + ":32:21";
         final String span6Position = FILE_NAME + ":38:16";
-        final String entryPointFunctionModule = "intg_tests/tracing_tests:0";
+        final String entryPointFunctionModule = DEFAULT_MODULE_ID;
         final String entryPointFunctionName = "main";
         final List<BMockSpan.CheckPoint> expectedCheckpoints = Arrays.asList(
                 new BMockSpan.CheckPoint(entryPointFunctionModule, FILE_NAME + ":20:5"),

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/SpanContextTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/SpanContextTestCase.java
@@ -48,7 +48,7 @@ public class SpanContextTestCase extends TracingBaseTestCase {
         Map<String, Object> spanContext = new Gson().fromJson(data, type);
 
         List<BMockSpan> spanList = getFinishedSpans("testServiceSeven",
-                "intg_tests/tracing_tests:0", "/resourceOne");
+                DEFAULT_MODULE_ID, "/resourceOne");
         Optional<BMockSpan> span1 = spanList.stream()
                 .filter(bMockSpan -> bMockSpan.getTags().get("src.position").equals(FILE_NAME + ":22:5"))
                 .findFirst();

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/TracingBaseTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/TracingBaseTestCase.java
@@ -46,8 +46,8 @@ public class TracingBaseTestCase extends ObservabilityBaseTest {
     protected static final String TEST_SRC_PACKAGE_NAME = "tracing_tests";
     protected static final String TEST_SRC_UTILS_MODULE_NAME = TEST_SRC_PACKAGE_NAME + ".utils";
 
-    protected static final String DEFAULT_MODULE_ID = TEST_SRC_ORG_NAME + "/" + TEST_SRC_PACKAGE_NAME + ":0";
-    protected static final String UTILS_MODULE_ID = TEST_SRC_ORG_NAME + "/" + TEST_SRC_UTILS_MODULE_NAME + ":0";
+    protected static final String DEFAULT_MODULE_ID = TEST_SRC_ORG_NAME + "/" + TEST_SRC_PACKAGE_NAME + ":0.0.1";
+    protected static final String UTILS_MODULE_ID = TEST_SRC_ORG_NAME + "/" + TEST_SRC_UTILS_MODULE_NAME + ":0.0.0";
 
     protected static final String MOCK_CLIENT_FILE_NAME = "mock_client_endpoint.bal";
 

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/TracingBaseTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/TracingBaseTestCase.java
@@ -47,7 +47,7 @@ public class TracingBaseTestCase extends ObservabilityBaseTest {
     protected static final String TEST_SRC_UTILS_MODULE_NAME = TEST_SRC_PACKAGE_NAME + ".utils";
 
     protected static final String DEFAULT_MODULE_ID = TEST_SRC_ORG_NAME + "/" + TEST_SRC_PACKAGE_NAME + ":0.0.1";
-    protected static final String UTILS_MODULE_ID = TEST_SRC_ORG_NAME + "/" + TEST_SRC_UTILS_MODULE_NAME + ":0.0.0";
+    protected static final String UTILS_MODULE_ID = TEST_SRC_ORG_NAME + "/" + TEST_SRC_UTILS_MODULE_NAME + ":0.0.1";
 
     protected static final String MOCK_CLIENT_FILE_NAME = "mock_client_endpoint.bal";
 


### PR DESCRIPTION
## Purpose
> Since the Observability module tag format changes are breaking changes and since we do not require it to be changed for Observability, we have reverted the changes done to the Observability module tag.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/32505

## Approach
> Revert the changes done to the `src.module` tag.

## Samples
> N/A

## Remarks
> N/A

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
