### PR TITLE
Add spec conformance tests for `typeOf()`

### DIFF
--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typeof/TypeOfQueryExprTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typeof/TypeOfQueryExprTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.semantic.api.test.typeof;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.ArrayTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
+import io.ballerina.semantic.api.test.util.SemanticAPITestUtils;
+import io.ballerina.tools.text.LinePosition;
+import io.ballerina.tools.text.LineRange;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.ballerina.compiler.api.symbols.TypeDescKind.ARRAY;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.ERROR;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.INT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.RECORD;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.STRING;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.TABLE;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.TYPE_REFERENCE;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.UNION;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests cases for testing typeOf() with query expressions.
+ */
+public class TypeOfQueryExprTest {
+
+    private SemanticModel model;
+
+    @BeforeClass
+    public void setup() {
+        model = SemanticAPITestUtils.getDefaultModulesSemanticModel(
+                "test-src/symbols/symbols_in_query_exprs_test.bal");
+    }
+
+    @Test(dataProvider = "QueryExprPos")
+    public void testQueryExprs(int sLine, int sCol, int eLine, int eCol, TypeDescKind kind) {
+        assertType(sLine, sCol, eLine, eCol, kind);
+    }
+
+    @DataProvider(name = "QueryExprPos")
+    public Object[][] getPos() {
+        return new Object[][]{
+                // Basics
+                {21, 18, 21, 89, ARRAY},
+                {21, 29, 21, 31, null},
+                {21, 33, 21, 41, ARRAY},
+                {21, 18, 21, 41, null},
+                {21, 54, 21, 59, INT},
+                {21, 49, 21, 89, TYPE_REFERENCE},
+                {22, 13, 22, 92, ARRAY},
+                {22, 44, 22, 92, TYPE_REFERENCE},
+                // Where clause
+                {26, 22, 26, 30, STRING},
+                // Let clause
+                {30, 13, 32, 43, ARRAY},
+                {31, 51, 31, 59, STRING},
+                // Join clause
+                {36, 30, 36, 34, null},
+                {36, 39, 36, 45, ARRAY},
+                {36, 49, 36, 54, INT},
+                // Order by clause
+                {41, 16, 41, 30, null},
+                {41, 25, 41, 30, INT},
+                // Limit clause
+                {46, 22, 46, 27, INT},
+                // On conflict clause
+                {52, 43, 52, 80, ERROR},
+        };
+    }
+
+    @Test(dataProvider = "ExprPos1")
+    public void testQueryExprInDetail1(int sLine, int sCol, int eLine, int eCol) {
+        ArrayTypeSymbol type = (ArrayTypeSymbol) assertType(sLine, sCol, eLine, eCol, ARRAY);
+        assertEquals(type.memberTypeDescriptor().typeKind(), TYPE_REFERENCE);
+        assertEquals(type.memberTypeDescriptor().getName().get(), "Person");
+    }
+
+    @DataProvider(name = "ExprPos1")
+    public Object[][] getExprPos1() {
+        return new Object[][]{
+                {21, 18, 21, 89},
+                {22, 13, 22, 92},
+        };
+    }
+
+    @Test(dataProvider = "ExprPos2")
+    public void testQueryExprInDetail2(int sLine, int sCol, int eLine, int eCol) {
+        TypeReferenceTypeSymbol type = (TypeReferenceTypeSymbol) assertType(sLine, sCol, eLine, eCol, TYPE_REFERENCE);
+        assertEquals(type.getName().get(), "Person");
+        assertEquals(type.typeDescriptor().typeKind(), RECORD);
+    }
+
+    @DataProvider(name = "ExprPos2")
+    public Object[][] getExprPos2() {
+        return new Object[][]{
+                {21, 49, 21, 89},
+                {22, 44, 22, 92},
+        };
+    }
+
+    @Test
+    public void testTableKeySpecifier() {
+        UnionTypeSymbol type = (UnionTypeSymbol) assertType(50, 37, 52, 80, UNION);
+        assertEquals(type.userSpecifiedMemberTypes().size(), 2);
+        assertEquals(type.userSpecifiedMemberTypes().get(0).typeKind(), TABLE);
+        assertEquals(type.userSpecifiedMemberTypes().get(1).typeKind(), ERROR);
+    }
+
+    private TypeSymbol assertType(int sLine, int sCol, int eLine, int eCol, TypeDescKind kind) {
+        Optional<TypeSymbol> type = model.typeOf(
+                LineRange.from("symbols_in_query_exprs_test.bal", LinePosition.from(sLine, sCol),
+                               LinePosition.from(eLine, eCol)));
+
+        if (kind == null) {
+            assertTrue(type.isEmpty());
+            return null;
+        }
+
+        assertEquals(type.get().typeKind(), kind);
+        return type.get();
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/expressions_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/expressions_test.bal
@@ -178,6 +178,112 @@ function testExpr() {
     int x = tc.testFn();
 }
 
+function testTableConstructor() {
+    table<Person> key(id) tbl1 = table key(id) [
+        {id: 1001, name: "John Doe"}
+    ];
+}
+
+function testXMLAttributeAccess() {
+    xml x = xml `<root attr="attr-val"><a></a><b></b></root>`;
+    string|error val = x.attr;
+
+    xmlns "www.url.com" as ns;
+    x = xml `<root attr="attr-val" ns:attr="attr-with-ns-val"><a></a><b></b></root>`;
+    val = x.ns:attr;
+
+    string|error|() val2 = x?.attr;
+}
+
+function testAnnotAccess() {
+    Annot? annot = Person.@v1;
+}
+
+function testErrorConstructor() {
+    string msg = "Op failed";
+    error err1 = error(msg, a = "foo");
+    Error err2 = error Error(msg, err1, b = 10);
+}
+
+function testAnonFuncs() {
+    string name = "Pubudu";
+    var greet = function () returns string => string `Hello ${name}`;
+
+    var fn1 = @v1 isolated function(int x, int y = 0, string... z) {
+        int total = x + y;
+    };
+
+    int c = 10;
+    function (int, int) returns int add = (a, b) => a + b + c;
+}
+
+function testLetExpr() {
+    var v = let int x = 10, @v1{foo: "Foo"} Person p = {id: 10, name: "J. Doe"} in x * 2;
+}
+
+function testTypeOf() {
+    int x = 10;
+    typedesc<anydata> td = typeof (x + 25);
+}
+
+function testBitwiseExpr() {
+    int x = 16284;
+    int res = x & 24;
+    res = x ^ 2048;
+    res = 12345 | x;
+}
+
+function testLogicalAndConditionalExpr() {
+    boolean expr = 10 < 20;
+    boolean res = expr && true;
+    res = (20 > 15) || expr;
+
+    string? name = ();
+    string greet = "Hello " + (name ?: "Foo");
+}
+
+function testShiftExpr() {
+    byte shift = 8;
+    int res = 16 << shift;
+    res = 16 >> 4;
+    res = shift >>> 2;
+}
+
+function testRangeExpr() {
+    int x = 256;
+    int a = 10;
+    int b = 20;
+    var v1 = x...1024;
+    var v2 = b...x;
+    var v3 = a..<b;
+}
+
+function testTrapExpr() {
+    int|error res = trap panics();
+}
+
+function testXMLFilterExpr() {
+    xml x1 = xml `<ns:root></ns:root>`;
+    xml x2 = x1.<ns:*>;
+    x2 = x1.<ns:*|k:*>;
+}
+
+function testXMLStepExpr() {
+    xml x1 = xml `<ns:root><ns:child></ns:child></ns:root>`;
+    xml x2 = x1/<ns:child>;
+    x2 = x1/*;
+    x2 = x1/<*>;
+    x2 = x1/**/<ns:child>;
+    x2 = x1/<ns:child>[2];
+    x2 = x1/**/<ns:child|k:child>;
+    string s = x1/**/<ns:child>.toString();
+}
+
+function testGroupExpr() {
+    int x = ((((10 + 5) / 3) + 7));
+}
+
+
 // utils
 
 class PersonObj {
@@ -217,3 +323,26 @@ class TestClass {
         return 1;
     }
 }
+
+@v1 {
+    foo: "bar"
+}
+type Person record {|
+    readonly int id;
+    string name;
+|};
+
+type Annot record {
+    string foo;
+};
+
+public annotation Annot v1 on type, var;
+
+type Error error<record {}>;
+
+function panics() returns int {
+    panic error("Failed");
+}
+
+xmlns "foo" as ns;
+xmlns "bar" as k;

--- a/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
+++ b/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
@@ -40,6 +40,7 @@
             <class name="io.ballerina.semantic.api.test.TestSourcesTest" />
             <class name="io.ballerina.semantic.api.test.TypeAssignabilityTest" />
             <class name="io.ballerina.semantic.api.test.TypedescriptorTest" />
+            <class name="io.ballerina.semantic.api.test.typeof.TypeOfQueryExprTest" />
             <class name="io.ballerina.semantic.api.test.WorkspaceSymbolLookupTest" />
 
             <class name="io.ballerina.semantic.api.test.allreferences.FindRefsWithinTargetDocumentTest" />


### PR DESCRIPTION
## Purpose
This PR adds tests for verifying the conformance of `typeOf()`'s behaviour with the spec. Some of the cases were already covered. This PR adds tests for the missing cases.

Fixes #32163

## Remarks
Came across the following issues while writing tests:
- #32994 
- #32999
- #33015 
- #33016
- #33017 
- #33018 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
