### PR TITLE
Add bad sad error message in missing places

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/constants/RuntimeConstants.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/constants/RuntimeConstants.java
@@ -107,12 +107,13 @@ public class RuntimeConstants {
                                                                                          MathContext.DECIMAL128);
     // runtime related error message constant values
     public static final String INTERNAL_ERROR_MESSAGE =
-            "ballerina: Oh no, something really went wrong.\n" +
+            "ballerina: Oh no, something really went wrong. Bad. Sad.\n" +
             "\n" +
-            "If you are able to share with us the code that broke Ballerina then\n" +
-            "we would REALLY appreciate if you would report this to us:\n" +
-            "go to https://github.com/ballerina-platform/ballerina-lang/issues and\n" +
-            "create a bug report with both this log and the sample code.\n";
+            "We appreciate it if you can report the code that broke Ballerina in\n" +
+            "https://github.com/ballerina-platform/ballerina-lang/issues with the\n" +
+            "log you get below and your sample code.\n" +
+            "\n" +
+            "We thank you for helping make us better.\n";
 
     public static final String DEFAULT_LOG_FILE_HANDLER_PATTERN =
             "org.ballerinalang.logging.handlers.DefaultLogFileHandler.pattern";

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/util/RuntimeUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/util/RuntimeUtils.java
@@ -36,6 +36,7 @@ import java.util.logging.Logger;
 
 import static io.ballerina.runtime.api.constants.RuntimeConstants.BBYTE_MAX_VALUE;
 import static io.ballerina.runtime.api.constants.RuntimeConstants.BBYTE_MIN_VALUE;
