### PR TITLE
Remove unnecessary forced clone of the expr in a type cast expr

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/NodeCloner.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/NodeCloner.java
@@ -1308,11 +1308,6 @@ public class NodeCloner extends BLangNodeVisitor {
 
         BLangTypeConversionExpr clone = new BLangTypeConversionExpr();
         source.cloneRef = clone;
-
-        // Forcefully clone the expression since it may clash with the clone of type cast expression type
-        // checking.
-        source.expr.cloneAttempt++;
-
         clone.expr = clone(source.expr);
         clone.typeNode = clone(source.typeNode);
         clone.targetType = source.targetType;


### PR DESCRIPTION
## Purpose
$title.

In https://github.com/ballerina-platform/ballerina-lang/pull/30655, [in the node cloner we had incremented the clone attempt](https://github.com/ballerina-platform/ballerina-lang/pull/30655/files#diff-d4a6b727edcc0963601932d1793e8a29b9cb2f3e79962cd6b3d2bf4532c1524fR1293) to force cloning the expression in a type cast expression, to help with compatibility checks with casts.

But this incrementing should have been done in the type checker as done in https://github.com/ballerina-platform/ballerina-lang/pull/30966/files#diff-f4fbb6e8ffab357b74e188781ad3f6e3235f8e48b64fba8dfb6ad72bf9ccaf93R4171.

While this does not seem to be an issue for normal compilation, this seems to have caused LS issues with subsequent compilations.

With the changes in #30966 we no longer need to forcefully clone in the node cloner even for the compiler. Thus, this PR removes the forced cloning.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/31676
Fixes https://github.com/ballerina-platform/ballerina-lang/issues/32650
Fixes https://github.com/ballerina-platform/ballerina-lang/issues/32323

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
