### PR TITLE
Fix `symbol()` API for Computed Keys in Mapping Constructors

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
@@ -1532,7 +1532,7 @@ class SymbolFinder extends BaseVisitor {
 
     @Override
     public void visit(BLangRecordLiteral.BLangRecordKey recordKey) {
-        if (setEnclosingNode(recordKey.fieldSymbol, recordKey.pos)) {
+        if (recordKey.fieldSymbol != null && setEnclosingNode(recordKey.fieldSymbol, recordKey.pos)) {
             return;
         }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
@@ -1532,7 +1532,7 @@ class SymbolFinder extends BaseVisitor {
 
     @Override
     public void visit(BLangRecordLiteral.BLangRecordKey recordKey) {
-        if (recordKey.fieldSymbol != null && setEnclosingNode(recordKey.fieldSymbol, recordKey.pos)) {
+        if (!recordKey.computedKey && setEnclosingNode(recordKey.fieldSymbol, recordKey.pos)) {
             return;
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
@@ -1913,9 +1913,13 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
                 BLangRecordKeyValueField bLRecordKeyValueField =
                         (BLangRecordKeyValueField) TreeBuilder.createRecordKeyValue();
                 bLRecordKeyValueField.valueExpr = createExpression(computedNameField.valueExpr());
+                bLRecordKeyValueField.pos = getPosition(computedNameField);
+
                 bLRecordKeyValueField.key =
                         new BLangRecordLiteral.BLangRecordKey(createExpression(computedNameField.fieldNameExpr()));
                 bLRecordKeyValueField.key.computedKey = true;
+                bLRecordKeyValueField.key.pos = getPosition(computedNameField.fieldNameExpr());
+
                 bLiteralNode.fields.add(bLRecordKeyValueField);
             } else {
                 SpecificFieldNode specificField = (SpecificFieldNode) field;

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolAtCursorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolAtCursorTest.java
@@ -116,6 +116,7 @@ public class SymbolAtCursorTest {
                 {122, 56, "myStr"},
                 {135, 5, "Atype"},
                 {150, 12, "ParseError"},
+                {163, 9, "foo"},
         };
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolAtCursorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolAtCursorTest.java
@@ -116,6 +116,8 @@ public class SymbolAtCursorTest {
                 {122, 56, "myStr"},
                 {135, 5, "Atype"},
                 {150, 12, "ParseError"},
+                {161, 8, "name"},
+                {162, 8, "age"},
                 {163, 9, "foo"},
         };
     }

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol_at_cursor_basic_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol_at_cursor_basic_test.bal
@@ -152,3 +152,16 @@ function testOnFail() returns boolean {
         return false;
     }
 }
+
+function foo() returns string {
+    return "abc";
+}
+
+function test(string name, int age) {
+    Person p = {
+        name: name,
+        age,
+        [foo()]: "FOO",
+        ...adrs
+    };
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol_at_cursor_basic_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol_at_cursor_basic_test.bal
@@ -161,7 +161,6 @@ function test(string name, int age) {
     Person p = {
         name: name,
         age,
-        [foo()]: "FOO",
-        ...adrs
+        [foo()]: "FOO"
     };
 }


### PR DESCRIPTION
## Purpose
> $title

Fixes #31803

## Approach
> 

## Samples
> 

## Remarks
> 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
