### PR TITLE
Fix Positional Argument Node Lookup in Semantic API

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SyntaxNodeToLocationMapper.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SyntaxNodeToLocationMapper.java
@@ -476,7 +476,7 @@ public class SyntaxNodeToLocationMapper extends NodeTransformer<Optional<Locatio
 
     @Override
     public Optional<Location> transform(PositionalArgumentNode positionalArgumentNode) {
-        return Optional.of(positionalArgumentNode.location());
+        return positionalArgumentNode.expression().apply(this);
     }
 
     @Override

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByImportTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByImportTest.java
@@ -23,7 +23,9 @@ import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.syntax.tree.ImportDeclarationNode;
 import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.compiler.syntax.tree.NodeVisitor;
+import io.ballerina.compiler.syntax.tree.PositionalArgumentNode;
 import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
+import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
@@ -33,8 +35,11 @@ import org.testng.annotations.Test;
 import java.util.Arrays;
 import java.util.Optional;
 
+import static io.ballerina.compiler.api.symbols.SymbolKind.CONSTANT;
 import static io.ballerina.compiler.api.symbols.SymbolKind.MODULE;
+import static io.ballerina.compiler.api.symbols.SymbolKind.VARIABLE;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 /**
  * Test cases for looking up a symbol given a module import/prefix.
@@ -75,18 +80,34 @@ public class SymbolByImportTest extends SymbolByNodeTest {
             public void visit(QualifiedNameReferenceNode qualifiedNameReferenceNode) {
                 assertSymbol(qualifiedNameReferenceNode.modulePrefix(), model, MODULE, "testproject");
             }
+
+            @Override
+            public void visit(PositionalArgumentNode positionalArgumentNode) {
+                if (positionalArgumentNode.expression().kind() == SyntaxKind.QUALIFIED_NAME_REFERENCE) {
+                    assertSymbol(positionalArgumentNode, model, CONSTANT, "PI");
+                }
+
+                if (positionalArgumentNode.expression().kind() == SyntaxKind.SIMPLE_NAME_REFERENCE){
+                    assertSymbol(positionalArgumentNode, model, VARIABLE, "abc");
+                }
+            }
         };
     }
 
     @Override
     void verifyAssertCount() {
-        assertEquals(getAssertCount(), 3);
+        assertEquals(getAssertCount(), 5);
     }
 
     private void assertSymbol(Node node, SemanticModel model, SymbolKind kind, String name) {
         Optional<Symbol> symbol = model.symbol(node);
+
+        assertTrue(symbol.isPresent());
         assertEquals(symbol.get().kind(), kind);
+
+        assertTrue(symbol.get().getName().isPresent());
         assertEquals(symbol.get().getName().get(), name);
+
         incrementAssertCount();
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByImportTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByImportTest.java
@@ -87,7 +87,7 @@ public class SymbolByImportTest extends SymbolByNodeTest {
                     assertSymbol(positionalArgumentNode, model, CONSTANT, "PI");
                 }
 
-                if (positionalArgumentNode.expression().kind() == SyntaxKind.SIMPLE_NAME_REFERENCE){
+                if (positionalArgumentNode.expression().kind() == SyntaxKind.SIMPLE_NAME_REFERENCE) {
                     assertSymbol(positionalArgumentNode, model, VARIABLE, "abc");
                 }
             }

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol-by-node/symbol_by_import_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol-by-node/symbol_by_import_test.bal
@@ -17,6 +17,10 @@
 import testorg/testproject;
 import ballerina/lang.'int as ints;
 
-function testAnonTypes() {
-    int sum = testproject:add(10, 20);
+function testAnonTypes(float value) returns int {
+    int abc = 10;
+    int sum = testproject:add(abc, 20);
+    return sum;
 }
+
+int x = testAnonTypes(testproject:PI);


### PR DESCRIPTION
## Purpose
> Fixes the issue of `PositionalArgumentNode` not being resolved properly in the `symbol()` API.

Fixes #32092

## Approach
> 

## Samples
> 

## Remarks
> 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
