### PR TITLE
Add type reference completions items to type test context

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/TypeTestExpressionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/TypeTestExpressionNodeContext.java
@@ -16,18 +16,28 @@
 package org.ballerinalang.langserver.completions.providers.context;
 
 import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
 import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
 import io.ballerina.compiler.syntax.tree.Token;
 import io.ballerina.compiler.syntax.tree.TypeTestExpressionNode;
+import io.ballerina.projects.Module;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.common.utils.completion.QNameReferenceUtil;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
 import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
+import org.ballerinalang.langserver.completions.SymbolCompletionItem;
+import org.ballerinalang.langserver.completions.builder.TypeCompletionItemBuilder;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
+import org.ballerinalang.langserver.completions.util.SortingUtil;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * Completion provider for {@link TypeTestExpressionNode} context.
@@ -53,32 +63,91 @@ public class TypeTestExpressionNodeContext extends AbstractCompletionProvider<Ty
             completionItems.addAll(this.getCompletionItemList(typesInModule, context));
         } else {
             completionItems.addAll(this.getTypeDescContextItems(context));
+            completionItems.addAll(getTypeDescCompletionsOfExpression(context, node));
         }
         this.sort(context, node, completionItems);
 
         return completionItems;
     }
-    
+
+    private List<LSCompletionItem> getTypeDescCompletionsOfExpression(BallerinaCompletionContext context,
+                                                                      TypeTestExpressionNode node) {
+        List<LSCompletionItem> completionItems = new ArrayList<>();
+        Optional<TypeSymbol> typeSymbol =
+                context.currentSemanticModel().flatMap(semanticModel -> semanticModel.typeOf(node.expression()));
+        Optional<Module> currentModule = context.currentModule();
+        if (typeSymbol.isEmpty() || currentModule.isEmpty()) {
+            return completionItems;
+        }
+        List<TypeReferenceTypeSymbol> typeReferences;
+        if (typeSymbol.get().typeKind() == TypeDescKind.UNION) {
+            typeReferences = ((UnionTypeSymbol) typeSymbol.get()).memberTypeDescriptors().stream()
+                    .filter(type -> type.typeKind() == TypeDescKind.TYPE_REFERENCE)
+                    .map(type -> (TypeReferenceTypeSymbol) type).collect(Collectors.toList());
+        } else if (typeSymbol.get().typeKind() == TypeDescKind.TYPE_REFERENCE) {
+            typeReferences = List.of((TypeReferenceTypeSymbol) typeSymbol.get());
+        } else {
+            //check for intersection as well.
+            return completionItems;
+        }
+        completionItems = typeReferences.stream().filter(typeRef -> typeRef.getModule().isPresent()
+                        && !typeRef.getModule().get().nameEquals(context.currentModule().get()
+                        .moduleName().moduleNamePart()))
+                .map(typeRef -> new SymbolCompletionItem(context, typeRef,
+                        TypeCompletionItemBuilder.build(typeRef, typeRef.signature())))
+                .collect(Collectors.toList());
+        return completionItems;
+    }
+
     private boolean onExpressionContext(BallerinaCompletionContext context, TypeTestExpressionNode node) {
         int cursor = context.getCursorPositionInTree();
         Token isKeyword = node.isKeyword();
-        
+
         return cursor < isKeyword.textRange().startOffset();
     }
-    
+
     protected List<LSCompletionItem> expressionCompletions(BallerinaCompletionContext context,
-                                                                   TypeTestExpressionNode node) {
+                                                           TypeTestExpressionNode node) {
         if (QNameReferenceUtil.onQualifiedNameIdentifier(context, context.getNodeAtCursor())) {
             QualifiedNameReferenceNode qNameRef = (QualifiedNameReferenceNode) context.getNodeAtCursor();
             List<Symbol> typesInModule = QNameReferenceUtil.getExpressionContextEntries(context, qNameRef);
             return this.getCompletionItemList(typesInModule, context);
         }
-        
+
         return this.expressionCompletions(context);
     }
 
     @Override
     public boolean onPreValidation(BallerinaCompletionContext context, TypeTestExpressionNode node) {
         return !node.isKeyword().isMissing();
+    }
+
+    @Override
+    public void sort(BallerinaCompletionContext context, TypeTestExpressionNode node,
+                     List<LSCompletionItem> completionItems) {
+
+        Optional<TypeSymbol> typeSymbol =
+                context.currentSemanticModel().flatMap(semanticModel -> semanticModel.typeOf(node.expression()));
+        if (typeSymbol.isEmpty()) {
+            super.sort(context, node, completionItems);
+        }
+        List<String> typeNames;
+        if (typeSymbol.get().typeKind() == TypeDescKind.UNION) {
+            typeNames = ((UnionTypeSymbol) typeSymbol.get()).memberTypeDescriptors().stream()
+                    .map(TypeSymbol::typeKind).map(TypeDescKind::getName).collect(Collectors.toList());
+        } else {
+            typeNames = List.of(typeSymbol.get().typeKind().getName());
+        }
+        completionItems.forEach(lsCItem -> {
+            String sortText;
+            if (typeNames.contains(lsCItem.getCompletionItem().getInsertText())) {
+                sortText = SortingUtil.genSortText(1) +
+                        SortingUtil.genSortTextForTypeDescContext(context, lsCItem);
+            } else {
+                sortText = SortingUtil.genSortText(2) +
+                        SortingUtil.genSortTextForTypeDescContext(context, lsCItem);
+            }
+            lsCItem.getCompletionItem().setSortText(sortText);
+        });
     }
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/type_test_expression_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/type_test_expression_ctx_config1.json
@@ -9,7 +9,7 @@
       "label": "Thread",
       "kind": "TypeParameter",
       "detail": "Union",
-      "sortText": "BBN",
+      "sortText": "ABN",
       "insertText": "Thread",
       "insertTextFormat": "Snippet"
     },
@@ -325,7 +325,7 @@
       "label": "float",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "AG",
+      "sortText": "BG",
       "insertText": "float",
       "insertTextFormat": "Snippet"
     },
@@ -341,7 +341,7 @@
       "label": "int",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "AG",
+      "sortText": "BG",
       "insertText": "int",
       "insertTextFormat": "Snippet"
     },
@@ -373,7 +373,7 @@
       "label": "string",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "AG",
+      "sortText": "BG",
       "insertText": "string",
       "insertTextFormat": "Snippet"
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/type_test_expression_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/type_test_expression_ctx_config1.json
@@ -9,7 +9,7 @@
       "label": "Thread",
       "kind": "TypeParameter",
       "detail": "Union",
-      "sortText": "N",
+      "sortText": "BBN",
       "insertText": "Thread",
       "insertTextFormat": "Snippet"
     },
@@ -20,7 +20,7 @@
       "documentation": {
         "left": "Describes Strand execution details for the runtime.\n"
       },
-      "sortText": "M",
+      "sortText": "BBM",
       "insertText": "StrandData",
       "insertTextFormat": "Snippet"
     },
@@ -28,7 +28,7 @@
       "label": "TestRecord1",
       "kind": "Struct",
       "detail": "Record",
-      "sortText": "M",
+      "sortText": "BAM",
       "insertText": "TestRecord1",
       "insertTextFormat": "Snippet"
     },
@@ -36,7 +36,7 @@
       "label": "readonly",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "readonly",
       "insertTextFormat": "Snippet"
     },
