### PR TITLE
Remove caching of BIR for current project

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/BuildCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/BuildCommand.java
@@ -145,7 +145,7 @@ public class BuildCommand implements BLauncherCmd {
     private boolean dumpBIR;
 
     @CommandLine.Option(names = "--dump-bir-file", hidden = true)
-    private String dumpBIRFile;
+    private Boolean dumpBIRFile;
 
     @CommandLine.Option(names = "--dump-graph", hidden = true)
     private boolean dumpGraph;

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/BuildCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/BuildCommandTest.java
@@ -231,9 +231,6 @@ public class BuildCommandTest extends BaseCommandTest {
         Assert.assertTrue(projectPath.resolve("target").resolve("cache").resolve("foo")
                 .resolve("winery").resolve("0.1.0").resolve("java11")
                 .resolve("foo-winery-0.1.0.jar").toFile().exists());
-        Assert.assertTrue(projectPath.resolve("target").resolve("cache").resolve("foo")
-                .resolve("winery").resolve("0.1.0").resolve("bir")
-                .resolve("winery.bir").toFile().exists());
     }
 
     /**
@@ -293,9 +290,6 @@ public class BuildCommandTest extends BaseCommandTest {
         Assert.assertTrue(projectPath.resolve("target").resolve("cache").resolve("pramodya")
                                   .resolve("conflictProject").resolve("0.1.7").resolve("java11")
                                   .resolve("pramodya-conflictProject-0.1.7.jar").toFile().exists());
-        Assert.assertTrue(projectPath.resolve("target").resolve("cache").resolve("pramodya")
-                                  .resolve("conflictProject").resolve("0.1.7").resolve("bir")
-                                  .resolve("conflictProject.bir").toFile().exists());
     }
 
     @Test(description = "Build a valid ballerina project with java imports")
@@ -314,9 +308,6 @@ public class BuildCommandTest extends BaseCommandTest {
         Assert.assertTrue(projectPath.resolve("target").resolve("cache").resolve("foo")
                                   .resolve("winery").resolve("0.1.0").resolve("java11")
                                   .resolve("foo-winery-0.1.0.jar").toFile().exists());
-        Assert.assertTrue(projectPath.resolve("target").resolve("cache").resolve("foo")
-                                  .resolve("winery").resolve("0.1.0").resolve("bir")
-                                  .resolve("winery.bir").toFile().exists());
     }
 
     @Test(description = "Build a valid ballerina project")
@@ -333,9 +324,6 @@ public class BuildCommandTest extends BaseCommandTest {
         Assert.assertTrue(projectPath.resolve("target").resolve("cache").resolve("foo")
                 .resolve("winery").resolve("0.1.0").resolve("java11")
                 .resolve("foo-winery-0.1.0.jar").toFile().exists());
-        Assert.assertTrue(projectPath.resolve("target").resolve("cache").resolve("foo")
-                .resolve("winery").resolve("0.1.0").resolve("bir")
-                .resolve("winery.bir").toFile().exists());
     }
 
     @Test(description = "Build a valid ballerina project")
@@ -353,9 +341,6 @@ public class BuildCommandTest extends BaseCommandTest {
         Assert.assertTrue(projectPath.resolve("target").resolve("cache").resolve("foo")
                 .resolve("winery").resolve("0.1.0").resolve("java11")
                 .resolve("foo-winery-0.1.0.jar").toFile().exists());
-        Assert.assertTrue(projectPath.resolve("target").resolve("cache").resolve("foo")
-                .resolve("winery").resolve("0.1.0").resolve("bir")
-                .resolve("winery.bir").toFile().exists());
     }
 
     @Test(description = "Build a valid ballerina project")
@@ -391,16 +376,10 @@ public class BuildCommandTest extends BaseCommandTest {
         Assert.assertTrue(projectPath.resolve("target").resolve("cache").resolve("foo")
                 .resolve("winery").resolve("0.1.0").resolve("java11")
                 .resolve("foo-winery-0.1.0.jar").toFile().exists());
-        Assert.assertTrue(projectPath.resolve("target").resolve("cache").resolve("foo")
-                .resolve("winery").resolve("0.1.0").resolve("bir")
-                .resolve("winery.bir").toFile().exists());
 
         Assert.assertTrue(projectPath.resolve("target").resolve("cache").resolve("foo")
                 .resolve("winery").resolve("0.1.0").resolve("java11")
                 .resolve("foo-winery.storage-0.1.0.jar").toFile().exists());
-        Assert.assertTrue(projectPath.resolve("target").resolve("cache").resolve("foo")
-                .resolve("winery").resolve("0.1.0").resolve("bir")
-                .resolve("winery.storage.bir").toFile().exists());
     }
 
     @Test(description = "Build a valid ballerina project with build options in toml")
@@ -422,9 +401,6 @@ public class BuildCommandTest extends BaseCommandTest {
         Assert.assertFalse(projectPath.resolve("target").resolve("cache").resolve("foo")
                 .resolve("winery").resolve("0.1.0").resolve("java11")
                 .resolve("foo-winery-testable-0.1.0.jar").toFile().exists());
-        Assert.assertTrue(projectPath.resolve("target").resolve("cache").resolve("foo")
-                .resolve("winery").resolve("0.1.0").resolve("bir")
-                .resolve("winery.bir").toFile().exists());
     }
 
     @Test(description = "Build a valid ballerina project with build options in toml")
@@ -453,9 +429,6 @@ public class BuildCommandTest extends BaseCommandTest {
         Assert.assertTrue(projectPath.resolve("target").resolve("cache").resolve("foo")
                 .resolve("winery").resolve("0.1.0").resolve("java11")
                 .resolve("foo-winery-0.1.0-testable.jar").toFile().exists());
-        Assert.assertTrue(projectPath.resolve("target").resolve("cache").resolve("foo")
-                .resolve("winery").resolve("0.1.0").resolve("bir")
-                .resolve("winery.bir").toFile().exists());
 
         Assert.assertTrue(
                 projectPath.resolve("target").resolve("report").resolve("test_results.json").toFile().exists());
@@ -578,9 +551,6 @@ public class BuildCommandTest extends BaseCommandTest {
         Assert.assertTrue(projectPath.resolve("target").resolve("cache").resolve("foo")
                 .resolve("winery").resolve("0.1.0").resolve("java11")
                 .resolve("foo-winery-0.1.0.jar").toFile().exists());
-        Assert.assertTrue(projectPath.resolve("target").resolve("cache").resolve("foo")
-                .resolve("winery").resolve("0.1.0").resolve("bir")
-                .resolve("winery.bir").toFile().exists());
     }
 
     @Test(description = "Compile an application package")

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BuildOptions.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BuildOptions.java
@@ -114,6 +114,7 @@ public class BuildOptions {
         buildOptionsBuilder.experimental(compilationOptions.experimental);
         buildOptionsBuilder.observabilityIncluded(compilationOptions.observabilityIncluded);
         buildOptionsBuilder.dumpBir(compilationOptions.dumpBir);
+        buildOptionsBuilder.dumpBirFile(compilationOptions.dumpBirFile);
         buildOptionsBuilder.dumpGraph(compilationOptions.dumpGraph);
         buildOptionsBuilder.dumpRawGraphs(compilationOptions.dumpRawGraphs);
         buildOptionsBuilder.cloud(compilationOptions.cloud);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BuildOptionsBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BuildOptionsBuilder.java
@@ -90,7 +90,7 @@ public class BuildOptionsBuilder {
         return this;
     }
 
-    public BuildOptionsBuilder dumpBirFile(String value) {
+    public BuildOptionsBuilder dumpBirFile(Boolean value) {
         compilationOptionsBuilder.dumpBirFile(value);
         return this;
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/CompilationOptions.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/CompilationOptions.java
@@ -27,7 +27,7 @@ public class CompilationOptions {
     Boolean experimental;
     Boolean observabilityIncluded;
     Boolean dumpBir;
-    String dumpBirFile;
+    Boolean dumpBirFile;
     String cloud;
     Boolean listConflictedClasses;
     Boolean sticky;
@@ -35,7 +35,7 @@ public class CompilationOptions {
     Boolean dumpRawGraphs;
 
     CompilationOptions(Boolean offlineBuild, Boolean experimental,
-                       Boolean observabilityIncluded, Boolean dumpBir, String dumpBirFile,
+                       Boolean observabilityIncluded, Boolean dumpBir, Boolean dumpBirFile,
                        String cloud, Boolean listConflictedClasses, Boolean sticky,
                        Boolean dumpGraph, Boolean dumpRawGraphs) {
         this.offlineBuild = offlineBuild;
@@ -70,8 +70,8 @@ public class CompilationOptions {
         return toBooleanDefaultIfNull(this.dumpBir);
     }
 
-    public String getBirDumpFile() {
-        return this.dumpBirFile;
+    public Boolean dumpBirFile() {
+        return toBooleanDefaultIfNull(this.dumpBirFile);
     }
 
     public Boolean dumpGraph() {
@@ -117,6 +117,11 @@ public class CompilationOptions {
             compilationOptionsBuilder.dumpBir(theirOptions.dumpBir);
         } else {
             compilationOptionsBuilder.dumpBir(this.dumpBir);
+        }
+        if (theirOptions.dumpBirFile != null) {
+            compilationOptionsBuilder.dumpBirFile(theirOptions.dumpBirFile);
+        } else {
+            compilationOptionsBuilder.dumpBirFile(this.dumpBirFile);
         }
         if (theirOptions.dumpGraph != null) {
             compilationOptionsBuilder.dumpGraph(theirOptions.dumpGraph);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/CompilationOptionsBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/CompilationOptionsBuilder.java
@@ -29,7 +29,7 @@ public class CompilationOptionsBuilder {
     private Boolean experimental;
     private Boolean observabilityIncluded;
     private Boolean dumpBir;
-    private String dumpBirFile;
+    private Boolean dumpBirFile;
     private String cloud;
     private Boolean listConflictedClasses;
     private Boolean sticky;
@@ -64,7 +64,7 @@ public class CompilationOptionsBuilder {
         return this;
     }
 
-    CompilationOptionsBuilder dumpBirFile(String value) {
+    CompilationOptionsBuilder dumpBirFile(Boolean value) {
         dumpBirFile = value;
         return this;
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ModuleContext.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ModuleContext.java
@@ -23,6 +23,7 @@ import io.ballerina.projects.environment.PackageResolver;
 import io.ballerina.projects.environment.ProjectEnvironment;
 import io.ballerina.projects.internal.CompilerPhaseRunner;
 import io.ballerina.projects.internal.ModuleContextDataHolder;
+import io.ballerina.projects.util.ProjectUtils;
 import io.ballerina.tools.diagnostics.Diagnostic;
 import org.ballerinalang.model.TreeBuilder;
 import org.ballerinalang.model.elements.Flag;
@@ -433,6 +434,11 @@ class ModuleContext {
     private static void cacheBIR(ModuleContext moduleContext) {
         // Skip caching BIR if there are diagnostics
         if (Diagnostics.hasErrors(moduleContext.diagnostics())) {
+            return;
+        }
+
+        if (moduleContext.project.kind().equals(ProjectKind.BUILD_PROJECT) && !ProjectUtils.isLangLibPackage(
+                moduleContext.descriptor().org(), moduleContext.descriptor().packageName())) {
             return;
         }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageCompilation.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageCompilation.java
@@ -91,7 +91,7 @@ public class PackageCompilation {
         options.put(EXPERIMENTAL, Boolean.toString(compilationOptions.experimental()));
         options.put(OBSERVABILITY_INCLUDED, Boolean.toString(compilationOptions.observabilityIncluded()));
         options.put(DUMP_BIR, Boolean.toString(compilationOptions.dumpBir()));
-        options.put(DUMP_BIR_FILE, compilationOptions.getBirDumpFile());
+        options.put(DUMP_BIR_FILE, Boolean.toString(compilationOptions.dumpBirFile()));
         options.put(CLOUD, compilationOptions.getCloud());
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageContext.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageContext.java
@@ -223,7 +223,7 @@ class PackageContext {
                 .observabilityIncluded(this.compilationOptions.observabilityIncluded())
                 .dumpBir(this.compilationOptions.dumpBir())
                 .cloud(this.compilationOptions.getCloud())
-                .dumpBirFile(this.compilationOptions.getBirDumpFile())
+                .dumpBirFile(this.compilationOptions.dumpBirFile())
                 .dumpGraph(this.compilationOptions.dumpGraph())
                 .dumpRawGraphs(this.compilationOptions.dumpRawGraphs())
                 .listConflictedClasses(this.compilationOptions.listConflictedClasses())

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/emit/BIREmitter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/emit/BIREmitter.java
@@ -17,17 +17,13 @@
  */
 package org.wso2.ballerinalang.compiler.bir.emit;
 
-import org.ballerinalang.compiler.BLangCompilerException;
 import org.ballerinalang.compiler.CompilerOptionName;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.CompilerOptions;
 
-import java.io.IOException;
 import java.io.PrintStream;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.List;
 
 import static org.wso2.ballerinalang.compiler.bir.emit.EmitterUtils.emitBasicBlockRef;
@@ -54,7 +50,6 @@ public class BIREmitter {
     private static final CompilerContext.Key<BIREmitter> BIR_EMITTER = new CompilerContext.Key<>();
     private static final PrintStream console = System.out;
     private boolean dumbBIR;
-    private final String dumpBIRFile;
 
     public static BIREmitter getInstance(CompilerContext context) {
 
@@ -71,19 +66,11 @@ public class BIREmitter {
         context.put(BIR_EMITTER, this);
         CompilerOptions compilerOptions = CompilerOptions.getInstance(context);
         this.dumbBIR = getBooleanValueIfSet(compilerOptions, CompilerOptionName.DUMP_BIR);
-        this.dumpBIRFile = compilerOptions.get(CompilerOptionName.DUMP_BIR_FILE);
     }
 
     public BLangPackage emit(BLangPackage bLangPackage) {
         if (dumbBIR) {
             console.println(emitModule(bLangPackage.symbol.bir));
-        }
-        if (dumpBIRFile != null) {
-            try {
-                Files.write(Paths.get(dumpBIRFile), bLangPackage.symbol.birPackageFile.pkgBirBinaryContent);
-            } catch (IOException e) {
-                throw new BLangCompilerException("BIR file dumping failed", e);
-            }
         }
         return bLangPackage;
     }

--- a/misc/lib-creator/src/main/java/org/ballerinalang/stdlib/utils/BuildLangLib.java
+++ b/misc/lib-creator/src/main/java/org/ballerinalang/stdlib/utils/BuildLangLib.java
@@ -18,6 +18,8 @@
 
 package org.ballerinalang.stdlib.utils;
 
+import io.ballerina.projects.BuildOptions;
+import io.ballerina.projects.BuildOptionsBuilder;
 import io.ballerina.projects.CompilationCache;
 import io.ballerina.projects.CompilerBackend;
 import io.ballerina.projects.JBallerinaBackend;
@@ -86,7 +88,8 @@ public class BuildLangLib {
             Path pkgTargetPath = targetPath.resolve(pkgName);
             ProjectEnvironmentBuilder environmentBuilder = createProjectEnvBuilder(pkgTargetPath);
 
-            Project project = BuildProject.load(environmentBuilder, projectDir);
+            BuildOptions defaultOptions = new BuildOptionsBuilder().offline(true).dumpBirFile(true).build();
+            Project project = BuildProject.load(environmentBuilder, projectDir, defaultOptions);
             Package pkg = project.currentPackage();
             PackageCompilation packageCompilation = pkg.getCompilation();
             JBallerinaBackend jBallerinaBackend = JBallerinaBackend.from(packageCompilation, JvmTarget.JAVA_11);

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBirAndJarCache.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBirAndJarCache.java
@@ -81,7 +81,7 @@ public class TestBirAndJarCache {
 
         int numOfModules = currentPackage.moduleIds().size();
         TestCompilationCache testCompilationCache = testCompCacheFactory.compilationCache();
-        Assert.assertEquals(testCompilationCache.birCachedCount, numOfModules);
+        Assert.assertEquals(testCompilationCache.birCachedCount, 0);
         // numOfModules * 2 : This includes testable jars as well
         Assert.assertEquals(testCompilationCache.jarCachedCount, numOfModules * 2);
 
@@ -99,7 +99,6 @@ public class TestBirAndJarCache {
             String jarName = getThinJarFileName(module.descriptor().org(),
                                                 moduleName.toString(),
                                                 module.descriptor().version());
-            Assert.assertTrue(foundPaths.contains(moduleName + ".bir"));
             Assert.assertTrue(foundPaths.contains(jarName + BLANG_COMPILED_JAR_EXT));
         }
     }

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProject.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProject.java
@@ -860,7 +860,7 @@ public class TestBuildProject extends BaseTest {
 
         // Test module level symbols
         List<Symbol> symbols = semanticModel.moduleSymbols();
-        Assert.assertEquals(symbols.size(), 5);
+        Assert.assertEquals(symbols.size(), 4);
 
         // Test symbol
         Optional<Symbol> symbol = semanticModel.symbol(srcFile, LinePosition.from(4, 10));

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProject.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProject.java
@@ -860,7 +860,7 @@ public class TestBuildProject extends BaseTest {
 
         // Test module level symbols
         List<Symbol> symbols = semanticModel.moduleSymbols();
-        Assert.assertEquals(symbols.size(), 4);
+        Assert.assertEquals(symbols.size(), 5);
 
         // Test symbol
         Optional<Symbol> symbol = semanticModel.symbol(srcFile, LinePosition.from(4, 10));

--- a/project-api/project-api-test/src/test/resources/projects_for_resolution_tests/package_n/Dependencies.toml
+++ b/project-api/project-api-test/src/test/resources/projects_for_resolution_tests/package_n/Dependencies.toml
@@ -10,7 +10,6 @@ dependencies-toml-version = "2"
 org = "samjs"
 name = "package_n"
 version = "0.1.0"
-transitive = false
 dependencies = [
 	{org = "samjs", name = "package_o"}
 ]
@@ -22,7 +21,6 @@ modules = [
 org = "samjs"
 name = "package_o"
 version = "1.0.0"
-transitive = false
 modules = [
 	{org = "samjs", packageName = "package_o", moduleName = "package_o"}
 ]

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/BCompileUtil.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/BCompileUtil.java
@@ -70,7 +70,9 @@ public class BCompileUtil {
 
         Path projectPath = Paths.get(sourceRoot.toString(), sourceFileName);
 
-        return ProjectLoader.loadProject(projectPath, buildOptions);
+        BuildOptions defaultOptions = new BuildOptionsBuilder().offline(true).dumpBirFile(true).build();
+        BuildOptions mergedOptions = buildOptions.acceptTheirs(defaultOptions);
+        return ProjectLoader.loadProject(projectPath, mergedOptions);
     }
 
     public static CompileResult compile(String sourceFilePath) {
@@ -146,7 +148,8 @@ public class BCompileUtil {
         Path sourceRoot = testSourcesDirectory.resolve(sourcePath.getParent());
 
         Path projectPath = Paths.get(sourceRoot.toString(), sourceFileName);
-        Project project = ProjectLoader.loadProject(projectPath, getTestProjectEnvironmentBuilder());
+        BuildOptions defaultOptions = new BuildOptionsBuilder().offline(true).dumpBirFile(true).build();
+        Project project = ProjectLoader.loadProject(projectPath, getTestProjectEnvironmentBuilder(), defaultOptions);
 
         if (isSingleFileProject(project)) {
             throw new RuntimeException("single file project is given for compilation at " + project.sourceRoot());


### PR DESCRIPTION
## Purpose
> - Stop generating the BIRs of the current package of BuildProject
> - Modify the `--dump-bir-flag` to be boolean and dump the BIR files at `target/cache/<org>/<name>/<version>/bir/<module-name>.bir` if the flag is passed

Fixes #32782

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
