### PR TITLE
Add service template generator implementation

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/ServiceTemplateCompletionItemBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/ServiceTemplateCompletionItemBuilder.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.ballerinalang.langserver.completions.builder;
+
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionItemKind;
+import org.eclipse.lsp4j.TextEdit;
+
+import java.util.List;
+
+/**
+ * Builder used to build service template snippet completion item.
+ *
+ * @since 2.0.0
+ */
+public class ServiceTemplateCompletionItemBuilder {
+
+    private ServiceTemplateCompletionItemBuilder() {
+
+    }
+
+    /**
+     * Creates and returns a snippet type completion item.
+     *
+     * @param snippet             Text to be inserted.
+     * @param label               Label of the completion item.
+     * @param detail              Detail of the completion item.
+     * @param filterText          Filter text of the completion item.
+     * @param additionalTextEdits additional TextEdits of the completion item.
+     * @return {@link CompletionItem}
+     */
+    public static CompletionItem build(String snippet,
+                                       String label, String detail,
+                                       String filterText,
+                                       List<TextEdit> additionalTextEdits) {
+        CompletionItem completionItem = new CompletionItem();
+        completionItem.setInsertText(snippet);
+        completionItem.setLabel(label);
+        completionItem.setDetail(detail);
+        completionItem.setFilterText(filterText);
+        completionItem.setAdditionalTextEdits(additionalTextEdits);
+        completionItem.setKind(CompletionItemKind.Snippet);
+        return completionItem;
+    }
+}

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ModulePartNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ModulePartNodeContext.java
@@ -31,6 +31,7 @@ import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.SnippetCompletionItem;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
 import org.ballerinalang.langserver.completions.providers.context.util.ModulePartNodeContextUtil;
+import org.ballerinalang.langserver.completions.providers.context.util.ServiceTemplateGenerator;
 import org.ballerinalang.langserver.completions.util.Snippet;
 
 import java.util.ArrayList;
@@ -108,8 +109,8 @@ public class ModulePartNodeContext extends AbstractCompletionProvider<ModulePart
                         Snippet.KW_TYPE, Snippet.KW_ISOLATED,
                         Snippet.KW_FINAL, Snippet.KW_CONST, Snippet.KW_LISTENER, Snippet.KW_CLIENT,
                         Snippet.KW_VAR, Snippet.KW_ENUM, Snippet.KW_XMLNS, Snippet.KW_CLASS,
-                        Snippet.KW_TRANSACTIONAL, Snippet.DEF_FUNCTION, Snippet.DEF_MAIN_FUNCTION,
-                        Snippet.DEF_SERVICE, Snippet.KW_CONFIGURABLE, Snippet.DEF_ANNOTATION,
+                        Snippet.KW_TRANSACTIONAL, Snippet.DEF_FUNCTION, Snippet.DEF_MAIN_FUNCTION, 
+                        Snippet.KW_CONFIGURABLE, Snippet.DEF_ANNOTATION,
                         Snippet.DEF_RECORD, Snippet.STMT_NAMESPACE_DECLARATION,
                         Snippet.DEF_OBJECT_SNIPPET, Snippet.DEF_CLASS, Snippet.DEF_ENUM, Snippet.DEF_CLOSED_RECORD,
                         Snippet.DEF_ERROR_TYPE, Snippet.DEF_TABLE_TYPE_DESC, Snippet.DEF_TABLE_WITH_KEY_TYPE_DESC,
@@ -159,7 +160,8 @@ public class ModulePartNodeContext extends AbstractCompletionProvider<ModulePart
         List<LSCompletionItem> completionItems = new ArrayList<>();
         completionItems.addAll(ModulePartNodeContextUtil.getTopLevelItems(context));
         completionItems.addAll(this.getTypeDescContextItems(context));
-
+        completionItems.addAll(ServiceTemplateGenerator.getInstance(context.languageServercontext())
+                .getServiceTemplates(context));
         return completionItems;
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ModuleVariableDeclarationNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ModuleVariableDeclarationNodeContext.java
@@ -152,7 +152,7 @@ public class ModuleVariableDeclarationNodeContext extends
                         Snippet.KW_FINAL, Snippet.KW_CONST, Snippet.KW_LISTENER, Snippet.KW_CLIENT,
                         Snippet.KW_VAR, Snippet.KW_ENUM, Snippet.KW_XMLNS, Snippet.KW_CLASS,
                         Snippet.KW_TRANSACTIONAL, Snippet.DEF_FUNCTION, Snippet.DEF_MAIN_FUNCTION,
