### PR TITLE
Add document symbols for all module-level nodes

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/documentsymbol/DocumentSymbolResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/documentsymbol/DocumentSymbolResolver.java
@@ -17,18 +17,34 @@
  */
 package org.ballerinalang.langserver.util.documentsymbol;
 
+import io.ballerina.compiler.syntax.tree.AnnotationDeclarationNode;
+import io.ballerina.compiler.syntax.tree.BindingPatternNode;
 import io.ballerina.compiler.syntax.tree.ClassDefinitionNode;
+import io.ballerina.compiler.syntax.tree.ConstantDeclarationNode;
+import io.ballerina.compiler.syntax.tree.EnumDeclarationNode;
+import io.ballerina.compiler.syntax.tree.EnumMemberNode;
 import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
 import io.ballerina.compiler.syntax.tree.IdentifierToken;
+import io.ballerina.compiler.syntax.tree.ListenerDeclarationNode;
 import io.ballerina.compiler.syntax.tree.MetadataNode;
+import io.ballerina.compiler.syntax.tree.MethodDeclarationNode;
 import io.ballerina.compiler.syntax.tree.ModuleMemberDeclarationNode;
 import io.ballerina.compiler.syntax.tree.ModulePartNode;
+import io.ballerina.compiler.syntax.tree.ModuleVariableDeclarationNode;
+import io.ballerina.compiler.syntax.tree.ModuleXMLNamespaceDeclarationNode;
 import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.compiler.syntax.tree.NodeList;
 import io.ballerina.compiler.syntax.tree.NodeTransformer;
+import io.ballerina.compiler.syntax.tree.ObjectFieldNode;
+import io.ballerina.compiler.syntax.tree.ObjectTypeDescriptorNode;
+import io.ballerina.compiler.syntax.tree.RecordFieldNode;
+import io.ballerina.compiler.syntax.tree.RecordFieldWithDefaultValueNode;
+import io.ballerina.compiler.syntax.tree.RecordRestDescriptorNode;
+import io.ballerina.compiler.syntax.tree.RecordTypeDescriptorNode;
 import io.ballerina.compiler.syntax.tree.ServiceDeclarationNode;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.compiler.syntax.tree.Token;
+import io.ballerina.compiler.syntax.tree.TypeDefinitionNode;
 import org.ballerinalang.langserver.commons.DocumentSymbolContext;
 import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.Range;
@@ -79,8 +95,8 @@ public class DocumentSymbolResolver extends NodeTransformer<Optional<DocumentSym
         if (context.getHierarchicalDocumentSymbolSupport()) {
             this.documentSymbolStore.addAll(memberSymbols);
         }
-        /*  since module part node is a collection of multiple documents. We don't create the 
-            document symbol node corresponding to the module part node here. 
+        /*  since module node is a collection of multiple documents. We don't create the 
+            document symbol node corresponding to the module node here. 
          */
         return Optional.empty();
     }
@@ -99,7 +115,11 @@ public class DocumentSymbolResolver extends NodeTransformer<Optional<DocumentSym
                 break;
             case OBJECT_METHOD_DEFINITION:
                 name = functionDefinitionNode.functionName().text();
-                symbolKind = SymbolKind.Method;
+                if ("init".equals(name)) {
+                    symbolKind = SymbolKind.Constructor;
+                } else {
+                    symbolKind = SymbolKind.Method;
+                }
                 break;
             case RESOURCE_ACCESSOR_DEFINITION:
                 String accessor = functionDefinitionNode.functionName().text();
@@ -137,6 +157,17 @@ public class DocumentSymbolResolver extends NodeTransformer<Optional<DocumentSym
     }
 
     @Override
