### PR TITLE
Fix type checking issues of Ternary and Elvis expressions

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -8883,7 +8883,10 @@ public class Desugar extends BLangNodeVisitor {
 
         types.setImplicitCastExpr(expr, rhsType, lhsType);
         if (expr.impConversionExpr != null) {
-            return expr;
+            BLangExpression expr2;
+            expr2 = expr.impConversionExpr;
+            expr.impConversionExpr = null;
+            return expr2;
         }
 
         if (lhsType.tag == TypeTags.JSON && rhsType.tag == TypeTags.NIL) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -5921,7 +5921,7 @@ public class Desugar extends BLangNodeVisitor {
                 if (constSymbol.literalType.tag <= TypeTags.BOOLEAN || constSymbol.literalType.tag == TypeTags.NIL) {
                     BLangLiteral literal = ASTBuilderUtil.createLiteral(varRefExpr.pos, constSymbol.literalType,
                             constSymbol.value.value);
-                    result = rewriteExpr(addConversionExprIfRequired(literal, varRefExpr.getBType()));
+                    result = addConversionExprIfRequired(literal, varRefExpr.getBType());
                     return;
                 }
             }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -4223,12 +4223,12 @@ public class TypeChecker extends BLangNodeVisitor {
         if (rhsReturnType == symTable.semanticError || lhsReturnType == symTable.semanticError) {
             resultType = symTable.semanticError;
         } else if (expType == symTable.noType) {
-            if (types.isSameType(rhsReturnType, lhsReturnType)) {
+            if (types.isAssignable(rhsReturnType, lhsReturnType)) {
                 resultType = lhsReturnType;
+            } else if (types.isAssignable(lhsReturnType, rhsReturnType)) {
+                resultType = rhsReturnType;
             } else {
-                dlog.error(elvisExpr.rhsExpr.pos, DiagnosticErrorCode.INCOMPATIBLE_TYPES, lhsReturnType,
-                        rhsReturnType);
-                resultType = symTable.semanticError;
+                resultType = BUnionType.create(null, rhsReturnType, rhsReturnType);
             }
         } else {
             resultType = expType;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -3931,6 +3931,8 @@ public class TypeChecker extends BLangNodeVisitor {
                 resultType = elseType;
             } else {
                 resultType = BUnionType.create(null, elseType, thenType);
+                types.setImplicitCastExpr(ternaryExpr.thenExpr, thenType, resultType);
+                types.setImplicitCastExpr(ternaryExpr.elseExpr, elseType, resultType);
             }
         } else {
             resultType = expType;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -3930,8 +3930,7 @@ public class TypeChecker extends BLangNodeVisitor {
             } else if (types.isAssignable(thenType, elseType)) {
                 resultType = elseType;
             } else {
-                dlog.error(ternaryExpr.pos, DiagnosticErrorCode.INCOMPATIBLE_TYPES, thenType, elseType);
-                resultType = symTable.semanticError;
+                resultType = BUnionType.create(null, elseType, thenType);
             }
         } else {
             resultType = expType;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -4229,7 +4229,7 @@ public class TypeChecker extends BLangNodeVisitor {
             } else if (types.isAssignable(lhsReturnType, rhsReturnType)) {
                 resultType = rhsReturnType;
             } else {
-                resultType = BUnionType.create(null, rhsReturnType, rhsReturnType);
+                resultType = BUnionType.create(null, lhsReturnType, rhsReturnType);
             }
         } else {
             resultType = expType;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/elvis/ElvisExpressionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/elvis/ElvisExpressionTest.java
@@ -228,17 +228,30 @@ public class ElvisExpressionTest {
         BAssertUtil.validateError(negativeResult, 2, "incompatible types: expected 'int', found 'string'", 19, 9);
         BAssertUtil.validateError(negativeResult, 3, "incompatible types: expected 'int', found 'string'", 26, 17);
         BAssertUtil.validateError(negativeResult, 4, "incompatible types: expected 'byte', found 'int'", 30, 17);
-        BAssertUtil.validateError(negativeResult, 5, "incompatible types: expected 'int', found '(int|byte)?'", 37, 10);
-        BAssertUtil.validateError(negativeResult, 6, "incompatible types: expected 'int', found '(int|int:Unsigned8|int:Signed8)?'", 44, 10);
-        BAssertUtil.validateError(negativeResult, 7, "incompatible types: expected 'int', found '(int|byte|int:Signed8)?'", 45, 10);
-        BAssertUtil.validateError(negativeResult, 8, "incompatible types: expected 'int', found '(decimal|float|int:Signed16)?'", 52, 10);
-        BAssertUtil.validateError(negativeResult, 9, "incompatible types: expected 'int', found '(decimal|float|int|int:Unsigned8|byte|int:Signed16)?'", 53, 10);
-        BAssertUtil.validateError(negativeResult, 10, "incompatible types: expected 'int', found '(int|string|string:Char|string[])'", 60, 10);
-        BAssertUtil.validateError(negativeResult, 11, "incompatible types: expected 'int', found '(int|byte)?'", 67, 14);
-        BAssertUtil.validateError(negativeResult, 12, "incompatible types: expected 'int', found '(int|int:Unsigned8|int:Signed8)?'", 74, 14);
-        BAssertUtil.validateError(negativeResult, 13, "incompatible types: expected 'int', found '(int|byte)?'", 75, 14);
-        BAssertUtil.validateError(negativeResult, 14, "incompatible types: expected 'int', found '(decimal|float|int:Signed8)?'", 82, 15);
-        BAssertUtil.validateError(negativeResult, 15, "incompatible types: expected 'int', found '(decimal|float|int|int:Unsigned8|byte|int:Signed8)?'", 83, 15);
-        BAssertUtil.validateError(negativeResult, 16, "incompatible types: expected 'int', found '(int|string|string:Char|string[])'", 90, 15);
+        BAssertUtil.validateError(negativeResult, 5, "incompatible types: expected 'int', found '(int|byte)?'", 37,
+                10);
+        BAssertUtil.validateError(negativeResult, 6,
+                "incompatible types: expected 'int', found '(int|int:Unsigned8|int:Signed8)?'", 44, 10);
+        BAssertUtil.validateError(negativeResult, 7,
+                "incompatible types: expected 'int', found '(int|byte|int:Signed8)?'", 45, 10);
+        BAssertUtil.validateError(negativeResult, 8,
+                "incompatible types: expected 'int', found '(decimal|float|int:Signed16)?'", 52, 10);
+        BAssertUtil.validateError(negativeResult, 9,
+                "incompatible types: expected 'int', found '(decimal|float|int|int:Unsigned8|byte|int:Signed16)?'", 53,
+                10);
+        BAssertUtil.validateError(negativeResult, 10,
+                "incompatible types: expected 'int', found '(int|string|string:Char|string[])'", 60, 10);
+        BAssertUtil.validateError(negativeResult, 11, "incompatible types: expected 'int', found '(int|byte)?'", 67,
+                14);
+        BAssertUtil.validateError(negativeResult, 12,
+                "incompatible types: expected 'int', found '(int|int:Unsigned8|int:Signed8)?'", 74, 14);
+        BAssertUtil.validateError(negativeResult, 13, "incompatible types: expected 'int', found '(int|byte)?'", 75,
+                14);
+        BAssertUtil.validateError(negativeResult, 14,
+                "incompatible types: expected 'int', found '(decimal|float|int:Signed8)?'", 82, 15);
+        BAssertUtil.validateError(negativeResult, 15,
+                "incompatible types: expected 'int', found '(decimal|float|int|int:Unsigned8|byte|int:Signed8)?'", 83, 15);
+        BAssertUtil.validateError(negativeResult, 16,
+                "incompatible types: expected 'int', found '(int|string|string:Char|string[])'", 90, 15);
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/elvis/ElvisExpressionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/elvis/ElvisExpressionTest.java
@@ -200,13 +200,45 @@ public class ElvisExpressionTest {
         BRunUtil.invoke(compileResult, "testElvisAsArgumentPositive");
     }
 
+    @Test(description = "Test Elvis with lang:value method calls in module level.")
+    public void testElvisWithLangValueMethodCallsModuleLevel() {
+        BRunUtil.invoke(compileResult, "testElvisWithLangValueMethodCallsModuleLevel");
+    }
+
+    @Test(description = "Test Elvis with lang:value method calls.")
+    public void testElvisWithLangValueMethodCalls() {
+        BRunUtil.invoke(compileResult, "testElvisWithLangValueMethodCalls");
+    }
+
+    @Test(description = "Test nested Elvis expressions without parenthesis in module level.")
+    public void testNestedElvisWithoutParenthesisModuleLevel() {
+        BRunUtil.invoke(compileResult, "testNestedElvisWithoutParenthesisModuleLevel");
+    }
+
+    @Test(description = "Test nested Elvis expressions without parenthesis.")
+    public void testNestedElvisWithoutParenthesis() {
+        BRunUtil.invoke(compileResult, "testNestedElvisWithoutParenthesis");
+    }
+
     @Test(description = "Negative test cases.")
     public void testElvisOperatorNegative() {
-        Assert.assertEquals(negativeResult.getErrorCount(), 5);
-        BAssertUtil.validateError(negativeResult, 0, "incompatible types: expected 'int', found 'int?'", 5, 14);
+        Assert.assertEquals(negativeResult.getErrorCount(), 17);
+        BAssertUtil.validateError(negativeResult, 0, "incompatible types: expected 'int', found 'int?'", 5, 19);
         BAssertUtil.validateError(negativeResult, 1, "incompatible types: expected 'int', found 'string'", 12, 14);
         BAssertUtil.validateError(negativeResult, 2, "incompatible types: expected 'int', found 'string'", 19, 9);
         BAssertUtil.validateError(negativeResult, 3, "incompatible types: expected 'int', found 'string'", 26, 17);
         BAssertUtil.validateError(negativeResult, 4, "incompatible types: expected 'byte', found 'int'", 30, 17);
+        BAssertUtil.validateError(negativeResult, 5, "incompatible types: expected 'int', found '(int|byte)?'", 37, 10);
+        BAssertUtil.validateError(negativeResult, 6, "incompatible types: expected 'int', found '(int|int:Unsigned8|int:Signed8)?'", 44, 10);
+        BAssertUtil.validateError(negativeResult, 7, "incompatible types: expected 'int', found '(int|byte|int:Signed8)?'", 45, 10);
+        BAssertUtil.validateError(negativeResult, 8, "incompatible types: expected 'int', found '(decimal|float|int:Signed16)?'", 52, 10);
+        BAssertUtil.validateError(negativeResult, 9, "incompatible types: expected 'int', found '(decimal|float|int|int:Unsigned8|byte|int:Signed16)?'", 53, 10);
+        BAssertUtil.validateError(negativeResult, 10, "incompatible types: expected 'int', found '(int|string|string:Char|string[])'", 60, 10);
+        BAssertUtil.validateError(negativeResult, 11, "incompatible types: expected 'int', found '(int|byte)?'", 67, 14);
+        BAssertUtil.validateError(negativeResult, 12, "incompatible types: expected 'int', found '(int|int:Unsigned8|int:Signed8)?'", 74, 14);
+        BAssertUtil.validateError(negativeResult, 13, "incompatible types: expected 'int', found '(int|byte)?'", 75, 14);
+        BAssertUtil.validateError(negativeResult, 14, "incompatible types: expected 'int', found '(decimal|float|int:Signed8)?'", 82, 15);
+        BAssertUtil.validateError(negativeResult, 15, "incompatible types: expected 'int', found '(decimal|float|int|int:Unsigned8|byte|int:Signed8)?'", 83, 15);
+        BAssertUtil.validateError(negativeResult, 16, "incompatible types: expected 'int', found '(int|string|string:Char|string[])'", 90, 15);
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/ternary/TernaryExpressionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/ternary/TernaryExpressionTest.java
@@ -370,6 +370,11 @@ public class TernaryExpressionTest {
         BRunUtil.invoke(compileResult, "testTernaryWithLangValueMethodCalls");
     }
 
+    @Test
+    public void testTernaryWithOtherOperators() {
+        BRunUtil.invoke(compileResult, "testTernaryWithOtherOperators");
+    }
+
     @AfterClass
     public void tearDown() {
         compileResult = null;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/ternary/TernaryExpressionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/ternary/TernaryExpressionTest.java
@@ -360,6 +360,16 @@ public class TernaryExpressionTest {
         BRunUtil.invoke(compileResult, "testTernaryAsArgument");
     }
 
+    @Test
+    public void testTernaryWithLangValueMethodCallsModuleLevel() {
+        BRunUtil.invoke(compileResult, "testTernaryWithLangValueMethodCallsModuleLevel");
+    }
+
+    @Test
+    public void testTernaryWithLangValueMethodCalls() {
+        BRunUtil.invoke(compileResult, "testTernaryWithLangValueMethodCalls");
+    }
+
     @AfterClass
     public void tearDown() {
         compileResult = null;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/elvis/elvis-expr-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/elvis/elvis-expr-negative.bal
@@ -2,7 +2,7 @@ function testElvisValueTypeNested () returns (int) {
     int|() x = ();
     int|() y = 3000;
     int b;
-    b = x ?: y ?: 1300;
+    b = x ?: y ?: x;
     return b;
 }
 
@@ -28,4 +28,64 @@ function testElvisAsArgumentNegative() {
     byte[] c = [];
     byte? d = ();
     c.push(d ?: 256);
+}
+
+int? x1 = ();
+byte? y1 = 255;
+() z1 = ();
+var elvisOutput1 = x1 ?: y1 ?: z1;
+int v1 = elvisOutput1;
+
+int? x2 = ();
+int:Unsigned8? y2 = 255;
+int:Signed8? z2 = -128;
+var elvisOutput2 = x2 ?: y2 ?: z2;
+var elvisOutput3 = x2 ?: y2 ?: x1 ?: y1 ?: z2;
+int v2 = elvisOutput2;
+int v3 = elvisOutput3;
+
+decimal? x3 = ();
+float? y3 = 1.213123;
+int:Signed16? z3 = -128;
+var elvisOutput4 = x3 ?: y3 ?: z3;
+var elvisOutput5 = x3 ?: y3 ?: x2 ?: y2 ?: x1 ?: y1 ?: z3;
+int v4 = elvisOutput4;
+int v5 = elvisOutput5;
+
+int? x4 = ();
+string? y4 = ();
+string:Char? z4 = ();
+string[] z5 = ["a"];
+var elvisOutput6 = x4 ?: y4 ?: z4 ?: z5;
+int v6 = elvisOutput6;
+
+function testNestedElvisNegative() {
+    int? x5 = ();
+    byte? y5 = ();
+    () z6 = ();
+    var elvisOutput7 = x5 ?: y5 ?: z6;
+    int v7 = elvisOutput7;
+
+    int? x6 = ();
+    int:Unsigned8? y6 = ();
+    int:Signed8? z7 = -128;
+    var elvisOutput8 = x6 ?: y6 ?: z7;
+    var elvisOutput9 = x6 ?: y6 ?: x5 ?: y5 ?: z6;
+    int v8 = elvisOutput8;
+    int v9 = elvisOutput9;
+
+    decimal? x7 = ();
+    float? y7 = ();
+    int:Signed8? z8 = -128;
+    var elvisOutput10 = x7 ?: y7 ?: z8;
+    var elvisOutput11 = x7 ?: y7 ?: x6 ?: y6 ?: x5 ?: y5 ?: z8;
+    int v10 = elvisOutput10;
+    int v11 = elvisOutput11;
+
+    int? x8 = ();
+    string? y8 = "b";
+    string:Char? z9 = "c";
+    string[] z10 = ["a"];
+    var elvisOutput12 = x8 ?: y8 ?: z9 ?: z10;
+    int v12 = elvisOutput12;
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/elvis/elvis-expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/elvis/elvis-expr.bal
@@ -160,6 +160,231 @@ function testElvisAsArgumentPositive() {
     assertEquals(a[1], 0);
 }
 
+int|() x1 = ();
+int|() y1 = 3000;
+string a1 = (x1 ?: y1).toBalString();
+
+int|() y2 = ();
+string a2 = (x1 ?: y2).toBalString();
+
+string y3 = "a";
+string a3 = (x1 ?: y3).toString();
+
+int|() x2 = 1;
+string a4 = (x2 ?: y3).toBalString();
+
+int:Signed8 y4 = 127;
+string a5 = (x2 ?: y4).toString();
+string a6 = (x1 ?: y4).toString();
+
+byte y5 = 255;
+string a7 = (x1 ?: y5).toString();
+
+int|() x3 = -9223372036854775807;
+string a8 = (x3 ?: y5).toString();
+
+float y6 = 123.12;
+string a9 = (x3 ?: y6).toString();
+string a10 = (x1 ?: y6).toString();
+
+decimal|() x4 = ();
+float y7 = -12.312;
+string a11 = (x4 ?: y7).toBalString();
+
+decimal|() x5 = 1.12321;
+string a12 = (x5 ?: y7).toString();
+
+string:Char|() x6 = ();
+string y8 = "b";
+string a13 = (x6 ?: y8).toString();
+
+string:Char|() x7 = "a";
+string a14 = (x7 ?: y8).toString();
+
+boolean? x8 = ();
+int[]|() y9 = [1, 3];
+string a15 = (x8 ?: y9).toBalString();
+
+boolean? x9 = true;
+string a16 = (x9 ?: y9).toBalString();
+
+function testElvisWithLangValueMethodCallsModuleLevel() {
+    assertEquals("3000", a1);
+    assertEquals("()", a2);
+    assertEquals("a", a3);
+    assertEquals("1", a4);
+    assertEquals("1", a5);
+    assertEquals("127", a6);
+    assertEquals("255", a7);
+    assertEquals("-9223372036854775807", a8);
+    assertEquals("-9223372036854775807", a9);
+    assertEquals("123.12", a10);
+    assertEquals("-12.312", a11);
+    assertEquals("1.12321", a12);
+    assertEquals("b", a13);
+    assertEquals("a", a14);
+    assertEquals("[1,3]", a15);
+    assertEquals("true", a16);
+}
+
+function testElvisWithLangValueMethodCalls() {
+    int|() x10 = ();
+    int|() y10 = 3000;
+    string b = (x10 ?: y10).toBalString();
+    assertEquals("3000", b);
+
+    y10 = ();
+    b = (x10 ?: y10).toBalString();
+    assertEquals("()", b);
+
+    string y11 = "a";
+    b = (x10 ?: y11).toString();
+    assertEquals("a", b);
+
+    x10 = 1;
+    b = (x10 ?: y11).toBalString();
+    assertEquals("1", b);
+
+    int:Signed8 y12 = 127;
+    b = (x10 ?: y12).toString();
+    assertEquals("1", b);
+
+    x10 = ();
+    b = (x10 ?: y12).toString();
+    assertEquals("127", b);
+
+    byte y13 = 255;
+    b = (x10 ?: y13).toString();
+    assertEquals("255", b);
+
+    x10 = -9223372036854775807;
+    b = (x10 ?: y13).toString();
+    assertEquals("-9223372036854775807", b);
+
+    float y14 = 123.12;
+    b = (x10 ?: y14).toString();
+    assertEquals("-9223372036854775807", b);
+
+    x10 = ();
+    b = (x10 ?: y14).toString();
+    assertEquals("123.12", b);
+
+    decimal|() x11 = ();
+    float y15 = -12.312;
+    b = (x11 ?: y15).toBalString();
+    assertEquals("-12.312", b);
+
+    x11 = 1.12321;
+    b = (x11 ?: y15).toString();
+    assertEquals("1.12321", b);
+
+    string:Char|() x12 = ();
+    string y16 = "b";
+    b = (x12 ?: y16).toString();
+    assertEquals("b", b);
+
+    x12 = "a";
+    b = (x12 ?: y16).toString();
+    assertEquals("a", b);
+
+    boolean? x13 = ();
+    int[]|() y17 = [1, 3];
+    b = (x13 ?: y17).toBalString();
+    assertEquals("[1,3]", b);
+
+    x13 = true;
+    b = (x13 ?: y17).toBalString();
+    assertEquals("true", b);
+}
+
+string? x14 = ();
+string? y18 = ();
+string:Char? z1 = "v";
+string? elvisOutput1 = x14 ?: y18 ?: z1;
+
+string? x15 = "a";
+string? elvisOutput2 = x15 ?: y18 ?: z1;
+
+string? x16 = ();
+string? y19 = "b";
+string? elvisOutput3 = x16 ?: y19 ?: z1;
+
+string? x17 = "a";
+string? elvisOutput4 = x17 ?: y19 ?: z1;
+string? elvisOutput5 = x17 ?: y19 ?: z1 ?: x14 ?: y19 ?: x15;
+string? elvisOutput6 = x16 ?: y18 ?: x14 ?: y18 ?: z1 ?: x15;
+
+int? x18 = ();
+byte? y20 = 255;
+() z2 = ();
+int? elvisOutput7 = x18 ?: y20 ?: z2;
+
+int? x19 = ();
+int:Unsigned8? y21 = 255;
+int:Signed8? z3 = -128;
+int? elvisOutput8 = x19 ?: y21 ?: z3;
+
+decimal? x20 = ();
+float? y22 = 1.213123;
+int:Signed8? z4 = -128;
+float|decimal|int:Signed8? elvisOutput9 = x20 ?: y22 ?: z4;
+
+function testNestedElvisWithoutParenthesisModuleLevel() {
+    assertEquals("v", elvisOutput1);
+    assertEquals("a", elvisOutput2);
+    assertEquals("b", elvisOutput3);
+    assertEquals("a", elvisOutput4);
+    assertEquals("a", elvisOutput5);
+    assertEquals("v", elvisOutput6);
+    assertEquals(255, elvisOutput7);
+    assertEquals(255, elvisOutput8);
+    assertEquals(1.213123, elvisOutput9);
+}
+
+function testNestedElvisWithoutParenthesis() {
+    string? x21 = ();
+    string? y23 = ();
+    string:Char? z5 = "v";
+    string? elvisOutput10 = x21 ?: y23 ?: z5;
+
+    string? x22 = "a";
+    string? elvisOutput11 = x22 ?: y23 ?: z5;
+
+    string? x23 = ();
+    string? y24 = "b";
+    string? elvisOutput12 = x23 ?: y24 ?: z5;
+
+    string? x24 = "a";
+    string? elvisOutput13 = x24 ?: y24 ?: z5;
+    string? elvisOutput14 = x24 ?: y24 ?: z5 ?: x21 ?: y24 ?: x22;
+    string? elvisOutput15 = x23 ?: y23 ?: x21 ?: y23 ?: z5 ?: x22;
+
+    int? x25 = ();
+    byte? y25 = 255;
+    () z6 = ();
+    int? elvisOutput16 = x25 ?: y25 ?: z6;
+
+    int? x26 = ();
+    int:Unsigned8? y26 = 255;
+    int:Signed8? z7 = -128;
+    int? elvisOutput17 = x26 ?: y26 ?: z7;
+
+    decimal? x27 = ();
+    float? y27 = 1.213123;
+    int:Signed8? z8 = -128;
+    float|decimal|int:Signed8? elvisOutput18 = x27 ?: y27 ?: z8;
+
+    assertEquals("v", elvisOutput10);
+    assertEquals("a", elvisOutput11);
+    assertEquals("b", elvisOutput12);
+    assertEquals("a", elvisOutput13);
+    assertEquals("a", elvisOutput14);
+    assertEquals("v", elvisOutput15);
+    assertEquals(255, elvisOutput16);
+    assertEquals(255, elvisOutput17);
+    assertEquals(1.213123, elvisOutput18);
+}
+
 const ASSERTION_ERROR_REASON = "AssertionError";
 
 function assertEquals(anydata expected, anydata actual) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/ternary/ternary-expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/ternary/ternary-expr.bal
@@ -311,6 +311,21 @@ function testTernaryWithLangValueMethodCalls() {
     assertEquals("a", b48);
 }
 
+boolean cond2 = true;
+int i1 =10;
+byte j1 = 100;
+int k1 = (cond2? i1 : j1) * i1;
+int k2 = (cond2? i1 : j1) * j1;
+int k3 = (cond2? i1 : j1) / i1;
+int k4 = (cond2? j1 : i1) % i1;
+
+function testTernaryWithOtherOperators() {
+    assertEquals(100, k1);
+    assertEquals(1000, k2);
+    assertEquals(1, k3);
+    assertEquals(0, k4);
+}
+
 const ASSERTION_ERROR_REASON = "AssertionError";
 
 function assertEquals(anydata expected, anydata actual) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/ternary/ternary-expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/ternary/ternary-expr.bal
@@ -141,6 +141,176 @@ function testTernaryAsArgument() {
     assertEquals(a[1], 255);
 }
 
+int|() x1 = ();
+int y1 = 3000;
+boolean cond = true;
+string b1 = (cond? x1 : y1).toBalString();
+string b2 = (cond? y1 : x1).toString();
+
+// Following lines should be uncommented after fixing 'ballerina-lang #33678'
+// int x2 = 123;
+// string y2 = "a";
+// string b3 = (cond? x2 : y2).toBalString();
+// string b4 = (cond? y2 : x2).toString();
+// string b5 = (cond? (cond? (cond? y2 : x2) : x2) : x2).toString();
+// string b6 = (cond? (cond? x2 : (cond? x2 : y2)) : (cond? x2 : y2)).toString();
+
+// int x3 = -9223372036854775807;
+// float y3 = 2.12;
+// string b7 = (cond? x3 : y3).toBalString();
+// string b8 = (cond? y3 : x3).toString();
+
+// decimal x4 = 123.12;
+// float y4 = 211.43;
+// string b9 = (cond? x4 : y4).toBalString();
+// string b10 = (cond? y4 : x4).toString();
+
+// int x5 = 123;
+// byte y5 = 250;
+// string b11 = (cond? x5 : y5).toBalString();
+// string b12 = (cond? y5 : x5).toString();
+
+// int x6 = 123;
+// int:Signed16 y6 = -32000;
+// string b13 = (cond? x6 : y6).toBalString();
+// string b14 = (cond? y6 : x6).toString();
+
+// int:Unsigned8 x7 = 223;
+// int:Signed8 y7 = -128;
+// string b15 = (cond? x7 : y7).toBalString();
+// string b16 = (cond? y7 : x7).toString();
+// string b17 = (cond? (cond? (cond? y7 : x7) : x7) : x7).toBalString();
+// string b18 = (cond? (cond? x4 : (cond? y1 : x3)) : (cond? y7 : x7)).toString();
+
+// string x8 = "abc";
+// string:Char y8 = "a";
+// string b19 = (cond? x8 : y8).toString();
+// string b20 = (cond? y8 : x8).toString();
+// string b21 = (cond? (cond? (cond? y1 : x3) : y8) : x8).toBalString();
+// string b22 = (cond? (cond? x3 : (cond? y6 : x7)) : (cond? y8 : x8)).toString();
+
+// int x9 = 123;
+// json y9 = "a";
+// string b23 = (cond? x9 : y9).toBalString();
+// string b24 = (cond? y9 : x9).toString();
+
+function testTernaryWithLangValueMethodCallsModuleLevel() {
+    assertEquals("()", b1);
+    assertEquals("3000", b2);
+
+    // Following lines should be uncommented after fixing 'ballerina-lang #33678'
+    // assertEquals("()", b1);
+    // assertEquals("3000", b2);
+    // assertEquals("123", b3);
+    // assertEquals("a", b4);
+    // assertEquals("a", b5);
+    // assertEquals("123", b6);
+    // assertEquals("-9223372036854775807", b7);
+    // assertEquals("2.12", b8);
+    // assertEquals("123.12d", b9);
+    // assertEquals("211.43", b10);
+    // assertEquals("123", b11);
+    // assertEquals("250", b12);
+    // assertEquals("123", b13);
+    // assertEquals("-32000", b14);
+    // assertEquals("223", b15);
+    // assertEquals("-128", b16);
+    // assertEquals("-128", b17);
+    // assertEquals("123.12", b18);
+    // assertEquals("abc", b19);
+    // assertEquals("a", b20);
+    // assertEquals("3000", b21);
+    // assertEquals("-9223372036854775807", b22);
+    // assertEquals("123", b23);
+    // assertEquals("a", b24);
+}
+
+function testTernaryWithLangValueMethodCalls() {
+    int|() x10 = ();
+    int y10 = 3000;
+
+    string b25 = (cond? x10 : y10).toBalString();
+    assertEquals("()", b25);
+    string b26 = (cond? y10 : x10).toString();
+    assertEquals("3000", b26);
+
+    int x11 = 123;
+    string y11 = "a";
+
+    string b27 = (cond? x11 : y11).toBalString();
+    assertEquals("123", b27);
+    string b28 = (cond? y11 : x11).toString();
+    assertEquals("a", b28);
+    string b29 = (cond? (cond? (cond? y11 : x11) : x11) : x11).toString();
+    assertEquals("a", b29);
+    string b30 = (cond? (cond? x11 : (cond? x11 : y11)) : (cond? x11 : y11)).toString();
+    assertEquals("123", b30);
+
+    int x12 = -9223372036854775807;
+    float y12 = 2.12;
+
+    string b31 = (cond? x12 : y12).toBalString();
+    assertEquals("-9223372036854775807", b31);
+    string b32 = (cond? y12 : x12).toString();
+    assertEquals("2.12", b32);
+
+    decimal x13 = 123.12;
+    float y13 = 211.43;
+
+    string b33 = (cond? x13 : y13).toBalString();
+    assertEquals("123.12d", b33);
+    string b34 = (cond? y13 : x13).toString();
+    assertEquals("211.43", b34);
+
+    int x14 = 123;
+    byte y14 = 250;
+
+    string b35 = (cond? x14 : y14).toBalString();
+    assertEquals("123", b35);
+    string b36 = (cond? y14 : x14).toString();
+    assertEquals("250", b36);
+
+    int x15 = 123;
+    int:Signed16 y15 = -32000;
+
+    string b37 = (cond? x15 : y15).toBalString();
+    assertEquals("123", b37);
+    string b38 = (cond? y15 : x15).toString();
+    assertEquals("-32000", b38);
+
+    int:Unsigned8 x16 = 223;
+    int:Signed8 y16 = -128;
+
+    string b39 = (cond? x16 : y16).toBalString();
+    assertEquals("223", b39);
+    string b40 = (cond? y16 : x16).toString();
+    assertEquals("-128", b40);
+    string b41 = (cond? (cond? (cond? y16 : x14) : x16) : x16).toBalString();
+    assertEquals("-128", b41);
+    string b42 = (cond? (cond? x15 : (cond? y12 : x14)) : (cond? y16 : x16)).toString();
+    assertEquals("123", b42);
+
+    string x17 = "abc";
+    string:Char y17 = "a";
+
+    string b43 = (cond? x17 : y17).toString();
+    assertEquals("abc", b43);
+    string b44 = (cond? y17 : x17).toString();
+    assertEquals("a", b44);
+    string b45 = (cond? (cond? (cond? y10 : x12) : y17) : x17).toBalString();
+    assertEquals("3000", b45);
+    string b46 = (cond? (cond? x12 : (cond? y15 : x16)) : (cond? y17 : x17)).toString();
+    assertEquals("-9223372036854775807", b46);
+
+    int x18 = 123;
+    json y18 = "a";
+
+    string b47 = (cond? x18 : y18).toBalString();
+    assertEquals("123", b47);
+    string b48 = (cond? y18 : x18).toString();
+    assertEquals("a", b48);
+}
+
 const ASSERTION_ERROR_REASON = "AssertionError";
 
 function assertEquals(anydata expected, anydata actual) {


### PR DESCRIPTION
## Purpose
> $title. Further, fix Desugaring logic of Ternary and Elvis expressions.

Fixes #33213 
Fixes #33683 
Fixes #33655 
Fixes #24582

## Approach
> Create a new union type (Union of LHS and RHS types) as the resultant type of the Ternary/Elvis expressions (for noType situations).

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
