### PR TITLE
Fix missing quotes for string literals in `SingletonTypeSymbol` and use finite type when creating singleton-type symbols

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSingletonTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSingletonTypeSymbol.java
@@ -23,7 +23,6 @@ import io.ballerina.compiler.api.symbols.SingletonTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BFiniteType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangLiteral;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
@@ -39,16 +38,16 @@ public class BallerinaSingletonTypeSymbol extends AbstractTypeSymbol implements 
 
     private final String typeName;
 
-    public BallerinaSingletonTypeSymbol(CompilerContext context, ModuleID moduleID, BLangExpression shape,
+    public BallerinaSingletonTypeSymbol(CompilerContext context, ModuleID moduleID, BLangLiteral shape,
                                         BType bType) {
         super(context, TypeDescKind.SINGLETON, bType);
 
         // Special case handling for `()` since in BLangLiteral, `null` is used to represent nil.
-        if (shape instanceof BLangLiteral && ((BLangLiteral) shape).value == null
+        if (shape.value == null
                 && shape.getBType().tag == TypeTags.NIL) {
             this.typeName = "()";
-        } else if (shape instanceof BLangLiteral && ((BLangLiteral) shape).getOriginalValue() != null) {
-            this.typeName = ((BLangLiteral) shape).getOriginalValue();
+        } else if (shape.getOriginalValue() != null) {
+            this.typeName = shape.getOriginalValue();
         } else {
             this.typeName = shape.toString();
         }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSingletonTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSingletonTypeSymbol.java
@@ -47,6 +47,8 @@ public class BallerinaSingletonTypeSymbol extends AbstractTypeSymbol implements 
         if (shape instanceof BLangLiteral && ((BLangLiteral) shape).value == null
                 && shape.getBType().tag == TypeTags.NIL) {
             this.typeName = "()";
+        } else if (shape instanceof BLangLiteral && ((BLangLiteral) shape).getOriginalValue() != null) {
+            this.typeName = ((BLangLiteral) shape).getOriginalValue();
         } else {
             this.typeName = shape.toString();
         }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaUnionTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaUnionTypeSymbol.java
@@ -33,6 +33,7 @@ import org.wso2.ballerinalang.util.Flags;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.StringJoiner;
 import java.util.regex.Pattern;
 
@@ -80,13 +81,15 @@ public class BallerinaUnionTypeSymbol extends AbstractTypeSymbol implements Unio
                     BFiniteType finiteType = (BFiniteType) memberType;
                     for (BLangExpression value : finiteType.getValueSpace()) {
                         ModuleID moduleID = getModule().isPresent() ? getModule().get().id() : null;
-                        members.add(new BallerinaSingletonTypeSymbol(this.context, moduleID, value, value.getBType()));
+                        BFiniteType bFiniteType = new BFiniteType(value.getBType().tsymbol, Set.of(value));
+                        members.add(new BallerinaSingletonTypeSymbol(this.context, moduleID, value, bFiniteType));
                     }
                 }
             } else {
                 for (BLangExpression value : ((BFiniteType) this.getBType()).getValueSpace()) {
                     ModuleID moduleID = getModule().isPresent() ? getModule().get().id() : null;
-                    members.add(new BallerinaSingletonTypeSymbol(this.context, moduleID, value, value.getBType()));
+                    BFiniteType bFiniteType = new BFiniteType(value.getBType().tsymbol, Set.of(value));
+                    members.add(new BallerinaSingletonTypeSymbol(this.context, moduleID, value, bFiniteType));
                 }
             }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaUnionTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaUnionTypeSymbol.java
@@ -26,6 +26,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BFiniteType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BUnionType;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangLiteral;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.util.Flags;
@@ -82,14 +83,16 @@ public class BallerinaUnionTypeSymbol extends AbstractTypeSymbol implements Unio
                     for (BLangExpression value : finiteType.getValueSpace()) {
                         ModuleID moduleID = getModule().isPresent() ? getModule().get().id() : null;
                         BFiniteType bFiniteType = new BFiniteType(value.getBType().tsymbol, Set.of(value));
-                        members.add(new BallerinaSingletonTypeSymbol(this.context, moduleID, value, bFiniteType));
+                        members.add(new BallerinaSingletonTypeSymbol(this.context, moduleID, (BLangLiteral) value,
+                                                                     bFiniteType));
                     }
                 }
             } else {
                 for (BLangExpression value : ((BFiniteType) this.getBType()).getValueSpace()) {
                     ModuleID moduleID = getModule().isPresent() ? getModule().get().id() : null;
                     BFiniteType bFiniteType = new BFiniteType(value.getBType().tsymbol, Set.of(value));
-                    members.add(new BallerinaSingletonTypeSymbol(this.context, moduleID, value, bFiniteType));
+                    members.add(new BallerinaSingletonTypeSymbol(this.context, moduleID, (BLangLiteral) value,
+                                                                 bFiniteType));
                 }
             }
 
