### PR TITLE
Add min and max value validation support for toml schema strings

### DIFF
--- a/misc/toml-parser/src/main/java/io/ballerina/toml/validator/SchemaValidator.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/validator/SchemaValidator.java
@@ -173,6 +173,26 @@ public class SchemaValidator extends TomlNodeVisitor {
         return typeCustomMessage;
     }
 
+    private String getMaxLengthErrorMessage(int maxLength) {
+        Map<String, String> message = this.schema.message();
+        String typeCustomMessage = message.get(SchemaDeserializer.MAX_LENGTH);
+        if (typeCustomMessage == null) {
+            return String.format("length of the value for key '%s' is greater than defined max length %s", this.key,
+                    maxLength);
+        }
+        return typeCustomMessage;
+    }
+
+    private String getMinLengthErrorMessage(int maxLength) {
+        Map<String, String> message = this.schema.message();
+        String typeCustomMessage = message.get(SchemaDeserializer.MIN_LENGTH);
+        if (typeCustomMessage == null) {
+            return String.format("length of the value for key '%s' is lower than defined min length %s", this.key,
+                    maxLength);
+        }
+        return typeCustomMessage;
+    }
+
     @Override
     public void visit(TomlStringValueNode tomlStringValueNode) {
         if (schema.type() != Type.STRING) {
@@ -189,6 +209,24 @@ public class SchemaValidator extends TomlNodeVisitor {
             if (!Pattern.compile(pattern).matcher(tomlStringValueNode.getValue()).matches()) {
                 TomlDiagnostic diagnostic = getTomlDiagnostic(tomlStringValueNode.location(), "TVE0003",
                         "error.regex.mismatch", DiagnosticSeverity.ERROR, getPatternErrorMessage(pattern));
+                tomlStringValueNode.addDiagnostic(diagnostic);
+            }
+        }
+        if (stringSchema.maxLength().isPresent()) {
+            int maxLength = stringSchema.maxLength().get();
+            String value = tomlStringValueNode.getValue();
+            if (value.length() > maxLength) {
+                TomlDiagnostic diagnostic = getTomlDiagnostic(tomlStringValueNode.location(), "TVE0007",
+                        "error.maxlen.exceeded", DiagnosticSeverity.ERROR, getMaxLengthErrorMessage(maxLength));
+                tomlStringValueNode.addDiagnostic(diagnostic);
+            }
+        }
+        if (stringSchema.minLength().isPresent()) {
+            int minLength = stringSchema.minLength().get();
+            String value = tomlStringValueNode.getValue();
+            if (value.length() < minLength) {
+                TomlDiagnostic diagnostic = getTomlDiagnostic(tomlStringValueNode.location(), "TVE0008",
+                        "error.minlen.deceed", DiagnosticSeverity.ERROR, getMinLengthErrorMessage(minLength));
                 tomlStringValueNode.addDiagnostic(diagnostic);
             }
         }

--- a/misc/toml-parser/src/main/java/io/ballerina/toml/validator/schema/SchemaDeserializer.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/validator/schema/SchemaDeserializer.java
@@ -52,6 +52,8 @@ public class SchemaDeserializer implements JsonDeserializer<AbstractSchema> {
     public static final String REQUIRED = "required";
     public static final String ITEMS = "items";
     public static final String PATTERN = "pattern";
+    public static final String MIN_LENGTH = "minLength";
+    public static final String MAX_LENGTH = "maxLength";
     public static final String MINIMUM = "minimum";
     public static final String MAXIMUM = "maximum";
     public static final String MESSAGE = "message";
@@ -115,8 +117,10 @@ public class SchemaDeserializer implements JsonDeserializer<AbstractSchema> {
     private StringSchema getStringSchema(JsonObject jsonObj) {
         String pattern = parseOptionalStringFromJson(jsonObj, PATTERN);
         String defaultValue = parseOptionalStringFromJson(jsonObj, DEFAULT_VALUE);
+        Integer minLength = parseOptionalIntFromJson(jsonObj, MIN_LENGTH);
+        Integer maxLength = parseOptionalIntFromJson(jsonObj, MAX_LENGTH);
         Map<String, String> customMessages = parseOptionalMapFromMessageJson(jsonObj);
-        return new StringSchema(Type.STRING, customMessages, pattern, defaultValue);
+        return new StringSchema(Type.STRING, customMessages, pattern, defaultValue, minLength, maxLength);
     }
 
     private NumericSchema getNumericSchema(JsonObject jsonObj, Type type) {
@@ -180,6 +184,18 @@ public class SchemaDeserializer implements JsonDeserializer<AbstractSchema> {
         throw new JsonSchemaException(key + " should always be a string");
     }
 
+    private Integer parseOptionalIntFromJson(JsonObject jsonObject, String key) {
+        JsonElement jsonElement = jsonObject.get(key);
+        if (jsonElement == null || jsonElement.isJsonNull()) {
+            return null;
+        }
+
+        if (jsonElement.isJsonPrimitive() && jsonElement.getAsJsonPrimitive().isNumber()) {
+            return jsonElement.getAsInt();
+        }
+        throw new JsonSchemaException(key + " should always be a int");
+    }
+
     private Map<String, String> parseOptionalMapFromMessageJson(JsonObject jsonObject) {
         Map<String, String> customMessages = new LinkedHashMap<>();
         JsonObject customMessageJson = jsonObject.getAsJsonObject(SchemaDeserializer.MESSAGE);
@@ -193,7 +209,9 @@ public class SchemaDeserializer implements JsonDeserializer<AbstractSchema> {
         addFieldToCustomMessagesMap(customMessages, customMessageJson, ADDITIONAL_PROPERTIES);
         addFieldToCustomMessagesMap(customMessages, customMessageJson, MINIMUM);
         addFieldToCustomMessagesMap(customMessages, customMessageJson, MAXIMUM);
-
+        addFieldToCustomMessagesMap(customMessages, customMessageJson, MAX_LENGTH);
+        addFieldToCustomMessagesMap(customMessages, customMessageJson, MIN_LENGTH);
+        
         return customMessages;
     }
 

--- a/misc/toml-parser/src/main/java/io/ballerina/toml/validator/schema/StringSchema.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/validator/schema/StringSchema.java
@@ -28,14 +28,27 @@ import java.util.Optional;
  */
 public class StringSchema extends PrimitiveValueSchema<String> {
     private final String pattern;
+    private final Integer minLength;
+    private final Integer maxLength;
 
-    public StringSchema(Type type, Map<String, String> message, String pattern, String defaultValue) {
+    public StringSchema(Type type, Map<String, String> message, String pattern, String defaultValue, Integer minLength
+            , Integer maxLength) {
         super(type, message, defaultValue);
         this.pattern = pattern;
+        this.minLength = minLength;
+        this.maxLength = maxLength;
     }
 
     public Optional<String> pattern() {
         return Optional.ofNullable(pattern);
+    }
+
+    public Optional<Integer> minLength() {
+        return Optional.ofNullable(minLength);
+    }
+
+    public Optional<Integer> maxLength() {
+        return Optional.ofNullable(maxLength);
     }
 
     @Override

--- a/misc/toml-parser/src/test/java/toml/parser/test/validator/CustomErrorTest.java
+++ b/misc/toml-parser/src/test/java/toml/parser/test/validator/CustomErrorTest.java
@@ -56,7 +56,7 @@ public class CustomErrorTest {
         Toml toml = Toml.read(sampleInput, Schema.from(resourceDirectory));
 
         Diagnostic customDiagMessage = toml.diagnostics().get(0);
-        Assert.assertEquals(customDiagMessage.message(), "org cant be empty");
+        Assert.assertEquals(customDiagMessage.message(), "org can only contain a-z chars");
 
         Diagnostic defaultDiagMessage = toml.diagnostics().get(1);
         Assert.assertEquals(defaultDiagMessage.message(), "value for key 'version' expected to match the regex: ^" +
@@ -90,5 +90,19 @@ public class CustomErrorTest {
 
         Diagnostic customDiagMessageAddtionalProp = toml.diagnostics().get(1);
         Assert.assertEquals(customDiagMessageAddtionalProp.message(), "field 'additional' is not supported");
+    }
+
+    @Test
+    public void testMinMaxLengthMessage() throws IOException {
+        Path resourceDirectory = basePath.resolve("schema.json");
+        Path sampleInput = basePath.resolve("string-length.toml");
+
+        Toml toml = Toml.read(sampleInput, Schema.from(resourceDirectory));
+
+        Diagnostic maxLenDiag = toml.diagnostics().get(0);
+        Assert.assertEquals(maxLenDiag.message(), "Custom message for exceeding max length goes here");
+
+        Diagnostic minLenDiag = toml.diagnostics().get(1);
+        Assert.assertEquals(minLenDiag.message(), "Custom message for min length goes here");
     }
 }

--- a/misc/toml-parser/src/test/java/toml/parser/test/validator/TomlValidateTest.java
+++ b/misc/toml-parser/src/test/java/toml/parser/test/validator/TomlValidateTest.java
@@ -142,4 +142,20 @@ public class TomlValidateTest {
         Assert.assertEquals(diagnostic.message(), "missing required field 'name'");
         Assert.assertEquals(diagnostic1.message(), "key 'test' not supported in schema 'Dependencies Toml Spec'");
     }
+
+    @Test
+    public void testMinMaxLengthMessage() throws IOException {
+        Path resourceDirectory = basePath.resolve("schema.json");
+        Path sampleInput = basePath.resolve("string-length.toml");
+
+        Toml toml = Toml.read(sampleInput, Schema.from(resourceDirectory));
+
+        Diagnostic maxLenDiag = toml.diagnostics().get(0);
+        Assert.assertEquals(maxLenDiag.message(),
+                "length of the value for key 'name' is greater than defined max length 10");
+
+        Diagnostic minLenDiag = toml.diagnostics().get(1);
+        Assert.assertEquals(minLenDiag.message(),
+                "length of the value for key 'org' is lower than defined min length 3");
+    }
 }

--- a/misc/toml-parser/src/test/resources/validator/basic/schema.json
+++ b/misc/toml-parser/src/test/resources/validator/basic/schema.json
@@ -1,0 +1,30 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Ballerina Manifest Spec",
+    "description": "Schema for Ballerina Manifest",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "package": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "maxLength": 10,
+                    "message" : {
+                        "type" : "invalid type"
+                    }
+                },
+                "org": {
+                    "type": "string",
+                    "pattern": ".*?",
+                    "minLength": 3,
+                    "message" : {
+                        "pattern" : "org cant be empty"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/misc/toml-parser/src/test/resources/validator/basic/string-length.toml
+++ b/misc/toml-parser/src/test/resources/validator/basic/string-length.toml
@@ -1,0 +1,3 @@
+[package]
+name = "123456789012"
+org = "aa"

--- a/misc/toml-parser/src/test/resources/validator/custom-error/schema.json
+++ b/misc/toml-parser/src/test/resources/validator/custom-error/schema.json
@@ -11,15 +11,19 @@
             "properties": {
                 "name": {
                     "type": "string",
+                    "maxLength": 10,
                     "message" : {
-                        "type" : "invalid type"
+                        "type" : "invalid type",
+                        "maxLength": "Custom message for exceeding max length goes here"
                     }
                 },
                 "org": {
                     "type": "string",
-                    "pattern": "^(?!\\s*$).+",
+                    "pattern": "^[a-z]+$",
+                    "minLength": 3,
                     "message" : {
-                        "pattern" : "org cant be empty"
+                        "pattern" : "org can only contain a-z chars",
+                        "minLength": "Custom message for min length goes here"
                     }
                 },
                 "version": {

--- a/misc/toml-parser/src/test/resources/validator/custom-error/string-length.toml
+++ b/misc/toml-parser/src/test/resources/validator/custom-error/string-length.toml
@@ -1,7 +1,7 @@
 [package]
-name = "anjana"
-org = "1234"
-version = ""
+name = "123456789012"
+org = "a"
+version = "v1.0.0"
 port = 5000
 capacity = 4
 repository = "https://github.com/ballerinalang/ballerina"


### PR DESCRIPTION
## Purpose
Adds min and max length validation support for toml schema strings


```
"org": {
  "type": "string",
  "pattern": "^[a-zA-Z0-9_]*$",
  "minLength": 1,
  "maxLength": 256 
  "message": {
      "pattern" : "invalid 'org' under [package]: 'org' can only contain alphanumerics, underscores",
      "minLength": "invalid 'org' under [package]: 'org' cannot be empty",
      "maxLength": "invalid 'org' under [package]: maximum length is 256 characters"
  }
}
```



Fixes Task 1 of #32752

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
