### PR TITLE
Use locked package compilation instance to avoid concurrent modifications

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/packages/BallerinaPackageServiceImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/packages/BallerinaPackageServiceImpl.java
@@ -26,6 +26,7 @@ import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.projects.Module;
 import io.ballerina.projects.Package;
+import io.ballerina.projects.PackageCompilation;
 import io.ballerina.projects.Project;
 import io.ballerina.projects.ProjectKind;
 import io.ballerina.tools.diagnostics.Location;
@@ -127,8 +128,12 @@ public class BallerinaPackageServiceImpl implements BallerinaPackageService {
             if (module.moduleName().moduleNamePart() != null) {
                 jsonModule.addProperty(PackageServiceConstants.NAME, module.moduleName().moduleNamePart());
             }
-            List<Symbol> symbolList = project.currentPackage()
-                    .getCompilation().getSemanticModel(moduleId).moduleSymbols();
+            Optional<PackageCompilation> packageCompilation =
+                    this.workspaceManager.waitAndGetPackageCompilation(project.sourceRoot());
+            if (packageCompilation.isEmpty()) {
+                return;
+            }
+            List<Symbol> symbolList = packageCompilation.get().getSemanticModel(moduleId).moduleSymbols();
 
             List<FunctionSymbol> functionList =
                     symbolList.stream().filter(symbol -> symbol.kind() == SymbolKind.FUNCTION)


### PR DESCRIPTION
## Purpose
Use the workspace manager's `waitAndGetPackageCompilation()` method, which uses a locked package compilation instance, to avoid concurrent modifications

Fix https://github.com/ballerina-platform/ballerina-lang/issues/32820
Related issue https://github.com/ballerina-platform/ballerina-lang/issues/32214

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
