### PR TITLE
Make `--dump-build-time option to print info in the console and hide the option to the end user

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/BuildCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/BuildCommand.java
@@ -197,7 +197,7 @@ public class BuildCommand implements BLauncherCmd {
             description = "list conflicted classes when generating executable")
     private Boolean listConflictedClasses;
 
-    @CommandLine.Option(names = "--dump-build-time", description = "calculate and dump build time")
+    @CommandLine.Option(names = "--dump-build-time", hidden = true, description = "calculate and dump build time")
     private Boolean dumpBuildTime;
 
     @CommandLine.Option(names = "--sticky", description = "stick to exact versions locked (if exists)")

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PackCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PackCommand.java
@@ -92,7 +92,7 @@ public class PackCommand implements BLauncherCmd {
             description = "hidden option for code coverage to include all classes")
     private String includes;
 
-    @CommandLine.Option(names = "--dump-build-time", description = "calculate and dump build time")
+    @CommandLine.Option(names = "--dump-build-time", hidden = true, description = "calculate and dump build time")
     private Boolean dumpBuildTime;
 
     @CommandLine.Option(names = "--sticky", description = "stick to exact versions locked (if exists)")

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/DumpBuildTimeTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/DumpBuildTimeTask.java
@@ -18,6 +18,7 @@
 package io.ballerina.cli.task;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 import io.ballerina.cli.utils.BuildTime;
 import io.ballerina.projects.Project;
 import io.ballerina.projects.ProjectKind;
@@ -85,15 +86,9 @@ public class DumpBuildTimeTask implements Task {
     }
 
     private void printBuildTime(BuildTime buildTime) {
-        this.out.println("\ttimestamp : " + buildTime.timestamp);
-        this.out.println("\toffline : " + buildTime.offline);
-        this.out.println("\tcompile : " + buildTime.compile);
-        this.out.println("\tprojectLoadDuration : " + buildTime.projectLoadDuration);
-        this.out.println("\tpackageResolutionDuration : " + buildTime.packageResolutionDuration);
-        this.out.println("\tpackageCompilationDuration : " + buildTime.packageCompilationDuration);
-        this.out.println("\tcodeGenDuration : " + buildTime.codeGenDuration);
-        this.out.println("\temitArtifactDuration : " + buildTime.emitArtifactDuration);
-        this.out.println("\ttestingExecutionDuration : " + buildTime.testingExecutionDuration);
-        this.out.println("\ttotalDuration : " + buildTime.totalDuration);
+        Gson gson = new Gson();
+        JsonObject buildTimeJson = (JsonObject) gson.toJsonTree(buildTime);
+        buildTimeJson.entrySet()
+                .forEach(entry -> this.out.println("\t" + entry.getKey() + " : " + entry.getValue().toString()));
     }
 }

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/DumpBuildTimeTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/DumpBuildTimeTask.java
@@ -65,8 +65,10 @@ public class DumpBuildTimeTask implements Task {
         try (FileOutputStream fileOutputStream = new FileOutputStream(jsonFile)) {
             try (Writer writer = new OutputStreamWriter(fileOutputStream, StandardCharsets.UTF_8)) {
                 Gson gson = new Gson();
-                String json = gson.toJson(BuildTime.getInstance());
+                BuildTime buildTime = BuildTime.getInstance();
+                String json = gson.toJson(buildTime);
                 writer.write(new String(json.getBytes(StandardCharsets.UTF_8), StandardCharsets.UTF_8));
+                printBuildTime(buildTime);
             } catch (IOException e) {
                 throw createLauncherException("couldn't write build time to file : " + e.getMessage());
             }
@@ -79,6 +81,19 @@ public class DumpBuildTimeTask implements Task {
         if (project.kind().equals(ProjectKind.BUILD_PROJECT)) {
             return project.sourceRoot().resolve("target").resolve(BUILD_TIME_JSON).toAbsolutePath();
         }
-        return currentDir.resolve("build-time.json").toAbsolutePath();
+        return currentDir.resolve(BUILD_TIME_JSON).toAbsolutePath();
+    }
+
+    private void printBuildTime(BuildTime buildTime) {
+        this.out.println("\ttimestamp : " + buildTime.timestamp);
+        this.out.println("\toffline : " + buildTime.offline);
+        this.out.println("\tcompile : " + buildTime.compile);
+        this.out.println("\tprojectLoadDuration : " + buildTime.projectLoadDuration);
+        this.out.println("\tpackageResolutionDuration : " + buildTime.packageResolutionDuration);
+        this.out.println("\tpackageCompilationDuration : " + buildTime.packageCompilationDuration);
+        this.out.println("\tcodeGenDuration : " + buildTime.codeGenDuration);
+        this.out.println("\temitArtifactDuration : " + buildTime.emitArtifactDuration);
+        this.out.println("\ttestingExecutionDuration : " + buildTime.testingExecutionDuration);
+        this.out.println("\ttotalDuration : " + buildTime.totalDuration);
     }
 }

--- a/cli/ballerina-cli/src/main/resources/cli-help/ballerina-build.help
+++ b/cli/ballerina-cli/src/main/resources/cli-help/ballerina-build.help
@@ -5,11 +5,11 @@ SYNOPSIS
        bal build
        bal build <ballerina-file-path>
        bal build <ballerina-package-path>
-       bal build [--test-report] [--offline] [--experimental] [-o | --output] <output-path> [--dump-build-time]
+       bal build [--test-report] [--offline] [--experimental] [-o | --output] <output-path>
                   <ballerina-file-path>
-       bal build [--offline] [experimental] [--cloud] [--observability-included] [--dump-build-time]
+       bal build [--offline] [experimental] [--cloud] [--observability-included]
                  [--with-tests] [--list-conflicted-classes] <ballerina-package-path>
-       bal build [--offline] [experimental] [--cloud] [--observability-included] [--dump-build-time]
+       bal build [--offline] [experimental] [--cloud] [--observability-included]
                  [--list-conflicted-classes] [--debug]  [--test-report] [--code-coverage]
                  <ballerina-package-path>
 
@@ -66,9 +66,6 @@ OPTIONS
 
        --list-conflicted-classes
        		List the conflicting classes of conflicting JARs in the project.
-
-       --dump-build-time
-            Calculate and dump build time.
 
 
 EXAMPLES

--- a/cli/ballerina-cli/src/main/resources/cli-help/ballerina-pack.help
+++ b/cli/ballerina-cli/src/main/resources/cli-help/ballerina-pack.help
@@ -4,11 +4,11 @@ NAME
 SYNOPSIS
        bal pack
        bal pack <ballerina-package-path>
-       bal pack [--test-report] [--offline] [--experimental] [--dump-build-time]
+       bal pack [--test-report] [--offline] [--experimental]
                   <ballerina-package-path>
-       bal pack [--offline] [experimental] [--cloud] [--observability-included] [--dump-build-time]
+       bal pack [--offline] [experimental] [--cloud] [--observability-included]
                  [--with-tests] [--list-conflicted-classes] <ballerina-package-path>
-       bal pack [--offline] [experimental] [--cloud] [--observability-included] [--dump-build-time]
+       bal pack [--offline] [experimental] [--cloud] [--observability-included]
                  [--list-conflicted-classes] [--debug]  [--test-report] [--code-coverage]
                  <ballerina-package-path>
 
@@ -43,9 +43,6 @@ OPTIONS
 
        --debug
            Run tests in remote debugging mode.
-
-       --dump-build-time
-            Calculate and dump build time.
 
 
 EXAMPLES

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/BuildCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/BuildCommandTest.java
@@ -676,7 +676,7 @@ public class BuildCommandTest extends BaseCommandTest {
         new CommandLine(buildCommand).parse();
         buildCommand.execute();
         String buildLog = readOutput(true);
-        Assert.assertEquals(buildLog.replaceAll("\r", ""), getOutput("dump-build-time-package.txt"));
+        Assert.assertTrue(buildLog.replaceAll("\r", "").contains(getOutput("dump-build-time-package.txt")));
 
         Assert.assertTrue(Files.exists(projectPath.resolve("target").resolve("build-time.json")));
         Assert.assertTrue(projectPath.resolve("target").resolve("build-time.json").toFile().length() > 0);
@@ -691,8 +691,7 @@ public class BuildCommandTest extends BaseCommandTest {
         new CommandLine(buildCommand).parse(balFilePath.toString());
         buildCommand.execute();
         String buildLog = readOutput(true);
-        Assert.assertEquals(buildLog.replaceAll("\r", ""),
-                getOutput("dump-build-time-standalone.txt"));
+        Assert.assertTrue(buildLog.replaceAll("\r", "").contains(getOutput("dump-build-time-standalone.txt")));
         Assert.assertTrue(Files.exists(this.testResources.resolve("valid-bal-file").resolve("build-time.json")));
         Assert.assertTrue(
                 this.testResources.resolve("valid-bal-file").resolve("build-time.json").toFile().length() > 0);

--- a/distribution/zip/jballerina-tools/resources/command-completion/command-completion.csv
+++ b/distribution/zip/jballerina-tools/resources/command-completion/command-completion.csv
@@ -2,7 +2,7 @@ cmdname,flags
 add, -t --template
 bal, -v -h --help --version add bindgen build clean dist doc encrypt format grpc help init new openapi pull push run search shell test update version
 bindgen, -cp -m -mvn -o --classpath --maven --modules --output --public
-build, -c -o --cloud --code-coverage --coverage-format --compile --debug --experimental --list-conflicted-classes --observability-included --offline --output --with-tests --sticky --test-report --dump-build-time
+build, -c -o --cloud --code-coverage --coverage-format --compile --debug --experimental --list-conflicted-classes --observability-included --offline --output --with-tests --sticky --test-report
 dist, list pull remove update use
 doc, -c -e -o --combine --exclude --output --experimental 
 encrypt, 


### PR DESCRIPTION
## Purpose
> $Title

- Fixes https://github.com/ballerina-platform/ballerina-lang/issues/33582
- Fixes https://github.com/ballerina-platform/ballerina-lang/issues/33599

## Approach
```
$ bal build --dump-build-time                                                                                  
Compiling source
	pramodya/woo:0.1.0

Generating executable
	target/bin/woo.jar

Dumping build time information
	target/build-time.json
	timestamp : 1635931601841
	offline : false
	compile : false
	projectLoadDuration : 618
	packageResolutionDuration : 211
	packageCompilationDuration : 200
	codeGenDuration : 208
	emitArtifactDuration : 444
	testingExecutionDuration : 0
	totalDuration : 1712
```

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