+    public Optional<DocumentSymbol> transform(MethodDeclarationNode methodDeclarationNode) {
+        String name = methodDeclarationNode.methodName().text();
+        SymbolKind symbolKind = SymbolKind.Method;
+        Range range = DocumentSymbolUtil.generateNodeRange(methodDeclarationNode);
+        Optional<MetadataNode> metadata = methodDeclarationNode.metadata();
+        boolean isDeprecated = metadata.isPresent() && DocumentSymbolUtil.isDeprecated(metadata.get());
+        return Optional.ofNullable(createDocumentSymbol(name, symbolKind,
+                null, range, range, isDeprecated, Collections.emptyList(), this.context));
+    }
+
+    @Override
     public Optional<DocumentSymbol> transform(ClassDefinitionNode classDefinitionNode) {
         String name = classDefinitionNode.className().text();
         SymbolKind symbolKind = SymbolKind.Class;
@@ -151,18 +182,182 @@ public class DocumentSymbolResolver extends NodeTransformer<Optional<DocumentSym
 
     @Override
     public Optional<DocumentSymbol> transform(ServiceDeclarationNode serviceDeclarationNode) {
-        String name = "service " + serviceDeclarationNode.absoluteResourcePath().stream()
-                .map(Node::toSourceCode).collect(Collectors.joining(""))
-                + " on " + serviceDeclarationNode.expressions().stream()
-                .map(Node::toSourceCode).collect(Collectors.joining(""));
-        SymbolKind symbolKind = SymbolKind.Interface;
+        StringBuilder name = new StringBuilder("service");
+        name.append(" ").append(serviceDeclarationNode.absoluteResourcePath().stream()
+                .map(Node::toSourceCode).collect(Collectors.joining("")));
+        SymbolKind symbolKind = SymbolKind.Object;
         Range range = DocumentSymbolUtil.generateNodeRange(serviceDeclarationNode);
         Optional<MetadataNode> metadata = serviceDeclarationNode.metadata();
         boolean isDeprecated = metadata.isPresent() &&
                 DocumentSymbolUtil.isDeprecated(metadata.get());
         List<DocumentSymbol> children = transformMembers(serviceDeclarationNode.members());
+        return Optional.ofNullable(createDocumentSymbol(name.toString(), symbolKind, null,
+                range, range, isDeprecated, children, this.context));
+    }
+
+    @Override
+    public Optional<DocumentSymbol> transform(TypeDefinitionNode typeDefinitionNode) {
+        String name = typeDefinitionNode.typeName().text();
+        Node typeDescriptor = typeDefinitionNode.typeDescriptor();
+        SymbolKind symbolKind;
+        List<DocumentSymbol> children = new ArrayList<>();
+        switch (typeDescriptor.kind()) {
+            case RECORD_TYPE_DESC:
+                symbolKind = SymbolKind.Struct;
+                RecordTypeDescriptorNode recordTypeDescriptorNode = (RecordTypeDescriptorNode) typeDescriptor;
+                children.addAll(transformMembers(recordTypeDescriptorNode.fields()));
+                Optional<RecordRestDescriptorNode> restTypeDec = recordTypeDescriptorNode.recordRestDescriptor();
+                if (restTypeDec.isPresent()) {
+                    Optional<DocumentSymbol> restDocSymbol = restTypeDec.get().apply(this);
+                    restDocSymbol.ifPresent(children::add);
+                }
+                break;
+            case OBJECT_TYPE_DESC:
+                symbolKind = SymbolKind.Interface;
+                children.addAll(transformMembers(((ObjectTypeDescriptorNode) typeDescriptor).members()));
+                break;
+            default:
+                symbolKind = SymbolKind.TypeParameter;
+        }
+        Range range = DocumentSymbolUtil.generateNodeRange(typeDefinitionNode);
+        Optional<MetadataNode> metadata = typeDefinitionNode.metadata();
+        boolean isDeprecated = metadata.isPresent() &&
+                DocumentSymbolUtil.isDeprecated(metadata.get());
         return Optional.ofNullable(createDocumentSymbol(name, symbolKind, null,
                 range, range, isDeprecated, children, this.context));
+    }
+
+    @Override
+    public Optional<DocumentSymbol> transform(ModuleVariableDeclarationNode moduleVariableDeclarationNode) {
+        BindingPatternNode bindingPatternNode = moduleVariableDeclarationNode.typedBindingPattern().bindingPattern();
+        //Only capture binding pattern is considered. Wildcard and other binding patterns are ignored.
+        String name = bindingPatternNode.kind() == SyntaxKind.CAPTURE_BINDING_PATTERN ?
+                bindingPatternNode.toSourceCode() : "";
+        SymbolKind symbolKind = SymbolKind.Variable;
+        Range range = DocumentSymbolUtil.generateNodeRange(moduleVariableDeclarationNode);
+        Optional<MetadataNode> metadata = moduleVariableDeclarationNode.metadata();
+        boolean isDeprecated = metadata.isPresent() &&
+                DocumentSymbolUtil.isDeprecated(metadata.get());
+        return Optional.ofNullable(createDocumentSymbol(name, symbolKind, null,
+                range, range, isDeprecated, Collections.emptyList(), this.context));
+    }
+
+    @Override
+    public Optional<DocumentSymbol> transform(ConstantDeclarationNode constantDeclarationNode) {
+        String name = constantDeclarationNode.variableName().text();
+        SymbolKind symbolKind = SymbolKind.Constant;
+        Range range = DocumentSymbolUtil.generateNodeRange(constantDeclarationNode);
+        Optional<MetadataNode> metadata = constantDeclarationNode.metadata();
+        boolean isDeprecated = metadata.isPresent() &&
+                DocumentSymbolUtil.isDeprecated(metadata.get());
+        return Optional.ofNullable(createDocumentSymbol(name, symbolKind, null,
+                range, range, isDeprecated, Collections.emptyList(), this.context));
+    }
+
+    @Override
+    public Optional<DocumentSymbol> transform(EnumDeclarationNode enumDeclarationNode) {
+        String name = enumDeclarationNode.identifier().text();
+        SymbolKind symbolKind = SymbolKind.Enum;
+        Range range = DocumentSymbolUtil.generateNodeRange(enumDeclarationNode);
+        Optional<MetadataNode> metadata = enumDeclarationNode.metadata();
+        List<DocumentSymbol> children = transformMembers(enumDeclarationNode.enumMemberList());
+        boolean isDeprecated = metadata.isPresent() &&
+                DocumentSymbolUtil.isDeprecated(metadata.get());
+        return Optional.ofNullable(createDocumentSymbol(name, symbolKind, null,
+                range, range, isDeprecated, children, this.context));
+    }
+
+    @Override
+    public Optional<DocumentSymbol> transform(ModuleXMLNamespaceDeclarationNode moduleXMLNamespaceDeclarationNode) {
+        Optional<IdentifierToken> prefix = moduleXMLNamespaceDeclarationNode.namespacePrefix();
+        String name = prefix.isPresent() ? prefix.get().text() : SyntaxKind.XMLNS_KEYWORD.stringValue() + " "
+                + moduleXMLNamespaceDeclarationNode.namespaceuri().toSourceCode();
+        SymbolKind symbolKind = SymbolKind.Namespace;
+        Range range = DocumentSymbolUtil.generateNodeRange(moduleXMLNamespaceDeclarationNode);
+        return Optional.ofNullable(createDocumentSymbol(name, symbolKind, null,
+                range, range, false, Collections.emptyList(), this.context));
+    }
+
+    @Override
+    public Optional<DocumentSymbol> transform(ListenerDeclarationNode listenerDeclarationNode) {
+        String name = listenerDeclarationNode.variableName().text();
+        SymbolKind symbolKind = SymbolKind.Object;
+        Range range = DocumentSymbolUtil.generateNodeRange(listenerDeclarationNode);
+        Optional<MetadataNode> metadata = listenerDeclarationNode.metadata();
+        boolean isDeprecated = metadata.isPresent() &&
+                DocumentSymbolUtil.isDeprecated(metadata.get());
+        return Optional.ofNullable(createDocumentSymbol(name, symbolKind, null,
+                range, range, isDeprecated, Collections.emptyList(), this.context));
+    }
+
+    @Override
+    public Optional<DocumentSymbol> transform(AnnotationDeclarationNode annotationDeclarationNode) {
+        String name = annotationDeclarationNode.annotationTag().text();
+        SymbolKind symbolKind = SymbolKind.Property;
+        Range range = DocumentSymbolUtil.generateNodeRange(annotationDeclarationNode);
+        Optional<MetadataNode> metadata = annotationDeclarationNode.metadata();
+        boolean isDeprecated = metadata.isPresent() &&
+                DocumentSymbolUtil.isDeprecated(metadata.get());
+        return Optional.ofNullable(createDocumentSymbol(name, symbolKind, null,
+                range, range, isDeprecated, Collections.emptyList(), this.context));
+    }
+
+    @Override
+    public Optional<DocumentSymbol> transform(ObjectFieldNode objectFieldNode) {
+        String name = objectFieldNode.fieldName().text();
+        SymbolKind symbolKind = SymbolKind.Field;
+        Range range = DocumentSymbolUtil.generateNodeRange(objectFieldNode);
+        Optional<MetadataNode> metadata = objectFieldNode.metadata();
+        boolean isDeprecated = metadata.isPresent() &&
+                DocumentSymbolUtil.isDeprecated(metadata.get());
+        return Optional.ofNullable(createDocumentSymbol(name, symbolKind, null,
+                range, range, isDeprecated, Collections.emptyList(), this.context));
+    }
+
+    @Override
+    public Optional<DocumentSymbol> transform(RecordFieldNode recordFieldNode) {
+        String name = recordFieldNode.fieldName().text();
+        SymbolKind symbolKind = SymbolKind.Field;
+        Range range = DocumentSymbolUtil.generateNodeRange(recordFieldNode);
+        Optional<MetadataNode> metadata = recordFieldNode.metadata();
+        boolean isDeprecated = metadata.isPresent() &&
+                DocumentSymbolUtil.isDeprecated(metadata.get());
+        return Optional.ofNullable(createDocumentSymbol(name, symbolKind, null,
+                range, range, isDeprecated, Collections.emptyList(), this.context));
+    }
+
+    @Override
+    public Optional<DocumentSymbol> transform(RecordFieldWithDefaultValueNode recordFieldWithDefaultValueNode) {
+        String name = recordFieldWithDefaultValueNode.fieldName().text();
+        SymbolKind symbolKind = SymbolKind.Field;
+        Range range = DocumentSymbolUtil.generateNodeRange(recordFieldWithDefaultValueNode);
+        Optional<MetadataNode> metadata = recordFieldWithDefaultValueNode.metadata();
+        boolean isDeprecated = metadata.isPresent() &&
+                DocumentSymbolUtil.isDeprecated(metadata.get());
+        return Optional.ofNullable(createDocumentSymbol(name, symbolKind, null,
+                range, range, isDeprecated, Collections.emptyList(), this.context));
+    }
+
+    @Override
+    public Optional<DocumentSymbol> transform(RecordRestDescriptorNode recordRestDescriptorNode) {
+        String name = recordRestDescriptorNode.ellipsisToken().text() +
+                recordRestDescriptorNode.typeName().toSourceCode().trim();
+        SymbolKind symbolKind = SymbolKind.Field;
+        Range range = DocumentSymbolUtil.generateNodeRange(recordRestDescriptorNode);
+        return Optional.ofNullable(createDocumentSymbol(name, symbolKind, null,
+                range, range, false, Collections.emptyList(), this.context));
+    }
+
+    @Override
+    public Optional<DocumentSymbol> transform(EnumMemberNode enumMemberNode) {
+        String name = enumMemberNode.identifier().text();
+        SymbolKind symbolKind = SymbolKind.EnumMember;
+        Range range = DocumentSymbolUtil.generateNodeRange(enumMemberNode);
+        Optional<MetadataNode> metadata = enumMemberNode.metadata();
+        boolean isDeprecated = metadata.isPresent() &&
+                DocumentSymbolUtil.isDeprecated(metadata.get());
+        return Optional.ofNullable(createDocumentSymbol(name, symbolKind, null,
+                range, range, isDeprecated, Collections.emptyList(), this.context));
     }
 
     /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/documentsymbol/DocumentSymbolResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/documentsymbol/DocumentSymbolResolver.java
@@ -152,8 +152,11 @@ public class DocumentSymbolResolver extends NodeTransformer<Optional<DocumentSym
             default:
                 return Optional.empty();
         }
