### PR TITLE
Give detailed errors when converting to record type

### DIFF
--- a/ballerina-shell/modules/shell-core/src/test/resources/testcases/evaluator/operations.conv.json
+++ b/ballerina-shell/modules/shell-core/src/test/resources/testcases/evaluator/operations.conv.json
@@ -40,7 +40,7 @@
   {
     "description": "Convert anydata to person with error",
     "code": "convertAnydataMapToPerson(n);",
-    "stdout": "Error occurred on conversion: {\"message\":\"'map<anydata>' value cannot be converted to 'Person'\"}\n"
+    "stdout": "Error occurred on conversion: {\"message\":\"'map<anydata>' value cannot be converted to 'Person': \n\t\tmissing required field 'age' of type 'int' in record 'Person'\"}\n"
   },
   {
     "description": "Attempt to convert strings to numeric types",

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/constants/RuntimeConstants.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/constants/RuntimeConstants.java
@@ -117,8 +117,6 @@ public class RuntimeConstants {
     public static final String DEFAULT_LOG_FILE_HANDLER_PATTERN =
             "org.ballerinalang.logging.handlers.DefaultLogFileHandler.pattern";
 
-    public static final byte MAX_CONVERSION_ERROR_COUNT = 20;
-
 
     // Ballerina version system property name
     public static final String BALLERINA_VERSION = "ballerina.version";

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/constants/RuntimeConstants.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/constants/RuntimeConstants.java
@@ -117,6 +117,8 @@ public class RuntimeConstants {
     public static final String DEFAULT_LOG_FILE_HANDLER_PATTERN =
             "org.ballerinalang.logging.handlers.DefaultLogFileHandler.pattern";
 
+    public static final byte MAX_CONVERSION_ERROR_COUNT = 20;
+
 
     // Ballerina version system property name
     public static final String BALLERINA_VERSION = "ballerina.version";

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/ErrorUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/ErrorUtils.java
@@ -31,6 +31,8 @@ import io.ballerina.runtime.internal.values.MapValueImpl;
 import io.ballerina.runtime.internal.values.MappingInitialValueEntry;
 
 import static io.ballerina.runtime.api.creators.ErrorCreator.createError;
+import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.VALUE_LANG_LIB_CONVERSION_ERROR;
+import static io.ballerina.runtime.internal.util.exceptions.RuntimeErrors.INCOMPATIBLE_CONVERT_OPERATION;
 
 /**
  * This class contains internal methods used by codegen and runtime classes to handle errors.
@@ -142,5 +144,17 @@ public class ErrorUtils {
     public static BError createUnorderedTypesError(Object lhsValue, Object rhsValue) {
         throw createError(BallerinaErrorReasons.UNORDERED_TYPES_ERROR, BLangExceptionHelper.getErrorMessage(
                 RuntimeErrors.UNORDERED_TYPES_IN_COMPARISON, lhsValue, rhsValue));
+    }
+
+    public static BError createConversionError(Object inputValue, Type targetType) {
+        return createError(VALUE_LANG_LIB_CONVERSION_ERROR,
+                BLangExceptionHelper.getErrorMessage(INCOMPATIBLE_CONVERT_OPERATION,
+                        TypeChecker.getType(inputValue), targetType));
+    }
+
+    public static BError createConversionError(Object inputValue, Type targetType, String detailMessage) {
+        return createError(VALUE_LANG_LIB_CONVERSION_ERROR, BLangExceptionHelper.getErrorMessage(
+                INCOMPATIBLE_CONVERT_OPERATION, TypeChecker.getType(inputValue), targetType)
+                .concat(StringUtils.fromString(": ".concat(detailMessage))));
     }
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/ErrorUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/ErrorUtils.java
@@ -155,6 +155,6 @@ public class ErrorUtils {
     public static BError createConversionError(Object inputValue, Type targetType, String detailMessage) {
         return createError(VALUE_LANG_LIB_CONVERSION_ERROR, BLangExceptionHelper.getErrorMessage(
                 INCOMPATIBLE_CONVERT_OPERATION, TypeChecker.getType(inputValue), targetType)
-                .concat(StringUtils.fromString(": ".concat(detailMessage))));
+                .concat(StringUtils.fromString(": " + detailMessage)));
     }
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeConverter.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeConverter.java
@@ -431,8 +431,6 @@ public class TypeConverter {
                 } else if (!targetType.sealed) {
                     if (getConvertibleTypesFromJson(valueEntry.getValue(), restFieldType, fieldNameLong,
                             unresolvedValues, errors).size() != 1) {
-                        errors.add("value of field '" + valueEntry.getKey() + "' adding to the record '" +
-                                targetType + "' should be of type '" + restFieldType + "'");
                         returnVal = false;
                     }
                 } else {
@@ -449,8 +447,6 @@ public class TypeConverter {
                 } else if (!targetType.sealed) {
                     if (getConvertibleTypes(valueEntry.getValue(), restFieldType, fieldNameLong, false,
                             unresolvedValues, errors).size() != 1) {
-                        errors.add("value of field '" + valueEntry.getKey() + "' adding to the record '" +
-                                targetType + "' should be of type '" + restFieldType + "'");
                         returnVal = false;
                     }
                 } else {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/util/exceptions/BallerinaErrorReasons.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/util/exceptions/BallerinaErrorReasons.java
@@ -25,7 +25,6 @@ import static io.ballerina.runtime.api.constants.RuntimeConstants.FUTURE_LANG_LI
 import static io.ballerina.runtime.api.constants.RuntimeConstants.MAP_LANG_LIB;
 import static io.ballerina.runtime.api.constants.RuntimeConstants.STRING_LANG_LIB;
 import static io.ballerina.runtime.api.constants.RuntimeConstants.TABLE_LANG_LIB;
-import static io.ballerina.runtime.api.constants.RuntimeConstants.TYPEDESC_LANG_LIB;
 import static io.ballerina.runtime.api.constants.RuntimeConstants.VALUE_LANG_LIB;
 import static io.ballerina.runtime.api.constants.RuntimeConstants.XML_LANG_LIB;
 
@@ -82,12 +81,8 @@ public class BallerinaErrorReasons {
     public static final BString STACK_OVERFLOW_ERROR =
             StringUtils.fromString(BALLERINA_PREFIX.concat("StackOverflow"));
 
-    public static final BString CONSTRUCT_FROM_CONVERSION_ERROR = getModulePrefixedReason(TYPEDESC_LANG_LIB,
-                                                                                          "ConversionError");
     public static final BString VALUE_LANG_LIB_CONVERSION_ERROR = getModulePrefixedReason(VALUE_LANG_LIB,
                                                                                           "ConversionError");
-    public static final BString CONSTRUCT_FROM_CYCLIC_VALUE_REFERENCE_ERROR =
-            getModulePrefixedReason(TYPEDESC_LANG_LIB, "CyclicValueReferenceError");
     public static final BString VALUE_LANG_LIB_CYCLIC_VALUE_REFERENCE_ERROR =
             getModulePrefixedReason(VALUE_LANG_LIB, "CyclicValueReferenceError");
     public static final BString MERGE_JSON_ERROR = getModulePrefixedReason(VALUE_LANG_LIB, "MergeJsonError");

--- a/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/CloneUtils.java
+++ b/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/CloneUtils.java
@@ -18,11 +18,17 @@
 
 package org.ballerinalang.langlib.value;
 
+import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.utils.StringUtils;
+import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.api.values.BRefValue;
 import io.ballerina.runtime.api.values.BString;
+import io.ballerina.runtime.internal.ErrorUtils;
 
 import java.util.HashMap;
+import java.util.List;
+
+import static io.ballerina.runtime.api.constants.RuntimeConstants.MAX_CONVERSION_ERROR_COUNT;
 
 /**
  * This class contains the functions related to cloning Ballerina values.
@@ -71,5 +77,21 @@ public class CloneUtils {
 
         BRefValue refValue = (BRefValue) value;
         return refValue.frozenCopy(new HashMap<>());
+    }
+
+    public static BError createConversionError(Object value, Type targetType, List<String> errors) {
+        if (errors.isEmpty()) {
+            return ErrorUtils.createConversionError(value, targetType);
+        } else {
+            if (errors.size() == MAX_CONVERSION_ERROR_COUNT + 1) {
+                errors.remove(MAX_CONVERSION_ERROR_COUNT);
+                errors.add("...");
+            }
+            StringBuilder errorMsg = new StringBuilder();
+            for (String error : errors) {
+                errorMsg.append("\n\t\t").append(error);
+            }
+            return ErrorUtils.createConversionError(value, targetType, errorMsg.toString());
+        }
     }
 }

--- a/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/CloneUtils.java
+++ b/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/CloneUtils.java
@@ -28,7 +28,7 @@ import io.ballerina.runtime.internal.ErrorUtils;
 import java.util.HashMap;
 import java.util.List;
 
-import static io.ballerina.runtime.api.constants.RuntimeConstants.MAX_CONVERSION_ERROR_COUNT;
+import static io.ballerina.runtime.internal.TypeConverter.MAX_CONVERSION_ERROR_COUNT;
 
 /**
  * This class contains the functions related to cloning Ballerina values.

--- a/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/CloneUtils.java
+++ b/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/CloneUtils.java
@@ -80,10 +80,4 @@ public class CloneUtils {
         BRefValue refValue = (BRefValue) value;
         return refValue.frozenCopy(new HashMap<>());
     }
-
-    public static BError createConversionError(Object inputValue, Type targetType) {
-        return createError(BALLERINA_PREFIXED_CONVERSION_ERROR,
-                           BLangExceptionHelper.getErrorMessage(INCOMPATIBLE_CONVERT_OPERATION,
-                                                                TypeChecker.getType(inputValue), targetType));
-    }
 }

--- a/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/CloneUtils.java
+++ b/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/CloneUtils.java
@@ -18,19 +18,11 @@
 
 package org.ballerinalang.langlib.value;
 
-import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.utils.StringUtils;
-import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.api.values.BRefValue;
 import io.ballerina.runtime.api.values.BString;
-import io.ballerina.runtime.internal.TypeChecker;
-import io.ballerina.runtime.internal.util.exceptions.BLangExceptionHelper;
 
 import java.util.HashMap;
-
-import static io.ballerina.runtime.api.creators.ErrorCreator.createError;
-import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.BALLERINA_PREFIXED_CONVERSION_ERROR;
-import static io.ballerina.runtime.internal.util.exceptions.RuntimeErrors.INCOMPATIBLE_CONVERT_OPERATION;
 
 /**
  * This class contains the functions related to cloning Ballerina values.

--- a/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/CloneWithType.java
+++ b/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/CloneWithType.java
@@ -112,7 +112,7 @@ public class CloneWithType {
 
         List<String> errors = new ArrayList<>();
         Set<Type> convertibleTypes;
-        convertibleTypes = TypeConverter.getConvertibleTypes(value, targetType, null, null, false, errors);
+        convertibleTypes = TypeConverter.getConvertibleTypes(value, targetType, null, false, errors);
 
         Type sourceType = TypeChecker.getType(value);
         if (convertibleTypes.isEmpty()) {

--- a/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/CloneWithType.java
+++ b/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/CloneWithType.java
@@ -109,7 +109,8 @@ public class CloneWithType {
                     BLangExceptionHelper.getErrorMessage(RuntimeErrors.CANNOT_CONVERT_NIL, targetType));
         }
         Set<Type> convertibleTypes;
-        convertibleTypes = TypeConverter.getConvertibleTypes(value, targetType, false, new ArrayList<>());
+        convertibleTypes = TypeConverter.getConvertibleTypes(value, targetType, null, false,
+                new ArrayList<>());
 
         Type sourceType = TypeChecker.getType(value);
         if (convertibleTypes.isEmpty()) {

--- a/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/CloneWithType.java
+++ b/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/CloneWithType.java
@@ -56,8 +56,9 @@ import java.util.Map;
 import java.util.Set;
 
 import static io.ballerina.runtime.api.creators.ErrorCreator.createError;
-import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.CONSTRUCT_FROM_CONVERSION_ERROR;
-import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.CONSTRUCT_FROM_CYCLIC_VALUE_REFERENCE_ERROR;
+import static io.ballerina.runtime.internal.ErrorUtils.createConversionError;
+import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.VALUE_LANG_LIB_CONVERSION_ERROR;
+import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.VALUE_LANG_LIB_CYCLIC_VALUE_REFERENCE_ERROR;
 import static io.ballerina.runtime.internal.util.exceptions.RuntimeErrors.INCOMPATIBLE_CONVERT_OPERATION;
 
 /**
@@ -89,7 +90,7 @@ public class CloneWithType {
         } catch (BError e) {
             return e;
         } catch (BallerinaException e) {
-            return createError(CONSTRUCT_FROM_CONVERSION_ERROR, StringUtils.fromString(e.getDetail()));
+            return createError(VALUE_LANG_LIB_CONVERSION_ERROR, StringUtils.fromString(e.getDetail()));
         }
     }
 
@@ -105,16 +106,30 @@ public class CloneWithType {
             if (targetType.isNilable()) {
                 return null;
             }
-            return createError(CONSTRUCT_FROM_CONVERSION_ERROR,
+            return createError(VALUE_LANG_LIB_CONVERSION_ERROR,
                     BLangExceptionHelper.getErrorMessage(RuntimeErrors.CANNOT_CONVERT_NIL, targetType));
         }
+
+        List<String> errors = new ArrayList<>();
         Set<Type> convertibleTypes;
-        convertibleTypes = TypeConverter.getConvertibleTypes(value, targetType, null, false,
-                new ArrayList<>());
+        convertibleTypes = TypeConverter.getConvertibleTypes(value, targetType, null, false, errors);
 
         Type sourceType = TypeChecker.getType(value);
         if (convertibleTypes.isEmpty()) {
-            throw createConversionError(value, targetType);
+            if (errors.isEmpty()) {
+                throw createConversionError(value, targetType);
+            } else {
+                StringBuilder errorMsg = new StringBuilder();
+                byte errorCount = 0;
+                for (String error : errors) {
+                    errorMsg.append("\n\t\t").append(error);
+                    errorCount++;
+                    if (errorCount == 100) {
+                        break;
+                    }
+                }
+                throw createConversionError(value, targetType, errorMsg.toString());
+            }
         } else if (!allowAmbiguity && convertibleTypes.size() > 1 && !convertibleTypes.contains(sourceType) &&
                 !TypeConverter.hasIntegerSubTypes(convertibleTypes)) {
             throw createAmbiguousConversionError(value, targetType);
@@ -144,7 +159,7 @@ public class CloneWithType {
         TypeValuePair typeValuePair = new TypeValuePair(value, targetType);
 
         if (unresolvedValues.contains(typeValuePair)) {
-            throw new BallerinaException(CONSTRUCT_FROM_CYCLIC_VALUE_REFERENCE_ERROR.getValue(),
+            throw new BallerinaException(VALUE_LANG_LIB_CYCLIC_VALUE_REFERENCE_ERROR.getValue(),
                                          BLangExceptionHelper
                                                  .getErrorMessage(RuntimeErrors.CYCLIC_VALUE_REFERENCE, value.getType())
                                                  .getValue());
@@ -175,7 +190,7 @@ public class CloneWithType {
                 break;
             default:
                 // should never reach here
-                throw CloneUtils.createConversionError(value, targetType);
+                throw createConversionError(value, targetType);
         }
 
         unresolvedValues.remove(typeValuePair);
@@ -219,7 +234,7 @@ public class CloneWithType {
                 break;
         }
         // should never reach here
-        throw CloneUtils.createConversionError(map, targetType);
+        throw createConversionError(map, targetType);
     }
 
     private static BMap<BString, Object> convertToRecord(BMap<?, ?> map, List<TypeValuePair> unresolvedValues,
@@ -291,7 +306,7 @@ public class CloneWithType {
                 break;
         }
         // should never reach here
-        throw CloneUtils.createConversionError(array, targetType);
+        throw createConversionError(array, targetType);
     }
 
     private static Object convertTable(BTable<?, ?> bTable, Type targetType,
@@ -314,17 +329,10 @@ public class CloneWithType {
         return ValueCreator.createTableValue(tableType, data, fieldNames);
     }
 
-    private static BError createConversionError(Object inputValue, Type targetType) {
-        return createError(CONSTRUCT_FROM_CONVERSION_ERROR,
-                           BLangExceptionHelper.getErrorMessage(INCOMPATIBLE_CONVERT_OPERATION,
-                        TypeChecker.getType(inputValue), targetType));
-    }
-
     private static BError createAmbiguousConversionError(Object inputValue, Type targetType) {
-        return createError(CONSTRUCT_FROM_CONVERSION_ERROR,
+        return createError(VALUE_LANG_LIB_CONVERSION_ERROR,
                            BLangExceptionHelper.getErrorMessage(INCOMPATIBLE_CONVERT_OPERATION,
                                                                 TypeChecker.getType(inputValue), targetType)
                                    .concat(StringUtils.fromString(": ".concat(CloneWithType.AMBIGUOUS_TARGET))));
     }
-
 }

--- a/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/CloneWithType.java
+++ b/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/CloneWithType.java
@@ -116,20 +116,7 @@ public class CloneWithType {
 
         Type sourceType = TypeChecker.getType(value);
         if (convertibleTypes.isEmpty()) {
-            if (errors.isEmpty()) {
-                throw createConversionError(value, targetType);
-            } else {
-                StringBuilder errorMsg = new StringBuilder();
-                byte errorCount = 0;
-                for (String error : errors) {
-                    errorMsg.append("\n\t\t").append(error);
-                    errorCount++;
-                    if (errorCount == 100) {
-                        break;
-                    }
-                }
-                throw createConversionError(value, targetType, errorMsg.toString());
-            }
+            throw CloneUtils.createConversionError(value, targetType, errors);
         } else if (!allowAmbiguity && convertibleTypes.size() > 1 && !convertibleTypes.contains(sourceType) &&
                 !TypeConverter.hasIntegerSubTypes(convertibleTypes)) {
             throw createAmbiguousConversionError(value, targetType);

--- a/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/CloneWithType.java
+++ b/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/CloneWithType.java
@@ -109,7 +109,7 @@ public class CloneWithType {
                     BLangExceptionHelper.getErrorMessage(RuntimeErrors.CANNOT_CONVERT_NIL, targetType));
         }
         Set<Type> convertibleTypes;
-        convertibleTypes = TypeConverter.getConvertibleTypes(value, targetType);
+        convertibleTypes = TypeConverter.getConvertibleTypes(value, targetType, false, new ArrayList<>());
 
         Type sourceType = TypeChecker.getType(value);
         if (convertibleTypes.isEmpty()) {

--- a/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/CloneWithType.java
+++ b/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/CloneWithType.java
@@ -112,7 +112,7 @@ public class CloneWithType {
 
         List<String> errors = new ArrayList<>();
         Set<Type> convertibleTypes;
-        convertibleTypes = TypeConverter.getConvertibleTypes(value, targetType, null, false, errors);
+        convertibleTypes = TypeConverter.getConvertibleTypes(value, targetType, null, null, false, errors);
 
         Type sourceType = TypeChecker.getType(value);
         if (convertibleTypes.isEmpty()) {

--- a/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/FromJsonWithType.java
+++ b/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/FromJsonWithType.java
@@ -99,7 +99,7 @@ public class FromJsonWithType {
 
         List<String> errors = new ArrayList<>();
         List<Type> convertibleTypes = TypeConverter.getConvertibleTypesFromJson(value, targetType,
-                null, null, new ArrayList<>(), errors);
+                null, new ArrayList<>(), errors);
         if (convertibleTypes.isEmpty()) {
             throw CloneUtils.createConversionError(value, targetType, errors);
         } else if (convertibleTypes.size() > 1) {

--- a/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/FromJsonWithType.java
+++ b/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/FromJsonWithType.java
@@ -101,20 +101,7 @@ public class FromJsonWithType {
         List<Type> convertibleTypes = TypeConverter.getConvertibleTypesFromJson(value, targetType,
                 null, new ArrayList<>(), errors);
         if (convertibleTypes.isEmpty()) {
-            if (errors.isEmpty()) {
-                throw createConversionError(value, targetType);
-            } else {
-                StringBuilder errorMsg = new StringBuilder();
-                byte errorCount = 0;
-                for (String error : errors) {
-                    errorMsg.append("\n\t\t").append(error);
-                    errorCount++;
-                    if (errorCount == 100) {
-                        break;
-                    }
-                }
-                throw createConversionError(value, targetType, errorMsg.toString());
-            }
+            throw CloneUtils.createConversionError(value, targetType, errors);
         } else if (convertibleTypes.size() > 1) {
             throw createConversionError(value, targetType, AMBIGUOUS_TARGET);
         }

--- a/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/FromJsonWithType.java
+++ b/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/FromJsonWithType.java
@@ -98,15 +98,20 @@ public class FromJsonWithType {
         unresolvedValues.add(typeValuePair);
 
         List<String> errors = new ArrayList<>();
-        List<Type> convertibleTypes = TypeConverter.getConvertibleTypesFromJson(value, targetType, new ArrayList<>(),
-                errors);
+        List<Type> convertibleTypes = TypeConverter.getConvertibleTypesFromJson(value, targetType,
+                null, new ArrayList<>(), errors);
         if (convertibleTypes.isEmpty()) {
             if (errors.isEmpty()) {
                 throw createConversionError(value, targetType);
             } else {
                 StringBuilder errorMsg = new StringBuilder();
+                byte errorCount = 0;
                 for (String error : errors) {
                     errorMsg.append("\n\t\t").append(error);
+                    errorCount++;
+                    if (errorCount == 100) {
+                        break;
+                    }
                 }
                 throw createConversionError(value, targetType, errorMsg.toString());
             }

--- a/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/FromJsonWithType.java
+++ b/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/FromJsonWithType.java
@@ -52,9 +52,9 @@ import java.util.List;
 import java.util.Map;
 
 import static io.ballerina.runtime.api.creators.ErrorCreator.createError;
+import static io.ballerina.runtime.internal.ErrorUtils.createConversionError;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.VALUE_LANG_LIB_CONVERSION_ERROR;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.VALUE_LANG_LIB_CYCLIC_VALUE_REFERENCE_ERROR;
-import static io.ballerina.runtime.internal.util.exceptions.RuntimeErrors.INCOMPATIBLE_CONVERT_OPERATION;
 
 /**
  * Extern function lang.values:fromJsonWithType.
@@ -152,7 +152,7 @@ public class FromJsonWithType {
                     break;
                 }
                 // should never reach here
-                throw CloneUtils.createConversionError(value, targetType);
+                throw createConversionError(value, targetType);
         }
 
         unresolvedValues.remove(typeValuePair);
@@ -194,7 +194,7 @@ public class FromJsonWithType {
                 return convertMap(map, ((IntersectionType) targetType).getEffectiveType(), unresolvedValues, t);
         }
         // should never reach here
-        throw CloneUtils.createConversionError(map, targetType);
+        throw createConversionError(map, targetType);
     }
 
     private static BMap<BString, Object> convertToRecord(BMap<?, ?> map, List<TypeValuePair> unresolvedValues,
@@ -283,18 +283,6 @@ public class FromJsonWithType {
                                     unresolvedValues, t);
         }
         // should never reach here
-        throw CloneUtils.createConversionError(array, targetType);
-    }
-
-    private static BError createConversionError(Object inputValue, Type targetType) {
-        return createError(VALUE_LANG_LIB_CONVERSION_ERROR,
-                           BLangExceptionHelper.getErrorMessage(INCOMPATIBLE_CONVERT_OPERATION,
-                                                                TypeChecker.getType(inputValue), targetType));
-    }
-
-    private static BError createConversionError(Object inputValue, Type targetType, String detailMessage) {
-        return createError(VALUE_LANG_LIB_CONVERSION_ERROR, BLangExceptionHelper.getErrorMessage(
-                INCOMPATIBLE_CONVERT_OPERATION, TypeChecker.getType(inputValue), targetType)
-                .concat(StringUtils.fromString(": ".concat(detailMessage))));
+        throw createConversionError(array, targetType);
     }
 }

--- a/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/FromJsonWithType.java
+++ b/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/FromJsonWithType.java
@@ -97,9 +97,19 @@ public class FromJsonWithType {
 
         unresolvedValues.add(typeValuePair);
 
-        List<Type> convertibleTypes = TypeConverter.getConvertibleTypesFromJson(value, targetType, new ArrayList<>());
+        List<String> errors = new ArrayList<>();
+        List<Type> convertibleTypes = TypeConverter.getConvertibleTypesFromJson(value, targetType, new ArrayList<>(),
+                errors);
         if (convertibleTypes.isEmpty()) {
-            throw createConversionError(value, targetType);
+            if (errors.isEmpty()) {
+                throw createConversionError(value, targetType);
+            } else {
+                StringBuilder errorMsg = new StringBuilder();
+                for (String error : errors) {
+                    errorMsg.append("\n\t\t").append(error);
+                }
+                throw createConversionError(value, targetType, errorMsg.toString());
+            }
         } else if (convertibleTypes.size() > 1) {
             throw createConversionError(value, targetType, AMBIGUOUS_TARGET);
         }

--- a/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/FromJsonWithType.java
+++ b/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/FromJsonWithType.java
@@ -99,7 +99,7 @@ public class FromJsonWithType {
 
         List<String> errors = new ArrayList<>();
         List<Type> convertibleTypes = TypeConverter.getConvertibleTypesFromJson(value, targetType,
-                null, new ArrayList<>(), errors);
+                null, null, new ArrayList<>(), errors);
         if (convertibleTypes.isEmpty()) {
             throw CloneUtils.createConversionError(value, targetType, errors);
         } else if (convertibleTypes.size() > 1) {

--- a/langlib/langlib-test/src/test/resources/test-src/valuelib_fromJson_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/valuelib_fromJson_test.bal
@@ -414,7 +414,8 @@ public function testConvertJsonToAmbiguousType() {
     Value|error res = j.cloneWithType(Value);
 
     if res is error {
-        assertEquality("'map<json>' value cannot be converted to 'Value'", res.detail()["message"]);
+        assertEquality("'map<json>' value cannot be converted to 'Value': " +
+        "\n\t\tfield 'value' in record 'Value' should be of type 'Maps'", res.detail()["message"]);
         return;
     }
 

--- a/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
@@ -531,7 +531,7 @@ function testCloneWithTypeTupleToJSON() {
     jsonValue = tupleValue2.cloneWithType();
     assert(jsonValue is error, true);
     error err = <error> jsonValue;
-    assert(err.message(), "{ballerina/lang.typedesc}ConversionError");
+    assert(err.message(), "{ballerina/lang.value}ConversionError");
     assert(<string> checkpanic err.detail()["message"], "'[string,string,xml<(lang.xml:Element|lang.xml:Comment|" +
          "lang.xml:ProcessingInstruction|lang.xml:Text)>]' value cannot be converted to 'json'");
 
@@ -554,7 +554,7 @@ function testCloneWithTypeTupleToJSON() {
     jsonValue = tupleValue6.cloneWithType();
     assert(jsonValue is error, true);
     err = <error> jsonValue;
-    assert(err.message(), "{ballerina/lang.typedesc}ConversionError");
+    assert(err.message(), "{ballerina/lang.value}ConversionError");
     assert(<string> checkpanic err.detail()["message"], "'[string,(int|xml<(lang.xml:Element|lang.xml:Comment|" +
          "lang.xml:ProcessingInstruction|lang.xml:Text)>)...]' value cannot be converted to 'json'");
 
@@ -562,14 +562,14 @@ function testCloneWithTypeTupleToJSON() {
     jsonValue = tupleValue7.cloneWithType();
     assert(jsonValue is error, true);
     err = <error> jsonValue;
-    assert(err.message(), "{ballerina/lang.typedesc}ConversionError");
+    assert(err.message(), "{ballerina/lang.value}ConversionError");
     assert(<string> checkpanic err.detail()["message"], "'[string,anydata...]' value cannot be converted to 'json'");
 
     [string, xml|int] tupleValue8 = ["text1", xml `</elem>`];
     jsonValue = tupleValue8.cloneWithType();
     assert(jsonValue is error, true);
     err = <error> jsonValue;
-    assert(err.message(), "{ballerina/lang.typedesc}ConversionError");
+    assert(err.message(), "{ballerina/lang.value}ConversionError");
     assert(<string> checkpanic err.detail()["message"], "'[string,(xml<(lang.xml:Element|lang.xml:Comment|" +
          "lang.xml:ProcessingInstruction|lang.xml:Text)>|int)]' value cannot be converted to 'json'");
 
@@ -582,7 +582,7 @@ function testCloneWithTypeTupleToJSON() {
     jsonValue = tupleValue10.cloneWithType();
     assert(jsonValue is error, true);
     err = <error> jsonValue;
-    assert(err.message(), "{ballerina/lang.typedesc}ConversionError");
+    assert(err.message(), "{ballerina/lang.value}ConversionError");
     assert(<string> checkpanic err.detail()["message"], "'[int,(string|xml<(lang.xml:Element|lang.xml:Comment|" +
         "lang.xml:ProcessingInstruction|lang.xml:Text)>),A...]' value cannot be converted to 'json'");
 }
@@ -623,8 +623,9 @@ public function testCloneWithTypeOptionalFieldToMandotoryField() {
     error bbe = <error> b;
     var message = bbe.detail()["message"];
     string messageString = message is error? message.toString(): message.toString();
-    assert(bbe.message(), "{ballerina/lang.typedesc}ConversionError");
-    assert(messageString, "'CRec' value cannot be converted to 'BRec'");
+    assert(bbe.message(), "{ballerina/lang.value}ConversionError");
+    assert(messageString, "'CRec' value cannot be converted to 'BRec': " +
+    "\n\t\tmissing required field 'i' of type 'int' in record 'BRec'");
 }
 
 type Foo record {
@@ -650,7 +651,7 @@ function testCloneWithTypeAmbiguousTargetType() {
     error bbe = <error> bb;
     var message = bbe.detail()["message"];
     string messageString = message is error? message.toString(): message.toString();
-    assert(bbe.message(), "{ballerina/lang.typedesc}ConversionError");
+    assert(bbe.message(), "{ballerina/lang.value}ConversionError");
     assert(messageString, "'Foo' value cannot be converted to '(Bar|Baz)': ambiguous target type");
 }
 
@@ -837,7 +838,7 @@ function testCloneWithTypeDecimalToIntNegative() {
     error err = <error>result;
     var message = err.detail()["message"];
     string messageString = message is error ? message.toString() : message.toString();
-    assert(err.message(), "{ballerina/lang.typedesc}ConversionError");
+    assert(err.message(), "{ballerina/lang.value}ConversionError");
     assert(messageString, "'decimal' value cannot be converted to 'int'");
 
     decimal[] a1 = [9223372036854775807.5, -9223372036854775807.6];
@@ -846,7 +847,7 @@ function testCloneWithTypeDecimalToIntNegative() {
     err = <error>a2e;
     message = err.detail()["message"];
     messageString = message is error ? message.toString() : message.toString();
-    assert(err.message(), "{ballerina/lang.typedesc}ConversionError");
+    assert(err.message(), "{ballerina/lang.value}ConversionError");
     assert(messageString, "'decimal' value cannot be converted to 'int'");
 
     decimal a2 = 0.0 / 0;
@@ -864,7 +865,7 @@ function checkDecimalToIntError(any|error result) {
     error err = <error>result;
     var message = err.detail()["message"];
     string messageString = message is error ? message.toString() : message.toString();
-    assert(err.message(), "{ballerina/lang.typedesc}ConversionError");
+    assert(err.message(), "{ballerina/lang.value}ConversionError");
     assert(messageString, "'decimal' value cannot be converted to 'int'");
 }
 
@@ -898,7 +899,7 @@ function testCloneWithTypeIntArrayToUnionArray() {
     error err = <error> e;
     var message = err.detail()["message"];
     string messageString = message is error ? message.toString() : message.toString();
-    assert(err.message(), "{ballerina/lang.typedesc}ConversionError");
+    assert(err.message(), "{ballerina/lang.value}ConversionError");
     assert(messageString, "'int[]' value cannot be converted to '(byte|float)[]'");
 
     float[] y = [10, 20];
@@ -932,7 +933,7 @@ function testCloneWithTypeIntArrayToUnionArray() {
     err = <error> m;
     message = err.detail()["message"];
     messageString = message is error ? message.toString() : message.toString();
-    assert(err.message(), "{ballerina/lang.typedesc}ConversionError");
+    assert(err.message(), "{ballerina/lang.value}ConversionError");
     assert(messageString, "'float[]' value cannot be converted to '(lang.int:Signed16|lang.int:Unsigned8|decimal)[]'");
 }
 
@@ -955,7 +956,7 @@ function testCloneWithTypeArrayToUnionTupleNegative() {
     error err = <error> c;
     var message = err.detail()["message"];
     string messageString = message is error ? message.toString() : message.toString();
-    assert(err.message(), "{ballerina/lang.typedesc}ConversionError");
+    assert(err.message(), "{ballerina/lang.value}ConversionError");
     assert(messageString, "'int[]' value cannot be converted to '[(int|decimal),(byte|lang.int:Unsigned8)]'");
 }
 
@@ -966,7 +967,7 @@ function testCloneWithTypeArrayToTupleWithMoreTargetTypes() {
     error err = <error> d;
     var message = err.detail()["message"];
     string messageString = message is error ? message.toString() : message.toString();
-    assert(err.message(), "{ballerina/lang.typedesc}ConversionError");
+    assert(err.message(), "{ballerina/lang.value}ConversionError");
     assert(messageString, "'int[]' value cannot be converted to '[int,float,decimal,byte]'");
 }
 
@@ -977,7 +978,7 @@ function testCloneWithTypeArrayToTupleWithUnionRestTypeNegative() {
     error err = <error> e;
     var message = err.detail()["message"];
     string messageString = message is error ? message.toString() : message.toString();
-    assert(err.message(), "{ballerina/lang.typedesc}ConversionError");
+    assert(err.message(), "{ballerina/lang.value}ConversionError");
     assert(messageString, "'int[]' value cannot be converted to '[(float|decimal),(int|byte)...]'");
 }
 
@@ -988,7 +989,7 @@ function testCloneWithTypeArrayToTupleNegative() {
     error err = <error> f;
     var message = err.detail()["message"];
     string messageString = message is error ? message.toString() : message.toString();
-    assert(err.message(), "{ballerina/lang.typedesc}ConversionError");
+    assert(err.message(), "{ballerina/lang.value}ConversionError");
     assert(messageString, "'float[]' value cannot be converted to '[string,lang.string:Char,(string|lang.string:Char)]'");
 }
 
@@ -999,7 +1000,7 @@ function testCloneWithTypeArrayToTupleWithStructureRestTypeNegative() {
     error err = <error> g;
     var message = err.detail()["message"];
     string messageString = message is error ? message.toString() : message.toString();
-    assert(err.message(), "{ballerina/lang.typedesc}ConversionError");
+    assert(err.message(), "{ballerina/lang.value}ConversionError");
     assert(messageString, "'int[]' value cannot be converted to '[map<int>,[string,int]...]'");
 }
 
@@ -1025,7 +1026,7 @@ function testCloneWithTypeTupleRestTypeNegative() {
     error err = <error> c;
     var message = err.detail()["message"];
     string messageString = message is error ? message.toString() : message.toString();
-    assert(err.message(), "{ballerina/lang.typedesc}ConversionError");
+    assert(err.message(), "{ballerina/lang.value}ConversionError");
     assert(messageString, "'[int,float,(int|float)...]' value cannot be converted to '[string...]'");
 }
 
@@ -1037,7 +1038,7 @@ function testCloneWithTypeUnionTupleRestTypeNegative() {
     error err = <error> d;
     var message = err.detail()["message"];
     string messageString = message is error ? message.toString() : message.toString();
-    assert(err.message(), "{ballerina/lang.typedesc}ConversionError");
+    assert(err.message(), "{ballerina/lang.value}ConversionError");
     assert(messageString, "'[int,float,(int|float)...]' value cannot be converted to '[(int|float),(decimal|int)...]'");
 }
 
@@ -1075,8 +1076,9 @@ function testCloneWithTypeWithInferredArgument() {
    error err = <error>h;
    var message = err.detail()["message"];
    string messageString = message is error ? message.toString() : message.toString();
-   assert(err.message(), "{ballerina/lang.typedesc}ConversionError");
-   assert(messageString, "'CRec' value cannot be converted to 'BRec'");
+   assert(err.message(), "{ballerina/lang.value}ConversionError");
+   assert(messageString, "'CRec' value cannot be converted to 'BRec': " +
+   "\n\t\tmissing required field 'i' of type 'int' in record 'BRec'");
 
    Foo i = {s: "test string"};
    Bar|Baz|error j = i.cloneWithType();
@@ -1085,7 +1087,7 @@ function testCloneWithTypeWithInferredArgument() {
    err = <error>j;
    message = err.detail()["message"];
    messageString = message is error ? message.toString() : message.toString();
-   assert(err.message(), "{ballerina/lang.typedesc}ConversionError");
+   assert(err.message(), "{ballerina/lang.value}ConversionError");
    assert(messageString, "'Foo' value cannot be converted to '(Bar|Baz)': ambiguous target type");
 
    anydata k = ();

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/conversion/NativeConversionNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/conversion/NativeConversionNegativeTest.java
@@ -55,7 +55,12 @@ public class NativeConversionNegativeTest {
         // check the error
         Assert.assertTrue(returns[0] instanceof BError);
         String errorMsg = ((BMap<String, BValue>) ((BError) returns[0]).getDetails()).get("message").stringValue();
-        Assert.assertEquals(errorMsg, "'map<json>' value cannot be converted to 'Person'");
+        Assert.assertEquals(errorMsg, "'map<json>' value cannot be converted to 'Person': " +
+                "\n\t\tvariable 'parent.parent' should be of type '()'" +
+                "\n\t\tvariable 'parent.address' should be of type '()'" +
+                "\n\t\tvariable 'parent' should be of type '()'" +
+                "\n\t\tvariable 'address' should be of type '()'" +
+                "\n\t\tvariable 'marks' should be of type '()'");
     }
 
     @Test
@@ -63,7 +68,8 @@ public class NativeConversionNegativeTest {
         BValue[] returns = BRunUtil.invoke(negativeResult, "testEmptyJSONtoStructWithoutDefaults");
         Assert.assertTrue(returns[0] instanceof BError);
         String errorMsg = ((BMap<String, BValue>) ((BError) returns[0]).getDetails()).get("message").stringValue();
-        Assert.assertEquals(errorMsg, "'map<json>' value cannot be converted to 'StructWithoutDefaults'");
+        Assert.assertEquals(errorMsg, "'map<json>' value cannot be converted to 'StructWithoutDefaults': " +
+                "\n\t\tmissing required field 'a' of type 'int' in record 'StructWithoutDefaults'");
     }
 
     @Test
@@ -71,7 +77,8 @@ public class NativeConversionNegativeTest {
         BValue[] returns = BRunUtil.invoke(negativeResult, "testEmptyMaptoStructWithoutDefaults");
         Assert.assertTrue(returns[0] instanceof BError);
         String errorMsg = ((BMap<String, BValue>) ((BError) returns[0]).getDetails()).get("message").stringValue();
-        Assert.assertEquals(errorMsg, "'map<anydata>' value cannot be converted to 'StructWithoutDefaults'");
+        Assert.assertEquals(errorMsg, "'map<anydata>' value cannot be converted to 'StructWithoutDefaults': " +
+                "\n\t\tmissing required field 'a' of type 'int' in record 'StructWithoutDefaults'");
     }
 
     @Test(description = "Test converting an unsupported array to json")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/conversion/NativeConversionNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/conversion/NativeConversionNegativeTest.java
@@ -28,6 +28,7 @@ import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 /**
@@ -56,11 +57,7 @@ public class NativeConversionNegativeTest {
         Assert.assertTrue(returns[0] instanceof BError);
         String errorMsg = ((BMap<String, BValue>) ((BError) returns[0]).getDetails()).get("message").stringValue();
         Assert.assertEquals(errorMsg, "'map<json>' value cannot be converted to 'Person': " +
-                "\n\t\tvariable 'parent.parent' should be of type '()'" +
-                "\n\t\tvariable 'parent.address' should be of type '()'" +
-                "\n\t\tvariable 'parent' should be of type '()'" +
-                "\n\t\tvariable 'address' should be of type '()'" +
-                "\n\t\tvariable 'marks' should be of type '()'");
+                "\n\t\tfield 'parent.parent' in record 'Person' should be of type 'Person?'");
     }
 
     @Test
@@ -140,5 +137,17 @@ public class NativeConversionNegativeTest {
         Assert.assertEquals(((BMap<String, BString>) ((BError) results[0]).getDetails()).get("message").stringValue(),
                             "'Manager' value has cyclic reference");
     }
-}
 
+    @Test(dataProvider = "testConversionFunctionList")
+    public void testConversionNegative(String funcName) {
+        BRunUtil.invoke(negativeResult, funcName);
+    }
+
+    @DataProvider(name = "testConversionFunctionList")
+    public Object[] testConversionFunctions() {
+        return new Object[] {
+                "testConvertJsonToNestedRecordsWithErrors",
+                "testConvertFromJsonWithCyclicValueReferences"
+        };
+    }
+}

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/JSONStampInbuiltFunctionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/JSONStampInbuiltFunctionTest.java
@@ -268,7 +268,8 @@ public class JSONStampInbuiltFunctionTest {
 
         Assert.assertEquals(error.getType().getClass(), BErrorType.class);
         Assert.assertEquals(((BMap<String, BString>) ((BError) results[0]).getDetails()).get("message").stringValue(),
-                            "'map<json>' value cannot be converted to 'Student'");
+                            "'map<json>' value cannot be converted to 'Student': " +
+                "\n\t\tfield 'age' cannot be added to the closed record 'Student'");
     }
 
     @Test

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/MapStampInbuiltFunctionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/MapStampInbuiltFunctionTest.java
@@ -532,34 +532,8 @@ public class MapStampInbuiltFunctionTest {
 
         Assert.assertEquals(error.getType().getClass(), BErrorType.class);
         Assert.assertEquals(((BMap<String, BString>) ((BError) results[0]).getDetails()).get("message").stringValue(),
-                            "'map<string>' value cannot be converted to 'EmployeeClosedRecord'");
-    }
-
-    @Test(description = "Test stamping to record when value has cyclic reference.")
-    public void testStampRecordToRecordWithCyclicValueReferences() {
-        BValue[] results = BRunUtil.invoke(compileResult, "testStampRecordToRecordWithCyclicValueReferences");
-        BValue error = results[0];
-        Assert.assertEquals(error.getType().getClass(), BErrorType.class);
-        Assert.assertEquals(((BMap<String, BString>) ((BError) results[0]).getDetails()).get("message").stringValue(),
-                            "'Person' value has cyclic reference");
-    }
-
-    @Test(description = "Test stamping to map when value has cyclic reference.")
-    public void testStampRecordToMapWithCyclicValueReferences() {
-        BValue[] results = BRunUtil.invoke(compileResult, "testStampRecordToMapWithCyclicValueReferences");
-        BValue error = results[0];
-        Assert.assertEquals(error.getType().getClass(), BErrorType.class);
-        Assert.assertEquals(((BMap<String, BString>) ((BError) results[0]).getDetails()).get("message").stringValue(),
-                            "'Person' value has cyclic reference");
-    }
-
-    @Test(description = "Test stamping to json when value has cyclic reference.")
-    public void testStampRecordToJsonWithCyclicValueReferences() {
-        BValue[] results = BRunUtil.invoke(compileResult, "testStampRecordToJsonWithCyclicValueReferences");
-        BValue error = results[0];
-        Assert.assertEquals(error.getType().getClass(), BErrorType.class);
-        Assert.assertEquals(((BMap<String, BString>) ((BError) results[0]).getDetails()).get("message").stringValue(),
-                            "'Person' value has cyclic reference");
+                            "'map<string>' value cannot be converted to 'EmployeeClosedRecord': " +
+                "\n\t\tfield 'school' cannot be added to the closed record 'EmployeeClosedRecord'");
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/RecordStampInbuiltFunctionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/RecordStampInbuiltFunctionTest.java
@@ -566,7 +566,8 @@ public class RecordStampInbuiltFunctionTest {
 
         Assert.assertEquals(error.getType().getClass(), BErrorType.class);
         Assert.assertEquals(((BMap<String, BString>) ((BError) results[0]).getDetails()).get("message").stringValue(),
-                            "'Teacher' value cannot be converted to 'NonAcademicStaff'");
+                            "'Teacher' value cannot be converted to 'NonAcademicStaff': " +
+                "\n\t\tvariable 'postalCode' should be of type 'string'");
     }
 
     @Test
@@ -576,7 +577,9 @@ public class RecordStampInbuiltFunctionTest {
 
         Assert.assertEquals(error.getType().getClass(), BErrorType.class);
         Assert.assertEquals(((BMap<String, BString>) ((BError) results[0]).getDetails()).get("message").stringValue(),
-                            "'Employee' value cannot be converted to 'Teacher'");
+                            "'Employee' value cannot be converted to 'Teacher': " +
+                "\n\t\tmissing required field 'school' of type 'string' in record 'Teacher'" +
+                "\n\t\tmissing required field 'age' of type 'int' in record 'Teacher'");
     }
 
     @Test
@@ -586,7 +589,8 @@ public class RecordStampInbuiltFunctionTest {
 
         Assert.assertEquals(error.getType().getClass(), BErrorType.class);
         Assert.assertEquals(((BMap<String, BString>) ((BError) results[0]).getDetails()).get("message").stringValue(),
-                            "'Employee' value cannot be converted to 'Teacher'");
+                            "'Employee' value cannot be converted to 'Teacher': " +
+                "\n\t\tvariable 'school' should be of type 'string'");
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/RecordStampInbuiltFunctionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/RecordStampInbuiltFunctionTest.java
@@ -567,7 +567,7 @@ public class RecordStampInbuiltFunctionTest {
         Assert.assertEquals(error.getType().getClass(), BErrorType.class);
         Assert.assertEquals(((BMap<String, BString>) ((BError) results[0]).getDetails()).get("message").stringValue(),
                             "'Teacher' value cannot be converted to 'NonAcademicStaff': " +
-                "\n\t\tvariable 'postalCode' should be of type 'string'");
+                "\n\t\tvalue of field 'postalCode' adding to the record 'NonAcademicStaff' should be of type 'string'");
     }
 
     @Test
@@ -590,7 +590,7 @@ public class RecordStampInbuiltFunctionTest {
         Assert.assertEquals(error.getType().getClass(), BErrorType.class);
         Assert.assertEquals(((BMap<String, BString>) ((BError) results[0]).getDetails()).get("message").stringValue(),
                             "'Employee' value cannot be converted to 'Teacher': " +
-                "\n\t\tvariable 'school' should be of type 'string'");
+                "\n\t\tfield 'school' in record 'Teacher' should be of type 'string'");
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/StampInbuiltFunctionNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/StampInbuiltFunctionNegativeTest.java
@@ -158,7 +158,8 @@ public class StampInbuiltFunctionNegativeTest {
         BValue error = results[0];
         Assert.assertEquals(error.getType().getClass(), BErrorType.class);
         Assert.assertEquals(((BMap<String, BString>) ((BError) results[0]).getDetails()).get("message").stringValue(),
-                            "'Teacher' value cannot be converted to 'Employee'");
+                            "'Teacher' value cannot be converted to 'Employee': " +
+                                    "\n\t\tmissing required field 'salary' of type 'float' in record 'Employee'");
     }
 
     @Test
@@ -167,7 +168,8 @@ public class StampInbuiltFunctionNegativeTest {
         BValue error = results[0];
         Assert.assertEquals(error.getType().getClass(), BErrorType.class);
         Assert.assertEquals(((BMap<String, BString>) ((BError) results[0]).getDetails()).get("message").stringValue(),
-                            "'Person' value cannot be converted to 'Student'");
+                            "'Person' value cannot be converted to 'Student': " +
+                                    "\n\t\tfield 'school' cannot be added to the closed record 'Student'");
     }
 
     @Test

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExprTest.java
@@ -462,7 +462,8 @@ public class TypeCastExprTest {
         Assert.assertTrue(returns[0] instanceof BError);
         BError error = (BError) returns[0];
         String errorMsg = ((BMap<String, BString>) error.getDetails()).get("message").stringValue();
-        Assert.assertEquals(errorMsg, "'B' value cannot be converted to 'A'");
+        Assert.assertEquals(errorMsg, "'B' value cannot be converted to 'A': " +
+                "\n\t\tmissing required field 'y' of type 'int' in record 'A'");
     }
 
     @Test (description = "Test any to int casting happens without errors, error struct should be null")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/json/BJSONValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/json/BJSONValueTest.java
@@ -486,7 +486,7 @@ public class BJSONValueTest {
     }
 
     @Test(expectedExceptions = { BLangRuntimeException.class },
-            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.typedesc\\}ConversionError " +
+            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.value\\}ConversionError " +
                     "\\{\"message\":\"cannot convert '\\(\\)' to type 'map<json>'.*")
     public void testNullJsonToMap() {
         BRunUtil.invoke(compileResult, "testNullJsonToMap");

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/map/ConstrainedMapTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/map/ConstrainedMapTest.java
@@ -434,7 +434,7 @@ public class ConstrainedMapTest {
         Assert.assertTrue(returns[0] instanceof BError);
         String errorMsg = ((BMap<String, BString>) ((BError) returns[0]).getDetails()).get("message").stringValue();
         Assert.assertEquals(errorMsg, "'map<json>' value cannot be converted to 'PersonComplexTwo': " +
-                "\n\t\tvariable 'parent' should be of type '()'");
+                "\n\t\tfield 'address' in record 'PersonComplexTwo' should be of type 'map<int>'");
     }
 
     @Test(description = "Test constrained map with union retrieving string value.")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/map/ConstrainedMapTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/map/ConstrainedMapTest.java
@@ -433,7 +433,8 @@ public class ConstrainedMapTest {
                 "testJsonToStructConversionStructWithConstrainedMapNegative");
         Assert.assertTrue(returns[0] instanceof BError);
         String errorMsg = ((BMap<String, BString>) ((BError) returns[0]).getDetails()).get("message").stringValue();
-        Assert.assertEquals(errorMsg, "'map<json>' value cannot be converted to 'PersonComplexTwo'");
+        Assert.assertEquals(errorMsg, "'map<json>' value cannot be converted to 'PersonComplexTwo': " +
+                "\n\t\tvariable 'parent' should be of type '()'");
     }
 
     @Test(description = "Test constrained map with union retrieving string value.")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/var/VarDeclaredAssignmentStmtTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/var/VarDeclaredAssignmentStmtTest.java
@@ -207,7 +207,15 @@ public class VarDeclaredAssignmentStmtTest {
         Assert.assertSame(returns[0].getClass(), BError.class);
 
         Assert.assertEquals(((BMap<String, BValue>) ((BError) returns[0]).getDetails()).get("message").stringValue(),
-                            "'map<json>' value cannot be converted to 'Person'");
+                            "'map<json>' value cannot be converted to 'Person': " +
+                                    "\n\t\tmissing required field 'a' of type 'anydata' in record 'Person'" +
+                                    "\n\t\tmissing required field 'score' of type 'float' in record 'Person'" +
+                                    "\n\t\tmissing required field 'alive' of type 'boolean' in record 'Person'" +
+                                    "\n\t\tmissing required field 'parent.a' of type 'anydata' in record 'Person'" +
+                                    "\n\t\tmissing required field 'parent.score' of type 'float' in record 'Person'" +
+                                    "\n\t\tmissing required field 'parent.alive' of type 'boolean' in record 'Person'" +
+                                    "\n\t\tvariable 'parent.parent' should be of type '()'" +
+                                    "\n\t\tvariable 'parent' should be of type '()'");
     }
 
     @Test(description = "Test incompatible json to struct with errors.")
@@ -219,7 +227,8 @@ public class VarDeclaredAssignmentStmtTest {
         Assert.assertSame(returns[0].getClass(), BError.class);
 
         Assert.assertEquals(((BMap<String, BValue>) ((BError) returns[0]).getDetails()).get("message").stringValue(),
-                            "'map<json>' value cannot be converted to 'PersonA'");
+                            "'map<json>' value cannot be converted to 'PersonA': " +
+                "\n\t\tvariable 'age' should be of type 'int'");
     }
 
     @Test(description = "Test compatible struct with force casting.")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/var/VarDeclaredAssignmentStmtTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/var/VarDeclaredAssignmentStmtTest.java
@@ -214,8 +214,8 @@ public class VarDeclaredAssignmentStmtTest {
                                     "\n\t\tmissing required field 'parent.a' of type 'anydata' in record 'Person'" +
                                     "\n\t\tmissing required field 'parent.score' of type 'float' in record 'Person'" +
                                     "\n\t\tmissing required field 'parent.alive' of type 'boolean' in record 'Person'" +
-                                    "\n\t\tvariable 'parent.parent' should be of type '()'" +
-                                    "\n\t\tvariable 'parent' should be of type '()'");
+                                    "\n\t\tfield 'parent.parent' in record 'Person' should be of type 'Person?'" +
+                                    "\n\t\tfield 'parent.marks' in record 'Person' should be of type 'int[]'");
     }
 
     @Test(description = "Test incompatible json to struct with errors.")
@@ -228,7 +228,7 @@ public class VarDeclaredAssignmentStmtTest {
 
         Assert.assertEquals(((BMap<String, BValue>) ((BError) returns[0]).getDetails()).get("message").stringValue(),
                             "'map<json>' value cannot be converted to 'PersonA': " +
-                "\n\t\tvariable 'age' should be of type 'int'");
+                "\n\t\tfield 'age' in record 'PersonA' should be of type 'int'");
     }
 
     @Test(description = "Test compatible struct with force casting.")

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/conversion/native-conversion-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/conversion/native-conversion-negative.bal
@@ -146,16 +146,8 @@ function testConvertRecordToMapWithCyclicValueReferences() returns map<anydata>|
     Manager p = { name: "Waruna", age: 25, parent: () };
     Manager p2 = { name: "Milinda", age: 25, parent:p };
     p.parent = p2;
-    anydata a = p;
-    basicMatch(a);
     map<anydata> m =  check trap p.cloneWithType(AnydataMap); // Cyclic value will be check when stamping the value.
     return m;
-}
-
-function basicMatch(any a) {
-    // match a {
-    //         var {var1, var2, var3} => {io:println("Matched");}
-    // }
 }
 
 type AnydataMap map<anydata>;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/conversion/native-conversion-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/conversion/native-conversion-negative.bal
@@ -13,7 +13,8 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-// import ballerina/io;
+
+import ballerina/test;
 
 type Person record {|
     string name = "";
@@ -150,5 +151,117 @@ function testConvertRecordToMapWithCyclicValueReferences() returns map<anydata>|
     return m;
 }
 
+function testConvertFromJsonWithCyclicValueReferences() {
+    json p = { name: "Waruna", age: 25, parent: () };
+    json p2 = { name: "Milinda", age: 25, parent: p };
+    map<json> p3 = <map<json>> p2;
+    p3["parent"] = p2;
+    json p4 = p3;
+    Engineer|error p5 = trap p4.fromJsonWithType(Engineer);
+    error err = <error> p5;
+    test:assertEquals(<string> checkpanic err.detail()["message"], "'map<json>' value has cyclic reference");
+    test:assertEquals(err.message(),"{ballerina/lang.value}ConversionError");
+}
+
 type AnydataMap map<anydata>;
 type T1_T2 [T1, T2];
+
+type Boss record {
+    Person3 man;
+    string department;
+};
+
+type Factory record {|
+    Person3 man1;
+    Person3 man2;
+    Boss man3;
+    float grade;
+    boolean permanant = false;
+    Student1 intern;
+    boolean...;
+|};
+
+type Person3 record {|
+    string name;
+    int age;
+|};
+
+type Apple record {
+    string color;
+};
+
+type Orange record {|
+    string colour;
+|};
+
+type Mango record {
+    string taste;
+    int amount;
+};
+
+type Student1 record {|
+    string name;
+    Apple|Orange|Mango fruit;
+|};
+
+function testConvertJsonToNestedRecordsWithErrors() {
+    json j = {
+        "man1": {
+            "fname": "Jane",
+            "age": "14"
+        },
+        "man2": {
+            "name": 2,
+            "aage": 14,
+            "height":67.5
+        },
+        "man3": {
+            "man": {
+                "namee": "Jane",
+                "age": "14",
+                "height":67.5
+            },
+            "department": 4
+        },
+        "intern": {
+            "name": 12,
+            "fruit": {
+                "color": 4,
+                "amount": "five"
+            }
+        },
+        "black": "color",
+        "blue": 4,
+        "white": true,
+        "yellow": "color",
+        "green": 4
+    };
+
+    Factory|error val = trap j.cloneWithType(Factory);
+
+    error err = <error> val;
+    string errorMsg = "'map<json>' value cannot be converted to 'Factory': " +
+        "\n\t\tmissing required field 'grade' of type 'float' in record 'Factory'" +
+        "\n\t\tmissing required field 'man1.name' of type 'string' in record 'Person3'" +
+        "\n\t\tfield 'man1.fname' cannot be added to the closed record 'Person3'" +
+        "\n\t\tfield 'man1.age' in record 'Person3' should be of type 'int'" +
+        "\n\t\tmissing required field 'man2.age' of type 'int' in record 'Person3'" +
+        "\n\t\tfield 'man2.name' in record 'Person3' should be of type 'string'" +
+        "\n\t\tfield 'man2.aage' cannot be added to the closed record 'Person3'" +
+        "\n\t\tfield 'man2.height' cannot be added to the closed record 'Person3'" +
+        "\n\t\tmissing required field 'man3.man.name' of type 'string' in record 'Person3'" +
+        "\n\t\tfield 'man3.man.namee' cannot be added to the closed record 'Person3'" +
+        "\n\t\tfield 'man3.man.age' in record 'Person3' should be of type 'int'" +
+        "\n\t\tfield 'man3.man.height' cannot be added to the closed record 'Person3'" +
+        "\n\t\tfield 'man3.department' in record 'Boss' should be of type 'string'" +
+        "\n\t\tfield 'intern.name' in record 'Student1' should be of type 'string'" +
+        "\n\t\tfield 'intern.fruit.color' in record 'Apple' should be of type 'string'" +
+        "\n\t\tmissing required field 'intern.fruit.colour' of type 'string' in record 'Orange'" +
+        "\n\t\tfield 'intern.fruit.color' cannot be added to the closed record 'Orange'" +
+        "\n\t\tfield 'intern.fruit.amount' cannot be added to the closed record 'Orange'" +
+        "\n\t\tmissing required field 'intern.fruit.taste' of type 'string' in record 'Mango'" +
+        "\n\t\tfield 'intern.fruit.amount' in record 'Mango' should be of type 'int'" +
+        "\n\t\t...";
+    test:assertEquals(<string> checkpanic err.detail()["message"], errorMsg);
+    test:assertEquals(err.message(),"{ballerina/lang.value}ConversionError");
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/stamp/map-stamp-expr-test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/stamp/map-stamp-expr-test.bal
@@ -33,18 +33,6 @@ type IntRecord record{
     int b;
 };
 
-type Person record {
-    string name = "";
-    int age = 0;
-    Person? parent = ();
-};
-
-type Engineer record {
-    string name = "";
-    int age = 0;
-    Engineer? parent = ();
-};
-
 type AnydataMap map<anydata>;
 type StringMap map<string>;
 type IntMap map<int>;
@@ -273,28 +261,4 @@ function stampMapToRecordNegative() returns EmployeeClosedRecord|error {
     EmployeeClosedRecord|error employee = m.cloneWithType(EmployeeClosedRecord);
 
     return employee;
-}
-
-function testStampRecordToRecordWithCyclicValueReferences() returns Engineer|error {
-    Person p = { name: "Waruna", age: 25, parent: () };
-    Person p2 = { name: "Milinda", age: 25, parent:p };
-    p.parent = p2;
-    Engineer|error e =  trap p.cloneWithType(Engineer); // Cyclic value will be check with isLikeType method.
-    return e;
-}
-
-function testStampRecordToJsonWithCyclicValueReferences() returns json|error {
-    Person p = { name: "Waruna", age: 25, parent: () };
-    Person p2 = { name: "Milinda", age: 25, parent:p };
-    p.parent = p2;
-    json|error j =  trap p.cloneWithType(json); // Cyclic value will be check with isLikeType method.
-    return j;
-}
-
-function testStampRecordToMapWithCyclicValueReferences() returns map<anydata>|error {
-    Person p = { name: "Waruna", age: 25, parent: () };
-    Person p2 = { name: "Milinda", age: 25, parent:p };
-    p.parent = p2;
-    map<anydata>|error m =  trap p.clone().cloneWithType(AnydataMap); // Cyclic value will be check when stamping the value.
-    return m;
 }


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues.
$title

Fixes #31815

## Approach
> Describe how you are implementing the solutions along with the design details.

1. Moved createError functions to `ErrorUtils` class and mentioned `lang.value` in the conversion errors
2. Removed duplicate tests which were same as `testConvertRecordToRecordWithCyclicValueReferences`, `testConvertRecordToMapWithCyclicValueReferences`, `testConvertRecordToJsonWithCyclicValueReferences`
3. Gave detailed errors (20 maximum) when converting to record type using `fromJsonWithType` and `cloneWithType` for the cases
  - missing required fields
  - wrong variable type
  - adding additional fields to closed records


## Samples
> Provide high-level details about the samples related to this feature.

In a Ballerina package named 'packageName', the 'main.bal' is as follows.
```bal
import packageName.newModuleName;

type Boss record {
    newModuleName:Person man;
    string department;
};

type Factory record {
    newModuleName:Person man1;
    newModuleName:Person man2;
    Boss man3;
    float grade;
    boolean permanant = false;
};

public function main() {
    json j = {
    "man1": {
        "fname": "Jane",
        "age": "14"
    },
    "man2": {
        "name": 2,
        "aage": 14
    },
    "man3": {
        "man": {
            "namee": "Jane",
            "age": "14"
        },
        "department": 4
    }
    };
    Factory f1 = checkpanic j.fromJsonWithType();
}
```
Another module named 'newModuleName.bal' is in the same package with content as follows.
```bal
public type Person record {
    string name;
    int age;
};
```
This will give the below output.
```
Running executable

error: {ballerina/lang.value}ConversionError {"message":"'map<json>' value cannot be converted to 'packageName:Factory': 
                missing required field 'grade' of type 'float' in record 'packageName:Factory'
                missing required field 'man1.name' of type 'string' in record 'packageName.newModuleName:Person'
                field 'man1.age' in record 'packageName.newModuleName:Person' should be of type 'int'
                missing required field 'man2.age' of type 'int' in record 'packageName.newModuleName:Person'
                field 'man2.name' in record 'packageName.newModuleName:Person' should be of type 'string'
                missing required field 'man3.man.name' of type 'string' in record 'packageName.newModuleName:Person'
                field 'man3.man.age' in record 'packageName.newModuleName:Person' should be of type 'int'
                field 'man3.department' in record 'packageName:Boss' should be of type 'string'"}
        at ballerina.lang.value.0:fromJsonWithType(value.bal:251)
           nadeeshand.packageName.0:main(main.bal:34)
```
## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

For union types the output is given as follows giving a union of possible errors.

In a single Ballerina file the content is as follows.
```bal
type Employee record {
    string name;
};

type Apple record {
    string color;
};

type Orange record {|
    string colour;
|};

type Mango record {
    string taste;
    int amount;
};

type Student record {|
    string name;
    Apple|Orange|Mango fruit;
|};

type Person record {|
    boolean name;
    int outcome;
|};

public function main() {
    json j = {
    "name": 12,
    "fruit": {
        "color": 4,
        "amount": "five"
    }
};
    Employee|Student|Person p1 = checkpanic j.cloneWithType();
}
```
This will give the following output.
```
Running executable

error: {ballerina/lang.value}ConversionError {"message":"'map<json>' value cannot be converted to '(Employee|Student|Person)': 
                field 'name' in record 'Employee' should be of type 'string'
                field 'name' in record 'Student' should be of type 'string'
                field 'fruit.color' in record 'Apple' should be of type 'string'
                missing required field 'fruit.colour' of type 'string' in record 'Orange'
                field 'fruit.color' cannot be added to the closed record 'Orange'
                field 'fruit.amount' cannot be added to the closed record 'Orange'
                missing required field 'fruit.taste' of type 'string' in record 'Mango'
                field 'fruit.amount' in record 'Mango' should be of type 'int'
                missing required field 'outcome' of type 'int' in record 'Person'
                field 'name' in record 'Person' should be of type 'boolean'
                field 'fruit' cannot be added to the closed record 'Person'"}
        at ballerina.lang.value.0:cloneWithType(value.bal:86)
           nestedunion2:main(nestedunion2.bal:36)
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
