### PR TITLE
Revert `typeof` changes done for  immutable values.

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/ValueUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/ValueUtils.java
@@ -18,16 +18,12 @@
 package io.ballerina.runtime.internal;
 
 import io.ballerina.runtime.api.Module;
-import io.ballerina.runtime.api.creators.TypeCreator;
 import io.ballerina.runtime.api.flags.SymbolFlags;
 import io.ballerina.runtime.api.types.Field;
-import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
-import io.ballerina.runtime.api.values.BTypedesc;
-import io.ballerina.runtime.api.values.BValue;
 import io.ballerina.runtime.api.values.BXml;
 import io.ballerina.runtime.internal.scheduling.Scheduler;
 import io.ballerina.runtime.internal.scheduling.State;
@@ -35,11 +31,9 @@ import io.ballerina.runtime.internal.scheduling.Strand;
 import io.ballerina.runtime.internal.types.BRecordType;
 import io.ballerina.runtime.internal.values.MapValue;
 import io.ballerina.runtime.internal.values.MapValueImpl;
-import io.ballerina.runtime.internal.values.TypedescValueImpl;
 import io.ballerina.runtime.internal.values.ValueCreator;
 
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Class @{@link ValueUtils} provides utils to create Ballerina Values.
@@ -170,26 +164,4 @@ public class ValueUtils {
         return xml;
     }
 
-
-    /**
-     * Provide the Typedesc Value with the singleton type with a value.
-     * @param value Ballerina value
-     * @return typedesc with singleton type
-     */
-    public static BTypedesc createSingletonTypedesc(BValue value) {
-        return io.ballerina.runtime.api.creators.ValueCreator
-                .createTypedescValue(TypeCreator.createFiniteType(value.toString(), Set.of(value), 0));
-    }
-
-    /**
-     * Provide the Typedesc Value depending on the immutability of a value.
-     * @param type Ballerina value
-     * @return typedesc with the suitable type
-     */
-    public static BTypedesc getTypedescValue(Type type, BValue value) {
-        if (type.isReadOnly()) {
-            return createSingletonTypedesc(value);
-        }
-        return new TypedescValueImpl(type);
-    }
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ArrayValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ArrayValueImpl.java
@@ -49,8 +49,6 @@ import java.util.StringJoiner;
 import java.util.stream.IntStream;
 
 import static io.ballerina.runtime.api.constants.RuntimeConstants.ARRAY_LANG_LIB;
