### PR TITLE
Fix crashes with unary add operator when using with non basic types

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -4262,11 +4262,10 @@ public class TypeChecker extends BLangNodeVisitor {
                 actualType = new BTypedescType(exprType, null);
             }
         } else {
-//            allow both addition and subtraction operators to get expected type as Decimal
-            boolean decimalNegation = OperatorKind.SUB.equals(unaryExpr.operator) && expType.tag == TypeTags.DECIMAL;
-            boolean isAdd = OperatorKind.ADD.equals(unaryExpr.operator);
-            exprType = (decimalNegation || isAdd) ? checkExpr(unaryExpr.expr, env, expType) :
-                    checkExpr(unaryExpr.expr, env);
+            //allow both addition and subtraction operators to get expected type as Decimal
+            boolean decimalAddNegate = expType.tag == TypeTags.DECIMAL &&
+                    (OperatorKind.ADD.equals(unaryExpr.operator) || OperatorKind.SUB.equals(unaryExpr.operator));
+            exprType = decimalAddNegate ? checkExpr(unaryExpr.expr, env, expType) : checkExpr(unaryExpr.expr, env);
             if (exprType != symTable.semanticError) {
                 BSymbol symbol = symResolver.resolveUnaryOperator(unaryExpr.pos, unaryExpr.operator, exprType);
                 if (symbol == symTable.notFoundSymbol) {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/unaryoperations/UnaryExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/unaryoperations/UnaryExprTest.java
@@ -27,6 +27,7 @@ import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 /**
@@ -179,14 +180,18 @@ public class UnaryExprTest {
 
     }
 
-    @Test(description = "Test complement operator")
-    public void testComplementOperator() {
-        BRunUtil.invoke(result, "testComplementOperator");
+    @Test(dataProvider = "dataToTestUnaryOperations", description = "test unary operators with types")
+    public void testUnaryOperations(String functionName) {
+        BRunUtil.invoke(result, functionName);
     }
 
-    @Test(description = "Test unary operators with int sub types")
-    public void testUnaryOperationsWithIntSubtypes() {
-        BRunUtil.invoke(result, "testUnaryOperationsWithIntSubtypes");
+    @DataProvider(name = "dataToTestUnaryOperations")
+    public Object[] dataToTestUnaryOperations() {
+        return new String[] {
+                "testComplementOperator",
+                "testUnaryOperationsWithIntSubtypes",
+                "testUnaryOperationsWithNonBasicTypes"
+        };
     }
 
     @Test(description = "Test unary statement with errors")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/unaryoperations/UnaryExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/unaryoperations/UnaryExprTest.java
@@ -196,7 +196,7 @@ public class UnaryExprTest {
 
     @Test(description = "Test unary statement with errors")
     public void testUnaryStmtNegativeCases() {
-        Assert.assertEquals(resultNegative.getErrorCount(), 8);
+        Assert.assertEquals(resultNegative.getErrorCount(), 12);
         BAssertUtil.validateError(resultNegative, 0, "operator '+' not defined for 'json'", 5, 10);
         BAssertUtil.validateError(resultNegative, 1, "operator '-' not defined for 'json'", 14, 10);
         BAssertUtil.validateError(resultNegative, 2, "operator '!' not defined for 'json'", 23, 10);
@@ -209,6 +209,10 @@ public class UnaryExprTest {
                 38, 15);
         BAssertUtil.validateError(resultNegative, 7, "incompatible types: expected 'int:Unsigned8', found 'int'",
                 41, 24);
+        BAssertUtil.validateError(resultNegative, 8, "operator '~' not defined for 'decimal'", 45, 18);
+        BAssertUtil.validateError(resultNegative, 9, "operator '~' not defined for 'float'", 46, 17);
+        BAssertUtil.validateError(resultNegative, 10, "operator '~' not defined for 'decimal'", 47, 18);
+        BAssertUtil.validateError(resultNegative, 11, "operator '!' not defined for 'decimal'", 48, 18);
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/unaryoperations/unary-operation-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/unaryoperations/unary-operation-negative.bal
@@ -30,7 +30,7 @@ function testNotOperator() returns int {
     return i;
 }
 
-function testIncompatibleSubtypesWithUnaryOpertaors() {
+function testIncompatibleSubtypesWithUnaryOperators() {
     int:Unsigned8 x1 = -7;
     int:Signed8 x2 = +1000;
 
@@ -39,4 +39,11 @@ function testIncompatibleSubtypesWithUnaryOpertaors() {
 
     int:Unsigned8 x5 = 0;
     int:Unsigned8 x6 = ~x5;
+}
+
+function testIncompatibleUnaryOperations() {
+    decimal x1 = ~12.5d;
+    float x2 = +~12.5;
+    anydata x3 = ~12d;
+    anydata x4 = !12d;
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/unaryoperations/unary-operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/unaryoperations/unary-operation.bal
@@ -185,19 +185,39 @@ function testUnaryOperationsWithNonBasicTypes() {
     int? a2 = ++i;
     int? a3 = ~i;
     int? a4 = +~i;
+    anydata a5 = +i;
+    int|float a6 = -i;
 
     float f = -5.2;
-    float? a5 = +f;
+    float? a7 = +f;
+    anydata a8 = -f;
 
     decimal d = 7.45;
-    decimal? a6 = +d;
+    decimal? a9 = +d;
+    anydata a10 = -d;
+    decimal|int a11 = +-d;
+    anydata a12 = ++d;
+
+    int:Signed16 s = 16;
+    anydata a13 = ++s;
+    int? a14 = +-s;
+    int|decimal a15 = +~s;
 
     test:assertEquals(a1, 5);
     test:assertEquals(a2, 5);
     test:assertEquals(a3, -6);
     test:assertEquals(a4, -6);
-    test:assertEquals(a5, -5.2);
-    test:assertEquals(a6, 7.45d);
+    test:assertEquals(a5, 5);
+    test:assertEquals(a6, -5);
+    test:assertEquals(a7, -5.2);
+    test:assertEquals(a8, 5.2);
+    test:assertEquals(a9, 7.45d);
+    test:assertEquals(a10, -7.45d);
+    test:assertEquals(a11, -7.45d);
+    test:assertEquals(a12, 7.45d);
+    test:assertEquals(a13, 16);
+    test:assertEquals(a14, -16);
+    test:assertEquals(a15, -17);
 }
 
 function assertEquality(anydata expected, anydata actual) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/unaryoperations/unary-operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/unaryoperations/unary-operation.bal
@@ -1,3 +1,5 @@
+import ballerina/test;
+
 function negativeIntTest() returns [int, int] {
     int x;
     int y;
@@ -149,6 +151,53 @@ function testUnaryOperationsWithIntSubtypes() {
     byte x17 = +7;
     assertEquality(-8, y7);
     assertEquality(7, x17);
+}
+
+function testUnaryOperationsWithNonBasicTypes() {
+    int|float x1 = +5;
+    int|float x2 = ++5;
+    int|float x3 = -5;
+    int|float x4 = --5;
+    int|decimal x5 = ~5;
+    int|float|string x6 = +~5;
+    anydata x7 = ++5;
+    anydata x8 = --5;
+    anydata x9 = +-5;
+    anydata x10 = +~5;
+    anydata x11 = ~-5;
+    anydata x12 = -~5;
+
+    test:assertEquals(x1, 5);
+    test:assertEquals(x2, 5);
+    test:assertEquals(x3, -5);
+    test:assertEquals(x4, 5);
+    test:assertEquals(x5, -6);
+    test:assertEquals(x6, -6);
+    test:assertEquals(x7, 5);
+    test:assertEquals(x8, 5);
+    test:assertEquals(x9, -5);
+    test:assertEquals(x10, -6);
+    test:assertEquals(x11, 4);
+    test:assertEquals(x12, 6);
+
+    int i = 5;
+    int? a1 = +i;
+    int? a2 = ++i;
+    int? a3 = ~i;
+    int? a4 = +~i;
+
+    float f = -5.2;
+    float? a5 = +f;
+
+    decimal d = 7.45;
+    decimal? a6 = +d;
+
+    test:assertEquals(a1, 5);
+    test:assertEquals(a2, 5);
+    test:assertEquals(a3, -6);
+    test:assertEquals(a4, -6);
+    test:assertEquals(a5, -5.2);
+    test:assertEquals(a6, 7.45d);
 }
 
 function assertEquality(anydata expected, anydata actual) {


### PR DESCRIPTION
## Purpose
> $title

Fixes #32702

## Approach

## Samples

## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