-                        Snippet.DEF_SERVICE, Snippet.KW_CONFIGURABLE, Snippet.DEF_ANNOTATION,
+                        Snippet.KW_CONFIGURABLE, Snippet.DEF_ANNOTATION,
                         Snippet.DEF_RECORD, Snippet.STMT_NAMESPACE_DECLARATION,
                         Snippet.DEF_OBJECT_SNIPPET, Snippet.DEF_CLASS, Snippet.DEF_ENUM, Snippet.DEF_CLOSED_RECORD,
                         Snippet.DEF_ERROR_TYPE, Snippet.DEF_TABLE_TYPE_DESC, Snippet.DEF_TABLE_WITH_KEY_TYPE_DESC,

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/util/ModulePartNodeContextUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/util/ModulePartNodeContextUtil.java
@@ -65,8 +65,7 @@ public class ModulePartNodeContextUtil {
                 Snippet.KW_IMPORT, Snippet.KW_TYPE, Snippet.KW_PUBLIC, Snippet.KW_ISOLATED,
                 Snippet.KW_FINAL, Snippet.KW_CONST, Snippet.KW_LISTENER, Snippet.KW_CLIENT, Snippet.KW_VAR,
                 Snippet.KW_ENUM, Snippet.KW_XMLNS, Snippet.KW_CLASS, Snippet.KW_TRANSACTIONAL,
-                Snippet.DEF_FUNCTION, Snippet.DEF_MAIN_FUNCTION, Snippet.DEF_SERVICE, Snippet.KW_CONFIGURABLE,
-                /*Snippet.DEF_SERVICE_WEBSOCKET, Snippet.DEF_SERVICE_WS_CLIENT, Snippet.DEF_SERVICE_GRPC,*/
+                Snippet.DEF_FUNCTION, Snippet.DEF_MAIN_FUNCTION, Snippet.KW_CONFIGURABLE,
                 Snippet.DEF_ANNOTATION, Snippet.DEF_RECORD, Snippet.STMT_NAMESPACE_DECLARATION,
                 Snippet.DEF_OBJECT_SNIPPET, Snippet.DEF_CLASS, Snippet.DEF_ENUM, Snippet.DEF_CLOSED_RECORD,
                 Snippet.DEF_ERROR_TYPE, Snippet.DEF_TABLE_TYPE_DESC, Snippet.DEF_TABLE_WITH_KEY_TYPE_DESC,

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/util/ServiceTemplateGenerator.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/util/ServiceTemplateGenerator.java
@@ -1,0 +1,530 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.langserver.completions.providers.context.util;
+
+import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.ClassSymbol;
+import io.ballerina.compiler.api.symbols.MethodSymbol;
+import io.ballerina.compiler.api.symbols.ModuleSymbol;
+import io.ballerina.compiler.api.symbols.ObjectTypeSymbol;
+import io.ballerina.compiler.api.symbols.ParameterKind;
+import io.ballerina.compiler.api.symbols.ParameterSymbol;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.SymbolKind;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
+import io.ballerina.compiler.syntax.tree.ImportDeclarationNode;
+import io.ballerina.compiler.syntax.tree.SyntaxKind;
+import io.ballerina.compiler.syntax.tree.Token;
+import io.ballerina.projects.Module;
+import io.ballerina.projects.Package;
+import io.ballerina.projects.PackageCompilation;
+import io.ballerina.projects.Project;
+import io.ballerina.projects.ProjectKind;
+import io.ballerina.projects.directory.ProjectLoader;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.ballerinalang.langserver.LSPackageLoader;
+import org.ballerinalang.langserver.common.ImportsAcceptor;
+import org.ballerinalang.langserver.common.utils.CommonKeys;
+import org.ballerinalang.langserver.common.utils.CommonUtil;
+import org.ballerinalang.langserver.common.utils.FunctionGenerator;
+import org.ballerinalang.langserver.common.utils.SymbolUtil;
+import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
+import org.ballerinalang.langserver.commons.CompletionContext;
+import org.ballerinalang.langserver.commons.LanguageServerContext;
+import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
+import org.ballerinalang.langserver.completions.StaticCompletionItem;
+import org.ballerinalang.langserver.completions.builder.ServiceTemplateCompletionItemBuilder;
+import org.ballerinalang.langserver.completions.util.ItemResolverConstants;
+import org.eclipse.lsp4j.TextEdit;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+/**
+ * Generates Service Template Snippet completion items.
+ *
+ * @since 2.0.0
+ */
+public class ServiceTemplateGenerator {
+
+    private static final LanguageServerContext.Key<ServiceTemplateGenerator> SERVICE_TEMPLATE_GENERATOR_KEY =
+            new LanguageServerContext.Key<>();
+
+    private final Map<Pair<String, String>, List<ListenerMetaData>> moduleListenerMetaDataMap;
+
+    private boolean isInitialized;
+
+    public boolean initialized() {
+        return isInitialized;
+    }
+
+    private ServiceTemplateGenerator(LanguageServerContext context) {
+        context.put(SERVICE_TEMPLATE_GENERATOR_KEY, this);
+        this.moduleListenerMetaDataMap = new ConcurrentHashMap<>();
+        CompletableFuture.runAsync(() -> initialize(context));
+    }
+
+    /**
+     * Get an instance of the Service Template Generator.
+     *
+     * @param context Language Server Context.
+     * @return {@link ServiceTemplateGenerator} Service Template Generator.
+     */
+    public static ServiceTemplateGenerator getInstance(LanguageServerContext context) {
+        ServiceTemplateGenerator serviceTemplateGenerator =
+                context.get(SERVICE_TEMPLATE_GENERATOR_KEY);
+        if (serviceTemplateGenerator == null) {
+            serviceTemplateGenerator = new ServiceTemplateGenerator(context);
+        }
+        return serviceTemplateGenerator;
+    }
+
+    /**
+     * Initializes the Service Template Generator.
+     *
+     * @param context Language Server Context.
+     */
+    private void initialize(LanguageServerContext context) {
+        if (!this.isInitialized) {
+            loadListenersFromDistribution(context);
+            this.isInitialized = true;
+        }
+    }
+
+    /**
+     * Given a module symbol, find and populate service metadata into the moduleServiceTemplateMap cache.
+     * Used to dynamically add new entries to the cache.
+     *
+     * @param moduleSymbol Module symbol.
+     * @param shouldImport Whether import text should be added.
+     * @param ctx          BallerinaCompletion context.
+     * @return {@link List<LSCompletionItem>} Set of completion items corresponding to the listeners
+     * in the given module.
+     */
+    public synchronized List<LSCompletionItem> generateAndPopulate(ModuleSymbol moduleSymbol,
+                                                                   Boolean shouldImport,
+                                                                   BallerinaCompletionContext ctx) {
+        ModuleID moduleId = moduleSymbol.id();
+        String moduleName = moduleId.moduleName();
+        String orgName = moduleId.orgName();
+        Pair<String, String> moduleKey = Pair.of(moduleName, orgName);
+        List<ListenerMetaData> items = new ArrayList<>();
+        moduleSymbol.allSymbols().stream().filter(listenerPredicate())
+                .forEach(listener -> generateServiceSnippetMetaData(listener,
+                        orgName, moduleName, moduleId.modulePrefix()).ifPresent(items::add));
+        if (!moduleListenerMetaDataMap.containsKey(moduleKey) && !items.isEmpty()) {
+            moduleListenerMetaDataMap.put(moduleKey, items);
+        }
+        return items.stream().map(item ->
+                generateServiceSnippet(item, shouldImport, ctx)).collect(Collectors.toList());
+    }
+
+    /**
+     * Generates and returns the service templates for a given completion context.
+     *
+     * @param ctx Completion context.
+     * @return {@link List<LSCompletionItem>} List of completion items.
+     */
+    public List<LSCompletionItem> getServiceTemplates(BallerinaCompletionContext ctx) {
+        List<LSCompletionItem> completionItems = new ArrayList<>();
+        Set<String> processedModuleList = new HashSet<>();
+
+        //Find listeners from current imports and generate completion items.
+        Map<ImportDeclarationNode, ModuleSymbol> currentDocImports = ctx.currentDocImportsMap();
+        currentDocImports.forEach((importNode, moduleSymbol) -> {
+            String orgName = importNode.orgName().isEmpty() ? "" : importNode.orgName().get().orgName().text();
+            String moduleName = importNode.moduleName().stream()
+                    .map(Token::text)
+                    .collect(Collectors.joining("."));
+            String modulePrefix;
+            if (importNode.prefix().isEmpty()) {
+                modulePrefix = CommonUtil.escapeReservedKeyword(
+                        importNode.moduleName().get(importNode.moduleName().size() - 1).text());
+            } else {
+                modulePrefix = CommonUtil.escapeReservedKeyword(importNode.prefix().get().prefix().text());
+            }
+            String moduleHash = generateModuleHash(orgName, moduleName);
+            if (processedModuleList.contains(moduleHash)) {
+                return;
+            }
+
+            Pair<String, String> key = Pair.of(moduleName, orgName);
+            //check if the module has already been processed to the cache.
+            if (this.moduleListenerMetaDataMap.containsKey(key)) {
+                moduleListenerMetaDataMap.get(key).forEach(item ->
+                        completionItems.add(generateServiceSnippet(item, false, ctx)));
+                processedModuleList.add(moduleHash);
+                return;
+            }
+
+            //Check if the module belongs to the current project. 
+            //If it is not from the current project populate to the cache.
+            if (!getModuleNamesOfCurrentProject(ctx).contains(moduleHash)) {
+                completionItems.addAll(generateAndPopulate(moduleSymbol, false, ctx));
+                processedModuleList.add(moduleHash);
+                return;
+            }
+
+            moduleSymbol.allSymbols().stream().filter(listenerPredicate())
+                    .forEach(listener -> generateServiceSnippetMetaData(listener, orgName, moduleName, modulePrefix)
+                            .ifPresent(item -> completionItems.add(generateServiceSnippet(item, false, ctx))));
+            processedModuleList.add(moduleHash);
+        });
+
+        //Generate service templates for listeners from the distribution
+        if (this.isInitialized) {
+            this.moduleListenerMetaDataMap.forEach((key, items) -> {
+                String moduleName = key.getLeft();
+                String orgName = key.getRight();
+                String modulePrefix = getModulePrefix(moduleName, ctx);
+                String moduleHash = generateModuleHash(orgName, moduleName);
+                if (processedModuleList.contains(moduleHash)) {
+                    return;
+                }
+                items.forEach(item -> {
+                    if (!item.modulePrefix.equals(modulePrefix)) {
+                        item.modulePrefix = modulePrefix;
+                    }
+                    completionItems.add(generateServiceSnippet(item, true, ctx));
+                });
+                processedModuleList.add(moduleHash);
+            });
+        }
+
+        //Generate completion items for the listeners in the current project.
+        Optional<Project> project = ctx.workspace().project(ctx.filePath());
+        Optional<Module> currentModule = ctx.workspace().module(ctx.filePath());
+        if (project.isEmpty() || currentModule.isEmpty()) {
+            return completionItems;
+        }
+        boolean isDefaultModule = currentModule.get().isDefaultModule();
+        PackageCompilation packageCompilation = project.get().currentPackage().getCompilation();
+        project.get().currentPackage().modules().forEach(module -> {
+            //Symbols in the default module should not be visible to other modules.
+            if (module.isDefaultModule() && !isDefaultModule) {
+                return;
+            }
+            String orgName = "";
+            String moduleName = module.moduleName().toString();
+            String moduleHash = generateModuleHash(orgName, moduleName);
+            if (processedModuleList.contains(moduleHash)) {
+                return;
+            }
+            boolean shouldImport = !(project.get().kind() == ProjectKind.SINGLE_FILE_PROJECT
+                    || currentModule.get().equals(module));
+            String modulePrefix = shouldImport ? getModulePrefix(moduleName) : "";
+            SemanticModel semanticModel = packageCompilation.getSemanticModel(module.moduleId());
+            semanticModel.moduleSymbols().stream().filter(listenerPredicate())
+                    .forEach(listener -> generateServiceSnippetMetaData(listener, orgName, moduleName, modulePrefix)
+                            .ifPresent(item -> completionItems.add(generateServiceSnippet(item, shouldImport, ctx))));
+        });
+        return completionItems;
+    }
+
+    /**
+     * Load projects from the distribution repo and generate service data holder.
+     *
+     * @param lsContext Language Server Context.
+     */
+    private void loadListenersFromDistribution(LanguageServerContext lsContext) {
+        List<Package> packages = LSPackageLoader.getInstance(lsContext).getDistributionRepoPackages();
+        packages.forEach(distPackage -> {
+            String orgName = CommonUtil.escapeModuleName(distPackage.packageOrg().value());
+            Project project = ProjectLoader.loadProject(distPackage.project().sourceRoot());
+            PackageCompilation packageCompilation = project.currentPackage().getCompilation();
+            project.currentPackage().modules().forEach(module -> {
+                Pair<String, String> moduleKey = Pair.of(module.moduleName().toString(), orgName);
+                String modulePrefix = getModulePrefix(module.moduleName().toString());
+                SemanticModel semanticModel = packageCompilation.getSemanticModel(module.moduleId());
+                List<ListenerMetaData> items = new ArrayList<>();
+                semanticModel.moduleSymbols().stream().filter(listenerPredicate())
+                        .forEach(listener ->
+                                generateServiceSnippetMetaData(listener, orgName, module.moduleName().toString(),
+                                        modulePrefix).ifPresent(items::add));
+                if (!items.isEmpty() && !this.moduleListenerMetaDataMap.containsKey(moduleKey)) {
+                    this.moduleListenerMetaDataMap.put(moduleKey, items);
+                }
+            });
+        });
+    }
+
+    private Predicate<Symbol> listenerPredicate() {
+        return symbol -> SymbolUtil.isListener(symbol) && symbol.kind() == SymbolKind.CLASS;
+    }
+
+    private String generateModuleHash(String orgName, String moduleName) {
+        return orgName.isEmpty() ? moduleName : orgName + CommonKeys.SLASH_KEYWORD_KEY + moduleName;
+    }
+
+    private String getModulePrefix(String moduleName, CompletionContext context) {
+        List<String> moduleNameComponents = Arrays.stream(moduleName.split("\\."))
+                .map(CommonUtil::escapeModuleName)
+                .collect(Collectors.toList());
+        if (moduleNameComponents.isEmpty()) {
+            return "";
+        }
+        String aliasComponent = moduleNameComponents.get(moduleNameComponents.size() - 1);
+        String validatedName = CommonUtil.getValidatedSymbolName(context, aliasComponent);
+        return !validatedName.equals(aliasComponent) ? validatedName : aliasComponent;
+    }
+
+    private String getModulePrefix(String moduleName) {
+        List<String> moduleNameComponents = Arrays.stream(moduleName.split("\\."))
+                .map(CommonUtil::escapeModuleName)
+                .collect(Collectors.toList());
+        if (moduleNameComponents.isEmpty()) {
+            return "";
+        }
+        return moduleNameComponents.get(moduleNameComponents.size() - 1);
+    }
+
+    private Set<String> getModuleNamesOfCurrentProject(BallerinaCompletionContext ctx) {
+        Set<String> modulesHashSet = new HashSet<>();
+        Optional<Project> project = ctx.workspace().project(ctx.filePath());
+        if (project.isEmpty()) {
+            return modulesHashSet;
+        }
+        String orgName = "";
+        project.get().currentPackage().modules().forEach(module -> {
+            String hash = generateModuleHash(orgName, module.moduleName().toString());
+            modulesHashSet.add(hash);
+        });
+        return modulesHashSet;
+    }
+
+    /**
+     * Given a Symbol of a listener, process and pre-generate listener meta data.
+     *
+     * @param symbol       Listener symbol.
+     * @param orgName      Organization name of the symbol.
+     * @param moduleName   Module name of the symbol.
+     * @param modulePrefix Module prefix of the symbol.
+     * @return {@link ListenerMetaData} Pre processed metadata of the symbol.
+     */
+    private Optional<ListenerMetaData> generateServiceSnippetMetaData(Symbol symbol,
+                                                                      String orgName,
+                                                                      String moduleName,
+                                                                      String modulePrefix) {
+
+        //Check if the provided symbol is a listener.
+        Optional<? extends TypeSymbol> symbolTypeDesc = SymbolUtil.getTypeDescriptor(symbol);
+        if (symbolTypeDesc.isEmpty() || !SymbolUtil.isListener(symbol) || symbol.kind() != SymbolKind.CLASS) {
+            return Optional.empty();
+        }
+        ClassSymbol classSymbol = (ClassSymbol) CommonUtil.getRawType(symbolTypeDesc.get());
+        if (classSymbol.getName().isEmpty()) {
+            return Optional.empty();
+        }
+
+        //Get the attach method of the listener.
+        MethodSymbol attachMethod = classSymbol.methods().get("attach");
+        if (attachMethod == null || classSymbol.getName().isEmpty()) {
+            return Optional.empty();
+        }
+
+        //Check if the first parameter of the attach method is a subtype of service object.
+        Optional<List<ParameterSymbol>> params = attachMethod.typeDescriptor().params();
+        if (params.isEmpty() || params.get().size() == 0) {
+            return Optional.empty();
+        }
+        TypeSymbol typeSymbol = CommonUtil.getRawType(params.get().get(0).typeDescriptor());
+        ObjectTypeSymbol serviceTypeSymbol;
+        if (typeSymbol.typeKind() == TypeDescKind.UNION) {
+            //Here we consider the first service type of the union. 
+            Optional<TypeSymbol> memberType = ((UnionTypeSymbol) typeSymbol).memberTypeDescriptors()
+                    .stream().filter(member -> member.typeKind() == TypeDescKind.OBJECT).findFirst();
+            if (memberType.isEmpty()) {
+                return Optional.empty();
+            }
+            serviceTypeSymbol = (ObjectTypeSymbol) memberType.get();
+        } else if (typeSymbol.typeKind() == TypeDescKind.OBJECT) {
+            serviceTypeSymbol = (ObjectTypeSymbol) typeSymbol;
+        } else {
+            return Optional.empty();
+        }
+
+        //Listener initialization snippet
+        //Snippet index 1 is provided for attachment point in service definition.
+        Optional<MethodSymbol> initMethod = classSymbol.initMethod();
+        int snippetIndex = 2;
+        String listenerInitArgs = "";
+        if (initMethod.isPresent() && initMethod.get().typeDescriptor().params().isPresent()) {
+            List<String> args = new ArrayList<>();
+            List<ParameterSymbol> requiredParams = initMethod.get().typeDescriptor().params().get().stream()
+                    .filter(parameterSymbol ->
+                            parameterSymbol.paramKind() == ParameterKind.REQUIRED).collect(Collectors.toList());
+            for (ParameterSymbol parameterSymbol : requiredParams) {
+                args.add("${" + snippetIndex + ":" +
+                        CommonUtil.getDefaultValueForType(parameterSymbol.typeDescriptor()).orElse("") + "}");
+                snippetIndex += 1;
+            }
+            listenerInitArgs = String.join(",", args);
+        }
+
+        String symbolName = classSymbol.getName().get();
+        return Optional.of(new ListenerMetaData(listenerInitArgs,
+                new ArrayList<>(serviceTypeSymbol.methods().values()),
+                symbolName, snippetIndex, orgName, moduleName, modulePrefix));
+    }
+
+    private LSCompletionItem generateServiceSnippet(ListenerMetaData serviceSnippet,
+                                                    Boolean shouldImport,
+                                                    BallerinaCompletionContext context) {
+
+        String symbolReference;
+        String modulePrefix = shouldImport ? getModulePrefix(serviceSnippet.moduleName, context) :
+                serviceSnippet.modulePrefix;
+        if (!modulePrefix.isEmpty()) {
+            symbolReference = modulePrefix + ":" + serviceSnippet.symbolName;
+        } else {
+            symbolReference = serviceSnippet.symbolName;
+        }
+
+        String listenerInitialization = "new " + symbolReference + "(" + serviceSnippet.listenerInitArgs + ")";
+        int snippetIndex = serviceSnippet.currentSnippetIndex;
+        List<String> methodSnippets = new ArrayList<>();
+        List<TextEdit> additionalTextEdits = new ArrayList<>();
+        if (!serviceSnippet.unimplementedMethods.isEmpty()) {
+            for (MethodSymbol methodSymbol : serviceSnippet.unimplementedMethods) {
+                Pair<String, List<TextEdit>> functionSnippet =
+                        generateMethodSnippet(methodSymbol, snippetIndex, context);
+                additionalTextEdits.addAll(functionSnippet.getRight());
+                methodSnippets.add(functionSnippet.getLeft());
+                snippetIndex += 1;
+            }
+        }
+
+        String snippet = SyntaxKind.SERVICE_KEYWORD.stringValue() + " ${1} " +
+                SyntaxKind.ON_KEYWORD.stringValue() + " " + listenerInitialization +
+                " {" + CommonUtil.LINE_SEPARATOR + (serviceSnippet.unimplementedMethods.isEmpty() ?
+                "    ${" + snippetIndex + "}" : String.join("", methodSnippets)) + CommonUtil.LINE_SEPARATOR + "}" +
+                CommonUtil.LINE_SEPARATOR;
+
+        String label;
+        String filterText;
+        String detail = ItemResolverConstants.SNIPPET_TYPE;
+        if (shouldImport) {
+            label = "service on " + serviceSnippet.modulePrefix + ":" + serviceSnippet.symbolName;
+            filterText = String.join("_", Arrays.asList(ItemResolverConstants.SERVICE, serviceSnippet.modulePrefix,
+                    serviceSnippet.symbolName));
+            if (serviceSnippet.modulePrefix.equals(modulePrefix)) {
+                modulePrefix = "";
+            }
+            additionalTextEdits.addAll(CommonUtil.getAutoImportTextEdits(serviceSnippet.orgName,
+                    serviceSnippet.moduleName, modulePrefix, context));
+        } else {
+            label = "service on " + symbolReference;
+            if (!serviceSnippet.modulePrefix.equals(modulePrefix)) {
+                filterText = String.join("_", Arrays.asList(ItemResolverConstants.SERVICE, serviceSnippet.modulePrefix,
+                        symbolReference.replace(":", "_")));
+            } else {
+                filterText = String.join("_", Arrays.asList(ItemResolverConstants.SERVICE,
+                        symbolReference.replace(":", "_")));
+            }
+        }
+
+        return new StaticCompletionItem(context, ServiceTemplateCompletionItemBuilder.build(snippet, label, detail,
+                filterText, additionalTextEdits), StaticCompletionItem.Kind.OTHER);
+
+    }
+
+    private Pair<String, List<TextEdit>> generateMethodSnippet(MethodSymbol methodSymbol, int snippetIndex,
+                                                               BallerinaCompletionContext context) {
+        ImportsAcceptor importsAcceptor = new ImportsAcceptor(context);
+        String functionTypeDesc =
+                FunctionGenerator.processModuleIDsInText(importsAcceptor, methodSymbol.signature(), context);
+        List<TextEdit> edits = new ArrayList<>(importsAcceptor.getNewImportTextEdits());
+
+        String returnStmt = "";
+        if (methodSymbol.typeDescriptor().returnTypeDescriptor().isPresent()) {
+            TypeSymbol returnTypeSymbol = methodSymbol.typeDescriptor().returnTypeDescriptor().get();
+            if (returnTypeSymbol.typeKind() != TypeDescKind.COMPILATION_ERROR) {
+                Optional<String> defaultReturnValueForType = CommonUtil.getDefaultValueForType(returnTypeSymbol);
+                if (defaultReturnValueForType.isPresent()) {
+                    String defaultReturnValue = defaultReturnValueForType.get();
+                    if (CommonKeys.PARANTHESES_KEY.equals(defaultReturnValue)) {
+                        returnStmt = "return;";
+                    } else {
+                        returnStmt = "return ${" + snippetIndex + ":" +
+                                defaultReturnValue + "}" + CommonKeys.SEMI_COLON_SYMBOL_KEY;
+                    }
+                }
+            }
+        }
+
+        //Build the snippet
+        String paddingStr = StringUtils.repeat(" ", 4);
+        StringBuilder functionSnippet = new StringBuilder();
+        functionSnippet.append(CommonUtil.LINE_SEPARATOR)
+                .append(paddingStr)
+                .append(functionTypeDesc)
+                .append(" ")
+                .append(CommonKeys.OPEN_BRACE_KEY)
+                .append(CommonUtil.LINE_SEPARATOR)
+                .append(StringUtils.repeat(paddingStr, 2))
+                .append((returnStmt.isEmpty() ? "${" + snippetIndex + "}" : returnStmt))
+                .append(CommonUtil.LINE_SEPARATOR)
+                .append(paddingStr)
+                .append(CommonKeys.CLOSE_BRACE_KEY)
+                .append(CommonUtil.LINE_SEPARATOR);
+        return Pair.of(functionSnippet.toString(), edits);
+    }
+
+    /**
+     * Holds data related to a particular listener symbol.
+     */
+    private static class ListenerMetaData {
+
+        private String listenerInitArgs;
+        private List<MethodSymbol> unimplementedMethods;
+        private String symbolName;
+        private int currentSnippetIndex;
+        private String moduleName;
+        private String orgName;
+        private String modulePrefix;
+
+        ListenerMetaData(String listenerInitialization,
+                         List<MethodSymbol> unimplementedMethods,
+                         String symbolReference,
+                         int currentSnippetIndex,
+                         String orgName,
+                         String moduleName,
+                         String modulePrefix) {
+            this.listenerInitArgs = listenerInitialization;
+            this.unimplementedMethods = unimplementedMethods;
+            this.symbolName = symbolReference;
+            this.currentSnippetIndex = currentSnippetIndex;
+            this.orgName = orgName;
+            this.moduleName = moduleName;
+            this.modulePrefix = modulePrefix;
+        }
+    }
+}

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/Snippet.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/Snippet.java
@@ -100,19 +100,9 @@ public enum Snippet {
 //
 //    DEF_RESOURCE_WEBSUB_NOTIFY(SnippetGenerator.getWebSubResourceOnNotificationSnippet()),
 
-    DEF_SERVICE(SnippetGenerator.getHttpServiceDefSnippet()),
-
     DEF_SERVICE_COMMON(SnippetGenerator.getCommonServiceSnippet()),
 
 //    DEF_SERVICE_VAR(SnippetGenerator.getServiceVarSnippet()),
-
-//    DEF_SERVICE_WEBSOCKET(SnippetGenerator.getWebSocketServiceDefSnippet()),
-
-//    DEF_SERVICE_WS_CLIENT(SnippetGenerator.getWebSocketClientServiceDefSnippet()),
-
-//    DEF_SERVICE_WEBSUB(SnippetGenerator.getWebSubServiceDefSnippet()),
-
-//    DEF_SERVICE_GRPC(SnippetGenerator.getGRPCServiceDefSnippet()),
 
     DEF_CLASS(SnippetGenerator.getClassDefSnippet()),
 
@@ -135,8 +125,7 @@ public enum Snippet {
     DEF_IMMEDIATE_STOP_FUNCTION(SnippetGenerator.getImmediateStopFunctionSnippet()),
 
     DEF_DETACH_FUNCTION(SnippetGenerator.getDetachFunctionSnippet()),
-
-
+    
     // Expressions Snippets
     EXPR_ERROR_CONSTRUCTOR(SnippetGenerator.getErrorConstructorSnippet()),
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/SnippetGenerator.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/SnippetGenerator.java
@@ -1049,23 +1049,7 @@ public class SnippetGenerator {
         return new SnippetBlock(ItemResolverConstants.RETURN_SC, ItemResolverConstants.RETURN_SC, "return;",
                 ItemResolverConstants.STATEMENT_TYPE, Kind.STATEMENT);
     }
-
-    /**
-     * Get Service Definition Snippet Block.
-     *
-     * @return {@link SnippetBlock}     Generated Snippet Block
-     */
-    public static SnippetBlock getHttpServiceDefSnippet() {
-        ImmutablePair<String, String> httpImport = new ImmutablePair<>("ballerina", "http");
-        String snippet = "service /${1} on new http:Listener(8080) {"
-                + CommonUtil.LINE_SEPARATOR + "\tresource function ${2:get} ${3:getResource}"
-                + "(http:Caller ${4:caller}, " + "http:Request ${5:req}) {" + CommonUtil.LINE_SEPARATOR
-                + "\t\t" + CommonUtil.LINE_SEPARATOR + "\t}" + CommonUtil.LINE_SEPARATOR + "}";
-        return new SnippetBlock(ItemResolverConstants.SERVICE_HTTP,
-                generateFilterText(Arrays.asList(ItemResolverConstants.SERVICE, "http")), snippet,
-                ItemResolverConstants.SNIPPET_TYPE, Kind.SNIPPET, httpImport);
-    }
-
+    
     /**
      * Get Service Variable Snippet Block.
      *

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/ClassDefContextTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/ClassDefContextTest.java
@@ -18,6 +18,7 @@
 package org.ballerinalang.langserver.completion;
 
 import org.ballerinalang.langserver.commons.workspace.WorkspaceDocumentException;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -31,6 +32,12 @@ import java.util.List;
  * @since 2.0.0
  */
 public class ClassDefContextTest extends CompletionTest {
+
+    @BeforeClass
+    @Override
+    public void init() throws InterruptedException {
+        preLoadAndInit();
+    }
 
     @Test(dataProvider = "completion-data-provider")
     @Override

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/EnumContextTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/EnumContextTest.java
@@ -17,6 +17,7 @@
  */
 package org.ballerinalang.langserver.completion;
 
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 
 /**
@@ -25,6 +26,13 @@ import org.testng.annotations.DataProvider;
  * @since 2.0.0
  */
 public class EnumContextTest extends CompletionTest {
+    
+    @BeforeClass
+    @Override
+    public void init() throws InterruptedException {
+        preLoadAndInit();
+    }
+    
     @DataProvider(name = "completion-data-provider")
     @Override
     public Object[][] dataProvider() {

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/ModulePartNodeContextTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/ModulePartNodeContextTest.java
@@ -17,14 +17,22 @@
  */
 package org.ballerinalang.langserver.completion;
 
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 
 /**
  * Expression Context tests.
- * 
+ *
  * @since 2.0.0
  */
 public class ModulePartNodeContextTest extends CompletionTest {
+
+    @BeforeClass
+    @Override
+    public void init() throws InterruptedException {
+        preLoadAndInit();
+    }
+
     @DataProvider(name = "completion-data-provider")
     @Override
     public Object[][] dataProvider() {

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/ServiceDeclarationTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/ServiceDeclarationTest.java
@@ -17,6 +17,7 @@
  */
 package org.ballerinalang.langserver.completion;
 
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 
 import java.util.Collections;
@@ -28,6 +29,13 @@ import java.util.List;
  * @since 2.0.0
  */
 public class ServiceDeclarationTest extends CompletionTest {
+
+    @BeforeClass
+    @Override
+    public void init() throws InterruptedException {
+        preLoadAndInit();
+    }
+    
     @DataProvider(name = "completion-data-provider")
     @Override
     public Object[][] dataProvider() {

--- a/language-server/modules/langserver-core/src/test/resources/completion/class_def/config/config15.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/class_def/config/config15.json
@@ -141,30 +141,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "service/http",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "A",
-      "filterText": "service_http",
-      "insertText": "service /${1} on new http:Listener(8080) {\n\tresource function ${2:get} ${3:getResource}(http:Caller ${4:caller}, http:Request ${5:req}) {\n\t\t\n\t}\n}",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/http;\n"
-        }
-      ]
-    },
-    {
       "label": "configurable",
       "kind": "Keyword",
       "detail": "Keyword",
@@ -678,6 +654,40 @@
       "sortText": "E",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "service on module1:Listener",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "E",
+      "filterText": "service_module1_Listener",
+      "insertText": "service ${1} on new module1:Listener(${2:0}) {\n    ${3}\n}\n",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
+    },
+    {
+      "label": "service on test:MockListener",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "E",
+      "filterText": "service_test_MockListener",
+      "insertText": "service ${1} on new test:MockListener(${2:0}) {\n    ${3}\n}\n",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.test;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/class_def/config/config22.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/class_def/config/config22.json
@@ -141,30 +141,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "service/http",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "A",
-      "filterText": "service_http",
-      "insertText": "service /${1} on new http:Listener(8080) {\n\tresource function ${2:get} ${3:getResource}(http:Caller ${4:caller}, http:Request ${5:req}) {\n\t\t\n\t}\n}",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/http;\n"
-        }
-      ]
-    },
-    {
       "label": "configurable",
       "kind": "Keyword",
       "detail": "Keyword",
@@ -701,6 +677,54 @@
       "sortText": "E",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "service on test:MockListener",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "E",
+      "filterText": "service_test_MockListener",
+      "insertText": "service ${1} on new test:MockListener(${2:0}) {\n    ${3}\n}\n",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.test;\n"
+        }
+      ]
+    },
+    {
+      "label": "service on module1:Listener",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "E",
+      "filterText": "service_module1_Listener",
+      "insertText": "service ${1} on new module1:Listener(${2:0}) {\n    ${3}\n}\n",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/module1;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/enum_decl_ctx/config/config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/enum_decl_ctx/config/config5.json
@@ -141,30 +141,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "service/http",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "A",
-      "filterText": "service_http",
-      "insertText": "service /${1} on new http:Listener(8080) {\n\tresource function ${2:get} ${3:getResource}(http:Caller ${4:caller}, http:Request ${5:req}) {\n\t\t\n\t}\n}",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/http;\n"
-        }
-      ]
-    },
-    {
       "label": "configurable",
       "kind": "Keyword",
       "detail": "Keyword",
@@ -686,6 +662,40 @@
       "sortText": "E",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "service on module1:Listener",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "E",
+      "filterText": "service_module1_Listener",
+      "insertText": "service ${1} on new module1:Listener(${2:0}) {\n    ${3}\n}\n",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
+    },
+    {
+      "label": "service on test:MockListener",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "E",
+      "filterText": "service_test_MockListener",
+      "insertText": "service ${1} on new test:MockListener(${2:0}) {\n    ${3}\n}\n",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.test;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/module_part_context/config/config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/module_part_context/config/config1.json
@@ -141,30 +141,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "service/http",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "A",
-      "filterText": "service_http",
-      "insertText": "service /${1} on new http:Listener(8080) {\n\tresource function ${2:get} ${3:getResource}(http:Caller ${4:caller}, http:Request ${5:req}) {\n\t\t\n\t}\n}",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/http;\n"
-        }
-      ]
-    },
-    {
       "label": "configurable",
       "kind": "Keyword",
       "detail": "Keyword",
@@ -685,6 +661,54 @@
       "sortText": "E",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "service on test:MockListener",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "E",
+      "filterText": "service_test_MockListener",
+      "insertText": "service ${1} on new test:MockListener(${2:0}) {\n    ${3}\n}\n",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.test;\n"
+        }
+      ]
+    },
+    {
+      "label": "service on module1:Listener",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "E",
+      "filterText": "service_module1_Listener",
+      "insertText": "service ${1} on new module1:Listener(${2:0}) {\n    ${3}\n}\n",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/module1;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/module_part_context/config/config14.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/module_part_context/config/config14.json
@@ -1,10 +1,19 @@
 {
   "position": {
-    "line": 2,
-    "character": 7
+    "line": 8,
+    "character": 5
   },
-  "source": "class_def/source/source14.bal",
+  "source": "module_part_context/source/lsproject/main.bal",
   "items": [
+    {
+      "label": "import",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "B",
+      "filterText": "import",
+      "insertText": "import ",
+      "insertTextFormat": "Snippet"
+    },
     {
       "label": "type",
       "kind": "Keyword",
@@ -12,6 +21,15 @@
       "sortText": "B",
       "filterText": "type",
       "insertText": "type ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "public",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "B",
+      "filterText": "public",
+      "insertText": "public ",
       "insertTextFormat": "Snippet"
     },
     {
@@ -240,17 +258,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "StrandData",
-      "kind": "Struct",
-      "detail": "Record",
-      "documentation": {
-        "left": "Describes Strand execution details for the runtime.\n"
-      },
-      "sortText": "D",
-      "insertText": "StrandData",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "Thread",
       "kind": "TypeParameter",
       "detail": "Union",
@@ -259,11 +266,14 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "testClass",
-      "kind": "Interface",
-      "detail": "Class",
+      "label": "StrandData",
+      "kind": "Struct",
+      "detail": "Record",
+      "documentation": {
+        "left": "Describes Strand execution details for the runtime.\n"
+      },
       "sortText": "D",
-      "insertText": "testClass",
+      "insertText": "StrandData",
       "insertTextFormat": "Snippet"
     },
     {
@@ -407,29 +417,73 @@
       "kind": "Module",
       "detail": "Module",
       "sortText": "C",
+      "filterText": "module1",
       "insertText": "module1",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "ballerina/lang.test",
+      "label": "mod1",
       "kind": "Module",
       "detail": "Module",
       "sortText": "C",
-      "insertText": "test",
+      "filterText": "mod1",
+      "insertText": "mod1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "module2",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "filterText": "module2",
+      "insertText": "module2",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.runtime",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "filterText": "runtime",
+      "insertText": "runtime",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
           "range": {
             "start": {
-              "line": 0,
+              "line": 2,
               "character": 0
             },
             "end": {
-              "line": 0,
+              "line": 2,
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.test;\n"
+          "newText": "import ballerina/lang.runtime;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "filterText": "value",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 2,
+              "character": 0
+            },
+            "end": {
+              "line": 2,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
         }
       ]
     },
@@ -438,17 +492,18 @@
       "kind": "Module",
       "detail": "Module",
       "sortText": "C",
+      "filterText": "array",
       "insertText": "array",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
           "range": {
             "start": {
-              "line": 0,
+              "line": 2,
               "character": 0
             },
             "end": {
-              "line": 0,
+              "line": 2,
               "character": 0
             }
           },
@@ -461,17 +516,18 @@
       "kind": "Module",
       "detail": "Module",
       "sortText": "C",
+      "filterText": "java",
       "insertText": "java",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
           "range": {
             "start": {
-              "line": 0,
+              "line": 2,
               "character": 0
             },
             "end": {
-              "line": 0,
+              "line": 2,
               "character": 0
             }
           },
@@ -480,48 +536,26 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
+      "label": "ballerina/lang.test",
       "kind": "Module",
       "detail": "Module",
       "sortText": "C",
-      "insertText": "value",
+      "filterText": "test",
+      "insertText": "test",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
           "range": {
             "start": {
-              "line": 0,
+              "line": 2,
               "character": 0
             },
             "end": {
-              "line": 0,
+              "line": 2,
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.value;\n"
-        }
-      ]
-    },
-    {
-      "label": "ballerina/lang.runtime",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "C",
-      "insertText": "runtime",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.runtime;\n"
+          "newText": "import ballerina/lang.test;\n"
         }
       ]
     },
