### PR TITLE
Fix incorrect behaviour of resulting type in `bitwise-or-expr`

### DIFF
--- a/ballerina-shell/modules/shell-core/src/test/resources/testcases/evaluator/operations.bitwise.json
+++ b/ballerina-shell/modules/shell-core/src/test/resources/testcases/evaluator/operations.bitwise.json
@@ -20,12 +20,12 @@
   {
     "description": "OR operation I.",
     "code": "e | f",
-    "expr": "255"
+    "expr": "511"
   },
   {
     "description": "XOR operation I.",
     "code": "e ^ f",
-    "expr": "1"
+    "expr": "257"
   },
   {
     "description": "OR operation II.",

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
@@ -546,7 +546,7 @@ public class JvmInstructionGen {
         }
     }
 
-    private BType getPossibleUnsignedIntSubType(BType lhsType, BType rhsType) {
+    private BType getSmallestBuiltInUnsignedIntSubTypeContainingTypes(BType lhsType, BType rhsType) {
 
         if (TypeTags.isSignedIntegerTypeTag(lhsType.tag) || TypeTags.isSignedIntegerTypeTag(rhsType.tag)) {
             throw new BLangCompilerException("expected two unsigned int subtypes, found '" + lhsType + "' and '" +
@@ -1159,7 +1159,7 @@ public class JvmInstructionGen {
 
         if (!TypeTags.isSignedIntegerTypeTag(opType1.tag) && !TypeTags.isSignedIntegerTypeTag(opType2.tag)) {
             generateIntToUnsignedIntConversion(this.mv,
-                    getPossibleUnsignedIntSubType(opType1, opType2));
+                    getSmallestBuiltInUnsignedIntSubTypeContainingTypes(opType1, opType2));
         }
 
         this.storeToVar(binaryIns.lhsOp.variableDcl);
@@ -1187,7 +1187,7 @@ public class JvmInstructionGen {
         this.mv.visitInsn(LXOR);
 
         if (!TypeTags.isSignedIntegerTypeTag(opType1.tag) && !TypeTags.isSignedIntegerTypeTag(opType2.tag)) {
-            generateIntToUnsignedIntConversion(this.mv, getPossibleUnsignedIntSubType(opType1, opType2));
+            generateIntToUnsignedIntConversion(this.mv, getSmallestBuiltInUnsignedIntSubTypeContainingTypes(opType1, opType2));
         }
 
         this.storeToVar(binaryIns.lhsOp.variableDcl);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
@@ -1187,7 +1187,8 @@ public class JvmInstructionGen {
         this.mv.visitInsn(LXOR);
 
         if (!TypeTags.isSignedIntegerTypeTag(opType1.tag) && !TypeTags.isSignedIntegerTypeTag(opType2.tag)) {
-            generateIntToUnsignedIntConversion(this.mv, getSmallestBuiltInUnsignedIntSubTypeContainingTypes(opType1, opType2));
+            generateIntToUnsignedIntConversion(this.mv,
+                    getSmallestBuiltInUnsignedIntSubTypeContainingTypes(opType1, opType2));
         }
 
         this.storeToVar(binaryIns.lhsOp.variableDcl);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
@@ -546,26 +546,26 @@ public class JvmInstructionGen {
         }
     }
 
-    private BType getSmallerUnsignedIntSubType(BType lhsType, BType rhsType) {
+    private BType getlargerUnsignedIntSubType(BType lhsType, BType rhsType) {
 
         if (TypeTags.isSignedIntegerTypeTag(lhsType.tag) || TypeTags.isSignedIntegerTypeTag(rhsType.tag)) {
             throw new BLangCompilerException("expected two unsigned int subtypes, found '" + lhsType + "' and '" +
                     rhsType + "'");
         }
 
-        if (lhsType.tag == TypeTags.BYTE || rhsType.tag == TypeTags.BYTE) {
-            return symbolTable.unsigned8IntType;
-        }
-
-        if (lhsType.tag == TypeTags.UNSIGNED8_INT || rhsType.tag == TypeTags.UNSIGNED8_INT) {
-            return symbolTable.unsigned8IntType;
+        if (lhsType.tag == TypeTags.UNSIGNED32_INT || rhsType.tag == TypeTags.UNSIGNED32_INT) {
+            return symbolTable.unsigned32IntType;
         }
 
         if (lhsType.tag == TypeTags.UNSIGNED16_INT || rhsType.tag == TypeTags.UNSIGNED16_INT) {
             return symbolTable.unsigned16IntType;
         }
 
-        return symbolTable.unsigned32IntType;
+        if (lhsType.tag == TypeTags.UNSIGNED8_INT || rhsType.tag == TypeTags.UNSIGNED8_INT) {
+            return symbolTable.unsigned8IntType;
+        }
+
+        return symbolTable.byteType;
     }
 
     void generatePlatformIns(JInstruction ins) {
@@ -1159,7 +1159,7 @@ public class JvmInstructionGen {
 
         if (!TypeTags.isSignedIntegerTypeTag(opType1.tag) && !TypeTags.isSignedIntegerTypeTag(opType2.tag)) {
             generateIntToUnsignedIntConversion(this.mv,
-                    getSmallerUnsignedIntSubType(opType1, opType2));
+                    getlargerUnsignedIntSubType(opType1, opType2));
         }
 
         this.storeToVar(binaryIns.lhsOp.variableDcl);
@@ -1187,7 +1187,7 @@ public class JvmInstructionGen {
         this.mv.visitInsn(LXOR);
 
         if (!TypeTags.isSignedIntegerTypeTag(opType1.tag) && !TypeTags.isSignedIntegerTypeTag(opType2.tag)) {
-            generateIntToUnsignedIntConversion(this.mv, getSmallerUnsignedIntSubType(opType1, opType2));
+            generateIntToUnsignedIntConversion(this.mv, getlargerUnsignedIntSubType(opType1, opType2));
         }
 
         this.storeToVar(binaryIns.lhsOp.variableDcl);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
@@ -546,7 +546,7 @@ public class JvmInstructionGen {
         }
     }
 
-    private BType getlargerUnsignedIntSubType(BType lhsType, BType rhsType) {
+    private BType getPossibleUnsignedIntSubType(BType lhsType, BType rhsType) {
 
         if (TypeTags.isSignedIntegerTypeTag(lhsType.tag) || TypeTags.isSignedIntegerTypeTag(rhsType.tag)) {
             throw new BLangCompilerException("expected two unsigned int subtypes, found '" + lhsType + "' and '" +
@@ -1159,7 +1159,7 @@ public class JvmInstructionGen {
 
         if (!TypeTags.isSignedIntegerTypeTag(opType1.tag) && !TypeTags.isSignedIntegerTypeTag(opType2.tag)) {
             generateIntToUnsignedIntConversion(this.mv,
-                    getlargerUnsignedIntSubType(opType1, opType2));
+                    getPossibleUnsignedIntSubType(opType1, opType2));
         }
 
         this.storeToVar(binaryIns.lhsOp.variableDcl);
@@ -1187,7 +1187,7 @@ public class JvmInstructionGen {
         this.mv.visitInsn(LXOR);
 
         if (!TypeTags.isSignedIntegerTypeTag(opType1.tag) && !TypeTags.isSignedIntegerTypeTag(opType2.tag)) {
-            generateIntToUnsignedIntConversion(this.mv, getlargerUnsignedIntSubType(opType1, opType2));
+            generateIntToUnsignedIntConversion(this.mv, getPossibleUnsignedIntSubType(opType1, opType2));
         }
 
         this.storeToVar(binaryIns.lhsOp.variableDcl);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
@@ -772,7 +772,7 @@ public class SymbolTable {
                 BType unsignedIntTypeLhs = unsignedIntTypes[i];
                 BType unsignedIntTypeRhs = unsignedIntTypes[j];
                 defineBinaryOperator(orOpKind, unsignedIntTypeLhs, unsignedIntTypeRhs,
-                                     i <= j ? unsignedIntTypeLhs : unsignedIntTypeRhs);
+                                     i >= j ? unsignedIntTypeLhs : unsignedIntTypeRhs);
             }
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
@@ -462,8 +462,8 @@ public class SymbolTable {
 
         // Binary bitwise operators for nullable integer types
         defineNilableIntegerBitwiseAndOperations();
-        defineNilableIntegerBitwiseOperations(OperatorKind.BITWISE_OR);
-        defineNilableIntegerBitwiseOperations(OperatorKind.BITWISE_XOR);
+        defineNilableIntegerBitwiseOrAndXorOperations(OperatorKind.BITWISE_OR);
+        defineNilableIntegerBitwiseOrAndXorOperations(OperatorKind.BITWISE_XOR);
 
         // Binary shift operators for nullable integer types
         defineNilableIntegerLeftShiftOperations();
@@ -840,7 +840,7 @@ public class SymbolTable {
         }
     }
 
-    private void defineNilableIntegerBitwiseOperations(OperatorKind opKind) {
+    private void defineNilableIntegerBitwiseOrAndXorOperations(OperatorKind opKind) {
         BType[] unsignedIntTypes = {byteType, unsigned8IntType, unsigned16IntType, unsigned32IntType};
         BType[] signedIntTypes = {intType, signed8IntType, signed16IntType, signed32IntType};
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
@@ -882,11 +882,11 @@ public class SymbolTable {
         for (int i = 0; i < unsignedNilableIntTypes.length; i++) {
             for (int j = 0; j < unsignedNilableIntTypes.length; j++) {
                 defineBinaryOperator(opKind, unsignedNilableIntTypes[i], unsignedNilableIntTypes[j],
-                        i <= j ? unsignedNilableIntTypes[i] : unsignedNilableIntTypes[j]);
+                        i >= j ? unsignedNilableIntTypes[i] : unsignedNilableIntTypes[j]);
                 defineBinaryOperator(opKind, unsignedNilableIntTypes[i], unsignedIntTypes[j],
-                        i <= j ? unsignedNilableIntTypes[i] : unsignedNilableIntTypes[j]);
+                        i >= j ? unsignedNilableIntTypes[i] : unsignedNilableIntTypes[j]);
                 defineBinaryOperator(opKind, unsignedIntTypes[i], unsignedNilableIntTypes[j],
-                        i <= j ? unsignedNilableIntTypes[i] : unsignedNilableIntTypes[j]);
+                        i >= j ? unsignedNilableIntTypes[i] : unsignedNilableIntTypes[j]);
             }
         }
     }

--- a/docs/bir-spec/src/test/resources/test-src/types_and_operations.bal
+++ b/docs/bir-spec/src/test/resources/test-src/types_and_operations.bal
@@ -591,9 +591,9 @@ public function functionWithBitwiseOperations() {
 
     'int:Unsigned8 e = 254;
     'int:Unsigned16 f = 511;
-    'int:Unsigned8 res3 = e | f;
+    'int:Unsigned16 res3 = e | f;
 
-    'int:Unsigned8 res4 = e ^ f;
+    'int:Unsigned16 res4 = e ^ f;
 
     int g = 12345678;
     'int:Signed8 h = -127;

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibSubTypeTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibSubTypeTest.java
@@ -221,8 +221,8 @@ public class LangLibSubTypeTest {
         BAssertUtil.validateError(result, err++, EXPECT_SIGNED_32 + FOUND_INT, 275, 23);
         BAssertUtil.validateError(result, err++, "incompatible types: expected 'decimal'," + FOUND_BYTE, 276, 17);
         BAssertUtil.validateError(result, err++, EXPECT_SIGNED_8 + FOUND_UNSIGNED_8, 277, 22);
-        BAssertUtil.validateError(result, err++, EXPECT_SIGNED_16 + FOUND_UNSIGNED_16, 278, 23);
-        BAssertUtil.validateError(result, err++, EXPECT_SIGNED_8 + FOUND_UNSIGNED_8, 279, 22);
+        BAssertUtil.validateError(result, err++, EXPECT_SIGNED_16 + FOUND_UNSIGNED_32, 278, 23);
+        BAssertUtil.validateError(result, err++, EXPECT_SIGNED_8 + FOUND_UNSIGNED_32, 279, 22);
         BAssertUtil.validateError(result, err++, EXPECT_SIGNED_8 + FOUND_INT, 280, 22);
         BAssertUtil.validateError(result, err++, EXPECT_SIGNED_8 + FOUND_INT, 281, 22);
 
@@ -231,8 +231,8 @@ public class LangLibSubTypeTest {
         BAssertUtil.validateError(result, err++, EXPECT_SIGNED_32 + FOUND_INT, 297, 23);
         BAssertUtil.validateError(result, err++, "incompatible types: expected 'decimal'," + FOUND_BYTE, 298, 17);
         BAssertUtil.validateError(result, err++, EXPECT_SIGNED_8 + FOUND_UNSIGNED_16, 299, 22);
-        BAssertUtil.validateError(result, err++, EXPECT_SIGNED_16 + FOUND_UNSIGNED_16, 300, 23);
-        BAssertUtil.validateError(result, err++, EXPECT_SIGNED_8 + FOUND_UNSIGNED_8, 301, 22);
+        BAssertUtil.validateError(result, err++, EXPECT_SIGNED_16 + FOUND_UNSIGNED_32, 300, 23);
+        BAssertUtil.validateError(result, err++, EXPECT_SIGNED_8 + FOUND_UNSIGNED_32, 301, 22);
         BAssertUtil.validateError(result, err++, EXPECT_SIGNED_8 + FOUND_INT, 302, 22);
         BAssertUtil.validateError(result, err++, EXPECT_SIGNED_8 + FOUND_INT, 303, 22);
 

--- a/langlib/langlib-test/src/test/resources/test-src/subtypes/int_subtypes_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/subtypes/int_subtypes_test.bal
@@ -1033,11 +1033,11 @@ function testBitwiseOr() {
     int v = f | d;
     test:assertValueEqual(6429485, v);
 
-    ints:Unsigned16 w = g | h;
-    test:assertValueEqual(39869, w);
+    ints:Unsigned32 w = g | h;
+    test:assertValueEqual(5741501, w);
 
-    ints:Unsigned8 x = h | f;
-    test:assertValueEqual(156, x);
+    ints:Unsigned32 x = h | f;
+    test:assertValueEqual(5739420, x);
 
     int y = a | h;
     test:assertValueEqual(5739413, y);
@@ -1101,11 +1101,11 @@ function testBitwiseXor() {
     int v = f ^ d;
     test:assertValueEqual(6429473, v);
 
-    ints:Unsigned16 w = g ^ h;
-    test:assertValueEqual(39613, w);
+    ints:Unsigned32 w = g ^ h;
+    test:assertValueEqual(5741245, w);
 
-    ints:Unsigned8 x = h ^ f;
-    test:assertValueEqual(152, x);
+    ints:Unsigned32 x = h ^ f;
+    test:assertValueEqual(5739416, x);
 
     int y = a ^ h;
     test:assertValueEqual(5739413, y);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/BinaryBitwiseOperationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/BinaryBitwiseOperationTest.java
@@ -61,7 +61,7 @@ public class BinaryBitwiseOperationTest {
 
     @Test(description = "Test binary bitwise operations negative scenarios")
     public void testBinaryBitwiseOperationsNegativeScenarios() {
-        Assert.assertEquals(negativeResult.getErrorCount(), 15);
+        Assert.assertEquals(negativeResult.getErrorCount(), 19);
         int index = 0;
         BAssertUtil.validateError(negativeResult, index++, "operator '&' not defined for 'float' and 'int'",
                 26, 14);
@@ -91,7 +91,15 @@ public class BinaryBitwiseOperationTest {
                 53, 15);
         BAssertUtil.validateError(negativeResult, index++, "operator '^' not defined for 'int' and 'B'",
                 55, 15);
-        BAssertUtil.validateError(negativeResult, index, "operator '^' not defined for 'int' and 'float'",
+        BAssertUtil.validateError(negativeResult, index++, "operator '^' not defined for 'int' and 'float'",
                 57, 15);
+        BAssertUtil.validateError(negativeResult, index++, "operator '&' not defined for 'float?' and 'int?'",
+                62, 16);
+        BAssertUtil.validateError(negativeResult, index++, "operator '|' not defined for 'float?' and 'int?'",
+                63, 16);
+        BAssertUtil.validateError(negativeResult, index++, "operator '^' not defined for 'float?' and 'int?'",
+                64, 16);
+        BAssertUtil.validateError(negativeResult, index, "incompatible types: expected 'int:Unsigned8?', found " +
+                        "'int:Unsigned16?'", 68, 26);
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/BinaryBitwiseOperationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/BinaryBitwiseOperationTest.java
@@ -61,7 +61,7 @@ public class BinaryBitwiseOperationTest {
 
     @Test(description = "Test binary bitwise operations negative scenarios")
     public void testBinaryBitwiseOperationsNegativeScenarios() {
-        Assert.assertEquals(negativeResult.getErrorCount(), 19);
+        Assert.assertEquals(negativeResult.getErrorCount(), 21);
         int index = 0;
         BAssertUtil.validateError(negativeResult, index++, "operator '&' not defined for 'float' and 'int'",
                 26, 14);
@@ -99,7 +99,11 @@ public class BinaryBitwiseOperationTest {
                 63, 16);
         BAssertUtil.validateError(negativeResult, index++, "operator '^' not defined for 'float?' and 'int?'",
                 64, 16);
-        BAssertUtil.validateError(negativeResult, index, "incompatible types: expected 'int:Unsigned8?', found " +
+        BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected 'int:Unsigned8?', found " +
                         "'int:Unsigned16?'", 68, 26);
+        BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected 'byte?', found " +
+                "'int:Unsigned16?'", 72, 17);
+        BAssertUtil.validateError(negativeResult, index, "incompatible types: expected 'byte?', found " +
+                "'int:Unsigned32?'", 75, 17);
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/binary_bitwise_operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/binary_bitwise_operation.bal
@@ -271,6 +271,66 @@ function testBinaryBitwiseOperationsForNullable() {
     assertEqual(a & f, 0);
     assertEqual(a & g, 42);
     assertEqual(a & h, 43);
+
+    assertEqual(a | b, 47);
+    assertEqual(a | c, -21474833);
+    assertEqual(a | d, -453);
+    assertEqual(a | e, 111);
+    assertEqual(a | f, 21474879);
+    assertEqual(a | g, 54523);
+    assertEqual(a | h, 255);
+    assertEqual(b | b, 5);
+    assertEqual(b | c, -21474835);
+    assertEqual(b | d, -449);
+    assertEqual(b | e, 101);
+    assertEqual(c | c, -21474836);
+    assertEqual(c | d, -2);
+    assertEqual(c | e, -21474836);
+    assertEqual(c | f, -4);
+    assertEqual(c | g, -21441026);
+    assertEqual(c | h, -21474817);
+    assertEqual(d | d, -454);
+    assertEqual(d | e, -386);
+    assertEqual(d | f, -450);
+    assertEqual(d | g, -262);
+    assertEqual(d | h, -257);
+    assertEqual(e | e, 100);
+    assertEqual(e | f, 21474932);
+    assertEqual(e | g, 54526);
+    assertEqual(e | h, 255);
+    assertEqual(f | f, 21474836);
+    assertEqual(g | g, 54522);
+    assertEqual(h | h, 255);
+
+    assertEqual(a ^ b, 46);
+    assertEqual(a ^ c, -21474873);
+    assertEqual(a ^ d, -495);
+    assertEqual(a ^ e, 79);
+    assertEqual(a ^ f, 21474879);
+    assertEqual(a ^ g, 54481);
+    assertEqual(a ^ h, 212);
+    assertEqual(b ^ b, 0);
+    assertEqual(b ^ c, -21474839);
+    assertEqual(b ^ d, -449);
+    assertEqual(b ^ e, 97);
+    assertEqual(c ^ c, 0);
+    assertEqual(c ^ d, 21475286);
+    assertEqual(c ^ e, -21474936);
+    assertEqual(c ^ f, -8);
+    assertEqual(c ^ g, -21461738);
+    assertEqual(c ^ h, -21475053);
+    assertEqual(d ^ d, 0);
+    assertEqual(d ^ e, -418);
+    assertEqual(d ^ f, -21475282);
+    assertEqual(d ^ g, -54592);
+    assertEqual(d ^ h, -315);
+    assertEqual(e ^ e, 0);
+    assertEqual(e ^ f, 21474928);
+    assertEqual(e ^ g, 54430);
+    assertEqual(e ^ h, 155);
+    assertEqual(f ^ f, 0);
+    assertEqual(g ^ g, 0);
+    assertEqual(h ^ h, 0);
 }
 
 function assertEqual(anydata actual, anydata expected) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/binary_bitwise_operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/binary_bitwise_operation.bal
@@ -331,6 +331,22 @@ function testBinaryBitwiseOperationsForNullable() {
     assertEqual(f ^ f, 0);
     assertEqual(g ^ g, 0);
     assertEqual(h ^ h, 0);
+
+    int:Unsigned16? l = 1;
+    byte? m = 1;
+    int:Unsigned16? n = l | m;
+    assertEqual(n, 1);
+
+    int:Unsigned32? o = 1;
+    int:Unsigned32? p = o | m;
+    assertEqual(p, 1);
+
+    int:Unsigned8? q = 1;
+    int:Unsigned8? r = q | m;
+    assertEqual(r, 1);
+
+    byte? s = q | m;
+    assertEqual(s, 1);
 }
 
 function assertEqual(anydata actual, anydata expected) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/binary_bitwise_operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/binary_bitwise_operation.bal
@@ -137,7 +137,7 @@ function testBitwiseOROperation() {
     assertEqual(a10, 13);
 
     int:Unsigned32 f = 5;
-    int:Unsigned16 a11 = e | f;
+    int:Unsigned32 a11 = e | f;
     assertEqual(a11, 13);
 
     int a12 = e | panicIndex;
@@ -145,6 +145,18 @@ function testBitwiseOROperation() {
 
     int:Unsigned16|int a13 = c | e;
     assertEqual(a13, 15);
+
+    int:Unsigned16 g = 256;
+    int:Unsigned8 h = 0;
+
+    int:Unsigned16 i = g | h;
+    assertEqual(i, 256);
+    assertEqual((i == (256|0)), true);
+
+    int:Unsigned32 j = 12;
+    int:Unsigned8 k = 5;
+    int:Unsigned32 l = j | k;
+    assertEqual(l, 13);
 }
 
 function testBitwiseXOROperation() {
@@ -188,7 +200,7 @@ function testBitwiseXOROperation() {
     assertEqual(a10, 9);
 
     int:Unsigned32 f = 5;
-    int:Unsigned16 a11 = e ^ f;
+    int:Unsigned32 a11 = e ^ f;
     assertEqual(a11, 9);
 
     int:Unsigned32|int a12 = e ^ panicIndex;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/binary_bitwise_operation_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/binary_bitwise_operation_negative.bal
@@ -66,4 +66,11 @@ function testBinaryBitwiseOperationsNegativeScenarios() {
     int:Unsigned8? x21 = 23;
     int:Unsigned16? x22 = 1;
     int:Unsigned8? x23 = x21 | x22;
+
+    int:Unsigned16? x24 = 1;
+    byte? x25 = 1;
+    byte? x26 = x24 | x25;
+
+    int:Unsigned32? x27 = 1;
+    byte? x28 = x27 | x25;
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/binary_bitwise_operation_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/binary_bitwise_operation_negative.bal
@@ -55,4 +55,15 @@ function testBinaryBitwiseOperationsNegativeScenarios() {
     int x14 = 1 ^ a4;
 
     int x15 = 1 ^ A2;
+
+    float? x16 = 4.0;
+    int? x17 = 1;
+
+    int? x18 = x16 & x17;
+    int? x19 = x16 | x17;
+    int? x20 = x16 ^ x17;
+
+    int:Unsigned8? x21 = 23;
+    int:Unsigned16? x22 = 1;
+    int:Unsigned8? x23 = x21 | x22;
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/compoundassignment/compound_assignment.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/compoundassignment/compound_assignment.bal
@@ -1142,8 +1142,8 @@ function testCompoundAssignmentBitwiseOROperation() {
     a7 |= b;
     assertEqual(a7, 13);
 
-    int:Unsigned32 a8 = 5;
-    int:Unsigned16 a9 = 12;
+    int:Unsigned16 a8 = 5;
+    int:Unsigned32 a9 = 12;
     a9 |= a8;
     assertEqual(a9, 13);
 }
@@ -1190,8 +1190,8 @@ function testCompoundAssignmentBitwiseXOROperation() {
     a9 ^= d;
     assertEqual(a9, 9);
 
-    int:Unsigned32 e = 5;
-    int:Unsigned16 a10 = 12;
+    int:Unsigned16 e = 5;
+    int:Unsigned32 a10 = 12;
     a10 ^= e;
     assertEqual(a10, 9);
 


### PR DESCRIPTION
## Purpose
> $subject

Fixes #32888

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
