### PR TITLE
Fix defaults from the applicable contextually-expected type not being used when a mapping constructor has `readonly` fields

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ImmutableTypeCloner.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ImmutableTypeCloner.java
@@ -58,7 +58,6 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BUnionType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BXMLSubType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BXMLType;
 import org.wso2.ballerinalang.compiler.tree.BLangClassDefinition;
-import org.wso2.ballerinalang.compiler.tree.BLangImportPackage;
 import org.wso2.ballerinalang.compiler.tree.BLangSimpleVariable;
 import org.wso2.ballerinalang.compiler.tree.BLangTypeDefinition;
 import org.wso2.ballerinalang.compiler.tree.types.BLangObjectTypeNode;
@@ -584,26 +583,13 @@ public class ImmutableTypeCloner {
         }
 
         BLangUserDefinedType origTypeRef = new BLangUserDefinedType(
-                ASTBuilderUtil.createIdentifier(pos, getPackageAlias(env, pos.lineRange().filePath(),
-                                                                     origStructureType.tsymbol.pkgID)),
+                ASTBuilderUtil.createIdentifier(pos,
+                                                TypeDefBuilderHelper.getPackageAlias(env, pos.lineRange().filePath(),
+                                                                                     origStructureType.tsymbol.pkgID)),
                 ASTBuilderUtil.createIdentifier(pos, origStructureType.tsymbol.name.value));
         origTypeRef.pos = pos;
         origTypeRef.setBType(origStructureType);
         immutableStructureTypeNode.typeRefs.add(origTypeRef);
