### PR TITLE
Filter Field Symbols from Visible Symbols in the Context of Fields

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
@@ -474,12 +474,23 @@ public class BallerinaSemanticModel implements SemanticModel {
             } else {
                 compiledSymbol = symbolFactory.getBCompiledSymbol(symbol, symbol.getOriginalName().getValue());
             }
-            if (compiledSymbol == null || compiledSymbols.contains(compiledSymbol)) {
+            if (compiledSymbol == null || compiledSymbols.contains(compiledSymbol) || isFieldSymbol(compiledSymbol)) {
                 return;
             }
             compiledSymbols.add(compiledSymbol);
         }
         addToCompiledSymbols(compiledSymbols, scopeEntry.next, cursorPos, name, states);
+    }
+
+    private boolean isFieldSymbol(Symbol compiledSymbol) {
+        switch (compiledSymbol.kind()) {
+            case CLASS_FIELD:
+            case OBJECT_FIELD:
+            case RECORD_FIELD:
+                return true;
+            default:
+                return false;
+        }
     }
 
     private boolean isServiceDeclSymbol(BSymbol symbol) {

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolLookupTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolLookupTest.java
@@ -493,6 +493,37 @@ public class SymbolLookupTest {
         }
     }
 
+    @Test(dataProvider = "FieldSymbolPosProvider")
+    public void testSymbolLookupInFields(int line, int column, int expSymbols, List<String> expSymbolNames) {
+        Project project = BCompileUtil.loadProject("test-src/symbol_lookup_in_fields.bal");
+        Package currentPackage = project.currentPackage();
+        ModuleId defaultModuleId = currentPackage.getDefaultModule().moduleId();
+        PackageCompilation packageCompilation = currentPackage.getCompilation();
+        SemanticModel model = packageCompilation.getSemanticModel(defaultModuleId);
+        Document srcFile = getDocumentForSingleSource(project);
+
+        BLangPackage pkg = packageCompilation.defaultModuleBLangPackage();
+        ModuleID moduleID = new BallerinaModuleID(pkg.packageID);
+
+        Map<String, Symbol> symbolsInFile = getSymbolsInFile(model, srcFile, line, column, moduleID);
+        assertEquals(symbolsInFile.size(), expSymbols);
+
+        for (String symName : expSymbolNames) {
+            assertTrue(symbolsInFile.containsKey(symName), "Symbol not found: " + symName);
+        }
+    }
+
+    @DataProvider(name = "FieldSymbolPosProvider")
+    public Object[][] getFieldSymbolPositions() {
+        return new Object[][]{
+                {2, 4, 4, asList("Foo", "Bar", "Person", "PersonObj")},
+                {8, 4, 4, asList("Foo", "Bar", "Person", "PersonObj")},
+                {16, 8, 8, asList("Foo", "Bar", "Person", "PersonObj", "init", "inc", "self", "x")},
+                {22, 4, 4, asList("Foo", "Bar", "Person", "PersonObj")},
+                {27, 4, 4, asList("Foo", "Bar", "Person", "PersonObj")},
+        };
+    }
+
     private String createSymbolString(Symbol symbol) {
         return (symbol.getName().isPresent() ? symbol.getName().get() : "") + symbol.kind();
     }

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol_lookup_in_fields.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol_lookup_in_fields.bal
@@ -1,0 +1,29 @@
+public class Foo {
+    string field1 = "abc";
+
+}
+
+public class Bar {
+    string name1 = "";
+    private int n;
+
+    public function init(int n = 0) {
+        self.n = n;
+    }
+
+    public function inc() {
+        self.n += 1;
+        int x = 5;
+
+    }
+}
+
+type Person record {|
+    string name2;
+
+|};
+
+type PersonObj object {
+    string name3;
+
+};


### PR DESCRIPTION
## Purpose
> Filter the field symbols in the visible symbols API when the cursor is in the context of fields. 

Fixes #29382

## Approach
> 
> - Class Field Symbols
> - Object Field Symbols
> - Record Field Symbols
> are filtered in the Semantic API.

## Samples
> 

## Remarks
> 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
