### PR TITLE
Fix escaping chars in XML texts twice

### DIFF
--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLLiteralTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLLiteralTest.java
@@ -21,7 +21,6 @@ import io.ballerina.runtime.api.values.BXml;
 import io.ballerina.runtime.internal.XmlFactory;
 import org.ballerinalang.core.model.values.BInteger;
 import org.ballerinalang.core.model.values.BIterator;
-import org.ballerinalang.core.model.values.BString;
 import org.ballerinalang.core.model.values.BValue;
 import org.ballerinalang.core.model.values.BValueArray;
 import org.ballerinalang.core.model.values.BXML;
@@ -43,7 +42,6 @@ import org.testng.annotations.Test;
 public class XMLLiteralTest {
 
     private CompileResult result;
-    private CompileResult negativeResult;
 
     @BeforeClass
     public void setup() {
@@ -52,7 +50,7 @@ public class XMLLiteralTest {
 
     @Test
     public void testXMLNegativeSemantics() {
-        negativeResult = BCompileUtil.compile("test-src/types/xml/xml-literals-negative.bal");
+        CompileResult negativeResult = BCompileUtil.compile("test-src/types/xml/xml-literals-negative.bal");
         int index = 0;
         BAssertUtil.validateError(negativeResult, index++, "invalid namespace prefix 'xmlns'", 4, 19);
         BAssertUtil.validateError(negativeResult, index++, "invalid namespace prefix 'xmlns'", 4, 36);
@@ -336,7 +334,7 @@ public class XMLLiteralTest {
         StringBuilder builder = new StringBuilder();
         BIterator bIterator = ar.newIterator();
         while (bIterator.hasNext()) {
-            String str = ((BString) bIterator.getNext()).stringValue();
+            String str = bIterator.getNext().stringValue();
             builder.append(str);
         }
         return builder.toString();

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-literals.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-literals.bal
@@ -280,6 +280,10 @@ function testXMLCDATASection() {
     xml x6 = xml `<![CDATA[]]>`;
     assert(x6.toString(), "");
     assert(x6 is xml:Text, true);
+
+   xml x7 = xml `<![CDATA[ abc --> <!-- --> some more text ]]>`;
+   assert(x7.toString(), " abc --&gt; &lt;!-- --&gt; some more text ");
+   assert(x7 is xml:Text, true);
 }
 
 function assert(anydata actual, anydata expected) {


### PR DESCRIPTION
## Purpose
In the implementation for xml `stringValue()` we use `XMLStreamWriter` to convert the xml texts from byte array stream to string. 
The stream writer instance is created from different classes when we run unit tests and when we externally run using `bal run`. 

Fixes #32673 

## Approach
When the unit tests are running,  the stream writer uses the default configurations where it escapes the characters in  the string output which is already escaped by the native implementation.  
https://github.com/ballerina-platform/ballerina-lang/blob/243aa0746732976f520802677cba1f257f096f0f/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/BallerinaXmlSerializer.java#L158

This PR unsets the `escapeCharacters` property for default stream writers to fix this error.

## Samples
Need to be tested within unit tests.
```ballerina
public function main() {
    xml x7 = xml `<![CDATA[ abc --> <!-- --> some more text ]]>`;
    assertTrue(x7.toString() == " abc --&gt; &lt;!-- --&gt; some more text ");  
}
```
## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
