### PR TITLE
Remove else statement right curly brace position

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -56,7 +56,6 @@ import org.wso2.ballerinalang.compiler.bir.model.InstructionKind;
 import org.wso2.ballerinalang.compiler.bir.model.VarKind;
 import org.wso2.ballerinalang.compiler.bir.model.VarScope;
 import org.wso2.ballerinalang.compiler.bir.optimizer.BIROptimizer;
-import org.wso2.ballerinalang.compiler.diagnostic.BLangDiagnosticLocation;
 import org.wso2.ballerinalang.compiler.semantics.analyzer.Types;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BAnnotationSymbol;
@@ -1569,17 +1568,7 @@ public class BIRGen extends BLangNodeVisitor {
 
             // If a terminator statement has not been set for the else-block then just add it.
             if (this.env.enclBB.terminator == null) {
-                if (astIfStmt.elseStmt.pos != null) {
-                    Location newLocation = new BLangDiagnosticLocation(
-                            astIfStmt.elseStmt.pos.lineRange().filePath(),
-                            astIfStmt.elseStmt.pos.lineRange().endLine().line(),
-                            astIfStmt.elseStmt.pos.lineRange().endLine().line(),
-                            astIfStmt.elseStmt.pos.lineRange().endLine().offset(),
-                            astIfStmt.elseStmt.pos.lineRange().endLine().offset());
-                    this.env.enclBB.terminator = new BIRTerminator.GOTO(newLocation, nextBB, this.currentScope);
-                } else {
-                    this.env.enclBB.terminator = new BIRTerminator.GOTO(null, nextBB, this.currentScope);
-                }
+                this.env.enclBB.terminator = new BIRTerminator.GOTO(null, nextBB, this.currentScope);
             }
         } else {
             branchIns.falseBB = nextBB;

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/TestReportTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/TestReportTest.java
@@ -189,13 +189,13 @@ public class TestReportTest extends BaseTestCase {
     private void validateCoverage() {
         JsonParser parser = new JsonParser();
         //math module
-        int[] mathAddCovered = new int[] {22, 23, 24, 26, 29, 30, 31}, mathAddMissed = new int[] {27};
+        int[] mathAddCovered = new int[] {22, 23, 24, 26, 29, 31}, mathAddMissed = new int[] {27};
         float mathAddPercentageVal =
                 (float) (mathAddCovered.length) / (mathAddCovered.length + mathAddMissed.length) * 100;
         float mathAddPercentage =
                 (float) (Math.round(mathAddPercentageVal * 100.0) / 100.0);
 
-        int[] mathDivideCovered = new int[] {22, 23, 25, 26, 30}, mathDivideMissed = new int[] {28, 29};
+        int[] mathDivideCovered = new int[] {22, 23, 25, 26, 30}, mathDivideMissed = new int[] {28};
         float mathDividePercentageVal =
                 (float) (mathDivideCovered.length) / (mathDivideCovered.length + mathDivideMissed.length) * 100;
         float mathDividePercentage =
@@ -207,7 +207,7 @@ public class TestReportTest extends BaseTestCase {
         float mathPercentage = (float) (Math.round(mathPercentageVal * 100.0) / 100.0);
 
         //foo module
-        int[] fooMainCovered = new int[]{19, 22, 23, 24, 29, 30, 36, 37}, fooMainMissed = new int[]{26, 27};
+        int[] fooMainCovered = new int[]{19, 22, 23, 24, 29, 30, 36, 37}, fooMainMissed = new int[]{26};
         float fooMainPercentageVal =
                 (float) (fooMainCovered.length) / (fooMainCovered.length + fooMainMissed.length) * 100;
         float fooMainPercentage =
@@ -304,12 +304,12 @@ public class TestReportTest extends BaseTestCase {
     private void validateModuleWiseCoverage() {
         JsonParser parser = new JsonParser();
         //math module
-        int[] mathAddCovered = new int[]{22, 23, 24, 26, 29, 30, 31}, mathAddMissed = new int[]{27};
+        int[] mathAddCovered = new int[]{22, 23, 24, 26, 29, 31}, mathAddMissed = new int[]{27};
         float mathAddPercentageVal =
                 (float) (mathAddCovered.length) / (mathAddCovered.length + mathAddMissed.length) * 100;
         float mathAddPercentage = (float) (Math.round(mathAddPercentageVal * 100.0) / 100.0);
 
-        int[] mathDivideCovered = new int[]{22, 23, 25, 26, 30}, mathDivideMissed = new int[]{28, 29};
+        int[] mathDivideCovered = new int[]{22, 23, 25, 26, 30}, mathDivideMissed = new int[]{28};
         float mathDividePercentageVal =
                 (float) (mathDivideCovered.length) / (mathDivideCovered.length + mathDivideMissed.length) * 100;
         float mathDividePercentage = (float) (Math.round(mathDividePercentageVal * 100.0) / 100.0);
@@ -321,7 +321,7 @@ public class TestReportTest extends BaseTestCase {
         float mathPercentage = (float) (Math.round(mathPercentageVal * 100.0) / 100.0);
 
         //foo module
-        int[] fooMainCovered = new int[]{}, fooMainMissed = new int[]{19, 22, 23, 24, 26, 27, 29, 30, 36, 37};
+        int[] fooMainCovered = new int[]{}, fooMainMissed = new int[]{19, 22, 23, 24, 26, 29, 30, 36, 37};
         float fooMainPercentageVal =
                 (float) (fooMainCovered.length) / (fooMainCovered.length + fooMainMissed.length) * 100;
         float fooMainPercentage = (float) (Math.round(fooMainPercentageVal * 100.0) / 100.0);


### PR DESCRIPTION
## Purpose
> $title
Actually the right curly brace of an else statement do not need to hold the position. We do not need to consider these lines as debugger break points or as well as for the code coverage. 

Fixes #32201

With this change the following report has been obtained for code coverage of the [project](https://github.com/Ibaqu/Covid19Stats) mentioned in the issue #32201   

![coverage](https://user-images.githubusercontent.com/35595065/140308325-d9e7caa2-c929-4e0c-b10c-8726d5ca75cc.png)


## Approach

## Samples

## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