@@ -44,7 +44,7 @@
       "label": "handle",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "handle",
       "insertTextFormat": "Snippet"
     },
@@ -52,7 +52,7 @@
       "label": "never",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "never",
       "insertTextFormat": "Snippet"
     },
@@ -60,7 +60,7 @@
       "label": "json",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "json",
       "insertTextFormat": "Snippet"
     },
@@ -68,7 +68,7 @@
       "label": "anydata",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "anydata",
       "insertTextFormat": "Snippet"
     },
@@ -76,7 +76,7 @@
       "label": "any",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "any",
       "insertTextFormat": "Snippet"
     },
@@ -84,7 +84,7 @@
       "label": "byte",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
     },
@@ -92,7 +92,7 @@
       "label": "service",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BR",
       "insertText": "service",
       "insertTextFormat": "Snippet"
     },
@@ -100,7 +100,7 @@
       "label": "record",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "BZ",
       "filterText": "record",
       "insertText": "record ",
       "insertTextFormat": "Snippet"
@@ -109,7 +109,7 @@
       "label": "function",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "BZ",
       "filterText": "function",
       "insertText": "function ",
       "insertTextFormat": "Snippet"
@@ -118,7 +118,7 @@
       "label": "record {}",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "BX",
       "filterText": "record",
       "insertText": "record {${1}}",
       "insertTextFormat": "Snippet"
@@ -127,7 +127,7 @@
       "label": "record {||}",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "BX",
       "filterText": "record",
       "insertText": "record {|${1}|}",
       "insertTextFormat": "Snippet"
@@ -136,7 +136,7 @@
       "label": "distinct",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "BZ",
       "filterText": "distinct",
       "insertText": "distinct",
       "insertTextFormat": "Snippet"
@@ -145,7 +145,7 @@
       "label": "object {}",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "BX",
       "filterText": "object",
       "insertText": "object {${1}}",
       "insertTextFormat": "Snippet"
@@ -154,7 +154,7 @@
       "label": "true",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "BZ",
       "filterText": "true",
       "insertText": "true",
       "insertTextFormat": "Snippet"
@@ -163,7 +163,7 @@
       "label": "false",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "BZ",
       "filterText": "false",
       "insertText": "false",
       "insertTextFormat": "Snippet"
@@ -172,7 +172,7 @@
       "label": "module1",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "O",
+      "sortText": "BBO",
       "filterText": "module1",
       "insertText": "module1",
       "insertTextFormat": "Snippet"
@@ -181,7 +181,7 @@
       "label": "ballerina/lang.array",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "R",
+      "sortText": "BCE",
       "filterText": "array",
       "insertText": "array",
       "insertTextFormat": "Snippet",
@@ -205,7 +205,7 @@
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "R",
+      "sortText": "BCE",
       "filterText": "runtime",
       "insertText": "runtime",
       "insertTextFormat": "Snippet",
@@ -229,7 +229,7 @@
       "label": "ballerina/lang.test",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "R",
+      "sortText": "BCE",
       "filterText": "test",
       "insertText": "test",
       "insertTextFormat": "Snippet",
@@ -253,7 +253,7 @@
       "label": "ballerina/jballerina.java",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "R",
+      "sortText": "BCF",
       "filterText": "java",
       "insertText": "java",
       "insertTextFormat": "Snippet",
@@ -277,7 +277,7 @@
       "label": "ballerina/lang.value",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "R",
+      "sortText": "BCE",
       "filterText": "value",
       "insertText": "value",
       "insertTextFormat": "Snippet",
@@ -301,7 +301,7 @@
       "label": "boolean",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "boolean",
       "insertTextFormat": "Snippet"
     },
@@ -309,7 +309,7 @@
       "label": "decimal",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "decimal",
       "insertTextFormat": "Snippet"
     },
@@ -317,7 +317,7 @@
       "label": "error",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "error",
       "insertTextFormat": "Snippet"
     },
@@ -325,7 +325,7 @@
       "label": "float",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "AG",
       "insertText": "float",
       "insertTextFormat": "Snippet"
     },
@@ -333,7 +333,7 @@
       "label": "future",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "future",
       "insertTextFormat": "Snippet"
     },
@@ -341,7 +341,7 @@
       "label": "int",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "AG",
       "insertText": "int",
       "insertTextFormat": "Snippet"
     },
@@ -349,7 +349,7 @@
       "label": "map",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "map",
       "insertTextFormat": "Snippet"
     },
@@ -357,7 +357,7 @@
       "label": "object",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "object",
       "insertTextFormat": "Snippet"
     },
@@ -365,7 +365,7 @@
       "label": "stream",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "stream",
       "insertTextFormat": "Snippet"
     },
@@ -373,7 +373,7 @@
       "label": "string",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "AG",
       "insertText": "string",
       "insertTextFormat": "Snippet"
     },
@@ -381,7 +381,7 @@
       "label": "table",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "table",
       "insertTextFormat": "Snippet"
     },
@@ -389,7 +389,7 @@
       "label": "transaction",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "transaction",
       "insertTextFormat": "Snippet"
     },
@@ -397,7 +397,7 @@
       "label": "typedesc",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "typedesc",
       "insertTextFormat": "Snippet"
     },
@@ -405,7 +405,7 @@
       "label": "xml",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/type_test_expression_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/type_test_expression_ctx_config2.json
@@ -9,7 +9,7 @@
       "label": "Thread",
       "kind": "TypeParameter",
       "detail": "Union",
-      "sortText": "BBN",
+      "sortText": "ABN",
       "insertText": "Thread",
       "insertTextFormat": "Snippet"
     },
@@ -325,7 +325,7 @@
       "label": "float",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "AG",
+      "sortText": "BG",
       "insertText": "float",
       "insertTextFormat": "Snippet"
     },
@@ -341,7 +341,7 @@
       "label": "int",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "AG",
+      "sortText": "BG",
       "insertText": "int",
       "insertTextFormat": "Snippet"
     },
@@ -373,7 +373,7 @@
       "label": "string",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "AG",
+      "sortText": "BG",
       "insertText": "string",
       "insertTextFormat": "Snippet"
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/type_test_expression_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/type_test_expression_ctx_config2.json
@@ -9,7 +9,7 @@
       "label": "Thread",
       "kind": "TypeParameter",
       "detail": "Union",
-      "sortText": "N",
+      "sortText": "BBN",
       "insertText": "Thread",
       "insertTextFormat": "Snippet"
     },
@@ -20,7 +20,7 @@
       "documentation": {
         "left": "Describes Strand execution details for the runtime.\n"
       },
-      "sortText": "M",
+      "sortText": "BBM",
       "insertText": "StrandData",
       "insertTextFormat": "Snippet"
     },
@@ -28,7 +28,7 @@
       "label": "TestRecord1",
       "kind": "Struct",
       "detail": "Record",
-      "sortText": "M",
+      "sortText": "BAM",
       "insertText": "TestRecord1",
       "insertTextFormat": "Snippet"
     },
@@ -36,7 +36,7 @@
       "label": "readonly",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "readonly",
       "insertTextFormat": "Snippet"
     },
@@ -44,7 +44,7 @@
       "label": "handle",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "handle",
       "insertTextFormat": "Snippet"
     },
@@ -52,7 +52,7 @@
       "label": "never",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "never",
       "insertTextFormat": "Snippet"
     },