@@ -636,6 +670,124 @@
       "sortText": "E",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "lsproject.module3",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "filterText": "",
+      "insertText": "module3",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 2,
+              "character": 0
+            },
+            "end": {
+              "line": 2,
+              "character": 0
+            }
+          },
+          "newText": "import lsproject.module3;\n"
+        }
+      ]
+    },
+    {
+      "label": "service on module1:Listener",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "E",
+      "filterText": "service_module1_Listener",
+      "insertText": "service ${1} on new module1:Listener(${2:0}) {\n    ${3}\n}\n",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
+    },
+    {
+      "label": "service on mod1:Listener",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "E",
+      "filterText": "service_mod1_Listener",
+      "insertText": "service ${1} on new mod1:Listener() {\n\n    remote function method1() {\n        ${2}\n    }\n\n    function method2() returns string|error {\n        return ${3:\"\"};\n    }\n\n    function method3($CompilationError$|int arg1) returns $CompilationError$ {\n        ${4}\n    }\n\n}\n",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
+    },
+    {
+      "label": "service on test:MockListener",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "E",
+      "filterText": "service_test_MockListener",
+      "insertText": "service ${1} on new test:MockListener(${2:0}) {\n    ${3}\n}\n",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 2,
+              "character": 0
+            },
+            "end": {
+              "line": 2,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.test;\n"
+        }
+      ]
+    },
+    {
+      "label": "Service",
+      "kind": "Interface",
+      "detail": "Object",
+      "sortText": "D",
+      "insertText": "Service",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Listener",
+      "kind": "Interface",
+      "detail": "Class",
+      "sortText": "D",
+      "insertText": "Listener",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "service on Listener",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "E",
+      "filterText": "service_Listener",
+      "insertText": "service ${1} on new Listener() {\n\n    remote function method1() {\n        ${2}\n    }\n\n    function method2() returns string|error {\n        return ${3:\"\"};\n    }\n\n    function method3($CompilationError$|int arg1) returns $CompilationError$ {\n        ${4}\n    }\n\n}\n",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
+    },
+    {
+      "label": "service on module3:Listener",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "E",
+      "filterText": "service_module3_Listener",
+      "insertText": "service ${1} on new module3:Listener() {\n\n    remote function method1() {\n        ${2}\n    }\n\n    function method2() returns string|error {\n        return ${3:\"\"};\n    }\n\n    function method3($CompilationError$|int arg1) returns $CompilationError$ {\n        ${4}\n    }\n\n}\n",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 2,
+              "character": 0
+            },
+            "end": {
+              "line": 2,
+              "character": 0
+            }
+          },
+          "newText": "import lsproject.module3;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/module_part_context/config/config15.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/module_part_context/config/config15.json
@@ -1,10 +1,19 @@
 {
   "position": {
-    "line": 2,
-    "character": 7
+    "line": 34,
+    "character": 4
   },
-  "source": "class_def/source/source14.bal",
+  "source": "module_part_context/source/source14.bal",
   "items": [
+    {
+      "label": "import",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "B",
+      "filterText": "import",
+      "insertText": "import ",
+      "insertTextFormat": "Snippet"
+    },
     {
       "label": "type",
       "kind": "Keyword",
@@ -12,6 +21,15 @@
       "sortText": "B",
       "filterText": "type",
       "insertText": "type ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "public",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "B",
+      "filterText": "public",
+      "insertText": "public ",
       "insertTextFormat": "Snippet"
     },
     {
@@ -240,6 +258,22 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "Thread",
+      "kind": "TypeParameter",
+      "detail": "Union",
+      "sortText": "D",
+      "insertText": "Thread",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Service",
+      "kind": "Interface",
+      "detail": "Object",
+      "sortText": "D",
+      "insertText": "Service",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "StrandData",
       "kind": "Struct",
       "detail": "Record",
@@ -251,19 +285,11 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "Thread",
-      "kind": "TypeParameter",
-      "detail": "Union",
-      "sortText": "D",
-      "insertText": "Thread",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "testClass",
+      "label": "Listener",
       "kind": "Interface",
       "detail": "Class",
       "sortText": "D",
-      "insertText": "testClass",
+      "insertText": "Listener",
       "insertTextFormat": "Snippet"
     },
     {
@@ -407,15 +433,17 @@
       "kind": "Module",
       "detail": "Module",
       "sortText": "C",
+      "filterText": "module1",
       "insertText": "module1",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "ballerina/lang.test",
+      "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
       "sortText": "C",
-      "insertText": "test",
+      "filterText": "runtime",
+      "insertText": "runtime",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -429,7 +457,31 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.test;\n"
+          "newText": "import ballerina/lang.runtime;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "filterText": "value",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
         }
       ]
     },
