### PR TITLE
Improve the subtyping support in the bindgen tool

### DIFF
--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/command/BindingsGenerator.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/command/BindingsGenerator.java
@@ -92,6 +92,12 @@ public class BindingsGenerator {
             outStream.println("\nGenerating bindings for: ");
             generateBindings(classNames, classLoader, modulePath);
 
+            // Generate bindings for super classes of directly specified Java classes.
+            if (!env.getSuperClasses().isEmpty()) {
+                env.setAllJavaClasses(env.getSuperClasses());
+                generateBindings(env.getSuperClasses(), classLoader, modulePath);
+            }
+
             // Generate bindings for dependent Java classes.
             if (!env.getClassListForLooping().isEmpty()) {
                 outStream.println("\nGenerating dependency bindings for: ");
@@ -100,6 +106,7 @@ public class BindingsGenerator {
             while (!env.getClassListForLooping().isEmpty()) {
                 Set<String> newSet = new HashSet<>(env.getClassListForLooping());
                 newSet.removeAll(classNames);
+                newSet.removeAll(env.getSuperClasses());
                 env.setAllJavaClasses(newSet);
                 env.clearClassListForLooping();
                 generateBindings(newSet, classLoader, dependenciesPath);

--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JClass.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JClass.java
@@ -78,7 +78,7 @@ public class JClass {
             sClass = sClass.getSuperclass();
         }
         if (sClass != null) {
-            env.setClassListForLooping(sClass.getName());
+            env.setSuperClasses(sClass);
             String simpleClassName = getAlias(sClass, env.getAliases()).replace("$", "");
             simpleClassName = getExceptionName(sClass, simpleClassName);
             superClassPackage.put(simpleClassName, sClass.getPackageName().replace(".", ""));

--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/utils/BindgenEnv.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/utils/BindgenEnv.java
@@ -30,6 +30,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.ballerinalang.bindgen.utils.BindgenUtils.isPublicClass;
+
 /**
  * The model that stores the details which will be passed on and updated while generating the mappings.
  *
@@ -40,7 +42,6 @@ public class BindgenEnv {
     private boolean modulesFlag = false; // Stores if the bindings are mapped as Java package per Ballerina module
     private boolean publicFlag = false; // Stores if the public flag is enabled for the binding generation
     private String outputPath; // Output path of the bindings generated
-    private Project project; // Ballerina project
     private String packageName; // Ballerina project's current package name
     private Path projectRoot; // Ballerina project root
     private TomlDocument tomlDocument; // TomlDocument object representing the Ballerina.toml file
@@ -54,6 +55,7 @@ public class BindgenEnv {
     private Set<JError> exceptionList = new HashSet<>();
     private Map<String, String> failedClassGens = new HashMap<>();
     private List<String> failedMethodGens = new ArrayList<>();
+    private Set<String> superClasses = new HashSet<>();
 
     public void setModulesFlag(boolean modulesFlag) {
         this.modulesFlag = modulesFlag;
@@ -64,7 +66,6 @@ public class BindgenEnv {
     }
 
     public void setProject(Project project) {
-        this.project = project;
         this.projectRoot = project.sourceRoot();
         if (project.currentPackage() != null) {
             Package currentPackage = project.currentPackage();
@@ -91,12 +92,16 @@ public class BindgenEnv {
         return projectRoot;
     }
 
-    public void setProjectRoot(Path projectRoot) {
-        this.projectRoot = projectRoot;
+    public void setSuperClasses(Class superClass) {
+        Class parent = superClass;
+        while (parent != null && isPublicClass(parent)) {
+            this.superClasses.add(parent.getName());
+            parent = parent.getSuperclass();
+        }
     }
 
-    public Project getProject() {
-        return project;
+    public Set<String> getSuperClasses() {
+        return this.superClasses;
     }
 
     public boolean getModulesFlag() {

--- a/misc/ballerina-bindgen/src/test/java/org/ballerinalang/bindgen/BindgenCommandTest.java
+++ b/misc/ballerina-bindgen/src/test/java/org/ballerinalang/bindgen/BindgenCommandTest.java
@@ -47,6 +47,7 @@ import java.util.Objects;
 public class BindgenCommandTest extends CommandTest {
 
     private Path testResources;
+    private String newLine = System.lineSeparator();
 
     @BeforeClass
     public void setup() throws IOException {
@@ -301,6 +302,26 @@ public class BindgenCommandTest extends CommandTest {
         String balFileContent2 = Files.readString(Paths.get(projectDir, "File.bal"));
         Assert.assertTrue(balFileContent2.contains("The function that maps to the `compareTo` method " +
                 "of `java.io.File`."));
+    }
+
+    @Test(description = "Test whether the bindgen tool generates the complete implementation of super classes")
+    public void testGenerationOfSuperClasses() throws IOException {
+        String projectDir = Paths.get(testResources.toString(), "balProject").toString();
+        System.setProperty("user.dir", projectDir);
+        String[] args = {"java.util.HashMap", "java.util.ArrayList"};
+
+        BindgenCommand bindgenCommand = new BindgenCommand(printStream, printStream, false);
+        new CommandLine(bindgenCommand).parseArgs(args);
+
+        bindgenCommand.execute();
+        String output = readOutput(true);
+        Assert.assertTrue(output.contains("Generating bindings for: " + newLine +
+                                                  "\tjava.util.HashMap" + newLine +
+                                                  "\tjava.util.ArrayList" + newLine +
+                                                  "\tjava.util.AbstractMap" + newLine +
+                                                  "\tjava.util.AbstractCollection" + newLine +
+                                                  "\tjava.util.AbstractList" + newLine +
+                                                  "\tjava.lang.Object"));
     }
 
     @AfterClass


### PR DESCRIPTION
## Purpose
Superclasses are automatically fully generated by the bindgen tool. This facilitates Java subtyping. Previously, the user had to manually generate them.

Fixes #30982

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