@@ -60,7 +60,7 @@
       "label": "json",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "json",
       "insertTextFormat": "Snippet"
     },
@@ -68,7 +68,7 @@
       "label": "anydata",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "anydata",
       "insertTextFormat": "Snippet"
     },
@@ -76,7 +76,7 @@
       "label": "any",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "any",
       "insertTextFormat": "Snippet"
     },
@@ -84,7 +84,7 @@
       "label": "byte",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
     },
@@ -92,7 +92,7 @@
       "label": "service",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BR",
       "insertText": "service",
       "insertTextFormat": "Snippet"
     },
@@ -100,7 +100,7 @@
       "label": "record",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "BZ",
       "filterText": "record",
       "insertText": "record ",
       "insertTextFormat": "Snippet"
@@ -109,7 +109,7 @@
       "label": "function",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "BZ",
       "filterText": "function",
       "insertText": "function ",
       "insertTextFormat": "Snippet"
@@ -118,7 +118,7 @@
       "label": "record {}",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "BX",
       "filterText": "record",
       "insertText": "record {${1}}",
       "insertTextFormat": "Snippet"
@@ -127,7 +127,7 @@
       "label": "record {||}",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "BX",
       "filterText": "record",
       "insertText": "record {|${1}|}",
       "insertTextFormat": "Snippet"
@@ -136,7 +136,7 @@
       "label": "distinct",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "BZ",
       "filterText": "distinct",
       "insertText": "distinct",
       "insertTextFormat": "Snippet"
@@ -145,7 +145,7 @@
       "label": "object {}",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "BX",
       "filterText": "object",
       "insertText": "object {${1}}",
       "insertTextFormat": "Snippet"
@@ -154,7 +154,7 @@
       "label": "true",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "BZ",
       "filterText": "true",
       "insertText": "true",
       "insertTextFormat": "Snippet"
@@ -163,7 +163,7 @@
       "label": "false",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "BZ",
       "filterText": "false",
       "insertText": "false",
       "insertTextFormat": "Snippet"
@@ -172,7 +172,7 @@
       "label": "module1",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "O",
+      "sortText": "BBO",
       "filterText": "module1",
       "insertText": "module1",
       "insertTextFormat": "Snippet"
@@ -181,7 +181,7 @@
       "label": "ballerina/lang.array",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "R",
+      "sortText": "BCE",
       "filterText": "array",
       "insertText": "array",
       "insertTextFormat": "Snippet",
@@ -205,7 +205,7 @@
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "R",
+      "sortText": "BCE",
       "filterText": "runtime",
       "insertText": "runtime",
       "insertTextFormat": "Snippet",
@@ -229,7 +229,7 @@
       "label": "ballerina/lang.test",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "R",
+      "sortText": "BCE",
       "filterText": "test",
       "insertText": "test",
       "insertTextFormat": "Snippet",
@@ -253,7 +253,7 @@
       "label": "ballerina/jballerina.java",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "R",
+      "sortText": "BCF",
       "filterText": "java",
       "insertText": "java",
       "insertTextFormat": "Snippet",
@@ -277,7 +277,7 @@
       "label": "ballerina/lang.value",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "R",
+      "sortText": "BCE",
       "filterText": "value",
       "insertText": "value",
       "insertTextFormat": "Snippet",
@@ -301,7 +301,7 @@
       "label": "boolean",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "boolean",
       "insertTextFormat": "Snippet"
     },
@@ -309,7 +309,7 @@
       "label": "decimal",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "decimal",
       "insertTextFormat": "Snippet"
     },
@@ -317,7 +317,7 @@
       "label": "error",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "error",
       "insertTextFormat": "Snippet"
     },
@@ -325,7 +325,7 @@
       "label": "float",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "AG",
       "insertText": "float",
       "insertTextFormat": "Snippet"
     },
@@ -333,7 +333,7 @@
       "label": "future",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "future",
       "insertTextFormat": "Snippet"
     },
@@ -341,7 +341,7 @@
       "label": "int",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "AG",
       "insertText": "int",
       "insertTextFormat": "Snippet"
     },
@@ -349,7 +349,7 @@
       "label": "map",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "map",
       "insertTextFormat": "Snippet"
     },
@@ -357,7 +357,7 @@
       "label": "object",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "object",
       "insertTextFormat": "Snippet"
     },
@@ -365,7 +365,7 @@
       "label": "stream",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "stream",
       "insertTextFormat": "Snippet"
     },
@@ -373,7 +373,7 @@
       "label": "string",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "AG",
       "insertText": "string",
       "insertTextFormat": "Snippet"
     },
@@ -381,7 +381,7 @@
       "label": "table",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "table",
       "insertTextFormat": "Snippet"
     },
@@ -389,7 +389,7 @@
       "label": "transaction",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "transaction",
       "insertTextFormat": "Snippet"
     },
@@ -397,7 +397,7 @@
       "label": "typedesc",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "typedesc",
       "insertTextFormat": "Snippet"
     },
@@ -405,7 +405,7 @@
       "label": "xml",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/type_test_expression_ctx_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/type_test_expression_ctx_config3.json
@@ -15,7 +15,7 @@
           "value": ""
         }
       },
-      "sortText": "BD",
+      "sortText": "AD",
       "insertText": "TEST_INT_CONST1",
       "insertTextFormat": "Snippet"
     },
@@ -29,7 +29,7 @@
           "value": ""
         }
       },
-      "sortText": "BD",
+      "sortText": "AD",
       "insertText": "TEST_STRING_CONST1",
       "insertTextFormat": "Snippet"
     },
@@ -43,7 +43,7 @@
           "value": ""
         }
       },
-      "sortText": "BE",
+      "sortText": "AE",
       "insertText": "ENUM1_FIELD1",
       "insertTextFormat": "Snippet"
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/type_test_expression_ctx_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/type_test_expression_ctx_config3.json
@@ -15,7 +15,7 @@
           "value": ""
         }
       },
-      "sortText": "C",
+      "sortText": "BD",
       "insertText": "TEST_INT_CONST1",
       "insertTextFormat": "Snippet"
     },
@@ -29,7 +29,7 @@
           "value": ""
         }
       },
-      "sortText": "C",
+      "sortText": "BD",
       "insertText": "TEST_STRING_CONST1",
       "insertTextFormat": "Snippet"
     },
@@ -43,7 +43,7 @@
           "value": ""
         }
       },
-      "sortText": "H",
+      "sortText": "BE",
       "insertText": "ENUM1_FIELD1",
       "insertTextFormat": "Snippet"
     },
@@ -51,7 +51,7 @@
       "label": "TestRecord1",
       "kind": "Struct",
       "detail": "Record",
-      "sortText": "M",
+      "sortText": "BBM",
       "insertText": "TestRecord1",
       "insertTextFormat": "Snippet"
     },
@@ -59,7 +59,7 @@
       "label": "TestRecord2",
       "kind": "Struct",
       "detail": "Record",
-      "sortText": "M",
+      "sortText": "BBM",
       "insertText": "TestRecord2",
       "insertTextFormat": "Snippet"
     },
@@ -67,7 +67,7 @@
       "label": "TestMap2",
       "kind": "TypeParameter",
       "detail": "Map",
-      "sortText": "N",
+      "sortText": "BBN",
       "insertText": "TestMap2",
       "insertTextFormat": "Snippet"
     },
