### PR TITLE
Fix missing annotations issue in local var decls

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
@@ -2770,8 +2770,11 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
 
     @Override
     public BLangNode transform(VariableDeclarationNode varDeclaration) {
-        return (BLangNode) createBLangVarDef(getPosition(varDeclaration), varDeclaration.typedBindingPattern(),
-                varDeclaration.initializer(), varDeclaration.finalKeyword());
+        VariableDefinitionNode varNode =
+                createBLangVarDef(getPosition(varDeclaration), varDeclaration.typedBindingPattern(),
+                                  varDeclaration.initializer(), varDeclaration.finalKeyword());
+        ((BLangVariable) varNode.getVariable()).annAttachments = applyAll(varDeclaration.annotations());
+        return (BLangNode) varNode;
     }
 
     private VariableDefinitionNode createBLangVarDef(Location location,

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/VarDeclSymbolTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/VarDeclSymbolTest.java
@@ -138,6 +138,8 @@ public class VarDeclSymbolTest {
                         List.of()},
                 {70, 19, "valueB", TypeDescKind.INT, null, null,
                         List.of()},
+                {74, 11, "str", TypeDescKind.STRING, null, "varDecl",
+                        List.of()},
         };
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbols/var_decl_symbol_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbols/var_decl_symbol_test.bal
@@ -70,4 +70,9 @@ public record {string a; int b;} {aValue, bValue} = {a: "one", b: 2};
 @varDecl
 var {a: valueA, b: valueB} = {a: "A", b: 2};
 
+function test() {
+    @varDecl
+    string str = "foo";
+}
+
 public annotation varDecl;


### PR DESCRIPTION
## Purpose
This PR modifies the node transformer to take annotations attached to local vars into account.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
