### PR TITLE
Add json subtype validation to record types in create variable code action

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionUtil.java
@@ -19,6 +19,7 @@ import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.ArrayTypeSymbol;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
+import io.ballerina.compiler.api.symbols.MapTypeSymbol;
 import io.ballerina.compiler.api.symbols.ModuleSymbol;
 import io.ballerina.compiler.api.symbols.RecordFieldSymbol;
 import io.ballerina.compiler.api.symbols.RecordTypeSymbol;
@@ -226,9 +227,19 @@ public class CodeActionUtil {
             RecordTypeSymbol recordLiteral = (RecordTypeSymbol) typeDescriptor;
             types.add((recordLiteral.fieldDescriptors().size() > 0) ? rType : "record {}");
 
-            // JSON
-            types.add("json");
+            // A record can be an open record or a closed record:
+            //      record {| int field1; anydata...; |}
+            //      record {| int field1; |}
+            RecordTypeSymbol recordTypeSymbol = (RecordTypeSymbol) typeDescriptor;
 
+            // JSON - Record fields and rest type descriptor should be json subtypes
+            boolean jsonSubType = recordTypeSymbol.fieldDescriptors().values().stream()
+                    .allMatch(recordFieldSymbol -> isJsonMemberType(recordFieldSymbol.typeDescriptor())) &&
+                    recordTypeSymbol.restTypeDescriptor().map(CodeActionUtil::isJsonMemberType).orElse(true);
+            if (jsonSubType) {
+                types.add("json");
+            }
+            
             // Map
             TypeSymbol prevType = null;
             boolean isConstrainedMap = true;
@@ -316,6 +327,34 @@ public class CodeActionUtil {
 
         importEdits.addAll(importsAcceptor.getNewImportTextEdits());
         return types;
+    }
+
+    /**
+     * Check if the provided type symbol is a valid subtype of JSON.
+     *
+     * @param typeSymbol Type symbol
+     * @return True is type is a valid json member type
+     */
+    public static boolean isJsonMemberType(TypeSymbol typeSymbol) {
+        // type json = () | boolean | int | float | decimal | string | json[] | map<json>;
+        switch (typeSymbol.typeKind()) {
+            case NIL:
+            case BOOLEAN:
+            case INT:
+            case FLOAT:
+            case DECIMAL:
+            case STRING:
+            case JSON:
+                return true;
+            case ARRAY:
+                ArrayTypeSymbol arrayTypeSymbol = (ArrayTypeSymbol) typeSymbol;
+                return isJsonMemberType(arrayTypeSymbol.memberTypeDescriptor());
+            case MAP:
+                MapTypeSymbol mapTypeSymbol = (MapTypeSymbol) typeSymbol;
+                return isJsonMemberType(mapTypeSymbol.typeParam());
+            default:
+                return false;
+        }
     }
 
     /**

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/CreateVariableTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/CreateVariableTest.java
@@ -104,6 +104,9 @@ public class CreateVariableTest extends AbstractCodeActionTest {
                 // Create variables of function/invocable type
                 {"createVariableWithFunctionType1.json", "createVariableWithFunctionType1.bal"},
                 {"createVariableWithFunctionType2.json", "createVariableWithFunctionType1.bal"},
+                
+                {"createVariableWithFunctionCall1.json", "createVariableWithFunctionCall1.bal"},
+                {"createVariableWithFunctionCall2.json", "createVariableWithFunctionCall2.bal"},
         };
     }
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithFunctionCall1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithFunctionCall1.json
@@ -1,0 +1,42 @@
+{
+  "line": 9,
+  "character": 7,
+  "expected": [
+    {
+      "title": "Create variable with \u0027record {}\u0027",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 9,
+              "character": 4
+            },
+            "end": {
+              "line": 9,
+              "character": 4
+            }
+          },
+          "newText": "record {} rec \u003d "
+        }
+      ]
+    },
+    {
+      "title": "Create variable with \u0027map\u003cany\u003e\u0027",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 9,
+              "character": 4
+            },
+            "end": {
+              "line": 9,
+              "character": 4
+            }
+          },
+          "newText": "map\u003cany\u003e rec \u003d "
+        }
+      ]
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithFunctionCall2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithFunctionCall2.json
@@ -1,0 +1,60 @@
+{
+  "line": 11,
+  "character": 7,
+  "expected": [
+    {
+      "title": "Create variable with 'record {| int a; |}'",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 11,
+              "character": 4
+            },
+            "end": {
+              "line": 11,
+              "character": 4
+            }
+          },
+          "newText": "record {| int a; |} rec = "
+        }
+      ]
+    },
+    {
+      "title": "Create variable with 'json'",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 11,
+              "character": 4
+            },
+            "end": {
+              "line": 11,
+              "character": 4
+            }
+          },
+          "newText": "json rec = "
+        }
+      ]
+    },
+    {
+      "title": "Create variable with \u0027map\u003cint\u003e\u0027",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 11,
+              "character": 4
+            },
+            "end": {
+              "line": 11,
+              "character": 4
+            }
+          },
+          "newText": "map\u003cint\u003e rec \u003d "
+        }
+      ]
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/source/createVariableWithFunctionCall1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/source/createVariableWithFunctionCall1.bal
@@ -1,0 +1,11 @@
+type MyRec record {|
+    int count;
+|};
+
+function getRec() returns record {} {
+    return {};
+}
+
+public function main() {
+    getRec();
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/source/createVariableWithFunctionCall2.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/source/createVariableWithFunctionCall2.bal
@@ -1,0 +1,13 @@
+type MyRec record {|
+    int count;
+|};
+
+function getRec() returns record {| int a; |} {
+    return {
+        a: 0
+    };
+}
+
+public function main() {
+    getRec();
+}


### PR DESCRIPTION
## Purpose
$subject in create variable code action.

Fixes #32990

## Approach
Added check to determine if a record is a subtype of json.

![create_var_record](https://user-images.githubusercontent.com/11285165/138834112-b779375f-fd4d-4141-83e9-5af2291ea116.gif)

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
