### PR TITLE
Fix showing change variable type codeaction at positional/named arguments

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/TypeGuardCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/TypeGuardCodeAction.java
@@ -99,7 +99,7 @@ public class TypeGuardCodeAction extends AbstractCodeActionProvider {
         }
 
         // Add type guard code action
-        String commandTitle = CommandConstants.TYPE_GUARD_TITLE;
+        String commandTitle = String.format(CommandConstants.TYPE_GUARD_TITLE, varName.get());
         Range range = CommonUtil.toRange(matchedNode.lineRange());
         List<TextEdit> edits = CodeActionUtil.getTypeGuardCodeActionEdits(varName.get(), range, varTypeSymbol, context);
         if (edits.isEmpty()) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/ChangeVariableTypeCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/ChangeVariableTypeCodeAction.java
@@ -113,6 +113,10 @@ public class ChangeVariableTypeCodeAction extends TypeCastCodeAction {
                 sNode.kind() != SyntaxKind.LOCAL_VAR_DECL &&
                 sNode.kind() != SyntaxKind.MODULE_VAR_DECL &&
                 sNode.kind() != SyntaxKind.ASSIGNMENT_STATEMENT) {
+            // The cursor can be within a positional/named arg. If so, don't show this code action
+            if (sNode.kind() == SyntaxKind.POSITIONAL_ARG || sNode.kind() == SyntaxKind.NAMED_ARG) {
+                return Optional.empty();
+            }
             sNode = sNode.parent();
         }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/constants/CommandConstants.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/constants/CommandConstants.java
@@ -110,7 +110,7 @@ public class CommandConstants {
 
     public static final String CREATE_VAR_TYPE_GUARD_TITLE = "Create variable and type guard";
 
-    public static final String TYPE_GUARD_TITLE = "Type guard variable";
+    public static final String TYPE_GUARD_TITLE = "Type guard variable '%s'";
 
     public static final String CREATE_VAR_ADD_CHECK_TITLE = "Create variable and check error";
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ChangeVariableTypeCodeActionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ChangeVariableTypeCodeActionTest.java
@@ -41,12 +41,26 @@ public class ChangeVariableTypeCodeActionTest extends AbstractCodeActionTest {
         super.test(config, source);
     }
 
+    @Test(dataProvider = "negative-test-data-provider")
+    @Override
+    public void negativeTest(String config, String source) throws IOException, WorkspaceDocumentException {
+        super.negativeTest(config, source);
+    }
+
     @DataProvider(name = "codeaction-data-provider")
     @Override
     public Object[][] dataProvider() {
         return new Object[][]{
                 {"changeVarType1.json", "changeVarType.bal"},
                 {"changeVarType2.json", "changeVarType.bal"},
+        };
+    }
+
+    @DataProvider(name = "negative-test-data-provider")
+    public Object[][] negativeTestDataProvider() {
+        return new Object[][]{
+                {"negative_changeVarType1.json", "negative_changeVarType1.bal"},
+                {"negative_changeVarType2.json", "negative_changeVarType2.bal"},
         };
     }
 }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/TypeGuardTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/TypeGuardTest.java
@@ -29,6 +29,7 @@ import java.io.IOException;
  * @since 2.0.0
  */
 public class TypeGuardTest extends AbstractCodeActionTest {
+
     @Override
     public String getResourceDir() {
         return "type-guard";
@@ -47,6 +48,8 @@ public class TypeGuardTest extends AbstractCodeActionTest {
                 {"typeGuardCodeAction1.json", "typeGuard.bal"},
                 {"typeGuardCodeAction2.json", "typeGuard.bal"},
                 {"typeGuardCodeAction3.json", "typeGuard.bal"},
+                {"typeGuardVariableCodeAction1.json", "typeGuardVariable1.bal"},
+                {"typeGuardVariableCodeAction2.json", "typeGuardVariable1.bal"},
         };
     }
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/config/negative_changeVarType1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/config/negative_changeVarType1.json
@@ -1,0 +1,9 @@
+{
+    "line": 7,
+    "character": 35,
+    "expected": [
+        {
+            "title": "Change variable 'val' type to 'string?'"
+        }
+    ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/config/negative_changeVarType2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/config/negative_changeVarType2.json
@@ -1,0 +1,9 @@
+{
+    "line": 7,
+    "character": 41,
+    "expected": [
+        {
+            "title": "Change variable 'val' type to 'string?'"
+        }
+    ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/source/negative_changeVarType1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/source/negative_changeVarType1.bal
@@ -1,0 +1,13 @@
+type Person record {
+    string name?;
+    int age = 0;
+};
+
+public function main() {
+    Person person = {};
+    string|int? val = createVar(person?.name)
+}
+
+function createVar(string val) returns string|int? {
+
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/source/negative_changeVarType2.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/source/negative_changeVarType2.bal
@@ -1,0 +1,13 @@
+type Person record {
+    string name?;
+    int age = 0;
+};
+
+public function main() {
+    Person person = {};
+    string|int? val = createVar(name = person?.name)
+}
+
+function createVar(string name) returns string|int? {
+
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/type-guard/config/typeGuardVariableCodeAction1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/type-guard/config/typeGuardVariableCodeAction1.json
@@ -1,0 +1,24 @@
+{
+    "line": 7,
+    "character": 17,
+    "expected": [
+        {
+            "title": "Type guard variable 'val'",
+            "edits": [
+                {
+                    "range": {
+                        "start": {
+                            "line": 7,
+                            "character": 45
+                        },
+                        "end": {
+                            "line": 7,
+                            "character": 45
+                        }
+                    },
+                    "newText": "\n    if val is string {\n\n    } else if val is int {\n\n    } else {\n\n    }\n"
+                }
+            ]
+        }
+    ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/type-guard/config/typeGuardVariableCodeAction2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/type-guard/config/typeGuardVariableCodeAction2.json
@@ -1,0 +1,24 @@
+{
+    "line": 7,
+    "character": 35,
+    "expected": [
+        {
+            "title": "Type guard variable 'val'",
+            "edits": [
+                {
+                    "range": {
+                        "start": {
+                            "line": 7,
+                            "character": 45
+                        },
+                        "end": {
+                            "line": 7,
+                            "character": 45
+                        }
+                    },
+                    "newText": "\n    if val is string {\n\n    } else if val is int {\n\n    } else {\n\n    }\n"
+                }
+            ]
+        }
+    ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/type-guard/source/typeGuardVariable1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/type-guard/source/typeGuardVariable1.bal
@@ -1,0 +1,13 @@
+type Person record {
+    string name?;
+    int age = 0;
+};
+
+public function main() {
+    Person person = {};
+    string|int? val = createVar(person?.name)
+}
+
+function createVar(string val) returns string|int? {
+
+}


### PR DESCRIPTION
## Purpose
$subject and add variable name to `Type guard variable` code action title.

Fixes #32567

## Approach
See description

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