@@ -75,7 +75,7 @@
       "label": "TestMap3",
       "kind": "TypeParameter",
       "detail": "Map",
-      "sortText": "N",
+      "sortText": "BBN",
       "insertText": "TestMap3",
       "insertTextFormat": "Snippet"
     },
@@ -83,7 +83,7 @@
       "label": "TestObject1",
       "kind": "Interface",
       "detail": "Object",
-      "sortText": "K",
+      "sortText": "BBK",
       "insertText": "TestObject1",
       "insertTextFormat": "Snippet"
     },
@@ -91,7 +91,7 @@
       "label": "ErrorOne",
       "kind": "Event",
       "detail": "Error",
-      "sortText": "L",
+      "sortText": "BBL",
       "insertText": "ErrorOne",
       "insertTextFormat": "Snippet"
     },
@@ -99,7 +99,7 @@
       "label": "ErrorTwo",
       "kind": "Event",
       "detail": "Error",
-      "sortText": "L",
+      "sortText": "BBL",
       "insertText": "ErrorTwo",
       "insertTextFormat": "Snippet"
     },
@@ -110,7 +110,7 @@
       "documentation": {
         "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
       },
-      "sortText": "I",
+      "sortText": "BBI",
       "insertText": "ResponseMessage",
       "insertTextFormat": "Snippet"
     },
@@ -121,7 +121,7 @@
       "documentation": {
         "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
       },
-      "sortText": "I",
+      "sortText": "BBI",
       "insertText": "RequestMessage",
       "insertTextFormat": "Snippet"
     },
@@ -129,7 +129,7 @@
       "label": "AnnotationType",
       "kind": "Struct",
       "detail": "Record",
-      "sortText": "M",
+      "sortText": "BBM",
       "insertText": "AnnotationType",
       "insertTextFormat": "Snippet"
     },
@@ -137,7 +137,7 @@
       "label": "TestEnum1",
       "kind": "Enum",
       "detail": "enum",
-      "sortText": "I",
+      "sortText": "BE",
       "insertText": "TestEnum1",
       "insertTextFormat": "Snippet"
     },
@@ -145,7 +145,7 @@
       "label": "TestClass1",
       "kind": "Interface",
       "detail": "Class",
-      "sortText": "K",
+      "sortText": "BBK",
       "insertText": "TestClass1",
       "insertTextFormat": "Snippet"
     },
@@ -153,7 +153,7 @@
       "label": "Listener",
       "kind": "Interface",
       "detail": "Class",
-      "sortText": "K",
+      "sortText": "BBK",
       "insertText": "Listener",
       "insertTextFormat": "Snippet"
     },
@@ -164,7 +164,7 @@
       "documentation": {
         "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs."
       },
-      "sortText": "K",
+      "sortText": "BBK",
       "insertText": "Client",
       "insertTextFormat": "Snippet"
     },
@@ -175,7 +175,7 @@
       "documentation": {
         "left": "Represents a response.\n"
       },
-      "sortText": "K",
+      "sortText": "BBK",
       "insertText": "Response",
       "insertTextFormat": "Snippet"
     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/type_test_expression_ctx_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/type_test_expression_ctx_config4.json
@@ -15,7 +15,7 @@
           "value": ""
         }
       },
-      "sortText": "BD",
+      "sortText": "AD",
       "insertText": "TEST_INT_CONST1",
       "insertTextFormat": "Snippet"
     },
@@ -29,7 +29,7 @@
           "value": ""
         }
       },
-      "sortText": "BD",
+      "sortText": "AD",
       "insertText": "TEST_STRING_CONST1",
       "insertTextFormat": "Snippet"
     },
@@ -43,7 +43,7 @@
           "value": ""
         }
       },
-      "sortText": "BE",
+      "sortText": "AE",
       "insertText": "ENUM1_FIELD1",
       "insertTextFormat": "Snippet"
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/type_test_expression_ctx_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/type_test_expression_ctx_config4.json
@@ -15,7 +15,7 @@
           "value": ""
         }
       },
-      "sortText": "C",
+      "sortText": "BD",
       "insertText": "TEST_INT_CONST1",
       "insertTextFormat": "Snippet"
     },
@@ -29,7 +29,7 @@
           "value": ""
         }
       },
-      "sortText": "C",
+      "sortText": "BD",
       "insertText": "TEST_STRING_CONST1",
       "insertTextFormat": "Snippet"
     },
@@ -43,7 +43,7 @@
           "value": ""
         }
       },
-      "sortText": "H",
+      "sortText": "BE",
       "insertText": "ENUM1_FIELD1",
       "insertTextFormat": "Snippet"
     },
@@ -51,7 +51,7 @@
       "label": "TestRecord1",
       "kind": "Struct",
       "detail": "Record",
-      "sortText": "M",
+      "sortText": "BBM",
       "insertText": "TestRecord1",
       "insertTextFormat": "Snippet"
     },
@@ -59,7 +59,7 @@
       "label": "TestRecord2",
       "kind": "Struct",
       "detail": "Record",
-      "sortText": "M",
+      "sortText": "BBM",
       "insertText": "TestRecord2",
       "insertTextFormat": "Snippet"
     },
@@ -67,7 +67,7 @@
       "label": "TestMap2",
       "kind": "TypeParameter",
       "detail": "Map",
-      "sortText": "N",
+      "sortText": "BBN",
       "insertText": "TestMap2",
       "insertTextFormat": "Snippet"
     },
@@ -75,7 +75,7 @@
       "label": "TestMap3",
       "kind": "TypeParameter",
       "detail": "Map",
-      "sortText": "N",
+      "sortText": "BBN",
       "insertText": "TestMap3",
       "insertTextFormat": "Snippet"
     },
@@ -83,7 +83,7 @@
       "label": "TestObject1",
       "kind": "Interface",
       "detail": "Object",
-      "sortText": "K",
+      "sortText": "BBK",
       "insertText": "TestObject1",
       "insertTextFormat": "Snippet"
     },
@@ -91,7 +91,7 @@
       "label": "ErrorOne",
       "kind": "Event",
       "detail": "Error",
-      "sortText": "L",
+      "sortText": "BBL",
       "insertText": "ErrorOne",
       "insertTextFormat": "Snippet"
     },
@@ -99,7 +99,7 @@
       "label": "ErrorTwo",
       "kind": "Event",
       "detail": "Error",
-      "sortText": "L",
+      "sortText": "BBL",
       "insertText": "ErrorTwo",
       "insertTextFormat": "Snippet"
     },
@@ -110,7 +110,7 @@
       "documentation": {
         "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
       },
-      "sortText": "I",
+      "sortText": "BBI",
       "insertText": "ResponseMessage",
       "insertTextFormat": "Snippet"
     },
@@ -121,7 +121,7 @@
       "documentation": {
         "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
       },
-      "sortText": "I",
+      "sortText": "BBI",
       "insertText": "RequestMessage",
       "insertTextFormat": "Snippet"
     },
@@ -129,7 +129,7 @@
       "label": "AnnotationType",
       "kind": "Struct",
       "detail": "Record",
-      "sortText": "M",
+      "sortText": "BBM",
       "insertText": "AnnotationType",
       "insertTextFormat": "Snippet"
     },
@@ -137,7 +137,7 @@
       "label": "TestEnum1",
       "kind": "Enum",
       "detail": "enum",
