### PR TITLE
Write bir to tmp file first to avoid corrupted files

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/repos/FileSystemCache.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/repos/FileSystemCache.java
@@ -28,6 +28,7 @@ import io.ballerina.projects.util.ProjectConstants;
 import org.apache.commons.io.FileUtils;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -79,8 +80,10 @@ public class FileSystemCache extends CompilationCache {
         Path birFilePath = getBirPath().resolve(moduleName.toString() + ProjectConstants.BLANG_COMPILED_PKG_BIR_EXT);
         if (!Files.exists(birFilePath)) {
             try {
+                File tempBirFile = birPath.resolve(".tmp").toFile();
                 // TODO Can we improve this logic
-                FileUtils.writeByteArrayToFile(birFilePath.toFile(), birContent.toByteArray());
+                FileUtils.writeByteArrayToFile(tempBirFile, birContent.toByteArray());
+                FileUtils.moveFile(tempBirFile, birFilePath.toFile());
             } catch (IOException e) {
                 // TODO proper error handling
                 throw new RuntimeException("Failed to cache the bir of module: " + moduleName, e);


### PR DESCRIPTION
## Purpose
> Write bir to tmp file first to avoid corrupted files
Fixes #32606

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