-        return Optional.ofNullable(createDocumentSymbol(name, symbolKind,
-                null, range, range, isDeprecated, Collections.emptyList(), this.context));
+        if (name == null || name.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(createDocumentSymbol(name, symbolKind, range, range, isDeprecated,
+                Collections.emptyList()));
     }
 
     @Override
@@ -163,8 +166,8 @@ public class DocumentSymbolResolver extends NodeTransformer<Optional<DocumentSym
         Range range = DocumentSymbolUtil.generateNodeRange(methodDeclarationNode);
         Optional<MetadataNode> metadata = methodDeclarationNode.metadata();
         boolean isDeprecated = metadata.isPresent() && DocumentSymbolUtil.isDeprecated(metadata.get());
-        return Optional.ofNullable(createDocumentSymbol(name, symbolKind,
-                null, range, range, isDeprecated, Collections.emptyList(), this.context));
+        return Optional.of(createDocumentSymbol(name, symbolKind, range, range, isDeprecated,
+                Collections.emptyList()));
     }
 
     @Override
@@ -176,8 +179,7 @@ public class DocumentSymbolResolver extends NodeTransformer<Optional<DocumentSym
         boolean isDeprecated = metadata.isPresent() &&
                 DocumentSymbolUtil.isDeprecated(metadata.get());
         List<DocumentSymbol> children = transformMembers(classDefinitionNode.members());
-        return Optional.ofNullable(createDocumentSymbol(name, symbolKind,
-                null, range, range, isDeprecated, children, this.context));
+        return Optional.of(createDocumentSymbol(name, symbolKind, range, range, isDeprecated, children));
     }
 
     @Override
@@ -191,8 +193,7 @@ public class DocumentSymbolResolver extends NodeTransformer<Optional<DocumentSym
         boolean isDeprecated = metadata.isPresent() &&
                 DocumentSymbolUtil.isDeprecated(metadata.get());
         List<DocumentSymbol> children = transformMembers(serviceDeclarationNode.members());
-        return Optional.ofNullable(createDocumentSymbol(name.toString(), symbolKind, null,
-                range, range, isDeprecated, children, this.context));
+        return Optional.of(createDocumentSymbol(name.toString(), symbolKind, range, range, isDeprecated, children));
     }
 
     @Override
@@ -223,23 +224,24 @@ public class DocumentSymbolResolver extends NodeTransformer<Optional<DocumentSym
         Optional<MetadataNode> metadata = typeDefinitionNode.metadata();
         boolean isDeprecated = metadata.isPresent() &&
                 DocumentSymbolUtil.isDeprecated(metadata.get());
-        return Optional.ofNullable(createDocumentSymbol(name, symbolKind, null,
-                range, range, isDeprecated, children, this.context));
+        return Optional.of(createDocumentSymbol(name, symbolKind, range, range, isDeprecated, children));
     }
 
     @Override
     public Optional<DocumentSymbol> transform(ModuleVariableDeclarationNode moduleVariableDeclarationNode) {
         BindingPatternNode bindingPatternNode = moduleVariableDeclarationNode.typedBindingPattern().bindingPattern();
         //Only capture binding pattern is considered. Wildcard and other binding patterns are ignored.
-        String name = bindingPatternNode.kind() == SyntaxKind.CAPTURE_BINDING_PATTERN ?
-                bindingPatternNode.toSourceCode() : "";
+        if (bindingPatternNode.kind() != SyntaxKind.CAPTURE_BINDING_PATTERN) {
+            return Optional.empty();
+        }
+        String name = bindingPatternNode.toSourceCode();
         SymbolKind symbolKind = SymbolKind.Variable;
         Range range = DocumentSymbolUtil.generateNodeRange(moduleVariableDeclarationNode);
         Optional<MetadataNode> metadata = moduleVariableDeclarationNode.metadata();
         boolean isDeprecated = metadata.isPresent() &&
                 DocumentSymbolUtil.isDeprecated(metadata.get());
-        return Optional.ofNullable(createDocumentSymbol(name, symbolKind, null,
-                range, range, isDeprecated, Collections.emptyList(), this.context));
+        return Optional.of(createDocumentSymbol(name, symbolKind, range, range, isDeprecated,
+                Collections.emptyList()));
     }
 
     @Override
@@ -250,8 +252,8 @@ public class DocumentSymbolResolver extends NodeTransformer<Optional<DocumentSym
         Optional<MetadataNode> metadata = constantDeclarationNode.metadata();
         boolean isDeprecated = metadata.isPresent() &&
                 DocumentSymbolUtil.isDeprecated(metadata.get());
-        return Optional.ofNullable(createDocumentSymbol(name, symbolKind, null,
-                range, range, isDeprecated, Collections.emptyList(), this.context));
+        return Optional.of(createDocumentSymbol(name, symbolKind, range, range, isDeprecated,
+                Collections.emptyList()));
     }
 
     @Override
