### PR TITLE
Update org.apache.commons:commons-lang3 version to 3.12.0

### DIFF
--- a/bvm/ballerina-rt/build.gradle
+++ b/bvm/ballerina-rt/build.gradle
@@ -82,7 +82,7 @@ dependencies {
     // config
     dist 'org.slf4j:slf4j-jdk14:1.7.22'
     dist 'org.slf4j:slf4j-api:1.7.22'
-    dist 'org.apache.commons:commons-lang3:3.8.1'
+    dist 'org.apache.commons:commons-lang3:3.12.0'
     dist 'org.apache.commons:commons-text:1.9'
     dist 'com.moandjiezana.toml:toml4j:0.7.2'
     dist 'org.codehaus.woodstox:woodstox-core-asl:4.4.1'


### PR DESCRIPTION
## Purpose
> $subject

Part of https://github.com/ballerina-platform/ballerina-standard-library/issues/2245

## Approach
> Upgrade `org.apache.commons:commons-lang3` version from `3.8.1` to `3.12.0`.