### PR TITLE
[LS] Implement a simulator for language server

### DIFF
--- a/language-server/modules/langserver-core/spotbugs-exclude.xml
+++ b/language-server/modules/langserver-core/spotbugs-exclude.xml
@@ -178,4 +178,10 @@
             <Bug pattern="DM_CONVERT_CASE" />
         </OR>
     </Match>
+    <Match>
+        <Class name="org.ballerinalang.langserver.util.TestUtil" />
+        <OR>
+            <Bug pattern="DM_DEFAULT_ENCODING" />
+        </OR>
+    </Match>
 </FindBugsFilter>

--- a/language-server/modules/langserver-core/src/main/java/module-info.java
+++ b/language-server/modules/langserver-core/src/main/java/module-info.java
@@ -13,6 +13,7 @@ module io.ballerina.language.server.core {
     exports org.ballerinalang.langserver.extensions;
     exports org.ballerinalang.langserver.config;
     exports org.ballerinalang.langserver.telemetry;
+    exports org.ballerinalang.langserver.util to io.ballerina.language.server.simulator;
     requires io.ballerina.formatter.core;
     requires org.eclipse.lsp4j;
     requires io.ballerina.language.server.commons;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/TestUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/TestUtil.java
@@ -46,6 +46,7 @@ import org.eclipse.lsp4j.CompletionItemCapabilities;
 import org.eclipse.lsp4j.CompletionParams;
 import org.eclipse.lsp4j.CompletionTriggerKind;
 import org.eclipse.lsp4j.DefinitionParams;
+import org.eclipse.lsp4j.DidChangeTextDocumentParams;
 import org.eclipse.lsp4j.DidCloseTextDocumentParams;
 import org.eclipse.lsp4j.DidOpenTextDocumentParams;
 import org.eclipse.lsp4j.DocumentFormattingParams;
@@ -74,9 +75,11 @@ import org.eclipse.lsp4j.SignatureInformationCapabilities;
 import org.eclipse.lsp4j.SymbolTag;
 import org.eclipse.lsp4j.SymbolTagSupportCapabilities;
 import org.eclipse.lsp4j.TextDocumentClientCapabilities;
+import org.eclipse.lsp4j.TextDocumentContentChangeEvent;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.TextDocumentItem;
 import org.eclipse.lsp4j.TextDocumentPositionParams;
+import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
 import org.eclipse.lsp4j.WorkspaceClientCapabilities;
 import org.eclipse.lsp4j.WorkspaceSymbolParams;
 import org.eclipse.lsp4j.jsonrpc.Endpoint;
@@ -470,6 +473,17 @@ public class TestUtil {
         serviceEndpoint.notify("textDocument/didOpen", documentParams);
     }
 
+    public static void didChangeDocument(Endpoint serviceEndpoint, Path filePath, String content) {
+        VersionedTextDocumentIdentifier identifier = new VersionedTextDocumentIdentifier();
+        identifier.setUri(filePath.toUri().toString());
+
+        DidChangeTextDocumentParams didChangeTextDocumentParams = new DidChangeTextDocumentParams();
+        didChangeTextDocumentParams.setTextDocument(identifier);
+        didChangeTextDocumentParams.setContentChanges(List.of(new TextDocumentContentChangeEvent(content)));
+
+        serviceEndpoint.notify("textDocument/didChange", didChangeTextDocumentParams);
+    }
+
     /**
      * Close an already opened document.
      *
@@ -504,8 +518,11 @@ public class TestUtil {
      * @return {@link Endpoint}     Service Endpoint
      */
     public static Endpoint initializeLanguageSever(BallerinaLanguageServer languageServer) {
+        return initializeLanguageSever(languageServer, OutputStream.nullOutputStream());
+    }
+    
+    public static Endpoint initializeLanguageSever(BallerinaLanguageServer languageServer, OutputStream out) {
         InputStream in = new ByteArrayInputStream(new byte[1024]);
-        OutputStream out = new ByteArrayOutputStream();
         Launcher<ExtendedLanguageClient> launcher = Launcher.createLauncher(languageServer,
                 ExtendedLanguageClient.class, in, out);
         ExtendedLanguageClient client = launcher.getRemoteProxy();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/TestUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/TestUtil.java
@@ -89,7 +89,6 @@ import org.eclipse.lsp4j.jsonrpc.messages.ResponseMessage;
 import org.eclipse.lsp4j.jsonrpc.services.ServiceEndpoints;
 
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;

--- a/settings.gradle
+++ b/settings.gradle
@@ -91,6 +91,7 @@ include(':testerina:report-tools')
 include(':testerina-integration-test')
 include(':jballerina-debugger-integration-test')
 include(':language-server-integration-tests')
+include(':language-server-simulator')
 // TODO: enable at 'dependsOn' of tools-intergration-tests
 // and 'mustRunAfter' of vs-code-pluggin
 
@@ -201,6 +202,7 @@ project(':test-launch-listener-03').projectDir = file('tests/launch-listener-tes
 project(':test-launch-listener-04').projectDir = file('tests/launch-listener-test-util-libs/test-launch-listener-04')
 project(':jballerina-integration-test').projectDir = file('tests/jballerina-integration-test')
 project(':language-server-integration-tests').projectDir = file('tests/language-server-integration-tests')
+project(':language-server-simulator').projectDir = file('tests/language-server-simulator')
 // project(':composer-integration-test').projectDir = file('tests/composer-integration-test')
 // project(':ballerina-tools-integration-test').projectDir = file('tests/ballerina-tools-integration-test')
 //project(':ballerina-stringutils').projectDir = file('stdlib/stringutils')

--- a/tests/language-server-simulator/build.gradle
+++ b/tests/language-server-simulator/build.gradle
@@ -15,6 +15,9 @@
  *
  */
 
+plugins {
+    id 'de.undercouch.download' version '4.1.1'
+}
 
 apply from: "$rootDir/gradle/javaProjectWithExtBala.gradle"
 apply from: "$rootDir/gradle/ballerinaLangLibLoad.gradle"
@@ -23,6 +26,10 @@ configurations.all {
     resolutionStrategy {
         preferProjectModules()
     }
+}
+
+ext {
+    balSourceDir = "nBallerinaSrc"
 }
 
 configurations {
@@ -74,11 +81,41 @@ test {
     }
 }
 
+task downloadBalTestProject(type: Download) {
+    // Download nBallerina latest tag
+    src "https://github.com/ballerina-platform/nballerina/archive/refs/tags/subset06.zip"
+    onlyIfModified true
+    dest new File("${buildDir}/nballeirna-src.zip")
+}
+
+def extractedBalSrcDir
+
+task unpackBalTestProject(type: Copy) {
+    def sourceDir = "${buildDir}/${balSourceDir}"
+    from zipTree { "${buildDir}/nballeirna-src.zip" }
+    new File("${sourceDir}").mkdirs()
+    into new File("${sourceDir}")
+
+    // Find the compiler directory within nballerina source
+    new File("${sourceDir}").eachDir { parentDir ->
+        if (parentDir.isDirectory()) {
+            parentDir.eachDir { child ->
+                if (child.name == "compiler" && child.isDirectory()) {
+                    extractedBalSrcDir = "${sourceDir}/${parentDir.name}/${child.name}"
+                }
+            }
+        }
+    }
+}
+
 task runLSSimulator(type: JavaExec) {
+    dependsOn unpackBalTestProject
     dependsOn loadDistributionCache
     systemProperty "ballerina.home", "$buildDir/"
     systemProperty "experimental", "true"
     systemProperty "ballerina.version", project.version
+    systemProperty "ls.simulation.duration", "60"
+    systemProperty "ls.simulation.src", "${extractedBalSrcDir}"
     systemProperty "LANG_REPO_BUILD", "false"
 
     jvmArgs = ['-Xms256m', '-Xmx1024m', '-XX:+HeapDumpOnOutOfMemoryError', "-XX:HeapDumpPath=\"$buildDir\""]
@@ -88,3 +125,5 @@ task runLSSimulator(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     main = "org.ballerinalang.langserver.simulator.EditorSimulator"
 }
+
+unpackBalTestProject.dependsOn downloadBalTestProject

--- a/tests/language-server-simulator/build.gradle
+++ b/tests/language-server-simulator/build.gradle
@@ -62,6 +62,19 @@ dependencies {
 
 description = 'Ballerina - Language Server Simulator'
 
+// Skip this module from coverage
+jacocoTestReport {
+    reports {
+        xml.enabled true // coveralls plugin depends on xml format report
+        html.enabled true
+    }
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: '**')
+        }))
+    }
+}
+
 task downloadBalTestProject(type: Download) {
     // Download nBallerina latest tag
     src "https://github.com/ballerina-platform/nballerina/archive/refs/tags/subset06.zip"

--- a/tests/language-server-simulator/build.gradle
+++ b/tests/language-server-simulator/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
  */
 
 plugins {
-    id 'de.undercouch.download' version '4.1.1'
+    id 'de.undercouch.download' version '4.1.2'
 }
 
 apply from: "$rootDir/gradle/javaProjectWithExtBala.gradle"
@@ -58,28 +58,9 @@ dependencies {
     implementation 'org.slf4j:slf4j-jdk14'
 
     testCompile 'org.testng:testng'
-
-    compilerPluginJar project(':project-api-test-artifact:compiler-plugin-with-codeactions')
 }
 
-description = 'Ballerina - Language Server Integration Tests'
-
-
-task copyCompilerPluginJars(type: Copy) {
-    from configurations.compilerPluginJar
-    into "$buildDir/compiler-plugin-jars"
-}
-
-test {
-    dependsOn copyCompilerPluginJars
-    dependsOn loadDistributionCache
-    systemProperty "ballerina.home", "$buildDir/"
-    systemProperty "experimental", "true"
-    systemProperty "ballerina.version", project.version
-    useTestNG() {
-        suites 'src/test/resources/testng.xml'
-    }
-}
+description = 'Ballerina - Language Server Simulator'
 
 task downloadBalTestProject(type: Download) {
     // Download nBallerina latest tag
@@ -112,7 +93,6 @@ task runLSSimulator(type: JavaExec) {
     dependsOn unpackBalTestProject
     dependsOn loadDistributionCache
     systemProperty "ballerina.home", "$buildDir/"
-    systemProperty "experimental", "true"
     systemProperty "ballerina.version", project.version
     systemProperty "ls.simulation.duration", "60"
     systemProperty "ls.simulation.src", "${extractedBalSrcDir}"

--- a/tests/language-server-simulator/build.gradle
+++ b/tests/language-server-simulator/build.gradle
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+
+apply from: "$rootDir/gradle/javaProjectWithExtBala.gradle"
+apply from: "$rootDir/gradle/ballerinaLangLibLoad.gradle"
+
+configurations.all {
+    resolutionStrategy {
+        preferProjectModules()
+    }
+}
+
+configurations {
+    dependency {
+        transitive true
+    }
+    compilerPluginJar {
+        transitive true
+    }
+}
+
+dependencies {
+    implementation project(':ballerina-tools-api')
+    implementation project(':ballerina-lang')
+    implementation project(':ballerina-parser')
+    implementation project(':language-server:language-server-commons')
+    implementation project(':language-server:language-server-core')
+    implementation project(':ballerina-test-utils')
+
+    implementation('org.eclipse.lsp4j:org.eclipse.lsp4j') {
+        exclude group: 'com.google.guava', module: 'guava'
+    }
+    implementation('org.eclipse.lsp4j:org.eclipse.lsp4j.jsonrpc') {
+        exclude group: 'com.google.guava', module: 'guava'
+    }
+    implementation 'org.slf4j:slf4j-jdk14'
+
+    testCompile 'org.testng:testng'
+
+    compilerPluginJar project(':project-api-test-artifact:compiler-plugin-with-codeactions')
+}
+
+description = 'Ballerina - Language Server Integration Tests'
+
+
+task copyCompilerPluginJars(type: Copy) {
+    from configurations.compilerPluginJar
+    into "$buildDir/compiler-plugin-jars"
+}
+
+test {
+    dependsOn copyCompilerPluginJars
+    dependsOn loadDistributionCache
+    systemProperty "ballerina.home", "$buildDir/"
+    systemProperty "experimental", "true"
+    systemProperty "ballerina.version", project.version
+    useTestNG() {
+        suites 'src/test/resources/testng.xml'
+    }
+}
+
+task runLSSimulator(type: JavaExec) {
+    dependsOn loadDistributionCache
+    systemProperty "ballerina.home", "$buildDir/"
+    systemProperty "experimental", "true"
+    systemProperty "ballerina.version", project.version
+    systemProperty "LANG_REPO_BUILD", "false"
+
+    jvmArgs = ['-Xms256m', '-Xmx1024m', '-XX:+HeapDumpOnOutOfMemoryError', "-XX:HeapDumpPath=\"$buildDir\""]
+
+    group = "Execution"
+    description = "Run the main class with JavaExecTask"
+    classpath = sourceSets.main.runtimeClasspath
+    main = "org.ballerinalang.langserver.simulator.EditorSimulator"
+}

--- a/tests/language-server-simulator/spotbugs-exclude.xml
+++ b/tests/language-server-simulator/spotbugs-exclude.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~ Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
   ~
   ~ WSO2 Inc. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except

--- a/tests/language-server-simulator/spotbugs-exclude.xml
+++ b/tests/language-server-simulator/spotbugs-exclude.xml
@@ -1,0 +1,23 @@
+<!--
+  ~ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<FindBugsFilter>
+    <Match>
+        <Class name="org.ballerinalang.langserver.simulator.EditorSimulator"/>
+        <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"/>
+    </Match>
+</FindBugsFilter>

--- a/tests/language-server-simulator/src/main/java/module-info.java
+++ b/tests/language-server-simulator/src/main/java/module-info.java
@@ -1,0 +1,12 @@
+module io.ballerina.language.server.simulator {
+    uses org.ballerinalang.langserver.simulator.generators.CodeSnippetGenerator;
+    requires org.eclipse.lsp4j;
+    requires io.ballerina.language.server.commons;
+    requires io.ballerina.language.server.core;
+    requires org.eclipse.lsp4j.jsonrpc;
+    requires io.ballerina.lang;
+    requires io.ballerina.parser;
+    requires io.ballerina.tools.api;
+    requires com.google.gson;
+    requires slf4j.api;
+}

--- a/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/Editor.java
+++ b/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/Editor.java
@@ -21,11 +21,15 @@ import org.eclipse.lsp4j.jsonrpc.Endpoint;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Represents the editor used by the end user. An  editor consists of a set of open tabs.
+ *
+ * @since 2.0.0
+ */
 public class Editor {
 
     private static final Logger logger = LoggerFactory.getLogger(Editor.class);
@@ -41,7 +45,12 @@ public class Editor {
         this.endpoint = endpoint;
     }
 
-    public static Editor open() throws IOException {
+    /**
+     * Simulates opening the editor. Here we initialize the language server.
+     *
+     * @return Editor instance
+     */
+    public static Editor open() {
         BallerinaLanguageServer languageServer = new BallerinaLanguageServer();
 
         EditorOutputStream outputStream = new EditorOutputStream();

--- a/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/Editor.java
+++ b/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/Editor.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.langserver.simulator;
+
+import org.ballerinalang.langserver.BallerinaLanguageServer;
+import org.ballerinalang.langserver.util.TestUtil;
+import org.eclipse.lsp4j.jsonrpc.Endpoint;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public class Editor {
+
+    private static final Logger logger = LoggerFactory.getLogger(Editor.class);
+
+    private BallerinaLanguageServer languageServer;
+    private Endpoint endpoint;
+
+    private final List<EditorTab> tabs = new ArrayList<>();
+    private EditorTab activeTab;
+
+    private Editor(BallerinaLanguageServer languageServer, Endpoint endpoint) {
+        this.languageServer = languageServer;
+        this.endpoint = endpoint;
+    }
+
+    public static Editor open() throws IOException {
+        BallerinaLanguageServer languageServer = new BallerinaLanguageServer();
+
+        EditorOutputStream outputStream = new EditorOutputStream();
+        Endpoint endpoint = TestUtil.initializeLanguageSever(languageServer, outputStream);
+
+        Editor editor = new Editor(languageServer, endpoint);
+        outputStream.setEditor(editor);
+        return editor;
+    }
+
+    public EditorTab openFile(Path filePath) {
+        EditorTab editorTab = tabs.stream()
+                .filter(tab -> tab.filePath().equals(filePath))
+                .findFirst()
+                .orElseGet(() -> {
+                    EditorTab tab = new EditorTab(filePath, endpoint, languageServer);
+                    tabs.add(tab);
+                    return tab;
+                });
+        this.activeTab = editorTab;
+        return editorTab;
+    }
+
+    public void closeFile(Path filePath) {
+        tabs.removeIf(tab -> {
+            if (filePath.equals(tab.filePath())) {
+                tab.close();
+                return true;
+            }
+            return false;
+        });
+    }
+
+    public void closeTab(EditorTab tab) {
+        tabs.remove(tab);
+    }
+
+    public void close() {
+        this.languageServer.shutdown();
+        tabs.forEach(tab -> tab.close());
+    }
+
+    public EditorTab activeTab() {
+        return activeTab;
+    }
+}

--- a/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/Editor.java
+++ b/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/Editor.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -34,8 +35,8 @@ public class Editor {
 
     private static final Logger logger = LoggerFactory.getLogger(Editor.class);
 
-    private BallerinaLanguageServer languageServer;
-    private Endpoint endpoint;
+    private final BallerinaLanguageServer languageServer;
+    private final Endpoint endpoint;
 
     private final List<EditorTab> tabs = new ArrayList<>();
     private EditorTab activeTab;
@@ -75,22 +76,28 @@ public class Editor {
     }
 
     public void closeFile(Path filePath) {
-        tabs.removeIf(tab -> {
+        Iterator<EditorTab> iterator = tabs.iterator();
+        while (iterator.hasNext()) {
+            EditorTab tab = iterator.next();
             if (filePath.equals(tab.filePath())) {
-                tab.close();
-                return true;
+                if (activeTab != null && activeTab.equals(tab)) {
+                    activeTab = null;
+                }
+                iterator.remove();
             }
-            return false;
-        });
+        }
     }
 
     public void closeTab(EditorTab tab) {
         tabs.remove(tab);
+        if (activeTab != null && activeTab.equals(tab)) {
+            activeTab = null;
+        }
     }
 
     public void close() {
         this.languageServer.shutdown();
-        tabs.forEach(tab -> tab.close());
+        tabs.forEach(EditorTab::close);
     }
 
     public EditorTab activeTab() {

--- a/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/EditorOutputStream.java
+++ b/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/EditorOutputStream.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.langserver.simulator;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+class EditorOutputStream extends ByteArrayOutputStream {
+
+    private static final Logger logger = LoggerFactory.getLogger(EditorOutputStream.class);
+
+    private Editor editor;
+
+    @Override
+    public void flush() throws IOException {
+        String message = this.toString();
+        reset();
+        try {
+            process(message);
+        } catch (Throwable t) {
+            logger.error("Error processing message", t);
+        }
+    }
+
+    void process(String message) {
+        String[] parts = message.replace("\r\n", "\n").split("\n");
+        if (parts.length > 1) {
+            message = parts[parts.length - 1];
+            JsonElement jsonMsg = JsonParser.parseString(message);
+
+            if (jsonMsg.isJsonObject()) {
+                JsonObject obj = jsonMsg.getAsJsonObject();
+                String method = obj.get("method").getAsString();
+
+                switch (method) {
+                    case "telemetry/event":
+                        logger.info("Got telemetry event: {}", obj);
+                        if (editor != null && editor.activeTab() != null) {
+                            logger.info("Current file: {}", editor.activeTab().filePath());
+                            logger.info("Current file content: \n{}\n========================",
+                                    editor.activeTab().textDocument().toString());
+                        }
+                    case "window/logMessage":
+                        logger.info("Received log message event: {}", obj);
+                    case "textDocument/publishDiagnostics":
+                        // pass
+                    default:
+                        // pass
+                }
+            }
+        }
+    }
+
+    public void setEditor(Editor editor) {
+        this.editor = editor;
+    }
+}

--- a/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/EditorOutputStream.java
+++ b/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/EditorOutputStream.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.Charset;
 
 /**
  * A custom output stream to consume messages sent from LS to the LS client side.
@@ -45,7 +46,7 @@ class EditorOutputStream extends ByteArrayOutputStream {
      */
     @Override
     public void flush() throws IOException {
-        String message = this.toString();
+        String message = this.toString(Charset.defaultCharset());
         reset();
         try {
             process(message);

--- a/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/EditorSimulator.java
+++ b/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/EditorSimulator.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.langserver.simulator;
+
+import io.ballerina.compiler.syntax.tree.ModuleMemberDeclarationNode;
+import io.ballerina.compiler.syntax.tree.ModulePartNode;
+import io.ballerina.compiler.syntax.tree.NodeList;
+import io.ballerina.tools.text.LinePosition;
+import org.ballerinalang.langserver.simulator.generators.Generators;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class EditorSimulator {
+
+    private static final Logger logger = LoggerFactory.getLogger(EditorSimulator.class);
+
+    private static final int DURATION_SECONDS = 60 * 60;
+
+    private static final Random random = new Random();
+
+    public static void main(String[] args) {
+        try {
+            run();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static void run() throws IOException {
+        String projectPath = "/home/imesha/Documents/WSO2/Ballerina/nballerina/compiler";
+        Path path = Paths.get(projectPath);
+        logger.info("Using project: {}", path.toString());
+
+        List<Path> balFiles = Files.list(path)
+                .filter(p -> {
+                    return Files.isRegularFile(p) && p.getFileName().toString().endsWith(".bal");
+                })
+                .collect(Collectors.toList());
+
+        if (balFiles.isEmpty()) {
+            throw new IllegalArgumentException("No bal files found in the provided directory");
+        }
+
+        Path modulesPath = path.resolve("modules");
+        if (Files.exists(modulesPath)) {
+            Files.list(modulesPath)
+                    .filter(modPath -> Files.isDirectory(modPath))
+                    .flatMap(modPath -> {
+                        try {
+                            return Files.list(modPath)
+                                    .filter(p -> Files.isRegularFile(p) && p.getFileName().toString().endsWith(".bal"));
+                        } catch (IOException e) {
+                            logger.error("Unable to read path: {}", modPath);
+                            return Stream.empty();
+                        }
+                    })
+                    .forEach(balFiles::add);
+        }
+
+        logger.info("Found bal files in project: {}", balFiles.stream().map(Path::toString).collect(Collectors.joining("\n")));
+
+        Editor editor = Editor.open();
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> editor.close()));
+
+        long endTime = Instant.now().getEpochSecond() + DURATION_SECONDS;
+        while (Instant.now().getEpochSecond() < endTime) {
+            int i = random.nextInt(balFiles.size());
+            Path balFile = balFiles.get(i);
+            EditorTab editorTab = editor.openFile(balFile);
+
+            // Select a random place to type random code
+            ModulePartNode modulePartNode = editorTab.syntaxTree().rootNode();
+            NodeList<ModuleMemberDeclarationNode> members = modulePartNode.members();
+            ModuleMemberDeclarationNode moduleMemberDeclarationNode = members.get(random.nextInt(members.size()));
+            LinePosition linePosition = moduleMemberDeclarationNode.location().lineRange().startLine();
+            // Set cursor to start of random node
+            editorTab.cursor(linePosition.line(), linePosition.offset());
+
+            logger.info("Generating random code snippet");
+            // Get random content to type
+            String content = getRandomNode();
+            logger.info("Typing in editor tab: {} -> {}", editorTab, content);
+
+            editorTab.type(content);
+            editorTab.completions();
+
+            try {
+                int sleepSecs = 1 + random.nextInt(5);
+                Thread.sleep(sleepSecs * 1000);
+            } catch (InterruptedException e) {
+                logger.warn("Interrupted simulation", e);
+                break;
+            }
+        }
+
+        editor.close();
+    }
+
+    public static String getRandomNode() {
+        List<Generators.Type> types = Arrays.stream(Generators.Type.values())
+                .filter(Generators.Type::isTopLevelNode)
+                .collect(Collectors.toList());
+
+        // Get random generator
+        Generators.Type type = types.get(random.nextInt(types.size()));
+        logger.info("Generating snippet of type: {}", type);
+        return Generators.generate(type);
+    }
+}

--- a/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/EditorSimulator.java
+++ b/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/EditorSimulator.java
@@ -69,7 +69,9 @@ public class EditorSimulator {
         logger.info("Using project: {}", path.toString());
 
         List<Path> balFiles = Files.list(path)
-                .filter(p -> Files.isRegularFile(p) && p.getFileName().toString().endsWith(".bal"))
+                .filter(Files::isRegularFile)
+                .filter(p -> p.getFileName() != null)
+                .filter(p -> p.getFileName().toString().endsWith(".bal"))
                 .collect(Collectors.toList());
 
         if (balFiles.isEmpty()) {
@@ -83,7 +85,9 @@ public class EditorSimulator {
                     .flatMap(modPath -> {
                         try {
                             return Files.list(modPath)
-                                    .filter(p -> Files.isRegularFile(p) && p.getFileName().toString().endsWith(".bal"));
+                                    .filter(Files::isRegularFile)
+                                    .filter(p -> p.getFileName() != null)
+                                    .filter(p -> p.getFileName().toString().endsWith(".bal"));
                         } catch (IOException e) {
                             logger.error("Unable to read path: {}", modPath);
                             return Stream.empty();
@@ -122,7 +126,7 @@ public class EditorSimulator {
 
             try {
                 int sleepSecs = 1 + random.nextInt(5);
-                Thread.sleep(sleepSecs * 1000);
+                Thread.sleep(sleepSecs * 1000L);
             } catch (InterruptedException e) {
                 logger.warn("Interrupted simulation", e);
                 break;

--- a/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/EditorSimulator.java
+++ b/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/EditorSimulator.java
@@ -49,11 +49,12 @@ public class EditorSimulator {
 
     private static final Random random = new Random();
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws IOException {
         try {
             run();
         } catch (Exception e) {
-            e.printStackTrace();
+            logger.error("Error occurred while running the simulator", e);
+            throw e;
         }
     }
 
@@ -91,7 +92,8 @@ public class EditorSimulator {
                     .forEach(balFiles::add);
         }
 
-        logger.info("Found bal files in project: {}", balFiles.stream().map(Path::toString).collect(Collectors.joining("\n")));
+        logger.info("Found bal files in project: {}", balFiles.stream()
+                .map(Path::toString).collect(Collectors.joining("\n")));
 
         Editor editor = Editor.open();
         Runtime.getRuntime().addShutdownHook(new Thread(editor::close));

--- a/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/EditorTab.java
+++ b/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/EditorTab.java
@@ -47,6 +47,8 @@ import java.util.concurrent.CompletableFuture;
 
 /**
  * Represents a tab in the {@link Editor}. Simulates the behavior of cursor and current text in the document.
+ *
+ * @since 2.0.0
  */
 public class EditorTab {
 
@@ -114,7 +116,7 @@ public class EditorTab {
                 CompletableFuture.runAsync(this::codeActions);
             }
 
-            if (!isDocumentInSync()) {
+            if (isDocumentNotInSync()) {
                 missCount++;
             }
 
@@ -129,7 +131,7 @@ public class EditorTab {
                 filePath, content.substring(0, Math.min(20, content.length())));
         logger.info("Typed {} characters with {} out of sync scenarios", content.length(), missCount);
 
-        while (!isDocumentInSync()) {
+        while (isDocumentNotInSync()) {
             logger.info("Document out of sync. Waiting 30 seconds and syncing...");
             try {
                 Thread.sleep(30 * 1000);
@@ -143,17 +145,17 @@ public class EditorTab {
     /**
      * Check if the document in this instance is similar to that is in the language server.
      *
-     * @return
+     * @return True if the document content is not equal to that in workspace manager
      */
-    private boolean isDocumentInSync() {
+    private boolean isDocumentNotInSync() {
         Optional<Document> document = languageServer.getWorkspaceManager().document(filePath);
         if (document.isPresent()) {
-            return document.get().textDocument().toString().equals(textDocument.toString());
+            return !document.get().textDocument().toString().equals(textDocument.toString());
         } else {
             logger.warn("Document not found in workspace manager: {}", filePath);
         }
 
-        return false;
+        return true;
     }
 
     /**

--- a/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/EditorTab.java
+++ b/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/EditorTab.java
@@ -35,6 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -58,6 +59,7 @@ public class EditorTab {
     private Position cursor;
 
     private final Random random = new Random();
+    private final PrintWriter writer = new PrintWriter(System.out);
 
     public EditorTab(Path filePath, Endpoint endpoint, BallerinaLanguageServer languageServer) {
         this.filePath = filePath;
@@ -102,7 +104,8 @@ public class EditorTab {
 
             if (i % 10 == 0) {
                 float completionPercentage = ((float) i / (float) content.length()) * 100;
-                System.out.printf("%.1f%%\r", completionPercentage);
+                writer.printf("%.1f%%\r", completionPercentage);
+                writer.flush();
             }
 
             // Get completions in the background
@@ -122,7 +125,8 @@ public class EditorTab {
                 break;
             }
         }
-        logger.info("Typed provided content in file: {} -> \n{}", filePath, content.substring(0, Math.min(20, content.length())));
+        logger.info("Typed provided content in file: {} -> \n{}",
+                filePath, content.substring(0, Math.min(20, content.length())));
         logger.info("Typed {} characters with {} out of sync scenarios", content.length(), missCount);
 
         while (!isDocumentInSync()) {

--- a/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/EditorTab.java
+++ b/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/EditorTab.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -59,7 +60,7 @@ public class EditorTab {
     private Position cursor;
 
     private final Random random = new Random();
-    private final PrintWriter writer = new PrintWriter(System.out);
+    private final PrintWriter writer = new PrintWriter(System.out, true, Charset.defaultCharset());
 
     public EditorTab(Path filePath, Endpoint endpoint, BallerinaLanguageServer languageServer) {
         this.filePath = filePath;
@@ -105,7 +106,6 @@ public class EditorTab {
             if (i % 10 == 0) {
                 float completionPercentage = ((float) i / (float) content.length()) * 100;
                 writer.printf("%.1f%%\r", completionPercentage);
-                writer.flush();
             }
 
             // Get completions in the background

--- a/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/EditorTab.java
+++ b/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/EditorTab.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.langserver.simulator;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import io.ballerina.compiler.syntax.tree.SyntaxTree;
+import io.ballerina.projects.Document;
+import io.ballerina.tools.text.LinePosition;
+import io.ballerina.tools.text.TextDocument;
+import io.ballerina.tools.text.TextDocumentChange;
+import io.ballerina.tools.text.TextDocuments;
+import io.ballerina.tools.text.TextEdit;
+import io.ballerina.tools.text.TextRange;
+import org.ballerinalang.langserver.BallerinaLanguageServer;
+import org.ballerinalang.langserver.util.TestUtil;
+import org.eclipse.lsp4j.CodeActionContext;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.jsonrpc.Endpoint;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+
+public class EditorTab {
+
+    private static final Logger logger = LoggerFactory.getLogger(EditorTab.class);
+
+    private final Path filePath;
+    private final Endpoint endpoint;
+    private final BallerinaLanguageServer languageServer;
+
+    private TextDocument textDocument;
+    private Position cursor;
+
+    private Random random = new Random();
+
+    public EditorTab(Path filePath, Endpoint endpoint, BallerinaLanguageServer languageServer) {
+        this.filePath = filePath;
+        this.endpoint = endpoint;
+        this.languageServer = languageServer;
+        try {
+            String content = Files.readString(filePath);
+            this.textDocument = TextDocuments.from(content);
+            LinePosition linePosition = textDocument.linePositionFrom(content.length() - 1);
+            cursor(linePosition.line(), linePosition.offset());
+        } catch (IOException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    public void type(String content) {
+        int missCount = 0;
+        for (int i = 0; i < content.length(); i++) {
+            String typedChar = Character.toString(content.charAt(i));
+
+            int startOffset = textDocument.textPositionFrom(LinePosition.from(cursor.getLine(), cursor.getCharacter()));
+            TextEdit edit = TextEdit.from(TextRange.from(startOffset, 0), typedChar);
+            TextDocumentChange change = TextDocumentChange.from(new TextEdit[]{edit});
+            textDocument = textDocument.apply(change);
+
+            LinePosition newLinePos = textDocument.linePositionFrom(startOffset + 1);
+            try {
+                TestUtil.didChangeDocument(this.endpoint, this.filePath, textDocument.toString());
+            } catch (Throwable t) {
+                logger.error("Caught error in didChange", t);
+            }
+            cursor(newLinePos.line(), newLinePos.offset());
+            // logger.info("Added char: {} and cursor advanced to: {}", typedChar, newLinePos);
+
+            // Get completions in the background
+            if (i % 3 == 0) {
+                CompletableFuture.runAsync(this::completions);
+                CompletableFuture.runAsync(this::codeActions);
+            }
+
+            if (!isDocumentInSync()) {
+                missCount++;
+            }
+
+            try {
+                Thread.sleep(100 + random.nextInt(300));
+            } catch (InterruptedException e) {
+                logger.error("Interrupted", e);
+                break;
+            }
+        }
+        logger.info("Typed provided content in file: {} -> \n{}", filePath, content.substring(0, Math.min(20, content.length())));
+        logger.info("Typed {} characters with {} out of sync scenarios", content.length(), missCount);
+
+        while (!isDocumentInSync()) {
+            logger.info("Document out of sync. Waiting 30 seconds and syncing...");
+            try {
+                Thread.sleep(30 * 1000);
+            } catch (InterruptedException e) {
+                break;
+            }
+            TestUtil.didChangeDocument(this.endpoint, this.filePath, textDocument.toString());
+        }
+    }
+
+    private boolean isDocumentInSync() {
+        Optional<Document> document = languageServer.getWorkspaceManager().document(filePath);
+        if (document.isPresent()) {
+            return document.get().textDocument().toString().equals(textDocument.toString());
+        } else {
+            logger.warn("Document not found in workspace manager: {}", filePath);
+        }
+
+        return false;
+    }
+
+    public void completions() {
+        String completionResponse = TestUtil.getCompletionResponse(filePath.toString(), cursor, endpoint, "");
+        JsonObject json = JsonParser.parseString(completionResponse).getAsJsonObject();
+        boolean hasError = false;
+        if (json.has("result") && json.get("result").isJsonObject()) {
+            JsonObject result = json.getAsJsonObject("result");
+            if (!result.has("left") || !result.get("left").isJsonArray()) {
+                hasError = true;
+            }
+        } else {
+            hasError = true;
+        }
+
+        if (hasError) {
+            logger.warn("Completion request unsuccessful! cursor: {} -> {}", filePath, cursor);
+        }
+    }
+
+    public void codeActions() {
+        CodeActionContext codeActionContext = new CodeActionContext(Collections.emptyList());
+        Range range = new Range(cursor, cursor);
+        String completionResponse = TestUtil.getCodeActionResponse(endpoint, filePath.toString(), range,
+                codeActionContext);
+    }
+
+    public void cursor(int line, int offset) {
+        this.cursor = new Position(line, offset);
+    }
+
+    public Position cursor() {
+        return this.cursor;
+    }
+
+    public SyntaxTree syntaxTree() {
+        return SyntaxTree.from(textDocument);
+    }
+
+    public TextDocument textDocument() {
+        return textDocument;
+    }
+
+    public Path filePath() {
+        return filePath;
+    }
+
+    public void close() {
+    }
+
+    @Override
+    public String toString() {
+        return "EditorTab{" +
+                "filePath=" + filePath +
+                ", cursor=(" + cursor.getLine() + ", " + cursor.getCharacter() + ")" +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        EditorTab editorTab = (EditorTab) o;
+        return Objects.equals(filePath, editorTab.filePath);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(filePath);
+    }
+}

--- a/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/ClassGenerator.java
+++ b/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/ClassGenerator.java
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2021, WSO2 Inc. (http://wso2.com) All Rights Reserved.
- *  
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,6 +20,9 @@ import org.ballerinalang.annotation.JavaSPIService;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+/**
+ * Class code snippet generator.
+ */
 @JavaSPIService("org.ballerinalang.langserver.simulator.generators.CodeSnippetGenerator")
 public class ClassGenerator extends CodeSnippetGenerator {
 

--- a/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/ClassGenerator.java
+++ b/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/ClassGenerator.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.langserver.simulator.generators;
+
+import org.ballerinalang.annotation.JavaSPIService;
+
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@JavaSPIService("org.ballerinalang.langserver.simulator.generators.CodeSnippetGenerator")
+public class ClassGenerator extends CodeSnippetGenerator {
+
+    @Override
+    public String generate() {
+        return generateRandomClass();
+    }
+
+    @Override
+    public Generators.Type type() {
+        return Generators.Type.CLASS;
+    }
+
+    private String generateRandomClass() {
+        FunctionGenerator functionGenerator = Generators.getGenerator(Generators.Type.FUNCTION);
+
+        int numOfFunctions = 1 + random.nextInt(100);
+        String body = IntStream.range(0, numOfFunctions)
+                .mapToObj(i -> functionGenerator.generateRandomFunction("fn" + i, "string"))
+                .collect(Collectors.joining("\n"));
+        return "class AClass {\n" +
+                "    " + body + "\n" +
+                "}";
+    }
+}

--- a/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/ClassGenerator.java
+++ b/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/ClassGenerator.java
@@ -22,6 +22,8 @@ import java.util.stream.IntStream;
 
 /**
  * Class code snippet generator.
+ *
+ * @since 2.0.0
  */
 @JavaSPIService("org.ballerinalang.langserver.simulator.generators.CodeSnippetGenerator")
 public class ClassGenerator extends CodeSnippetGenerator {

--- a/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/CodeSnippetGenerator.java
+++ b/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/CodeSnippetGenerator.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.langserver.simulator.generators;
+
+import java.util.List;
+import java.util.Random;
+
+public abstract class CodeSnippetGenerator {
+
+    protected final List<String> primitiveTypes = List.of("string", "int", "float", "decimal", "boolean");
+    protected Random random = new Random();
+
+    public abstract String generate();
+
+    public abstract Generators.Type type();
+}

--- a/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/CodeSnippetGenerator.java
+++ b/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/CodeSnippetGenerator.java
@@ -20,6 +20,8 @@ import java.util.Random;
 
 /**
  * Abstract implementation of code snippet generator for the LS simulator.
+ *
+ * @since 2.0.0
  */
 public abstract class CodeSnippetGenerator {
 

--- a/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/CodeSnippetGenerator.java
+++ b/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/CodeSnippetGenerator.java
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2021, WSO2 Inc. (http://wso2.com) All Rights Reserved.
- *  
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,6 +18,9 @@ package org.ballerinalang.langserver.simulator.generators;
 import java.util.List;
 import java.util.Random;
 
+/**
+ * Abstract implementation of code snippet generator for the LS simulator.
+ */
 public abstract class CodeSnippetGenerator {
 
     protected final List<String> primitiveTypes = List.of("string", "int", "float", "decimal", "boolean");

--- a/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/FunctionGenerator.java
+++ b/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/FunctionGenerator.java
@@ -19,6 +19,8 @@ import org.ballerinalang.annotation.JavaSPIService;
 
 /**
  * Function code snippet generator.
+ *
+ * @since 2.0.0
  */
 @JavaSPIService("org.ballerinalang.langserver.simulator.generators.CodeSnippetGenerator")
 public class FunctionGenerator extends CodeSnippetGenerator {

--- a/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/FunctionGenerator.java
+++ b/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/FunctionGenerator.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.langserver.simulator.generators;
+
+import org.ballerinalang.annotation.JavaSPIService;
+
+@JavaSPIService("org.ballerinalang.langserver.simulator.generators.CodeSnippetGenerator")
+public class FunctionGenerator extends CodeSnippetGenerator {
+
+    @Override
+    public String generate() {
+        return generateRandomFunction();
+    }
+
+    @Override
+    public Generators.Type type() {
+        return Generators.Type.FUNCTION;
+    }
+
+    public String generateRandomFunction() {
+        String name = "fn";
+        String returnType = "string";
+        return generateRandomFunction(name, returnType);
+    }
+
+    public String generateRandomFunction(String name, String returnType) {
+        return "\npublic function " + name + "() returns " + returnType + " {\n" +
+                "    " + getRandomFunctionBody(returnType) + "\n" +
+                "}\n";
+    }
+
+    public String getRandomFunctionBody(String returnType) {
+        StatementGenerator statementGenerator = Generators.getGenerator(Generators.Type.STATEMENT);
+        String body = "";
+        body += "\t" + statementGenerator.getRandomStatement();
+        body += "\t" + statementGenerator.getRandomStatement();
+        body += "\t" + statementGenerator.getRandomStatement();
+        body += "\treturn " + returnType + ";";
+        return body;
+    }
+}

--- a/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/FunctionGenerator.java
+++ b/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/FunctionGenerator.java
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2021, WSO2 Inc. (http://wso2.com) All Rights Reserved.
- *  
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,6 +17,9 @@ package org.ballerinalang.langserver.simulator.generators;
 
 import org.ballerinalang.annotation.JavaSPIService;
 
+/**
+ * Function code snippet generator.
+ */
 @JavaSPIService("org.ballerinalang.langserver.simulator.generators.CodeSnippetGenerator")
 public class FunctionGenerator extends CodeSnippetGenerator {
 

--- a/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/Generators.java
+++ b/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/Generators.java
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2021, WSO2 Inc. (http://wso2.com) All Rights Reserved.
- *  
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,6 +19,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.ServiceLoader;
 
+/**
+ * Factory to access {@link CodeSnippetGenerator}s.
+ */
 public class Generators {
 
     private static Generators instance;
@@ -30,6 +33,12 @@ public class Generators {
                 .forEach(generator -> generators.put(generator.type(), generator));
     }
 
+    /**
+     * Generate a code snippet of provided type.
+     *
+     * @param type Type of the required code snippet.
+     * @return Generated code snippet.
+     */
     public static String generate(Type type) {
         if (instance == null) {
             instance = new Generators();
@@ -46,6 +55,9 @@ public class Generators {
         return (T) instance.generators.get(type);
     }
 
+    /**
+     * Different types of code snippets which can be generated.
+     */
     public enum Type {
         FUNCTION(true),
         CLASS(true),
@@ -55,7 +67,7 @@ public class Generators {
         MATCH_STATEMENT(false),
         VARIABLE_DECLARATION_STATEMENT(true);
 
-        private boolean topLevelNode;
+        private final boolean topLevelNode;
 
         Type(boolean topLevelNode) {
             this.topLevelNode = topLevelNode;

--- a/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/Generators.java
+++ b/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/Generators.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.langserver.simulator.generators;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.ServiceLoader;
+
+public class Generators {
+
+    private static Generators instance;
+    private final Map<Type, CodeSnippetGenerator> generators;
+
+    private Generators() {
+        generators = new HashMap<>();
+        ServiceLoader.load(CodeSnippetGenerator.class)
+                .forEach(generator -> generators.put(generator.type(), generator));
+    }
+
+    public static String generate(Type type) {
+        if (instance == null) {
+            instance = new Generators();
+        }
+
+        if (instance.generators.containsKey(type)) {
+            return instance.generators.get(type).generate();
+        }
+
+        return "";
+    }
+
+    public static <T> T getGenerator(Type type) {
+        return (T) instance.generators.get(type);
+    }
+
+    public enum Type {
+        FUNCTION(true),
+        CLASS(true),
+        SERVICE(true),
+        TYPE_DEFINITION(true),
+        STATEMENT(false),
+        MATCH_STATEMENT(false),
+        VARIABLE_DECLARATION_STATEMENT(true);
+
+        private boolean topLevelNode;
+
+        Type(boolean topLevelNode) {
+            this.topLevelNode = topLevelNode;
+        }
+
+        public boolean isTopLevelNode() {
+            return topLevelNode;
+        }
+    }
+}

--- a/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/Generators.java
+++ b/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/Generators.java
@@ -21,6 +21,8 @@ import java.util.ServiceLoader;
 
 /**
  * Factory to access {@link CodeSnippetGenerator}s.
+ *
+ * @since 2.0.0
  */
 public class Generators {
 

--- a/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/Generators.java
+++ b/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/Generators.java
@@ -24,7 +24,7 @@ import java.util.ServiceLoader;
  */
 public class Generators {
 
-    private static Generators instance;
+    private static final Generators instance = new Generators();
     private final Map<Type, CodeSnippetGenerator> generators;
 
     private Generators() {
@@ -40,11 +40,7 @@ public class Generators {
      * @return Generated code snippet.
      */
     public static String generate(Type type) {
-        if (instance == null) {
-            instance = new Generators();
-        }
-
-        if (instance.generators.containsKey(type)) {
+        if (getInstance().generators.containsKey(type)) {
             return instance.generators.get(type).generate();
         }
 
@@ -53,6 +49,10 @@ public class Generators {
 
     public static <T> T getGenerator(Type type) {
         return (T) instance.generators.get(type);
+    }
+
+    public static Generators getInstance() {
+        return instance;
     }
 
     /**

--- a/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/MatchStatementGenerator.java
+++ b/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/MatchStatementGenerator.java
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2021, WSO2 Inc. (http://wso2.com) All Rights Reserved.
- *  
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,10 +17,20 @@ package org.ballerinalang.langserver.simulator.generators;
 
 import org.ballerinalang.annotation.JavaSPIService;
 
+/**
+ * Match statement code snippet generator.
+ */
 @JavaSPIService("org.ballerinalang.langserver.simulator.generators.CodeSnippetGenerator")
 public class MatchStatementGenerator extends CodeSnippetGenerator {
 
+    /**
+     * Generates a match statement.
+     *
+     * @return Match statement
+     */
+    @Override
     public String generate() {
+        // This statement has intentionally added syntax errors.
         return "\nmatch t {\n" +
                 "    () => {\n}" +
                 "    [1, 2] => {\n}" +

--- a/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/MatchStatementGenerator.java
+++ b/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/MatchStatementGenerator.java
@@ -19,6 +19,8 @@ import org.ballerinalang.annotation.JavaSPIService;
 
 /**
  * Match statement code snippet generator.
+ *
+ * @since 2.0.0
  */
 @JavaSPIService("org.ballerinalang.langserver.simulator.generators.CodeSnippetGenerator")
 public class MatchStatementGenerator extends CodeSnippetGenerator {

--- a/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/MatchStatementGenerator.java
+++ b/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/MatchStatementGenerator.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.langserver.simulator.generators;
+
+import org.ballerinalang.annotation.JavaSPIService;
+
+@JavaSPIService("org.ballerinalang.langserver.simulator.generators.CodeSnippetGenerator")
+public class MatchStatementGenerator extends CodeSnippetGenerator {
+
+    public String generate() {
+        return "\nmatch t {\n" +
+                "    () => {\n}" +
+                "    [1, 2] => {\n}" +
+                "    [1, 2, 10] => {\n}" +
+                "    [int => {\n" +
+                "    _ => {\n}" +
+                "}\n";
+    }
+
+    @Override
+    public Generators.Type type() {
+        return Generators.Type.MATCH_STATEMENT;
+    }
+}

--- a/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/ServiceGenerator.java
+++ b/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/ServiceGenerator.java
@@ -19,6 +19,8 @@ import org.ballerinalang.annotation.JavaSPIService;
 
 /**
  * Service code snippet generator.
+ *
+ * @since 2.0.0
  */
 @JavaSPIService("org.ballerinalang.langserver.simulator.generators.CodeSnippetGenerator")
 public class ServiceGenerator extends CodeSnippetGenerator {

--- a/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/ServiceGenerator.java
+++ b/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/ServiceGenerator.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.langserver.simulator.generators;
+
+import org.ballerinalang.annotation.JavaSPIService;
+
+@JavaSPIService("org.ballerinalang.langserver.simulator.generators.CodeSnippetGenerator")
+public class ServiceGenerator extends CodeSnippetGenerator {
+
+    @Override
+    public String generate() {
+        return generateRandomService();
+    }
+
+    @Override
+    public Generators.Type type() {
+        return Generators.Type.SERVICE;
+    }
+
+    public String generateRandomService() {
+        return "\nservice /context1 on new http:Listener(8080) {\n" +
+                "    resource function get path1(http:Caller caller, http:Request req) {\n" +
+                "        \n" +
+                "    }\n" +
+                "}\n";
+    }
+}

--- a/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/ServiceGenerator.java
+++ b/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/ServiceGenerator.java
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2021, WSO2 Inc. (http://wso2.com) All Rights Reserved.
- *  
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,6 +17,9 @@ package org.ballerinalang.langserver.simulator.generators;
 
 import org.ballerinalang.annotation.JavaSPIService;
 
+/**
+ * Service code snippet generator.
+ */
 @JavaSPIService("org.ballerinalang.langserver.simulator.generators.CodeSnippetGenerator")
 public class ServiceGenerator extends CodeSnippetGenerator {
 

--- a/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/StatementGenerator.java
+++ b/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/StatementGenerator.java
@@ -17,6 +17,9 @@ package org.ballerinalang.langserver.simulator.generators;
 
 import org.ballerinalang.annotation.JavaSPIService;
 
+/**
+ * Statement code snippet generator.
+ */
 @JavaSPIService("org.ballerinalang.langserver.simulator.generators.CodeSnippetGenerator")
 public class StatementGenerator extends CodeSnippetGenerator {
 

--- a/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/StatementGenerator.java
+++ b/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/StatementGenerator.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.langserver.simulator.generators;
+
+import org.ballerinalang.annotation.JavaSPIService;
+
+@JavaSPIService("org.ballerinalang.langserver.simulator.generators.CodeSnippetGenerator")
+public class StatementGenerator extends CodeSnippetGenerator {
+
+    @Override
+    public String generate() {
+        return getRandomStatement();
+    }
+
+    @Override
+    public Generators.Type type() {
+        return Generators.Type.STATEMENT;
+    }
+
+    public String getRandomStatement() {
+        switch (random.nextInt(2)) {
+            case 0:
+                return Generators.generate(Generators.Type.MATCH_STATEMENT);
+            case 1:
+            default:
+                return Generators.generate(Generators.Type.VARIABLE_DECLARATION_STATEMENT);
+        }
+    }
+
+}

--- a/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/StatementGenerator.java
+++ b/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/StatementGenerator.java
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2021, WSO2 Inc. (http://wso2.com) All Rights Reserved.
- *  
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,6 +19,8 @@ import org.ballerinalang.annotation.JavaSPIService;
 
 /**
  * Statement code snippet generator.
+ *
+ * @since 2.0.0
  */
 @JavaSPIService("org.ballerinalang.langserver.simulator.generators.CodeSnippetGenerator")
 public class StatementGenerator extends CodeSnippetGenerator {

--- a/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/TypeDefinitionGenerator.java
+++ b/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/TypeDefinitionGenerator.java
@@ -53,7 +53,8 @@ public class TypeDefinitionGenerator extends CodeSnippetGenerator {
             if (random.nextBoolean() || generatedTypeDefNames.isEmpty()) {
                 field = String.format("\t%s field%d;", primitiveTypes.get(random.nextInt(primitiveTypes.size())), i);
             } else {
-                field = String.format("\t%s field%d;", generatedTypeDefNames.get(random.nextInt(generatedTypeDefNames.size())), i);
+                field = String.format("\t%s field%d;",
+                        generatedTypeDefNames.get(random.nextInt(generatedTypeDefNames.size())), i);
             }
             fields.add(field);
         }

--- a/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/TypeDefinitionGenerator.java
+++ b/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/TypeDefinitionGenerator.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.langserver.simulator.generators;
+
+import org.ballerinalang.annotation.JavaSPIService;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@JavaSPIService("org.ballerinalang.langserver.simulator.generators.CodeSnippetGenerator")
+public class TypeDefinitionGenerator extends CodeSnippetGenerator {
+
+    private final List<String> generatedTypeDefNames = new ArrayList<>();
+    private int typeCount = 0;
+
+    @Override
+    public String generate() {
+        switch (random.nextInt(3)) {
+            case 1:
+                return generateUnionType();
+            case 2:
+                return generateRecordType();
+            case 3:
+            default:
+                return generateObjectTypeDef();
+        }
+    }
+
+    public String generateRecordType() {
+        String typeName = "Rec" + typeCount;
+
+        List<String> fields = new ArrayList<>();
+        for (int i = 0; i < 2 + random.nextInt(100); i++) {
+            String field;
+            if (random.nextBoolean() || generatedTypeDefNames.isEmpty()) {
+                field = String.format("\t%s field%d;", primitiveTypes.get(random.nextInt(primitiveTypes.size())), i);
+            } else {
+                field = String.format("\t%s field%d;", generatedTypeDefNames.get(random.nextInt(generatedTypeDefNames.size())), i);
+            }
+            fields.add(field);
+        }
+
+        typeCount++;
+        generatedTypeDefNames.add(typeName);
+        return String.format("%ntype %s {|%n%s%n|};%n", typeName, String.join("\n", fields));
+    }
+
+    public String generateUnionType() {
+        // Member types
+        Set<String> memberTypes = new HashSet<>();
+        for (int i = 0; i < 2 + random.nextInt(3); i++) {
+            String memberType;
+            do {
+                if (random.nextBoolean() || generatedTypeDefNames.isEmpty()) {
+                    memberType = primitiveTypes.get(random.nextInt(primitiveTypes.size()));
+                } else {
+                    memberType = generatedTypeDefNames.get(random.nextInt(generatedTypeDefNames.size()));
+                }
+            } while (memberTypes.contains(memberType));
+            memberTypes.add(memberType);
+        }
+
+        String typeName = "Type" + typeCount;
+        typeCount++;
+        generatedTypeDefNames.add(typeName);
+        return String.format("%ntype %s %s;%n", typeName, String.join(" | ", memberTypes));
+    }
+
+    public String generateObjectTypeDef() {
+        String typeName = "ObjectDef" + typeCount;
+        typeCount++;
+        generatedTypeDefNames.add(typeName);
+        return "\ntype " + typeName + " object {\n" +
+                "\n\tpublic function doSomething() returns UnkType;\n" +
+                "};\n";
+    }
+
+    @Override
+    public Generators.Type type() {
+        return Generators.Type.TYPE_DEFINITION;
+    }
+}

--- a/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/TypeDefinitionGenerator.java
+++ b/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/TypeDefinitionGenerator.java
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2021, WSO2 Inc. (http://wso2.com) All Rights Reserved.
- *  
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,6 +22,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+/**
+ * Type definition code snippet generator.
+ */
 @JavaSPIService("org.ballerinalang.langserver.simulator.generators.CodeSnippetGenerator")
 public class TypeDefinitionGenerator extends CodeSnippetGenerator {
 

--- a/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/TypeDefinitionGenerator.java
+++ b/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/TypeDefinitionGenerator.java
@@ -24,6 +24,8 @@ import java.util.Set;
 
 /**
  * Type definition code snippet generator.
+ *
+ * @since 2.0.0
  */
 @JavaSPIService("org.ballerinalang.langserver.simulator.generators.CodeSnippetGenerator")
 public class TypeDefinitionGenerator extends CodeSnippetGenerator {

--- a/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/VarDeclarationStatementGenerator.java
+++ b/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/VarDeclarationStatementGenerator.java
@@ -19,6 +19,8 @@ import org.ballerinalang.annotation.JavaSPIService;
 
 /**
  * Variable declaration code snippet generator.
+ *
+ * @since 2.0.0
  */
 @JavaSPIService("org.ballerinalang.langserver.simulator.generators.CodeSnippetGenerator")
 public class VarDeclarationStatementGenerator extends CodeSnippetGenerator {

--- a/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/VarDeclarationStatementGenerator.java
+++ b/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/VarDeclarationStatementGenerator.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.langserver.simulator.generators;
+
+import org.ballerinalang.annotation.JavaSPIService;
+
+@JavaSPIService("org.ballerinalang.langserver.simulator.generators.CodeSnippetGenerator")
+public class VarDeclarationStatementGenerator extends CodeSnippetGenerator {
+
+    private int varCount = 0;
+
+    public String generate() {
+        varCount++;
+        return String.format("\n%s %s = createVar();\n", primitiveTypes.get(random.nextInt(primitiveTypes.size())), "myVar" + varCount);
+    }
+
+    @Override
+    public Generators.Type type() {
+        return Generators.Type.VARIABLE_DECLARATION_STATEMENT;
+    }
+}

--- a/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/VarDeclarationStatementGenerator.java
+++ b/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/VarDeclarationStatementGenerator.java
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2021, WSO2 Inc. (http://wso2.com) All Rights Reserved.
- *  
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,6 +17,9 @@ package org.ballerinalang.langserver.simulator.generators;
 
 import org.ballerinalang.annotation.JavaSPIService;
 
+/**
+ * Variable declaration code snippet generator.
+ */
 @JavaSPIService("org.ballerinalang.langserver.simulator.generators.CodeSnippetGenerator")
 public class VarDeclarationStatementGenerator extends CodeSnippetGenerator {
 

--- a/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/VarDeclarationStatementGenerator.java
+++ b/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/VarDeclarationStatementGenerator.java
@@ -27,7 +27,8 @@ public class VarDeclarationStatementGenerator extends CodeSnippetGenerator {
 
     public String generate() {
         varCount++;
-        return String.format("\n%s %s = createVar();\n", primitiveTypes.get(random.nextInt(primitiveTypes.size())), "myVar" + varCount);
+        return String.format("\n%s %s = createVar();\n",
+                primitiveTypes.get(random.nextInt(primitiveTypes.size())), "myVar" + varCount);
     }
 
     @Override

--- a/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/VarDeclarationStatementGenerator.java
+++ b/tests/language-server-simulator/src/main/java/org/ballerinalang/langserver/simulator/generators/VarDeclarationStatementGenerator.java
@@ -27,7 +27,7 @@ public class VarDeclarationStatementGenerator extends CodeSnippetGenerator {
 
     public String generate() {
         varCount++;
-        return String.format("\n%s %s = createVar();\n",
+        return String.format("%n%s %s = createVar();%n",
                 primitiveTypes.get(random.nextInt(primitiveTypes.size())), "myVar" + varCount);
     }
 


### PR DESCRIPTION
## Purpose
This PR introduces a set of classes to simulate the behavior of LS and vscode combination. It uses the language server protocol's messages to send document changes to the LS to simulate a user writing some code character by character.

This is will be helpful in finding issues like #32020.
Fixes #32658

## Approach
Introduced classes `Editor`, `EditorTab`, `code snippet generators, etc to simulate the vscode behavior.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