@@ -113,7 +116,8 @@ public class BallerinaUnionTypeSymbol extends AbstractTypeSymbol implements Unio
             } else {
                 for (BLangExpression value : ((BFiniteType) this.getBType()).getValueSpace()) {
                     ModuleID moduleID = getModule().isPresent() ? getModule().get().id() : null;
-                    members.add(new BallerinaSingletonTypeSymbol(this.context, moduleID, value, value.getBType()));
+                    members.add(new BallerinaSingletonTypeSymbol(this.context, moduleID, (BLangLiteral) value,
+                                                                 value.getBType()));
                 }
             }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/TypesFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/TypesFactory.java
@@ -59,6 +59,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BUnionType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BXMLSubType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BXMLType;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangLiteral;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Names;
 import org.wso2.ballerinalang.util.Flags;
@@ -248,7 +249,7 @@ public class TypesFactory {
 
                 if (valueSpace.size() == 1) {
                     BLangExpression shape = valueSpace.iterator().next();
-                    return new BallerinaSingletonTypeSymbol(this.context, moduleID, shape, bType);
+                    return new BallerinaSingletonTypeSymbol(this.context, moduleID, (BLangLiteral) shape, bType);
                 }
 
                 return new BallerinaUnionTypeSymbol(this.context, moduleID, finiteType);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
@@ -816,6 +816,7 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
                     (BLangLiteral) TreeBuilder.createLiteralExpression() :
                     (BLangLiteral) TreeBuilder.createNumericLiteralExpression();
             literal.setValue(((BLangLiteral) constantNode.expr).value);
+            literal.setOriginalValue(((BLangLiteral) constantNode.expr).originalValue);
             literal.setBType(constantNode.expr.getBType());
             literal.isConstant = true;
 

--- a/language-server/modules/langserver-core/src/test/resources/completion/enum_decl_ctx/config/config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/enum_decl_ctx/config/config3.json
@@ -281,7 +281,7 @@
     {
       "label": "super",
       "kind": "Variable",
-      "detail": "SUPER",
+      "detail": "\"SUPER\"",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/enum_decl_ctx/config/config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/enum_decl_ctx/config/config4.json
@@ -8,7 +8,7 @@
     {
       "label": "super",
       "kind": "Variable",
-      "detail": "SUPER",
+      "detail": "\"SUPER\"",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config51.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config51.json
@@ -25,7 +25,7 @@
     {
       "label": "CONST1",
       "kind": "Variable",
-      "detail": "Test",
+      "detail": "\"Test\"",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config52.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config52.json
@@ -25,7 +25,7 @@
     {
       "label": "CONST1",
       "kind": "Variable",
-      "detail": "Test",
+      "detail": "\"Test\"",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config53.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config53.json
@@ -16,7 +16,7 @@
     {
       "label": "CONST1",
       "kind": "Variable",
-      "detail": "Test",
+      "detail": "\"Test\"",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config54.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config54.json
@@ -16,7 +16,7 @@
     {
       "label": "CONST1",
       "kind": "Variable",
-      "detail": "Test",
+      "detail": "\"Test\"",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/module_xml_namespace_decl/config/config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/module_xml_namespace_decl/config/config1.json
@@ -8,7 +8,7 @@
     {
       "label": "STRING_CONST",
       "kind": "Variable",
-      "detail": "http://ballerina.com/",
+      "detail": "\"http://ballerina.com/\"",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/module_xml_namespace_decl/config/config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/module_xml_namespace_decl/config/config2.json
@@ -8,7 +8,7 @@
     {
       "label": "STRING_CONST",
       "kind": "Variable",
-      "detail": "http://ballerina.com/",
+      "detail": "\"http://ballerina.com/\"",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/module_xml_namespace_decl/config/config8.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/module_xml_namespace_decl/config/config8.json
@@ -8,7 +8,7 @@
     {
       "label": "STRING_CONST",
       "kind": "Variable",
-      "detail": "http://ballerina.com/",
+      "detail": "\"http://ballerina.com/\"",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/record_type_desc/config/config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/record_type_desc/config/config5.json
@@ -450,7 +450,7 @@
     {
       "label": "STRING_VAL_TWO",
       "kind": "Variable",
-      "detail": "string value two",
+      "detail": "\"string value two\"",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -560,7 +560,7 @@
     {
       "label": "STRING_VAL",
       "kind": "Variable",
-      "detail": "string value",
+      "detail": "\"string value\"",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/record_type_desc/config/config6.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/record_type_desc/config/config6.json
@@ -450,7 +450,7 @@
     {
       "label": "STRING_VAL_TWO",
       "kind": "Variable",
-      "detail": "string value two",
+      "detail": "\"string value two\"",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -560,7 +560,7 @@
     {
       "label": "STRING_VAL",
       "kind": "Variable",
-      "detail": "string value",
+      "detail": "\"string value\"",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/record_type_desc/config/config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/record_type_desc/config/config7.json
@@ -450,7 +450,7 @@
     {
       "label": "STRING_VAL_TWO",
       "kind": "Variable",
-      "detail": "string value two",
+      "detail": "\"string value two\"",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -560,7 +560,7 @@
     {
       "label": "STRING_VAL",
       "kind": "Variable",
-      "detail": "string value",
+      "detail": "\"string value\"",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/record_type_desc/config/config8.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/record_type_desc/config/config8.json
@@ -450,7 +450,7 @@
     {
       "label": "STRING_VAL_TWO",
       "kind": "Variable",
-      "detail": "string value two",
+      "detail": "\"string value two\"",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -560,7 +560,7 @@
     {
       "label": "STRING_VAL",
       "kind": "Variable",
-      "detail": "string value",
+      "detail": "\"string value\"",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/match_stmt_ctx_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/match_stmt_ctx_config4.json
@@ -35,7 +35,7 @@
     {
       "label": "CONST1",
       "kind": "Variable",
-      "detail": "Test Const",
+      "detail": "\"Test Const\"",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/match_stmt_ctx_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/match_stmt_ctx_config5.json
@@ -35,7 +35,7 @@
     {
       "label": "CONST1",
       "kind": "Variable",
-      "detail": "Test Const",
+      "detail": "\"Test Const\"",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/xmlns_ctx_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/xmlns_ctx_config3.json
@@ -8,7 +8,7 @@
     {
       "label": "CONST1",
       "kind": "Variable",
-      "detail": "http://ballerina.com/",
+      "detail": "\"http://ballerina.com/\"",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/xmlns_ctx_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/xmlns_ctx_config4.json
@@ -8,7 +8,7 @@
     {
       "label": "CONST1",
       "kind": "Variable",
-      "detail": "http://ballerina.com/",
+      "detail": "\"http://ballerina.com/\"",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/LangLibFunctionTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/LangLibFunctionTest.java
@@ -25,7 +25,9 @@ import io.ballerina.compiler.api.symbols.FunctionTypeSymbol;
 import io.ballerina.compiler.api.symbols.RecordFieldSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.TypeDefinitionSymbol;
+import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
 import io.ballerina.compiler.api.symbols.VariableSymbol;
 import io.ballerina.projects.Document;
 import io.ballerina.projects.Project;
@@ -122,10 +124,47 @@ public class LangLibFunctionTest {
         assertEquals(type.typeKind(), DECIMAL);
 
         List<String> expFunctions = List.of("abs", "max", "min", "sum", "round", "floor", "ceiling", "clone",
-                                            "cloneReadOnly", "cloneWithType", "isReadOnly", "toString", "toBalString",
-                                            "toJson", "toJsonString", "fromJsonWithType", "mergeJson", "ensureType");
+                "cloneReadOnly", "cloneWithType", "isReadOnly", "toString", "toBalString",
+                "toJson", "toJsonString", "fromJsonWithType", "mergeJson", "ensureType");
 
         assertLangLibList(type.langLibMethods(), expFunctions);
+    }
+
+    @Test
+    public void testSingletonLangLib1() {
+        Symbol symbol = getSymbol(72, 4);
+        TypeReferenceTypeSymbol typeRefTypeSymbol = (TypeReferenceTypeSymbol) symbol;
+        UnionTypeSymbol unionSymbol = (UnionTypeSymbol) typeRefTypeSymbol.typeDescriptor();
+        List<TypeSymbol> memberTypeDescriptors = unionSymbol.memberTypeDescriptors();
+        TypeSymbol typeSymbol = memberTypeDescriptors.get(0);
+        assertEquals(typeSymbol.typeKind(), SINGLETON);
+
+        List<String> expFunctions = List.of("abs", "max", "min", "sum", "clone", "cloneReadOnly", "cloneWithType",
+                "isReadOnly", "toString", "toBalString", "toJson", "toJsonString",
+                "fromJsonWithType", "mergeJson", "ensureType", "toHexString");
+
+        assertLangLibList(typeSymbol.langLibMethods(), expFunctions);
+    }
+
+    @Test
+    public void testSingletonLangLib2() {
+        Symbol symbol = getSymbol(74, 4);
+        TypeReferenceTypeSymbol typeRefTypeSymbol = (TypeReferenceTypeSymbol) symbol;
+        UnionTypeSymbol unionSymbol = (UnionTypeSymbol) typeRefTypeSymbol.typeDescriptor();
+        List<TypeSymbol> memberTypeDescriptors = unionSymbol.memberTypeDescriptors();
+        TypeSymbol typeSymbol = memberTypeDescriptors.get(0);
+        assertEquals(typeSymbol.typeKind(), SINGLETON);
+
+        List<String> expFunctions = List.of("length", "iterator", "getCodePoint", "substring", "codePointCompare",
+                "'join", "indexOf", "lastIndexOf", "startsWith", "endsWith", "toLowerAscii",
+                "toUpperAscii", "equalsIgnoreCaseAscii", "trim", "toBytes",
+                "toCodePointInts", "clone", "cloneReadOnly", "cloneWithType", "isReadOnly",
+                "toString", "toBalString", "fromBalString", "toJson", "toJsonString",
+                "fromJsonWithType", "mergeJson", "ensureType", "fromJsonString",
+                "fromJsonFloatString", "fromJsonDecimalString", "fromJsonStringWithType",
+                "includes", "concat");
+
+        assertLangLibList(typeSymbol.langLibMethods(), expFunctions);
     }
 
     @Test
@@ -135,8 +174,8 @@ public class LangLibFunctionTest {
         assertEquals(type.typeKind(), STRING);
 
         List<String> expFunctions = List.of("length", "iterator", "getCodePoint", "substring", "codePointCompare",
-                                            "'join", "indexOf", "lastIndexOf", "startsWith", "endsWith", "toLowerAscii",
-                                            "toUpperAscii", "equalsIgnoreCaseAscii", "trim", "toBytes",
+                "'join", "indexOf", "lastIndexOf", "startsWith", "endsWith", "toLowerAscii",
+                "toUpperAscii", "equalsIgnoreCaseAscii", "trim", "toBytes",
                                             "toCodePointInts", "clone", "cloneReadOnly", "cloneWithType", "isReadOnly",
                                             "toString", "toBalString", "fromBalString", "toJson", "toJsonString",
                                             "fromJsonWithType", "mergeJson", "ensureType", "fromJsonString",

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
@@ -344,7 +344,7 @@ public class TypedescriptorTest {
         return new Object[][]{
                 {204, 11, "int?"},
                 {205, 17, "int|float|()"},
-                {206, 11, "A?"},
+                {206, 11, "\"A\"?"},
 //                {207, 15, "A|B|()"}, TODO: Disabled due to /ballerina-lang/issues/27957
         };
     }
@@ -375,7 +375,7 @@ public class TypedescriptorTest {
     public Object[][] getFiniteTypePos() {
         return new Object[][]{
                 {60, 10, "Digit", List.of("0", "1", "2", "3")},
-                {62, 11, "Format", List.of("default", "csv", "tdf")}
+                {62, 11, "Format", List.of("\"default\"", "\"csv\"", "\"tdf\"")}
         };
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/UnionTypeSymbolTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/UnionTypeSymbolTest.java
@@ -100,10 +100,26 @@ public class UnionTypeSymbolTest {
         };
     }
 
-    public static void assertList(List<TypeDescKind> actualValues, List<TypeDescKind> expectedValues) {
+    @Test
+    public void testSingletonMembers() {
+        TypeDefinitionSymbol symbol = (TypeDefinitionSymbol) assertBasicsAndGetSymbol(model, srcFile, 39, 5, "Keyword",
+                                                                                      SymbolKind.TYPE_DEFINITION);
+        assertEquals(symbol.typeDescriptor().typeKind(), TypeDescKind.UNION);
+        UnionTypeSymbol typeSymbol = (UnionTypeSymbol) symbol.typeDescriptor();
+
+        List<TypeSymbol> memberTypeDescriptors = typeSymbol.memberTypeDescriptors();
+        List<String> signatures = memberTypeDescriptors
+                                                    .stream()
+                                                    .filter(member -> member.typeKind() == TypeDescKind.SINGLETON)
+                                                    .map(TypeSymbol::signature)
+                                                    .collect(Collectors.toList());
+        assertList(signatures, List.of("\"int\"", "\"string\"", "100", "\"200\"", "true"));
+    }
+
+    public static <T> void assertList(List<T> actualValues, List<T> expectedValues) {
         assertEquals(actualValues.size(), expectedValues.size());
 
-        for (TypeDescKind val : expectedValues) {
+        for (T val : expectedValues) {
             assertTrue(actualValues.stream().anyMatch(val::equals));
         }
     }

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/langlib_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/langlib_test.bal
@@ -69,4 +69,12 @@ function test() {
     'xml:Element xm2 = xml `<Greeting>Hola</Greeting>`;
 
     int[] & readonly iarr = [1, 2];
+
+    T1 t1 = 2;
+
+    T2 t2 = "a";
 }
+
+type T1 1|2|3;
+
+type T2 "a"|"b";

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbols/union_type_symbol_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbols/union_type_symbol_test.bal
@@ -36,3 +36,6 @@ type Person record {|
 type T8 map<string>|Person;
 
 type T9 int[]|T8;
+
+type Keyword KEY | boolean | "string" | 100 | "200" | true;
+const KEY = "int";


### PR DESCRIPTION
## Purpose
$title

Fixes #33207
Fixes #33039

## Remarks
This PR sends the commits from https://github.com/ballerina-platform/ballerina-lang/pull/33251  to `stage-slbeta4`

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