-      "sortText": "I",
+      "sortText": "BE",
       "insertText": "TestEnum1",
       "insertTextFormat": "Snippet"
     },
@@ -145,7 +145,7 @@
       "label": "TestClass1",
       "kind": "Interface",
       "detail": "Class",
-      "sortText": "K",
+      "sortText": "BBK",
       "insertText": "TestClass1",
       "insertTextFormat": "Snippet"
     },
@@ -153,7 +153,7 @@
       "label": "Listener",
       "kind": "Interface",
       "detail": "Class",
-      "sortText": "K",
+      "sortText": "BBK",
       "insertText": "Listener",
       "insertTextFormat": "Snippet"
     },
@@ -164,7 +164,7 @@
       "documentation": {
         "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs."
       },
-      "sortText": "K",
+      "sortText": "BBK",
       "insertText": "Client",
       "insertTextFormat": "Snippet"
     },
@@ -175,7 +175,7 @@
       "documentation": {
         "left": "Represents a response.\n"
       },
-      "sortText": "K",
+      "sortText": "BBK",
       "insertText": "Response",
       "insertTextFormat": "Snippet"
     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/type_test_expression_ctx_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/type_test_expression_ctx_config5.json
@@ -9,7 +9,7 @@
       "label": "TestRecord1",
       "kind": "Struct",
       "detail": "Record",
-      "sortText": "M",
+      "sortText": "BAM",
       "insertText": "TestRecord1",
       "insertTextFormat": "Snippet"
     },
@@ -17,7 +17,7 @@
       "label": "module1",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "O",
+      "sortText": "BBO",
       "filterText": "module1",
       "insertText": "module1",
       "insertTextFormat": "Snippet"
@@ -26,7 +26,7 @@
       "label": "ballerina/lang.test",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "R",
+      "sortText": "BCE",
       "filterText": "test",
       "insertText": "test",
       "insertTextFormat": "Snippet",
@@ -50,7 +50,7 @@
       "label": "ballerina/lang.array",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "R",
+      "sortText": "BCE",
       "filterText": "array",
       "insertText": "array",
       "insertTextFormat": "Snippet",
@@ -74,7 +74,7 @@
       "label": "ballerina/jballerina.java",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "R",
+      "sortText": "BCF",
       "filterText": "java",
       "insertText": "java",
       "insertTextFormat": "Snippet",
@@ -98,7 +98,7 @@
       "label": "ballerina/lang.value",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "R",
+      "sortText": "BCE",
       "filterText": "value",
       "insertText": "value",
       "insertTextFormat": "Snippet",
@@ -122,7 +122,7 @@
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "R",
+      "sortText": "BCE",
       "filterText": "runtime",
       "insertText": "runtime",
       "insertTextFormat": "Snippet",
@@ -146,7 +146,7 @@
       "label": "boolean",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "boolean",
       "insertTextFormat": "Snippet"
     },
@@ -154,7 +154,7 @@
       "label": "decimal",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "decimal",
       "insertTextFormat": "Snippet"
     },
@@ -162,7 +162,7 @@
       "label": "error",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "error",
       "insertTextFormat": "Snippet"
     },
@@ -170,7 +170,7 @@
       "label": "float",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "float",
       "insertTextFormat": "Snippet"
     },
@@ -178,7 +178,7 @@
       "label": "future",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "future",
       "insertTextFormat": "Snippet"
     },
@@ -186,7 +186,7 @@
       "label": "int",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "int",
       "insertTextFormat": "Snippet"
     },
@@ -194,7 +194,7 @@
       "label": "map",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "map",
       "insertTextFormat": "Snippet"
     },
@@ -202,7 +202,7 @@
       "label": "object",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "object",
       "insertTextFormat": "Snippet"
     },
@@ -210,7 +210,7 @@
       "label": "stream",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "stream",
       "insertTextFormat": "Snippet"
     },
@@ -218,7 +218,7 @@
       "label": "string",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "string",
       "insertTextFormat": "Snippet"
     },
@@ -226,7 +226,7 @@
       "label": "table",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "table",
       "insertTextFormat": "Snippet"
     },
@@ -234,7 +234,7 @@
       "label": "transaction",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "transaction",
       "insertTextFormat": "Snippet"
     },
@@ -242,7 +242,7 @@
       "label": "typedesc",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "typedesc",
       "insertTextFormat": "Snippet"
     },
@@ -250,7 +250,7 @@
       "label": "xml",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
     },
@@ -258,7 +258,7 @@
       "label": "service",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "BZ",
       "filterText": "service",
       "insertText": "service",
       "insertTextFormat": "Snippet"
@@ -267,7 +267,7 @@
       "label": "new",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "BZ",
       "filterText": "new",
       "insertText": "new ",
       "insertTextFormat": "Snippet"
@@ -276,7 +276,7 @@
       "label": "isolated",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "BZ",
       "filterText": "isolated",
       "insertText": "isolated ",
       "insertTextFormat": "Snippet"
@@ -285,7 +285,7 @@
       "label": "transactional",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "BZ",
       "filterText": "transactional",
       "insertText": "transactional",
       "insertTextFormat": "Snippet"
@@ -294,7 +294,7 @@
       "label": "function",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "BZ",
       "filterText": "function",
       "insertText": "function ",
       "insertTextFormat": "Snippet"
@@ -303,7 +303,7 @@
       "label": "let",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "BZ",
       "filterText": "let",
       "insertText": "let",
       "insertTextFormat": "Snippet"
@@ -312,7 +312,7 @@
       "label": "typeof",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "BZ",
       "filterText": "typeof",
       "insertText": "typeof ",
       "insertTextFormat": "Snippet"
@@ -321,7 +321,7 @@
       "label": "trap",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "BZ",
       "filterText": "trap",
       "insertText": "trap",
       "insertTextFormat": "Snippet"
@@ -330,7 +330,7 @@
       "label": "client",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "BZ",
       "filterText": "client",
       "insertText": "client ",
       "insertTextFormat": "Snippet"
@@ -339,7 +339,7 @@
       "label": "true",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "BZ",
       "filterText": "true",
       "insertText": "true",
       "insertTextFormat": "Snippet"
@@ -348,7 +348,7 @@
       "label": "false",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "BZ",
       "filterText": "false",
       "insertText": "false",
       "insertTextFormat": "Snippet"
@@ -357,7 +357,7 @@
       "label": "check",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "BZ",
       "filterText": "check",
       "insertText": "check ",
       "insertTextFormat": "Snippet"
@@ -366,7 +366,7 @@
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "BZ",
       "filterText": "checkpanic",
       "insertText": "checkpanic ",
       "insertTextFormat": "Snippet"
@@ -375,7 +375,7 @@
       "label": "is",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "BZ",
       "filterText": "is",
       "insertText": "is",
       "insertTextFormat": "Snippet"
@@ -384,7 +384,7 @@
       "label": "error constructor",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "BX",
       "filterText": "error",
       "insertText": "error(\"${1}\")",
       "insertTextFormat": "Snippet"
@@ -393,7 +393,7 @@
       "label": "object constructor",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "BX",
       "filterText": "object",
       "insertText": "object {${1}}",
       "insertTextFormat": "Snippet"
@@ -402,7 +402,7 @@
       "label": "base16",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "BX",
       "filterText": "base16",
       "insertText": "base16 `${1}`",
       "insertTextFormat": "Snippet"