-import static io.ballerina.runtime.internal.ValueUtils.createSingletonTypedesc;
-import static io.ballerina.runtime.internal.ValueUtils.getTypedescValue;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.INDEX_OUT_OF_RANGE_ERROR_IDENTIFIER;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.INHERENT_TYPE_VIOLATION_ERROR_IDENTIFIER;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.getModulePrefixedReason;
@@ -87,35 +85,35 @@ public class ArrayValueImpl extends AbstractArrayValue {
         if (type.getTag() == TypeTags.ARRAY_TAG) {
             this.elementType = type.getElementType();
         }
-        this.typedesc = getTypedescValue(arrayType, this);
+        this.typedesc = new TypedescValueImpl(arrayType);
     }
 
     public ArrayValueImpl(long[] values, boolean readonly) {
         this.intValues = values;
         this.size = values.length;
         setArrayType(PredefinedTypes.TYPE_INT, readonly);
-        this.typedesc = getTypedescValue(arrayType, this);
+        this.typedesc = new TypedescValueImpl(arrayType);
     }
 
     public ArrayValueImpl(boolean[] values, boolean readonly) {
         this.booleanValues = values;
         this.size = values.length;
         setArrayType(PredefinedTypes.TYPE_BOOLEAN, readonly);
-        this.typedesc = getTypedescValue(arrayType, this);
+        this.typedesc = new TypedescValueImpl(arrayType);
     }
 
     public ArrayValueImpl(byte[] values, boolean readonly) {
         this.byteValues = values;
         this.size = values.length;
         setArrayType(PredefinedTypes.TYPE_BYTE, readonly);
-        this.typedesc = getTypedescValue(arrayType, this);
+        this.typedesc = new TypedescValueImpl(arrayType);
     }
 
     public ArrayValueImpl(double[] values, boolean readonly) {
         this.floatValues = values;
         this.size = values.length;
         setArrayType(PredefinedTypes.TYPE_FLOAT, readonly);
-        this.typedesc = getTypedescValue(arrayType, this);
+        this.typedesc = new TypedescValueImpl(arrayType);
     }
 
     public ArrayValueImpl(String[] values, boolean readonly) {
@@ -125,14 +123,14 @@ public class ArrayValueImpl extends AbstractArrayValue {
             bStringValues[i] = StringUtils.fromString(values[i]);
         }
         setArrayType(PredefinedTypes.TYPE_STRING, readonly);
-        this.typedesc = getTypedescValue(arrayType, this);
+        this.typedesc = new TypedescValueImpl(arrayType);
     }
 
     public ArrayValueImpl(BString[] values, boolean readonly) {
         this.bStringValues = values;
         this.size = values.length;
         setArrayType(PredefinedTypes.TYPE_STRING, readonly);
-        this.typedesc = getTypedescValue(arrayType, this);
+        this.typedesc = new TypedescValueImpl(arrayType);
     }
 
     public ArrayValueImpl(ArrayType type) {
@@ -142,7 +140,7 @@ public class ArrayValueImpl extends AbstractArrayValue {
         if (type.getState() == ArrayState.CLOSED) {
             this.size = maxSize = type.getSize();
         }
-        this.typedesc = getTypedescValue(arrayType, this);
+        this.typedesc = new TypedescValueImpl(arrayType);
     }
 
     private void initArrayValues(Type elementType) {
@@ -246,7 +244,7 @@ public class ArrayValueImpl extends AbstractArrayValue {
         if (size != -1) {
             this.size = this.maxSize = (int) size;
         }
-        this.typedesc = getTypedescValue(arrayType, this);
+        this.typedesc = new TypedescValueImpl(arrayType);
     }
 
     public ArrayValueImpl(ArrayType type, long size, BListInitialValueEntry[] initialValues) {
@@ -265,7 +263,7 @@ public class ArrayValueImpl extends AbstractArrayValue {
         for (int index = 0; index < initialValues.length; index++) {
             addRefValue(index, ((ListInitialValueEntry.ExpressionEntry) initialValues[index]).value);
         }
-        this.typedesc = getTypedescValue(arrayType, this);
+        this.typedesc = new TypedescValueImpl(arrayType);
     }
 
     // ----------------------- get methods ----------------------------------------------------
@@ -959,7 +957,7 @@ public class ArrayValueImpl extends AbstractArrayValue {
                 }
             }
         }
-        this.typedesc = createSingletonTypedesc(this);
+        this.typedesc = new TypedescValueImpl(arrayType);
     }
 
     /**

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValueImpl.java
@@ -63,8 +63,6 @@ import java.util.stream.Collectors;
 
 import static io.ballerina.runtime.api.constants.RuntimeConstants.MAP_LANG_LIB;
 import static io.ballerina.runtime.internal.JsonUtils.mergeJson;
-import static io.ballerina.runtime.internal.ValueUtils.createSingletonTypedesc;
-import static io.ballerina.runtime.internal.ValueUtils.getTypedescValue;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.INVALID_UPDATE_ERROR_IDENTIFIER;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.MAP_KEY_NOT_FOUND_ERROR;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.getModulePrefixedReason;
@@ -97,30 +95,26 @@ public class MapValueImpl<K, V> extends LinkedHashMap<K, V> implements RefValue,
 
     public MapValueImpl(TypedescValue typedesc) {
         this(typedesc.getDescribingType());
-        if (!type.isReadOnly()) {
-            this.typedesc = typedesc;
-        }
+        this.typedesc = typedesc;
     }
 
     public MapValueImpl(Type type) {
         super();
         this.type = type;
-        this.typedesc = getTypedescValue(type, this);
+        this.typedesc = new TypedescValueImpl(type);
     }
 
     public MapValueImpl(Type type, BMapInitialValueEntry[] initialValues) {
         super();
         this.type = type;
         populateInitialValues(initialValues);
-        if (!type.isReadOnly()) {
-            this.typedesc = new TypedescValueImpl(type);
-        }
+        this.typedesc = new TypedescValueImpl(type);
     }
 
     public MapValueImpl() {
         super();
         type = PredefinedTypes.TYPE_MAP;
-        this.typedesc = getTypedescValue(type, this);
+        this.typedesc = new TypedescValueImpl(type);
     }
 
     public Long getIntValue(BString key) {
@@ -292,9 +286,6 @@ public class MapValueImpl<K, V> extends LinkedHashMap<K, V> implements RefValue,
             for (Map.Entry<K, V> entry : values.entrySet()) {
                 populateInitialValue(entry.getKey(), entry.getValue());
             }
-        }
-        if (this.type.isReadOnly()) {
-            this.typedesc = createSingletonTypedesc(this);
         }
     }
 
@@ -520,7 +511,7 @@ public class MapValueImpl<K, V> extends LinkedHashMap<K, V> implements RefValue,
                 ((RefValue) val).freezeDirect();
             }
         });
-        this.typedesc = createSingletonTypedesc(this);
+        this.typedesc = new TypedescValueImpl(type);
     }
 
     public String getJSONString() {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TableValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TableValueImpl.java
@@ -60,8 +60,6 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static io.ballerina.runtime.api.constants.RuntimeConstants.TABLE_LANG_LIB;
-import static io.ballerina.runtime.internal.ValueUtils.createSingletonTypedesc;
-import static io.ballerina.runtime.internal.ValueUtils.getTypedescValue;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.INHERENT_TYPE_VIOLATION_ERROR_IDENTIFIER;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.OPERATION_NOT_SUPPORTED_ERROR;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.TABLE_HAS_A_VALUE_FOR_KEY_ERROR;
@@ -111,7 +109,7 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
         } else {
             this.valueHolder = new ValueHolder();
         }
-        this.typedesc = getTypedescValue(type, this);
+        this.typedesc = new TypedescValueImpl(type);
     }
 
     public TableValueImpl(TableType type, ArrayValue data, ArrayValue fieldNames) {
@@ -121,9 +119,6 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
         }
 
         addData(data);
-        if (type.isReadOnly()) {
-            this.typedesc = createSingletonTypedesc(this);
-        }
     }
 
     private void addData(ArrayValue data) {
@@ -333,7 +328,7 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
         this.type = (BTableType) ReadOnlyUtils.setImmutableTypeAndGetEffectiveType(this.type);
         //we know that values are always RefValues
         this.values().forEach(val -> ((RefValue) val).freezeDirect());
-        this.typedesc = createSingletonTypedesc(this);
+        this.typedesc = new TypedescValueImpl(type);
     }
 
     public String stringValue(BLink parent) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TupleValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TupleValueImpl.java
@@ -46,8 +46,6 @@ import java.util.StringJoiner;
 import java.util.stream.IntStream;
 
 import static io.ballerina.runtime.api.constants.RuntimeConstants.ARRAY_LANG_LIB;
-import static io.ballerina.runtime.internal.ValueUtils.createSingletonTypedesc;
-import static io.ballerina.runtime.internal.ValueUtils.getTypedescValue;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.INDEX_OUT_OF_RANGE_ERROR_IDENTIFIER;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.INHERENT_TYPE_VIOLATION_ERROR_IDENTIFIER;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.getModulePrefixedReason;
@@ -111,7 +109,7 @@ public class TupleValueImpl extends AbstractArrayValue {
         }
         this.minSize = memTypes.size();
         this.size = refValues.length;
-        this.typedesc = getTypedescValue(tupleType, this);
+        this.typedesc = new TypedescValueImpl(tupleType);
     }
 
     public TupleValueImpl(TupleType type) {
@@ -137,7 +135,7 @@ public class TupleValueImpl extends AbstractArrayValue {
             }
             this.refValues[i] = memType.getZeroValue();
         }
-        this.typedesc = getTypedescValue(tupleType, this);
+        this.typedesc = new TypedescValueImpl(tupleType);
     }
 
     public TupleValueImpl(TupleType type, long size, BListInitialValueEntry[] initialValues) {
@@ -162,7 +160,7 @@ public class TupleValueImpl extends AbstractArrayValue {
         }
 
         if (size >= memCount) {
-            this.typedesc = getTypedescValue(tupleType, this);
+            this.typedesc = new TypedescValueImpl(tupleType);
             return;
         }
 
@@ -174,7 +172,7 @@ public class TupleValueImpl extends AbstractArrayValue {
 
             this.refValues[i] = memType.getZeroValue();
         }
-        this.typedesc = getTypedescValue(tupleType, this);
+        this.typedesc = new TypedescValueImpl(tupleType);
     }
 
     @Override
@@ -566,7 +564,7 @@ public class TupleValueImpl extends AbstractArrayValue {
                 ((RefValue) value).freezeDirect();
             }
         }
-        this.typedesc = createSingletonTypedesc(this);
+        this.typedesc = new TypedescValueImpl(tupleType);
     }
 
     /**

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlItem.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlItem.java
@@ -55,7 +55,6 @@ import static io.ballerina.runtime.api.constants.RuntimeConstants.STRING_NULL_VA
 import static io.ballerina.runtime.api.constants.RuntimeConstants.XML_LANG_LIB;
 import static io.ballerina.runtime.api.types.XmlNodeType.ELEMENT;
 import static io.ballerina.runtime.api.types.XmlNodeType.TEXT;
-import static io.ballerina.runtime.internal.ValueUtils.createSingletonTypedesc;
 
 /**
  * {@code XMLItem} represents a single XML element in Ballerina.
@@ -630,7 +629,7 @@ public final class XmlItem extends XmlValue implements BXmlItem {
         this.type = ReadOnlyUtils.setImmutableTypeAndGetEffectiveType(this.type);
         this.children.freezeDirect();
         this.attributes.freezeDirect();
-        this.typedesc = createSingletonTypedesc(this);
+        this.typedesc = new TypedescValueImpl(type);
     }
 
     private QName getQName(String localName, String namespaceUri, String prefix) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlNonElementItem.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlNonElementItem.java
@@ -33,7 +33,6 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 import static io.ballerina.runtime.api.constants.RuntimeConstants.STRING_NULL_VALUE;
-import static io.ballerina.runtime.internal.ValueUtils.createSingletonTypedesc;
 
 /**
  * Functionality common to PI, COMMENT and TEXT nodes.
@@ -215,7 +214,7 @@ public abstract class XmlNonElementItem extends XmlValue implements BXmlNonEleme
     @Override
     public void freezeDirect() {
         this.type = ReadOnlyUtils.setImmutableTypeAndGetEffectiveType(this.type);
-        this.typedesc = createSingletonTypedesc(this);
+        this.typedesc = new TypedescValueImpl(type);
     }
 
     @Override

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlSequence.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlSequence.java
@@ -45,7 +45,6 @@ import java.util.Set;
 
 import static io.ballerina.runtime.api.constants.RuntimeConstants.STRING_EMPTY_VALUE;
 import static io.ballerina.runtime.api.constants.RuntimeConstants.XML_LANG_LIB;
-import static io.ballerina.runtime.internal.ValueUtils.createSingletonTypedesc;
 
 /**
  * <p>
@@ -593,7 +592,7 @@ public final class XmlSequence extends XmlValue implements BXmlSequence {
         for (BXml elem : children) {
             elem.freezeDirect();
         }
-        this.typedesc = createSingletonTypedesc(this);
+        this.typedesc = new TypedescValueImpl(type);
     }
 
     @Override

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlValue.java
@@ -35,8 +35,6 @@ import java.util.Map;
 
 import javax.xml.namespace.QName;
 
-import static io.ballerina.runtime.internal.ValueUtils.getTypedescValue;
-
 /**
  * {@code BXML} represents an XML in Ballerina. An XML could be one of:
  * <ul>
@@ -252,7 +250,7 @@ public abstract class XmlValue implements RefValue, BXml, CollectionValue {
     }
 
     protected void setTypedescValue(Type type) {
-        this.typedesc = getTypedescValue(type, this);
+        this.typedesc = new TypedescValueImpl(type);
     }
 
     @Override

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typeof/typeof.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typeof/typeof.bal
@@ -133,35 +133,35 @@ function compareTypeOfValues() {
 }
 
 function typeOfImmutableStructuralValues() {
-
+    // TODO: need to change the return value after fixing #13189
     // xml Value
     xml & readonly xmlValue = xml `<data>test</data>`;
     test:assertTrue(typeof xmlValue === typeof xmlValue);
-    test:assertEquals((typeof xmlValue).toString(), "typedesc <data></data>");
+    test:assertEquals((typeof xmlValue).toString(), "typedesc lang.xml:Element & readonly");
 
     // Structural types - Array, Tuple
     int[] & readonly arr = [1, 2, 3];
     test:assertTrue(typeof arr === typeof arr);
-    test:assertEquals((typeof arr).toString(), "typedesc [1,2,3]");
+    test:assertEquals((typeof arr).toString(), "typedesc int[] & readonly");
 
     [string, int] & readonly tuple = ["ballerina", 123];
     test:assertTrue(typeof tuple === typeof tuple);
-    test:assertEquals((typeof tuple).toString(), "typedesc [\"ballerina\",123]");
+    test:assertEquals((typeof tuple).toString(), "typedesc [string,int] & readonly");
 
     // Structural types - Records, Maps
     RecType0 & readonly rec = {name: "test"};
     test:assertTrue(typeof rec === typeof rec);
     test:assertTrue(typeof rec !== RecType0);
-    test:assertEquals((typeof rec).toString(), "typedesc {\"name\":\"test\"}");
+    test:assertEquals((typeof rec).toString(), "typedesc (RecType0 & readonly)");
 
     map<string> & readonly mapVal = {s: "test"};
     test:assertTrue(typeof mapVal === typeof mapVal);
-    test:assertEquals((typeof mapVal).toString(), "typedesc {\"s\":\"test\"}");
+    test:assertEquals((typeof mapVal).toString(), "typedesc map<string> & readonly");
 
     // Structural types -tables 
     table<map<string>> & readonly tableVal = table [{s: "test"}];
     test:assertTrue(typeof tableVal === typeof tableVal);
-    test:assertEquals((typeof tableVal).toString(), "typedesc [{\"s\":\"test\"}]");
+    test:assertEquals((typeof tableVal).toString(), "typedesc table<map<string> & readonly> & readonly");
 }
 
 function typeOfWithCloneReadOnly() {
@@ -170,35 +170,34 @@ function typeOfWithCloneReadOnly() {
     xml & readonly xmlValue = xml `<?xml-stylesheet href="mystyle.css" type="text/css"?>`;
     any val = xmlValue.cloneReadOnly();
     test:assertTrue(typeof val === typeof val);
-    test:assertEquals((typeof val).toString(), "typedesc <?xml-stylesheet href=\"mystyle.css\" " + 
-    "type=\"text/css\"?>");
+    test:assertEquals((typeof val).toString(), "typedesc lang.xml:ProcessingInstruction & readonly");
 
     // Structural types - Array, Tuple
     int[] arr = [1, 2, 3];
     val = arr.cloneReadOnly();
     test:assertTrue(typeof val === typeof val);
-    test:assertEquals((typeof val).toString(), "typedesc [1,2,3]");
+    test:assertEquals((typeof val).toString(), "typedesc int[] & readonly");
 
     [string, int] tuple = ["ballerina", 123];
     val = tuple.cloneReadOnly();
     test:assertTrue(typeof val === typeof val);
-    test:assertEquals((typeof val).toString(), "typedesc [\"ballerina\",123]");
+    test:assertEquals((typeof val).toString(), "typedesc [string,int] & readonly");
 
     // Structural types - Records, Maps
     RecType0 rec = {name: "test"};
     val = rec.cloneReadOnly();
     test:assertTrue(typeof val === typeof val);
     test:assertTrue(typeof val !== RecType0);
-    test:assertEquals((typeof val).toString(), "typedesc {\"name\":\"test\"}");
+    test:assertEquals((typeof val).toString(), "typedesc (RecType0 & readonly)");
 
     map<string> mapVal = {s: "test"};
     val = mapVal.cloneReadOnly();
     test:assertTrue(typeof val === typeof val);
-    test:assertEquals((typeof val).toString(), "typedesc {\"s\":\"test\"}");
+    test:assertEquals((typeof val).toString(), "typedesc map<string> & readonly");
 
-    // Structural types -tables 
+    // Structural types - Tables
     table<map<string>> tableVal = table [{s: "test"}];
     val = tableVal.cloneReadOnly();
     test:assertTrue(typeof val === typeof val);
-    test:assertEquals((typeof val).toString(), "typedesc [{\"s\":\"test\"}]");
+    test:assertEquals((typeof val).toString(), "typedesc table<(map<string> & readonly)> & readonly");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/typedesc/typedesc_positive.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/typedesc/typedesc_positive.bal
@@ -208,7 +208,7 @@ function testTypeDefWithIntersectionTypeDescAsTypedesc() {
     typedesc<anydata> a = ImmutableIntArray;
     (int|string)[] arr = [1, 2, 3];
     anydata|error b = arr.cloneWithType(a);
-    assertEquality("typedesc [1,2,3]", (typeof b).toString());
+    assertEquality("typedesc int[] & readonly", (typeof b).toString());
     assertEquality(true, b is int[]);
     assertEquality(true, (<int[]> checkpanic b).isReadOnly());
     assertEquality(<int[]> [1, 2, 3], b);


### PR DESCRIPTION
## Purpose
This is to revert the partial change done on the `typeof` implementation for immutable container values (PR- https://github.com/ballerina-platform/ballerina-lang/pull/32105). 
Created issue https://github.com/ballerina-platform/ballerina-lang/issues/32531 to address this change.

## Approach

## Samples
```ballerina
int[] & readonly arr = [1, 2, 3];
io:println(typeof arr); // typedesc int[] & readonly -  earlier returned typedesc [1,2,3]
```

## Remarks
related to #15278 , #13189

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
