### PR TITLE
Update annotatable-type API to provide support to retrieve all available annotations

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/types/AnnotatableType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/types/AnnotatableType.java
@@ -17,6 +17,7 @@
  */
 package io.ballerina.runtime.api.types;
 
+import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BString;
 
 /**
@@ -32,4 +33,5 @@ public interface AnnotatableType extends Type {
 
     Object getAnnotation(BString pkg, BString annotName);
 
+    BMap<BString, Object> getAnnotations();
 }


### PR DESCRIPTION
## Purpose

With [#32328](https://github.com/ballerina-platform/ballerina-lang/pull/32328) PR we have introduced `IntrospectionDocConfig` annotation. In our HTTP module we use information in above annotation to generate introspection resource for a HTTP service. But with current API we could only retrieve annotation information by only providing the fully qualified name of the annotation. To simplify this process we need to provide an API to retrieve all annotations attached to an annotatable-type and then the developer can filter out only the required annotations.

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
