### PR TITLE
Fix issue in parseing invalid identifier escape sequence

### DIFF
--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/diagnostics/DiagnosticWarningCode.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/diagnostics/DiagnosticWarningCode.java
@@ -47,6 +47,7 @@ public enum DiagnosticWarningCode implements DiagnosticCode {
     WARNING_INVALID_BALLERINA_NAME_REFERENCE("BCE10100", "warning.invalid.ballerina.name.reference"),
     WARNING_CANNOT_HAVE_DOCUMENTATION_INLINE_WITH_A_CODE_REFERENCE_BLOCK("BCE10101",
             "warning.cannot.have.documentation.inline.with.a.code.reference.block"),
+    WARNING_INVALID_ESCAPE_SEQUENCE("BCE10102", "warning.invalid.escape.sequence"),
     ;
 
     String diagnosticId;

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/BallerinaLexer.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/BallerinaLexer.java
@@ -1122,7 +1122,7 @@ public class BallerinaLexer extends AbstractLexer {
                             }
                             continue;
                         default:
-                            reportInvalidEscapeSequence(this.reader.peek(2));
+                            reportInvalidEscapeSequence(this.reader.peek(1));
                             this.reader.advance();
                             continue;
                     }
@@ -1422,7 +1422,7 @@ public class BallerinaLexer extends AbstractLexer {
                 case LexerTerminals.CARRIAGE_RETURN:
                 case LexerTerminals.TAB:
                     reader.advance();
-                    reportInvalidEscapeSequence((char) 0);
+                    reportLexerError(DiagnosticErrorCode.ERROR_INVALID_ESCAPE_SEQUENCE, "");
                     break;
                 case 'u':
                     // NumericEscape

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/BallerinaLexer.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/BallerinaLexer.java
@@ -1421,6 +1421,8 @@ public class BallerinaLexer extends AbstractLexer {
                 case LexerTerminals.NEWLINE:
                 case LexerTerminals.CARRIAGE_RETURN:
                 case LexerTerminals.TAB:
+                    reader.advance();
+                    reportInvalidEscapeSequence((char) 0);
                     break;
                 case 'u':
                     // NumericEscape

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/DocumentationLexer.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/DocumentationLexer.java
@@ -17,6 +17,7 @@
  */
 package io.ballerina.compiler.internal.parser;
 
+import io.ballerina.compiler.internal.diagnostics.DiagnosticWarningCode;
 import io.ballerina.compiler.internal.parser.tree.STNode;
 import io.ballerina.compiler.internal.parser.tree.STNodeDiagnostic;
 import io.ballerina.compiler.internal.parser.tree.STNodeFactory;
@@ -173,6 +174,8 @@ public class DocumentationLexer extends AbstractLexer {
                 case LexerTerminals.NEWLINE:
                 case LexerTerminals.CARRIAGE_RETURN:
                 case LexerTerminals.TAB:
+                    reader.advance();
+                    reportLexerError(DiagnosticWarningCode.WARNING_INVALID_ESCAPE_SEQUENCE, "");
                     break;
                 case 'u':
                     // NumericEscape

--- a/compiler/ballerina-parser/src/main/resources/syntax_diagnostic_message.properties
+++ b/compiler/ballerina-parser/src/main/resources/syntax_diagnostic_message.properties
@@ -32,6 +32,7 @@ warning.missing.parameter.name=missing parameter name
 warning.missing.code.reference=missing code reference
 warning.invalid.ballerina.name.reference=invalid ballerina name reference ''{0}''
 warning.cannot.have.documentation.inline.with.a.code.reference.block=cannot have documentation inline with a code reference block
+warning.invalid.escape.sequence=invalid escape sequence ''\\{0}''
 
 # -------------------------
 # Syntax error messages

--- a/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/syntax/expressions/QuotedStringLiteralTest.java
+++ b/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/syntax/expressions/QuotedStringLiteralTest.java
@@ -44,5 +44,6 @@ public class QuotedStringLiteralTest extends AbstractExpressionsTest {
     @Test
     public void testQuotedWithInvalidEscapeSequence() {
         test("\"hello \\u{K} world \\h how are you?\"", "basic-literals/quoted_string_literal_assert_03.json");
+        test("\"\\Ballerina\"", "basic-literals/quoted_string_literal_assert_04.json");
     }
 }

--- a/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/syntax/misc/DocumentationTest.java
+++ b/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/syntax/misc/DocumentationTest.java
@@ -143,4 +143,9 @@ public class DocumentationTest extends AbstractMiscTest {
     public void testDocumentationEOF() {
         testFile("documentation/doc_source_26.bal", "documentation/doc_assert_26.json");
     }
+
+    @Test
+    public void testInvalidEscapeSequenceInDocParameter() {
+        testFile("documentation/doc_source_27.bal", "documentation/doc_assert_27.json");
+    }
 }

--- a/compiler/ballerina-parser/src/test/resources/expressions/basic-literals/quoted_string_literal_assert_04.json
+++ b/compiler/ballerina-parser/src/test/resources/expressions/basic-literals/quoted_string_literal_assert_04.json
@@ -1,0 +1,14 @@
+{
+  "kind": "STRING_LITERAL",
+  "hasDiagnostics": true,
+  "children": [
+    {
+      "kind": "STRING_LITERAL_TOKEN",
+      "hasDiagnostics": true,
+      "diagnostics": [
+        "ERROR_INVALID_ESCAPE_SEQUENCE"
+      ],
+      "value": "\\Ballerina"
+    }
+  ]
+}

--- a/compiler/ballerina-parser/src/test/resources/misc/documentation/doc_assert_27.json
+++ b/compiler/ballerina-parser/src/test/resources/misc/documentation/doc_assert_27.json
@@ -1,0 +1,331 @@
+{
+  "kind": "MODULE_PART",
+  "hasDiagnostics": true,
+  "children": [
+    {
+      "kind": "LIST",
+      "children": []
+    },
+    {
+      "kind": "LIST",
+      "hasDiagnostics": true,
+      "children": [
+        {
+          "kind": "FUNCTION_DEFINITION",
+          "hasDiagnostics": true,
+          "children": [
+            {
+              "kind": "METADATA",
+              "hasDiagnostics": true,
+              "children": [
+                {
+                  "kind": "MARKDOWN_DOCUMENTATION",
+                  "hasDiagnostics": true,
+                  "children": [
+                    {
+                      "kind": "LIST",
+                      "hasDiagnostics": true,
+                      "children": [
+                        {
+                          "kind": "MARKDOWN_DOCUMENTATION_LINE",
+                          "children": [
+                            {
+                              "kind": "HASH_TOKEN",
+                              "trailingMinutiae": [
+                                {
+                                  "kind": "WHITESPACE_MINUTIAE",
+                                  "value": " "
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "LIST",
+                              "children": [
+                                {
+                                  "kind": "DOCUMENTATION_DESCRIPTION",
+                                  "value": "Description",
+                                  "trailingMinutiae": [
+                                    {
+                                      "kind": "END_OF_LINE_MINUTIAE",
+                                      "value": "\n"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "MARKDOWN_PARAMETER_DOCUMENTATION_LINE",
+                          "hasDiagnostics": true,
+                          "children": [
+                            {
+                              "kind": "HASH_TOKEN",
+                              "trailingMinutiae": [
+                                {
+                                  "kind": "WHITESPACE_MINUTIAE",
+                                  "value": " "
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "PLUS_TOKEN",
+                              "trailingMinutiae": [
+                                {
+                                  "kind": "WHITESPACE_MINUTIAE",
+                                  "value": " "
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "PARAMETER_NAME",
+                              "hasDiagnostics": true,
+                              "diagnostics": [
+                                "WARNING_INVALID_ESCAPE_SEQUENCE"
+                              ],
+                              "value": "v\\",
+                              "trailingMinutiae": [
+                                {
+                                  "kind": "WHITESPACE_MINUTIAE",
+                                  "value": "\t"
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "MINUS_TOKEN",
+                              "trailingMinutiae": [
+                                {
+                                  "kind": "WHITESPACE_MINUTIAE",
+                                  "value": " "
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "LIST",
+                              "children": [
+                                {
+                                  "kind": "DOCUMENTATION_DESCRIPTION",
+                                  "value": "Parameter",
+                                  "trailingMinutiae": [
+                                    {
+                                      "kind": "END_OF_LINE_MINUTIAE",
+                                      "value": "\n"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "MARKDOWN_PARAMETER_DOCUMENTATION_LINE",
+                          "hasDiagnostics": true,
+                          "children": [
+                            {
+                              "kind": "HASH_TOKEN",
+                              "trailingMinutiae": [
+                                {
+                                  "kind": "WHITESPACE_MINUTIAE",
+                                  "value": " "
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "PLUS_TOKEN",
+                              "trailingMinutiae": [
+                                {
+                                  "kind": "WHITESPACE_MINUTIAE",
+                                  "value": " "
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "PARAMETER_NAME",
+                              "hasDiagnostics": true,
+                              "diagnostics": [
+                                "WARNING_INVALID_ESCAPE_SEQUENCE"
+                              ],
+                              "value": "a\\",
+                              "trailingMinutiae": [
+                                {
+                                  "kind": "END_OF_LINE_MINUTIAE",
+                                  "value": "\n"
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "MINUS_TOKEN",
+                              "isMissing": true,
+                              "hasDiagnostics": true,
+                              "diagnostics": [
+                                "WARNING_MISSING_HYPHEN_TOKEN"
+                              ]
+                            },
+                            {
+                              "kind": "LIST",
+                              "children": []
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "LIST",
+                  "children": []
+                }
+              ]
+            },
+            {
+              "kind": "LIST",
+              "children": [
+                {
+                  "kind": "PUBLIC_KEYWORD",
+                  "trailingMinutiae": [
+                    {
+                      "kind": "WHITESPACE_MINUTIAE",
+                      "value": " "
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "FUNCTION_KEYWORD",
+              "trailingMinutiae": [
+                {
+                  "kind": "WHITESPACE_MINUTIAE",
+                  "value": " "
+                }
+              ]
+            },
+            {
+              "kind": "IDENTIFIER_TOKEN",
+              "value": "main1"
+            },
+            {
+              "kind": "LIST",
+              "children": []
+            },
+            {
+              "kind": "FUNCTION_SIGNATURE",
+              "children": [
+                {
+                  "kind": "OPEN_PAREN_TOKEN"
+                },
+                {
+                  "kind": "LIST",
+                  "children": [
+                    {
+                      "kind": "REQUIRED_PARAM",
+                      "children": [
+                        {
+                          "kind": "LIST",
+                          "children": []
+                        },
+                        {
+                          "kind": "INT_TYPE_DESC",
+                          "children": [
+                            {
+                              "kind": "INT_KEYWORD",
+                              "trailingMinutiae": [
+                                {
+                                  "kind": "WHITESPACE_MINUTIAE",
+                                  "value": " "
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "IDENTIFIER_TOKEN",
+                          "value": "v\\\u003c"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "COMMA_TOKEN",
+                      "trailingMinutiae": [
+                        {
+                          "kind": "WHITESPACE_MINUTIAE",
+                          "value": " "
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "REQUIRED_PARAM",
+                      "children": [
+                        {
+                          "kind": "LIST",
+                          "children": []
+                        },
+                        {
+                          "kind": "STRING_TYPE_DESC",
+                          "children": [
+                            {
+                              "kind": "STRING_KEYWORD",
+                              "trailingMinutiae": [
+                                {
+                                  "kind": "WHITESPACE_MINUTIAE",
+                                  "value": " "
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "IDENTIFIER_TOKEN",
+                          "value": "a\\|"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "CLOSE_PAREN_TOKEN",
+                  "trailingMinutiae": [
+                    {
+                      "kind": "WHITESPACE_MINUTIAE",
+                      "value": " "
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "FUNCTION_BODY_BLOCK",
+              "children": [
+                {
+                  "kind": "OPEN_BRACE_TOKEN",
+                  "trailingMinutiae": [
+                    {
+                      "kind": "END_OF_LINE_MINUTIAE",
+                      "value": "\n"
+                    }
+                  ]
+                },
+                {
+                  "kind": "LIST",
+                  "children": []
+                },
+                {
+                  "kind": "CLOSE_BRACE_TOKEN",
+                  "trailingMinutiae": [
+                    {
+                      "kind": "END_OF_LINE_MINUTIAE",
+                      "value": "\n"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "EOF_TOKEN"
+    }
+  ]
+}

--- a/compiler/ballerina-parser/src/test/resources/misc/documentation/doc_source_27.bal
+++ b/compiler/ballerina-parser/src/test/resources/misc/documentation/doc_source_27.bal
@@ -1,0 +1,5 @@
+# Description
+# + v\	- Parameter
+# + a\
+public function main1(int v\<, string a\|) {
+}

--- a/compiler/ballerina-parser/src/test/resources/misc/identifiers/invalid_identifier_assert_02.json
+++ b/compiler/ballerina-parser/src/test/resources/misc/identifiers/invalid_identifier_assert_02.json
@@ -269,6 +269,314 @@
               ]
             }
           ]
+        },
+        {
+          "kind": "FUNCTION_DEFINITION",
+          "hasDiagnostics": true,
+          "children": [
+            {
+              "kind": "LIST",
+              "children": []
+            },
+            {
+              "kind": "FUNCTION_KEYWORD",
+              "leadingMinutiae": [
+                {
+                  "kind": "END_OF_LINE_MINUTIAE",
+                  "value": "\n"
+                }
+              ],
+              "trailingMinutiae": [
+                {
+                  "kind": "WHITESPACE_MINUTIAE",
+                  "value": " "
+                }
+              ]
+            },
+            {
+              "kind": "IDENTIFIER_TOKEN",
+              "value": "foo"
+            },
+            {
+              "kind": "LIST",
+              "children": []
+            },
+            {
+              "kind": "FUNCTION_SIGNATURE",
+              "children": [
+                {
+                  "kind": "OPEN_PAREN_TOKEN"
+                },
+                {
+                  "kind": "LIST",
+                  "children": []
+                },
+                {
+                  "kind": "CLOSE_PAREN_TOKEN",
+                  "trailingMinutiae": [
+                    {
+                      "kind": "WHITESPACE_MINUTIAE",
+                      "value": " "
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "FUNCTION_BODY_BLOCK",
+              "hasDiagnostics": true,
+              "children": [
+                {
+                  "kind": "OPEN_BRACE_TOKEN",
+                  "trailingMinutiae": [
+                    {
+                      "kind": "END_OF_LINE_MINUTIAE",
+                      "value": "\n"
+                    }
+                  ]
+                },
+                {
+                  "kind": "LIST",
+                  "hasDiagnostics": true,
+                  "children": [
+                    {
+                      "kind": "LOCAL_VAR_DECL",
+                      "hasDiagnostics": true,
+                      "children": [
+                        {
+                          "kind": "LIST",
+                          "children": []
+                        },
+                        {
+                          "kind": "TYPED_BINDING_PATTERN",
+                          "hasDiagnostics": true,
+                          "children": [
+                            {
+                              "kind": "INT_TYPE_DESC",
+                              "children": [
+                                {
+                                  "kind": "INT_KEYWORD",
+                                  "leadingMinutiae": [
+                                    {
+                                      "kind": "WHITESPACE_MINUTIAE",
+                                      "value": "    "
+                                    }
+                                  ],
+                                  "trailingMinutiae": [
+                                    {
+                                      "kind": "WHITESPACE_MINUTIAE",
+                                      "value": " "
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "CAPTURE_BINDING_PATTERN",
+                              "hasDiagnostics": true,
+                              "children": [
+                                {
+                                  "kind": "IDENTIFIER_TOKEN",
+                                  "hasDiagnostics": true,
+                                  "diagnostics": [
+                                    "ERROR_INVALID_ESCAPE_SEQUENCE"
+                                  ],
+                                  "value": "\\",
+                                  "trailingMinutiae": [
+                                    {
+                                      "kind": "END_OF_LINE_MINUTIAE",
+                                      "value": "\n"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "SEMICOLON_TOKEN",
+                          "leadingMinutiae": [
+                            {
+                              "kind": "WHITESPACE_MINUTIAE",
+                              "value": "    "
+                            }
+                          ],
+                          "trailingMinutiae": [
+                            {
+                              "kind": "END_OF_LINE_MINUTIAE",
+                              "value": "\n"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "LOCAL_VAR_DECL",
+                      "hasDiagnostics": true,
+                      "children": [
+                        {
+                          "kind": "LIST",
+                          "children": []
+                        },
+                        {
+                          "kind": "TYPED_BINDING_PATTERN",
+                          "hasDiagnostics": true,
+                          "children": [
+                            {
+                              "kind": "STRING_TYPE_DESC",
+                              "children": [
+                                {
+                                  "kind": "STRING_KEYWORD",
+                                  "leadingMinutiae": [
+                                    {
+                                      "kind": "WHITESPACE_MINUTIAE",
+                                      "value": "    "
+                                    }
+                                  ],
+                                  "trailingMinutiae": [
+                                    {
+                                      "kind": "WHITESPACE_MINUTIAE",
+                                      "value": " "
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "CAPTURE_BINDING_PATTERN",
+                              "hasDiagnostics": true,
+                              "children": [
+                                {
+                                  "kind": "IDENTIFIER_TOKEN",
+                                  "hasDiagnostics": true,
+                                  "diagnostics": [
+                                    "ERROR_INVALID_ESCAPE_SEQUENCE"
+                                  ],
+                                  "value": "head\\",
+                                  "trailingMinutiae": [
+                                    {
+                                      "kind": "END_OF_LINE_MINUTIAE",
+                                      "value": "\n"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "SEMICOLON_TOKEN",
+                          "leadingMinutiae": [
+                            {
+                              "kind": "WHITESPACE_MINUTIAE",
+                              "value": "    "
+                            }
+                          ],
+                          "trailingMinutiae": [
+                            {
+                              "kind": "END_OF_LINE_MINUTIAE",
+                              "value": "\n"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "LOCAL_VAR_DECL",
+                      "hasDiagnostics": true,
+                      "children": [
+                        {
+                          "kind": "LIST",
+                          "children": []
+                        },
+                        {
+                          "kind": "TYPED_BINDING_PATTERN",
+                          "hasDiagnostics": true,
+                          "children": [
+                            {
+                              "kind": "INT_TYPE_DESC",
+                              "children": [
+                                {
+                                  "kind": "INT_KEYWORD",
+                                  "leadingMinutiae": [
+                                    {
+                                      "kind": "WHITESPACE_MINUTIAE",
+                                      "value": "    "
+                                    }
+                                  ],
+                                  "trailingMinutiae": [
+                                    {
+                                      "kind": "WHITESPACE_MINUTIAE",
+                                      "value": " "
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "CAPTURE_BINDING_PATTERN",
+                              "hasDiagnostics": true,
+                              "children": [
+                                {
+                                  "kind": "IDENTIFIER_TOKEN",
+                                  "hasDiagnostics": true,
+                                  "diagnostics": [
+                                    "ERROR_INVALID_ESCAPE_SEQUENCE"
+                                  ],
+                                  "value": "first\\",
+                                  "trailingMinutiae": [
+                                    {
+                                      "kind": "WHITESPACE_MINUTIAE",
+                                      "value": "\t"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "EQUAL_TOKEN",
+                          "isMissing": true,
+                          "hasDiagnostics": true,
+                          "diagnostics": [
+                            "ERROR_MISSING_EQUAL_TOKEN"
+                          ]
+                        },
+                        {
+                          "kind": "SIMPLE_NAME_REFERENCE",
+                          "children": [
+                            {
+                              "kind": "IDENTIFIER_TOKEN",
+                              "value": "second"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "SEMICOLON_TOKEN",
+                          "trailingMinutiae": [
+                            {
+                              "kind": "END_OF_LINE_MINUTIAE",
+                              "value": "\n"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "CLOSE_BRACE_TOKEN",
+                  "trailingMinutiae": [
+                    {
+                      "kind": "END_OF_LINE_MINUTIAE",
+                      "value": "\n"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
         }
       ]
     },

--- a/compiler/ballerina-parser/src/test/resources/misc/identifiers/invalid_identifier_source_02.bal
+++ b/compiler/ballerina-parser/src/test/resources/misc/identifiers/invalid_identifier_source_02.bal
@@ -5,3 +5,11 @@ function getStringValue() {
 function getStringValue() {
     return \a\B\c\x\y\z_var;
 }
+
+function foo() {
+    int \
+    ;
+    string head\
+    ;
+    int first\	second;
+}

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/ParserTestFormatter.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/ParserTestFormatter.java
@@ -65,6 +65,8 @@ public class ParserTestFormatter extends FormatterTest {
                 "doc_source_06.bal",
                 "module_var_decl_source_16.bal",
                 "doc_source_24.bal",
+                "doc_source_27.bal",
+                "invalid_identifier_source_02.bal",
 
                 // the following tests need to be enabled in the future
                 "annotations_source_04.bal", // could be considered an invalid scenario

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/documentation/MarkdownDocumentationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/documentation/MarkdownDocumentationTest.java
@@ -391,7 +391,7 @@ public class MarkdownDocumentationTest {
     public void testDocumentationNegative() {
         CompileResult compileResult = BCompileUtil.compile("test-src/documentation/markdown_negative.bal");
         Assert.assertEquals(compileResult.getErrorCount(), 0);
-        Assert.assertEquals(compileResult.getWarnCount(), 48);
+        Assert.assertEquals(compileResult.getWarnCount(), 53);
 
         int index = 0;
 
@@ -459,7 +459,12 @@ public class MarkdownDocumentationTest {
         BAssertUtil.validateWarning(compileResult, index++,
                 "invalid usage of parameter reference outside of function definition 'invalidParameter'", 126, 3);
         BAssertUtil.validateWarning(compileResult, index++, "undocumented parameter 'val1'", 132, 39);
-        BAssertUtil.validateWarning(compileResult, index, "undocumented parameter 'val2'", 139, 32);
+        BAssertUtil.validateWarning(compileResult, index++, "undocumented parameter 'val2'", 139, 32);
+        BAssertUtil.validateWarning(compileResult, index++, "invalid escape sequence '\\'", 144, 5);
+        BAssertUtil.validateWarning(compileResult, index++, "no such documentable parameter 'v\\'", 144, 5);
+        BAssertUtil.validateWarning(compileResult, index++, "invalid escape sequence '\\'", 145, 5);
+        BAssertUtil.validateWarning(compileResult, index++, "no such documentable parameter 'a\\'", 145, 5);
+        BAssertUtil.validateWarning(compileResult, index, "missing hyphen token", 146, 1);
     }
 
     @Test(description = "Test doc service")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/literals/IdentifierLiteralTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/literals/IdentifierLiteralTest.java
@@ -160,9 +160,10 @@ public class IdentifierLiteralTest {
         BAssertUtil.validateError(resultNeg, i++, "missing double quote", 3, 32);
         BAssertUtil.validateError(resultNeg, i++, "missing equal token", 3, 32);
         BAssertUtil.validateError(resultNeg, i++, "missing semicolon token", 4, 1);
-        BAssertUtil.validateError(resultNeg, i++, "invalid escape sequence '\\\u0000'", 4, 9);
-        BAssertUtil.validateError(resultNeg, i++, "missing semicolon token", 5, 1);
-        BAssertUtil.validateError(resultNeg, i++, "undefined symbol 'global\\ v\\ ar'", 5, 12);
+        BAssertUtil.validateError(resultNeg, i++, "invalid escape sequence '\\'", 4, 9);
+        BAssertUtil.validateError(resultNeg, i++, "invalid escape sequence '\\'", 6, 12);
+        BAssertUtil.validateError(resultNeg, i++, "missing semicolon token", 7, 1);
+        BAssertUtil.validateError(resultNeg, i++, "undefined symbol 'global\\ v\\ ar'", 7, 12);
         Assert.assertEquals(resultNeg.getErrorCount(), i);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/literals/IdentifierLiteralTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/literals/IdentifierLiteralTest.java
@@ -160,7 +160,9 @@ public class IdentifierLiteralTest {
         BAssertUtil.validateError(resultNeg, i++, "missing double quote", 3, 32);
         BAssertUtil.validateError(resultNeg, i++, "missing equal token", 3, 32);
         BAssertUtil.validateError(resultNeg, i++, "missing semicolon token", 4, 1);
-        BAssertUtil.validateError(resultNeg, i++, "undefined symbol 'global\\ v\\ ar'", 4, 12);
+        BAssertUtil.validateError(resultNeg, i++, "invalid escape sequence '\\\u0000'", 4, 9);
+        BAssertUtil.validateError(resultNeg, i++, "missing semicolon token", 5, 1);
+        BAssertUtil.validateError(resultNeg, i++, "undefined symbol 'global\\ v\\ ar'", 5, 12);
         Assert.assertEquals(resultNeg.getErrorCount(), i);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/StringTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/StringTest.java
@@ -245,6 +245,7 @@ public class StringTest {
         validateError(multilineLiterals, indx++, "missing binary operator", 21, 22);
         validateError(multilineLiterals, indx++, "missing double quote", 21, 22);
         validateError(multilineLiterals, indx++, "missing semicolon token", 22, 1);
+        validateError(multilineLiterals, indx++, "invalid escape sequence '\\B'", 25, 16);
         Assert.assertEquals(multilineLiterals.getErrorCount(), indx);
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/documentation/markdown_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/documentation/markdown_negative.bal
@@ -139,3 +139,9 @@ public function myFunc1(string name1, string val1) {
 function myFunc2(string name2, string val2) {
 
 }
+
+# Description
+# + v\	- Parameter
+# + a\
+public function main1() {
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/literals/identifierliteral/identifier-literal-wrong-character-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/literals/identifierliteral/identifier-literal-wrong-character-negative.bal
@@ -2,6 +2,8 @@
 function getGlobalVarWithIL() returns string {
     string 'global\ var" = "dfs";
     int \
+    ;
+    string head\
     return 'global\ v\ ar;
 }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/literals/identifierliteral/identifier-literal-wrong-character-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/literals/identifierliteral/identifier-literal-wrong-character-negative.bal
@@ -1,6 +1,7 @@
 
 function getGlobalVarWithIL() returns string {
     string 'global\ var" = "dfs";
+    int \
     return 'global\ v\ ar;
 }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/string/string_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/string/string_negative.bal
@@ -20,3 +20,7 @@ function testMultilineStrings() {
     string name = "Alice " Bob "
     string name2 = """
 }
+
+public function main() {
+    string a = "\Ballerina";
+}


### PR DESCRIPTION
## Purpose
$title
For the sample 
```bal
function foo() {
     int \
}
```
Ballerina lexer continues to produce empty identifier tokens which will result in an infinite loop.

Fixes #32369
Fixes #32230

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