@@ -438,6 +490,7 @@
       "kind": "Module",
       "detail": "Module",
       "sortText": "C",
+      "filterText": "array",
       "insertText": "array",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -461,6 +514,7 @@
       "kind": "Module",
       "detail": "Module",
       "sortText": "C",
+      "filterText": "java",
       "insertText": "java",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -480,11 +534,12 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
+      "label": "ballerina/lang.test",
       "kind": "Module",
       "detail": "Module",
       "sortText": "C",
-      "insertText": "value",
+      "filterText": "test",
+      "insertText": "test",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -498,30 +553,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.value;\n"
-        }
-      ]
-    },
-    {
-      "label": "ballerina/lang.runtime",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "C",
-      "insertText": "runtime",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.runtime;\n"
+          "newText": "import ballerina/lang.test;\n"
         }
       ]
     },
@@ -636,6 +668,50 @@
       "sortText": "E",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "service on module1:Listener",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "E",
+      "filterText": "service_module1_Listener",
+      "insertText": "service ${1} on new module1:Listener(${2:0}) {\n    ${3}\n}\n",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
+    },
+    {
+      "label": "service on test:MockListener",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "E",
+      "filterText": "service_test_MockListener",
+      "insertText": "service ${1} on new test:MockListener(${2:0}) {\n    ${3}\n}\n",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.test;\n"
+        }
+      ]
+    },
+    {
+      "label": "service on Listener",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "E",
+      "filterText": "service_Listener",
+      "insertText": "service ${1} on new Listener() {\n\n    remote function method1() {\n        ${2}\n    }\n\n}\n",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/module_part_context/config/config16.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/module_part_context/config/config16.json
@@ -1,10 +1,19 @@
 {
   "position": {
-    "line": 2,
-    "character": 7
+    "line": 7,
+    "character": 5
   },
-  "source": "class_def/source/source14.bal",
+  "source": "module_part_context/source/lsproject/modules/module2/module2.bal",
   "items": [
+    {
+      "label": "import",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "B",
+      "filterText": "import",
+      "insertText": "import ",
+      "insertTextFormat": "Snippet"
+    },
     {
       "label": "type",
       "kind": "Keyword",
@@ -12,6 +21,15 @@
       "sortText": "B",
       "filterText": "type",
       "insertText": "type ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "public",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "B",
+      "filterText": "public",
+      "insertText": "public ",
       "insertTextFormat": "Snippet"
     },
     {
@@ -240,17 +258,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "StrandData",
-      "kind": "Struct",
-      "detail": "Record",
-      "documentation": {
-        "left": "Describes Strand execution details for the runtime.\n"
-      },
-      "sortText": "D",
-      "insertText": "StrandData",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "Thread",
       "kind": "TypeParameter",
       "detail": "Union",
@@ -259,11 +266,14 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "testClass",
-      "kind": "Interface",
-      "detail": "Class",
+      "label": "StrandData",
+      "kind": "Struct",
+      "detail": "Record",
+      "documentation": {
+        "left": "Describes Strand execution details for the runtime.\n"
+      },
       "sortText": "D",
-      "insertText": "testClass",
+      "insertText": "StrandData",
       "insertTextFormat": "Snippet"
     },
     {
@@ -407,15 +417,17 @@
       "kind": "Module",
       "detail": "Module",
       "sortText": "C",
+      "filterText": "module1",
       "insertText": "module1",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "ballerina/lang.test",
+      "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
       "sortText": "C",
-      "insertText": "test",
+      "filterText": "runtime",
+      "insertText": "runtime",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -429,7 +441,31 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.test;\n"
+          "newText": "import ballerina/lang.runtime;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "filterText": "value",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
         }
       ]
     },
@@ -438,6 +474,7 @@
       "kind": "Module",
       "detail": "Module",
       "sortText": "C",
+      "filterText": "array",
       "insertText": "array",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -461,6 +498,7 @@
       "kind": "Module",
       "detail": "Module",
       "sortText": "C",
+      "filterText": "java",
       "insertText": "java",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -480,11 +518,12 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
+      "label": "ballerina/lang.test",
       "kind": "Module",
       "detail": "Module",
       "sortText": "C",
-      "insertText": "value",
+      "filterText": "test",
+      "insertText": "test",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -498,30 +537,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.value;\n"
-        }
-      ]
-    },
-    {
-      "label": "ballerina/lang.runtime",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "C",
-      "insertText": "runtime",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.runtime;\n"
+          "newText": "import ballerina/lang.test;\n"
         }
       ]
     },
