### PR TITLE
Desugar configurable variable's expression while visiting init function

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -880,7 +880,7 @@ public class Desugar extends BLangNodeVisitor {
         BLangStatementExpression stmtExpr = createStatementExpression(ifElse, resultVarRef);
         stmtExpr.setBType(configurableVar.getBType());
 
-        return rewriteExpr(stmtExpr);
+        return stmtExpr;
     }
 
     private List<BLangExpression> getConfigurableLangLibInvocationParam(BLangSimpleVariable configurableVar) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -880,6 +880,7 @@ public class Desugar extends BLangNodeVisitor {
         BLangStatementExpression stmtExpr = createStatementExpression(ifElse, resultVarRef);
         stmtExpr.setBType(configurableVar.getBType());
 
+        //not rewriting the statement expression here, so that it will be desugared while visiting the init function
         return stmtExpr;
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/elvis/ElvisExpressionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/elvis/ElvisExpressionTest.java
@@ -200,6 +200,11 @@ public class ElvisExpressionTest {
         BRunUtil.invoke(compileResult, "testElvisAsArgumentPositive");
     }
 
+    @Test(description = "Test Elvis as a configurable variable.")
+    public void testElvisWithConfigurableVar() {
+        BRunUtil.invoke(compileResult, "testElvisWithConfigurableVar");
+    }
+
     @Test(description = "Negative test cases.")
     public void testElvisOperatorNegative() {
         Assert.assertEquals(negativeResult.getErrorCount(), 5);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/ternary/TernaryExpressionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/ternary/TernaryExpressionTest.java
@@ -365,6 +365,11 @@ public class TernaryExpressionTest {
         BRunUtil.invoke(compileResult, "testIfAndThenExprBeingFieldAccess");
     }
 
+    @Test
+    public void testTernaryWithConfigurableVar() {
+        BRunUtil.invoke(compileResult, "testTernaryWithConfigurableVar");
+    }
+
     @AfterClass
     public void tearDown() {
         compileResult = null;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/elvis/elvis-expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/elvis/elvis-expr.bal
@@ -160,6 +160,24 @@ function testElvisAsArgumentPositive() {
     assertEquals(a[1], 0);
 }
 
+int? nilVal = ();
+string? stringOrNilVal = "dummyStr";
+int? intOrNilVal = 1;
+
+configurable string CONFIGURABLE_1 = stringOrNilVal ?: "val2";
+configurable int CONFIGURABLE_2 = intOrNilVal ?: -1;
+
+//enable after #33655 is fixed
+//configurable int|string CONFIGURABLE_3 = nilVal ?: stringOrNilVal ?: "val2";
+configurable int|string CONFIGURABLE_4 = stringOrNilVal ?: -1;
+
+function testElvisWithConfigurableVar() {
+    assertEquals(CONFIGURABLE_1, "dummyStr");
+    assertEquals(CONFIGURABLE_2, 1);
+    //assertEquals(CONFIGURABLE_3, "dummyStr");
+    assertEquals(CONFIGURABLE_4, "dummyStr");
+}
+
 const ASSERTION_ERROR_REASON = "AssertionError";
 
 function assertEquals(anydata expected, anydata actual) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/ternary/ternary-expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/ternary/ternary-expr.bal
@@ -141,6 +141,19 @@ function testTernaryAsArgument() {
     assertEquals(a[1], 255);
 }
 
+boolean bool = true;
+configurable string CONFIGURABLE_1 = bool ? "val1" : "val2";
+configurable int CONFIGURABLE_2 = bool ? 1 : 0;
+configurable string CONFIGURABLE_3 = bool ? !bool ? "val1" : "val2" : "val3";
+configurable int|string CONFIGURABLE_4 = bool ? 1 : "invalid";
+
+function testTernaryWithConfigurableVar() {
+    assertEquals(CONFIGURABLE_1, "val1");
+    assertEquals(CONFIGURABLE_2, 1);
+    assertEquals(CONFIGURABLE_3, "val2");
+    assertEquals(CONFIGURABLE_4, 1);
+}
+
 type Point record {|
     int x;
     int y;


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues.

Fixes #33768

## Approach
> When we try to desugar the config variable's expression while visiting the global variables; the owner is not changed as `.<init>`. This causes the variable definitions to be created during desugaring the expression created as BLangPackageVars instead of BLangLocalVars.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
