### PR TITLE
Add fine grained error handling to CodeActionManager

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/CodeActionResult.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/CodeActionResult.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.ballerina.projects;
+
+import io.ballerina.projects.plugins.codeaction.CodeActionException;
+import io.ballerina.projects.plugins.codeaction.CodeActionInfo;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A wrapper to include codeactions returned by compiler plugins and exceptions captured in the process.
+ *
+ * @since 2.0.0
+ */
+public class CodeActionResult {
+
+    private final List<CodeActionInfo> codeActions = new ArrayList<>();
+    private final List<CodeActionException> errors = new ArrayList<>();
+
+    public void addCodeAction(CodeActionInfo codeAction) {
+        codeActions.add(codeAction);
+    }
+
+    public void addError(CodeActionException ex) {
+        errors.add(ex);
+    }
+
+    /**
+     * Get codeactions provided by compiler plugins.
+     *
+     * @return Codeactions
+     */
+    public List<CodeActionInfo> getCodeActions() {
+        return codeActions;
+    }
+
+    /**
+     * Get errors catch while processing compiler plugin codeactions.
+     *
+     * @return List of errors
+     */
+    public List<CodeActionException> getErrors() {
+        return errors;
+    }
+}

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/plugins/codeaction/CodeActionException.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/plugins/codeaction/CodeActionException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.ballerina.projects.plugins.codeaction;
+
+/**
+ * A runtime exception thrown to capture exceptions captured while executing compiler plugins.
+ *
+ * @since 2.0.0
+ */
+public class CodeActionException extends RuntimeException {
+
+    private final String codeActionName;
+
+    public CodeActionException(String codeActionName, Throwable cause) {
+        super(cause);
+        this.codeActionName = codeActionName;
+    }
+
+    public String getCodeActionName() {
+        return codeActionName;
+    }
+}

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/plugins/codeaction/PositionedActionContext.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/plugins/codeaction/PositionedActionContext.java
@@ -20,6 +20,7 @@ import io.ballerina.projects.Document;
 import io.ballerina.tools.text.LinePosition;
 
 import java.nio.file.Path;
+import java.util.Optional;
 
 /**
  * A parent context to hold information related to an operation performed against a position.
@@ -45,9 +46,9 @@ public interface PositionedActionContext {
     /**
      * Get the cursor position.
      *
-     * @return {@link LinePosition}
+     * @return Optional {@link LinePosition}
      */
-    LinePosition cursorPosition();
+    Optional<LinePosition> cursorPosition();
 
     /**
      * Get the current document where the given file URI resides.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/plugins/codeaction/PositionedActionContextImpl.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/plugins/codeaction/PositionedActionContextImpl.java
@@ -20,6 +20,7 @@ import io.ballerina.projects.Document;
 import io.ballerina.tools.text.LinePosition;
 
 import java.nio.file.Path;
+import java.util.Optional;
 
 /**
  * Abstract implementation of {@link PositionedActionContext}.
@@ -28,11 +29,11 @@ import java.nio.file.Path;
  */
 public abstract class PositionedActionContextImpl implements PositionedActionContext {
 
-    private String fileUri;
-    private Path filePath;
-    private LinePosition cursorPosition;
-    private Document document;
-    private SemanticModel semanticModel;
+    private final String fileUri;
+    private final Path filePath;
+    private final LinePosition cursorPosition;
+    private final Document document;
+    private final SemanticModel semanticModel;
 
     protected PositionedActionContextImpl(String fileUri, Path filePath, LinePosition cursorPosition,
                                         Document document, SemanticModel semanticModel) {
@@ -54,8 +55,8 @@ public abstract class PositionedActionContextImpl implements PositionedActionCon
     }
 
     @Override
-    public LinePosition cursorPosition() {
-        return cursorPosition;
+    public Optional<LinePosition> cursorPosition() {
+        return Optional.ofNullable(cursorPosition);
     }
 
     @Override

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/plugins/LanguageServerExtensionTests.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/plugins/LanguageServerExtensionTests.java
@@ -19,6 +19,7 @@ import com.google.gson.Gson;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.syntax.tree.SyntaxTree;
 import io.ballerina.projects.CodeActionManager;
+import io.ballerina.projects.CodeActionResult;
 import io.ballerina.projects.Document;
 import io.ballerina.projects.DocumentId;
 import io.ballerina.projects.Module;
@@ -94,10 +95,10 @@ public class LanguageServerExtensionTests {
         CodeActionContext codeActionContext = CodeActionContextImpl.from(filePath.toUri().toString(),
                 filePath, LinePosition.from(6, 5), document, module.getCompilation().getSemanticModel(), diagnostic);
 
-        List<CodeActionInfo> codeActionInfos = codeActionManager.codeActions(codeActionContext);
+        CodeActionResult codeActionResult = codeActionManager.codeActions(codeActionContext);
 
-        Assert.assertFalse(codeActionInfos.isEmpty());
-        Optional<CodeActionInfo> info = codeActionInfos.stream()
+        Assert.assertFalse(codeActionResult.getCodeActions().isEmpty());
+        Optional<CodeActionInfo> info = codeActionResult.getCodeActions().stream()
                 .filter(codeActionInfo -> "BCE2526/lstest/package_comp_plugin_with_codeactions/CREATE_VAR"
                         .equals(codeActionInfo.getProviderName()))
                 .filter(codeActionInfo -> "Introduce Variable".equals(codeActionInfo.getTitle()))


### PR DESCRIPTION
## Purpose
$subject

Fixes #33006

**Note**: This will break the `websocket` package's codeaction tests. They should be fixed after merging this.

## Approach
introduce a new class named `CodeActionResult` to hold both codeactions and exceptioned thrown while calculating codeactions. These exceptions are then logged in VSCode plugin output by LS.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