@@ -636,6 +652,136 @@
       "sortText": "E",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "lsproject.module3",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "filterText": "",
+      "insertText": "module3",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import lsproject.module3;\n"
+        }
+      ]
+    },
+    {
+      "label": "service on module1:Listener",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "E",
+      "filterText": "service_module1_Listener",
+      "insertText": "service ${1} on new module1:Listener(${2:0}) {\n    ${3}\n}\n",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
+    },
+    {
+      "label": "service on test:MockListener",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "E",
+      "filterText": "service_test_MockListener",
+      "insertText": "service ${1} on new test:MockListener(${2:0}) {\n    ${3}\n}\n",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.test;\n"
+        }
+      ]
+    },
+    {
+      "label": "service on module3:Listener",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "E",
+      "filterText": "service_module3_Listener",
+      "insertText": "service ${1} on new module3:Listener() {\n\n    remote function method1() {\n        ${2}\n    }\n\n    function method2() returns string|error {\n        return ${3:\"\"};\n    }\n\n    function method3($CompilationError$|int arg1) returns $CompilationError$ {\n        ${4}\n    }\n\n}\n",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import lsproject.module3;\n"
+        }
+      ]
+    },
+    {
+      "label": "lsproject.module1",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "filterText": "module11",
+      "insertText": "module11",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import lsproject.module1 as module11 ;\n"
+        }
+      ]
+    },
+    {
+      "label": "service on module1:Listener",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "E",
+      "filterText": "service_module1_Listener",
+      "insertText": "service ${1} on new module11:Listener() {\n\n    remote function method1() {\n        ${2}\n    }\n\n    function method2() returns string|error {\n        return ${3:\"\"};\n    }\n\n    function method3($CompilationError$|int arg1) returns $CompilationError$ {\n        ${4}\n    }\n\n}\n",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import lsproject.module1 as module11 ;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/module_part_context/config/config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/module_part_context/config/config2.json
@@ -141,30 +141,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "service/http",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "A",
-      "filterText": "service_http",
-      "insertText": "service /${1} on new http:Listener(8080) {\n\tresource function ${2:get} ${3:getResource}(http:Caller ${4:caller}, http:Request ${5:req}) {\n\t\t\n\t}\n}",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/http;\n"
-        }
-      ]
-    },
-    {
       "label": "configurable",
       "kind": "Keyword",
       "detail": "Keyword",
@@ -685,6 +661,54 @@
       "sortText": "E",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "service on test:MockListener",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "E",
+      "filterText": "service_test_MockListener",
+      "insertText": "service ${1} on new test:MockListener(${2:0}) {\n    ${3}\n}\n",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.test;\n"
+        }
+      ]
+    },
+    {
+      "label": "service on module1:Listener",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "E",
+      "filterText": "service_module1_Listener",
+      "insertText": "service ${1} on new module1:Listener(${2:0}) {\n    ${3}\n}\n",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/module1;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/module_part_context/config/config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/module_part_context/config/config3.json
@@ -141,30 +141,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "service/http",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "A",
-      "filterText": "service_http",
-      "insertText": "service /${1} on new http:Listener(8080) {\n\tresource function ${2:get} ${3:getResource}(http:Caller ${4:caller}, http:Request ${5:req}) {\n\t\t\n\t}\n}",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/http;\n"
-        }
-      ]
-    },
-    {
       "label": "configurable",
       "kind": "Keyword",
       "detail": "Keyword",
@@ -685,6 +661,54 @@
       "sortText": "E",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "service on test:MockListener",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "E",
+      "filterText": "service_test_MockListener",
+      "insertText": "service ${1} on new test:MockListener(${2:0}) {\n    ${3}\n}\n",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.test;\n"
+        }
+      ]
+    },
+    {
+      "label": "service on module1:Listener",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "E",
+      "filterText": "service_module1_Listener",
+      "insertText": "service ${1} on new module1:Listener(${2:0}) {\n    ${3}\n}\n",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/module1;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/module_part_context/config/config6.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/module_part_context/config/config6.json
@@ -141,30 +141,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "service/http",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "A",
-      "filterText": "service_http",
-      "insertText": "service /${1} on new http:Listener(8080) {\n\tresource function ${2:get} ${3:getResource}(http:Caller ${4:caller}, http:Request ${5:req}) {\n\t\t\n\t}\n}",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/http;\n"
-        }
-      ]
-    },
-    {
       "label": "configurable",
       "kind": "Keyword",
       "detail": "Keyword",
@@ -670,6 +646,40 @@
       "sortText": "E",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "service on module1:Listener",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "E",
+      "filterText": "service_module1_Listener",
+      "insertText": "service ${1} on new module1:Listener(${2:0}) {\n    ${3}\n}\n",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
+    },
+    {
+      "label": "service on test:MockListener",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "E",
+      "filterText": "service_test_MockListener",
+      "insertText": "service ${1} on new test:MockListener(${2:0}) {\n    ${3}\n}\n",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.test;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/module_part_context/source/lsproject/Ballerina.toml
+++ b/language-server/modules/langserver-core/src/test/resources/completion/module_part_context/source/lsproject/Ballerina.toml
@@ -1,0 +1,2 @@
+[build-options]
+observabilityIncluded = true

--- a/language-server/modules/langserver-core/src/test/resources/completion/module_part_context/source/lsproject/main.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/module_part_context/source/lsproject/main.bal
@@ -1,0 +1,38 @@
+import ballerina/module1;
+import lsproject.module1 as mod1;
+import lsproject.module2;
+
+public function main() {
+    
+}
+
+servi
+
+public type Service service object {
+    remote function method1();
+    function method2() returns string|error;
+    function method3(MyType|int arg1) returns MyType; 
+};
+
+public class Listener {
+
+    public function attach(Service s, string|string[]? name = ()) returns error? {
+          
+    }
+
+    public function detach(Service s) returns error? {
+
+    }
+
+    public function 'start() returns error? {
+
+    }
+
+    public function gracefulStop() returns error? {
+
+    }
+
+    public function immediateStop() returns error? {
+
+    }
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/module_part_context/source/lsproject/modules/module1/module1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/module_part_context/source/lsproject/modules/module1/module1.bal
@@ -1,0 +1,28 @@
+public type Service service object {
+    remote function method1();
+    function method2() returns string|error;
+    function method3(MyType|int arg1) returns MyType; 
+};
+
+public class Listener {
+
+    public function attach(Service s, string|string[]? name = ()) returns error? {
+          
+    }
+
+    public function detach(Service s) returns error? {
+
+    }
+
+    public function 'start() returns error? {
+
+    }
+
+    public function gracefulStop() returns error? {
+
+    }
+
+    public function immediateStop() returns error? {
+
+    }
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/module_part_context/source/lsproject/modules/module2/module2.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/module_part_context/source/lsproject/modules/module2/module2.bal
@@ -1,0 +1,8 @@
+import ballerina/module1;
+import lsproject.module1;
+
+public function main() {
+    
+}
+
+servi

--- a/language-server/modules/langserver-core/src/test/resources/completion/module_part_context/source/lsproject/modules/module3/module3.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/module_part_context/source/lsproject/modules/module3/module3.bal
@@ -1,0 +1,28 @@
+public type Service service object {
+    remote function method1();
+    function method2() returns string|error;
+    function method3(MyType|int arg1) returns MyType; 
+};
+
+public class Listener {
+
+    public function attach(Service s, string|string[]? name = ()) returns error? {
+          
+    }
+
+    public function detach(Service s) returns error? {
+
+    }
+
+    public function 'start() returns error? {
+
+    }
+
+    public function gracefulStop() returns error? {
+
+    }
+
+    public function immediateStop() returns error? {
+
+    }
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/module_part_context/source/source14.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/module_part_context/source/source14.bal
@@ -1,0 +1,35 @@
+import ballerina/module1;
+
+
+public type Service service object {
+    remote function method1();
+};
+
+public class Listener {
+
+    public function attach(Service s, string|string[]? name = ()) returns error? {
+          
+    }
+
+    public function detach(Service s) returns error? {
+
+    }
+
+    public function 'start() returns error? {
+
+    }
+
+    public function gracefulStop() returns error? {
+
+    }
+
+    public function immediateStop() returns error? {
+
+    }
+}
+
+public function main() {
+    
+}
+
+serv

