### PR TITLE
Implement the Annotation Access Express Lookup Method

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/NodeFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/NodeFinder.java
@@ -71,6 +71,7 @@ import org.wso2.ballerinalang.compiler.tree.clauses.BLangOrderByClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangOrderKey;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangSelectClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangWhereClause;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangAnnotAccessExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangArrowFunction;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangBinaryExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangCheckPanickedExpr;
@@ -869,6 +870,11 @@ class NodeFinder extends BaseVisitor {
     public void visit(BLangIsLikeExpr typeTestExpr) {
         lookupNode(typeTestExpr.expr);
         lookupNode(typeTestExpr.typeNode);
+    }
+
+    @Override
+    public void visit(BLangAnnotAccessExpr annotAccessExpr) {
+        lookupNode(annotAccessExpr.expr);
     }
 
     @Override

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ExpressionTypeTestNew.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ExpressionTypeTestNew.java
@@ -439,9 +439,7 @@ public class ExpressionTypeTestNew {
 
         assertEquals(type.userSpecifiedMemberTypes().get(0).typeKind(), TYPE_REFERENCE);
         assertEquals(type.userSpecifiedMemberTypes().get(1).typeKind(), NIL);
-
-//        TODO: https://github.com/ballerina-platform/ballerina-lang/issues/33017
-//        assertType(198, 19, 198, 25, TYPEDESC);
+        assertType(198, 19, 198, 25, TYPEDESC);
     }
 
     @Test(dataProvider = "ErrorCtrPos")


### PR DESCRIPTION
## Purpose
> Implement the Annotation Access Express Lookup Method in `NodeFinder`

Fixes #33017

## Approach
> 

## Samples
> 

## Remarks
> 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
