### PR TITLE
Avoid providing completions after `function` keyword in anon function expression

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ExplicitAnonymousFunctionExpressionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ExplicitAnonymousFunctionExpressionNodeContext.java
@@ -80,11 +80,8 @@ public class ExplicitAnonymousFunctionExpressionNodeContext
             return false;
         }
         Token openParenToken = node.functionSignature().openParenToken();
-        if (openParenToken.isMissing()) {
-            return false;
-        }
         int cursor = context.getCursorPositionInTree();
         
-        return openParenToken.textRange().endOffset() <= cursor;
+        return !openParenToken.isMissing() && openParenToken.textRange().endOffset() <= cursor;
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ExplicitAnonymousFunctionExpressionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ExplicitAnonymousFunctionExpressionNodeContext.java
@@ -79,8 +79,12 @@ public class ExplicitAnonymousFunctionExpressionNodeContext
         if (functionKeyword.isMissing()) {
             return false;
         }
+        Token openParenToken = node.functionSignature().openParenToken();
+        if (openParenToken.isMissing()) {
+            return false;
+        }
         int cursor = context.getCursorPositionInTree();
-
-        return cursor > functionKeyword.textRange().endOffset();
+        
+        return openParenToken.textRange().endOffset() <= cursor;
     }
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/anon_func_expr_ctx_config12.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/anon_func_expr_ctx_config12.json
@@ -1,0 +1,8 @@
+{
+  "position": {
+    "line": 3,
+    "character": 63
+  },
+  "source": "expression_context/source/anon_func_expr_ctx_source12.bal",
+  "items": []
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/anon_func_expr_ctx_source12.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/anon_func_expr_ctx_source12.bal
@@ -1,0 +1,6 @@
+
+public function main() {
+    
+    function (int i, string s) returns int testfunc = function 
+}
+


### PR DESCRIPTION
## Purpose
Fixes #33292

## Approach
Checks whether the open paranthesis token is missing.

## Samples
<img width="807" alt="Screenshot 2021-10-27 at 10 41 42" src="https://user-images.githubusercontent.com/27485094/139004795-7f9acb37-d356-4060-b3fc-d8e965db8dd1.png">

<img width="888" alt="Screenshot 2021-10-27 at 10 42 02" src="https://user-images.githubusercontent.com/27485094/139004811-d52079c9-4cb7-4df7-9cc5-b96881c4e39b.png">

<img width="888" alt="Screenshot 2021-10-27 at 10 55 26" src="https://user-images.githubusercontent.com/27485094/139004898-0196e0e7-0f8a-41ee-a946-7ef2323f6d12.png">


## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
