### PR TITLE
Fix compiler crashing while using variable-name field for key and spread field with table constructor

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
@@ -214,7 +214,6 @@ import org.wso2.ballerinalang.compiler.util.Names;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.util.Flags;
 
-import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
@@ -987,10 +987,19 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
 
     private List<BLangExpression> createKeyArray(BLangRecordLiteral literal, List<String> fieldNames) {
         //fieldNames have to be literals in table constructor's record literal list
-        Map<String, BLangExpression> fieldMap =
-                literal.fields.stream().map(recordField -> (BLangRecordLiteral.BLangRecordKeyValueField) recordField)
-                        .map(d -> new SimpleEntry<>(d.key.expr.toString(), d.valueExpr)).
-                        collect(Collectors.toMap(SimpleEntry::getKey, SimpleEntry::getValue));
+        Map<String, BLangExpression> fieldMap = new HashMap<>();
+
+        for (RecordLiteralNode.RecordField recordField : literal.fields) {
+            if (recordField.isKeyValueField()) {
+                BLangRecordLiteral.BLangRecordKeyValueField keyVal =
+                        (BLangRecordLiteral.BLangRecordKeyValueField) recordField;
+                fieldMap.put(keyVal.key.expr.toString(), keyVal.valueExpr);
+            } else if (recordField.getKind() == NodeKind.SIMPLE_VARIABLE_REF) {
+                BLangRecordLiteral.BLangRecordVarNameField recordVarNameField =
+                        (BLangRecordLiteral.BLangRecordVarNameField) recordField;
+                fieldMap.put(recordVarNameField.getVariableName().value, recordVarNameField);
+            }
+        }
         return fieldNames.stream().map(fieldMap::get).collect(Collectors.toList());
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -1204,15 +1204,10 @@ public class TypeChecker extends BLangNodeVisitor {
             } else if (recordField.getKind() == NodeKind.RECORD_LITERAL_SPREAD_OP) {
                 BLangRecordLiteral.BLangRecordSpreadOperatorField spreadOperatorField =
                         (BLangRecordLiteral.BLangRecordSpreadOperatorField) recordField;
-                BLangExpression spreadOpExpr = spreadOperatorField.expr;
-
-                BType spreadOpExprType = spreadOpExpr.getBType();
-                int spreadFieldTypeTag = spreadOpExprType.tag;
-
-                if (spreadFieldTypeTag != TypeTags.RECORD) {
+                BType spreadOpExprType = spreadOperatorField.expr.getBType();
+                if (spreadOpExprType.tag != TypeTags.RECORD) {
                     continue;
                 }
-
                 BRecordType recordType = (BRecordType) spreadOpExprType;
                 for (BField recField : recordType.fields.values()) {
                     if (fieldName.equals(recField.name.value)) {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/RecordConstraintTableTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/RecordConstraintTableTest.java
@@ -44,12 +44,14 @@ public class RecordConstraintTableTest {
 
     @Test
     public void testDuplicateKeysInTableConstructorExpr() {
-        Assert.assertEquals(negativeResult.getErrorCount(), 3);
+        Assert.assertEquals(negativeResult.getErrorCount(), 4);
         BAssertUtil.validateError(negativeResult, 0, "duplicate key found in table row key('name') : 'AAA'", 18, 5);
         BAssertUtil.validateError(negativeResult, 1, "duplicate key found in table row key('id, name') : '13, Foo'",
                 23, 5);
         BAssertUtil.validateError(negativeResult, 2, "duplicate key found in table row key('m') : ' {AAA: DDDD}'",
                 36, 7);
+        BAssertUtil.validateError(negativeResult, 3, "duplicate key found in table row key('idNum') : 'idNum'",
+                46, 9);
     }
 
     @Test(description = "Test global table constructor expr")
@@ -123,6 +125,11 @@ public class RecordConstraintTableTest {
     @Test(description = "Test table iteration with a union constrained table")
     public void testUnionConstrainedTableIteration() {
         BRunUtil.invoke(result, "testUnionConstrainedTableIteration");
+    }
+
+    @Test(description = "Test using spread field in table constructor")
+    public void testSpreadFieldInConstructor() {
+        BRunUtil.invoke(result, "testSpreadFieldInConstructor");
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableNegativeTest.java
@@ -35,7 +35,7 @@ public class TableNegativeTest {
     @Test
     public void testTableNegativeCases() {
         CompileResult compileResult = BCompileUtil.compile("test-src/types/table/table-negative.bal");
-        Assert.assertEquals(compileResult.getErrorCount(), 35);
+        Assert.assertEquals(compileResult.getErrorCount(), 36);
         int index = 0;
 
         validateError(compileResult, index++, "unknown type 'CusTable'",
@@ -107,7 +107,9 @@ public class TableNegativeTest {
                 "with key constraint type '[EmployeeId]'", 217, 47);
         validateError(compileResult, index++, "table key specifier mismatch with key constraint. " +
                 "expected: '[string, string]' fields but found '[firstname]'", 219, 47);
-        validateError(compileResult, index, "field name 'firstname' used in key specifier " +
+        validateError(compileResult, index++, "field name 'firstname' used in key specifier " +
                 "is not found in table constraint type 'CustomerDetail'", 236, 35);
+        validateError(compileResult, index++, "value expression of key specifier 'id' must be " +
+                "a constant expression", 243, 9);
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/table/record-constraint-table-value.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/table/record-constraint-table-value.bal
@@ -460,6 +460,39 @@ function testUnionConstrainedTableIteration() {
     assertEquality(expectedNames, names);
 }
 
+type FooRec record {
+    readonly int x;
+    int y;
+};
+
+public function testSpreadFieldInConstructor() {
+    string expected = "[{\"x\":1001,\"y\":20},{\"x\":1002,\"y\":30}]";
+    FooRec spreadField1 = {x: 1002, y: 30};
+
+    table<FooRec> tb1 = table key(x) [
+            {x: 1001, y: 20},
+            {...spreadField1}
+        ];
+    assertEquality(expected, tb1.toString());
+
+    var spreadField2 = {x: 1002, y: 30};
+
+    var tb2 = table key(x) [
+            {x: 1001, y: 20},
+            {...spreadField2}
+        ];
+    assertEquality(expected, tb2.toString());
+
+    var spreadField3 = {id: 2, name: "Jo", age: 12};
+    var tb3 = table [
+            {id: 1, name: "Mary", salary: 100.0},
+            {...spreadField3}
+        ];
+    assertEquality("[{\"id\":1,\"name\":\"Mary\",\"salary\":100.0},{\"id\":2,\"name\":\"Jo\",\"age\":12}]",
+    tb3.toString());
+}
+
+
 const ASSERTION_ERROR_REASON = "AssertionError";
 
 function assertTrue(any|error actual) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/table/record-type-table-key.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/table/record-type-table-key.bal
@@ -6,6 +6,7 @@ function runKeySpecifierTestCases() {
     testTableTypeWithKeyTypeConstraint();
     testTableTypeWithCompositeKeyTypeConstraint();
     testTableTypeWithMultiFieldKeys();
+    testVariableNameFieldAsKeyField();
 }
 
 type Customer record {
@@ -187,6 +188,17 @@ function testInferTableTypeV2() {
 
     tb.put({id: 3, name: "Pope", salary: 200.0, age: 19, address: {no: 12, road: "Sea street"}});
     assertEquality(3, tb.length());
+}
+
+const int id = 1;
+
+function testVariableNameFieldAsKeyField() {
+    string expected = "[{\"id\":1,\"name\":\"Jo\"},{\"id\":2,\"name\":\"Amy\"}]";
+    table<record {readonly int id; string name;}> key (id) tb = table [
+        {id, name: "Jo"},
+        {id: 2, name: "Amy"}
+    ];
+    assertEquality(expected, tb.toString());
 }
 
 function assertTrue(any|error actual) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/table/table-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/table/table-negative.bal
@@ -235,3 +235,14 @@ type CustomerTableWithKTC table<CustomerDetail> key<Name>;
 
 CustomerTableWithKTC tbl4 = table key(firstname, lastname) [{name: {fname: "Sanjiva", lname: "Weerawarana"},
                 id: 13, address: "Sri Lanka"}];
+
+function variableNameFieldAsKeyField() {
+    int id = 1;
+
+    table<record {readonly int id; string name;}> key (id) _ = table [
+        {id, name: "Jo"},
+        {id: 1, name: "Amy"},
+        {id: 2, name: "Amy"},
+        {id, name: "Alex"}
+    ];
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/table/table-value-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/table/table-value-negative.bal
@@ -38,3 +38,12 @@ function testTableConstructExprWithDuplicateKeys() returns string {
 
     return tab2.toString();
 }
+
+const int idNum = 1;
+function testVariableNameFieldAsKeyField() {
+    table<record {readonly int idNum; string name;}> key (idNum) tb = table [
+        {idNum, name: "Jo"},
+        {idNum, name: "Chiran"},
+        {idNum: 2, name: "Amy"}
+    ];
+}


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues.

Fixes #33299
Fixes #32707

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
