### PR TITLE
Update unused variable analysis

### DIFF
--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/dataflow/analysis/UnusedVariableTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/dataflow/analysis/UnusedVariableTest.java
@@ -40,8 +40,6 @@ public class UnusedVariableTest {
         validateWarning(result, i++, getUnusedVariableWarning("i"), 18, 5);
         validateWarning(result, i++, getUnusedVariableWarning("j"), 20, 5);
         validateWarning(result, i++, getUnusedVariableWarning("k"), 22, 5);
-        validateWarning(result, i++, getUnusedVariableWarning("arr"), 29, 5);
-        validateWarning(result, i++, getUnusedVariableWarning("o"), 37, 5);
         validateWarning(result, i++, getUnusedVariableWarning("i"), 43, 5);
         validateWarning(result, i++, getUnusedVariableWarning("a"), 51, 5);
         validateWarning(result, i++, getUnusedVariableWarning("a"), 55, 13);
@@ -66,8 +64,6 @@ public class UnusedVariableTest {
         validateWarning(result, i++, getUnusedVariableWarning("p"), 96, 9);
         validateWarning(result, i++, getUnusedVariableWarning("a"), 112, 5);
         validateWarning(result, i++, getUnusedVariableWarning("e"), 122, 7);
-        validateWarning(result, i++, getUnusedVariableWarning("arr"), 152, 5);
-        validateWarning(result, i++, getUnusedVariableWarning("o"), 157, 5);
         validateWarning(result, i++, getUnusedVariableWarning("i"), 163, 5);
         validateWarning(result, i++, getUnusedVariableWarning("a"), 171, 5);
         validateWarning(result, i++, getUnusedVariableWarning("i"), 183, 13);
@@ -100,7 +96,6 @@ public class UnusedVariableTest {
         validateWarning(result, i++, getUnusedVariableWarning("d"), 293, 9);
         validateWarning(result, i++, getUnusedVariableWarning("m"), 295, 9);
         validateWarning(result, i++, getUnusedVariableWarning("i"), 302, 9);
-        validateWarning(result, i++, getUnusedVariableWarning("a"), 306, 9);
         validateWarning(result, i++, getUnusedVariableWarning("j"), 312, 9);
         validateWarning(result, i++, getUnusedVariableWarning("j"), 321, 9);
         validateWarning(result, i++, getUnusedVariableWarning("x"), 332, 9);
@@ -109,6 +104,8 @@ public class UnusedVariableTest {
         validateWarning(result, i++, getUnusedVariableWarning("s"), 351, 5);
         validateWarning(result, i++, getUnusedVariableWarning("m"), 359, 5);
         validateWarning(result, i++, getUnusedVariableWarning("n"), 365, 5);
+        validateWarning(result, i++, getUnusedVariableWarning("h"), 385, 5);
+        validateWarning(result, i++, getUnusedVariableWarning("i"), 388, 5);
         Assert.assertEquals(result.getWarnCount(), i);
         Assert.assertEquals(result.getErrorCount(), 0);
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/dataflow/analysis/UnusedVariableTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/dataflow/analysis/UnusedVariableTest.java
@@ -107,6 +107,8 @@ public class UnusedVariableTest {
         validateWarning(result, i++, getUnusedVariableWarning("i"), 343, 5);
         validateWarning(result, i++, getUnusedVariableWarning("k"), 345, 5);
         validateWarning(result, i++, getUnusedVariableWarning("s"), 351, 5);
+        validateWarning(result, i++, getUnusedVariableWarning("m"), 359, 5);
+        validateWarning(result, i++, getUnusedVariableWarning("n"), 365, 5);
         Assert.assertEquals(result.getWarnCount(), i);
         Assert.assertEquals(result.getErrorCount(), 0);
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/isolation/IsolatedObjectTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/isolation/IsolatedObjectTest.java
@@ -251,7 +251,6 @@ public class IsolatedObjectTest {
         validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 667, 20);
         validateError(result, i++, ERROR_INVALID_TRANSFER_OUT_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 667, 20);
         validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 673, 17);
-        validateWarning(result, i++, "unused variable 'y'", 682, 9);
         validateWarning(result, i++, "unused variable 'z'", 683, 9);
         validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 686, 13);
         validateError(result, i++, ERROR_INVALID_TRANSFER_OUT_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 687, 17);
@@ -282,8 +281,8 @@ public class IsolatedObjectTest {
         validateWarning(result, i++, "unused variable 'item2'", 822, 29);
         validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 822, 62);
         validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 822, 71);
-        Assert.assertEquals(result.getErrorCount(), i - 20);
-        Assert.assertEquals(result.getWarnCount(), 20);
+        Assert.assertEquals(result.getErrorCount(), i - 19);
+        Assert.assertEquals(result.getWarnCount(), 19);
     }
 
     @Test
@@ -291,7 +290,7 @@ public class IsolatedObjectTest {
         CompileResult compileResult = BCompileUtil.compile("test-src/isolated-objects/isolated_objects.bal");
         Assert.assertEquals(compileResult.getErrorCount(), 0);
 
-        Assert.assertEquals(compileResult.getWarnCount(), 17);
+        Assert.assertEquals(compileResult.getWarnCount(), 15);
         for (Diagnostic diagnostic : compileResult.getDiagnostics()) {
             Assert.assertTrue(diagnostic.message().startsWith("unused variable"));
         }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/isolation/IsolatedVariableTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/isolation/IsolatedVariableTest.java
@@ -133,7 +133,6 @@ public class IsolatedVariableTest {
         validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 308, 16);
         validateError(result, i++, ERROR_INVALID_TRANSFER_OUT_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 308, 16);
         validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 314, 13);
-        validateWarning(result, i++, "unused variable 'y'", 319, 5);
         validateWarning(result, i++, "unused variable 'z'", 320, 5);
         validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 323, 9);
         validateError(result, i++, ERROR_INVALID_TRANSFER_OUT_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 324, 13);