@@ -411,7 +411,7 @@
       "label": "base64",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "BX",
       "filterText": "base64",
       "insertText": "base64 `${1}`",
       "insertTextFormat": "Snippet"
@@ -420,7 +420,7 @@
       "label": "from",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "BZ",
       "filterText": "from",
       "insertText": "from ",
       "insertTextFormat": "Snippet"
@@ -435,7 +435,7 @@
           "value": "**Package:** _._  \n  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "BAC",
       "filterText": "testFunction",
       "insertText": "testFunction()",
       "insertTextFormat": "Snippet"
@@ -444,7 +444,7 @@
       "label": "Thread",
       "kind": "TypeParameter",
       "detail": "Union",
-      "sortText": "N",
+      "sortText": "BBN",
       "insertText": "Thread",
       "insertTextFormat": "Snippet"
     },
@@ -455,7 +455,7 @@
       "documentation": {
         "left": "Describes Strand execution details for the runtime.\n"
       },
-      "sortText": "M",
+      "sortText": "BBM",
       "insertText": "StrandData",
       "insertTextFormat": "Snippet"
     },
@@ -463,7 +463,7 @@
       "label": "testVar",
       "kind": "Variable",
       "detail": "int|string|float",
-      "sortText": "B",
+      "sortText": "BAB",
       "insertText": "testVar",
       "insertTextFormat": "Snippet"
     },
@@ -471,7 +471,7 @@
       "label": "readonly",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "readonly",
       "insertTextFormat": "Snippet"
     },
@@ -479,7 +479,7 @@
       "label": "handle",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "handle",
       "insertTextFormat": "Snippet"
     },
@@ -487,7 +487,7 @@
       "label": "never",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "never",
       "insertTextFormat": "Snippet"
     },
@@ -495,7 +495,7 @@
       "label": "json",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "json",
       "insertTextFormat": "Snippet"
     },
@@ -503,7 +503,7 @@
       "label": "anydata",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "anydata",
       "insertTextFormat": "Snippet"
     },
@@ -511,7 +511,7 @@
       "label": "any",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "any",
       "insertTextFormat": "Snippet"
     },
@@ -519,7 +519,7 @@
       "label": "byte",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "BG",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
     },
@@ -527,7 +527,7 @@
       "label": "null",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "BZ",
       "filterText": "null",
       "insertText": "null",
       "insertTextFormat": "Snippet"

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/type_test_expression_ctx_config6.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/type_test_expression_ctx_config6.json
@@ -251,7 +251,7 @@
       "label": "TEST_FUTURE_INT",
       "kind": "Variable",
       "detail": "future<int>",
-      "sortText": "C",
+      "sortText": "BBC",
       "insertText": "TEST_FUTURE_INT",
       "insertTextFormat": "Snippet"
     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/type_test_expression_ctx_config6.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/type_test_expression_ctx_config6.json
@@ -15,7 +15,7 @@
           "value": ""
         }
       },
-      "sortText": "C",
+      "sortText": "BD",
       "insertText": "TEST_INT_CONST1",
       "insertTextFormat": "Snippet"
     },
@@ -29,7 +29,7 @@
           "value": ""
         }
       },
-      "sortText": "C",
+      "sortText": "BD",
       "insertText": "TEST_STRING_CONST1",
       "insertTextFormat": "Snippet"
     },
@@ -43,7 +43,7 @@
           "value": ""
         }
       },
-      "sortText": "H",
+      "sortText": "BE",
       "insertText": "ENUM1_FIELD1",
       "insertTextFormat": "Snippet"
     },
@@ -51,7 +51,7 @@
       "label": "TestRecord1",
       "kind": "Struct",
       "detail": "Record",
-      "sortText": "M",
+      "sortText": "BBM",
       "insertText": "TestRecord1",
       "insertTextFormat": "Snippet"
     },
@@ -59,7 +59,7 @@
       "label": "TestRecord2",
       "kind": "Struct",
       "detail": "Record",
-      "sortText": "M",
+      "sortText": "BBM",
       "insertText": "TestRecord2",
       "insertTextFormat": "Snippet"
     },
@@ -67,7 +67,7 @@
       "label": "TestMap2",
       "kind": "TypeParameter",
       "detail": "Map",
-      "sortText": "N",
+      "sortText": "BBN",
       "insertText": "TestMap2",
       "insertTextFormat": "Snippet"
     },
@@ -75,7 +75,7 @@
       "label": "TestMap3",
       "kind": "TypeParameter",
       "detail": "Map",
-      "sortText": "N",
+      "sortText": "BBN",
       "insertText": "TestMap3",
       "insertTextFormat": "Snippet"
     },
@@ -83,7 +83,7 @@
       "label": "TestObject1",
       "kind": "Interface",
       "detail": "Object",
-      "sortText": "K",
+      "sortText": "BBK",
       "insertText": "TestObject1",
       "insertTextFormat": "Snippet"
     },
@@ -91,7 +91,7 @@
       "label": "ErrorOne",
       "kind": "Event",
       "detail": "Error",
-      "sortText": "L",
+      "sortText": "BBL",
       "insertText": "ErrorOne",
       "insertTextFormat": "Snippet"
     },
@@ -99,7 +99,7 @@
       "label": "ErrorTwo",
       "kind": "Event",
       "detail": "Error",
-      "sortText": "L",
+      "sortText": "BBL",
       "insertText": "ErrorTwo",
       "insertTextFormat": "Snippet"
     },
@@ -110,7 +110,7 @@
       "documentation": {
         "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
       },
-      "sortText": "I",
+      "sortText": "BBI",
       "insertText": "ResponseMessage",
       "insertTextFormat": "Snippet"
     },
@@ -121,7 +121,7 @@
       "documentation": {
         "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
       },
-      "sortText": "I",
+      "sortText": "BBI",
       "insertText": "RequestMessage",
       "insertTextFormat": "Snippet"
     },
@@ -129,7 +129,7 @@
       "label": "AnnotationType",
       "kind": "Struct",
       "detail": "Record",
-      "sortText": "M",
+      "sortText": "BBM",
       "insertText": "AnnotationType",
       "insertTextFormat": "Snippet"
     },
@@ -137,7 +137,7 @@
       "label": "TestClass1",
       "kind": "Interface",
       "detail": "Class",
-      "sortText": "K",
+      "sortText": "BBK",
       "insertText": "TestClass1",
       "insertTextFormat": "Snippet"
     },
@@ -145,7 +145,7 @@
       "label": "Listener",
       "kind": "Interface",
       "detail": "Class",
-      "sortText": "K",
+      "sortText": "BBK",
       "insertText": "Listener",
       "insertTextFormat": "Snippet"
     },
@@ -156,7 +156,7 @@
       "documentation": {
         "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs."
       },
-      "sortText": "K",
+      "sortText": "BBK",
       "insertText": "Client",
       "insertTextFormat": "Snippet"
     },
@@ -167,7 +167,7 @@
       "documentation": {
         "left": "Represents a response.\n"
       },
-      "sortText": "K",
+      "sortText": "BBK",
       "insertText": "Response",
       "insertTextFormat": "Snippet"
     },
@@ -175,7 +175,7 @@
       "label": "listener1",
       "kind": "Variable",
       "detail": "module1:Listener",
