### PR TITLE
Fix finite type creation with decimal members

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/DecimalValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/DecimalValue.java
@@ -54,7 +54,7 @@ public class DecimalValue implements SimpleValue, BDecimal {
     @Deprecated
     public DecimalValueKind valueKind = DecimalValueKind.OTHER;
 
-    private BigDecimal value;
+    private final BigDecimal value;
 
     public DecimalValue(BigDecimal value) {
         this.value = value;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCodeGenUtil.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCodeGenUtil.java
@@ -672,7 +672,7 @@ public class JvmCodeGenUtil {
             case TypeTags.DECIMAL:
                 mv.visitTypeInsn(NEW, DECIMAL_VALUE);
                 mv.visitInsn(DUP);
-                mv.visitLdcInsn(String.valueOf(constVal));
+                mv.visitLdcInsn(removeDecimalDiscriminator(String.valueOf(constVal)));
                 mv.visitMethodInsn(INVOKESPECIAL, DECIMAL_VALUE, JVM_INIT_METHOD, INIT_WITH_STRING, false);
                 break;
             case TypeTags.NIL:
@@ -680,9 +680,20 @@ public class JvmCodeGenUtil {
                 mv.visitInsn(ACONST_NULL);
                 break;
             default:
-                throw new BLangCompilerException("JVM generation is not supported for type : " +
-                                                         bType);
+                throw new BLangCompilerException("JVM generation is not supported for type : " + bType);
         }
+    }
+
+    private static String removeDecimalDiscriminator(String value) {
+        int length = value.length();
+        if (length < 2) {
+            return value;
+        }
+        char lastChar = value.charAt(length - 1);
+        if (lastChar == 'd' || lastChar == 'D') {
+            return value.substring(0, length - 1);
+        }
+        return value;
     }
 
     public static void createDefaultCase(MethodVisitor mv, Label defaultCaseLabel, int nameRegIndex,

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/uniontypes/UnionTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/uniontypes/UnionTypeTest.java
@@ -31,6 +31,7 @@ import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 /**
@@ -149,24 +150,20 @@ public class UnionTypeTest {
         }
     }
 
-    @Test(description = "Test union type with a function pointer accessing")
-    public void testUnionTypeWithFunctionPointerAccess() {
-        BRunUtil.invoke(result, "testUnionTypeWithFunctionPointerAccess");
+    @Test(dataProvider = "function-name-provider")
+    public void testUnionMemberTypes(String funcName) {
+        BRunUtil.invoke(result, funcName);
     }
 
-    @Test
-    public void testCastToImmutableUnion() {
-        BRunUtil.invoke(result, "testCastToImmutableUnion");
-    }
-
-    @Test(description = "Test union with integer subtypes")
-    public void testUnionWithIntegerSubTypes() {
-        BRunUtil.invoke(result, "testUnionWithIntegerSubTypes");
-    }
-
-    @Test(description = "Test union with string subtypes")
-    public void testUnionWithStringSubTypes() {
-        BRunUtil.invoke(result, "testUnionWithStringSubTypes");
+    @DataProvider(name = "function-name-provider")
+    public Object[] unionMemberTypesTests() {
+        return new String[]{
+                "testUnionTypeWithFunctionPointerAccess",
+                "testCastToImmutableUnion",
+                "testUnionWithIntegerSubTypes",
+                "testUnionWithStringSubTypes",
+                "testUnionWithDecimalFiniteTypes"
+        };
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/uniontypes/union_types_basic.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/uniontypes/union_types_basic.bal
@@ -314,6 +314,17 @@ function foo2() returns string:Char|object{} {
     return "A";
 }
 
+const A = 1.0f;
+const B = 2.0d;
+
+type Decimals A|B|2;
+
+function testUnionWithDecimalFiniteTypes() {
+    Decimals value = 2.0d;
+    assertEquality(true, value is decimal);
+    assertEquality(4.3d, <decimal>value + 2.3d);
+}
+
 function assertEquality(any|error expected, any|error actual) {
     if expected is anydata && actual is anydata && expected == actual {
         return;


### PR DESCRIPTION
## Purpose
$subject

Fixes #33266

## Approach
Check the string format at code generation before creating new decimal value.

## Samples
```ballerina
const A = 1.0f;
const B = 2.0d;

type Decimals A|B|2;
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