@@ -263,8 +265,7 @@ public class DocumentSymbolResolver extends NodeTransformer<Optional<DocumentSym
         List<DocumentSymbol> children = transformMembers(enumDeclarationNode.enumMemberList());
         boolean isDeprecated = metadata.isPresent() &&
                 DocumentSymbolUtil.isDeprecated(metadata.get());
-        return Optional.ofNullable(createDocumentSymbol(name, symbolKind, null,
-                range, range, isDeprecated, children, this.context));
+        return Optional.of(createDocumentSymbol(name, symbolKind, range, range, isDeprecated, children));
     }
 
     @Override
@@ -274,8 +275,7 @@ public class DocumentSymbolResolver extends NodeTransformer<Optional<DocumentSym
                 + moduleXMLNamespaceDeclarationNode.namespaceuri().toSourceCode();
         SymbolKind symbolKind = SymbolKind.Namespace;
         Range range = DocumentSymbolUtil.generateNodeRange(moduleXMLNamespaceDeclarationNode);
-        return Optional.ofNullable(createDocumentSymbol(name, symbolKind, null,
-                range, range, false, Collections.emptyList(), this.context));
+        return Optional.of(createDocumentSymbol(name, symbolKind, range, range, Collections.emptyList()));
     }
 
     @Override
@@ -286,8 +286,8 @@ public class DocumentSymbolResolver extends NodeTransformer<Optional<DocumentSym
         Optional<MetadataNode> metadata = listenerDeclarationNode.metadata();
         boolean isDeprecated = metadata.isPresent() &&
                 DocumentSymbolUtil.isDeprecated(metadata.get());
-        return Optional.ofNullable(createDocumentSymbol(name, symbolKind, null,
-                range, range, isDeprecated, Collections.emptyList(), this.context));
+        return Optional.of(createDocumentSymbol(name, symbolKind, range, range, isDeprecated,
+                Collections.emptyList()));
     }
 
     @Override
@@ -298,8 +298,8 @@ public class DocumentSymbolResolver extends NodeTransformer<Optional<DocumentSym
         Optional<MetadataNode> metadata = annotationDeclarationNode.metadata();
         boolean isDeprecated = metadata.isPresent() &&
                 DocumentSymbolUtil.isDeprecated(metadata.get());
-        return Optional.ofNullable(createDocumentSymbol(name, symbolKind, null,
-                range, range, isDeprecated, Collections.emptyList(), this.context));
+        return Optional.of(createDocumentSymbol(name, symbolKind, range, range, isDeprecated,
+                Collections.emptyList()));
     }
 
     @Override
@@ -310,8 +310,8 @@ public class DocumentSymbolResolver extends NodeTransformer<Optional<DocumentSym
         Optional<MetadataNode> metadata = objectFieldNode.metadata();
         boolean isDeprecated = metadata.isPresent() &&
                 DocumentSymbolUtil.isDeprecated(metadata.get());
-        return Optional.ofNullable(createDocumentSymbol(name, symbolKind, null,
-                range, range, isDeprecated, Collections.emptyList(), this.context));
+        return Optional.of(createDocumentSymbol(name, symbolKind, range, range, isDeprecated,
+                Collections.emptyList()));
     }
 
     @Override
@@ -322,8 +322,8 @@ public class DocumentSymbolResolver extends NodeTransformer<Optional<DocumentSym
         Optional<MetadataNode> metadata = recordFieldNode.metadata();
         boolean isDeprecated = metadata.isPresent() &&
                 DocumentSymbolUtil.isDeprecated(metadata.get());
-        return Optional.ofNullable(createDocumentSymbol(name, symbolKind, null,
-                range, range, isDeprecated, Collections.emptyList(), this.context));
+        return Optional.of(createDocumentSymbol(name, symbolKind, range, range, isDeprecated,
+                Collections.emptyList()));
     }
 
     @Override
@@ -334,8 +334,8 @@ public class DocumentSymbolResolver extends NodeTransformer<Optional<DocumentSym
         Optional<MetadataNode> metadata = recordFieldWithDefaultValueNode.metadata();
         boolean isDeprecated = metadata.isPresent() &&
                 DocumentSymbolUtil.isDeprecated(metadata.get());
-        return Optional.ofNullable(createDocumentSymbol(name, symbolKind, null,
-                range, range, isDeprecated, Collections.emptyList(), this.context));
+        return Optional.of(createDocumentSymbol(name, symbolKind, range, range, isDeprecated,
+                Collections.emptyList()));
     }
 
     @Override
@@ -344,8 +344,7 @@ public class DocumentSymbolResolver extends NodeTransformer<Optional<DocumentSym
                 recordRestDescriptorNode.typeName().toSourceCode().trim();
         SymbolKind symbolKind = SymbolKind.Field;
         Range range = DocumentSymbolUtil.generateNodeRange(recordRestDescriptorNode);
-        return Optional.ofNullable(createDocumentSymbol(name, symbolKind, null,
-                range, range, false, Collections.emptyList(), this.context));
+        return Optional.of(createDocumentSymbol(name, symbolKind, range, range, Collections.emptyList()));
     }
 
     @Override
@@ -356,8 +355,8 @@ public class DocumentSymbolResolver extends NodeTransformer<Optional<DocumentSym
         Optional<MetadataNode> metadata = enumMemberNode.metadata();
         boolean isDeprecated = metadata.isPresent() &&
                 DocumentSymbolUtil.isDeprecated(metadata.get());
-        return Optional.ofNullable(createDocumentSymbol(name, symbolKind, null,
-                range, range, isDeprecated, Collections.emptyList(), this.context));
+        return Optional.of(createDocumentSymbol(name, symbolKind, range, range, isDeprecated,
+                Collections.emptyList()));
     }
 
     /**
@@ -374,6 +373,17 @@ public class DocumentSymbolResolver extends NodeTransformer<Optional<DocumentSym
         return childSymbols;
     }
 
+    private DocumentSymbol createDocumentSymbol(String name, SymbolKind kind, Range range,
+                                                Range selectionRange, List<DocumentSymbol> children) {
+        return createDocumentSymbol(name, kind, null, range, selectionRange, false, children);
+    }
+
+    private DocumentSymbol createDocumentSymbol(String name, SymbolKind kind, Range range,
+                                                Range selectionRange, boolean isDeprecated,
+                                                List<DocumentSymbol> children) {
+        return createDocumentSymbol(name, kind, null, range, selectionRange, isDeprecated, children);
+    }
+
     /**
      * Document symbol builder.
      *
@@ -384,26 +394,22 @@ public class DocumentSymbolResolver extends NodeTransformer<Optional<DocumentSym
      * @param selectionRange selection range of the symbol.
      * @param isDeprecated   Whether the symbol is deprecated.
      * @param children       Child document symbols.
-     * @param context        Document symbol context.
      * @return
      */
