### PR TITLE
Load the inbuilt compiler plugins before the package provided ones

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/CompilerPluginManager.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/CompilerPluginManager.java
@@ -54,9 +54,9 @@ class CompilerPluginManager {
                 packageResolution.packageContext().project().currentPackage(), PackageDependencyScope.DEFAULT);
         DependencyGraph<ResolvedPackageDependency> dependencyGraph = packageResolution.dependencyGraph();
         List<Package> directDependencies = getDirectDependencies(rootPkgNode, dependencyGraph);
-        List<CompilerPluginInfo> compilerPlugins = loadEngagedCompilerPlugins(directDependencies);
-        List<CompilerPluginInfo> inBuiltCompilerPlugins = loadInBuiltCompilerPlugins(rootPkgNode.packageInstance());
-        compilerPlugins.addAll(inBuiltCompilerPlugins);
+        List<CompilerPluginInfo> compilerPlugins = new ArrayList<>(
+                loadInBuiltCompilerPlugins(rootPkgNode.packageInstance()));
+        compilerPlugins.addAll(loadEngagedCompilerPlugins(directDependencies));
         List<CompilerPluginContextIml> compilerPluginContexts = initializePlugins(compilerPlugins);
         return new CompilerPluginManager(compilation, compilerPluginContexts);
     }


### PR DESCRIPTION
## Purpose
> Load the inbuilt compiler plugins before the package provided ones
> Temprorary fix for #32648

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