--- a/language-server/modules/langserver-core/src/test/resources/completion/service_decl/config/config17.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/service_decl/config/config17.json
@@ -141,30 +141,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "service/http",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "A",
-      "filterText": "service_http",
-      "insertText": "service /${1} on new http:Listener(8080) {\n\tresource function ${2:get} ${3:getResource}(http:Caller ${4:caller}, http:Request ${5:req}) {\n\t\t\n\t}\n}",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/http;\n"
-        }
-      ]
-    },
-    {
       "label": "configurable",
       "kind": "Keyword",
       "detail": "Keyword",
@@ -678,6 +654,40 @@
       "sortText": "E",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "service on module1:Listener",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "E",
+      "filterText": "service_module1_Listener",
+      "insertText": "service ${1} on new module1:Listener(${2:0}) {\n    ${3}\n}\n",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
+    },
+    {
+      "label": "service on test:MockListener",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "E",
+      "filterText": "service_test_MockListener",
+      "insertText": "service ${1} on new test:MockListener(${2:0}) {\n    ${3}\n}\n",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.test;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/service_decl/config/config18.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/service_decl/config/config18.json
@@ -141,30 +141,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "service/http",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "A",
-      "filterText": "service_http",
-      "insertText": "service /${1} on new http:Listener(8080) {\n\tresource function ${2:get} ${3:getResource}(http:Caller ${4:caller}, http:Request ${5:req}) {\n\t\t\n\t}\n}",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/http;\n"
-        }
-      ]
-    },
-    {
       "label": "configurable",
       "kind": "Keyword",
       "detail": "Keyword",
@@ -678,6 +654,40 @@
       "sortText": "E",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "service on module1:Listener",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "E",
+      "filterText": "service_module1_Listener",
+      "insertText": "service ${1} on new module1:Listener(${2:0}) {\n    ${3}\n}\n",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
+    },
+    {
+      "label": "service on test:MockListener",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "E",
+      "filterText": "service_test_MockListener",
+      "insertText": "service ${1} on new test:MockListener(${2:0}) {\n    ${3}\n}\n",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.test;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/service_decl/config/config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/service_decl/config/config7.json
@@ -141,30 +141,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "service/http",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "A",
-      "filterText": "service_http",
-      "insertText": "service /${1} on new http:Listener(8080) {\n\tresource function ${2:get} ${3:getResource}(http:Caller ${4:caller}, http:Request ${5:req}) {\n\t\t\n\t}\n}",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/http;\n"
-        }
-      ]
-    },
-    {
       "label": "configurable",
       "kind": "Keyword",
       "detail": "Keyword",
@@ -678,6 +654,40 @@
       "sortText": "E",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "service on module1:Listener",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "E",
+      "filterText": "service_module1_Listener",
+      "insertText": "service ${1} on new module1:Listener(${2:0}) {\n    ${3}\n}\n",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
+    },
+    {
+      "label": "service on test:MockListener",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "E",
+      "filterText": "service_test_MockListener",
+      "insertText": "service ${1} on new test:MockListener(${2:0}) {\n    ${3}\n}\n",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.test;\n"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Purpose
$subject to revamp the auto-completion around service typing. With this improvement, a service templates is provided as a completion item for each listener class symbol that is either visible or can be imported to the current module as depicted below.

Fixes #33263
Fixes #33191
Fixes #33133

## Approach
Add a service template generator to filter and create completion items for each listener class symbol.

## Samples
![139797962-18ba53c5-cc79-4227-8d44-ddc3f179f9ee](https://user-images.githubusercontent.com/35211477/141409071-3cda13ba-ee6e-4bb0-9073-83f5dd93df12.gif)


## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