-    public DocumentSymbol createDocumentSymbol(String name, SymbolKind kind,
-                                               String detail, Range range,
-                                               Range selectionRange, boolean isDeprecated,
-                                               List<DocumentSymbol> children, DocumentSymbolContext context) {
-        if (name == null || name.isEmpty()) {
-            return null;
-        }
+    private DocumentSymbol createDocumentSymbol(String name, SymbolKind kind,
+                                                String detail, Range range,
+                                                Range selectionRange, boolean isDeprecated,
+                                                List<DocumentSymbol> children) {
         DocumentSymbol documentSymbol = new DocumentSymbol();
         documentSymbol.setName(name);
         documentSymbol.setKind(kind);
         documentSymbol.setDetail(detail);
         documentSymbol.setRange(range);
         documentSymbol.setSelectionRange(selectionRange);
-        if (isDeprecated && context.deprecatedSupport()) {
+        if (isDeprecated && this.context.deprecatedSupport()) {
             documentSymbol.setTags(List.of(SymbolTag.Deprecated));
         }
-        if (context.getHierarchicalDocumentSymbolSupport()) {
+        if (this.context.getHierarchicalDocumentSymbolSupport()) {
             documentSymbol.setChildren(children);
         } else {
             this.documentSymbolStore.add(documentSymbol);

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/documentsymbol/DocumentSymbolTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/documentsymbol/DocumentSymbolTest.java
@@ -49,7 +49,7 @@ public class DocumentSymbolTest {
     }
 
     @DataProvider
-    public Object[] testDataProvider() {
+    public Object[] testDataProvider() {    
         return new Object[]{"config1.json", "config2.json"};
     }
 

--- a/language-server/modules/langserver-core/src/test/resources/documentsymbol/config/config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/documentsymbol/config/config1.json
@@ -29,8 +29,83 @@
         },
         "children": [
           {
+            "name": "email",
+            "kind": "Field",
+            "range": {
+              "start": {
+                "line": 7,
+                "character": 4
+              },
+              "end": {
+                "line": 7,
+                "character": 17
+              }
+            },
+            "selectionRange": {
+              "start": {
+                "line": 7,
+                "character": 4
+              },
+              "end": {
+                "line": 7,
+                "character": 17
+              }
+            },
+            "children": []
+          },
+          {
+            "name": "userName",
+            "kind": "Field",
+            "range": {
+              "start": {
+                "line": 8,
+                "character": 4
+              },
+              "end": {
+                "line": 8,
+                "character": 20
+              }
+            },
+            "selectionRange": {
+              "start": {
+                "line": 8,
+                "character": 4
+              },
+              "end": {
+                "line": 8,
+                "character": 20
+              }
+            },
+            "children": []
+          },
+          {
+            "name": "address",
+            "kind": "Field",
+            "range": {
+              "start": {
+                "line": 9,
+                "character": 4
+              },
+              "end": {
+                "line": 9,
+                "character": 26
+              }
+            },
+            "selectionRange": {
+              "start": {
+                "line": 9,
+                "character": 4
+              },
+              "end": {
+                "line": 9,
+                "character": 26
+              }
+            },
+            "children": []
+          },
+          {
             "name": "init",
-            "kind": "Method",
+            "kind": "Constructor",
             "range": {
               "start": {
                 "line": 11,
@@ -182,8 +257,33 @@
         },
         "children": [
           {
+            "name": "code",
+            "kind": "Field",
+            "range": {
+              "start": {
+                "line": 44,
+                "character": 4
+              },
+              "end": {
+                "line": 44,
+                "character": 16
+              }
+            },
+            "selectionRange": {
+              "start": {
+                "line": 44,
+                "character": 4
+              },
+              "end": {
+                "line": 44,
+                "character": 16
+              }
+            },
+            "children": []
+          },
+          {
             "name": "init",
-            "kind": "Method",
+            "kind": "Constructor",
             "range": {
               "start": {
                 "line": 46,
@@ -263,8 +363,8 @@
     },
     {
       "right": {
-        "name": "service /abc/users  on new http:Listener(8080) ",
-        "kind": "Interface",
+        "name": "service /abc/users ",
+        "kind": "Object",
         "range": {
           "start": {
             "line": 77,
@@ -391,8 +491,8 @@
     },
     {
       "right": {
-        "name": "service /abc/items  on new http:Listener(8090) ",
-        "kind": "Interface",
+        "name": "service /abc/items ",
+        "kind": "Object",
         "range": {
           "start": {
             "line": 96,
@@ -469,8 +569,8 @@
     },
     {
       "right": {
-        "name": "service  on new udp:Listener(8080) ",
-        "kind": "Interface",
+        "name": "service ",
+        "kind": "Object",
         "range": {
           "start": {
             "line": 111,
@@ -573,6 +673,692 @@
           "Deprecated"
         ],
         "children": []
+      }
+    },
+    {
+      "right": {
+        "name": "MyType",
+        "kind": "Struct",
+        "range": {
+          "start": {
+            "line": 131,
+            "character": 0
+          },
+          "end": {
+            "line": 134,
+            "character": 3
+          }
+        },
+        "selectionRange": {
+          "start": {
+            "line": 131,
+            "character": 0
+          },
+          "end": {
+            "line": 134,
+            "character": 3
+          }
+        },
+        "children": [
+          {
+            "name": "arg1",
+            "kind": "Field",
+            "range": {
+              "start": {
+                "line": 132,
+                "character": 4
+              },
+              "end": {
+                "line": 132,
+                "character": 13
+              }
+            },
+            "selectionRange": {
+              "start": {
+                "line": 132,
+                "character": 4
+              },
+              "end": {
+                "line": 132,
+                "character": 13
+              }
+            },
+            "children": []
+          },
+          {
+            "name": "arg2",
+            "kind": "Field",
+            "range": {
+              "start": {
+                "line": 133,
+                "character": 4
+              },
+              "end": {
+                "line": 133,
+                "character": 16
+              }
+            },
+            "selectionRange": {
+              "start": {
+                "line": 133,
+                "character": 4
+              },
+              "end": {
+                "line": 133,
+                "character": 16
+              }
+            },
+            "children": []
+          }
+        ]
+      }
+    },
+    {
+      "right": {
+        "name": "ObjectType",
+        "kind": "Interface",
+        "range": {
+          "start": {
+            "line": 136,
+            "character": 0
+          },
+          "end": {
+            "line": 138,
+            "character": 2
+          }
+        },
+        "selectionRange": {
+          "start": {
+            "line": 136,
+            "character": 0
+          },
+          "end": {
+            "line": 138,
+            "character": 2
+          }
+        },
+        "children": [
+          {
+            "name": "attach",
+            "kind": "Method",
+            "range": {
+              "start": {
+                "line": 137,
+                "character": 4
+              },
+              "end": {
+                "line": 137,
+                "character": 29
+              }
+            },
+            "selectionRange": {
+              "start": {
+                "line": 137,
+                "character": 4
+              },
+              "end": {
+                "line": 137,
+                "character": 29
+              }
+            },
+            "children": []
+          }
+        ]
+      }
+    },
+    {
+      "right": {
+        "name": "OtherType",
+        "kind": "TypeParameter",
+        "range": {
+          "start": {
+            "line": 140,
+            "character": 0
+          },
+          "end": {
+            "line": 140,
+            "character": 22
+          }
+        },
+        "selectionRange": {
+          "start": {
+            "line": 140,
+            "character": 0
+          },
+          "end": {
+            "line": 140,
+            "character": 22
+          }
+        },
+        "children": []
+      }
+    },
+    {
+      "right": {
+        "name": "modVar1 ",
+        "kind": "Variable",
+        "range": {
+          "start": {
+            "line": 142,
+            "character": 0
+          },
+          "end": {
+            "line": 142,
+            "character": 43
+          }
+        },
+        "selectionRange": {
+          "start": {
+            "line": 142,
+            "character": 0
+          },
+          "end": {
+            "line": 142,
+            "character": 43
+          }
+        },
+        "children": []
+      }
+    },
+    {
+      "right": {
+        "name": "myConst",
+        "kind": "Constant",
+        "range": {
+          "start": {
+            "line": 146,
+            "character": 0
+          },
+          "end": {
+            "line": 146,
+            "character": 41
+          }
+        },
+        "selectionRange": {
+          "start": {
+            "line": 146,
+            "character": 0
+          },
+          "end": {
+            "line": 146,
+            "character": 41
+          }
+        },
+        "children": []
+      }
+    },
+    {
+      "right": {
+        "name": "KIND",
+        "kind": "Enum",
+        "range": {
+          "start": {
+            "line": 148,
+            "character": 0
+          },
+          "end": {
+            "line": 151,
+            "character": 1
+          }
+        },
+        "selectionRange": {
+          "start": {
+            "line": 148,
+            "character": 0
+          },
+          "end": {
+            "line": 151,
+            "character": 1
+          }
+        },
+        "children": [
+          {
+            "name": "KIND1",
+            "kind": "EnumMember",
+            "range": {
+              "start": {
+                "line": 149,
+                "character": 4
+              },
+              "end": {
+                "line": 149,
+                "character": 9
+              }
+            },
+            "selectionRange": {
+              "start": {
+                "line": 149,
+                "character": 4
+              },
+              "end": {
+                "line": 149,
+                "character": 9
+              }
+            },
+            "children": []
+          },
+          {
+            "name": "KIND2",
+            "kind": "EnumMember",
+            "range": {
+              "start": {
+                "line": 150,
+                "character": 4
+              },
+              "end": {
+                "line": 150,
+                "character": 9
+              }
+            },
+            "selectionRange": {
+              "start": {
+                "line": 150,
+                "character": 4
+              },
+              "end": {
+                "line": 150,
+                "character": 9
+              }
+            },
+            "children": []
+          }
+        ]
+      }
+    },
+    {
+      "right": {
+        "name": "ballerina ",
+        "kind": "Variable",
+        "range": {
+          "start": {
+            "line": 153,
+            "character": 0
+          },
+          "end": {
+            "line": 153,
+            "character": 41
+          }
+        },
+        "selectionRange": {
+          "start": {
+            "line": 153,
+            "character": 0
+          },
+          "end": {
+            "line": 153,
+            "character": 41
+          }
+        },
+        "children": []
+      }
+    },
+    {
+      "right": {
+        "name": "bal",
+        "kind": "Namespace",
+        "range": {
+          "start": {
+            "line": 155,
+            "character": 0
+          },
+          "end": {
+            "line": 155,
+            "character": 23
+          }
+        },
+        "selectionRange": {
+          "start": {
+            "line": 155,
+            "character": 0
+          },
+          "end": {
+            "line": 155,
+            "character": 23
+          }
+        },
+        "children": []
+      }
+    },
+    {
+      "right": {
+        "name": "xmlns \"http://ballerina.io\"",
+        "kind": "Namespace",
+        "range": {
+          "start": {
+            "line": 157,
+            "character": 0
+          },
+          "end": {
+            "line": 157,
+            "character": 28
+          }
+        },
+        "selectionRange": {
+          "start": {
+            "line": 157,
+            "character": 0
+          },
+          "end": {
+            "line": 157,
+            "character": 28
+          }
+        },
+        "children": []
+      }
+    },
+    {
+      "right": {
+        "name": "myListener",
+        "kind": "Object",
+        "range": {
+          "start": {
+            "line": 159,
+            "character": 0
+          },
+          "end": {
+            "line": 159,
+            "character": 57
+          }
+        },
+        "selectionRange": {
+          "start": {
+            "line": 159,
+            "character": 0
+          },
+          "end": {
+            "line": 159,
+            "character": 57
+          }
+        },
+        "children": []
+      }
+    },
+    {
+      "right": {
+        "name": "AnnotationType1",
+        "kind": "Struct",
+        "range": {
+          "start": {
+            "line": 161,
+            "character": 0
+          },
+          "end": {
+            "line": 165,
+            "character": 3
+          }
+        },
+        "selectionRange": {
+          "start": {
+            "line": 161,
+            "character": 0
+          },
+          "end": {
+            "line": 165,
+            "character": 3
+          }
+        },
+        "children": [
+          {
+            "name": "prop1",
+            "kind": "Field",
+            "range": {
+              "start": {
+                "line": 162,
+                "character": 4
+              },
+              "end": {
+                "line": 162,
+                "character": 17
+              }
+            },
+            "selectionRange": {
+              "start": {
+                "line": 162,
+                "character": 4
+              },
+              "end": {
+                "line": 162,
+                "character": 17
+              }
+            },
+            "children": []
+          },
+          {
+            "name": "prop2",
+            "kind": "Field",
+            "range": {
+              "start": {
+                "line": 163,
+                "character": 4
+              },
+              "end": {
+                "line": 163,
+                "character": 17
+              }
+            },
+            "selectionRange": {
+              "start": {
+                "line": 163,
+                "character": 4
+              },
+              "end": {
+                "line": 163,
+                "character": 17
+              }
+            },
+            "children": []
+          },
+          {
+            "name": "...string",
+            "kind": "Field",
+            "range": {
+              "start": {
+                "line": 164,
+                "character": 4
+              },
+              "end": {
+                "line": 164,
+                "character": 15
+              }
+            },
+            "selectionRange": {
+              "start": {
+                "line": 164,
+                "character": 4
+              },
+              "end": {
+                "line": 164,
+                "character": 15
+              }
+            },
+            "children": []
+          }
+        ]
+      }
+    },
+    {
+      "right": {
+        "name": "AnnotationType2",
+        "kind": "Struct",
+        "range": {
+          "start": {
+            "line": 167,
+            "character": 0
+          },
+          "end": {
+            "line": 169,
+            "character": 3
+          }
+        },
+        "selectionRange": {
+          "start": {
+            "line": 167,
+            "character": 0
+          },
+          "end": {
+            "line": 169,
+            "character": 3
+          }
+        },
+        "children": [
+          {
+            "name": "prop1",
+            "kind": "Field",
+            "range": {
+              "start": {
+                "line": 168,
+                "character": 4
+              },
+              "end": {
+                "line": 168,
+                "character": 18
+              }
+            },
+            "selectionRange": {
+              "start": {
+                "line": 168,
+                "character": 4
+              },
+              "end": {
+                "line": 168,
+                "character": 18
+              }
+            },
+            "children": []
+          }
+        ]
+      }
+    },
+    {
+      "right": {
+        "name": "MyAnnotation1",
+        "kind": "Property",
+        "range": {
+          "start": {
+            "line": 171,
+            "character": 0
+          },
+          "end": {
+            "line": 171,
+            "character": 66
+          }
+        },
+        "selectionRange": {
+          "start": {
+            "line": 171,
+            "character": 0
+          },
+          "end": {
+            "line": 171,
+            "character": 66
+          }
+        },
+        "children": []
+      }
+    },
+    {
+      "right": {
+        "name": "MyAnnotation2",
+        "kind": "Property",
+        "range": {
+          "start": {
+            "line": 173,
+            "character": 0
+          },
+          "end": {
+            "line": 173,
+            "character": 65
+          }
+        },
+        "selectionRange": {
+          "start": {
+            "line": 173,
+            "character": 0
+          },
+          "end": {
+            "line": 173,
+            "character": 65
+          }
+        },
+        "children": []
+      }
+    },
+    {
+      "right": {
+        "name": "MyObjectType",
+        "kind": "Interface",
+        "range": {
+          "start": {
+            "line": 175,
+            "character": 0
+          },
+          "end": {
+            "line": 178,
+            "character": 1
+          }
+        },
+        "selectionRange": {
+          "start": {
+            "line": 175,
+            "character": 0
+          },
+          "end": {
+            "line": 178,
+            "character": 1
+          }
+        },
+        "children": [
+          {
+            "name": "function1",
+            "kind": "Method",
+            "range": {
+              "start": {
+                "line": 176,
+                "character": 4
+              },
+              "end": {
+                "line": 176,
+                "character": 32
+              }
+            },
+            "selectionRange": {
+              "start": {
+                "line": 176,
+                "character": 4
+              },
+              "end": {
+                "line": 176,
+                "character": 32
+              }
+            },
+            "children": []
+          },
+          {
+            "name": "function2",
+            "kind": "Method",
+            "range": {
+              "start": {
+                "line": 177,
+                "character": 4
+              },
+              "end": {
+                "line": 177,
+                "character": 32
+              }
+            },
+            "selectionRange": {
+              "start": {
+                "line": 177,
+                "character": 4
+              },
+              "end": {
+                "line": 177,
+                "character": 32
+              }
+            },
+            "children": []
+          }
+        ]
       }
     }
   ]

--- a/language-server/modules/langserver-core/src/test/resources/documentsymbol/config/config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/documentsymbol/config/config2.json
@@ -5,6 +5,547 @@
   "result": [
     {
       "right": {
+        "name": "UserType",
+        "kind": "Enum",
+        "range": {
+          "start": {
+            "line": 0,
+            "character": 0
+          },
+          "end": {
+            "line": 2,
+            "character": 1
+          }
+        },
+        "selectionRange": {
+          "start": {
+            "line": 0,
+            "character": 0
+          },
+          "end": {
+            "line": 2,
+            "character": 1
+          }
+        },
+        "children": [
+          {
+            "name": "ADMIN",
+            "kind": "EnumMember",
+            "range": {
+              "start": {
+                "line": 1,
+                "character": 4
+              },
+              "end": {
+                "line": 1,
+                "character": 9
+              }
+            },
+            "selectionRange": {
+              "start": {
+                "line": 1,
+                "character": 4
+              },
+              "end": {
+                "line": 1,
+                "character": 9
+              }
+            },
+            "children": []
+          },
+          {
+            "name": "CUSTOMER",
+            "kind": "EnumMember",
+            "range": {
+              "start": {
+                "line": 1,
+                "character": 11
+              },
+              "end": {
+                "line": 1,
+                "character": 19
+              }
+            },
+            "selectionRange": {
+              "start": {
+                "line": 1,
+                "character": 11
+              },
+              "end": {
+                "line": 1,
+                "character": 19
+              }
+            },
+            "children": []
+          },
+          {
+            "name": "SELLER",
+            "kind": "EnumMember",
+            "range": {
+              "start": {
+                "line": 1,
+                "character": 21
+              },
+              "end": {
+                "line": 1,
+                "character": 27
+              }
+            },
+            "selectionRange": {
+              "start": {
+                "line": 1,
+                "character": 21
+              },
+              "end": {
+                "line": 1,
+                "character": 27
+              }
+            },
+            "children": []
+          }
+        ]
+      }
+    },
+    {
+      "right": {
+        "name": "STATE",
+        "kind": "Enum",
+        "range": {
+          "start": {
+            "line": 4,
+            "character": 0
+          },
+          "end": {
+            "line": 6,
+            "character": 1
+          }
+        },
+        "selectionRange": {
+          "start": {
+            "line": 4,
+            "character": 0
+          },
+          "end": {
+            "line": 6,
+            "character": 1
+          }
+        },
+        "children": [
+          {
+            "name": "SOUTH",
+            "kind": "EnumMember",
+            "range": {
+              "start": {
+                "line": 5,
+                "character": 4
+              },
+              "end": {
+                "line": 5,
+                "character": 9
+              }
+            },
+            "selectionRange": {
+              "start": {
+                "line": 5,
+                "character": 4
+              },
+              "end": {
+                "line": 5,
+                "character": 9
+              }
+            },
+            "children": []
+          },
+          {
+            "name": "WEST",
+            "kind": "EnumMember",
+            "range": {
+              "start": {
+                "line": 5,
+                "character": 11
+              },
+              "end": {
+                "line": 5,
+                "character": 15
+              }
+            },
+            "selectionRange": {
+              "start": {
+                "line": 5,
+                "character": 11
+              },
+              "end": {
+                "line": 5,
+                "character": 15
+              }
+            },
+            "children": []
+          },
+          {
+            "name": "NORTH",
+            "kind": "EnumMember",
+            "range": {
+              "start": {
+                "line": 5,
+                "character": 17
+              },
+              "end": {
+                "line": 5,
+                "character": 22
+              }
+            },
+            "selectionRange": {
+              "start": {
+                "line": 5,
+                "character": 17
+              },
+              "end": {
+                "line": 5,
+                "character": 22
+              }
+            },
+            "children": []
+          },
+          {
+            "name": "EAST",
+            "kind": "EnumMember",
+            "range": {
+              "start": {
+                "line": 5,
+                "character": 24
+              },
+              "end": {
+                "line": 5,
+                "character": 28
+              }
+            },
+            "selectionRange": {
+              "start": {
+                "line": 5,
+                "character": 24
+              },
+              "end": {
+                "line": 5,
+                "character": 28
+              }
+            },
+            "children": []
+          }
+        ]
+      }
+    },
+    {
+      "right": {
+        "name": "Address",
+        "kind": "Struct",
+        "range": {
+          "start": {
+            "line": 8,
+            "character": 0
+          },
+          "end": {
+            "line": 13,
+            "character": 2
+          }
+        },
+        "selectionRange": {
+          "start": {
+            "line": 8,
+            "character": 0
+          },
+          "end": {
+            "line": 13,
+            "character": 2
+          }
+        },
+        "children": [
+          {
+            "name": "addressLine1",
+            "kind": "Field",
+            "range": {
+              "start": {
+                "line": 9,
+                "character": 4
+              },
+              "end": {
+                "line": 9,
+                "character": 24
+              }
+            },
+            "selectionRange": {
+              "start": {
+                "line": 9,
+                "character": 4
+              },
+              "end": {
+                "line": 9,
+                "character": 24
+              }
+            },
+            "children": []
+          },
+          {
+            "name": "addressLine2",
+            "kind": "Field",
+            "range": {
+              "start": {
+                "line": 10,
+                "character": 4
+              },
+              "end": {
+                "line": 10,
+                "character": 24
+              }
+            },
+            "selectionRange": {
+              "start": {
+                "line": 10,
+                "character": 4
+              },
+              "end": {
+                "line": 10,
+                "character": 24
+              }
+            },
+            "children": []
+          },
+          {
+            "name": "state",
+            "kind": "Field",
+            "range": {
+              "start": {
+                "line": 11,
+                "character": 4
+              },
+              "end": {
+                "line": 11,
+                "character": 16
+              }
+            },
+            "selectionRange": {
+              "start": {
+                "line": 11,
+                "character": 4
+              },
+              "end": {
+                "line": 11,
+                "character": 16
+              }
+            },
+            "children": []
+          },
+          {
+            "name": "postalCode",
+            "kind": "Field",
+            "range": {
+              "start": {
+                "line": 12,
+                "character": 4
+              },
+              "end": {
+                "line": 12,
+                "character": 19
+              }
+            },
+            "selectionRange": {
+              "start": {
+                "line": 12,
+                "character": 4
+              },
+              "end": {
+                "line": 12,
+                "character": 19
+              }
+            },
+            "children": []
+          }
+        ]
+      }
+    },
+    {
+      "right": {
+        "name": "User",
+        "kind": "Interface",
+        "range": {
+          "start": {
+            "line": 15,
+            "character": 0
+          },
+          "end": {
+            "line": 20,
+            "character": 2
+          }
+        },
+        "selectionRange": {
+          "start": {
+            "line": 15,
+            "character": 0
+          },
+          "end": {
+            "line": 20,
+            "character": 2
+          }
+        },
+        "children": [
+          {
+            "name": "getUserName",
+            "kind": "Method",
+            "range": {
+              "start": {
+                "line": 16,
+                "character": 4
+              },
+              "end": {
+                "line": 16,
+                "character": 49
+              }
+            },
+            "selectionRange": {
+              "start": {
+                "line": 16,
+                "character": 4
+              },
+              "end": {
+                "line": 16,
+                "character": 49
+              }
+            },
+            "children": []
+          },
+          {
+            "name": "getEmail",
+            "kind": "Method",
+            "range": {
+              "start": {
+                "line": 17,
+                "character": 4
+              },
+              "end": {
+                "line": 17,
+                "character": 46
+              }
+            },
+            "selectionRange": {
+              "start": {
+                "line": 17,
+                "character": 4
+              },
+              "end": {
+                "line": 17,
+                "character": 46
+              }
+            },
+            "children": []
+          },
+          {
+            "name": "getType",
+            "kind": "Method",
+            "range": {
+              "start": {
+                "line": 18,
+                "character": 4
+              },
+              "end": {
+                "line": 18,
+                "character": 47
+              }
+            },
+            "selectionRange": {
+              "start": {
+                "line": 18,
+                "character": 4
+              },
+              "end": {
+                "line": 18,
+                "character": 47
+              }
+            },
+            "children": []
+          },
+          {
+            "name": "getAddress",
+            "kind": "Method",
+            "range": {
+              "start": {
+                "line": 19,
+                "character": 4
+              },
+              "end": {
+                "line": 19,
+                "character": 49
+              }
+            },
+            "selectionRange": {
+              "start": {
+                "line": 19,
+                "character": 4
+              },
+              "end": {
+                "line": 19,
+                "character": 49
+              }
+            },
+            "children": []
+          }
+        ]
+      }
+    },
+    {
+      "right": {
+        "name": "AnotherItem ",
+        "kind": "Variable",
+        "range": {
+          "start": {
+            "line": 22,
+            "character": 0
+          },
+          "end": {
+            "line": 22,
+            "character": 26
+          }
+        },
+        "selectionRange": {
+          "start": {
+            "line": 22,
+            "character": 0
+          },
+          "end": {
+            "line": 22,
+            "character": 26
+          }
+        },
+        "children": []
+      }
+    },
+    {
+      "right": {
+        "name": "code",
+        "kind": "Variable",
+        "range": {
+          "start": {
+            "line": 23,
+            "character": 4
+          },
+          "end": {
+            "line": 23,
+            "character": 16
+          }
+        },
+        "selectionRange": {
+          "start": {
+            "line": 23,
+            "character": 4
+          },
+          "end": {
+            "line": 23,
+            "character": 16
+          }
+        },
+        "children": []
+      }
+    },
+    {
+      "right": {
         "name": "init",
         "kind": "Function",
         "range": {

--- a/language-server/modules/langserver-core/src/test/resources/documentsymbol/source/project1/main.bal
+++ b/language-server/modules/langserver-core/src/test/resources/documentsymbol/source/project1/main.bal
@@ -128,3 +128,53 @@ service on new udp:Listener(8080) {
 public function deprecatedFunction() {
     
 }
+
+public type MyType record {|
+    int arg1;
+    string arg2;
+|};
+
+public type ObjectType object {
+    public function attach();
+};
+
+type OtherType string;
+
+public MyType modVar1 = {arg1:10, arg2:""};
+
+public int _ = 10;
+
+public const string myConst = "CONSTANT";
+
+public enum KIND {
+    KIND1,
+    KIND2
+}
+
+string ballerina = "http://ballerina.io";
+
+xmlns ballerina as bal;
+
+xmlns "http://ballerina.io";
+
+public listener http:ListenerType myListener = new(8080);
+
+type AnnotationType1 record {|
+    string prop1;
+    string prop2;
+    string ...;
+|};
+
+type AnnotationType2 record {|
+    boolean prop1;
+|};
+
+public const annotation AnnotationType1 MyAnnotation1 on function;
+
+public const annotation AnnotationType2 MyAnnotation2 on service;
+
+type MyObjectType object {
+    public function function1();
+    public function function2();
+}
+


### PR DESCRIPTION
## Purpose
$subject to cover the following nodes. 
1. annotation-def
2. listener-decl
3. xmlns-decl
4. type-def
5. module-var-decl
6. enum-decl
7. object-field

Please find the document symbol specification below.
https://docs.google.com/document/d/1jZ1zvrnMX182qaNCKAddMU0xYpO68l2N5p36_IN5sUU/edit?usp=sharing

Fixes #32629 

## Approach
Implement transform methods for above nodes in Document Symbol Resolver

## Samples
TBA

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
