### PR TITLE
[Debugger] Add readonly editor support for bala sources debugging in VSCode

### DIFF
--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/BallerinaStackFrame.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/BallerinaStackFrame.java
@@ -105,7 +105,7 @@ public class BallerinaStackFrame {
             DebugSourceType sourceType = sourcePathAndType.get().getValue();
             Source source = new Source();
             source.setName(jStackFrame.location().sourceName());
-            URI uri = frameLocationPath.toUri();
+            URI uri = frameLocationPath.toAbsolutePath().toUri();
 
             // If the corresponding source file of the stack frame is a bala source, the source should be readonly in
             // the editor side. Therefore adds a custom URI scheme to the file path, after verifying that the connected
@@ -118,9 +118,9 @@ public class BallerinaStackFrame {
                 // Note: Since we are using a Ballerina-specific custom URI scheme, the future DAP client
                 // implementations may have to implement custom editor providers in order to support URIs coming
                 // from the debug server.
-                source.setPath(URI.create(BALA_URI_SCHEME_NAME + uri.getPath()).normalize().toString());
+                source.setPath(URI.create(BALA_URI_SCHEME_NAME + uri.getPath()).toString());
             } else {
-                source.setPath(uri.normalize().toString());
+                source.setPath(uri.toString());
             }
             dapStackFrame.setSource(source);
             return dapStackFrame;

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/BallerinaStackFrame.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/BallerinaStackFrame.java
@@ -21,6 +21,7 @@ package org.ballerinalang.debugadapter;
 import com.sun.jdi.ArrayReference;
 import com.sun.jdi.ObjectReference;
 import com.sun.jdi.Value;
+import org.ballerinalang.debugadapter.config.ClientConfigHolder;
 import org.ballerinalang.debugadapter.jdi.JdiProxyException;
 import org.ballerinalang.debugadapter.jdi.LocalVariableProxyImpl;
 import org.ballerinalang.debugadapter.jdi.StackFrameProxyImpl;
@@ -108,7 +109,10 @@ public class BallerinaStackFrame {
             // If the corresponding source file of the stack frame is a bala source, the source should be readonly in
             // the editor side. Therefore adds a custom URI scheme to the file path, after verifying that the connected
             // debug client support custom URI schemes.
-            if (sourceType == DebugSourceType.DEPENDENCY) {
+            Optional<ClientConfigHolder.ExtendedClientCapabilities> capabilities =
+                    context.getAdapter().getClientConfigHolder().getExtendedCapabilities();
+            boolean supportsReadOnlyEditors = capabilities.isPresent() && capabilities.get().supportsReadOnlyEditors();
+            if (supportsReadOnlyEditors && sourceType == DebugSourceType.DEPENDENCY) {
                 source.setPath(URI.create(BALA_URI_SCHEME_NAME + uri.getPath()).normalize().toString());
             } else {
                 source.setPath(uri.normalize().toString());

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/BallerinaStackFrame.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/BallerinaStackFrame.java
@@ -118,7 +118,7 @@ public class BallerinaStackFrame {
                 // Note: Since we are using a Ballerina-specific custom URI scheme, the future DAP client
                 // implementations may have to implement custom editor providers in order to support URIs coming
                 // from the debug server.
-                source.setPath(URI.create(BALA_URI_SCHEME_NAME + uri.getPath()).toString());
+                source.setPath(PackageUtils.covertToBalaUri(uri).toString());
             } else {
                 source.setPath(uri.toString());
             }

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/BallerinaStackFrame.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/BallerinaStackFrame.java
@@ -115,6 +115,9 @@ public class BallerinaStackFrame {
             boolean supportsReadOnlyEditors = capabilities.isPresent() && capabilities.get().supportsReadOnlyEditors();
 
             if (supportsReadOnlyEditors && sourceType == DebugSourceType.DEPENDENCY) {
+                // Note: Since we are using a Ballerina-specific custom URI scheme, the future DAP client
+                // implementations may have to implement custom editor providers in order to support URIs coming
+                // from the debug server.
                 source.setPath(URI.create(BALA_URI_SCHEME_NAME + uri.getPath()).normalize().toString());
             } else {
                 source.setPath(uri.normalize().toString());

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/BallerinaStackFrame.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/BallerinaStackFrame.java
@@ -24,17 +24,19 @@ import com.sun.jdi.Value;
 import org.ballerinalang.debugadapter.jdi.JdiProxyException;
 import org.ballerinalang.debugadapter.jdi.LocalVariableProxyImpl;
 import org.ballerinalang.debugadapter.jdi.StackFrameProxyImpl;
+import org.ballerinalang.debugadapter.utils.PackageUtils;
 import org.ballerinalang.debugadapter.variable.BVariableType;
 import org.eclipse.lsp4j.debug.Source;
 import org.eclipse.lsp4j.debug.StackFrame;
 
+import java.net.URI;
 import java.nio.file.Path;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
 import static org.ballerinalang.debugadapter.JBallerinaDebugServer.isBalStackFrame;
 import static org.ballerinalang.debugadapter.evaluation.utils.EvaluationUtils.STRAND_VAR_NAME;
-import static org.ballerinalang.debugadapter.utils.PackageUtils.getSrcPathFromBreakpointLocation;
 import static org.ballerinalang.debugadapter.variable.VariableUtils.isService;
 import static org.ballerinalang.debugadapter.variable.VariableUtils.removeRedundantQuotes;
 import static org.wso2.ballerinalang.compiler.parser.BLangAnonymousModelHelper.LAMBDA;
@@ -60,6 +62,7 @@ public class BallerinaStackFrame {
     private static final String METHOD_INIT = "$init$";
     private static final String SELF_VAR_NAME = "self";
     private static final String WORKER_LAMBDA_REGEX = "(\\$lambda\\$)\\b(.*)\\b(\\$lambda)(.*)";
+    private static final String BALA_URI_SCHEME_NAME = "bala:";
 
     public BallerinaStackFrame(ExecutionContext context, Integer frameId, StackFrameProxyImpl stackFrameProxy) {
         this.context = context;
@@ -86,22 +89,31 @@ public class BallerinaStackFrame {
             if (!isBalStackFrame(jStackFrame.getStackFrame())) {
                 return null;
             }
-
             StackFrame dapStackFrame = new StackFrame();
             dapStackFrame.setId(frameId);
             dapStackFrame.setName(getStackFrameName(jStackFrame));
             dapStackFrame.setLine(jStackFrame.location().lineNumber());
             dapStackFrame.setColumn(0);
 
-            // Adds ballerina source information.
-            Optional<Path> sourcePath = getSrcPathFromBreakpointLocation(jStackFrame.location(),
-                    context.getSourceProject());
-            if (sourcePath.isPresent()) {
-                Source source = new Source();
-                source.setPath(sourcePath.get().toString());
-                source.setName(jStackFrame.location().sourceName());
-                dapStackFrame.setSource(source);
+            Optional<Map.Entry<Path, DebugSourceType>> sourcePathAndType =
+                    PackageUtils.getStackFrameSourcePath(jStackFrame.location(), context.getSourceProject());
+            if (sourcePathAndType.isEmpty()) {
+                return null;
             }
+            Path frameLocationPath = sourcePathAndType.get().getKey();
+            DebugSourceType sourceType = sourcePathAndType.get().getValue();
+            Source source = new Source();
+            source.setName(jStackFrame.location().sourceName());
+            URI uri = frameLocationPath.toUri();
+            // If the corresponding source file of the stack frame is a bala source, the source should be readonly in
+            // the editor side. Therefore adds a custom URI scheme to the file path, after verifying that the connected
+            // debug client support custom URI schemes.
+            if (sourceType == DebugSourceType.DEPENDENCY) {
+                source.setPath(URI.create(BALA_URI_SCHEME_NAME + uri.getPath()).normalize().toString());
+            } else {
+                source.setPath(uri.normalize().toString());
+            }
+            dapStackFrame.setSource(source);
             return dapStackFrame;
         } catch (Exception e) {
             return null;

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/BallerinaStackFrame.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/BallerinaStackFrame.java
@@ -106,12 +106,14 @@ public class BallerinaStackFrame {
             Source source = new Source();
             source.setName(jStackFrame.location().sourceName());
             URI uri = frameLocationPath.toUri();
+
             // If the corresponding source file of the stack frame is a bala source, the source should be readonly in
             // the editor side. Therefore adds a custom URI scheme to the file path, after verifying that the connected
             // debug client support custom URI schemes.
             Optional<ClientConfigHolder.ExtendedClientCapabilities> capabilities =
                     context.getAdapter().getClientConfigHolder().getExtendedCapabilities();
             boolean supportsReadOnlyEditors = capabilities.isPresent() && capabilities.get().supportsReadOnlyEditors();
+
             if (supportsReadOnlyEditors && sourceType == DebugSourceType.DEPENDENCY) {
                 source.setPath(URI.create(BALA_URI_SCHEME_NAME + uri.getPath()).normalize().toString());
             } else {

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/SuspendedContext.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/SuspendedContext.java
@@ -28,15 +28,16 @@ import org.ballerinalang.debugadapter.jdi.JdiProxyException;
 import org.ballerinalang.debugadapter.jdi.StackFrameProxyImpl;
 import org.ballerinalang.debugadapter.jdi.ThreadReferenceProxyImpl;
 import org.ballerinalang.debugadapter.jdi.VirtualMachineProxyImpl;
-import org.ballerinalang.debugadapter.utils.PackageUtils;
 
 import java.nio.file.Path;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.ballerinalang.debugadapter.DebugSourceType.DEPENDENCY;
 import static org.ballerinalang.debugadapter.DebugSourceType.PACKAGE;
 import static org.ballerinalang.debugadapter.DebugSourceType.SINGLE_FILE;
 import static org.ballerinalang.debugadapter.utils.PackageUtils.getFileNameFrom;
+import static org.ballerinalang.debugadapter.utils.PackageUtils.getStackFrameSourcePath;
 
 /**
  * Context holder for debug suspended state related information.
@@ -149,7 +150,11 @@ public class SuspendedContext {
 
     private Optional<Path> getSourcePath(StackFrameProxyImpl frame) {
         try {
-            return PackageUtils.getSrcPathFromBreakpointLocation(frame.location(), project);
+            Optional<Map.Entry<Path, DebugSourceType>> pathAndType = getStackFrameSourcePath(frame.location(), project);
+            if (pathAndType.isEmpty()) {
+                return Optional.empty();
+            }
+            return Optional.ofNullable(pathAndType.get().getKey());
         } catch (InvalidStackFrameException | JdiProxyException e) {
             // Todo - How to handle InvalidStackFrameException?
             return Optional.empty();

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/config/ClientConfigHolder.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/config/ClientConfigHolder.java
@@ -67,12 +67,12 @@ public class ClientConfigHolder {
         if (extendedClientCapabilities != null) {
             return Optional.of(extendedClientCapabilities);
         }
-        Object envObject = clientRequestArgs.get(ARG_CAPABILITIES);
-        if (!(envObject instanceof Map)) {
+        Object capabilitiesObj = clientRequestArgs.get(ARG_CAPABILITIES);
+        if (!(capabilitiesObj instanceof Map)) {
             return Optional.empty();
         }
 
-        Map<String, Object> capabilities = (Map<String, Object>) envObject;
+        Map<String, Object> capabilities = (Map<String, Object>) capabilitiesObj;
         extendedClientCapabilities = new ExtendedClientCapabilities();
         Object readOnlyEditorConfig = capabilities.get(ARG_SUPPORT_READONLY_EDITOR);
         if (readOnlyEditorConfig instanceof Boolean) {
@@ -104,6 +104,7 @@ public class ClientConfigHolder {
      * Inner class to hold the extended capabilities of the connected debug client.
      */
     public static class ExtendedClientCapabilities {
+
         private boolean supportsReadOnlyEditors = false;
 
         public boolean supportsReadOnlyEditors() {

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/config/ClientConfigHolder.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/config/ClientConfigHolder.java
@@ -17,6 +17,7 @@
 package org.ballerinalang.debugadapter.config;
 
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Ballerina DAP Client Configuration holder.
@@ -29,10 +30,13 @@ public class ClientConfigHolder {
     private final ClientConfigKind kind;
     private String sourcePath;
     private Integer debuggePort;
+    private ExtendedClientCapabilities extendedClientCapabilities;
 
     protected static final String ARG_FILE_PATH = "script";
     protected static final String ARG_DEBUGGEE_HOST = "debuggeeHost";
     protected static final String ARG_DEBUGGEE_PORT = "debuggeePort";
+    private static final String ARG_CAPABILITIES = "capabilities";
+    private static final String ARG_SUPPORT_READONLY_EDITOR = "supportsReadOnlyEditors";
 
     protected ClientConfigHolder(Map<String, Object> clientRequestArgs, ClientConfigKind kind) {
         this.clientRequestArgs = clientRequestArgs;
@@ -59,6 +63,29 @@ public class ClientConfigHolder {
         return debuggePort;
     }
 
+    public Optional<ExtendedClientCapabilities> getExtendedCapabilities() {
+        if (extendedClientCapabilities != null) {
+            return Optional.of(extendedClientCapabilities);
+        }
+        Object envObject = clientRequestArgs.get(ARG_CAPABILITIES);
+        if (!(envObject instanceof Map)) {
+            return Optional.empty();
+        }
+
+        Map<String, Object> capabilities = (Map<String, Object>) envObject;
+        extendedClientCapabilities = new ExtendedClientCapabilities();
+        Object readOnlyEditorConfig = capabilities.get(ARG_SUPPORT_READONLY_EDITOR);
+        if (readOnlyEditorConfig instanceof Boolean) {
+            extendedClientCapabilities.setSupportsReadOnlyEditors((Boolean) readOnlyEditorConfig);
+        } else if (readOnlyEditorConfig instanceof String) {
+            extendedClientCapabilities.setSupportsReadOnlyEditors(Boolean.parseBoolean((String) readOnlyEditorConfig));
+        } else {
+            extendedClientCapabilities.setSupportsReadOnlyEditors(false);
+        }
+
+        return Optional.ofNullable(extendedClientCapabilities);
+    }
+
     protected void failIfConfigMissing(String configName) throws ClientConfigurationException {
         if (clientRequestArgs.get(configName) == null) {
             throw new ClientConfigurationException("Required client configuration missing: '" + configName + "'");
@@ -71,5 +98,20 @@ public class ClientConfigHolder {
     public enum ClientConfigKind {
         ATTACH_CONFIG,
         LAUNCH_CONFIG
+    }
+
+    /**
+     * Inner class to hold the extended capabilities of the connected debug client.
+     */
+    public static class ExtendedClientCapabilities {
+        private boolean supportsReadOnlyEditors = false;
+
+        public boolean supportsReadOnlyEditors() {
+            return supportsReadOnlyEditors;
+        }
+
+        public void setSupportsReadOnlyEditors(boolean supportsReadOnlyEditors) {
+            this.supportsReadOnlyEditors = supportsReadOnlyEditors;
+        }
     }
 }

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/utils/DebugSourceLocation.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/utils/DebugSourceLocation.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ballerinalang.debugadapter.utils;
+
+import com.sun.jdi.Location;
+
+import static io.ballerina.runtime.api.utils.IdentifierUtils.decodeIdentifier;
+import static org.ballerinalang.debugadapter.utils.PackageUtils.getQModuleNameParts;
+
+/**
+ * Holds source information of a given JDI source location.
+ *
+ * @since 2.0.0
+ */
+public class DebugSourceLocation {
+
+    private final Location jdiLocation;
+    private boolean isValid;
+    private String orgName;
+    private String moduleName;
+    private String moduleVersion;
+    private String fileName;
+
+    DebugSourceLocation(Location frameLocation) {
+        this.jdiLocation = frameLocation;
+        resolveLocation();
+    }
+
+    public boolean isValid() {
+        return isValid;
+    }
+
+    public String orgName() {
+        return orgName;
+    }
+
+    public String moduleName() {
+        return moduleName;
+    }
+
+    public String moduleVersion() {
+        return moduleVersion;
+    }
+
+    public String fileName() {
+        return fileName;
+    }
+
+    private void resolveLocation() {
+        try {
+            String sourcePath = jdiLocation.sourcePath();
+            String[] moduleParts = getQModuleNameParts(sourcePath);
+
+            orgName = moduleParts[0];
+            moduleName = decodeIdentifier(moduleParts[1]);
+            moduleVersion = moduleParts[2];
+            fileName = moduleParts[3];
+
+            isValid = true;
+        } catch (Exception e) {
+            isValid = false;
+        }
+    }
+}

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/utils/PackageUtils.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/utils/PackageUtils.java
@@ -37,6 +37,8 @@ import org.ballerinalang.debugadapter.SuspendedContext;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -62,6 +64,8 @@ public class PackageUtils {
     public static final String INIT_TYPE_INSTANCE_PREFIX = "$type$";
     public static final String GENERATED_VAR_PREFIX = "$";
     static final String MODULE_DIR_NAME = "modules";
+    private static final String URI_SCHEME_FILE = "file";
+    private static final String URI_SCHEME_BALA = "bala";
 
     private static final String FILE_SEPARATOR_REGEX = File.separatorChar == '\\' ? "\\\\" : File.separator;
 
@@ -72,7 +76,7 @@ public class PackageUtils {
      * @param sourceProject      project instance of the detected debug source
      */
     public static Optional<Map.Entry<Path, DebugSourceType>> getStackFrameSourcePath(Location stackFrameLocation,
-                                                                           Project sourceProject) {
+                                                                                     Project sourceProject) {
         // Source resolving is processed according to the following order .
         // 1. Checks whether debug hit location resides within the current debug source project and if so, returns
         // the absolute path of the project file source.
@@ -296,6 +300,20 @@ public class PackageUtils {
             moduleParts = new String[]{path};
         }
         return moduleParts;
+    }
+
+    /**
+     * Converts a given file URI to a Ballerina-specific custom URI scheme.
+     *
+     * @param fileUri file URI
+     * @return bala URI
+     */
+    public static URI covertToBalaUri(URI fileUri) throws URISyntaxException, IllegalArgumentException {
+        if (fileUri.getScheme().equals(URI_SCHEME_FILE)) {
+            return new URI(URI_SCHEME_BALA, fileUri.getHost(), fileUri.getPath(), fileUri.getFragment());
+        }
+
+        throw new IllegalArgumentException("unsupported URI with scheme: " + fileUri.getScheme());
     }
 
     private static String replaceSeparators(String path) {

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/utils/ProjectSourceResolver.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/utils/ProjectSourceResolver.java
@@ -52,8 +52,8 @@ public class ProjectSourceResolver extends SourceResolver {
                 return document.name().equals(location.sourcePath()) && document.name().equals(location.sourceName());
             } else if (sourceProject.kind() == ProjectKind.BUILD_PROJECT) {
                 String projectOrg = getOrgName(sourceProject);
-                LocationInfo locationInfo = new LocationInfo(location);
-                return locationInfo.isValid() && locationInfo.orgName().equals(projectOrg);
+                DebugSourceLocation debugSourceLocation = new DebugSourceLocation(location);
+                return debugSourceLocation.isValid() && debugSourceLocation.orgName().equals(projectOrg);
             } else {
                 return false;
             }
@@ -78,13 +78,13 @@ public class ProjectSourceResolver extends SourceResolver {
                 String projectOrg = getOrgName(sourceProject);
                 String defaultModuleName = getDefaultModuleName(sourceProject);
                 String locationName = location.sourceName();
-                LocationInfo locationInfo = new LocationInfo(location);
+                DebugSourceLocation debugSourceLocation = new DebugSourceLocation(location);
 
-                if (!locationInfo.isValid() || !locationInfo.orgName().equals(projectOrg)) {
+                if (!debugSourceLocation.isValid() || !debugSourceLocation.orgName().equals(projectOrg)) {
                     return Optional.empty();
                 }
 
-                String modulePart = decodeIdentifier(locationInfo.moduleName());
+                String modulePart = decodeIdentifier(debugSourceLocation.moduleName());
                 modulePart = modulePart.replaceFirst(defaultModuleName, "");
                 if (modulePart.startsWith(".")) {
                     modulePart = modulePart.replaceFirst("\\.", "");

--- a/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/BallerinaTestDebugPoint.java
+++ b/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/BallerinaTestDebugPoint.java
@@ -17,13 +17,19 @@
  */
 package org.ballerinalang.debugger.test.utils;
 
+import org.ballerinalang.test.context.BallerinaTestException;
 import org.eclipse.lsp4j.debug.Source;
 import org.eclipse.lsp4j.debug.SourceBreakpoint;
 
-import java.io.File;
 import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+
+import static org.ballerinalang.debugger.test.utils.FileUtils.FILE_SEPARATOR;
+import static org.ballerinalang.debugger.test.utils.FileUtils.FILE_SEPARATOR_REGEX;
+import static org.ballerinalang.debugger.test.utils.FileUtils.URI_SCHEME_BALA;
+import static org.ballerinalang.debugger.test.utils.FileUtils.URI_SCHEME_FILE;
+import static org.ballerinalang.debugger.test.utils.FileUtils.URI_SEPARATOR;
 
 /**
  * Ballerina debug point (breakpoint/debug hit point) representation used for integration test scenarios.
@@ -58,12 +64,19 @@ public class BallerinaTestDebugPoint {
         return filePathUri;
     }
 
-    public Source getSource() {
+    public Source getSource() throws BallerinaTestException {
         Source source = new Source();
-        String fileSeparatorRegEx = File.separatorChar == '\\' ? "\\\\" : File.separator;
-        String[] paths = Paths.get(filePathUri).toAbsolutePath().toString().split(fileSeparatorRegEx);
-        source.setPath(Paths.get(filePathUri).toAbsolutePath().toString());
-        source.setName(paths[paths.length - 1]);
+        if (filePathUri.getScheme().equals(URI_SCHEME_FILE)) {
+            String[] paths = Paths.get(filePathUri).toAbsolutePath().toString().split(FILE_SEPARATOR_REGEX);
+            source.setName(paths[paths.length - 1]);
+            source.setPath(Paths.get(filePathUri).toAbsolutePath().toString());
+        } else if (filePathUri.getScheme().equals(URI_SCHEME_BALA)) {
+            String[] paths = filePathUri.getPath().split(URI_SEPARATOR);
+            source.setName(paths[paths.length - 1]);
+            source.setPath(String.join(FILE_SEPARATOR, paths));
+        } else {
+            throw new BallerinaTestException("unsupported URI scheme found: '" + filePathUri.getScheme() + "'");
+        }
         return source;
     }
 

--- a/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/BallerinaTestDebugPoint.java
+++ b/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/BallerinaTestDebugPoint.java
@@ -53,6 +53,10 @@ public class BallerinaTestDebugPoint {
         this.logMessage = logMessage;
     }
 
+    public URI getSourceURI() {
+        return filePathUri;
+    }
+
     public Source getSource() {
         Source source = new Source();
         String fileSeparatorRegEx = File.separatorChar == '\\' ? "\\\\" : File.separator;

--- a/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/BallerinaTestDebugPoint.java
+++ b/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/BallerinaTestDebugPoint.java
@@ -23,6 +23,7 @@ import org.eclipse.lsp4j.debug.SourceBreakpoint;
 import java.io.File;
 import java.net.URI;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 /**
  * Ballerina debug point (breakpoint/debug hit point) representation used for integration test scenarios.
@@ -60,8 +61,8 @@ public class BallerinaTestDebugPoint {
     public Source getSource() {
         Source source = new Source();
         String fileSeparatorRegEx = File.separatorChar == '\\' ? "\\\\" : File.separator;
-        String[] paths = filePathUri.getPath().split(fileSeparatorRegEx);
-        source.setPath(filePathUri.getPath());
+        String[] paths = Paths.get(filePathUri).toAbsolutePath().toString().split(fileSeparatorRegEx);
+        source.setPath(Paths.get(filePathUri).toAbsolutePath().toString());
         source.setName(paths[paths.length - 1]);
         return source;
     }

--- a/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/BallerinaTestDebugPoint.java
+++ b/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/BallerinaTestDebugPoint.java
@@ -32,12 +32,14 @@ public class BallerinaTestDebugPoint {
     private final String condition;
     private final String logMessage;
 
+    private static final String FILE_URI_SCHEME = "file://";
+
     public BallerinaTestDebugPoint(String filePath, int line) {
         this(filePath, line, null, null);
     }
 
     public BallerinaTestDebugPoint(String filePath, int line, String condition, String logMessage) {
-        this.filePath = filePath;
+        this.filePath = getPathWithoutURIScheme(filePath);
         this.line = line;
         this.condition = condition;
         this.logMessage = logMessage;
@@ -81,5 +83,15 @@ public class BallerinaTestDebugPoint {
     @Override
     public String toString() {
         return "Ballerina test breakpoint at line: " + line + " in " + filePath;
+    }
+
+    /**
+     * Since the debug server may return URIs of the source files, URI schemes should be ignored when asserting debug
+     * point locations.
+     *
+     * @param filePath file path with possible URI schemes
+     */
+    private String getPathWithoutURIScheme(String filePath) {
+        return filePath.startsWith(FILE_URI_SCHEME) ? filePath.replaceFirst(FILE_URI_SCHEME, "") : filePath;
     }
 }

--- a/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/DebugHitListener.java
+++ b/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/DebugHitListener.java
@@ -30,8 +30,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.URI;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.TimerTask;
 import java.util.concurrent.ConcurrentLinkedQueue;

--- a/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/DebugHitListener.java
+++ b/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/DebugHitListener.java
@@ -29,6 +29,9 @@ import org.eclipse.lsp4j.debug.ThreadsResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.TimerTask;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -109,7 +112,8 @@ public class DebugHitListener extends TimerTask {
             if (stackFrames.length == 0) {
                 return null;
             }
-            return new BallerinaTestDebugPoint(stackFrames[0].getSource().getPath(), stackFrames[0].getLine());
+            URI stackFrameLocation = URI.create(stackFrames[0].getSource().getPath());
+            return new BallerinaTestDebugPoint(stackFrameLocation, stackFrames[0].getLine());
         } catch (Exception e) {
             LOGGER.warn("Error occurred when fetching stack frames", e);
             throw new BallerinaTestException("Error occurred when fetching stack frames.", e);

--- a/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/DebugTestRunner.java
+++ b/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/DebugTestRunner.java
@@ -60,7 +60,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Timer;
-import java.util.stream.Collectors;
 
 import static org.ballerinalang.debugger.test.utils.DebugUtils.findFreePort;
 
@@ -260,8 +259,12 @@ public class DebugTestRunner {
      */
     public void addBreakPoint(BallerinaTestDebugPoint breakpoint) throws BallerinaTestException {
         testBreakpoints.add(breakpoint);
-        List<BallerinaTestDebugPoint> breakpointsToBeSent = testBreakpoints.stream().filter(bp ->
-            bp.getSource().getPath().equals(breakpoint.getSource().getPath())).collect(Collectors.toList());
+        List<BallerinaTestDebugPoint> breakpointsToBeSent = new ArrayList<>();
+        for (org.ballerinalang.debugger.test.utils.BallerinaTestDebugPoint bp : testBreakpoints) {
+            if (bp.getSource().getPath().equals(breakpoint.getSource().getPath())) {
+                breakpointsToBeSent.add(bp);
+            }
+        }
 
         if (debugClientConnector != null && debugClientConnector.isConnected()) {
             setBreakpoints(breakpointsToBeSent);
@@ -301,8 +304,12 @@ public class DebugTestRunner {
      */
     public void removeBreakPoint(BallerinaTestDebugPoint breakpoint) throws BallerinaTestException {
         testBreakpoints.remove(breakpoint);
-        List<BallerinaTestDebugPoint> breakpointsToBeSent = testBreakpoints.stream().filter(bp ->
-            bp.getSource().getPath().equals(breakpoint.getSource().getPath())).collect(Collectors.toList());
+        List<BallerinaTestDebugPoint> breakpointsToBeSent = new ArrayList<>();
+        for (org.ballerinalang.debugger.test.utils.BallerinaTestDebugPoint bp : testBreakpoints) {
+            if (bp.getSource().getPath().equals(breakpoint.getSource().getPath())) {
+                breakpointsToBeSent.add(bp);
+            }
+        }
 
         if (debugClientConnector != null && debugClientConnector.isConnected()) {
             setBreakpoints(breakpointsToBeSent);

--- a/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/DebugTestRunner.java
+++ b/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/DebugTestRunner.java
@@ -51,11 +51,9 @@ import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.asserts.SoftAssert;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -72,8 +70,8 @@ import static org.ballerinalang.debugger.test.utils.DebugUtils.findFreePort;
 public class DebugTestRunner {
 
     public List<BallerinaTestDebugPoint> testBreakpoints = new ArrayList<>();
-    public String testProjectPath;
-    public String testEntryFilePath;
+    public Path testProjectPath;
+    public Path testEntryFilePath;
 
     private static Path testProjectBaseDir;
     private static Path testSingleFileBaseDir;
@@ -91,11 +89,11 @@ public class DebugTestRunner {
 
     public DebugTestRunner(String testProjectName, String testModuleFileName, boolean isProjectBasedTest) {
         if (isProjectBasedTest) {
-            testProjectPath = testProjectBaseDir.toString() + File.separator + testProjectName;
-            testEntryFilePath = Paths.get(testProjectPath, testModuleFileName).toString();
+            testProjectPath = testProjectBaseDir.resolve(testProjectName);
+            testEntryFilePath = testProjectPath.resolve(testModuleFileName);
         } else {
-            testProjectPath = Paths.get(testProjectBaseDir.toString(), testProjectName).toString();
-            testEntryFilePath = Paths.get(testSingleFileBaseDir.toString(), testModuleFileName).toString();
+            testProjectPath = testProjectBaseDir.resolve(testProjectName);
+            testEntryFilePath = testSingleFileBaseDir.resolve(testModuleFileName);
         }
 
         // Hard assertions will be used by default.
@@ -139,7 +137,11 @@ public class DebugTestRunner {
      * @throws BallerinaTestException if any exception is occurred during initialization.
      */
     public void initDebugSession(DebugUtils.DebuggeeExecutionKind executionKind) throws BallerinaTestException {
-        initDebugSession(executionKind, new HashMap<>());
+        HashMap<String, Object> launchConfigs = new HashMap<>();
+        HashMap<String, Object> extendedCapabilities = new HashMap<>();
+        extendedCapabilities.put("supportsReadOnlyEditors", true);
+        launchConfigs.put("capabilities", extendedCapabilities);
+        initDebugSession(executionKind, launchConfigs);
     }
 
     /**

--- a/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/FileUtils.java
+++ b/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/FileUtils.java
@@ -17,6 +17,7 @@
  */
 package org.ballerinalang.debugger.test.utils;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -27,6 +28,12 @@ import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
  * Util class for file operations.
  */
 public class FileUtils {
+
+    static final String URI_SCHEME_BALA = "bala";
+    static final String URI_SCHEME_FILE = "file";
+    static final String URI_SEPARATOR = "/";
+    static final String FILE_SEPARATOR = File.separator;
+    static final String FILE_SEPARATOR_REGEX = File.separatorChar == '\\' ? "\\\\" : File.separator;
 
     /**
      * Recursively copy a directory from a source to destination.

--- a/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/client/TestDAPClientConnector.java
+++ b/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/client/TestDAPClientConnector.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -52,8 +53,8 @@ public class TestDAPClientConnector {
     private static final Logger LOGGER = LoggerFactory.getLogger(TestDAPClientConnector.class);
 
     private final String balHome;
-    private final String projectPath;
-    private final String entryFilePath;
+    private final Path projectPath;
+    private final Path entryFilePath;
     private final String host;
     private final int port;
     private DAPClient debugClient;
@@ -72,15 +73,11 @@ public class TestDAPClientConnector {
     private static final String CONFIG_BAL_HOME = "ballerina.home";
     private static final String CONFIG_IS_TEST_CMD = "debugTests";
 
-    public TestDAPClientConnector(String balHome, String projectPath,
-                                  String entryFilePath,
-                                  int port) {
+    public TestDAPClientConnector(String balHome, Path projectPath, Path entryFilePath, int port) {
         this(balHome, projectPath, entryFilePath, "localhost", port);
     }
 
-    public TestDAPClientConnector(String balHome, String projectPath,
-                                  String entryFilePath, String host,
-                                  int port) {
+    public TestDAPClientConnector(String balHome, Path projectPath, Path entryFilePath, String host, int port) {
         this.balHome = balHome;
         this.projectPath = projectPath;
         this.entryFilePath = entryFilePath;
@@ -95,7 +92,7 @@ public class TestDAPClientConnector {
         return requestManager;
     }
 
-    public String getProjectPath() {
+    public Path getProjectPath() {
         return projectPath;
     }
 
@@ -154,7 +151,7 @@ public class TestDAPClientConnector {
     public void attachToServer() throws BallerinaTestException {
         try {
             Map<String, Object> requestArgs = new HashMap<>();
-            requestArgs.put(CONFIG_SOURCE, entryFilePath);
+            requestArgs.put(CONFIG_SOURCE, entryFilePath.toString());
             requestArgs.put(CONFIG_DEBUGEE_HOST, host);
             requestArgs.put(CONFIG_DEBUGEE_PORT, Integer.toString(port));
             requestManager.attach(requestArgs);
@@ -168,7 +165,7 @@ public class TestDAPClientConnector {
             throws BallerinaTestException {
         try {
             Map<String, Object> requestArgs = new HashMap<>(args);
-            requestArgs.put(CONFIG_SOURCE, entryFilePath);
+            requestArgs.put(CONFIG_SOURCE, entryFilePath.toString());
             requestArgs.put(CONFIG_DEBUGEE_HOST, host);
             requestArgs.put(CONFIG_DEBUGEE_PORT, Integer.toString(port));
             requestArgs.put(CONFIG_BAL_HOME, balHome);
@@ -183,14 +180,10 @@ public class TestDAPClientConnector {
     }
 
     public void disconnectFromServer() throws Exception {
-        try {
-            DisconnectArguments disconnectArgs = new DisconnectArguments();
-            disconnectArgs.setTerminateDebuggee(true);
-            requestManager.disconnect(disconnectArgs);
-            stop();
-        } catch (Exception e) {
-            throw e;
-        }
+        DisconnectArguments disconnectArgs = new DisconnectArguments();
+        disconnectArgs.setTerminateDebuggee(true);
+        requestManager.disconnect(disconnectArgs);
+        stop();
     }
 
     public boolean isConnected() {
@@ -232,7 +225,7 @@ public class TestDAPClientConnector {
 
         processArgs.add(DebugUtils.JBAL_DEBUG_CMD_NAME);
         processArgs.add(Integer.toString(debugAdapterPort));
-        return new TestSocketStreamConnectionProvider(processArgs, projectPath, host, debugAdapterPort);
+        return new TestSocketStreamConnectionProvider(processArgs, projectPath.toString(), host, debugAdapterPort);
     }
 
     private enum ConnectionState {

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/ConditionalBreakpointTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/ConditionalBreakpointTest.java
@@ -30,6 +30,8 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.nio.file.Path;
+
 /**
  * Test class for conditional breakpoint related debug scenarios.
  */
@@ -46,7 +48,7 @@ public class ConditionalBreakpointTest extends BaseTestCase {
 
     @Test
     public void testConditionalBreakpointScenarios() throws BallerinaTestException {
-        String filePath = debugTestRunner.testEntryFilePath;
+        Path filePath = debugTestRunner.testEntryFilePath;
         debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(filePath, 29));
         debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(filePath, 34, "y == 3", null));
         debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(filePath, 44, "capital == \"London\"", null));

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/DebugInstructionTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/DebugInstructionTest.java
@@ -127,21 +127,6 @@ public class DebugInstructionTest extends BaseTestCase {
         Assert.assertEquals(debugHitInfo.getLeft(), new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 35));
     }
 
-    @Test(description = "STEP_IN instruction related debug test")
-    public void stepInInstructionTest() throws BallerinaTestException {
-        // Todo
-    }
-
-    @Test(description = "STEP_OUT instruction related debug test")
-    public void stepOutInstructionTest() throws BallerinaTestException {
-        // Todo
-    }
-
-    @Test(description = "CONTINUE/NEXT_BREAKPOINT instruction related debug test")
-    public void continueInstructionTest() throws BallerinaTestException {
-        // Todo
-    }
-
     @AfterMethod(alwaysRun = true)
     public void cleanUp() {
         debugTestRunner.terminateDebugSession();

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/DebugOutputTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/DebugOutputTest.java
@@ -32,6 +32,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.nio.file.Path;
 import java.util.List;
 
 /**
@@ -50,7 +51,7 @@ public class DebugOutputTest extends BaseTestCase {
 
     @Test(description = "Debug output test for Ballerina programs with runtime errors")
     public void testProgramOutput() throws BallerinaTestException {
-        String filePath = debugTestRunner.testEntryFilePath;
+        Path filePath = debugTestRunner.testEntryFilePath;
         debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(filePath, 19));
         debugTestRunner.initDebugSession(DebugUtils.DebuggeeExecutionKind.RUN);
 

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/LangLibDebugTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/LangLibDebugTest.java
@@ -19,6 +19,7 @@
 package org.ballerinalang.debugger.test.adapter;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.ballerinalang.debugger.test.BaseTestCase;
 import org.ballerinalang.debugger.test.utils.BallerinaTestDebugPoint;
 import org.ballerinalang.debugger.test.utils.DebugTestRunner;
 import org.ballerinalang.debugger.test.utils.DebugUtils;
@@ -34,10 +35,10 @@ import org.testng.annotations.Test;
  *
  * @since 2.0.0
  */
-public class LangLibDebugTest {
+public class LangLibDebugTest extends BaseTestCase {
 
     private DebugTestRunner debugTestRunner;
-    private static final String BALA_URI_SCHEME = "bala:";
+    private static final String BALA_URI_SCHEME = "bala";
 
     @BeforeClass
     public void setup() {
@@ -57,7 +58,7 @@ public class LangLibDebugTest {
         // Steps into `int` language library.
         debugTestRunner.resumeProgram(debugHitInfo.getRight(), DebugTestRunner.DebugResumeKind.STEP_IN);
         debugHitInfo = debugTestRunner.waitForDebugHit(10000);
-        Assert.assertTrue(debugHitInfo.getLeft().getSource().getPath().startsWith(BALA_URI_SCHEME));
+        Assert.assertEquals(debugHitInfo.getLeft().getSourceURI().getScheme(), BALA_URI_SCHEME);
         Assert.assertTrue(debugHitInfo.getLeft().getSource().getPath().replaceAll("\\\\", "/")
                 .endsWith("ballerina/lang.int/1.1.0/any/modules/lang.int/int.bal"));
 
@@ -69,7 +70,7 @@ public class LangLibDebugTest {
         // Steps into `float` language library.
         debugTestRunner.resumeProgram(debugHitInfo.getRight(), DebugTestRunner.DebugResumeKind.STEP_IN);
         debugHitInfo = debugTestRunner.waitForDebugHit(10000);
-        Assert.assertTrue(debugHitInfo.getLeft().getSource().getPath().startsWith(BALA_URI_SCHEME));
+        Assert.assertEquals(debugHitInfo.getLeft().getSourceURI().getScheme(), BALA_URI_SCHEME);
         Assert.assertTrue(debugHitInfo.getLeft().getSource().getPath().replaceAll("\\\\", "/")
                 .endsWith("ballerina/lang.float/1.0.0/any/modules/lang.float/float.bal"));
     }

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/LangLibDebugTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/LangLibDebugTest.java
@@ -37,6 +37,7 @@ import org.testng.annotations.Test;
 public class LangLibDebugTest {
 
     private DebugTestRunner debugTestRunner;
+    private static final String BALA_URI_SCHEME = "bala:";
 
     @BeforeClass
     public void setup() {
@@ -56,6 +57,7 @@ public class LangLibDebugTest {
         // Steps into `int` language library.
         debugTestRunner.resumeProgram(debugHitInfo.getRight(), DebugTestRunner.DebugResumeKind.STEP_IN);
         debugHitInfo = debugTestRunner.waitForDebugHit(10000);
+        Assert.assertTrue(debugHitInfo.getLeft().getSource().getPath().startsWith(BALA_URI_SCHEME));
         Assert.assertTrue(debugHitInfo.getLeft().getSource().getPath().replaceAll("\\\\", "/")
                 .endsWith("ballerina/lang.int/1.1.0/any/modules/lang.int/int.bal"));
 
@@ -67,6 +69,7 @@ public class LangLibDebugTest {
         // Steps into `float` language library.
         debugTestRunner.resumeProgram(debugHitInfo.getRight(), DebugTestRunner.DebugResumeKind.STEP_IN);
         debugHitInfo = debugTestRunner.waitForDebugHit(10000);
+        Assert.assertTrue(debugHitInfo.getLeft().getSource().getPath().startsWith(BALA_URI_SCHEME));
         Assert.assertTrue(debugHitInfo.getLeft().getSource().getPath().replaceAll("\\\\", "/")
                 .endsWith("ballerina/lang.float/1.0.0/any/modules/lang.float/float.bal"));
     }

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/LogPointTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/LogPointTest.java
@@ -32,6 +32,8 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.nio.file.Path;
+
 /**
  * Test class for log points related debug scenarios.
  */
@@ -48,7 +50,7 @@ public class LogPointTest extends BaseTestCase {
 
     @Test
     public void testConditionalBreakpointScenarios() throws BallerinaTestException {
-        String filePath = debugTestRunner.testEntryFilePath;
+        Path filePath = debugTestRunner.testEntryFilePath;
         debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(filePath, 29));
         debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(filePath, 34, "y == 3", "LogPoint: 1"));
         debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(filePath, 44, "capital == \"London\"", null));

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/build/MultiModuleBuildDebugTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/build/MultiModuleBuildDebugTest.java
@@ -52,7 +52,7 @@ public class MultiModuleBuildDebugTest extends BaseTestCase {
     @Test
     public void testMultiModuleBuildDebugScenarios() throws BallerinaTestException {
         int port = findFreePort();
-        debugTestRunner.runDebuggeeProgram(debugTestRunner.testProjectPath, port);
+        debugTestRunner.runDebuggeeProgram(debugTestRunner.testProjectPath.toString(), port);
         debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 22));
         debugTestRunner.initDebugSession(DebugUtils.DebuggeeExecutionKind.BUILD, port);
 

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/run/DebugEngageTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/run/DebugEngageTest.java
@@ -30,7 +30,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import java.nio.file.Paths;
+import java.nio.file.Path;
 
 /**
  * Test class for debugger engaging in debug launch mode.
@@ -51,7 +51,7 @@ public class DebugEngageTest extends BaseTestCase {
     @Test(description = "Debug engage test for launch mode, with special ballerina project files as input(i.e. " +
             "Ballerina.toml, Dependencies.toml, etc.)")
     public void testNonBallerinaInputSource() throws BallerinaTestException {
-        String breakpointFilePath = Paths.get(debugTestRunner.testProjectPath, "main.bal").toString();
+        Path breakpointFilePath = debugTestRunner.testProjectPath.resolve("main.bal");
         debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(breakpointFilePath, 22));
         debugTestRunner.initDebugSession(DebugUtils.DebuggeeExecutionKind.RUN);
 

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/run/MultiModuleRunDebugTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/run/MultiModuleRunDebugTest.java
@@ -30,7 +30,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import java.nio.file.Paths;
+import java.nio.file.Path;
 
 import static org.ballerinalang.debugger.test.utils.DebugTestRunner.DebugResumeKind;
 
@@ -50,8 +50,8 @@ public class MultiModuleRunDebugTest extends BaseTestCase {
 
     @Test
     public void testMultiModuleDebugScenarios() throws BallerinaTestException {
-        String filePath1 = Paths.get(debugTestRunner.testProjectPath, "utils.bal").toString();
-        String filePath2 = Paths.get(debugTestRunner.testProjectPath, "modules", "math", "add.bal").toString();
+        Path filePath1 = debugTestRunner.testProjectPath.resolve("utils.bal");
+        Path filePath2 = debugTestRunner.testProjectPath.resolve("modules").resolve("math").resolve("add.bal");
 
         debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 22));
         debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 28));

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/remote/BallerinaBuildRemoteDebugTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/remote/BallerinaBuildRemoteDebugTest.java
@@ -49,8 +49,8 @@ public class BallerinaBuildRemoteDebugTest extends BaseTestCase {
         int port = findFreePort();
         String msg = "Listening for transport dt_socket at address: " + port;
         LogLeecher clientLeecher = new LogLeecher(msg);
-        balClient.debugMain("build", new String[]{"--debug", String.valueOf(port)}, null,
-                new String[]{}, new LogLeecher[]{clientLeecher}, debugTestRunner.testProjectPath, 20);
+        balClient.debugMain("build", new String[]{"--debug", String.valueOf(port)}, null, null,
+                new LogLeecher[]{clientLeecher}, debugTestRunner.testProjectPath.toString(), 20);
         clientLeecher.waitForText(20000);
     }
 
@@ -59,8 +59,8 @@ public class BallerinaBuildRemoteDebugTest extends BaseTestCase {
         int port = findFreePort();
         String msg = "Listening for transport dt_socket at address: " + port;
         LogLeecher clientLeecher = new LogLeecher(msg);
-        balClient.debugMain("build", new String[]{"--debug", String.valueOf(port)}, null,
-                new String[]{}, new LogLeecher[]{clientLeecher}, debugTestRunner.testProjectPath, 20);
+        balClient.debugMain("build", new String[]{"--debug", String.valueOf(port)}, null, null,
+                new LogLeecher[]{clientLeecher}, debugTestRunner.testProjectPath.toString(), 20);
         clientLeecher.waitForText(20000);
     }
 
@@ -77,8 +77,8 @@ public class BallerinaBuildRemoteDebugTest extends BaseTestCase {
         String msg = "Listening for transport dt_socket at address: " + port;
         LogLeecher clientLeecher = new LogLeecher(msg);
         try {
-            balClient.debugMain("build", new String[]{"--debug", String.valueOf(port), "--skip-tests"},
-                    null, new String[]{}, new LogLeecher[]{clientLeecher}, debugTestRunner.testProjectPath, 20);
+            balClient.debugMain("build", new String[]{"--debug", String.valueOf(port), "--skip-tests"}, null, null,
+                    new LogLeecher[]{clientLeecher}, debugTestRunner.testProjectPath.toString(), 20);
             clientLeecher.waitForText(20000);
             throw new BallerinaTestException("Ballerina tests running is suspended even when the test skip flag is " +
                     "used.");

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/remote/BallerinaRunRemoteDebugTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/remote/BallerinaRunRemoteDebugTest.java
@@ -56,8 +56,8 @@ public class BallerinaRunRemoteDebugTest extends BaseTestCase {
         int port = findFreePort();
         String msg = REMOTE_DEBUG_LISTENING + port;
         LogLeecher clientLeecher = new LogLeecher(msg);
-        balClient.debugMain("run", new String[]{"--debug", String.valueOf(port)}, null,
-                new String[]{}, new LogLeecher[]{clientLeecher}, debugTestRunner.testProjectPath, 10);
+        balClient.debugMain("run", new String[]{"--debug", String.valueOf(port)}, null, null,
+                new LogLeecher[]{clientLeecher}, debugTestRunner.testProjectPath.toString(), 10);
         clientLeecher.waitForText(20000);
     }
 
@@ -66,9 +66,9 @@ public class BallerinaRunRemoteDebugTest extends BaseTestCase {
         int port = findFreePort();
         String msg = REMOTE_DEBUG_LISTENING + port;
         LogLeecher clientLeecher = new LogLeecher(msg);
-        balClient.debugMain("run", new String[]{"--debug", String.valueOf(port),
-                        debugTestRunner.testEntryFilePath}, null, new String[]{}, new LogLeecher[]{clientLeecher},
-                debugTestRunner.testProjectPath, 10);
+        balClient.debugMain("run", new String[]{"--debug", String.valueOf(port), debugTestRunner.testEntryFilePath
+                        .toString()}, null, null, new LogLeecher[]{clientLeecher},
+                debugTestRunner.testProjectPath.toString(), 10);
         clientLeecher.waitForText(20000);
     }
 
@@ -88,8 +88,8 @@ public class BallerinaRunRemoteDebugTest extends BaseTestCase {
         String executablePath = Paths.get("target", "bin", testProjectName.replaceAll("-", "_") + ".jar")
                 .toFile().getPath();
         LogLeecher clientLeecher = new LogLeecher(executablePath);
-        balClient.runMain("build", new String[]{}, null, new String[]{},
-                new LogLeecher[]{clientLeecher}, debugTestRunner.testProjectPath);
+        balClient.runMain("build", new String[0], null, null, new LogLeecher[]{clientLeecher},
+                debugTestRunner.testProjectPath.toString());
         clientLeecher.waitForText(20000);
 
         String port = debugOptions[0].contains("=") ? debugOptions[0].split("=")[1] : debugOptions[1];
@@ -97,8 +97,8 @@ public class BallerinaRunRemoteDebugTest extends BaseTestCase {
         clientLeecher = new LogLeecher(msg);
         List<String> debugOptionsList = new ArrayList<>(Arrays.asList(debugOptions));
         debugOptionsList.add(executablePath);
-        balClient.debugMain("run", debugOptionsList.toArray(new String[0]), null,
-                new String[]{}, new LogLeecher[]{clientLeecher}, debugTestRunner.testProjectPath, 10);
+        balClient.debugMain("run", debugOptionsList.toArray(new String[0]), null, null, new LogLeecher[]{clientLeecher},
+                debugTestRunner.testProjectPath.toString(), 10);
         clientLeecher.waitForText(20000);
     }
 

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/remote/BallerinaTestRemoteDebugTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/remote/BallerinaTestRemoteDebugTest.java
@@ -49,8 +49,8 @@ public class BallerinaTestRemoteDebugTest extends BaseTestCase {
         int port = findFreePort();
         String msg = "Listening for transport dt_socket at address: " + port;
         LogLeecher clientLeecher = new LogLeecher(msg);
-        balClient.debugMain("test", new String[]{"--debug", String.valueOf(port)}, null,
-                new String[]{}, new LogLeecher[]{clientLeecher}, debugTestRunner.testProjectPath, 10);
+        balClient.debugMain("test", new String[]{"--debug", String.valueOf(port)}, null, null,
+                new LogLeecher[]{clientLeecher}, debugTestRunner.testProjectPath.toString(), 10);
         clientLeecher.waitForText(20000);
     }
 


### PR DESCRIPTION
## Purpose
- This PR enables the read-only editor view when debugging bala sources in VSCode. With this improvement, all the Ballerina lang library, standard library, central module sources will be opened in a read-only view when trying to stepping into dependency modules while debugging. 
- This PR also updates the debugger integration test suite for added changes.
- Partially fixes https://github.com/ballerina-platform/ballerina-lang/issues/32772

## Related PRs
https://github.com/wso2-enterprise/ballerina-plugin-vscode/pull/83

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [x] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [x] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
