### PR TITLE
Fix `float:min` and `float:max` functions for `NaN` values

### DIFF
--- a/langlib/lang.float/src/main/java/org/ballerinalang/langlib/floatingpoint/FromHexString.java
+++ b/langlib/lang.float/src/main/java/org/ballerinalang/langlib/floatingpoint/FromHexString.java
@@ -23,6 +23,8 @@ import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.api.values.BString;
 
+import java.util.regex.Pattern;
+
 import static io.ballerina.runtime.api.constants.RuntimeConstants.FLOAT_LANG_LIB;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.NUMBER_PARSING_ERROR_IDENTIFIER;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.getModulePrefixedReason;
@@ -33,6 +35,8 @@ import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReason
  * @since 1.0
  */
 public class FromHexString {
+
+    private static final Pattern HEX_FLOAT_LITERAL = Pattern.compile("[-+]?0[xX][\\dA-Fa-f.pP\\-+]+");
 
     private FromHexString() {
     }
@@ -50,14 +54,15 @@ public class FromHexString {
     }
 
     private static boolean isValidHexString(String hexValue) {
-        if ((hexValue.length() > 3) && (hexValue.startsWith("+") || hexValue.startsWith("-"))) {
-            return ((hexValue.charAt(1) == '0' && hexValue.charAt(2) == 'x') || hexValue.equals("+infinity") ||
-                    hexValue.equals("-infinity"));
+        switch (hexValue) {
+            case "+infinity":
+            case "-infinity":
+            case "infinity":
+            case "nan":
+                return true;
+            default:
+                return HEX_FLOAT_LITERAL.matcher(hexValue).matches();
         }
-        if ((hexValue.length() > 1) && (hexValue.charAt(0) == '0' && hexValue.charAt(1) == 'x')) {
-            return true;
-        }
-        return hexValue.equals("nan") || hexValue.equals("infinity");
     }
 
     private static BError getNumberFormatError(String message) {

--- a/langlib/lang.float/src/main/java/org/ballerinalang/langlib/floatingpoint/FromHexString.java
+++ b/langlib/lang.float/src/main/java/org/ballerinalang/langlib/floatingpoint/FromHexString.java
@@ -40,13 +40,24 @@ public class FromHexString {
     public static Object fromHexString(BString s) {
         String hexValue = s.getValue();
         try {
-            if (hexValue.startsWith("0x") || hexValue.startsWith("0X")) {
+            if (isValidHexString(hexValue.toLowerCase())) {
                 return Double.parseDouble(hexValue);
             }
             return getNumberFormatError("invalid hex string: '" + hexValue + "'");
         } catch (NumberFormatException e) {
             return getNumberFormatError(e.getMessage());
         }
+    }
+
+    private static boolean isValidHexString(String hexValue) {
+        if ((hexValue.length() > 3) && (hexValue.startsWith("+") || hexValue.startsWith("-"))) {
+            return ((hexValue.charAt(1) == '0' && hexValue.charAt(2) == 'x') || hexValue.equals("+infinity") ||
+                    hexValue.equals("-infinity"));
+        }
+        if ((hexValue.length() > 1) && (hexValue.charAt(0) == '0' && hexValue.charAt(1) == 'x')) {
+            return true;
+        }
+        return hexValue.equals("nan") || hexValue.equals("infinity");
     }
 
     private static BError getNumberFormatError(String message) {

--- a/langlib/lang.float/src/main/java/org/ballerinalang/langlib/floatingpoint/FromHexString.java
+++ b/langlib/lang.float/src/main/java/org/ballerinalang/langlib/floatingpoint/FromHexString.java
@@ -20,6 +20,7 @@ package org.ballerinalang.langlib.floatingpoint;
 
 import io.ballerina.runtime.api.creators.ErrorCreator;
 import io.ballerina.runtime.api.utils.StringUtils;
+import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.api.values.BString;
 
 import static io.ballerina.runtime.api.constants.RuntimeConstants.FLOAT_LANG_LIB;
@@ -33,12 +34,23 @@ import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReason
  */
 public class FromHexString {
 
+    private FromHexString() {
+    }
+
     public static Object fromHexString(BString s) {
+        String hexValue = s.getValue();
         try {
-            return Double.parseDouble(s.getValue());
+            if (hexValue.startsWith("0x") || hexValue.startsWith("0X")) {
+                return Double.parseDouble(hexValue);
+            }
+            return getNumberFormatError("invalid hex string: '" + hexValue + "'");
         } catch (NumberFormatException e) {
-            return ErrorCreator.createError(getModulePrefixedReason(FLOAT_LANG_LIB, NUMBER_PARSING_ERROR_IDENTIFIER),
-                    StringUtils.fromString(e.getMessage()));
+            return getNumberFormatError(e.getMessage());
         }
+    }
+
+    private static BError getNumberFormatError(String message) {
+        return ErrorCreator.createError(getModulePrefixedReason(FLOAT_LANG_LIB, NUMBER_PARSING_ERROR_IDENTIFIER),
+                StringUtils.fromString(message));
     }
 }

--- a/langlib/lang.float/src/main/java/org/ballerinalang/langlib/floatingpoint/Max.java
+++ b/langlib/lang.float/src/main/java/org/ballerinalang/langlib/floatingpoint/Max.java
@@ -37,9 +37,6 @@ public class Max {
     public static double max(double[] ns) {
         double max = Double.NEGATIVE_INFINITY;
         for (double current : ns) {
-            if (Double.isNaN(current)) {
-                return current;
-            }
             max = Math.max(current, max);
         }
         return max;

--- a/langlib/lang.float/src/main/java/org/ballerinalang/langlib/floatingpoint/Max.java
+++ b/langlib/lang.float/src/main/java/org/ballerinalang/langlib/floatingpoint/Max.java
@@ -31,12 +31,16 @@ package org.ballerinalang.langlib.floatingpoint;
 //)
 public class Max {
 
+    private Max() {
+    }
+
     public static double max(double[] ns) {
         double max = Double.NEGATIVE_INFINITY;
-        int size = ns.length;
-        for (int i = 0; i < size; i++) {
-            double current = ns[i];
-            max = current >= max ? current : max;
+        for (double current : ns) {
+            if (Double.isNaN(current)) {
+                return current;
+            }
+            max = Math.max(current, max);
         }
         return max;
     }

--- a/langlib/lang.float/src/main/java/org/ballerinalang/langlib/floatingpoint/Min.java
+++ b/langlib/lang.float/src/main/java/org/ballerinalang/langlib/floatingpoint/Min.java
@@ -37,9 +37,6 @@ public class Min {
     public static double min(double[] ns) {
         double min = Double.POSITIVE_INFINITY;
         for (double current : ns) {
-            if (Double.isNaN(current)) {
-                return current;
-            }
             min = Math.min(current, min);
         }
         return min;

--- a/langlib/lang.float/src/main/java/org/ballerinalang/langlib/floatingpoint/Min.java
+++ b/langlib/lang.float/src/main/java/org/ballerinalang/langlib/floatingpoint/Min.java
@@ -31,12 +31,16 @@ package org.ballerinalang.langlib.floatingpoint;
 //)
 public class Min {
 
+    private Min() {
+    }
+
     public static double min(double[] ns) {
         double min = Double.POSITIVE_INFINITY;
-        int size = ns.length;
-        for (int i = 0; i < size; i++) {
-            double current = ns[i];
-            min = current <= min ? current : min;
+        for (double current : ns) {
+            if (Double.isNaN(current)) {
+                return current;
+            }
+            min = Math.min(current, min);
         }
         return min;
     }

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibFloatTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibFloatTest.java
@@ -100,4 +100,9 @@ public class LangLibFloatTest {
     public void testFromHexString() {
         BRunUtil.invoke(compileResult, "testFromHexString");
     }
+
+    @Test
+    public void testMinAndMaxWithNaN() {
+        BRunUtil.invoke(compileResult, "testMinAndMaxWithNaN");
+    }
 }

--- a/langlib/langlib-test/src/test/resources/test-src/floatlib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/floatlib_test.bal
@@ -117,3 +117,11 @@ function testFromHexString() {
     test:assertValueEqual(err.message(), "{ballerina/lang.float}NumberParsingError");
     test:assertValueEqual(<string> checkpanic err.detail()["message"], "For input string: \"AInvalidNum\"");
 }
+
+function testMinAndMaxWithNaN() {
+    float a = float:max(1, float:NaN);
+    test:assertTrue(a === float:NaN);
+
+    float b = float:min(5, float:NaN);
+    test:assertTrue(b === float:NaN);
+}

--- a/langlib/langlib-test/src/test/resources/test-src/floatlib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/floatlib_test.bal
@@ -77,50 +77,88 @@ function testFromHexString() {
     float|error v1 = float:fromHexString("0xa.bp1");
     test:assertValueEqual(checkpanic v1, 21.375);
 
-    float|error v2 = float:fromHexString("+0xa.bp1");
-    test:assertValueEqual(checkpanic v2, 21.375);
+    v1 = float:fromHexString("+0xa.bp1");
+    test:assertValueEqual(checkpanic v1, 21.375);
 
-    float|error v3 = float:fromHexString("-0xa.bp1");
-    test:assertValueEqual(checkpanic v3, -21.375);
+    v1 = float:fromHexString("-0xa.bp1");
+    test:assertValueEqual(checkpanic v1, -21.375);
 
-    float|error v4 = float:fromHexString("0Xa2c.b32p2");
-    test:assertValueEqual(checkpanic v4, 10418.798828125);
+    v1 = float:fromHexString("0Xa2c.b32p2");
+    test:assertValueEqual(checkpanic v1, 10418.798828125);
 
-    float|error v5 = float:fromHexString("0Xa.b32P-5");
-    test:assertValueEqual(checkpanic v5, 0.3343658447265625);
+    v1 = float:fromHexString("0Xa.b32P-5");
+    test:assertValueEqual(checkpanic v1, 0.3343658447265625);
 
-    float|error v6 = float:fromHexString("-0x123.fp-5");
-    test:assertValueEqual(checkpanic v6, -9.123046875);
+    v1 = float:fromHexString("-0x123.fp-5");
+    test:assertValueEqual(checkpanic v1, -9.123046875);
 
-    float|error v7 = float:fromHexString("0x123fp-5");
-    test:assertValueEqual(checkpanic v7, 145.96875);
+    v1 = float:fromHexString("0x123fp-5");
+    test:assertValueEqual(checkpanic v1, 145.96875);
 
-    float|error v8 = float:fromHexString("0x.ab5p2");
-    test:assertValueEqual(checkpanic v8, 2.6767578125);
+    v1 = float:fromHexString("0x.ab5p2");
+    test:assertValueEqual(checkpanic v1, 2.6767578125);
 
-    float|error v9 = float:fromHexString("0x1a");
-    error err = <error> v9;
+    v1 = float:fromHexString("0x1a");
+    error err = <error> v1;
     test:assertValueEqual(err.message(), "{ballerina/lang.float}NumberParsingError");
     test:assertValueEqual(<string> checkpanic err.detail()["message"], "For input string: \"0x1a\"");
 
-    float|error v10 = float:fromHexString("NaN");
-    test:assertValueEqual(checkpanic v10, float:NaN);
+    v1 = float:fromHexString("NaN");
+    test:assertValueEqual(checkpanic v1, float:NaN);
 
-    float|error v11 = float:fromHexString("+Infinity");
-    test:assertValueEqual(checkpanic v11, float:Infinity);
+    v1 = float:fromHexString("+Infinity");
+    test:assertValueEqual(checkpanic v1, float:Infinity);
 
-    float|error v12 = float:fromHexString("-Infinity");
-    test:assertValueEqual(checkpanic v12, -float:Infinity);
+    v1 = float:fromHexString("-Infinity");
+    test:assertValueEqual(checkpanic v1, -float:Infinity);
 
-    float|error v13 = float:fromHexString("AInvalidNum");
-    err = <error> v13;
+    v1 = float:fromHexString("Infinity");
+    test:assertValueEqual(checkpanic v1, float:Infinity);
+
+    v1 = float:fromHexString("AInvalidNum");
+    err = <error> v1;
     test:assertValueEqual(err.message(), "{ballerina/lang.float}NumberParsingError");
-    test:assertValueEqual(<string> checkpanic err.detail()["message"], "For input string: \"AInvalidNum\"");
+    test:assertValueEqual(<string> checkpanic err.detail()["message"], "invalid hex string: 'AInvalidNum'");
 
-    float|error v14 = float:fromHexString("12.3");
-    err = <error> v14;
+    v1 = float:fromHexString("12.3");
+    err = <error> v1;
     test:assertValueEqual(err.message(), "{ballerina/lang.float}NumberParsingError");
     test:assertValueEqual(<string> checkpanic err.detail()["message"], "invalid hex string: '12.3'");
+
+    v1 = float:fromHexString("1");
+    err = <error> v1;
+    test:assertValueEqual(err.message(), "{ballerina/lang.float}NumberParsingError");
+    test:assertValueEqual(<string> checkpanic err.detail()["message"], "invalid hex string: '1'");
+
+    v1 = float:fromHexString("+1");
+    err = <error> v1;
+    test:assertValueEqual(err.message(), "{ballerina/lang.float}NumberParsingError");
+    test:assertValueEqual(<string> checkpanic err.detail()["message"], "invalid hex string: '+1'");
+
+    v1 = float:fromHexString("-1");
+    err = <error> v1;
+    test:assertValueEqual(err.message(), "{ballerina/lang.float}NumberParsingError");
+    test:assertValueEqual(<string> checkpanic err.detail()["message"], "invalid hex string: '-1'");
+
+    v1 = float:fromHexString("2A");
+    err = <error> v1;
+    test:assertValueEqual(err.message(), "{ballerina/lang.float}NumberParsingError");
+    test:assertValueEqual(<string> checkpanic err.detail()["message"], "invalid hex string: '2A'");
+
+    v1 = float:fromHexString("0i");
+    err = <error> v1;
+    test:assertValueEqual(err.message(), "{ballerina/lang.float}NumberParsingError");
+    test:assertValueEqual(<string> checkpanic err.detail()["message"], "invalid hex string: '0i'");
+
+    v1 = float:fromHexString("0i123");
+    err = <error> v1;
+    test:assertValueEqual(err.message(), "{ballerina/lang.float}NumberParsingError");
+    test:assertValueEqual(<string> checkpanic err.detail()["message"], "invalid hex string: '0i123'");
+
+    v1 = float:fromHexString("+inf");
+    err = <error> v1;
+    test:assertValueEqual(err.message(), "{ballerina/lang.float}NumberParsingError");
+    test:assertValueEqual(<string> checkpanic err.detail()["message"], "invalid hex string: '+inf'");
 }
 
 function testMinAndMaxWithNaN() {

--- a/langlib/langlib-test/src/test/resources/test-src/floatlib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/floatlib_test.bal
@@ -145,6 +145,11 @@ function testFromHexString() {
     test:assertValueEqual(err.message(), "{ballerina/lang.float}NumberParsingError");
     test:assertValueEqual(<string> checkpanic err.detail()["message"], "invalid hex string: '2A'");
 
+    v1 = float:fromHexString("0x");
+    err = <error> v1;
+    test:assertValueEqual(err.message(), "{ballerina/lang.float}NumberParsingError");
+    test:assertValueEqual(<string> checkpanic err.detail()["message"], "invalid hex string: '0x'");
+
     v1 = float:fromHexString("0i");
     err = <error> v1;
     test:assertValueEqual(err.message(), "{ballerina/lang.float}NumberParsingError");

--- a/langlib/langlib-test/src/test/resources/test-src/floatlib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/floatlib_test.bal
@@ -116,6 +116,11 @@ function testFromHexString() {
     err = <error> v13;
     test:assertValueEqual(err.message(), "{ballerina/lang.float}NumberParsingError");
     test:assertValueEqual(<string> checkpanic err.detail()["message"], "For input string: \"AInvalidNum\"");
+
+    float|error v14 = float:fromHexString("12.3");
+    err = <error> v14;
+    test:assertValueEqual(err.message(), "{ballerina/lang.float}NumberParsingError");
+    test:assertValueEqual(<string> checkpanic err.detail()["message"], "invalid hex string: '12.3'");
 }
 
 function testMinAndMaxWithNaN() {


### PR DESCRIPTION
## Purpose
$subject

Fixes #33404
Fixes #33412 

## Approach
Fixed the langlib method to consider `NaN`
Fixed fromHexString() to validate the string values.

## Samples
```ballerina
import ballerina/test;

public function main() {
    float a = float:max(1, float:NaN);
    test:assertTrue(a === float:NaN); 
    float b = float:min(5, float:NaN);
    test:assertTrue(b === float:NaN);

    float v1 = checkpanic float:fromHexString("12"); // should give error
}
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