-      "sortText": "C",
+      "sortText": "BBC",
       "insertText": "listener1",
       "insertTextFormat": "Snippet"
     },
@@ -189,7 +189,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \n  \n"
         }
       },
-      "sortText": "A",
+      "sortText": "BBA",
       "filterText": "function1",
       "insertText": "function1()",
       "insertTextFormat": "Snippet"
@@ -204,7 +204,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function2  \n"
         }
       },
-      "sortText": "A",
+      "sortText": "BBA",
       "filterText": "function2",
       "insertText": "function2()",
       "insertTextFormat": "Snippet"
@@ -219,7 +219,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function3 with input parameters\n  \n**Params**  \n- `int` param1: param1 Parameter Description   \n- `int` param2: param2 Parameter Description  \n- `float[]` param3: param3 Parameter Description  \n  \n**Return** `int`   \n- Return Value Description  \n  \n"
         }
       },
-      "sortText": "A",
+      "sortText": "BBA",
       "filterText": "function3",
       "insertText": "function3(${1})",
       "insertTextFormat": "Snippet",
@@ -238,7 +238,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function4 with input parameters\n  \n**Params**  \n- `int` param1: param1 Parameter Description   \n- `int` param2: param2 Parameter Description  \n- `string` param3: param3 Parameter Description(Defaultable)  \n- `float[]` param4: param4 Parameter Description"
         }
       },
-      "sortText": "A",
+      "sortText": "BBA",
       "filterText": "function4",
       "insertText": "function4(${1})",
       "insertTextFormat": "Snippet",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/type_test_expression_ctx_config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/type_test_expression_ctx_config7.json
@@ -251,7 +251,7 @@
       "label": "TEST_FUTURE_INT",
       "kind": "Variable",
       "detail": "future<int>",
-      "sortText": "C",
+      "sortText": "BBC",
       "insertText": "TEST_FUTURE_INT",
       "insertTextFormat": "Snippet"
     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/type_test_expression_ctx_config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/type_test_expression_ctx_config7.json
@@ -15,7 +15,7 @@
           "value": ""
         }
       },
-      "sortText": "C",
+      "sortText": "BD",
       "insertText": "TEST_INT_CONST1",
       "insertTextFormat": "Snippet"
     },
@@ -29,7 +29,7 @@
           "value": ""
         }
       },
-      "sortText": "C",
+      "sortText": "BD",
       "insertText": "TEST_STRING_CONST1",
       "insertTextFormat": "Snippet"
     },
@@ -43,7 +43,7 @@
           "value": ""
         }
       },
-      "sortText": "H",
+      "sortText": "BE",
       "insertText": "ENUM1_FIELD1",
       "insertTextFormat": "Snippet"
     },
@@ -51,7 +51,7 @@
       "label": "TestRecord1",
       "kind": "Struct",
       "detail": "Record",
-      "sortText": "M",
+      "sortText": "BBM",
       "insertText": "TestRecord1",
       "insertTextFormat": "Snippet"
     },
@@ -59,7 +59,7 @@
       "label": "TestRecord2",
       "kind": "Struct",
       "detail": "Record",
-      "sortText": "M",
+      "sortText": "BBM",
       "insertText": "TestRecord2",
       "insertTextFormat": "Snippet"
     },
@@ -67,7 +67,7 @@
       "label": "TestMap2",
       "kind": "TypeParameter",
       "detail": "Map",
-      "sortText": "N",
+      "sortText": "BBN",
       "insertText": "TestMap2",
       "insertTextFormat": "Snippet"
     },
@@ -75,7 +75,7 @@
       "label": "TestMap3",
       "kind": "TypeParameter",
       "detail": "Map",
-      "sortText": "N",
+      "sortText": "BBN",
       "insertText": "TestMap3",
       "insertTextFormat": "Snippet"
     },
@@ -83,7 +83,7 @@
       "label": "TestObject1",
       "kind": "Interface",
       "detail": "Object",
-      "sortText": "K",
+      "sortText": "BBK",
       "insertText": "TestObject1",
       "insertTextFormat": "Snippet"
     },
@@ -91,7 +91,7 @@
       "label": "ErrorOne",
       "kind": "Event",
       "detail": "Error",
-      "sortText": "L",
+      "sortText": "BBL",
       "insertText": "ErrorOne",
       "insertTextFormat": "Snippet"
     },
@@ -99,7 +99,7 @@
       "label": "ErrorTwo",
       "kind": "Event",
       "detail": "Error",
-      "sortText": "L",
+      "sortText": "BBL",
       "insertText": "ErrorTwo",
       "insertTextFormat": "Snippet"
     },
@@ -110,7 +110,7 @@
       "documentation": {
         "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
       },
-      "sortText": "I",
+      "sortText": "BBI",
       "insertText": "ResponseMessage",
       "insertTextFormat": "Snippet"
     },
@@ -121,7 +121,7 @@
       "documentation": {
         "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
       },
-      "sortText": "I",
+      "sortText": "BBI",
       "insertText": "RequestMessage",
       "insertTextFormat": "Snippet"
     },
@@ -129,7 +129,7 @@
       "label": "AnnotationType",
       "kind": "Struct",
       "detail": "Record",
-      "sortText": "M",
+      "sortText": "BBM",
       "insertText": "AnnotationType",
       "insertTextFormat": "Snippet"
     },
@@ -137,7 +137,7 @@
       "label": "TestClass1",
       "kind": "Interface",
       "detail": "Class",
-      "sortText": "K",
+      "sortText": "BBK",
       "insertText": "TestClass1",
       "insertTextFormat": "Snippet"
     },
@@ -145,7 +145,7 @@
       "label": "Listener",
       "kind": "Interface",
       "detail": "Class",
-      "sortText": "K",
+      "sortText": "BBK",
       "insertText": "Listener",
       "insertTextFormat": "Snippet"
     },
@@ -156,7 +156,7 @@
       "documentation": {
         "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs."
       },
-      "sortText": "K",
+      "sortText": "BBK",
       "insertText": "Client",
       "insertTextFormat": "Snippet"
     },
@@ -167,7 +167,7 @@
       "documentation": {
         "left": "Represents a response.\n"
       },
-      "sortText": "K",
+      "sortText": "BBK",
       "insertText": "Response",
       "insertTextFormat": "Snippet"
     },
@@ -175,7 +175,7 @@
       "label": "listener1",
       "kind": "Variable",
       "detail": "module1:Listener",
-      "sortText": "C",
+      "sortText": "BBC",
       "insertText": "listener1",
       "insertTextFormat": "Snippet"
     },
@@ -189,7 +189,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \n  \n"
         }
       },
-      "sortText": "A",
+      "sortText": "BBA",
       "filterText": "function1",
       "insertText": "function1()",
       "insertTextFormat": "Snippet"
@@ -204,7 +204,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function2  \n"
         }
       },
-      "sortText": "A",
+      "sortText": "BBA",
       "filterText": "function2",
       "insertText": "function2()",
       "insertTextFormat": "Snippet"
@@ -219,7 +219,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function3 with input parameters\n  \n**Params**  \n- `int` param1: param1 Parameter Description   \n- `int` param2: param2 Parameter Description  \n- `float[]` param3: param3 Parameter Description  \n  \n**Return** `int`   \n- Return Value Description  \n  \n"
         }
       },
