### PR TITLE
Add support for create function within if statements

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/visitors/FunctionCallExpressionTypeFinder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/visitors/FunctionCallExpressionTypeFinder.java
@@ -59,6 +59,10 @@ public class FunctionCallExpressionTypeFinder extends NodeVisitor {
         this.semanticModel = semanticModel;
     }
 
+    public void findTypeOf(FunctionCallExpressionNode functionCallExpressionNode) {
+        functionCallExpressionNode.accept(this);
+    }
+
     @Override
     public void visit(ModuleVariableDeclarationNode moduleVariableDeclarationNode) {
         Symbol symbol = semanticModel.symbol(moduleVariableDeclarationNode).orElse(null);
@@ -180,10 +184,22 @@ public class FunctionCallExpressionTypeFinder extends NodeVisitor {
         }
     }
 
+    /**
+     * Get the type symbol of the return type of the function call expression provided to this instance. Should be
+     * invoked after invoking {@link #findTypeOf(FunctionCallExpressionNode)}.
+     *
+     * @return Optional type symbol of the return type of function call expression
+     */
     public Optional<TypeSymbol> getReturnTypeSymbol() {
         return Optional.ofNullable(returnTypeSymbol);
     }
 
+    /**
+     * Get the type descriptor kind of the return type of the function call expression. Should be used when
+     * {@link #getReturnTypeSymbol()} returns empty.
+     *
+     * @return Return type descriptor kind
+     */
     public Optional<TypeDescKind> getReturnTypeDescKind() {
         return Optional.ofNullable(returnTypeDescKind);
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -386,14 +386,16 @@ public class CommonUtil {
                 return getDefaultValueForTypeDescKind(typeKind);
         }
         
-        return Optional.ofNullable(typeString);
+        return Optional.of(typeString);
     }
 
     /**
-     * Used to get the default values for a {@link TypeDescKind}.
-     * @see #getDefaultValueForType(TypeSymbol) which is preferred over this function. This function should be used as a compliment to .
+     * Used to get the default values for a {@link TypeDescKind}. {@link #getDefaultValueForType(TypeSymbol)}
+     * is preferred over this function. This function should be used as a compliment to .
+     *
      * @param typeKind Type desc kind
      * @return Optional default value
+     * @see #getDefaultValueForType(TypeSymbol)
      */
     public static Optional<String> getDefaultValueForTypeDescKind(TypeDescKind typeKind) {
         String defaultValue = null;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -274,12 +274,6 @@ public class CommonUtil {
         TypeSymbol rawType = getRawType(bType);
         TypeDescKind typeKind = rawType.typeKind();
         switch (typeKind) {
-            case FLOAT:
-                typeString = Float.toString(0);
-                break;
-            case BOOLEAN:
-                typeString = Boolean.toString(false);
-                break;
             case TUPLE:
                 TupleTypeSymbol tupleType = (TupleTypeSymbol) rawType;
                 String memberTypes = tupleType.memberTypeDescriptors().stream()
@@ -310,9 +304,6 @@ public class CommonUtil {
                                 getDefaultValueForType(recordFieldSymbol.typeDescriptor(), depth + 1).orElse(""))
                         .collect(Collectors.joining(", "));
                 typeString += "}";
-                break;
-            case MAP:
-                typeString = "{}";
                 break;
             case OBJECT:
                 if (depth > MAX_DEPTH) {
@@ -385,29 +376,58 @@ public class CommonUtil {
                 errorString.append(")");
                 typeString = errorString.toString();
                 break;
+            case MAP:
+            case FLOAT:
+            case BOOLEAN:
             case STREAM:
-                typeString = "new ()";
+            case XML:
+            case DECIMAL:
+            default:
+                return getDefaultValueForTypeDescKind(typeKind);
+        }
+        
+        return Optional.ofNullable(typeString);
+    }
+
+    /**
+     * Used to get the default values for a {@link TypeDescKind}.
+     * @see #getDefaultValueForType(TypeSymbol) which is preferred over this function. This function should be used as a compliment to .
+     * @param typeKind Type desc kind
+     * @return Optional default value
+     */
+    public static Optional<String> getDefaultValueForTypeDescKind(TypeDescKind typeKind) {
+        String defaultValue = null;
+        switch (typeKind) {
+            case FLOAT:
+                defaultValue = Float.toString(0);
+                break;
+            case BOOLEAN:
+                defaultValue = Boolean.toString(false);
+                break;
+            case MAP:
+                defaultValue = "{}";
+                break;
+            case STREAM:
+                defaultValue = "new ()";
                 break;
             case XML:
-                typeString = "xml ``";
+                defaultValue = "xml ``";
                 break;
             case DECIMAL:
-                typeString = Integer.toString(0);
+                defaultValue = Integer.toString(0);
                 break;
             default:
                 if (typeKind.isIntegerType()) {
-                    typeString = Integer.toString(0);
+                    defaultValue = Integer.toString(0);
                     break;
                 }
 
                 if (typeKind.isStringType()) {
-                    typeString = "\"\"";
+                    defaultValue = "\"\"";
                     break;
                 }
-
-                return Optional.empty();
         }
-        return Optional.ofNullable(typeString);
+        return Optional.ofNullable(defaultValue);
     }
 
     /**

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/command/CreateFunctionCommandExecTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/command/CreateFunctionCommandExecTest.java
@@ -97,6 +97,12 @@ public class CreateFunctionCommandExecTest extends AbstractCommandExecutionTest 
                 {"create_function_with_strands2.json", "create_function_with_strands1.bal"},
                 {"create_function_with_strands3.json", "create_function_with_strands1.bal"},
                 {"create_function_with_strands4.json", "create_function_with_strands1.bal"},
+                
+                {"create_function_in_if_statement1.json", "create_function_in_if_statement1.bal"},
+                {"create_function_in_if_statement2.json", "create_function_in_if_statement2.bal"},
+                {"create_function_in_if_statement3.json", "create_function_in_if_statement3.bal"},
+                
+                {"create_function_in_expression1.json", "create_function_in_expression1.bal"},
         };
     }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/command/CreateFunctionCommandExecTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/command/CreateFunctionCommandExecTest.java
@@ -101,6 +101,7 @@ public class CreateFunctionCommandExecTest extends AbstractCommandExecutionTest 
                 {"create_function_in_if_statement1.json", "create_function_in_if_statement1.bal"},
                 {"create_function_in_if_statement2.json", "create_function_in_if_statement2.bal"},
                 {"create_function_in_if_statement3.json", "create_function_in_if_statement3.bal"},
+                {"create_function_in_if_statement4.json", "create_function_in_if_statement4.bal"},
                 
                 {"create_function_in_expression1.json", "create_function_in_expression1.bal"},
         };

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/create_function_in_expression1.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/create_function_in_expression1.json
@@ -1,0 +1,40 @@
+{
+  "arguments": {
+    "node.range": {
+      "start": {
+        "line": 2,
+        "character": 15
+      },
+      "end": {
+        "line": 2,
+        "character": 32
+      }
+    }
+  },
+  "expected": {
+    "result": {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "range": {
+                  "start": {
+                    "line": 3,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 3,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction computeCount(int val) returns int {\n    return 0;\n}\n"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "jsonrpc": "2.0"
+  }
+}

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/create_function_in_if_statement1.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/create_function_in_if_statement1.json
@@ -1,0 +1,40 @@
+{
+  "arguments": {
+    "node.range": {
+      "start": {
+        "line": 1,
+        "character": 7
+      },
+      "end": {
+        "line": 1,
+        "character": 12
+      }
+    }
+  },
+  "expected": {
+    "result": {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "range": {
+                  "start": {
+                    "line": 4,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 4,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction foo() returns boolean {\n    return false;\n}\n"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "jsonrpc": "2.0"
+  }
+}

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/create_function_in_if_statement2.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/create_function_in_if_statement2.json
@@ -1,0 +1,40 @@
+{
+  "arguments": {
+    "node.range": {
+      "start": {
+        "line": 3,
+        "character": 24
+      },
+      "end": {
+        "line": 3,
+        "character": 45
+      }
+    }
+  },
+  "expected": {
+    "result": {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "range": {
+                  "start": {
+                    "line": 5,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 5,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction performAction(int result) returns json {\n    \n}\n"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "jsonrpc": "2.0"
+  }
+}

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/create_function_in_if_statement3.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/create_function_in_if_statement3.json
@@ -1,0 +1,40 @@
+{
+  "arguments": {
+    "node.range": {
+      "start": {
+        "line": 1,
+        "character": 7
+      },
+      "end": {
+        "line": 1,
+        "character": 12
+      }
+    }
+  },
+  "expected": {
+    "result": {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "range": {
+                  "start": {
+                    "line": 4,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 4,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction foo() returns int {\n    return 0;\n}\n"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "jsonrpc": "2.0"
+  }
+}

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/create_function_in_if_statement4.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/create_function_in_if_statement4.json
@@ -1,0 +1,40 @@
+{
+  "arguments": {
+    "node.range": {
+      "start": {
+        "line": 1,
+        "character": 7
+      },
+      "end": {
+        "line": 1,
+        "character": 12
+      }
+    }
+  },
+  "expected": {
+    "result": {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "range": {
+                  "start": {
+                    "line": 4,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 4,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction foo() returns boolean {\n    return false;\n}\n"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "jsonrpc": "2.0"
+  }
+}

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/source/create_function_in_expression1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/source/create_function_in_expression1.bal
@@ -1,0 +1,4 @@
+public function main() {
+    int val = 100;
+    val = 20 * computeCount(val) / 3;
+}

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/source/create_function_in_if_statement1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/source/create_function_in_if_statement1.bal
@@ -1,0 +1,5 @@
+public function main() {
+    if foo() {
+
+    }
+}

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/source/create_function_in_if_statement2.bal
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/source/create_function_in_if_statement2.bal
@@ -1,0 +1,10 @@
+public function main() {
+    int result = getInt();
+    if result > 0 {
+        json response = performAction(result);
+    }
+}
+
+function getInt() returns int {
+    return 1;
+}

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/source/create_function_in_if_statement3.bal
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/source/create_function_in_if_statement3.bal
@@ -1,0 +1,5 @@
+public function main() {
+    if foo() > 100 {
+
+    }
+}

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/source/create_function_in_if_statement4.bal
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/source/create_function_in_if_statement4.bal
@@ -1,0 +1,9 @@
+public function main() {
+    if foo() && check1() {
+
+    }
+}
+
+function check1() returns boolean {
+    return false;
+}


### PR DESCRIPTION
## Purpose
$subject

Fixes #32279

## Approach
Updated `FunctionCallExpressionTypeFinder` to return either the return type symbol or return type desc kind. Function's return type and return values are generated based on them.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
