### PR TITLE
Quick fix for cyclic record resolution intermittent fail `testCyclicRecordViaFields`

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -1487,7 +1487,7 @@ public class SymbolEnter extends BLangNodeVisitor {
         }
 
         // check for unresolved fields. This record may be referencing another record
-        if (!this.resolveRecordsUnresolvedDueToFields && typeNodeKind == NodeKind.RECORD_TYPE) {
+        if (hasTypeInclusions && !this.resolveRecordsUnresolvedDueToFields && typeNodeKind == NodeKind.RECORD_TYPE) {
             BLangStructureTypeNode structureTypeNode = (BLangStructureTypeNode) typeDefinition.typeNode;
             for (BLangSimpleVariable variable : structureTypeNode.fields) {
                 Scope scope = new Scope(structureTypeNode.symbol);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/typedefs/TypeDefinitionsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/typedefs/TypeDefinitionsTest.java
@@ -156,10 +156,10 @@ public class TypeDefinitionsTest {
         BRunUtil.invoke(compileResult, "testTypeDefReferringToTypeDefDefinedAfter");
     }
 
-    @Test
-    public void testRecordTypeResolving() {
-        BRunUtil.invoke(recordFieldRes, "testRecordTypeResolving");
-    }
+//    @Test
+//    public void testRecordTypeResolving() {
+//        BRunUtil.invoke(recordFieldRes, "testRecordTypeResolving");
+//    }
 
     @Test
     public void testRecordTypeResolvingWithTypeInclusion() {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/typedefs/record-type-field-resolving.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/typedefs/record-type-field-resolving.bal
@@ -14,27 +14,28 @@
 // specific language governing permissions and limitations
 // under the License.
 
-public type Foo record {
-    string code?;
-    string message?;
-};
+// public type Foo record {
+//     string code?;
+//     string message?;
+// };
 
-public type Bar record {
-    string processId?;
-    Qux[] reasons?;
-    boolean success?;
-};
+// public type Bar record {
+//     string processId?;
+//     Qux[] reasons?;
+//     boolean success?;
+// };
 
-public type Baz record {
-    *Bar;
-    string id?;
-    Foo[] reasons?;
-};
+// public type Baz record {
+//     *Bar;
+//     string id?;
+//     Foo[] reasons?;
+// };
 
-public type Qux record {
-    string code?;
-    string message?;
-};
+// public type Qux record {
+//     string code?;
+//     string message?;
+// };
+
 
 public type Bdd Node|boolean;
 
@@ -49,17 +50,17 @@ public type Node readonly & record {|
 type R record {
 };
 
-function testRecordTypeResolving() {
-    Baz & readonly baz = {reasons: [{code: "22", message: "message-22"}]};
-    var reasons = baz?.reasons;
-    if (reasons is Foo[]) {
-        Foo foo = reasons[0];
-        assertEquality("22", foo?.code);
-        assertEquality("message-22", foo?.message);
-    } else {
-        panic error("Assertion error: expected Foo[], found: " + (typeof reasons).toString());
-    }
-}
+// function testRecordTypeResolving() {
+//     Baz & readonly baz = {reasons: [{code: "22", message: "message-22"}]};
+//     var reasons = baz?.reasons;
+//     if (reasons is Foo[]) {
+//         Foo foo = reasons[0];
+//         assertEquality("22", foo?.code);
+//         assertEquality("message-22", foo?.message);
+//     } else {
+//         panic error("Assertion error: expected Foo[], found: " + (typeof reasons).toString());
+//     }
+// }
 
 function testRecordTypeResolvingWithTypeInclusion() {
     Node node = {


### PR DESCRIPTION
## Purpose
This is a temporary fix to make the build stable

This PR is reverting the change done by PR #32095 temporarily 
Test cases added by the reverted PR is disabled for issue #32044

Originally `testCyclicRecordViaFields` is fixed by having priority for unresolved types due to type refs. Recent PR removes this but fix record resolution in a more clean way. The final solution should have both of these properties.

Please see the issue https://github.com/ballerina-platform/ballerina-lang/issues/32617
## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
