### PR TITLE
Remove 'test' running from bal build and bal pack commands

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/BuildCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/BuildCommand.java
@@ -24,7 +24,6 @@ import io.ballerina.cli.task.CompileTask;
 import io.ballerina.cli.task.CreateExecutableTask;
 import io.ballerina.cli.task.DumpBuildTimeTask;
 import io.ballerina.cli.task.ResolveMavenDependenciesTask;
-import io.ballerina.cli.task.RunTestsTask;
 import io.ballerina.cli.utils.BuildTime;
 import io.ballerina.cli.utils.FileUtils;
 import io.ballerina.projects.BuildOptions;
@@ -45,7 +44,6 @@ import java.nio.file.Paths;
 
 import static io.ballerina.cli.cmd.Constants.BUILD_COMMAND;
 import static io.ballerina.runtime.api.constants.RuntimeConstants.SYSTEM_PROP_BAL_DEBUG;
-import static org.ballerinalang.test.runtime.util.TesterinaConstants.JACOCO_XML_FORMAT;
 
 /**
  * This class represents the "bal build" command.
@@ -60,7 +58,6 @@ public class BuildCommand implements BLauncherCmd {
     private final PrintStream errStream;
     private boolean exitWhenFinish;
     private boolean skipCopyLibsFromDist;
-    private Boolean skipTests;
 
     public BuildCommand() {
         this.projectPath = Paths.get(System.getProperty(ProjectConstants.USER_DIR));
@@ -68,7 +65,6 @@ public class BuildCommand implements BLauncherCmd {
         this.errStream = System.err;
         this.exitWhenFinish = true;
         this.skipCopyLibsFromDist = false;
-        this.skipTests = true;
     }
 
     public BuildCommand(Path projectPath, PrintStream outStream, PrintStream errStream, boolean dumpBuildTime) {
@@ -86,20 +82,6 @@ public class BuildCommand implements BLauncherCmd {
         this.errStream = errStream;
         this.exitWhenFinish = exitWhenFinish;
         this.skipCopyLibsFromDist = skipCopyLibsFromDist;
-    }
-
-    public BuildCommand(Path projectPath, PrintStream outStream, PrintStream errStream, boolean exitWhenFinish,
-                        boolean skipCopyLibsFromDist, Boolean skipTests, Boolean testReport, Boolean coverage,
-                        String coverageFormat) {
-        this.projectPath = projectPath;
-        this.outStream = outStream;
-        this.errStream = errStream;
-        this.exitWhenFinish = exitWhenFinish;
-        this.skipCopyLibsFromDist = skipCopyLibsFromDist;
-        this.skipTests = skipTests;
-        this.testReport = testReport;
-        this.coverage = coverage;
-        this.coverageFormat = coverageFormat;
     }
 
     public BuildCommand(Path projectPath, PrintStream outStream, PrintStream errStream, boolean exitWhenFinish,
@@ -122,21 +104,6 @@ public class BuildCommand implements BLauncherCmd {
         this.targetDir = targetDir;
     }
 
-    public BuildCommand(Path projectPath, PrintStream outStream, PrintStream errStream, boolean exitWhenFinish,
-                        boolean skipCopyLibsFromDist, Boolean skipTests, Boolean testReport, Boolean coverage,
-                        String coverageFormat, Path targetDir) {
-        this.projectPath = projectPath;
-        this.outStream = outStream;
-        this.errStream = errStream;
-        this.exitWhenFinish = exitWhenFinish;
-        this.skipCopyLibsFromDist = skipCopyLibsFromDist;
-        this.skipTests = skipTests;
-        this.testReport = testReport;
-        this.coverage = coverage;
-        this.coverageFormat = coverageFormat;
-        this.targetDir = targetDir;
-    }
-
     @CommandLine.Option(names = {"--output", "-o"}, description = "Write the output to the given file. The provided " +
                                                                   "output file name may or may not contain the " +
                                                                   "'.jar' extension.")
@@ -145,9 +112,6 @@ public class BuildCommand implements BLauncherCmd {
     @CommandLine.Option(names = {"--offline"}, description = "Build/Compile offline without downloading " +
                                                               "dependencies.")
     private Boolean offline;
-
-    @CommandLine.Option(names = {"--with-tests"}, description = "Run test compilation and execution.")
-    private Boolean withTests;
 
     @CommandLine.Parameters (arity = "0..1")
     private final Path projectPath;
@@ -173,17 +137,8 @@ public class BuildCommand implements BLauncherCmd {
     @CommandLine.Option(names = "--debug", description = "run tests in remote debugging mode")
     private String debugPort;
 
-    private static final String buildCmd = "bal build [-o <output>] [--offline] [--with-tests] [--taint-check]\n" +
+    private static final String buildCmd = "bal build [-o <output>] [--offline] [--taint-check]\n" +
             "                    [<ballerina-file | package-path>]";
-
-    @CommandLine.Option(names = "--test-report", description = "enable test report generation")
-    private Boolean testReport;
-
-    @CommandLine.Option(names = "--code-coverage", description = "enable code coverage")
-    private Boolean coverage;
-
-    @CommandLine.Option(names = "--coverage-format", description = "list of supported coverage report formats")
-    private String coverageFormat;
 
     @CommandLine.Option(names = "--observability-included", description = "package observability in the executable " +
             "JAR file(s).")
@@ -191,10 +146,6 @@ public class BuildCommand implements BLauncherCmd {
 
     @CommandLine.Option(names = "--cloud", description = "Enable cloud artifact generation")
     private String cloud;
-
-    @CommandLine.Option(names = "--includes", hidden = true,
-            description = "hidden option for code coverage to include all classes")
-    private String includes;
 
     @CommandLine.Option(names = "--list-conflicted-classes",
             description = "list conflicted classes when generating executable")
@@ -206,6 +157,9 @@ public class BuildCommand implements BLauncherCmd {
     @CommandLine.Option(names = "--sticky", description = "stick to exact versions locked (if exists)")
     private Boolean sticky;
 
+    @CommandLine.Option(names = "--target-dir", description = "target directory path")
+    private Path targetDir;
+
     // TODO : Remove after Beta4
     @CommandLine.Option(names = {"--compile", "-c"}, description = "Compile the source without generating " +
             "executable(s).")
@@ -213,9 +167,6 @@ public class BuildCommand implements BLauncherCmd {
 
     @CommandLine.Option(names = {"--skip-tests"}, description = "Skip test compilation and execution.")
     private Boolean skipTestsTemp;
-
-    @CommandLine.Option(names = "--target-dir", description = "target directory path")
-    private Path targetDir;
 
     public void execute() {
         long start = 0;
@@ -232,8 +183,7 @@ public class BuildCommand implements BLauncherCmd {
         }
 
         if (this.skipTestsTemp != null) {
-            this.outStream.println("error : '--skip-tests' flag is deprecated. The build command skips test execution" +
-                    " by default. Please make use of --with-tests to execute tests");
+            this.outStream.println("error : '--skip-tests' flag is deprecated.");
             CommandUtil.exitError(this.exitWhenFinish);
             return;
         }
@@ -241,22 +191,8 @@ public class BuildCommand implements BLauncherCmd {
         // load project
         Project project;
 
-        // Skip code coverage for single bal files if option is set
-        if (FileUtils.hasExtension(this.projectPath)) {
-            if (coverage != null && coverage) {
-                this.outStream.println("Code coverage is not yet supported with single bal files. Ignoring the flag " +
-                        "and continuing the test run...\n");
-            }
-            coverage = false;
-        }
-
         if (sticky == null) {
             sticky = false;
-        }
-
-        // If withTests flag is not provided, we change the skipTests flag accordingly
-        if (withTests != null) {
-            this.skipTests = !withTests;
         }
 
         BuildOptions buildOptions = constructBuildOptions();
@@ -319,27 +255,7 @@ public class BuildCommand implements BLauncherCmd {
         if (!project.buildOptions().skipTests() && this.debugPort != null) {
             System.setProperty(SYSTEM_PROP_BAL_DEBUG, this.debugPort);
         }
-        if (project.buildOptions().codeCoverage()) {
-            if (coverageFormat != null) {
-                if (!coverageFormat.equals(JACOCO_XML_FORMAT)) {
-                    String errMsg = "unsupported coverage report format '" + coverageFormat + "' found. Only '" +
-                            JACOCO_XML_FORMAT + "' format is supported.";
-                    CommandUtil.printError(this.errStream, errMsg, null, false);
-                    CommandUtil.exitError(this.exitWhenFinish);
-                    return;
-                }
-            }
-        } else {
-            // Skip --includes flag if it is set without code coverage
-            if (includes != null) {
-                this.outStream.println("warning: ignoring --includes flag since code coverage is not enabled");
-            }
-            // Skip --coverage-format flag if it is set without code coverage
-            if (coverageFormat != null) {
-                this.outStream.println("warning: ignoring --coverage-format flag since code coverage is not " +
-                        "enabled");
-            }
-        }
+
         // Validate Settings.toml file
         try {
             RepoUtils.readSettings();
@@ -354,11 +270,6 @@ public class BuildCommand implements BLauncherCmd {
                 .addTask(new ResolveMavenDependenciesTask(outStream))
                 // compile the modules
                 .addTask(new CompileTask(outStream, errStream))
-//                .addTask(new CopyResourcesTask()) // merged with CreateJarTask
-                // run tests (projects only)
-                .addTask(new RunTestsTask(outStream, errStream, includes, coverageFormat),
-                        project.buildOptions().skipTests() || isSingleFileBuild)
-                // create the executable jar, skip if -c flag is provided
                 .addTask(new CreateExecutableTask(outStream, this.output))
                 .addTask(new DumpBuildTimeTask(outStream), !project.buildOptions().dumpBuildTime())
                 .build();
@@ -383,11 +294,8 @@ public class BuildCommand implements BLauncherCmd {
         BuildOptions.BuildOptionsBuilder buildOptionsBuilder = BuildOptions.builder();
 
         buildOptionsBuilder
-                .setCodeCoverage(coverage)
                 .setExperimental(experimentalFlag)
                 .setOffline(offline)
-                .setSkipTests(skipTests)
-                .setTestReport(testReport)
                 .setObservabilityIncluded(observabilityIncluded)
                 .setCloud(cloud)
                 .setDumpBir(dumpBIR)
@@ -426,7 +334,7 @@ public class BuildCommand implements BLauncherCmd {
 
     @Override
     public void printUsage(StringBuilder out) {
-        out.append("  bal build [-o <output>] [--offline] [--with-tests]\\n\" +\n" +
+        out.append("  bal build [-o <output>] [--offline] \\n\" +\n" +
                 "            \"                    [<ballerina-file | package-path>]");
     }
 

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PackCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PackCommand.java
@@ -31,7 +31,6 @@ import java.util.List;
 import static io.ballerina.cli.cmd.Constants.PACK_COMMAND;
 import static io.ballerina.projects.internal.ManifestBuilder.getStringValueFromTomlTableNode;
 import static io.ballerina.runtime.api.constants.RuntimeConstants.SYSTEM_PROP_BAL_DEBUG;
-import static org.ballerinalang.test.runtime.util.TesterinaConstants.JACOCO_XML_FORMAT;
 
 /**
  * This class represents the "bal pack" command.

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/TestCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/TestCommand.java
@@ -75,6 +75,17 @@ public class TestCommand implements BLauncherCmd {
         this.exitWhenFinish = exitWhenFinish;
     }
 
+    public TestCommand(Path projectPath, PrintStream outStream, PrintStream errStream, boolean exitWhenFinish,
+                       Boolean testReport, Boolean coverage, String coverageFormat) {
+        this.projectPath = projectPath;
+        this.outStream = outStream;
+        this.errStream = errStream;
+        this.exitWhenFinish = exitWhenFinish;
+        this.testReport = testReport;
+        this.coverage = coverage;
+        this.coverageFormat = coverageFormat;
+    }
+
     @CommandLine.Option(names = {"--offline"}, description = "Builds/Compiles offline without downloading " +
             "dependencies.")
     private Boolean offline;

--- a/cli/ballerina-cli/src/main/resources/cli-help/ballerina-build.help
+++ b/cli/ballerina-cli/src/main/resources/cli-help/ballerina-build.help
@@ -9,10 +9,7 @@ SYNOPSIS
        bal build [--test-report] [--offline] [--experimental] [-o | --output] <output-path> [--dump-build-time]
                   <ballerina-file-path>
        bal build [--offline] [experimental] [--cloud] [--observability-included] [--dump-build-time]
-                 [--with-tests] [--list-conflicted-classes] <ballerina-package-path>
-       bal build [--offline] [experimental] [--cloud] [--observability-included] [--dump-build-time]
-                 [--list-conflicted-classes] [--debug] [--with-tests] [--test-report] [--code-coverage]
-                 <ballerina-package-path>
+                 [--list-conflicted-classes] <ballerina-package-path>
 
 
 DESCRIPTION
@@ -37,9 +34,6 @@ OPTIONS
        --offline
             Build offline using the local artifacts without downloading the latest artifacts of
             the dependencies from the remote repository (Ballerina Central).
-
-       --with-tests
-            Compile and execute tests.
 
        --experimental
            Enable experimental language features.
@@ -85,12 +79,3 @@ EXAMPLES
 
        Build the 'hello' package from a different directory location.
           $ bal build `<hello-package-path>`
-
-       Build the current package and generate the test report. This will generate an
-       HTML test report in addition to the executable JAR files.
-          $ bal build --with-tests --test-report
-
-       Build the current package and generate the test report with
-       the code coverage information. This will add an additional section
-       to the test report for code coverage information.
-          $ bal build --with-tests --code-coverage

--- a/cli/ballerina-cli/src/main/resources/cli-help/ballerina-build.help
+++ b/cli/ballerina-cli/src/main/resources/cli-help/ballerina-build.help
@@ -6,10 +6,10 @@ SYNOPSIS
        bal build <ballerina-file-path>
        bal build <ballerina-package-path>
        bal build [--target-dir] <target-directory-path>
-       bal build [--test-report] [--offline] [--experimental] [-o | --output] <output-path> [--dump-build-time]
+       bal build [--offline] [--experimental] [-o | --output] <output-path> [--dump-build-time]
                   <ballerina-file-path>
-       bal build [--offline] [experimental] [--cloud] [--observability-included] [--dump-build-time]
-                 [--list-conflicted-classes] <ballerina-package-path>
+       bal build [--offline] [--experimental] [--cloud] [--observability-included]
+                 [--dump-build-time] [--list-conflicted-classes] <ballerina-package-path>
 
 
 DESCRIPTION
@@ -37,16 +37,6 @@ OPTIONS
 
        --experimental
            Enable experimental language features.
-
-       --code-coverage
-           Enable code coverage. This will analyze the line coverage of the
-           source `.bal` files in the Ballerina package and add a section
-           to the testerina report with the code coverage details. This feature is not supported
-           with single BAL file executions.
-
-       --test-report
-           Generate an HTML report containing the test results. Defaults to 'true'
-           if code coverage is enabled.
 
        --debug
            Run tests in remote debugging mode.

--- a/cli/ballerina-cli/src/main/resources/cli-help/ballerina-pack.help
+++ b/cli/ballerina-cli/src/main/resources/cli-help/ballerina-pack.help
@@ -8,9 +8,9 @@ SYNOPSIS
        bal pack [--test-report] [--offline] [--experimental] [--dump-build-time]
                   <ballerina-package-path>
        bal pack [--offline] [experimental] [--cloud] [--observability-included] [--dump-build-time]
-                 [--with-tests] [--list-conflicted-classes] <ballerina-package-path>
+                 [--list-conflicted-classes] <ballerina-package-path>
        bal pack [--offline] [experimental] [--cloud] [--observability-included] [--dump-build-time]
-                 [--list-conflicted-classes] [--debug] [--with-tests] [--test-report] [--code-coverage]
+                 [--list-conflicted-classes] [--debug] [--test-report] [--code-coverage]
                  <ballerina-package-path>
 
 
@@ -25,9 +25,6 @@ OPTIONS
        --offline
             Pack offline using the local artifacts without downloading the latest artifacts of
             the dependencies from the remote repository (Ballerina Central).
-
-       --with-tests
-            Compile and execute tests.
 
        --experimental
            Enable experimental language features.
@@ -61,12 +58,3 @@ EXAMPLES
 
        Pack the 'hello' package from a different directory location.
           $ bal pack `<hello-package-path>`
-
-       Pack the current package and generate the test report. This will generate an
-       HTML test report in addition to the executable JAR files.
-          $ bal pack --with-tests --test-report
-
-       Pack the current package and generate the test report with
-       the code coverage information. This will add an additional section
-       to the test report for code coverage information.
-          $ bal pack --with-tests --code-coverage

--- a/cli/ballerina-cli/src/main/resources/cli-help/ballerina-pack.help
+++ b/cli/ballerina-cli/src/main/resources/cli-help/ballerina-pack.help
@@ -9,9 +9,6 @@ SYNOPSIS
                   <ballerina-package-path>
        bal pack [--offline] [experimental] [--cloud] [--observability-included] [--dump-build-time]
                  [--list-conflicted-classes] <ballerina-package-path>
-       bal pack [--offline] [experimental] [--cloud] [--observability-included] [--dump-build-time]
-                 [--list-conflicted-classes] [--debug] [--test-report] [--code-coverage]
-                 <ballerina-package-path>
 
 
 DESCRIPTION
@@ -28,16 +25,6 @@ OPTIONS
 
        --experimental
            Enable experimental language features.
-
-       --code-coverage
-           Enable code coverage. This will analyze the line coverage of the
-           source `.bal` files in the Ballerina package and add a section
-           to the testerina report with the code coverage details. This feature is not supported
-           with single BAL file executions.
-
-       --test-report
-           Generate an HTML report containing the test results. Defaults to 'true'
-           if code coverage is enabled.
 
        --debug
            Run tests in remote debugging mode.

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/BuildCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/BuildCommandTest.java
@@ -341,22 +341,6 @@ public class BuildCommandTest extends BaseCommandTest {
     }
 
     @Test(description = "Build a valid ballerina project")
-    public void testArtifactCreationWhenTestsFail() {
-        Path projectPath = this.testResources.resolve("validProjectWithFailingTests");
-        System.setProperty("user.dir", projectPath.toString());
-        BuildCommand buildCommand = new BuildCommand(projectPath, printStream, printStream, false, true,
-                false, false, false, null);
-        // non existing bal file
-        new CommandLine(buildCommand).parse();
-        try {
-            buildCommand.execute();
-            Assert.fail("exception expected");
-        } catch (BLauncherException e) {
-            Assert.assertFalse(projectPath.resolve("target").resolve("bin").resolve("winery.jar").toFile().exists());
-        }
-    }
-
-    @Test(description = "Build a valid ballerina project")
     public void testBuildMultiModuleProject() throws IOException {
         Path projectPath = this.testResources.resolve("validMultiModuleProject");
         System.setProperty("user.dir", projectPath.toString());
@@ -384,8 +368,7 @@ public class BuildCommandTest extends BaseCommandTest {
     public void testBuildProjectWithDefaultBuildOptions() throws IOException {
         Path projectPath = this.testResources.resolve("validProjectWithBuildOptions");
         System.setProperty("user.dir", projectPath.toString());
-        BuildCommand buildCommand = new BuildCommand(
-                projectPath, printStream, printStream, false, true, null, null, null, null);
+        BuildCommand buildCommand = new BuildCommand(projectPath, printStream, printStream, false, true);
         // non existing bal file
         new CommandLine(buildCommand).parse();
         buildCommand.execute();
@@ -406,7 +389,7 @@ public class BuildCommandTest extends BaseCommandTest {
         Path projectPath = this.testResources.resolve("validProjectWithBuildOptions");
         System.setProperty("user.dir", projectPath.toString());
         BuildCommand buildCommand = new BuildCommand(
-                projectPath, printStream, printStream, false, true, false, true, false, null);
+                projectPath, printStream, printStream, false, true);
         // non existing bal file
         new CommandLine(buildCommand).parse();
         try {
@@ -424,11 +407,11 @@ public class BuildCommandTest extends BaseCommandTest {
         Assert.assertTrue(projectPath.resolve("target").resolve("cache").resolve("foo")
                 .resolve("winery").resolve("0.1.0").resolve("java11")
                 .resolve("foo-winery-0.1.0.jar").toFile().exists());
-        Assert.assertTrue(projectPath.resolve("target").resolve("cache").resolve("foo")
+
+        Assert.assertFalse(projectPath.resolve("target").resolve("cache").resolve("foo")
                 .resolve("winery").resolve("0.1.0").resolve("java11")
                 .resolve("foo-winery-0.1.0-testable.jar").toFile().exists());
-
-        Assert.assertTrue(
+        Assert.assertFalse(
                 projectPath.resolve("target").resolve("report").resolve("test_results.json").toFile().exists());
     }
 
@@ -437,7 +420,7 @@ public class BuildCommandTest extends BaseCommandTest {
         Path projectPath = this.testResources.resolve("valid-bal-file").resolve("hello_world.bal");
         System.setProperty("user.dir", this.testResources.resolve("valid-bal-file").toString());
         BuildCommand buildCommand = new BuildCommand(
-                projectPath, printStream, printStream, false, true, null, null, null, null);
+                projectPath, printStream, printStream, false, true);
         // non existing bal file
         new CommandLine(buildCommand).parse();
         try {
@@ -462,7 +445,7 @@ public class BuildCommandTest extends BaseCommandTest {
         Path projectPath = this.testResources.resolve("valid-bal-file").resolve("hello_world.bal");
         System.setProperty("user.dir", this.testResources.resolve("valid-bal-file").toString());
         BuildCommand buildCommand = new BuildCommand(
-                projectPath, printStream, printStream, false, true, false, true, true, null);
+                projectPath, printStream, printStream, false, true);
         // non existing bal file
         new CommandLine(buildCommand).parse();
         try {
@@ -656,19 +639,6 @@ public class BuildCommandTest extends BaseCommandTest {
     }
 
     @Test
-    public void testUnsupportedCoverageFormat() throws IOException {
-        Path projectPath = this.testResources.resolve("validProjectWithBuildOptions");
-        // Build project
-        BuildCommand buildCommand = new BuildCommand(
-                projectPath, printStream, printStream, false, true, null, null, true, "html");
-        new CommandLine(buildCommand).parse();
-        buildCommand.execute();
-        String buildLog = readOutput(true);
-        Assert.assertTrue(buildLog.contains("unsupported coverage report format 'html' found. Only 'xml' format is " +
-                "supported."));
-    }
-
-    @Test
     public void testDumpBuildTimeForPackage() throws IOException {
         Path projectPath = this.testResources.resolve("validApplicationProject");
         System.setProperty("user.dir", projectPath.toString());
@@ -722,16 +692,16 @@ public class BuildCommandTest extends BaseCommandTest {
         System.setProperty("user.dir", projectPath.toString());
 
         BuildCommand buildCommand = new BuildCommand(projectPath, printStream, printStream, false, true,
-                false, true, false, null, customTargetDir);
+                customTargetDir);
         new CommandLine(buildCommand).parse();
         buildCommand.execute();
 
         Assert.assertTrue(Files.exists(customTargetDir.resolve("bin")));
         Assert.assertTrue(Files.exists(customTargetDir.resolve("cache")));
         Assert.assertTrue(Files.exists(customTargetDir.resolve("build")));
-        Assert.assertTrue(Files.exists(customTargetDir.resolve("report")));
-        Assert.assertTrue(Files.exists(customTargetDir.resolve("rerun_test.json")));
-        Assert.assertTrue(Files.exists(customTargetDir.resolve("cache").resolve("tests_cache").resolve("test_suit" +
+        Assert.assertFalse(Files.exists(customTargetDir.resolve("report")));
+        Assert.assertFalse(Files.exists(customTargetDir.resolve("rerun_test.json")));
+        Assert.assertFalse(Files.exists(customTargetDir.resolve("cache").resolve("tests_cache").resolve("test_suit" +
                 ".json")));
     }
 

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/TestCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/TestCommandTest.java
@@ -216,11 +216,11 @@ public class TestCommandTest extends BaseCommandTest {
     @Test
     public void testUnsupportedCoverageFormat() throws IOException {
         Path projectPath = this.testResources.resolve("validProjectWithTests");
-        // Build project
-        BuildCommand buildCommand = new BuildCommand(
-                projectPath, printStream, printStream, false, true, null, null, true, "html");
-        new CommandLine(buildCommand).parse();
-        buildCommand.execute();
+        TestCommand testCommand = new TestCommand(
+                projectPath, printStream, printStream, false, false, true, "html");
+
+        new CommandLine(testCommand).parse();
+        testCommand.execute();
         String buildLog = readOutput(true);
         Assert.assertTrue(buildLog.contains("unsupported coverage report format 'html' found. Only 'xml' format is " +
                 "supported."));

--- a/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/unix/build-bal-project-override-build-options.txt
+++ b/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/unix/build-bal-project-override-build-options.txt
@@ -1,10 +1,5 @@
 Compiling source
 	foo/winery:0.1.0
 
-Generating Test Report
-	<TEST_RESULTS_JSON_PATH>
-
-warning: Could not find the required HTML report tools for code coverage at <ballerina.home>/lib/tools/coverage/report.zip
-
 Generating executable
 	target/bin/winery.jar

--- a/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/unix/build-hello-world-bal-with-build-options.txt
+++ b/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/unix/build-hello-world-bal-with-build-options.txt
@@ -1,5 +1,3 @@
-Code coverage is not yet supported with single bal files. Ignoring the flag and continuing the test run...
-
 Compiling source
 	hello_world.bal
 

--- a/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/windows/build-bal-project-override-build-options.txt
+++ b/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/windows/build-bal-project-override-build-options.txt
@@ -1,10 +1,5 @@
 Compiling source
 	foo/winery:0.1.0
 
-Generating Test Report
-	<TEST_RESULTS_JSON_PATH>
-
-warning: Could not find the required HTML report tools for code coverage at <ballerina.home>\lib\tools\coverage\report.zip
-
 Generating executable
 	target\bin\winery.jar

--- a/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/windows/build-hello-world-bal-with-build-options.txt
+++ b/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/windows/build-hello-world-bal-with-build-options.txt
@@ -1,5 +1,3 @@
-Code coverage is not yet supported with single bal files. Ignoring the flag and continuing the test run...
-
 Compiling source
 	hello_world.bal
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BuildOptions.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BuildOptions.java
@@ -161,8 +161,8 @@ public class BuildOptions {
         SKIP_TESTS("skipTests"),
         TEST_REPORT("testReport"),
         CODE_COVERAGE("codeCoverage"),
-        DUMP_BUILD_TIME("dumpBuildTime")
-        ;
+        DUMP_BUILD_TIME("dumpBuildTime"),
+        TARGET_DIR("targetDir");
 
         private final String name;
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ManifestBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ManifestBuilder.java
@@ -384,8 +384,6 @@ public class ManifestBuilder {
 
         BuildOptions.BuildOptionsBuilder buildOptionsBuilder = BuildOptions.builder();
 
-        Boolean skipTests =
-                getBooleanFromBuildOptionsTableNode(tableNode, BuildOptions.OptionName.SKIP_TESTS.toString());
         Boolean offline = getBooleanFromBuildOptionsTableNode(tableNode, CompilerOptionName.OFFLINE.toString());
         Boolean experimental =
                 getBooleanFromBuildOptionsTableNode(tableNode, CompilerOptionName.EXPERIMENTAL.toString());
@@ -408,7 +406,6 @@ public class ManifestBuilder {
                 getBooleanFromBuildOptionsTableNode(tableNode, CompilerOptionName.LIST_CONFLICTED_CLASSES.toString());
 
         return buildOptionsBuilder
-                .setSkipTests(skipTests)
                 .setOffline(offline)
                 .setExperimental(experimental)
                 .setObservabilityIncluded(observabilityIncluded)

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ManifestBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ManifestBuilder.java
@@ -405,7 +405,10 @@ public class ManifestBuilder {
         Boolean listConflictedClasses =
                 getBooleanFromBuildOptionsTableNode(tableNode, CompilerOptionName.LIST_CONFLICTED_CLASSES.toString());
 
-        return buildOptionsBuilder
+        String targetDir = getStringFromBuildOptionsTableNode(tableNode,
+                BuildOptions.OptionName.TARGET_DIR.toString());
+
+        buildOptionsBuilder
                 .setOffline(offline)
                 .setExperimental(experimental)
                 .setObservabilityIncluded(observabilityIncluded)
@@ -414,8 +417,13 @@ public class ManifestBuilder {
                 .setCloud(cloud)
                 .setListConflictedClasses(listConflictedClasses)
                 .setDumpBuildTime(dumpBuildTime)
-                .setSticky(sticky)
-                .build();
+                .setSticky(sticky);
+
+        if (targetDir != null) {
+            buildOptionsBuilder.targetDir(targetDir);
+        }
+
+        return buildOptionsBuilder.build();
     }
 
     private Boolean getBooleanFromBuildOptionsTableNode(TomlTableNode tableNode, String key) {
@@ -430,6 +438,23 @@ public class ManifestBuilder {
             if (value.kind() == TomlType.BOOLEAN) {
                 TomlBooleanValueNode tomlBooleanValueNode = (TomlBooleanValueNode) value;
                 return tomlBooleanValueNode.getValue();
+            }
+        }
+        return null;
+    }
+
+    private String getStringFromBuildOptionsTableNode(TomlTableNode tableNode, String key) {
+        TopLevelNode topLevelNode = tableNode.entries().get(key);
+        if (topLevelNode == null || topLevelNode.kind() == TomlType.NONE) {
+            return null;
+        }
+
+        if (topLevelNode.kind() == TomlType.KEY_VALUE) {
+            TomlKeyValueNode keyValueNode = (TomlKeyValueNode) topLevelNode;
+            TomlValueNode value = keyValueNode.value();
+            if (value.kind() == TomlType.STRING) {
+                TomlStringValueNode tomlStringValueNode = (TomlStringValueNode) value;
+                return tomlStringValueNode.getValue();
             }
         }
         return null;

--- a/distribution/zip/jballerina-tools/resources/command-completion/command-completion.csv
+++ b/distribution/zip/jballerina-tools/resources/command-completion/command-completion.csv
@@ -2,7 +2,7 @@ cmdname,flags
 add, -t --template
 bal, -v -h --help --version add bindgen build clean dist doc encrypt format grpc help init new openapi pull push run search shell test update version
 bindgen, -cp -m -mvn -o --classpath --maven --modules --output --public
-build, -c -o --cloud --code-coverage --coverage-format --compile --debug --experimental --list-conflicted-classes --observability-included --offline --output --with-tests --sticky --test-report --dump-build-time
+build, -c -o --cloud --code-coverage --coverage-format --compile --debug --experimental --list-conflicted-classes --observability-included --offline --output --sticky --test-report --dump-build-time
 dist, list pull remove update use
 doc, -c -e -o --combine --exclude --output --experimental 
 encrypt, 

--- a/distribution/zip/jballerina-tools/resources/command-completion/command-completion.csv
+++ b/distribution/zip/jballerina-tools/resources/command-completion/command-completion.csv
@@ -2,7 +2,8 @@ cmdname,flags
 add, -t --template
 bal, -v -h --help --version add bindgen build clean dist doc encrypt format grpc help init new openapi pull push run search shell test update version
 bindgen, -cp -m -mvn -o --classpath --maven --modules --output --public
-build, -c -o --cloud --code-coverage --coverage-format --compile --debug --experimental --list-conflicted-classes --observability-included --offline --output --sticky --test-report --dump-build-time
+build, -o --cloud --debug --experimental --list-conflicted-classes --observability-included --offline --output --sticky --dump-build-time --target-dir
+pack, -o --debug --list-conflicted-classes --observability-included --offline --output --sticky --dump-build-time --target-dir
 dist, list pull remove update use
 doc, -c -e -o --combine --exclude --output --experimental 
 encrypt, 

--- a/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/ModuleBuildTestCase.java
+++ b/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/ModuleBuildTestCase.java
@@ -230,7 +230,7 @@ public class ModuleBuildTestCase extends BaseTest {
         Files.write(projectPath.resolve("foo").resolve("tests").resolve("main_test.bal"), testContent.getBytes(),
                     StandardOpenOption.TRUNCATE_EXISTING);
 
-        balClient.runMain("build", new String[] {"--with-tests"}, envVariables, new String[0], new LogLeecher[]{},
+        balClient.runMain("build", new String[0], envVariables, new String[0], new LogLeecher[]{},
                           projectPath.toString());
 
         Path genPkgPath = Paths.get(ProjectDirConstants.DOT_BALLERINA_DIR_NAME,
@@ -292,23 +292,10 @@ public class ModuleBuildTestCase extends BaseTest {
 
         // Test for bal build on module with test sources
         String buildMsg = "Compiling source\n" +
-                    "    foo:0.0.0\n" +
-                    "\n" +
-                    "Running tests\n" +
-                    "    foo:0.0.0\n" +
-                    "I'm the before suite function!\n" +
-                    "I'm the before function!\n" +
-                    "I'm in test function!\n" +
-                    "I'm the after function!\n" +
-                    "I'm the after suite function!\n" +
-                    "\t[pass] testFunction\n" +
-                    "\n" +
-                    "\t1 passing\n" +
-                    "\t0 failing\n" +
-                    "\t0 skipped\n";
+                    "    foo:0.0.0\n";
 
         LogLeecher firstLeecher = new LogLeecher(buildMsg);
-        balClient.runMain("build", new String[] {"foo", "--with-tests"},
+        balClient.runMain("build", new String[] {"foo"},
                 envVariables, new String[0],
                 new LogLeecher[]{firstLeecher}, projectPath.toString());
         Assert.assertTrue(Files.notExists(projectPath.resolve("target").resolve("foo.balx")));

--- a/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/ModuleInitTestCase.java
+++ b/tests/ballerina-tools-integration-test/src/test/java/org/ballerinalang/test/packaging/ModuleInitTestCase.java
@@ -71,7 +71,7 @@ public class ModuleInitTestCase extends BaseTest {
         Assert.assertTrue(Files.exists(projectPath.resolve("foo").resolve("tests").resolve("main_test.bal")));
 
         // Test bal build
-        balClient.runMain("build", new String[] {"--with-tests"}, envVariables, new String[]{},
+        balClient.runMain("build", new String[0], envVariables, new String[]{},
                 new LogLeecher[]{}, projectPath.toString());
         Path generatedBalx = projectPath.resolve("target").resolve("foo.balx");
         Assert.assertTrue(Files.exists(generatedBalx));
@@ -102,7 +102,7 @@ public class ModuleInitTestCase extends BaseTest {
         Assert.assertTrue(Files.exists(projectPath.resolve("foo").resolve("tests").resolve("hello_service_test.bal")));
 
         // Test bal build
-        balClient.runMain("build", new String[] {"--with-tests"}, envVariables, new String[]{},
+        balClient.runMain("build", new String[0], envVariables, new String[]{},
                 new LogLeecher[]{}, projectPath.toString());
         Path generatedBalx = projectPath.resolve("target").resolve("foo.balx");
         Assert.assertTrue(Files.exists(generatedBalx));
@@ -135,7 +135,7 @@ public class ModuleInitTestCase extends BaseTest {
         Assert.assertTrue(Files.exists(projectPath.resolve("bar").resolve("tests").resolve("hello_service_test.bal")));
 
         // Test bal build
-        balClient.runMain("build", new String[] {"--with-tests"}, envVariables, new String[]{},
+        balClient.runMain("build", new String[0], envVariables, new String[]{},
                 new LogLeecher[]{}, projectPath.toString());
         Assert.assertTrue(Files.exists(projectPath.resolve("target").resolve("foo.balx")));
         Assert.assertTrue(Files.exists(projectPath.resolve("target").resolve("bar.balx")));
@@ -219,7 +219,7 @@ public class ModuleInitTestCase extends BaseTest {
         Assert.assertTrue(Files.exists(modulePath.resolve("tests").resolve("main_test.bal")));
 
         // Test bal build
-        balClient.runMain("build", new String[] {"--with-tests"}, envVariables, new String[]{},
+        balClient.runMain("build", new String[0], envVariables, new String[]{},
                 new LogLeecher[]{}, projectPath.toString());
         Assert.assertTrue(Files.exists(projectPath.resolve("target").resolve("foo.balx")));
         Assert.assertTrue(Files.exists(projectPath.resolve(".ballerina").resolve("repo").resolve(orgName)

--- a/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/DebugTestRunner.java
+++ b/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/DebugTestRunner.java
@@ -127,7 +127,7 @@ public class DebugTestRunner {
         String msg = "Listening for transport dt_socket at address: " + port;
         LogLeecher clientLeecher = new LogLeecher(msg);
         balClient = new BMainInstance(balServer);
-        debuggeeProcess = balClient.debugMain("build", new String[]{"--with-tests", "--debug", String.valueOf(port)},
+        debuggeeProcess = balClient.debugMain("build", new String[]{"--debug", String.valueOf(port)},
                 null, new String[]{}, new LogLeecher[]{clientLeecher}, projectPath, 20, true);
         clientLeecher.waitForText(20000);
     }

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/build/MultiModuleBuildDebugTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/build/MultiModuleBuildDebugTest.java
@@ -49,7 +49,7 @@ public class MultiModuleBuildDebugTest extends BaseTestCase {
         debugTestRunner = new DebugTestRunner(testProjectName, testModuleFileName, true);
     }
 
-    @Test
+    @Test (enabled = false)
     public void testMultiModuleBuildDebugScenarios() throws BallerinaTestException {
         int port = findFreePort();
         debugTestRunner.runDebuggeeProgram(debugTestRunner.testProjectPath.toString(), port);

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/remote/BallerinaBuildRemoteDebugTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/remote/BallerinaBuildRemoteDebugTest.java
@@ -44,7 +44,7 @@ public class BallerinaBuildRemoteDebugTest extends BaseTestCase {
         balClient = new BMainInstance(debugTestRunner.getBalServer());
     }
 
-    @Test
+    @Test (enabled = false)
     public void testSuspendOnBallerinaModuleBuild() throws BallerinaTestException {
         int port = findFreePort();
         String msg = "Listening for transport dt_socket at address: " + port;
@@ -54,7 +54,7 @@ public class BallerinaBuildRemoteDebugTest extends BaseTestCase {
         clientLeecher.waitForText(20000);
     }
 
-    @Test
+    @Test (enabled = false)
     public void testSuspendOnBallerinaProjectBuild() throws BallerinaTestException {
         int port = findFreePort();
         String msg = "Listening for transport dt_socket at address: " + port;

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/identifier/IdentifierLiteralTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/identifier/IdentifierLiteralTest.java
@@ -51,7 +51,7 @@ public class IdentifierLiteralTest  extends BaseTest {
         Path projectPath = Paths.get(testFileLocation, "ModuleNameClashProject")
                 .toAbsolutePath();
         LogLeecher runLeecher = new LogLeecher("1 passing");
-        bMainInstance.runMain("build", new String[]{"--with-tests"}, new HashMap<>(), new String[0],
+        bMainInstance.runMain("test", new String[0], new HashMap<>(), new String[0],
                 new LogLeecher[]{runLeecher}, projectPath.toString());
         runLeecher.waitForText(5000);
     }

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/isolated/IsolatedInferenceWithTestsTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/isolated/IsolatedInferenceWithTestsTest.java
@@ -63,12 +63,10 @@ public class IsolatedInferenceWithTestsTest extends BaseTest {
     private void testPkg(String pkg, int testCount) throws BallerinaTestException {
         LogLeecher passedLeecher = new LogLeecher(testCount + " passing");
         LogLeecher failedLeecher = new LogLeecher("0 failing");
-        LogLeecher jarGenerationLeecher = new LogLeecher("target/bin/" + pkg + ".jar");
-        bMainInstance.runMain("build", new String[]{"--with-tests"}, null, null,
-                              new LogLeecher[]{passedLeecher, failedLeecher, jarGenerationLeecher},
+        bMainInstance.runMain("test", new String[0], null, null,
+                              new LogLeecher[]{passedLeecher, failedLeecher},
                               Paths.get(testFileLocation, pkg).toString());
         passedLeecher.waitForText(5000);
         failedLeecher.waitForText(5000);
-        jarGenerationLeecher.waitForText(5000);
     }
 }


### PR DESCRIPTION
## Purpose
Removes the `tests` aspect from Build and Pack command. 
- Removed --with-tests , --code-coverage, -report etc and RunTestTask from the BuildOptions for `build` and `pack`

Also added `targetDir` as an BuildOption from Ballerina.toml 

Fixes #33733

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
