### PR TITLE
Fix `typeof` expression for immutable values

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -2152,7 +2152,8 @@ public class TypeChecker {
             case TypeTags.ANYDATA_TAG:
                 return checkIsLikeAnydataType(sourceValue, sourceType, unresolvedValues, allowNumericConversion);
             case TypeTags.FINITE_TYPE_TAG:
-                return checkFiniteTypeAssignable(sourceValue, sourceType, (BFiniteType) targetType);
+                return checkFiniteTypeAssignable(sourceValue, sourceType, (BFiniteType) targetType,
+                 unresolvedValues, allowNumericConversion);
             case TypeTags.XML_ELEMENT_TAG:
                 if (sourceTypeTag == TypeTags.XML_TAG) {
                     XmlValue xmlSource = (XmlValue) sourceValue;
@@ -2609,7 +2610,15 @@ public class TypeChecker {
         return true;
     }
 
-    private static boolean checkFiniteTypeAssignable(Object sourceValue, Type sourceType, BFiniteType targetType) {
+    private static boolean checkFiniteTypeAssignable(Object sourceValue, Type sourceType, BFiniteType targetType,
+                                                     List<TypeValuePair> unresolvedValues,
+                                                     boolean allowNumericConversion) {
+        Type firstValueType = getType(targetType.valueSpace.iterator().next());
+        if (targetType.valueSpace.size() == 1 && !isSimpleBasicType(firstValueType) &&
+                firstValueType.getTag() != TypeTags.NULL_TAG) {
+            return checkIsLikeOnValue(sourceValue, sourceType, firstValueType, unresolvedValues, allowNumericConversion);
+        }
+
         for (Object valueSpaceItem : targetType.valueSpace) {
             // TODO: 8/13/19 Maryam fix for conversion
             if (isFiniteTypeValue(sourceValue, sourceType, valueSpaceItem)) {
@@ -2698,7 +2707,7 @@ public class TypeChecker {
         return sourceIdSet.containsAll(targetType.typeIdSet);
     }
 
-    private static boolean isSimpleBasicType(Type type) {
+    static boolean isSimpleBasicType(Type type) {
         return type.getTag() < TypeTags.NULL_TAG;
     }
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -2613,10 +2613,12 @@ public class TypeChecker {
     private static boolean checkFiniteTypeAssignable(Object sourceValue, Type sourceType, BFiniteType targetType,
                                                      List<TypeValuePair> unresolvedValues,
                                                      boolean allowNumericConversion) {
-        Type firstValueType = getType(targetType.valueSpace.iterator().next());
-        if (targetType.valueSpace.size() == 1 && !isSimpleBasicType(firstValueType) &&
-                firstValueType.getTag() != TypeTags.NULL_TAG) {
-            return checkIsLikeOnValue(sourceValue, sourceType, firstValueType, unresolvedValues, allowNumericConversion);
+        if (targetType.valueSpace.size() == 1) {
+            Type valueType = getType(targetType.valueSpace.iterator().next());
+            if (!isSimpleBasicType(valueType) && valueType.getTag() != TypeTags.NULL_TAG) {
+                return checkIsLikeOnValue(sourceValue, sourceType, valueType, unresolvedValues,
+                        allowNumericConversion);
+            }
         }
 
         for (Object valueSpaceItem : targetType.valueSpace) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeConverter.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeConverter.java
@@ -311,10 +311,11 @@ public class TypeConverter {
                 break;
             case TypeTags.FINITE_TYPE_TAG:
                 BFiniteType finiteType = (BFiniteType) targetType;
-                Type firstValueType = getType(finiteType.valueSpace.iterator().next());
-                if (finiteType.valueSpace.size() == 1 && !isSimpleBasicType(firstValueType) &&
-                        firstValueType.getTag() != TypeTags.NULL_TAG) {
-                    return getConvertibleTypes(inputValue, firstValueType, unresolvedValues);
+                if (finiteType.valueSpace.size() == 1) {
+                    Type valueType = getType(finiteType.valueSpace.iterator().next());
+                    if (!isSimpleBasicType(valueType) && valueType.getTag() != TypeTags.NULL_TAG) {
+                        return getConvertibleTypes(inputValue, valueType, unresolvedValues);
+                    }
                 }
                 for (Object valueSpaceItem : finiteType.valueSpace) {
                     Type inputValueType = TypeChecker.getType(inputValue);

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeConverter.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeConverter.java
@@ -66,11 +66,13 @@ import static io.ballerina.runtime.internal.TypeChecker.anyToUnsigned16;
 import static io.ballerina.runtime.internal.TypeChecker.anyToUnsigned32;
 import static io.ballerina.runtime.internal.TypeChecker.anyToUnsigned8;
 import static io.ballerina.runtime.internal.TypeChecker.checkIsLikeType;
+import static io.ballerina.runtime.internal.TypeChecker.getType;
 import static io.ballerina.runtime.internal.TypeChecker.isCharLiteralValue;
 import static io.ballerina.runtime.internal.TypeChecker.isNumericType;
 import static io.ballerina.runtime.internal.TypeChecker.isSigned16LiteralValue;
 import static io.ballerina.runtime.internal.TypeChecker.isSigned32LiteralValue;
 import static io.ballerina.runtime.internal.TypeChecker.isSigned8LiteralValue;
+import static io.ballerina.runtime.internal.TypeChecker.isSimpleBasicType;
 import static io.ballerina.runtime.internal.TypeChecker.isUnsigned16LiteralValue;
 import static io.ballerina.runtime.internal.TypeChecker.isUnsigned32LiteralValue;
 import static io.ballerina.runtime.internal.TypeChecker.isUnsigned8LiteralValue;
@@ -308,7 +310,13 @@ public class TypeConverter {
                 convertibleTypes.addAll(getConvertibleTypes(inputValue, effectiveType, unresolvedValues));
                 break;
             case TypeTags.FINITE_TYPE_TAG:
-                for (Object valueSpaceItem : ((BFiniteType) targetType).valueSpace) {
+                BFiniteType finiteType = (BFiniteType) targetType;
+                Type firstValueType = getType(finiteType.valueSpace.iterator().next());
+                if (finiteType.valueSpace.size() == 1 && !isSimpleBasicType(firstValueType) &&
+                        firstValueType.getTag() != TypeTags.NULL_TAG) {
+                    return getConvertibleTypes(inputValue, firstValueType, unresolvedValues);
+                }
+                for (Object valueSpaceItem : finiteType.valueSpace) {
                     Type inputValueType = TypeChecker.getType(inputValue);
                     if (inputValue == valueSpaceItem) {
                         return Set.of(inputValueType);

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/ValueUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/ValueUtils.java
@@ -18,12 +18,16 @@
 package io.ballerina.runtime.internal;
 
 import io.ballerina.runtime.api.Module;
+import io.ballerina.runtime.api.creators.TypeCreator;
 import io.ballerina.runtime.api.flags.SymbolFlags;
 import io.ballerina.runtime.api.types.Field;
+import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
+import io.ballerina.runtime.api.values.BTypedesc;
+import io.ballerina.runtime.api.values.BValue;
 import io.ballerina.runtime.api.values.BXml;
 import io.ballerina.runtime.internal.scheduling.Scheduler;
 import io.ballerina.runtime.internal.scheduling.State;
@@ -31,9 +35,11 @@ import io.ballerina.runtime.internal.scheduling.Strand;
 import io.ballerina.runtime.internal.types.BRecordType;
 import io.ballerina.runtime.internal.values.MapValue;
 import io.ballerina.runtime.internal.values.MapValueImpl;
+import io.ballerina.runtime.internal.values.TypedescValueImpl;
 import io.ballerina.runtime.internal.values.ValueCreator;
 
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Class @{@link ValueUtils} provides utils to create Ballerina Values.
@@ -162,6 +168,28 @@ public class ValueUtils {
         BXml xml = TypeConverter.stringToXml(value);
         xml.freezeDirect();
         return xml;
+    }
+
+    /**
+     * Provide the Typedesc Value with the singleton type with a value.
+     * @param value Ballerina value
+     * @return typedesc with singleton type
+     */
+    public static BTypedesc createSingletonTypedesc(BValue value) {
+        return io.ballerina.runtime.api.creators.ValueCreator
+                .createTypedescValue(TypeCreator.createFiniteType(value.toString(), Set.of(value), 0));
+    }
+
+    /**
+     * Provide the Typedesc Value depending on the immutability of a value.
+     * @param type Ballerina value
+     * @return typedesc with the suitable type
+     */
+    public static BTypedesc getTypedescValue(Type type, BValue value) {
+        if (type.isReadOnly()) {
+            return createSingletonTypedesc(value);
+        }
+        return new TypedescValueImpl(type);
     }
 
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ArrayValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ArrayValueImpl.java
@@ -49,6 +49,8 @@ import java.util.StringJoiner;
 import java.util.stream.IntStream;
 
 import static io.ballerina.runtime.api.constants.RuntimeConstants.ARRAY_LANG_LIB;
+import static io.ballerina.runtime.internal.ValueUtils.createSingletonTypedesc;
+import static io.ballerina.runtime.internal.ValueUtils.getTypedescValue;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.INDEX_OUT_OF_RANGE_ERROR_IDENTIFIER;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.INHERENT_TYPE_VIOLATION_ERROR_IDENTIFIER;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.getModulePrefixedReason;
@@ -85,35 +87,35 @@ public class ArrayValueImpl extends AbstractArrayValue {
         if (type.getTag() == TypeTags.ARRAY_TAG) {
             this.elementType = type.getElementType();
         }
-        this.typedesc = new TypedescValueImpl(arrayType);
+        this.typedesc = getTypedescValue(arrayType, this);
     }
 
     public ArrayValueImpl(long[] values, boolean readonly) {
         this.intValues = values;
         this.size = values.length;
         setArrayType(PredefinedTypes.TYPE_INT, readonly);
-        this.typedesc = new TypedescValueImpl(arrayType);
+        this.typedesc = getTypedescValue(arrayType, this);
     }
 
     public ArrayValueImpl(boolean[] values, boolean readonly) {
         this.booleanValues = values;
         this.size = values.length;
         setArrayType(PredefinedTypes.TYPE_BOOLEAN, readonly);
-        this.typedesc = new TypedescValueImpl(arrayType);
+        this.typedesc = getTypedescValue(arrayType, this);
     }
 
     public ArrayValueImpl(byte[] values, boolean readonly) {
         this.byteValues = values;
         this.size = values.length;
         setArrayType(PredefinedTypes.TYPE_BYTE, readonly);
-        this.typedesc = new TypedescValueImpl(arrayType);
+        this.typedesc = getTypedescValue(arrayType, this);
     }
 
     public ArrayValueImpl(double[] values, boolean readonly) {
         this.floatValues = values;
         this.size = values.length;
         setArrayType(PredefinedTypes.TYPE_FLOAT, readonly);
-        this.typedesc = new TypedescValueImpl(arrayType);
+        this.typedesc = getTypedescValue(arrayType, this);
     }
 
     public ArrayValueImpl(String[] values, boolean readonly) {
@@ -123,14 +125,14 @@ public class ArrayValueImpl extends AbstractArrayValue {
             bStringValues[i] = StringUtils.fromString(values[i]);
         }
         setArrayType(PredefinedTypes.TYPE_STRING, readonly);
-        this.typedesc = new TypedescValueImpl(arrayType);
+        this.typedesc = getTypedescValue(arrayType, this);
     }
 
     public ArrayValueImpl(BString[] values, boolean readonly) {
         this.bStringValues = values;
         this.size = values.length;
         setArrayType(PredefinedTypes.TYPE_STRING, readonly);
-        this.typedesc = new TypedescValueImpl(arrayType);
+        this.typedesc = getTypedescValue(arrayType, this);
     }
 
     public ArrayValueImpl(ArrayType type) {
@@ -140,7 +142,7 @@ public class ArrayValueImpl extends AbstractArrayValue {
         if (type.getState() == ArrayState.CLOSED) {
             this.size = maxSize = type.getSize();
         }
-        this.typedesc = new TypedescValueImpl(arrayType);
+        this.typedesc = getTypedescValue(arrayType, this);
     }
 
     private void initArrayValues(Type elementType) {
@@ -244,7 +246,7 @@ public class ArrayValueImpl extends AbstractArrayValue {
         if (size != -1) {
             this.size = this.maxSize = (int) size;
         }
-        this.typedesc = new TypedescValueImpl(arrayType);
+        this.typedesc = getTypedescValue(arrayType, this);
     }
 
     public ArrayValueImpl(ArrayType type, long size, BListInitialValueEntry[] initialValues) {
@@ -263,7 +265,7 @@ public class ArrayValueImpl extends AbstractArrayValue {
         for (int index = 0; index < initialValues.length; index++) {
             addRefValue(index, ((ListInitialValueEntry.ExpressionEntry) initialValues[index]).value);
         }
-        this.typedesc = new TypedescValueImpl(arrayType);
+        this.typedesc = getTypedescValue(arrayType, this);
     }
 
     // ----------------------- get methods ----------------------------------------------------
@@ -957,7 +959,7 @@ public class ArrayValueImpl extends AbstractArrayValue {
                 }
             }
         }
-        this.typedesc = new TypedescValueImpl(arrayType);
+        this.typedesc = createSingletonTypedesc(this);
     }
 
     /**

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValueImpl.java
@@ -293,9 +293,6 @@ public class MapValueImpl<K, V> extends LinkedHashMap<K, V> implements RefValue,
                 populateInitialValue(entry.getKey(), entry.getValue());
             }
         }
-        if (this.type.isReadOnly()) {
-            this.typedesc = createSingletonTypedesc(this);
-        }
     }
 
     public void populateInitialValue(K key, V value) {
@@ -307,6 +304,9 @@ public class MapValueImpl<K, V> extends LinkedHashMap<K, V> implements RefValue,
         }
 
         putValue(key, value);
+        if (this.type.isReadOnly()) {
+            this.typedesc = createSingletonTypedesc(this);
+        }
     }
 
     /**

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TableValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TableValueImpl.java
@@ -60,6 +60,8 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static io.ballerina.runtime.api.constants.RuntimeConstants.TABLE_LANG_LIB;
+import static io.ballerina.runtime.internal.ValueUtils.createSingletonTypedesc;
+import static io.ballerina.runtime.internal.ValueUtils.getTypedescValue;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.INHERENT_TYPE_VIOLATION_ERROR_IDENTIFIER;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.OPERATION_NOT_SUPPORTED_ERROR;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.TABLE_HAS_A_VALUE_FOR_KEY_ERROR;
@@ -109,7 +111,7 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
         } else {
             this.valueHolder = new ValueHolder();
         }
-        this.typedesc = new TypedescValueImpl(type);
+        this.typedesc = getTypedescValue(type, this);
     }
 
     public TableValueImpl(TableType type, ArrayValue data, ArrayValue fieldNames) {
@@ -119,6 +121,9 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
         }
 
         addData(data);
+        if (type.isReadOnly()) {
+            this.typedesc = createSingletonTypedesc(this);
+        }
     }
 
     private void addData(ArrayValue data) {
@@ -328,7 +333,7 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
         this.type = (BTableType) ReadOnlyUtils.setImmutableTypeAndGetEffectiveType(this.type);
         //we know that values are always RefValues
         this.values().forEach(val -> ((RefValue) val).freezeDirect());
-        this.typedesc = new TypedescValueImpl(type);
+        this.typedesc = createSingletonTypedesc(this);
     }
 
     public String stringValue(BLink parent) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TupleValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TupleValueImpl.java
@@ -46,6 +46,8 @@ import java.util.StringJoiner;
 import java.util.stream.IntStream;
 
 import static io.ballerina.runtime.api.constants.RuntimeConstants.ARRAY_LANG_LIB;
+import static io.ballerina.runtime.internal.ValueUtils.createSingletonTypedesc;
+import static io.ballerina.runtime.internal.ValueUtils.getTypedescValue;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.INDEX_OUT_OF_RANGE_ERROR_IDENTIFIER;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.INHERENT_TYPE_VIOLATION_ERROR_IDENTIFIER;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.getModulePrefixedReason;
@@ -109,7 +111,7 @@ public class TupleValueImpl extends AbstractArrayValue {
         }
         this.minSize = memTypes.size();
         this.size = refValues.length;
-        this.typedesc = new TypedescValueImpl(tupleType);
+        this.typedesc = getTypedescValue(tupleType, this);
     }
 
     public TupleValueImpl(TupleType type) {
@@ -135,7 +137,7 @@ public class TupleValueImpl extends AbstractArrayValue {
             }
             this.refValues[i] = memType.getZeroValue();
         }
-        this.typedesc = new TypedescValueImpl(tupleType);
+        this.typedesc = getTypedescValue(tupleType, this);
     }
 
     public TupleValueImpl(TupleType type, long size, BListInitialValueEntry[] initialValues) {
@@ -160,7 +162,7 @@ public class TupleValueImpl extends AbstractArrayValue {
         }
 
         if (size >= memCount) {
-            this.typedesc = new TypedescValueImpl(tupleType);
+            this.typedesc = getTypedescValue(tupleType, this);
             return;
         }
 
@@ -172,7 +174,7 @@ public class TupleValueImpl extends AbstractArrayValue {
 
             this.refValues[i] = memType.getZeroValue();
         }
-        this.typedesc = new TypedescValueImpl(tupleType);
+        this.typedesc = getTypedescValue(tupleType, this);
     }
 
     @Override
@@ -564,7 +566,7 @@ public class TupleValueImpl extends AbstractArrayValue {
                 ((RefValue) value).freezeDirect();
             }
         }
-        this.typedesc = new TypedescValueImpl(tupleType);
+        this.typedesc = createSingletonTypedesc(this);
     }
 
     /**

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlItem.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlItem.java
@@ -55,6 +55,7 @@ import static io.ballerina.runtime.api.constants.RuntimeConstants.STRING_NULL_VA
 import static io.ballerina.runtime.api.constants.RuntimeConstants.XML_LANG_LIB;
 import static io.ballerina.runtime.api.types.XmlNodeType.ELEMENT;
 import static io.ballerina.runtime.api.types.XmlNodeType.TEXT;
+import static io.ballerina.runtime.internal.ValueUtils.createSingletonTypedesc;
 
 /**
  * {@code XMLItem} represents a single XML element in Ballerina.
@@ -629,7 +630,7 @@ public final class XmlItem extends XmlValue implements BXmlItem {
         this.type = ReadOnlyUtils.setImmutableTypeAndGetEffectiveType(this.type);
         this.children.freezeDirect();
         this.attributes.freezeDirect();
-        this.typedesc = new TypedescValueImpl(type);
+        this.typedesc = createSingletonTypedesc(this);
     }
 
     private QName getQName(String localName, String namespaceUri, String prefix) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlNonElementItem.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlNonElementItem.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 import static io.ballerina.runtime.api.constants.RuntimeConstants.STRING_NULL_VALUE;
+import static io.ballerina.runtime.internal.ValueUtils.createSingletonTypedesc;
 
 /**
  * Functionality common to PI, COMMENT and TEXT nodes.
@@ -214,7 +215,7 @@ public abstract class XmlNonElementItem extends XmlValue implements BXmlNonEleme
     @Override
     public void freezeDirect() {
         this.type = ReadOnlyUtils.setImmutableTypeAndGetEffectiveType(this.type);
-        this.typedesc = new TypedescValueImpl(type);
+        this.typedesc = createSingletonTypedesc(this);
     }
 
     @Override

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlSequence.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlSequence.java
@@ -45,6 +45,7 @@ import java.util.Set;
 
 import static io.ballerina.runtime.api.constants.RuntimeConstants.STRING_EMPTY_VALUE;
 import static io.ballerina.runtime.api.constants.RuntimeConstants.XML_LANG_LIB;
+import static io.ballerina.runtime.internal.ValueUtils.createSingletonTypedesc;
 
 /**
  * <p>
@@ -592,7 +593,7 @@ public final class XmlSequence extends XmlValue implements BXmlSequence {
         for (BXml elem : children) {
             elem.freezeDirect();
         }
-        this.typedesc = new TypedescValueImpl(type);
+        this.typedesc = createSingletonTypedesc(this);
     }
 
     @Override

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/XmlValue.java
@@ -35,6 +35,8 @@ import java.util.Map;
 
 import javax.xml.namespace.QName;
 
+import static io.ballerina.runtime.internal.ValueUtils.getTypedescValue;
+
 /**
  * {@code BXML} represents an XML in Ballerina. An XML could be one of:
  * <ul>
@@ -250,7 +252,7 @@ public abstract class XmlValue implements RefValue, BXml, CollectionValue {
     }
 
     protected void setTypedescValue(Type type) {
-        this.typedesc = new TypedescValueImpl(type);
+        this.typedesc = getTypedescValue(type, this);
     }
 
     @Override

--- a/langlib/lang.__internal/src/main/java/org/ballerinalang/langlib/internal/GetElementType.java
+++ b/langlib/lang.__internal/src/main/java/org/ballerinalang/langlib/internal/GetElementType.java
@@ -22,10 +22,12 @@ import io.ballerina.runtime.api.TypeTags;
 import io.ballerina.runtime.api.creators.TypeCreator;
 import io.ballerina.runtime.api.creators.ValueCreator;
 import io.ballerina.runtime.api.types.ArrayType;
+import io.ballerina.runtime.api.types.FiniteType;
 import io.ballerina.runtime.api.types.StreamType;
 import io.ballerina.runtime.api.types.TupleType;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.values.BTypedesc;
+import io.ballerina.runtime.api.values.BValue;
 
 /**
  * Native implementation of lang.internal:getElementType(typedesc).
@@ -49,6 +51,10 @@ public class GetElementType {
             case TypeTags.TUPLE_TAG:
                 return ValueCreator.createTypedescValue(
                         TypeCreator.createUnionType(((TupleType) type).getTupleTypes()));
+            case TypeTags.FINITE_TYPE_TAG:
+                // this is reached only for immutable values
+                return getElementTypeDescValue(
+                        ((BValue) (((FiniteType) type).getValueSpace().iterator().next())).getType());
             default:
                 return ValueCreator.createTypedescValue(((StreamType) type).getConstrainedType());
         }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typeof/TypeofOverLiteralExpressionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typeof/TypeofOverLiteralExpressionTest.java
@@ -26,7 +26,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 /**
- * Tests to test thypeof operator over literal expressions.
+ * Tests to test typeof operator over literal expressions.
  *
  * @since 0.995
  */
@@ -48,7 +48,8 @@ public class TypeofOverLiteralExpressionTest {
     public Object[] provideFunctionNames() {
         return new String[]{"typeDescOfExpressionsOfLiterals", "passTypeofToAFunction", "typeDescOfARecord",
                 "typeDescOrAObject", "passTypeofAsRestParams", "compareTypeOfValues", "typeDescOfLiterals",
-                "typeOfImmutableStructuralValues", "typeOfWithCloneReadOnly"};
+                "typeOfImmutableStructuralValues", "typeOfWithCloneReadOnly", "typeOfWithCloneWithTypeOnSameValue",
+                "typeOfWithCloneWithTypeOnDifferentValue", "typeOfWithEnsureTypeOnSameValue"};
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typeof/typeof.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typeof/typeof.bal
@@ -133,35 +133,34 @@ function compareTypeOfValues() {
 }
 
 function typeOfImmutableStructuralValues() {
-    // TODO: need to change the return value after fixing #13189
     // xml Value
     xml & readonly xmlValue = xml `<data>test</data>`;
     test:assertTrue(typeof xmlValue === typeof xmlValue);
-    test:assertEquals((typeof xmlValue).toString(), "typedesc lang.xml:Element & readonly");
+    test:assertEquals((typeof xmlValue).toString(), "typedesc <data></data>");
 
     // Structural types - Array, Tuple
     int[] & readonly arr = [1, 2, 3];
     test:assertTrue(typeof arr === typeof arr);
-    test:assertEquals((typeof arr).toString(), "typedesc int[] & readonly");
+    test:assertEquals((typeof arr).toString(), "typedesc [1,2,3]");
 
     [string, int] & readonly tuple = ["ballerina", 123];
     test:assertTrue(typeof tuple === typeof tuple);
-    test:assertEquals((typeof tuple).toString(), "typedesc [string,int] & readonly");
+    test:assertEquals((typeof tuple).toString(), "typedesc [\"ballerina\",123]");
 
     // Structural types - Records, Maps
     RecType0 & readonly rec = {name: "test"};
     test:assertTrue(typeof rec === typeof rec);
     test:assertTrue(typeof rec !== RecType0);
-    test:assertEquals((typeof rec).toString(), "typedesc (RecType0 & readonly)");
+    test:assertEquals((typeof rec).toString(), "typedesc {\"name\":\"test\"}");
 
     map<string> & readonly mapVal = {s: "test"};
     test:assertTrue(typeof mapVal === typeof mapVal);
-    test:assertEquals((typeof mapVal).toString(), "typedesc map<string> & readonly");
+    test:assertEquals((typeof mapVal).toString(), "typedesc {\"s\":\"test\"}");
 
     // Structural types -tables 
     table<map<string>> & readonly tableVal = table [{s: "test"}];
     test:assertTrue(typeof tableVal === typeof tableVal);
-    test:assertEquals((typeof tableVal).toString(), "typedesc table<map<string> & readonly> & readonly");
+    test:assertEquals((typeof tableVal).toString(), "typedesc [{\"s\":\"test\"}]");
 }
 
 function typeOfWithCloneReadOnly() {
@@ -170,34 +169,35 @@ function typeOfWithCloneReadOnly() {
     xml & readonly xmlValue = xml `<?xml-stylesheet href="mystyle.css" type="text/css"?>`;
     any val = xmlValue.cloneReadOnly();
     test:assertTrue(typeof val === typeof val);
-    test:assertEquals((typeof val).toString(), "typedesc lang.xml:ProcessingInstruction & readonly");
+    test:assertEquals((typeof val).toString(), "typedesc <?xml-stylesheet href=\"mystyle.css\" " +
+    "type=\"text/css\"?>");
 
     // Structural types - Array, Tuple
     int[] arr = [1, 2, 3];
     val = arr.cloneReadOnly();
     test:assertTrue(typeof val === typeof val);
-    test:assertEquals((typeof val).toString(), "typedesc int[] & readonly");
+    test:assertEquals((typeof val).toString(), "typedesc [1,2,3]");
 
     [string, int] tuple = ["ballerina", 123];
     val = tuple.cloneReadOnly();
     test:assertTrue(typeof val === typeof val);
-    test:assertEquals((typeof val).toString(), "typedesc [string,int] & readonly");
+    test:assertEquals((typeof val).toString(), "typedesc [\"ballerina\",123]");
 
     // Structural types - Records, Maps
     RecType0 rec = {name: "test"};
     val = rec.cloneReadOnly();
     test:assertTrue(typeof val === typeof val);
     test:assertTrue(typeof val !== RecType0);
-    test:assertEquals((typeof val).toString(), "typedesc (RecType0 & readonly)");
+    test:assertEquals((typeof val).toString(), "typedesc {\"name\":\"test\"}");
 
     map<string> mapVal = {s: "test"};
     val = mapVal.cloneReadOnly();
     test:assertTrue(typeof val === typeof val);
-    test:assertEquals((typeof val).toString(), "typedesc map<string> & readonly");
+    test:assertEquals((typeof val).toString(), "typedesc {\"s\":\"test\"}");
 
     // Structural types - Tables
     table<map<string>> tableVal = table [{s: "test"}];
     val = tableVal.cloneReadOnly();
     test:assertTrue(typeof val === typeof val);
-    test:assertEquals((typeof val).toString(), "typedesc table<(map<string> & readonly)> & readonly");
+    test:assertEquals((typeof val).toString(), "typedesc [{\"s\":\"test\"}]");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/typedesc/typedesc_positive.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/typedesc/typedesc_positive.bal
@@ -208,7 +208,7 @@ function testTypeDefWithIntersectionTypeDescAsTypedesc() {
     typedesc<anydata> a = ImmutableIntArray;
     (int|string)[] arr = [1, 2, 3];
     anydata|error b = arr.cloneWithType(a);
-    assertEquality("typedesc int[] & readonly", (typeof b).toString());
+    assertEquality("typedesc [1,2,3]", (typeof b).toString());
     assertEquality(true, b is int[]);
     assertEquality(true, (<int[]> checkpanic b).isReadOnly());
     assertEquality(<int[]> [1, 2, 3], b);


### PR DESCRIPTION
## Purpose
This is to complete the fix done on `typeof` implementation for immutable values. 

Fixes #32531

## Approach
The `typeof` will provide a Finite type that contains the immutable value. 
This is to comply with the spec,
```
When v is a reference value,
- For containers, this is the same as the inherent type
- when the container is immutable, it will be a singleton type.  
```
## Samples
```ballerina
int[] & readonly arr = [1, 2, 3];
io:println(typeof arr); // typedesc int[] & readonly -  should be typedesc [1,2,3]
```
## Remarks
This implementation was earlier reverted due to some issues found  in `langlib:value`.  https://github.com/ballerina-platform/ballerina-lang/pull/32530
This PR fixes them and redo the earlier change.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
