### PR TITLE
Fix map<json> map access negative cases

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -9573,7 +9573,7 @@ public class Desugar extends BLangNodeVisitor {
 
         if (!(accessExpr.errorSafeNavigation || accessExpr.nilSafeNavigation)) {
             BType originalType = types.getReferredType(accessExpr.originalType);
-            if (TypeTags.isXMLTypeTag(originalType.tag)) {
+            if (TypeTags.isXMLTypeTag(originalType.tag) || isMapJson(originalType)) {
                 accessExpr.setBType(BUnionType.create(null, originalType, symTable.errorType));
             } else {
                 accessExpr.setBType(originalType);
@@ -9652,6 +9652,10 @@ public class Desugar extends BLangNodeVisitor {
                                   accessExpr.errorSafeNavigation);
         matchStmt.patternClauses.add(successPattern);
         pushToMatchStatementStack(matchStmt, accessExpr, successPattern);
+    }
+
+    private boolean isMapJson(BType originalType) {
+        return originalType.tag == TypeTags.MAP && ((BMapType) originalType).getConstraint().tag == TypeTags.JSON;
     }
 
     private void pushToMatchStatementStack(BLangMatch matchStmt, BLangAccessExpression accessExpr,

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/json/BJSONValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/json/BJSONValueTest.java
@@ -518,8 +518,8 @@ public class BJSONValueTest {
     }
 
     @Test
-    public void testJsonMapAccessNegative() {
-        BRunUtil.invoke(compileResult, "testJsonMapAccessNegative");
+    public void testJsonMapAccess() {
+        BRunUtil.invoke(compileResult, "testJsonMapAccess");
     }
 
     @Test

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/json/BJSONValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/json/BJSONValueTest.java
@@ -518,6 +518,11 @@ public class BJSONValueTest {
     }
 
     @Test
+    public void testJsonMapAccessNegative() {
+        BRunUtil.invoke(compileResult, "testJsonMapAccessNegative");
+    }
+
+    @Test
     public void testIntArrayToJsonAssignment() {
         BValue[] returns = BRunUtil.invoke(compileResult, "testIntArrayToJsonAssignment");
         Assert.assertTrue(returns[0] instanceof BNewArray);

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/jsontype/json-value.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/jsontype/json-value.bal
@@ -497,6 +497,29 @@ function foo() returns json {
     return j;
 }
 
+function testJsonMapAccessNegative() {
+    map<map<json>> mapVal = {};
+    json|error result = mapVal.__.__;
+    assertTrue(result is error);
+    error err = <error>result;
+    assertEquals("{ballerina/lang.map}KeyNotFound", err.message());
+    assertEquals("key '__' not found in JSON mapping", <string>checkpanic err.detail()["message"]); 
+
+    mapVal = {a: {a : "aaa"}};
+    result = mapVal.b.a;
+    assertTrue(result is error);
+    err = <error>result;
+    assertEquals("{ballerina/lang.map}KeyNotFound", err.message());
+    assertEquals("key 'b' not found in JSON mapping", <string>checkpanic err.detail()["message"]);
+
+    json jsonVal = {};
+    result = jsonVal.b.a;
+    assertTrue(result is error);
+    err = <error>result;
+    assertEquals("{ballerina/lang.map}KeyNotFound", err.message());
+    assertEquals("key 'b' not found in JSON mapping", <string>checkpanic err.detail()["message"]);     
+}
+
 const ASSERTION_ERROR_REASON = "AssertionError";
 
 function assertTrue(boolean actual) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/jsontype/json-value.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/jsontype/json-value.bal
@@ -497,7 +497,7 @@ function foo() returns json {
     return j;
 }
 
-function testJsonMapAccessNegative() {
+function testJsonMapAccess() returns error? {
     map<map<json>> mapVal = {};
     json|error result = mapVal.__.__;
     assertTrue(result is error);
@@ -511,6 +511,14 @@ function testJsonMapAccessNegative() {
     err = <error>result;
     assertEquals("{ballerina/lang.map}KeyNotFound", err.message());
     assertEquals("key 'b' not found in JSON mapping", <string>checkpanic err.detail()["message"]);
+
+    result = mapVal.a;
+    assertTrue(result is json);
+    assertEquals({a: "aaa"}, check result);
+
+    result = mapVal.a.a;
+    assertTrue(result is json);
+    assertEquals("aaa", check result);
 
     json jsonVal = {};
     result = jsonVal.b.a;


### PR DESCRIPTION
## Purpose
$subject
Fixes #33294 

## Approach
Since `map<json>` is represented as `MapValue`, it gives a CCE when the map access returns an error value. This PR fixes it by changing the temperory variable type to `map<json>|error`

## Samples
```ballerina
public function main() {
    map<map<json>> x = {};
    json|error result = x.__.__;
}
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
