### PR TITLE
Avoid birgen and interop validation for test sources when --skip-tests is true

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ModuleContext.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ModuleContext.java
@@ -370,7 +370,8 @@ class ModuleContext {
         pkgNode.moduleContextDataHolder = new ModuleContextDataHolder(
                 moduleContext.isExported(),
                 moduleContext.descriptor(),
-                moduleContext.project().kind());
+                moduleContext.project.kind(),
+                moduleContext.project.buildOptions().skipTests());
         packageCache.put(moduleCompilationId, pkgNode);
 
         // Parse source files

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ModuleContextDataHolder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ModuleContextDataHolder.java
@@ -30,11 +30,14 @@ public class ModuleContextDataHolder {
     private final boolean exported;
     private final ModuleDescriptor descriptor;
     private final ProjectKind projectKind;
+    private final boolean skipTests;
 
-    public ModuleContextDataHolder(boolean exported, ModuleDescriptor descriptor, ProjectKind projectKind) {
+    public ModuleContextDataHolder(boolean exported, ModuleDescriptor descriptor, ProjectKind projectKind,
+                                   boolean skipTests) {
         this.exported = exported;
         this.descriptor = descriptor;
         this.projectKind = projectKind;
+        this.skipTests = skipTests;
     }
 
     public boolean isExported() {
@@ -47,5 +50,9 @@ public class ModuleContextDataHolder {
 
     public ProjectKind projectKind() {
         return projectKind;
+    }
+
+    public boolean skipTests() {
+        return skipTests;
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -271,7 +271,7 @@ public class BIRGen extends BLangNodeVisitor {
         this.birOptimizer.optimizePackage(birPkg);
         astPkg.symbol.birPackageFile = new BIRPackageFile(new BIRBinaryWriter(birPkg).serialize());
 
-        if (astPkg.hasTestablePackage()) {
+        if (!astPkg.moduleContextDataHolder.skipTests() && astPkg.hasTestablePackage()) {
             BIRPackage testBirPkg = new BIRPackage(astPkg.pos, astPkg.packageID.orgName, astPkg.packageID.pkgName,
                     astPkg.packageID.name, astPkg.packageID.version, astPkg.packageID.sourceFileName);
             this.env = new BIRGenEnv(testBirPkg);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropValidator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropValidator.java
@@ -98,7 +98,7 @@ public class InteropValidator {
 
     private void validateTestPackages(ModuleId moduleId, CompilerBackend compilerBackend,
                                       BLangPackage bLangPackage) {
-        if (!bLangPackage.hasTestablePackage()) {
+        if (bLangPackage.moduleContextDataHolder.skipTests() || !bLangPackage.hasTestablePackage()) {
             return;
         }
         Set<Path> testDependencies = getPlatformDependencyPaths(moduleId, compilerBackend,


### PR DESCRIPTION
## Purpose
> Avoid birgen and interop validation for test sources when --skip-tests is true
> Fixes #32748

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
