### PR TITLE
Fix `int:abs()` to panic for overflow values

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/util/exceptions/BallerinaErrorReasons.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/util/exceptions/BallerinaErrorReasons.java
@@ -47,7 +47,9 @@ public class BallerinaErrorReasons {
 
     public static final BString DIVISION_BY_ZERO_ERROR =
             StringUtils.fromString(BALLERINA_PREFIX.concat("DivisionByZero"));
-    public static final BString NUMBER_OVERFLOW = StringUtils.fromString(BALLERINA_PREFIX.concat("NumberOverflow"));
+    public static final String NUMBER_OVERFLOW_ERROR_IDENTIFIER = "NumberOverflow";
+    public static final BString NUMBER_OVERFLOW =
+            StringUtils.fromString(BALLERINA_PREFIX.concat(NUMBER_OVERFLOW_ERROR_IDENTIFIER));
     public static final BString ARITHMETIC_OPERATION_ERROR =
             StringUtils.fromString(BALLERINA_PREFIX.concat("ArithmeticOperationError"));
     public static final BString JAVA_NULL_REFERENCE_ERROR =

--- a/langlib/lang.int/src/main/java/org/ballerinalang/langlib/integer/Abs.java
+++ b/langlib/lang.int/src/main/java/org/ballerinalang/langlib/integer/Abs.java
@@ -18,6 +18,14 @@
 
 package org.ballerinalang.langlib.integer;
 
+import io.ballerina.runtime.api.creators.ErrorCreator;
+import io.ballerina.runtime.internal.util.exceptions.BLangExceptionHelper;
+import io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons;
+import io.ballerina.runtime.internal.util.exceptions.RuntimeErrors;
+
+import static io.ballerina.runtime.api.constants.RuntimeConstants.INT_LANG_LIB;
+import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.getModulePrefixedReason;
+
 /**
  * Native implementation of lang.int:abs(int).
  *
@@ -32,6 +40,11 @@ package org.ballerinalang.langlib.integer;
 public class Abs {
 
     public static long abs(long n) {
+        if (n <= Long.MIN_VALUE) {
+            throw ErrorCreator.createError(getModulePrefixedReason(INT_LANG_LIB,
+                            BallerinaErrorReasons.NUMBER_OVERFLOW_ERROR_IDENTIFIER),
+                    BLangExceptionHelper.getErrorDetails(RuntimeErrors.INT_RANGE_OVERFLOW_ERROR));
+        }
         return Math.abs(n);
     }
 }

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibIntTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibIntTest.java
@@ -97,11 +97,6 @@ public class LangLibIntTest {
     }
 
     @Test
-    public void testToHexStringNonPositives() {
-        BRunUtil.invoke(compileResult, "testToHexStringNonPositives");
-    }
-
-    @Test
     public void testFromHexString() {
         BValue[] returns = BRunUtil.invoke(compileResult, "testFromHexString");
         assertEquals(((BInteger) returns[0]).intValue(), 11259205);
@@ -137,26 +132,15 @@ public class LangLibIntTest {
         assertEquals(((BInteger) returns[0]).intValue(), 1);
     }
 
-    @Test
-    public void testLangLibCallOnIntSubTypes() {
-        BRunUtil.invoke(compileResult, "testLangLibCallOnIntSubTypes");
-    }
-
-    @Test
-    public void testLangLibCallOnFiniteType() {
-        BRunUtil.invoke(compileResult, "testLangLibCallOnFiniteType");
-    }
-
-    @Test(expectedExceptions = {RuntimeException.class}, dataProvider = "functionProvider",
-            expectedExceptionsMessageRegExp = ".*\\{ballerina\\/lang\\.int}NumberOverflow \\{\"message\":\"int range " +
-                    "overflow\"}.*")
-    public void testIntOverflow(String funcName) {
+    @Test(dataProvider = "functionProvider")
+    public void testIntFunctions(String funcName) {
         BRunUtil.invoke(compileResult, funcName);
     }
 
     @DataProvider
     public Object[] functionProvider() {
-        return new String[]{"testIntOverflow1", "testIntOverflow2"};
+        return new String[] {"testToHexStringNonPositives", "testLangLibCallOnIntSubTypes",
+                "testLangLibCallOnFiniteType", "testIntOverflow"};
     }
 
 }

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibIntTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibIntTest.java
@@ -146,4 +146,17 @@ public class LangLibIntTest {
     public void testLangLibCallOnFiniteType() {
         BRunUtil.invoke(compileResult, "testLangLibCallOnFiniteType");
     }
+
+    @Test(expectedExceptions = {RuntimeException.class}, dataProvider = "functionProvider",
+            expectedExceptionsMessageRegExp = ".*\\{ballerina\\/lang\\.int}NumberOverflow \\{\"message\":\"int range " +
+                    "overflow\"}.*")
+    public void testIntOverflow(String funcName) {
+        BRunUtil.invoke(compileResult, funcName);
+    }
+
+    @DataProvider
+    public Object[] functionProvider() {
+        return new String[]{"testIntOverflow1", "testIntOverflow2"};
+    }
+
 }

--- a/langlib/langlib-test/src/test/resources/test-src/intlib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/intlib_test.bal
@@ -49,9 +49,9 @@ function testToHexString() returns [string, string, string] {
 }
 
 function testToHexStringNonPositives() {
-    assertValueEquality("-2", (-2).toHexString());
-    assertValueEquality("0", (0).toHexString());
-    assertValueEquality("-400", (-1024).toHexString());
+    test:assertValueEqual("-2", (-2).toHexString());
+    test:assertValueEqual("0", (0).toHexString());
+    test:assertValueEqual("-400", (-1024).toHexString());
 }
 
 function testFromHexString() returns [int|error, int|error] {
@@ -107,22 +107,19 @@ function testLangLibCallOnFiniteType() {
     test:assertValueEqual("c", s);
 }
 
-function testIntOverflow1() {
+function testIntOverflow() {
     int a1 = -9223372036854775808;
-    int b1 = a1.abs(); 
-}
+    int|error result = trap a1.abs();
 
-function testIntOverflow2() {
-    int a2 = (-9223372036854775807 - 1).abs();
-}
+    test:assertValueEqual(true, result is error);
+    error err = <error>result;
+    test:assertValueEqual("{ballerina/lang.int}NumberOverflow", err.message());
+    test:assertValueEqual("int range overflow", <string>checkpanic err.detail()["message"]);
 
-type AssertionError distinct error;
-const ASSERTION_ERROR_REASON = "AssertionError";
+    result = trap (-9223372036854775807 - 1).abs();
 
-function assertValueEquality(anydata expected, anydata actual) {
-    if expected == actual {
-        return;
-    }
-    panic error(ASSERTION_ERROR_REASON,
-                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+    test:assertValueEqual(true, result is error);
+    err = <error>result;
+    test:assertValueEqual("{ballerina/lang.int}NumberOverflow", err.message());
+    test:assertValueEqual("int range overflow", <string>checkpanic err.detail()["message"]);
 }

--- a/langlib/langlib-test/src/test/resources/test-src/intlib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/intlib_test.bal
@@ -107,6 +107,15 @@ function testLangLibCallOnFiniteType() {
     test:assertValueEqual("c", s);
 }
 
+function testIntOverflow1() {
+    int a1 = -9223372036854775808;
+    int b1 = a1.abs(); 
+}
+
+function testIntOverflow2() {
+    int a2 = (-9223372036854775807 - 1).abs();
+}
+
 type AssertionError distinct error;
 const ASSERTION_ERROR_REASON = "AssertionError";
 


### PR DESCRIPTION
## Purpose
$subject

Fixes #32590

## Approach
Added a validation for `int:abs()` implementation. 

## Samples
```ballerina
public function main() {
    int a1 = -9223372036854775808;
    int b1 = a1.abs(); // should panic

    int a2 = (-9223372036854775807 - 1).abs(); // should panic
}
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
