### PR TITLE
Fix symbol visibility issue related to type test expression

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
@@ -2740,10 +2740,6 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
         bLBlockStmt.stmts = generateBLangStatements(blockStatement.statements());
         this.isInLocalContext = false;
         bLBlockStmt.pos = getPosition(blockStatement);
-        SyntaxKind parent = blockStatement.parent().kind();
-        if (parent == SyntaxKind.IF_ELSE_STATEMENT || parent == SyntaxKind.ELSE_BLOCK) {
-            bLBlockStmt.pos = expandLeft(bLBlockStmt.pos, getPosition(blockStatement.parent()));
-        }
         return bLBlockStmt;
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolLookupTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolLookupTest.java
@@ -493,6 +493,42 @@ public class SymbolLookupTest {
         }
     }
 
+    @Test(dataProvider = "PositionProvider6")
+    public void testTypeTest(int line, int col, List<String> expSymbolNames, TypeDescKind expVarType) {
+        Project project = BCompileUtil.loadProject("test-src/symbol_lookup_with_type_test.bal");
+        Package currentPackage = project.currentPackage();
+        ModuleId defaultModuleId = currentPackage.getDefaultModule().moduleId();
+        PackageCompilation packageCompilation = currentPackage.getCompilation();
+        SemanticModel model = packageCompilation.getSemanticModel(defaultModuleId);
+        Document srcFile = getDocumentForSingleSource(project);
+
+        BLangPackage pkg = packageCompilation.defaultModuleBLangPackage();
+        ModuleID moduleID = new BallerinaModuleID(pkg.packageID);
+
+        Map<String, Symbol> symbolsInFile = getSymbolsInFile(model, srcFile, line, col, moduleID);
+
+        assertEquals(symbolsInFile.size(), expSymbolNames.size());
+        for (String symName : expSymbolNames) {
+            assertTrue(symbolsInFile.containsKey(symName), "Symbol not found: " + symName);
+        }
+
+        Symbol getResultSym = symbolsInFile.get("getResult");
+
+        assertEquals(getResultSym.kind(), SymbolKind.VARIABLE);
+        assertEquals(((VariableSymbol) getResultSym).typeDescriptor().typeKind(), expVarType);
+    }
+
+    @DataProvider(name = "PositionProvider6")
+    public Object[][] getPosForTypeTest() {
+        List<String> expSymbolNames = List.of("getValue", "testTypeTest", "getResult");
+        return new Object[][]{
+                {18, 20, expSymbolNames, TypeDescKind.INT},
+                {19, 8, expSymbolNames, TypeDescKind.COMPILATION_ERROR},
+                {22, 24, expSymbolNames, TypeDescKind.INT},
+                {23, 8, expSymbolNames, TypeDescKind.COMPILATION_ERROR},
+        };
+    }
+
     private String createSymbolString(Symbol symbol) {
         return (symbol.getName().isPresent() ? symbol.getName().get() : "") + symbol.kind();
     }

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol_lookup_with_type_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol_lookup_with_type_test.bal
@@ -1,0 +1,30 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+function testTypeTest() {
+    int getResult = getValue();
+    if getResult is  {
+
+    }
+
+    while (getResult is ) {
+
+    }
+}
+
+function getValue() returns int {
+    return 0;
+}


### PR DESCRIPTION
## Purpose
This PR fixes an issue that was there for type test expressions where the wrong symbol would be visible when the cursor is within the type test expression.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
