### PR TITLE
Fix syntax error in source generated by type guard code action

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionUtil.java
@@ -70,11 +70,13 @@ import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextEdit;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.StringJoiner;
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.ballerinalang.langserver.common.utils.CommonUtil.LINE_SEPARATOR;
@@ -398,7 +400,14 @@ public class CodeActionUtil {
             }
             List<String> memberTypes = new ArrayList<>();
             for (TypeSymbol tMember : tMembers) {
-                memberTypes.add(CodeActionUtil.getPossibleType(tMember, edits, context).orElseThrow());
+                String possibleType = CodeActionUtil.getPossibleType(tMember, edits, context).orElseThrow();
+                if (tMember.typeKind() == TypeDescKind.UNION || tMember.typeKind() == TypeDescKind.SINGLETON) {
+                    String[] parts = possibleType.split(Pattern.quote("|"));
+                    possibleType = Arrays.stream(parts)
+                            .map(s -> "\"" + s + "\"")
+                            .collect(Collectors.joining("| "));
+                }
+                memberTypes.add(possibleType);
             }
             if (addErrorTypeAtEnd) {
                 memberTypes.add("error");

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/TypeGuardTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/TypeGuardTest.java
@@ -47,6 +47,7 @@ public class TypeGuardTest extends AbstractCodeActionTest {
                 {"typeGuardCodeAction1.json", "typeGuard.bal"},
                 {"typeGuardCodeAction2.json", "typeGuard.bal"},
                 {"typeGuardCodeAction3.json", "typeGuard.bal"},
+                {"typeGuardCodeAction4.json", "typeGuard2.bal"},
         };
     }
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/type-guard/config/typeGuardCodeAction4.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/type-guard/config/typeGuardCodeAction4.json
@@ -1,0 +1,24 @@
+{
+  "line": 8,
+  "character": 8,
+  "expected": [
+    {
+      "title": "Type guard variable",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 8,
+              "character": 28
+            },
+            "end": {
+              "line": 8,
+              "character": 28
+            }
+          },
+          "newText": "\n    if cur is SingleCharDelim {\n\n    } else if cur is CompoundAssignDelim {\n\n    } else if cur is \"\u003c\u003c\"| \"\u003e\u003e\" {\n\n    } else if cur is \"int\" {\n\n    } else if cur is \"string\" {\n\n    } else {\n\n    }\n"
+        }
+      ]
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/type-guard/source/typeGuard2.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/type-guard/source/typeGuard2.bal
@@ -1,0 +1,10 @@
+type Token SingleCharDelim|MultiCharDelim|Keyword;
+type SingleCharDelim "+" | "-" ;
+type MultiCharDelim "<<" | ">>" | CompoundAssignDelim;
+type CompoundAssignDelim "+=" | "-=" ;
+type Keyword KEY | "string";
+const KEY = "int";
+
+public function main(string... args) {
+    Token? cur = getToken();
+}


### PR DESCRIPTION
## Purpose
Fixes generating a syntactically incorrect source by the type guard code action.

Fixes #32313 

## Samples
Before :
<img width="514" alt="Screenshot 2021-09-02 at 10 59 10" src="https://user-images.githubusercontent.com/27485094/131787105-0acb7f42-9abb-4f5e-b739-e603f2c70376.png">

After : 
<img width="514" alt="Screenshot 2021-09-02 at 10 58 45" src="https://user-images.githubusercontent.com/27485094/131787124-ba3957c5-9e31-4625-b23f-969b4fc986e5.png">



## Check List 
- [X] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [X] Added necessary tests
  - [X] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