+import static io.ballerina.runtime.api.constants.RuntimeConstants.INTERNAL_ERROR_MESSAGE;
 
 /**
  * Util methods required for jBallerina runtime.
@@ -174,6 +175,7 @@ public class RuntimeUtils {
 
     public static void logBadSad(Throwable throwable) {
         // These errors are unhandled errors in JVM, hence logging them to bre log.
+        errStream.println(INTERNAL_ERROR_MESSAGE);
         printCrashLog(throwable);
     }
 

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/launcher/Main.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/launcher/Main.java
@@ -19,13 +19,11 @@
 package io.ballerina.cli.launcher;
 
 import io.ballerina.cli.BLauncherCmd;
-import io.ballerina.cli.launcher.util.BCompileUtil;
 import io.ballerina.runtime.internal.util.RuntimeUtils;
 import io.ballerina.runtime.internal.util.exceptions.BLangRuntimeException;
 import org.ballerinalang.compiler.BLangCompilerException;
 import picocli.CommandLine;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
 import java.util.ArrayList;
@@ -67,8 +65,6 @@ public class Main {
         } catch (RuntimePanicException e) {
             Runtime.getRuntime().exit(e.getExitCode());
         } catch (Throwable e) {
-            errStream.println(getMessageForInternalErrors());
-            errStream.println();
             RuntimeUtils.logBadSad(e);
             Runtime.getRuntime().exit(1);
         }
@@ -183,16 +179,6 @@ public class Main {
         } else {
             throw LauncherUtils.createUsageExceptionWithHelp("home info not available");
         }
-    }
-
-    private static String getMessageForInternalErrors() {
-        String errorMsg;
-        try {
-            errorMsg = BCompileUtil.readFileAsString("cli-help/internal-error-message.txt");
-        } catch (IOException e) {
-            errorMsg = "ballerina: internal error occurred";
-        }
-        return errorMsg;
     }
 
     private static String prepareCompilerErrorMessage(String message) {

--- a/cli/ballerina-cli/src/main/resources/cli-help/internal-error-message.txt
+++ b/cli/ballerina-cli/src/main/resources/cli-help/internal-error-message.txt
@@ -1,7 +1,0 @@
-ballerina: Oh no, something really went wrong. Bad. Sad.
-
-We appreciate it if you can report the code that broke Ballerina in 
-https://github.com/ballerina-platform/ballerina-lang/issues with the 
-log you get below and your sample code.
-
-We thank you for helping make us better.


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues.

$title
Fixes #32708

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

Now it will give the error message for the code sample in the issue as belows.
```
Compiling source
        issuecode.bal
ballerina: Oh no, something really went wrong. Bad. Sad.

We appreciate it if you can report the code that broke Ballerina in
https://github.com/ballerina-platform/ballerina-lang/issues with the
log you get below and your sample code.

We thank you for helping make us better.

[2021-09-27 17:10:26,466] SEVERE {b7a.log.crash} - class org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral$BLangRecordSpreadOperatorField cannot be cast to class org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral$BLangRecordKeyValueField (org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral$BLangRecordSpreadOperatorField and org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral$BLangRecordKeyValueField are in unnamed module of loader 'app') 
java.lang.ClassCastException: class org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral$BLangRecordSpreadOperatorField cannot be cast to class org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral$BLangRecordKeyValueField (org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral$BLangRecordSpreadOperatorField and org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral$BLangRecordKeyValueField are in unnamed module of loader 'app')
        at org.wso2.ballerinalang.compiler.semantics.analyzer.TypeChecker.getRecordKeyValueField(TypeChecker.java:1197)
        at org.wso2.ballerinalang.compiler.semantics.analyzer.TypeChecker.validateTableKeyValue(TypeChecker.java:1154)
        at org.wso2.ballerinalang.compiler.semantics.analyzer.TypeChecker.checkKeySpecifier(TypeChecker.java:1007)
        at org.wso2.ballerinalang.compiler.semantics.analyzer.TypeChecker.visit(TypeChecker.java:885)
        at org.wso2.ballerinalang.compiler.tree.expressions.BLangTableConstructorExpr.accept(BLangTableConstructorExpr.java:67)
        at org.wso2.ballerinalang.compiler.semantics.analyzer.TypeChecker.checkExpr(TypeChecker.java:374)
        at org.wso2.ballerinalang.compiler.semantics.analyzer.TypeChecker.checkExpr(TypeChecker.java:353)
        at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.handleDeclaredWithVar(SemanticAnalyzer.java:1435)
        at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.visit(SemanticAnalyzer.java:797)
        at org.wso2.ballerinalang.compiler.tree.BLangSimpleVariable.accept(BLangSimpleVariable.java:53)
        at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.analyzeNode(SemanticAnalyzer.java:3806)
        at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.analyzeNode(SemanticAnalyzer.java:3774)
        at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.analyzeDef(SemanticAnalyzer.java:3766)
        at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.visit(SemanticAnalyzer.java:1743)
        at org.wso2.ballerinalang.compiler.tree.statements.BLangSimpleVariableDef.accept(BLangSimpleVariableDef.java:46)
        at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.analyzeNode(SemanticAnalyzer.java:3806)
        at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.analyzeNode(SemanticAnalyzer.java:3774)
        at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.analyzeStmt(SemanticAnalyzer.java:3770)
        at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.visit(SemanticAnalyzer.java:477)
        at org.wso2.ballerinalang.compiler.tree.BLangBlockFunctionBody.accept(BLangBlockFunctionBody.java:57)
        at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.analyzeNode(SemanticAnalyzer.java:3806)
        at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.visit(SemanticAnalyzer.java:447)
        at org.wso2.ballerinalang.compiler.tree.BLangFunction.accept(BLangFunction.java:73)
        at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.analyzeNode(SemanticAnalyzer.java:3806)
        at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.analyzeNode(SemanticAnalyzer.java:3774)
        at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.analyzeDef(SemanticAnalyzer.java:3766)
        at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.visit(SemanticAnalyzer.java:333)
        at org.wso2.ballerinalang.compiler.tree.BLangPackage.accept(BLangPackage.java:163)
        at org.wso2.ballerinalang.compiler.semantics.analyzer.SemanticAnalyzer.analyze(SemanticAnalyzer.java:299)
        at io.ballerina.projects.internal.CompilerPhaseRunner.typeCheck(CompilerPhaseRunner.java:206)
        at io.ballerina.projects.internal.CompilerPhaseRunner.performTypeCheckPhases(CompilerPhaseRunner.java:114)
        at io.ballerina.projects.ModuleContext.compileInternal(ModuleContext.java:398)
        at io.ballerina.projects.ModuleCompilationState$1.compile(ModuleCompilationState.java:45)
        at io.ballerina.projects.ModuleContext.compile(ModuleContext.java:344)
        at io.ballerina.projects.PackageCompilation.compileModulesInternal(PackageCompilation.java:201)
        at io.ballerina.projects.PackageCompilation.compileModules(PackageCompilation.java:186)
        at io.ballerina.projects.PackageCompilation.compile(PackageCompilation.java:111)
        at io.ballerina.projects.PackageCompilation.from(PackageCompilation.java:100)
        at io.ballerina.projects.PackageContext.getPackageCompilation(PackageContext.java:214)
        at io.ballerina.projects.Package.getCompilation(Package.java:140)
        at io.ballerina.cli.task.CompileTask.execute(CompileTask.java:75)
        at io.ballerina.cli.TaskExecutor.executeTasks(TaskExecutor.java:40)
        at io.ballerina.cli.cmd.BuildCommand.execute(BuildCommand.java:343)
        at java.base/java.util.Optional.ifPresent(Optional.java:183)
        at io.ballerina.cli.launcher.Main.main(Main.java:51)
 
ERROR [.:(1:1,1:1)] Compilation failed due to: class org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral$BLangRecordSpreadOperatorField cannot be cast to class org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral$BLangRecordKeyValueField (org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral$BLangRecordSpreadOperatorField and org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral$BLangRecordKeyValueField are in unnamed module of loader 'app')
error: compilation contains errors
```
## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
