### PR TITLE
Fix allowing concurrent calls from non-isolated resource functions

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/Runtime.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/Runtime.java
@@ -80,7 +80,7 @@ public class Runtime {
         try {
             validateArgs(object, methodName);
             Function<?, ?> func = o -> object.call((Strand) (((Object[]) o)[0]), methodName, args);
-            return scheduler.scheduleToObjectGroup(object, new Object[1], func, null, callback, properties,
+            return scheduler.scheduleToObjectGroup(new Object[1], func, null, callback, properties,
                                                    returnType, strandName, metadata);
         } catch (BError e) {
             callback.notifyFailure(e);
@@ -159,7 +159,7 @@ public class Runtime {
                 return scheduler.schedule(new Object[1], func, null, callback, properties, returnType, strandName,
                                           metadata);
             } else {
-                return scheduler.scheduleToObjectGroup(object, new Object[1], func, null, callback, properties,
+                return scheduler.scheduleToObjectGroup(new Object[1], func, null, callback, properties,
                                                        returnType, strandName, metadata);
             }
         } catch (BError e) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/scheduling/Scheduler.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/scheduling/Scheduler.java
@@ -32,17 +32,16 @@ import io.ballerina.runtime.internal.values.ChannelDetails;
 import io.ballerina.runtime.internal.values.FutureValue;
 
 import java.io.PrintStream;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.Stack;
-import java.util.WeakHashMap;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -82,7 +81,7 @@ public class Scheduler {
 
     private Semaphore mainBlockSem;
     private ListenerRegistry listenerRegistry;
-    private Map<BObject, ItemGroup> objectGroups = Collections.synchronizedMap(new WeakHashMap<>());
+    private AtomicReference<ItemGroup> objectGroup = new AtomicReference<>();
 
     public Scheduler(boolean immortal) {
         try {
@@ -169,7 +168,7 @@ public class Scheduler {
         return future;
     }
 
-    public FutureValue scheduleToObjectGroup(BObject object, Object[] params, Function function, Strand parent,
+    public FutureValue scheduleToObjectGroup(Object[] params, Function function, Strand parent,
                                              Callback callback, Map<String, Object> properties, Type returnType,
                                              String strandName, StrandMetadata metadata) {
         FutureValue future = createFuture(parent, callback, properties, returnType, strandName, metadata);
@@ -177,14 +176,13 @@ public class Scheduler {
         SchedulerItem item = new SchedulerItem(function, params, future);
         future.strand.schedulerItem = item;
         totalStrands.incrementAndGet();
-        ItemGroup group = objectGroups.compute(object, (o, groupInMap) -> {
-            if (groupInMap == null) {
-                return new ItemGroup(item);
-            } else {
-                groupInMap.add(item);
-                return groupInMap;
-            }
-        });
+        ItemGroup group = objectGroup.get();
+        if (group == null) {
+            group = new ItemGroup(item);
+            objectGroup.set(group);
+        } else {
+            group.add(item);
+        }
         future.strand.strandGroup = group;
         if (group.scheduled.compareAndSet(false, true)) {
             runnableList.add(group);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Async.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Async.java
@@ -65,6 +65,16 @@ public class Async {
         return 0;
     }
 
+    public static long getNonIsolatedResourceA(Environment env, BObject obj) {
+        invokeMethodAsyncConcurrently(env, obj, "$gen$$getA$$0046");
+        return 0;
+    }
+
+    public static long getNonIsolatedResourceB(Environment env, BObject obj) {
+        invokeMethodAsyncConcurrently(env, obj, "$gen$$getB$$0046");
+        return 0;
+    }
+
     public static boolean nonIsolatedClassIsIsolated(BObject obj) {
         return obj.getType().isIsolated();
     }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/async/main.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/async/main.bal
@@ -173,6 +173,33 @@ public function callAsyncInvalidObjectMethod(IsolatedClass s) returns int|error 
 } external;
 
 
+int globalVar1 = 2;
+
+public service class NonIsolatedServiceClass1 {
+
+    resource function getA .() returns int {
+        globalVar1 = globalVar1 + 2;
+        return globalVar1;
+    }
+
+    public function getNonIsolatedResourceA() returns int = @java:Method {
+        name: "getNonIsolatedResourceA",
+        'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Async"
+    } external;
+}
+
+public service class NonIsolatedServiceClass2 {
+    resource function getB .() returns int {
+        globalVar1 = globalVar1 + 2;
+        return globalVar1;
+    }
+
+    public function getNonIsolatedResourceB() returns int = @java:Method {
+        name: "getNonIsolatedResourceB",
+        'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Async"
+    } external;
+
+}
 
 public function main() {
     IsolatedClass isolatedClass = new ();
@@ -247,4 +274,14 @@ public function main() {
     test:assertTrue(r9 is error);
     error e9 = <error> r9;
     test:assertEquals(e9.message(), "No such method: foo");
+
+    testNonIsolatedSequentialCall();
+}
+
+function testNonIsolatedSequentialCall() {
+    NonIsolatedServiceClass1 obj1 = new ();
+    NonIsolatedServiceClass2 obj2 = new ();
+
+    test:assertEquals(obj1.getNonIsolatedResourceA(), 4);
+    test:assertEquals(obj2.getNonIsolatedResourceB(), 6);
 }


### PR DESCRIPTION
## Purpose
Currently, the strands used to execute the resource functions are mapped according to their objects in the scheduler. 
This allows concurrent execution of resource functions if they are non-isolated. This can cause errors if multiple functions access same entity. 

Fixes #32652

## Approach
Fixed by not mapping the strand according to service object;

## Samples

## Remarks
TODO: add a unit test to test this scenario.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