@@ -144,7 +143,6 @@ public class IsolatedVariableTest {
         validateError(result, i++, ERROR_INVALID_ISOLATED_VAR_ACCESS_OUTSIDE_LOCK, 343, 17);
         validateWarning(result, i++, "unused variable 'k'", 350, 17);
         validateError(result, i++, ERROR_INVALID_ISOLATED_VAR_ACCESS_OUTSIDE_LOCK, 354, 9);
-        validateWarning(result, i++, "unused variable 'item'", 357, 13);
         validateWarning(result, i++, "unused variable 'e'", 359, 7);
         validateError(result, i++, ERROR_INVALID_ISOLATED_VAR_ACCESS_OUTSIDE_LOCK, 360, 9);
         validateWarning(result, i++, "unused variable 'e'", 367, 7);
@@ -152,8 +150,8 @@ public class IsolatedVariableTest {
         validateWarning(result, i++, "unused variable 'e'", 373, 7);
         validateError(result, i++, ERROR_INVALID_ISOLATED_VAR_ACCESS_OUTSIDE_LOCK, 374, 9);
         validateError(result, i++, ERROR_INVALID_ISOLATED_VAR_ACCESS_OUTSIDE_LOCK, 374, 11);
-        Assert.assertEquals(result.getErrorCount(), i - 15);
-        Assert.assertEquals(result.getWarnCount(), 15);
+        Assert.assertEquals(result.getErrorCount(), i - 13);
+        Assert.assertEquals(result.getWarnCount(), 13);
     }
 
     @Test
@@ -161,7 +159,7 @@ public class IsolatedVariableTest {
         CompileResult compileResult = BCompileUtil.compile("test-src/isolated-variables/isolated_variables.bal");
         Assert.assertEquals(compileResult.getErrorCount(), 0);
 
-        Assert.assertEquals(compileResult.getWarnCount(), 12);
+        Assert.assertEquals(compileResult.getWarnCount(), 10);
         for (Diagnostic diagnostic : compileResult.getDiagnostics()) {
             Assert.assertTrue(diagnostic.message().startsWith("unused variable"));
         }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/narrowing/AssignmentToNarrowedVarsInLoopsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/narrowing/AssignmentToNarrowedVarsInLoopsTest.java
@@ -40,7 +40,7 @@ public class AssignmentToNarrowedVarsInLoopsTest {
         Assert.assertEquals(result.getErrorCount(), 0);
         Assert.assertEquals(result.getHintCount(), 2);
 
-        Assert.assertEquals(result.getWarnCount(), 88);
+        Assert.assertEquals(result.getWarnCount(), 69);
         for (Diagnostic diagnostic : result.getDiagnostics()) {
             if (diagnostic.diagnosticInfo().severity() != DiagnosticSeverity.WARNING) {
                 continue;
@@ -76,38 +76,24 @@ public class AssignmentToNarrowedVarsInLoopsTest {
         BAssertUtil.validateWarning(result, index++, "unused variable 'c'", 120, 21);
         BAssertUtil.validateError(result, index++, INVALID_ASSIGNMENT_TO_NARROWED_VAR_ERROR, 121, 21);
         BAssertUtil.validateError(result, index++, INVALID_ASSIGNMENT_TO_NARROWED_VAR_ERROR, 136, 21);
-        BAssertUtil.validateWarning(result, index++, "unused variable 'm'", 148, 17);
         BAssertUtil.validateError(result, index++, INVALID_ASSIGNMENT_TO_NARROWED_VAR_ERROR, 150, 13);
-        BAssertUtil.validateWarning(result, index++, "unused variable 'm'", 156, 17);
         BAssertUtil.validateError(result, index++, INVALID_ASSIGNMENT_TO_NARROWED_VAR_ERROR, 158, 13);
-        BAssertUtil.validateWarning(result, index++, "unused variable 'm'", 164, 17);
         BAssertUtil.validateError(result, index++, INVALID_ASSIGNMENT_TO_NARROWED_VAR_ERROR, 166, 13);
-        BAssertUtil.validateWarning(result, index++, "unused variable 'm'", 173, 17);
         BAssertUtil.validateError(result, index++, INVALID_ASSIGNMENT_TO_NARROWED_VAR_ERROR, 175, 13);
-        BAssertUtil.validateWarning(result, index++, "unused variable 'm'", 186, 17);
         BAssertUtil.validateError(result, index++, INVALID_ASSIGNMENT_TO_NARROWED_VAR_ERROR, 188, 17);
-        BAssertUtil.validateWarning(result, index++, "unused variable 'm'", 197, 17);
         BAssertUtil.validateError(result, index++, INVALID_ASSIGNMENT_TO_NARROWED_VAR_ERROR, 199, 17);
-        BAssertUtil.validateWarning(result, index++, "unused variable 'm'", 213, 21);
         BAssertUtil.validateError(result, index++, INVALID_ASSIGNMENT_TO_NARROWED_VAR_ERROR, 215, 17);
-        BAssertUtil.validateWarning(result, index++, "unused variable 'm'", 222, 21);
         BAssertUtil.validateError(result, index++, INVALID_ASSIGNMENT_TO_NARROWED_VAR_ERROR, 224, 17);
         BAssertUtil.validateError(result, index++, INVALID_ASSIGNMENT_TO_NARROWED_VAR_ERROR, 239, 21);
-        BAssertUtil.validateWarning(result, index++, "unused variable 'm'", 248, 21);
         BAssertUtil.validateError(result, index++, INVALID_ASSIGNMENT_TO_NARROWED_VAR_ERROR, 254, 21);
-        BAssertUtil.validateWarning(result, index++, "unused variable 'm'", 262, 21);
         BAssertUtil.validateError(result, index++, INVALID_ASSIGNMENT_TO_NARROWED_VAR_ERROR, 268, 21);
-        BAssertUtil.validateWarning(result, index++, "unused variable 'm'", 281, 21);
         BAssertUtil.validateError(result, index++, INVALID_ASSIGNMENT_TO_NARROWED_VAR_ERROR, 284, 21);
         BAssertUtil.validateError(result, index++, INVALID_ASSIGNMENT_TO_NARROWED_VAR_ERROR, 302, 21);
-        BAssertUtil.validateWarning(result, index++, "unused variable 'm'", 316, 21);
         BAssertUtil.validateError(result, index++, INVALID_ASSIGNMENT_TO_NARROWED_VAR_ERROR, 325, 25);
         BAssertUtil.validateError(result, index++, INVALID_ASSIGNMENT_TO_NARROWED_VAR_ERROR, 340, 25);
-        BAssertUtil.validateWarning(result, index++, "unused variable 'm'", 358, 21);
         BAssertUtil.validateError(result, index++, INVALID_ASSIGNMENT_TO_NARROWED_VAR_ERROR, 360, 17);
         BAssertUtil.validateError(result, index++, INVALID_ASSIGNMENT_TO_NARROWED_VAR_ERROR, 363, 25);
         BAssertUtil.validateError(result, index++, INVALID_ASSIGNMENT_TO_NARROWED_VAR_ERROR, 369, 25);
-        BAssertUtil.validateWarning(result, index++, "unused variable 'm'", 378, 21);
         BAssertUtil.validateError(result, index++, INVALID_ASSIGNMENT_TO_NARROWED_VAR_ERROR, 380, 17);
         BAssertUtil.validateError(result, index++, INVALID_ASSIGNMENT_TO_NARROWED_VAR_ERROR, 383, 21);
         BAssertUtil.validateError(result, index++, INVALID_ASSIGNMENT_TO_NARROWED_VAR_ERROR, 387, 21);
@@ -118,12 +104,10 @@ public class AssignmentToNarrowedVarsInLoopsTest {
         BAssertUtil.validateWarning(result, index++, "unused variable 'f'", 444, 41);
         BAssertUtil.validateError(result, index++, INVALID_ASSIGNMENT_TO_NARROWED_VAR_ERROR, 445, 13);
         BAssertUtil.validateError(result, index++, INVALID_ASSIGNMENT_TO_NARROWED_VAR_ERROR, 446, 13);
-        BAssertUtil.validateWarning(result, index++, "unused variable 'i'", 451, 17);
         BAssertUtil.validateWarning(result, index++, "unused variable 'e'", 452, 38);
         BAssertUtil.validateWarning(result, index++, "unused variable 'f'", 452, 41);
         BAssertUtil.validateError(result, index++, INVALID_ASSIGNMENT_TO_NARROWED_VAR_ERROR, 459, 13);
         BAssertUtil.validateError(result, index++, INVALID_ASSIGNMENT_TO_NARROWED_VAR_ERROR, 460, 13);
-        BAssertUtil.validateWarning(result, index++, "unused variable 'i'", 465, 17);
         BAssertUtil.validateWarning(result, index++, "unused variable 'f'", 466, 41);
         BAssertUtil.validateError(result, index++, INVALID_ASSIGNMENT_TO_NARROWED_VAR_ERROR, 468, 13);
         BAssertUtil.validateError(result, index++, INVALID_ASSIGNMENT_TO_NARROWED_VAR_ERROR, 469, 13);
@@ -136,7 +120,7 @@ public class AssignmentToNarrowedVarsInLoopsTest {
         BAssertUtil.validateError(result, index++, INVALID_ASSIGNMENT_TO_NARROWED_VAR_ERROR, 609, 21);
         BAssertUtil.validateError(result, index++, INVALID_ASSIGNMENT_TO_NARROWED_VAR_ERROR, 628, 13);
 
-        Assert.assertEquals(result.getErrorCount(), index - 29);
-        Assert.assertEquals(result.getWarnCount(), 29);
+        Assert.assertEquals(result.getErrorCount(), index - 13);
+        Assert.assertEquals(result.getWarnCount(), 13);
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/FinalObjectFieldTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/FinalObjectFieldTest.java
@@ -24,7 +24,6 @@ import org.ballerinalang.test.CompileResult;
 import org.testng.annotations.Test;
 
 import static org.ballerinalang.test.BAssertUtil.validateError;
-import static org.ballerinalang.test.BAssertUtil.validateWarning;
 import static org.testng.Assert.assertEquals;
 
 /**
@@ -62,13 +61,9 @@ public class FinalObjectFieldTest {
         CompileResult result = BCompileUtil.compile("test-src/object/final_object_fields_negative.bal");
         int index = 0;
 
-        validateWarning(result, index++, "unused variable 'st'", 28, 5);
         validateError(result, index++, "cannot update 'final' object field 'name'", 30, 5);
-        validateWarning(result, index++, "unused variable 'e'", 54, 5);
         validateError(result, index++, "cannot update 'final' object field 'details'", 56, 5);
-        validateWarning(result, index++, "unused variable 'sd'", 73, 5);
         validateError(result, index++, "cannot update 'final' object field 'name'", 74, 5);
-        validateWarning(result, index++, "unused variable 'cl'", 90, 5);
         validateError(result, index++, "cannot update 'final' object field 'name'", 91, 5);
         validateError(result, index++, "cannot update 'final' object field 'name'", 92, 5);
         assertEquals(result.getDiagnostics().length, index);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/SealedArrayTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/SealedArrayTest.java
@@ -195,9 +195,7 @@ public class SealedArrayTest {
     @Test()
     public void testNegativeSealedArrays() {
         Assert.assertEquals(resultNegative.getErrorCount(), 1);
-        Assert.assertEquals(resultNegative.getWarnCount(), 1);
-        BAssertUtil.validateWarning(resultNegative, 0, "unused variable 'sealedArray1'", 18, 5);
-        BAssertUtil.validateError(resultNegative, 1, "variable 'sealedArray1' is not initialized", 19, 5);
+        BAssertUtil.validateError(resultNegative, 0, "variable 'sealedArray1' is not initialized", 19, 5);
     }
 
     @Test

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/structs/StructNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/structs/StructNegativeTest.java
@@ -40,9 +40,6 @@ public class StructNegativeTest {
 
         result2 = BCompileUtil.compile("test-src/structs/struct.bal");
         Assert.assertEquals(result2.getErrorCount(), 0);
-        Assert.assertEquals(result2.getWarnCount(), 2);
-        BAssertUtil.validateWarning(result2, 0, "unused variable 'person'", 132, 5);
-        BAssertUtil.validateWarning(result2, 1, "unused variable 'dpt'", 137, 5);
     }
 
     @Test

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/BasicWorkerActionsNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/BasicWorkerActionsNegativeTest.java
@@ -103,7 +103,6 @@ public class BasicWorkerActionsNegativeTest {
         BAssertUtil.validateError(resultNegative, index++, notSupportedMsg, 263, 17);
         BAssertUtil.validateError(resultNegative, index++, notSupportedMsg, 266, 17);
         BAssertUtil.validateError(resultNegative, index++, "undefined worker 'w1'", 271, 26);
-        BAssertUtil.validateWarning(resultNegative, index++, "unused variable 'index'", 277, 17);
         BAssertUtil.validateError(resultNegative, index++,
                 "invalid worker receive statement position, must be a top level statement in a worker", 278, 21);
         BAssertUtil.validateError(resultNegative, index++,
@@ -117,7 +116,6 @@ public class BasicWorkerActionsNegativeTest {
         BAssertUtil.validateError(resultNegative, index++, notSupportedMsg, 309, 30);
         BAssertUtil.validateError(resultNegative, index++, notSupportedMsg, 312, 30);
         BAssertUtil.validateError(resultNegative, index++, "undefined worker 'w1'", 317, 39);
-        BAssertUtil.validateWarning(resultNegative, index++, "unused variable 'index'", 323, 30);
         BAssertUtil.validateError(resultNegative, index++,
                 "invalid worker receive statement position, must be a top level statement in a worker", 324, 34);
         BAssertUtil.validateError(resultNegative, index++,

--- a/tests/jballerina-unit-test/src/test/resources/test-src/dataflow/analysis/unused_variable_analysis_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/dataflow/analysis/unused_variable_analysis_test.bal
@@ -350,3 +350,25 @@ function f16() {
     string format = "";
     string s = format == "JSON" ? logRecord.toJsonString() : value:toString(logRecord); // Warning should be only for `s`.
 }
+
+function f17() {
+    foreach int i in 0 ... 9 { // OK to not use `i`.
+
+    }
+
+    int[] m = [];
+
+    foreach int j in 0 ..< 9 { // OK to not use `j`.
+        m = []; // Unused `m`.
+    }
+
+    int[] n = from int k in 0 ..< 8 select 0; // Unused `n`, OK to not use `k`.
+
+    int[] _ = from int l in 0 ... 8 select 0; // OK to not use `l`.
+
+    foreach int i in 0 ... 9 { // OK to not use `i`.
+        _ = i; // `i` is used anyway.
+    }
+
+    int[] _ = from int l in 0 ... 8 select l; // OK to not use `l`, `l` is used anyway.
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/dataflow/analysis/unused_variable_analysis_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/dataflow/analysis/unused_variable_analysis_test.bal
@@ -26,7 +26,7 @@ function f1() {
 function f2() {
     int l; // used `l`
     l = 0;
-    int[] arr = []; // unused `arr`
+    int[] arr = []; // used `arr`
     arr[l] = 1;
 
     int m = 0; // used `m`
@@ -34,7 +34,7 @@ function f2() {
 
     string n = "x"; // used `n`
 
-    record {int x;} o = {x: 12}; // unused `o`
+    record {int x;} o = {x: 12}; // used `o`
     o.x = 1;
     o[n] = 1;
 
@@ -149,12 +149,12 @@ function f9(int a, int b = 1, int... c) { // OK, warning only for local variable
 
 function f10() {
     var l = 0; // used `l`
-    var arr = <int[]> []; // unused `arr`
+    var arr = <int[]> []; // used `arr`
     arr[l] = 1;
 
     var n = "x"; // used `n`
 
-    var o = <record {int x;}> {x: 12}; // unused `o`
+    var o = <record {int x;}> {x: 12}; // used `o`
     o.x = 1;
     o[n] = 1;
 
@@ -371,4 +371,23 @@ function f17() {
     }
 
     int[] _ = from int l in 0 ... 8 select l; // OK to not use `l`, `l` is used anyway.
+}
+
+type Bar record { int i?; };
+
+function f18(Foo foo) {
+    Bar f = {i: 1}; // used
+    f.i = 2;
+
+    int[] g = [];  // used
+    g[0] = 1;
+
+    int h = 1; // unused
+    h = 2;
+
+    int[] i; // unused
+    i = [];
+
+    string[] j = foo.j; // used
+    j[0] = "str";
 }


### PR DESCRIPTION
## Purpose
$title.

Fixes #33734 - Only consider `variable-reference-lvexpr` lvexpr as dead stores
Fixes #33737 - Stop giving the "unused variable" warning when the collection expression is a range-expr

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