-      "sortText": "A",
+      "sortText": "BBA",
       "filterText": "function3",
       "insertText": "function3(${1})",
       "insertTextFormat": "Snippet",
@@ -238,7 +238,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function4 with input parameters\n  \n**Params**  \n- `int` param1: param1 Parameter Description   \n- `int` param2: param2 Parameter Description  \n- `string` param3: param3 Parameter Description(Defaultable)  \n- `float[]` param4: param4 Parameter Description"
         }
       },
-      "sortText": "A",
+      "sortText": "BBA",
       "filterText": "function4",
       "insertText": "function4(${1})",
       "insertTextFormat": "Snippet",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/type_test_expression_ctx_config8.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/type_test_expression_ctx_config8.json
@@ -1,6 +1,6 @@
 {
   "position": {
-    "line": 3,
+    "line": 16,
     "character": 16
   },
   "source": "expression_context/source/type_test_expression_ctx_source8.bal",
@@ -12,16 +12,56 @@
       "documentation": {
         "left": "Describes Strand execution details for the runtime.\n"
       },
-      "sortText": "BBM",
+      "sortText": "ABM",
       "insertText": "StrandData",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Error",
+      "kind": "Event",
+      "detail": "Error",
+      "sortText": "AAL",
+      "insertText": "Error",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Type2",
+      "kind": "TypeParameter",
+      "detail": "String",
+      "sortText": "AAN",
+      "insertText": "Type2",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Type4",
+      "kind": "Struct",
+      "detail": "Record",
+      "sortText": "AAM",
+      "insertText": "Type4",
       "insertTextFormat": "Snippet"
     },
     {
       "label": "Thread",
       "kind": "TypeParameter",
       "detail": "Union",
-      "sortText": "BBN",
+      "sortText": "ABN",
       "insertText": "Thread",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Type3",
+      "kind": "Struct",
+      "detail": "Record",
+      "sortText": "AAM",
+      "insertText": "Type3",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Type1",
+      "kind": "Enum",
+      "detail": "Union",
+      "sortText": "AAI",
+      "insertText": "Type1",
       "insertTextFormat": "Snippet"
     },
     {
@@ -333,7 +373,7 @@
       "label": "int",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "AG",
+      "sortText": "BG",
       "insertText": "int",
       "insertTextFormat": "Snippet"
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/type_test_expression_ctx_config8.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/type_test_expression_ctx_config8.json
@@ -1,0 +1,8 @@
+{
+  "position": {
+    "line": 3,
+    "character": 16
+  },
+  "source": "expression_context/source/type_test_expression_ctx_source8.bal",
+  "items": []
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/type_test_expression_ctx_config9.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/type_test_expression_ctx_config9.json
@@ -1,9 +1,9 @@
 {
   "position": {
-    "line": 3,
+    "line": 5,
     "character": 16
   },
-  "source": "expression_context/source/type_test_expression_ctx_source8.bal",
+  "source": "expression_context/source/projectls/modules/lsmod4/lsmod4.bal",
   "items": [
     {
       "label": "StrandData",
@@ -170,6 +170,15 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "mod3",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "BBO",
+      "filterText": "mod3",
+      "insertText": "mod3",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
@@ -181,11 +190,11 @@
         {
           "range": {
             "start": {
-              "line": 0,
+              "line": 1,
               "character": 0
             },
             "end": {
-              "line": 0,
+              "line": 1,
               "character": 0
             }
           },
@@ -205,11 +214,11 @@
         {
           "range": {
             "start": {
-              "line": 0,
+              "line": 1,
               "character": 0
             },
             "end": {
-              "line": 0,
+              "line": 1,
               "character": 0
             }
           },
@@ -229,11 +238,11 @@
         {
           "range": {
             "start": {
-              "line": 0,
+              "line": 1,
               "character": 0
             },
             "end": {
-              "line": 0,
+              "line": 1,
               "character": 0
             }
           },
@@ -253,11 +262,11 @@
         {
           "range": {
             "start": {
-              "line": 0,
+              "line": 1,
               "character": 0
             },
             "end": {
-              "line": 0,
+              "line": 1,
               "character": 0
             }
           },
@@ -277,11 +286,11 @@
         {
           "range": {
             "start": {
-              "line": 0,
+              "line": 1,
               "character": 0
             },
             "end": {
-              "line": 0,
+              "line": 1,
               "character": 0
             }
           },
@@ -400,6 +409,78 @@
       "sortText": "BG",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "projectls.ls.mod4",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "BCG",
+      "filterText": "",
+      "insertText": "mod4",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 0
+            },
+            "end": {
+              "line": 1,
+              "character": 0
+            }
+          },
+          "newText": "import projectls.ls.mod4;\n"
+        }
+      ]
+    },
+    {
+      "label": "projectls.lsmod2",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "BCG",
+      "filterText": "",
+      "insertText": "lsmod2",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 0
+            },
+            "end": {
+              "line": 1,
+              "character": 0
+            }
+          },
+          "newText": "import projectls.lsmod2;\n"
+        }
+      ]
+    },
+    {
+      "label": "projectls.lsmod1",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "BCG",
+      "filterText": "",
+      "insertText": "lsmod1",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 0
+            },
+            "end": {
+              "line": 1,
+              "character": 0
+            }
+          },
+          "newText": "import projectls.lsmod1;\n"
+        }
+      ]
     },
     {
       "label": "module1:TestMap2",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/type_test_expression_ctx_config9.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/type_test_expression_ctx_config9.json
@@ -12,7 +12,7 @@
       "documentation": {
         "left": "Describes Strand execution details for the runtime.\n"
       },
-      "sortText": "BBM",
+      "sortText": "ABM",
       "insertText": "StrandData",
       "insertTextFormat": "Snippet"
     },
@@ -342,7 +342,7 @@
       "label": "int",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "AG",
+      "sortText": "BG",
       "insertText": "int",
       "insertTextFormat": "Snippet"
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/projectls/modules/lsmod4/lsmod4.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/projectls/modules/lsmod4/lsmod4.bal
@@ -1,0 +1,7 @@
+import ballerina/module1;
+import projectls.lsmod3 as mod3;
+
+public function typeTest() {
+    module1:TestMap2 | module1:TestMap3 | int | mod3:PositionRec myVar = 10;
+    if myVar is 
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/type_test_expression_ctx_source8.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/type_test_expression_ctx_source8.bal
@@ -1,0 +1,5 @@
+import ballerina/module1;
+public function main() {
+    module1:TestMap2 | module1:TestMap3 | int myVar = 10;
+    if myVar is 
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/type_test_expression_ctx_source8.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/type_test_expression_ctx_source8.bal
@@ -1,5 +1,18 @@
 import ballerina/module1;
+
+type Type1 string | int;
+
+type Type2 string;
+
+type Type3 record {|
+      int a;
+|};
+
+type Type4 record {||};
+
+type Error error;
+
 public function main() {
-    module1:TestMap2 | module1:TestMap3 | int myVar = 10;
+    module1:TestMap2 | module1:TestMap3 | int | Type1 | Error | Type3 myVar = 10;
     if myVar is 
 }


### PR DESCRIPTION
## Purpose
Add type reference completion items to type test(type guard) context and fix sorting to show expression's types at the top. 

Fixes #32607 

![new pic](https://user-images.githubusercontent.com/35211477/145829271-53ea59d7-fd89-443e-9e22-b2b602480188.png)



## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
