### PR TITLE
Ignore LS simulator module from code coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,4 +7,5 @@ fixes:
 
 ignore:
   - "**/tests"
+  - "tests/language-server-simulator"
 


### PR DESCRIPTION
## Purpose
$subject

Language server simulator was introduced in #32658 and #32613

## Approach
Ignored `language-server-simulator` module from codecov.yml.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
