### PR TITLE
Add getConstituentTypes API for Intersection type

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/types/IntersectionType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/types/IntersectionType.java
@@ -17,6 +17,8 @@
  */
 package io.ballerina.runtime.api.types;
 
+import java.util.List;
+
 /**
  * {@code BIntersectionType} represents an intersection type in Ballerina.
  *
@@ -25,4 +27,6 @@ package io.ballerina.runtime.api.types;
 public interface IntersectionType extends SelectivelyImmutableReferenceType {
 
     Type getEffectiveType();
+
+    List<Type> getConstituentTypes();
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/configurable/providers/toml/ConfigValueCreator.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/configurable/providers/toml/ConfigValueCreator.java
@@ -198,7 +198,7 @@ public class ConfigValueCreator {
             recordName = type.getName();
             recordType = (RecordType) type;
         } else {
-            recordType = (RecordType) ((BIntersectionType) type).getConstituentTypes().get(0);
+            recordType = (RecordType) ((BIntersectionType) type).constituentTypes.get(0);
             recordName = recordType.getName();
         }
         TomlTableNode tomlValue = (TomlTableNode) tomlNode;
@@ -226,7 +226,7 @@ public class ConfigValueCreator {
                 constraintType = ((IntersectionType) constraintType).getEffectiveType();
             }
             if (constraintType.getTag() == TypeTags.RECORD_TYPE_TAG) {
-                tableType = (TableType) ((BIntersectionType) type).getConstituentTypes().get(0);
+                tableType = (TableType) ((BIntersectionType) type).constituentTypes.get(0);
             }
         } else {
             tableType = (TableType) type;

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/configurable/providers/toml/TomlProvider.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/configurable/providers/toml/TomlProvider.java
@@ -703,7 +703,7 @@ public class TomlProvider implements ConfigProvider {
         if (type.getTag() == TypeTags.RECORD_TYPE_TAG) {
             recordType = (RecordType) type;
         } else {
-            recordType = (RecordType) ((BIntersectionType) type).getConstituentTypes().get(0);
+            recordType = (RecordType) ((BIntersectionType) type).constituentTypes.get(0);
         }
         if (tomlNode.kind() != getEffectiveTomlType(recordType, variableName)) {
             invalidTomlLines.add(tomlNode.location().lineRange());

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BIntersectionType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BIntersectionType.java
@@ -41,10 +41,10 @@ public class BIntersectionType extends BType implements IntersectionType {
     private static final String OPENING_PARENTHESIS = "(";
     private static final String CLOSING_PARENTHESIS = ")";
 
-    private List<Type> constituentTypes;
+    private final List<Type> constituentTypes;
     private Type effectiveType;
 
-    private int typeFlags;
+    private final int typeFlags;
     private final boolean readonly;
     private IntersectionType immutableType;
     private IntersectionType intersectionType = null;
@@ -75,6 +75,7 @@ public class BIntersectionType extends BType implements IntersectionType {
         }
     }
 
+    @Override
     public List<Type> getConstituentTypes() {
         return constituentTypes;
     }
@@ -152,6 +153,7 @@ public class BIntersectionType extends BType implements IntersectionType {
         return Objects.hash(super.hashCode(), constituentTypes);
     }
 
+    @Override
     public boolean isNilable() {
         return TypeFlags.isFlagOn(this.typeFlags, TypeFlags.NILABLE);
     }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BIntersectionType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BIntersectionType.java
@@ -24,6 +24,7 @@ import io.ballerina.runtime.api.types.IntersectableReferenceType;
 import io.ballerina.runtime.api.types.IntersectionType;
 import io.ballerina.runtime.api.types.Type;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -41,7 +42,7 @@ public class BIntersectionType extends BType implements IntersectionType {
     private static final String OPENING_PARENTHESIS = "(";
     private static final String CLOSING_PARENTHESIS = ")";
 
-    private final List<Type> constituentTypes;
+    public final List<Type> constituentTypes;
     private Type effectiveType;
 
     private final int typeFlags;
@@ -77,7 +78,7 @@ public class BIntersectionType extends BType implements IntersectionType {
 
     @Override
     public List<Type> getConstituentTypes() {
-        return constituentTypes;
+        return new ArrayList<>(constituentTypes);
     }
 
 

--- a/bvm/ballerina-runtime/src/test/java/io/ballerina/runtime/test/api/IntersectionTypeApiTests.java
+++ b/bvm/ballerina-runtime/src/test/java/io/ballerina/runtime/test/api/IntersectionTypeApiTests.java
@@ -23,11 +23,14 @@ import io.ballerina.runtime.api.PredefinedTypes;
 import io.ballerina.runtime.api.TypeTags;
 import io.ballerina.runtime.api.creators.TypeCreator;
 import io.ballerina.runtime.api.types.ArrayType;
+import io.ballerina.runtime.api.types.IntersectionType;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.internal.types.BIntersectionType;
 import io.ballerina.runtime.internal.types.BType;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import java.util.List;
 
 /**
  * Test cases for runtime APIs related to intersection type.
@@ -53,6 +56,7 @@ public class IntersectionTypeApiTests {
                 new BIntersectionType(module, new BType[]{}, arrayType, 0, true);
         Assert.assertEquals(bIntersectionType1.getTag(), TypeTags.INTERSECTION_TAG);
         Assert.assertEquals(bIntersectionType1.getEffectiveType(), arrayType);
+        Assert.assertTrue(arrayType.getIntersectionType().isPresent());
         Assert.assertEquals(arrayType.getIntersectionType().get(), bIntersectionType1);
     }
 
@@ -71,5 +75,17 @@ public class IntersectionTypeApiTests {
         Assert.assertEquals(arrayType.getIntersectionType().get(), bIntersectionType1);
         Assert.assertEquals(bIntersectionType1.getIntersectionType().get(), bIntersectionType2);
         Assert.assertNotEquals(arrayType.getIntersectionType().get(), bIntersectionType2);
+    }
+
+    @Test
+    public void getConstituentTypesAPITest() {
+        ArrayType arrayType = TypeCreator.createArrayType(PredefinedTypes.TYPE_INT);
+        IntersectionType intersectionType =
+                new BIntersectionType(module, new Type[]{arrayType, PredefinedTypes.TYPE_READONLY},
+                        arrayType, 0, true);
+        List<Type> constituentTypes = intersectionType.getConstituentTypes();
+        Assert.assertEquals(constituentTypes.size(), 2);
+        Assert.assertEquals(constituentTypes.get(0), arrayType);
+        Assert.assertEquals(constituentTypes.get(1), PredefinedTypes.TYPE_READONLY);
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
@@ -22,6 +22,8 @@ import io.ballerina.runtime.api.Module;
 import io.ballerina.runtime.api.PredefinedTypes;
 import io.ballerina.runtime.api.creators.TypeCreator;
 import io.ballerina.runtime.api.creators.ValueCreator;
+import io.ballerina.runtime.api.types.IntersectableReferenceType;
+import io.ballerina.runtime.api.types.IntersectionType;
 import io.ballerina.runtime.api.types.MethodType;
 import io.ballerina.runtime.api.types.ObjectType;
 import io.ballerina.runtime.api.types.Parameter;
@@ -51,8 +53,8 @@ import java.util.Optional;
  */
 public class Values {
 
-    private static Module objectModule = new Module("testorg", "runtime_api.objects", "1");
-    private static Module recordModule = new Module("testorg", "runtime_api.records", "1");
+    private static final Module objectModule = new Module("testorg", "runtime_api.objects", "1");
+    private static final Module recordModule = new Module("testorg", "runtime_api.records", "1");
 
     public static BMap<BString, Object> getRecord(BString recordName) {
         HashMap<String, Object> address = new HashMap<>();
@@ -116,5 +118,20 @@ public class Values {
             sb.append(type.toString()).append(" ");
         }
         return StringUtils.fromString(sb.toString());
+    }
+
+    public static BArray getConstituentTypes(BArray array) {
+        Optional<IntersectionType> arrayType = ((IntersectableReferenceType) array.getType()).getIntersectionType();
+        assert arrayType.isPresent();
+        List<Type> constituentTypes = arrayType.get().getConstituentTypes();
+        int size = constituentTypes.size();
+        BArray arrayValue = ValueCreator.createArrayValue(TypeCreator.createArrayType(PredefinedTypes.TYPE_STRING, size)
+                , size);
+        int index = 0;
+        for (Type type : constituentTypes) {
+            arrayValue.add(index, StringUtils.fromString(type.toString()));
+            index++;
+        }
+        return arrayValue;
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/types/main.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/types/main.bal
@@ -23,6 +23,15 @@ public function main() {
     testRemoteFunctionParameters();
     testFunctionToString();
     testParamTypesString();
+    testConstituentTypes();
+}
+
+function testConstituentTypes() {
+    int[] arr = [1, 2, 3];
+    string[] types = objects:getConstituentTypes(arr.cloneReadOnly());
+    test:assertEquals(types.length(), 2);
+    test:assertEquals(types[0], "int[]");
+    test:assertEquals(types[1], "readonly");
 }
 
 function testFunctionToString() {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/types/modules/objects/objects.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/types/modules/objects/objects.bal
@@ -46,3 +46,7 @@ public function getFunctionString(object {} obj, string name) returns string = @
 public function getParamTypesString(function func) returns string = @java:Method {
     'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
 } external;
+
+public function getConstituentTypes(any value) returns string[] = @java:Method {
+    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
+} external;


### PR DESCRIPTION
## Purpose
$subject
Fixes #32215 

## Approach
Made the old internal API `getConstituentTypes()` in intersection type to be public.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
