### PR TITLE
Update compiler plugin codeaction doc to not use SyntaxTree.from(SyntaxTree, TextDocumentChange)

### DIFF
--- a/language-server/docs/CompilerPluginCodeActionExtensions.md
+++ b/language-server/docs/CompilerPluginCodeActionExtensions.md
@@ -214,8 +214,10 @@ public class AddResourceMethod implements CodeAction {
         textEdits.add(TextEdit.from(textRange, insertText));
         // Create a text document change with our edits
         TextDocumentChange change = TextDocumentChange.from(textEdits.toArray(new TextEdit[0]));
-        // Create the new syntax tree after applying the changes
-        SyntaxTree modifiedSyntaxTree = SyntaxTree.from(syntaxTree, change);
+        // Modify the existing text document with the change
+        TextDocument modifiedTextDocument = syntaxTree.textDocument().apply(change);
+        // Create the new syntax tree with the new text document
+        SyntaxTree modifiedSyntaxTree = SyntaxTree.from(modifiedTextDocument);
 
         // Create a document edit. Represents an edit to a specific document in the workspace. Document is specified
         //  by the fileUri. Need to provide the modified syntax tree.
@@ -232,6 +234,11 @@ public class AddResourceMethod implements CodeAction {
     }
 }
 ```
+
+#### Note
+
+Do not use `SyntaxTree.from(oldSyntaxTree, change)` to create the new syntax tree due to 
+https://github.com/ballerina-platform/ballerina-lang/issues/24058. It may cause an out of memory issue in the runtime.
 
 ### Step 3 - Manual Testing
 


### PR DESCRIPTION
## Purpose
SyntaxTree.from(SyntaxTree, TextDocumentChange) can cause an OOM. It should not be used to create new syntax trees.
See #24058 for the related issue

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
