### PR TITLE
Add isDefaultModule flag to api docs

### DIFF
--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
@@ -137,7 +137,7 @@ public class BallerinaDocGenerator {
                                     moduleMeta.summary = module.summary;
                                     moduleMeta.orgName = module.orgName;
                                     moduleMeta.version = module.version;
-                                    moduleMeta.isSubModule = module.isSubModule;
+                                    moduleMeta.isDefaultModule = module.isDefaultModule;
                                     if (module.id.startsWith("lang.")) {
                                         centralLib.langLibs.add(moduleMeta);
                                         moduleLib.langLibs.add(module);
@@ -331,7 +331,7 @@ public class BallerinaDocGenerator {
 
         for (Module module: allModules) {
             if (module.summary != null) {
-                searchModules.add(new ModuleSearchJson(module.id, module.orgName, module.version, module.summary, module.isSubModule));
+                searchModules.add(new ModuleSearchJson(module.id, module.orgName, module.version, module.summary, module.isDefaultModule));
             }
 
             module.functions.forEach((function) ->
@@ -472,7 +472,7 @@ public class BallerinaDocGenerator {
                     moduleVersion;
             module.summary = moduleDoc.getValue().summary;
             module.description = moduleDoc.getValue().description;
-            module.isSubModule = !moduleDoc.getValue().isDefault;
+            module.isDefaultModule = moduleDoc.getValue().isDefault;
 
             // collect module's doc resources
             module.resources.addAll(moduleDoc.getValue().resources);
@@ -504,7 +504,7 @@ public class BallerinaDocGenerator {
                 moduleMeta.orgName = module.orgName;
                 moduleMeta.summary = module.summary;
                 moduleMeta.version = module.version;
-                moduleMeta.isSubModule = module.isSubModule;
+                moduleMeta.isDefaultModule = module.isDefaultModule;
                 relatedModules.add(moduleMeta);
             }
 

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
@@ -331,7 +331,8 @@ public class BallerinaDocGenerator {
 
         for (Module module: allModules) {
             if (module.summary != null) {
-                searchModules.add(new ModuleSearchJson(module.id, module.orgName, module.version, module.summary, module.isDefaultModule));
+                searchModules.add(new ModuleSearchJson(module.id, module.orgName, module.version, module.summary,
+                        module.isDefaultModule));
             }
 
             module.functions.forEach((function) ->

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
@@ -137,6 +137,7 @@ public class BallerinaDocGenerator {
                                     moduleMeta.summary = module.summary;
                                     moduleMeta.orgName = module.orgName;
                                     moduleMeta.version = module.version;
+                                    moduleMeta.isSubModule = module.isSubModule;
                                     if (module.id.startsWith("lang.")) {
                                         centralLib.langLibs.add(moduleMeta);
                                         moduleLib.langLibs.add(module);
@@ -330,7 +331,7 @@ public class BallerinaDocGenerator {
 
         for (Module module: allModules) {
             if (module.summary != null) {
-                searchModules.add(new ModuleSearchJson(module.id, module.orgName, module.version, module.summary));
+                searchModules.add(new ModuleSearchJson(module.id, module.orgName, module.version, module.summary, module.isSubModule));
             }
 
             module.functions.forEach((function) ->
@@ -418,7 +419,7 @@ public class BallerinaDocGenerator {
             // we cannot remove the module.getCompilation() here since the semantic model is accessed
             // after the code gen phase here. package.getCompilation() throws an IllegalStateException
             ModuleDoc moduleDoc = new ModuleDoc(moduleMdText, resources,
-                    syntaxTreeMap, module.getCompilation().getSemanticModel());
+                    syntaxTreeMap, module.getCompilation().getSemanticModel(), module.isDefaultModule());
             moduleDocMap.put(moduleName, moduleDoc);
         }
         return moduleDocMap;
@@ -471,6 +472,7 @@ public class BallerinaDocGenerator {
                     moduleVersion;
             module.summary = moduleDoc.getValue().summary;
             module.description = moduleDoc.getValue().description;
+            module.isSubModule = !moduleDoc.getValue().isDefault;
 
             // collect module's doc resources
             module.resources.addAll(moduleDoc.getValue().resources);
@@ -502,6 +504,7 @@ public class BallerinaDocGenerator {
                 moduleMeta.orgName = module.orgName;
                 moduleMeta.summary = module.summary;
                 moduleMeta.version = module.version;
+                moduleMeta.isSubModule = module.isSubModule;
                 relatedModules.add(moduleMeta);
             }
 

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/ModuleDoc.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/ModuleDoc.java
@@ -35,6 +35,7 @@ public class ModuleDoc {
     public final Map<String, SyntaxTree> syntaxTreeMap;
     public final SemanticModel semanticModel;
     public final List<Path> resources;
+    public final boolean isDefault;
 
     /**
      * Constructor.
@@ -43,14 +44,16 @@ public class ModuleDoc {
      * @param resources       resources of this package.
      * @param syntaxTreeMap a hash map of bal file names and syntax trees.
      * @param semanticModel the semantic model
+     * @param isDefault whether this is the default module (not a sub-module)
      * @throws IOException on error.
      */
     public ModuleDoc(String moduleMd, List<Path> resources, Map<String, SyntaxTree> syntaxTreeMap,
-                     SemanticModel semanticModel) throws IOException {
+                     SemanticModel semanticModel, boolean isDefault) throws IOException {
         this.description = moduleMd;
         this.summary = BallerinaDocUtils.getSummary(moduleMd);
         this.resources = resources;
         this.syntaxTreeMap = syntaxTreeMap;
         this.semanticModel = semanticModel;
+        this.isDefault = isDefault;
     }
 }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/ModuleMetaData.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/ModuleMetaData.java
@@ -34,5 +34,5 @@ public class ModuleMetaData {
     @Expose
     public String version;
     @Expose
-    public boolean isSubModule = false;
+    public boolean isDefaultModule = true;
 }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/ModuleMetaData.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/ModuleMetaData.java
@@ -33,4 +33,6 @@ public class ModuleMetaData {
     public String orgName;
     @Expose
     public String version;
+    @Expose
+    public boolean isSubModule = false;
 }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/search/ModuleSearchJson.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/search/ModuleSearchJson.java
@@ -32,14 +32,14 @@ public class ModuleSearchJson {
     @Expose
     private String version;
     @Expose
-    private boolean isSubModule;
+    private boolean isDefaultModule;
 
-    public ModuleSearchJson(String id, String orgName, String version, String description, boolean isSubModule) {
+    public ModuleSearchJson(String id, String orgName, String version, String description, boolean isDefaultModule) {
         this.setId(id);
         this.setDescription(description);
         this.setOrgName(orgName);
         this.setVersion(version);
-        this.setIsSubModule(isSubModule);
+        this.setIsDefaultModule(isDefaultModule);
     }
 
     public String getId() {
@@ -74,11 +74,11 @@ public class ModuleSearchJson {
         this.version = version;
     }
 
-    public boolean getIsSubModule() {
-        return isSubModule;
+    public boolean getIsDefaultModule() {
+        return isDefaultModule;
     }
 
-    public void setIsSubModule(boolean isSubModule) {
-        this.isSubModule = isSubModule;
+    public void setIsDefaultModule(boolean isDefaultModule) {
+        this.isDefaultModule = isDefaultModule;
     }
 }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/search/ModuleSearchJson.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/search/ModuleSearchJson.java
@@ -31,12 +31,15 @@ public class ModuleSearchJson {
     private String orgName;
     @Expose
     private String version;
+    @Expose
+    private boolean isSubModule;
 
-    public ModuleSearchJson(String id, String orgName, String version, String description) {
+    public ModuleSearchJson(String id, String orgName, String version, String description, boolean isSubModule) {
         this.setId(id);
         this.setDescription(description);
         this.setOrgName(orgName);
         this.setVersion(version);
+        this.setIsSubModule(isSubModule);
     }
 
     public String getId() {
@@ -71,4 +74,11 @@ public class ModuleSearchJson {
         this.version = version;
     }
 
+    public boolean getIsSubModule() {
+        return isSubModule;
+    }
+
+    public void setIsSubModule(boolean isSubModule) {
+        this.isSubModule = isSubModule;
+    }
 }


### PR DESCRIPTION
## Purpose
$subject to differentiate sub modules from default modules when rendering in the API docs site
* Related to https://github.com/wso2-enterprise/ballerina-central/issues/528

## Approach

## Samples

## Remarks

## Check List 
- [*] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
