### PR TITLE
Return the effective type of `BIntersectionType`s in `org.wso2.ballerinalang.compiler.semantics.analyzer.Types#getIntersection`

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -4326,9 +4326,18 @@ public class Types {
                     .collect(Collectors.toList());
             if (types.size() == 1) {
                 BType bType = types.get(0);
-                return ImmutableTypeCloner.getImmutableType(null, this, bType, env, env.enclPkg.packageID, null,
-                        symTable, anonymousModelHelper, names,
-                        new LinkedHashSet<>());
+
+                if (isInherentlyImmutableType(type) || Symbols.isFlagOn(type.flags, Flags.READONLY)) {
+                    return type;
+                }
+
+                if (!isSelectivelyImmutableType(type, new HashSet<>())) {
+                    return symTable.semanticError;
+                }
+
+                return ImmutableTypeCloner.getEffectiveImmutableType(null, this,
+                                                                     (SelectivelyImmutableReferenceType) bType,
+                                                                     env, symTable, anonymousModelHelper, names);
             }
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ImmutableTypeCloner.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ImmutableTypeCloner.java
@@ -161,7 +161,7 @@ public class ImmutableTypeCloner {
         }
     }
 
-    public static BType getImmutableType(Location pos, Types types, BType type, SymbolEnv env,
+    private static BType getImmutableType(Location pos, Types types, BType type, SymbolEnv env,
                                           PackageID pkgId,
                                           BSymbol owner, SymbolTable symTable,
                                           BLangAnonymousModelHelper anonymousModelHelper, Names names,

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStmtListMatchPatternTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStmtListMatchPatternTest.java
@@ -204,6 +204,11 @@ public class MatchStmtListMatchPatternTest {
     }
 
     @Test
+    public void testListMatchPattern31() {
+        BRunUtil.invoke(result, "testListMatchPattern31");
+    }
+
+    @Test
     public void testRestMatchPattern1() {
         BRunUtil.invoke(restMatchPatternResult, "testListMatchPatternWithRest1");
     }
@@ -377,6 +382,10 @@ public class MatchStmtListMatchPatternTest {
                 40, 21);
         BAssertUtil.validateError(resultSemanticsNegative, ++i, "incompatible types: expected 'boolean', found 'json'",
                 40, 25);
+        BAssertUtil.validateError(resultSemanticsNegative, ++i, "incompatible types: expected 'int', found 'string'",
+                                  55, 21);
+        BAssertUtil.validateError(resultSemanticsNegative, ++i, "incompatible types: expected 'string?', " +
+                                          "found 'int'", 58, 25);
         Assert.assertEquals(resultSemanticsNegative.getErrorCount(), i + 1);
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/matchstmt/list-match-pattern-negative-semantics.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/matchstmt/list-match-pattern-negative-semantics.bal
@@ -42,3 +42,21 @@ function testInvalidTypesWithJson(json j) returns [int, boolean[]] {
     }
     return [0, []];
 }
+
+type T readonly & S;
+type S [INT, int]|[STRING, string];
+
+const INT = 1;
+const STRING = 2;
+
+function testInvalidTypesWithImmutableIntersection(T t) {
+    match t {
+        [STRING, var val] => {
+            int _ = val;
+        }
+        [INT, var val] => {
+            string? _ = val;
+        }
+    }
+}
+

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/matchstmt/list-match-pattern.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/matchstmt/list-match-pattern.bal
@@ -853,6 +853,36 @@ function testListMatchPattern30() {
     assertEquals("Pattern2", result);
 }
 
+type T readonly & S;
+type S [INT, int]|[STRING, string];
+
+const INT = 1;
+const STRING = 2;
+
+function testListMatchPattern31() {
+    T t1 = [STRING, "hello"];
+    T t2 = [INT, 1234];
+
+    assertEquals(["hello", ()], listMatchPattern31(t1));
+    assertEquals([(), 1234], listMatchPattern31(t2));
+}
+
+function listMatchPattern31(T t) returns [string?, int?] {
+    string? s = ();
+    int? i = ();
+
+    match t {
+        [STRING, var val] => {
+            s = val;
+        }
+        [INT, var val] => {
+            i = val;
+        }
+    }
+
+    return [s, i];
+}
+
 function assertEquals(anydata expected, anydata actual) {
     if expected == actual {
         return;


### PR DESCRIPTION
## Purpose
$title. This is because most other analysis depend on a concrete type, and don't expect an intersection type.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/33694

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
