### PR TITLE
Fix symbol owner bug in intersection type symbols when it's read from BIR

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
@@ -1272,7 +1272,7 @@ public class BIRPackageSymbolEnter {
                     BTypeSymbol intersectionTypeSymbol = Symbols.createTypeSymbol(SymTag.INTERSECTION_TYPE,
                                                                                   Flags.asMask(EnumSet.of(Flag.PUBLIC)),
                                                                                   Names.EMPTY, env.pkgSymbol.pkgID,
-                                                                                  null, env.pkgSymbol.owner,
+                                                                                  null, env.pkgSymbol,
                                                                                   symTable.builtinPos, COMPILED_SOURCE);
                     int intersectionMemberCount = inputStream.readInt();
                     LinkedHashSet<BType> constituentTypes = new LinkedHashSet<>(intersectionMemberCount);

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolOwnerTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolOwnerTest.java
@@ -26,6 +26,7 @@ import io.ballerina.projects.Project;
 import io.ballerina.tools.text.LinePosition;
 import org.ballerinalang.test.BCompileUtil;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
@@ -51,15 +52,23 @@ public class SymbolOwnerTest {
         srcFile = getDocumentForSingleSource(project);
     }
 
-    @Test
-    public void testLangLibSymbols() {
-        Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(19, 10));
+    @Test (dataProvider = "LangLibSymbolProvider")
+    public void testLangLibSymbols(int line, int column, String orgName, String moduleName) {
+        Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, column));
         assertTrue(symbol.isPresent());
 
         Optional<ModuleSymbol> module = symbol.get().getModule();
 
         assertTrue(module.isPresent());
-        assertEquals(module.get().id().orgName(), "ballerina");
-        assertEquals(module.get().id().moduleName(), "lang.value");
+        assertEquals(module.get().id().orgName(), orgName);
+        assertEquals(module.get().id().moduleName(), moduleName);
+    }
+
+    @DataProvider(name = "LangLibSymbolProvider")
+    public Object[][] getLangLibSymbols() {
+        return new Object[][]{
+                {20, 10, "ballerina", "lang.value"},
+                {22, 12, "ballerina", "lang.runtime"},
+        };
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol_owner_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol_owner_test.bal
@@ -15,7 +15,10 @@
 // under the License.
 
 import ballerina/lang.value;
+import ballerina/lang.runtime;
 
 public function test() {
     value:JsonDecimal jsonDecimal = 23;
+
+    runtime:StackFrame[] stackTrace = runtime:getStackTrace();
 }

--- a/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
+++ b/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
@@ -29,16 +29,18 @@
             <class name="io.ballerina.semantic.api.test.ExpressionTypeTestNew" />
             <class name="io.ballerina.semantic.api.test.FieldSymbolTest" />
             <class name="io.ballerina.semantic.api.test.LangLibFunctionTest" />
+            <class name="io.ballerina.semantic.api.test.ServiceSemanticAPITest" />
             <class name="io.ballerina.semantic.api.test.SymbolAtCursorTest" />
             <class name="io.ballerina.semantic.api.test.SymbolBIRTest" />
             <class name="io.ballerina.semantic.api.test.SymbolEquivalenceTest" />
             <class name="io.ballerina.semantic.api.test.SymbolFlagToQualifierMappingTest" />
-            <class name="io.ballerina.semantic.api.test.TestSourcesTest" />
             <class name="io.ballerina.semantic.api.test.SymbolLookupTest" />
+            <class name="io.ballerina.semantic.api.test.SymbolOwnerTest" />
             <class name="io.ballerina.semantic.api.test.SymbolPositionTest" />
+            <class name="io.ballerina.semantic.api.test.TestSourcesTest" />
+            <class name="io.ballerina.semantic.api.test.TypeAssignabilityTest" />
             <class name="io.ballerina.semantic.api.test.TypedescriptorTest" />
             <class name="io.ballerina.semantic.api.test.WorkspaceSymbolLookupTest" />
-            <class name="io.ballerina.semantic.api.test.ServiceSemanticAPITest" />
 
             <class name="io.ballerina.semantic.api.test.allreferences.FindRefsWithinTargetDocumentTest" />
             <class name="io.ballerina.semantic.api.test.allreferences.AnnotationRefsTest" />


### PR DESCRIPTION
## Purpose
This PR fixes an issue in `BIRPackageSymbolEnter` in reading intersection type symbols, where the created type symbol's owner was set incorrectly.

Fixes #32610 
Fixes #32085 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