-    }
-
-    private static String getPackageAlias(SymbolEnv env, String compUnitName, PackageID typePkgId) {
-        for (BLangImportPackage importStmt : env.enclPkg.imports) {
-            if (!importStmt.compUnit.value.equals(compUnitName)) {
-                continue;
-            }
-
-            if (importStmt.symbol != null && typePkgId.equals(importStmt.symbol.pkgID)) {
-                return importStmt.alias.value;
-            }
-        }
-
-        return ""; // current module
     }
 
     private static void setRestType(Types types, SymbolTable symTable, BLangAnonymousModelHelper anonymousModelHelper,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/TypeDefBuilderHelper.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/TypeDefBuilderHelper.java
@@ -44,6 +44,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.tree.BLangClassDefinition;
 import org.wso2.ballerinalang.compiler.tree.BLangFunction;
 import org.wso2.ballerinalang.compiler.tree.BLangIdentifier;
+import org.wso2.ballerinalang.compiler.tree.BLangImportPackage;
 import org.wso2.ballerinalang.compiler.tree.BLangSimpleVariable;
 import org.wso2.ballerinalang.compiler.tree.BLangTypeDefinition;
 import org.wso2.ballerinalang.compiler.tree.types.BLangBuiltInRefTypeNode;
@@ -269,5 +270,19 @@ public class TypeDefBuilderHelper {
         errorType.detailType = userDefinedTypeNode;
 
         return errorType;
+    }
+
+    public static String getPackageAlias(SymbolEnv env, String compUnitName, PackageID typePkgId) {
+        for (BLangImportPackage importStmt : env.enclPkg.imports) {
+            if (!importStmt.compUnit.value.equals(compUnitName)) {
+                continue;
+            }
+
+            if (importStmt.symbol != null && typePkgId.equals(importStmt.symbol.pkgID)) {
+                return importStmt.alias.value;
+            }
+        }
+
+        return ""; // current module
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/record/ReadOnlyMappingConstructorFieldBalaTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/record/ReadOnlyMappingConstructorFieldBalaTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.test.bala.record;
+
+import org.ballerinalang.test.BCompileUtil;
+import org.ballerinalang.test.BRunUtil;
+import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * Bala test for readonly fields in mapping constructor expressions.
+ *
+ * @since 2.0.0
+ */
+public class ReadOnlyMappingConstructorFieldBalaTest {
+
+    private CompileResult result;
+
+    @BeforeClass
+    public void setup() {
+        BCompileUtil.compileAndCacheBala("test-src/bala/test_projects/test_project");
+        result = BCompileUtil.compile("test-src/record/mapping_constructor_with_readonly_fields_in_bala.bal");
+    }
+
+    @Test
+    public void testDefaultValueFromCETBeingUsedWithReadOnlyFieldsInTheMappingConstructor() {
+        BRunUtil.invoke(result, "testDefaultValueFromCETBeingUsedWithReadOnlyFieldsInTheMappingConstructor");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
+    }
+}

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/ReadonlyRecordFieldTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/ReadonlyRecordFieldTest.java
@@ -60,7 +60,8 @@ public class ReadonlyRecordFieldTest {
                 {"testReadOnlyFieldsOfClassTypes"},
                 {"testTypeReadOnlynessNegativeWithNonReadOnlyFieldsViaInclusion"},
                 {"testTypeReadOnlynessWithReadOnlyFieldsViaInclusion"},
-                {"testRecordWithFunctionTypeField"}
+                {"testRecordWithFunctionTypeField"},
+                {"testDefaultValueFromCETBeingUsedWithReadOnlyFieldsInTheMappingConstructor"}
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/test_project/modules/records/records.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/test_project/modules/records/records.bal
@@ -1,0 +1,21 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+public type Corge record {|
+   string a = "hello";
+   string b = "world";
+   string[] c = <readonly> ["x", "y"];
+|};

--- a/tests/jballerina-unit-test/src/test/resources/test-src/record/mapping_constructor_with_readonly_fields_in_bala.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/record/mapping_constructor_with_readonly_fields_in_bala.bal
@@ -1,0 +1,47 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import testorg/foo.records;
+
+function testDefaultValueFromCETBeingUsedWithReadOnlyFieldsInTheMappingConstructor() {
+    records:Corge d = {readonly b: "ballerina"};
+    string[] & readonly e = ["x", "y"];
+    assertEquality({a: "hello", b: "ballerina", c: e}, d);
+    assertTrue(d is record {|string a; readonly string b; string[] c;|});
+    assertFalse(d is record {|string a; readonly string b; readonly string[] c;|});
+
+    records:Corge f = {readonly b: "val", readonly c: ["a", "b", "c"]};
+    assertEquality({a: "hello", b: "val", c: <readonly> ["a", "b", "c"]}, f);
+    assertTrue(f is record {|string a; readonly string b; string[] c;|});
+    assertTrue(f is record {|string a; readonly string b; readonly string[] c;|});
+    assertFalse(f is record {|readonly string a; readonly string b; readonly string[] c;|});
+}
+
+function assertTrue(anydata actual) {
+    assertEquality(true, actual);
+}
+
+function assertFalse(anydata actual) {
+    assertEquality(false, actual);
+}
+
+function assertEquality(anydata expected, anydata actual) {
+    if expected == actual {
+        return;
+    }
+
+    panic error("expected '" + expected.toString() + "', found '" + actual.toString() + "'");
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/record/readonly_record_fields.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/record/readonly_record_fields.bal
@@ -883,6 +883,41 @@ function getRecord(boolean b) returns IncludingRec1|IncludingRec2? {
     return {k: 1, l: 2};
 }
 
+type Corge record {|
+    string a = "hello";
+    string b = "world";
+    string[] c = <readonly> ["x", "y"];
+|};
+
+function testDefaultValueFromCETBeingUsedWithReadOnlyFieldsInTheMappingConstructor() {
+    record {int a; string b = "default";} a = {readonly a: 2};
+    assertEquality(<anydata> {a: 2, b: "default"}, a);
+    assertTrue(a is record {readonly int a; string b;});
+    assertFalse(a is record {readonly int a; readonly string b;});
+
+    record {int a; string b = "default";} b = {readonly a: 3, b: "val"};
+    assertEquality(<anydata> {a: 3, b: "val"}, b);
+    assertTrue(b is record {readonly int a; string b;});
+    assertFalse(b is record {readonly int a; readonly string b;});
+
+    record {int a; string b = "default";} c = {readonly a: 3, readonly b: "val"};
+    assertEquality(<anydata> {a: 3, b: "val"}, c);
+    assertTrue(c is record {readonly int a; string b;});
+    assertTrue(c is record {readonly int a; readonly string b;});
+
+    Corge d = {readonly b: "ballerina"};
+    string[] & readonly e = ["x", "y"];
+    assertEquality(<anydata> {a: "hello", b: "ballerina", c: e}, d);
+    assertTrue(d is record {|string a; readonly string b; string[] c;|});
+    assertFalse(d is record {|string a; readonly string b; readonly string[] c;|});
+
+    Corge f = {readonly b: "val", readonly c: ["a", "b", "c"]};
+    assertEquality(<anydata> {a: "hello", b: "val", c: <readonly> ["a", "b", "c"]}, f);
+    assertTrue(f is record {|string a; readonly string b; string[] c;|});
+    assertTrue(f is record {|string a; readonly string b; readonly string[] c;|});
+    assertFalse(f is record {|readonly string a; readonly string b; readonly string[] c;|});
+}
+
 const ASSERTION_ERROR_REASON = "AssertionError";
 
 function assertTrue(any|error actual) {


### PR DESCRIPTION
## Purpose
$title.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/33162

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
