### PR TITLE
Fix issues related to Central API calls

### DIFF
--- a/cli/central-client/src/main/java/org/ballerinalang/central/client/model/PackageResolutionRequest.java
+++ b/cli/central-client/src/main/java/org/ballerinalang/central/client/model/PackageResolutionRequest.java
@@ -27,6 +27,8 @@ import com.google.gson.stream.JsonWriter;
 
 
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -129,7 +131,8 @@ public class PackageResolutionRequest {
     }
 
     public void addPackage(String orgName, String name, String version, Mode mode) {
-        packages.add(new Package(orgName, name, version, mode));
+        // The version is encoded to avoid issue handling the dash in pre-release version tag
+        packages.add(new Package(orgName, name, URLEncoder.encode(version, StandardCharsets.UTF_8), mode));
     }
 
     static class EmptyStringTypeAdapter

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/RemotePackageRepository.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/RemotePackageRepository.java
@@ -214,7 +214,8 @@ public class RemotePackageRepository implements PackageRepository {
                             && m.getOrganization().equals(packageOrg.value())).findFirst();
             if (resolvedModule.isPresent()) {
                 PackageDescriptor packageDescriptor = PackageDescriptor.from(packageOrg,
-                        PackageName.from(resolvedModule.get().getPackageName()));
+                        PackageName.from(resolvedModule.get().getPackageName()),
+                        PackageVersion.from(resolvedModule.get().getVersion()));
                 ImportModuleResponse importModuleResponse = new ImportModuleResponse(packageDescriptor,
                         module.importModuleRequest());
                 result.add(importModuleResponse);


### PR DESCRIPTION
## Purpose
This PR Fixes the following issues identified during https://github.com/ballerina-platform/ballerina-lang/issues/32770.

- When the Dependencies.toml has a locked package and there is an update to the package adding another module. If the code is modified to import new module, it should pull latest package even if sticky true. 
Fixed by adding package version to package descriptor.

- Central API call to `getPackageVersions` failed for pre-release versions due to the hyphen in pre-release tag. It's fixed by encoding the package version.


## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
