### PR TITLE
Fix issue in return type validation

### DIFF
--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/mock/ObjectMock.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/mock/ObjectMock.java
@@ -351,7 +351,9 @@ public class ObjectMock {
         List<Type> memberTypes = functionReturnType.getMemberTypes();
         for (Type memberType : memberTypes) {
             if (memberType.getTag() == TypeTags.PARAMETERIZED_TYPE_TAG) {
-                return validateParameterizedValue(returnVal, ((ParameterizedType) memberType));
+                if (validateParameterizedValue(returnVal, ((ParameterizedType) memberType))) {
+                    return true;
+                }
             } else {
                 if (TypeChecker.checkIsType(returnVal, memberType)) {
                     return true;


### PR DESCRIPTION
## Purpose
Fix bug when mocking return value of a member function when return type is a union with a parameterized type.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/33058

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
