### PR TITLE
Avoid providing foreach snippets for stream types with completion type

### DIFF
--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/foreach_stmt_ctx_config25.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/foreach_stmt_ctx_config25.json
@@ -3,34 +3,8 @@
     "line": 3,
     "character": 14
   },
-  "source": "field_access_expression_context/source/foreach_stmt_ctx_source19.bal",
+  "source": "field_access_expression_context/source/foreach_stmt_ctx_source23.bal",
   "items": [
-    {
-      "label": "foreach",
-      "kind": "Snippet",
-      "detail": "foreach var item in expr",
-      "documentation": {
-        "left": "foreach statement for iterable variable - numStream"
-      },
-      "sortText": "BR",
-      "insertText": "foreach int item in numStream {\n\t${1}\n}",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 3,
-              "character": 4
-            },
-            "end": {
-              "line": 3,
-              "character": 14
-            }
-          },
-          "newText": ""
-        }
-      ]
-    },
     {
       "label": "filter(function () func)",
       "kind": "Function",
@@ -119,6 +93,25 @@
       }
     },
     {
+      "label": "map(function () func)",
+      "kind": "Function",
+      "detail": "stream<any|error, error?>",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.stream:0.0.0_  \n  \nApplies a function to each member of a stream and returns a stream of the results.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Return** `stream<any|error, error?>`   \n- new stream containing result of applying function `func` to each member of parameter `stm` in order  \n  \n"
+        }
+      },
+      "sortText": "BD",
+      "filterText": "map",
+      "insertText": "map(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
       "label": "close()",
       "kind": "Function",
       "detail": "error??",
@@ -181,25 +174,6 @@
       "filterText": "toString",
       "insertText": "toString()",
       "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "map(function () func)",
-      "kind": "Function",
-      "detail": "stream<any|error, error?>",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.stream:0.0.0_  \n  \nApplies a function to each member of a stream and returns a stream of the results.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Return** `stream<any|error, error?>`   \n- new stream containing result of applying function `func` to each member of parameter `stm` in order  \n  \n"
-        }
-      },
-      "sortText": "BD",
-      "filterText": "map",
-      "insertText": "map(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/source/foreach_stmt_ctx_source23.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/source/foreach_stmt_ctx_source23.bal
@@ -1,0 +1,5 @@
+public function testFunction() {
+    int[] arr = [1,2,2];
+    stream<int, error?> numStream = arr.toStream();
+    numStream.
+}


### PR DESCRIPTION
## Purpose
$subject to remove erroneous suggestion. The foreach snippets will be shown if the type descriptor of the expression (field access) is a stream type with a `NIL` completion param type. 

Fixes #33339 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
