### PR TITLE
Introduce Project.clearCaches and Project.duplicate

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/DocumentContext.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/DocumentContext.java
@@ -56,9 +56,9 @@ class DocumentContext {
     private Set<ModuleLoadRequest> moduleLoadRequests;
     private BLangCompilationUnit compilationUnit;
     private NodeCloner nodeCloner;
-    private DocumentId documentId;
-    private String name;
-    private String content;
+    private final DocumentId documentId;
+    private final String name;
+    private final String content;
 
     private DocumentContext(DocumentId documentId, String name, String content) {
         this.documentId = documentId;
@@ -176,5 +176,9 @@ class DocumentContext {
         for (Diagnostic syntaxDiagnostic : tree.diagnostics()) {
             dlog.logDiagnostic(pkgID, syntaxDiagnostic);
         }
+    }
+
+    DocumentContext duplicate() {
+        return new DocumentContext(this.documentId, this.name, syntaxTree().toSourceCode());
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ModuleContext.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ModuleContext.java
@@ -495,4 +495,20 @@ class ModuleContext {
     Optional<MdDocumentContext> moduleMdContext() {
         return Optional.ofNullable(this.moduleMdContext);
     }
+
+    ModuleContext duplicate() {
+        Map<DocumentId, DocumentContext> srcDocContextMap = new HashMap<>();
+        for (DocumentId documentId : this.srcDocumentIds()) {
+            DocumentContext documentContext = this.documentContext(documentId);
+            srcDocContextMap.put(documentId, documentContext.duplicate());
+        }
+
+        Map<DocumentId, DocumentContext> testDocContextMap = new HashMap<>();
+        for (DocumentId documentId : this.testSrcDocumentIds()) {
+            DocumentContext documentContext = this.documentContext(documentId);
+            testDocContextMap.put(documentId, documentContext.duplicate());
+        }
+        return new ModuleContext(this.project, this.moduleId, this.moduleDescriptor, this.isDefaultModule,
+                srcDocContextMap, testDocContextMap, this.moduleMdContext().orElse(null), this.moduleDescDependencies);
+    }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ModuleContext.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ModuleContext.java
@@ -496,7 +496,7 @@ class ModuleContext {
         return Optional.ofNullable(this.moduleMdContext);
     }
 
-    ModuleContext duplicate() {
+    ModuleContext duplicate(Project project) {
         Map<DocumentId, DocumentContext> srcDocContextMap = new HashMap<>();
         for (DocumentId documentId : this.srcDocumentIds()) {
             DocumentContext documentContext = this.documentContext(documentId);
@@ -508,7 +508,7 @@ class ModuleContext {
             DocumentContext documentContext = this.documentContext(documentId);
             testDocContextMap.put(documentId, documentContext.duplicate());
         }
-        return new ModuleContext(this.project, this.moduleId, this.moduleDescriptor, this.isDefaultModule,
+        return new ModuleContext(project, this.moduleId, this.moduleDescriptor, this.isDefaultModule,
                 srcDocContextMap, testDocContextMap, this.moduleMdContext().orElse(null), this.moduleDescDependencies);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Package.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Package.java
@@ -210,8 +210,8 @@ public class Package {
         return this.packageMd;
     }
 
-    Package duplicate() {
-        return new Package(packageContext.duplicate(), this.project);
+    Package duplicate(Project project) {
+        return new Package(packageContext.duplicate(project), project);
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Package.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Package.java
@@ -210,6 +210,10 @@ public class Package {
         return this.packageMd;
     }
 
+    Package duplicate() {
+        return new Package(packageContext.duplicate(), this.project);
+    }
+
     /**
      * Run {@code CodeGenerator} tasks in engaged {@code CompilerPlugin}s.
      * <p>

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageContext.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageContext.java
@@ -244,7 +244,8 @@ class PackageContext {
     }
 
     PackageResolution getResolution(CompilationOptions compilationOptions) {
-        return PackageResolution.from(this, compilationOptions);
+        packageResolution = PackageResolution.from(this, compilationOptions);
+        return packageResolution;
     }
 
     Collection<PackageDependency> packageDependencies() {
@@ -291,5 +292,18 @@ class PackageContext {
                 packageDependencies.add(moduleDependency.packageDependency());
             }
         }
+    }
+
+    PackageContext duplicate() {
+        Map<ModuleId, ModuleContext> duplicatedModuleContextMap = new HashMap<>();
+        for (ModuleId moduleId : this.moduleIds) {
+            ModuleContext moduleContext = this.moduleContext(moduleId);
+            duplicatedModuleContextMap.put(moduleId, moduleContext.duplicate());
+        }
+
+        return new PackageContext(this.project, this.packageId, this.packageManifest,
+                this.dependencyManifest, this.ballerinaTomlContext, this.dependenciesTomlContext,
+                this.cloudTomlContext, this.compilerPluginTomlContext, this.packageMdContext,
+                this.compilationOptions, duplicatedModuleContextMap, this.pkgDescDependencyGraph);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageContext.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageContext.java
@@ -294,14 +294,14 @@ class PackageContext {
         }
     }
 
-    PackageContext duplicate() {
+    PackageContext duplicate(Project project) {
         Map<ModuleId, ModuleContext> duplicatedModuleContextMap = new HashMap<>();
         for (ModuleId moduleId : this.moduleIds) {
             ModuleContext moduleContext = this.moduleContext(moduleId);
-            duplicatedModuleContextMap.put(moduleId, moduleContext.duplicate());
+            duplicatedModuleContextMap.put(moduleId, moduleContext.duplicate(project));
         }
 
-        return new PackageContext(this.project, this.packageId, this.packageManifest,
+        return new PackageContext(project, this.packageId, this.packageManifest,
                 this.dependencyManifest, this.ballerinaTomlContext, this.dependenciesTomlContext,
                 this.cloudTomlContext, this.compilerPluginTomlContext, this.packageMdContext,
                 this.compilationOptions, duplicatedModuleContextMap, this.pkgDescDependencyGraph);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Project.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Project.java
@@ -18,6 +18,7 @@
 package io.ballerina.projects;
 
 import io.ballerina.projects.environment.ProjectEnvironment;
+import org.wso2.ballerinalang.compiler.PackageCache;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.CompilerOptions;
 
@@ -98,6 +99,18 @@ public abstract class Project {
         CompilerContext compilerContext = this.projectEnvironmentContext().getService(CompilerContext.class);
         CompilerOptions options = CompilerOptions.getInstance(compilerContext);
         options.put(PROJECT_DIR, this.sourceRoot().toAbsolutePath().toString());
+    }
+
+    /**
+     * Refresh the project to clear compilation caches.
+     */
+    public void refresh() {
+        Package clone = this.currentPackage().duplicate();
+        setCurrentPackage(clone);
+        CompilerContext compilerContext = this.projectEnvironmentContext()
+                .getService(CompilerContext.class);
+        PackageCache packageCache = PackageCache.getInstance(compilerContext);
+        packageCache.flush();
     }
 
     public abstract DocumentId documentId(Path file);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Project.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Project.java
@@ -105,12 +105,19 @@ public abstract class Project {
      * Refresh the project to clear compilation caches.
      */
     public void refresh() {
-        Package clone = this.currentPackage().duplicate();
-        setCurrentPackage(clone);
+        cloneProject(this);
         CompilerContext compilerContext = this.projectEnvironmentContext()
                 .getService(CompilerContext.class);
         PackageCache packageCache = PackageCache.getInstance(compilerContext);
         packageCache.flush();
+    }
+
+    public abstract Project duplicate();
+
+    protected Project cloneProject(Project project) {
+        Package clone = this.currentPackage.duplicate(project);
+        project.setCurrentPackage(clone);
+        return project;
     }
 
     public abstract DocumentId documentId(Path file);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Project.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Project.java
@@ -102,9 +102,13 @@ public abstract class Project {
     }
 
     /**
-     * Refresh the project to clear compilation caches.
+     * Clears all caches of this project.
+     *
+     * The current content and the structure will be preserved. In-memory caches
+     * (i.e. package resolution caches, compilation caches)
+     * generated during project compilation will be discarded.
      */
-    public void refresh() {
+    public void clearCaches() {
         cloneProject(this);
         CompilerContext compilerContext = this.projectEnvironmentContext()
                 .getService(CompilerContext.class);
@@ -112,6 +116,14 @@ public abstract class Project {
         packageCache.flush();
     }
 
+    /**
+     * Creates a new Project instance which has the same structure as this Project.
+     *
+     * The new project will have the same structure and content as this. The caches of
+     * this project generated during project compilation will not be copied.
+     *
+     * @return The new Project instance.
+     */
     public abstract Project duplicate();
 
     protected Project cloneProject(Project project) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/bala/BalaProject.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/bala/BalaProject.java
@@ -29,6 +29,7 @@ import io.ballerina.projects.ProjectException;
 import io.ballerina.projects.ProjectKind;
 import io.ballerina.projects.internal.BalaFiles;
 import io.ballerina.projects.internal.PackageConfigCreator;
+import io.ballerina.projects.repos.TempDirCompilationCache;
 import io.ballerina.projects.util.ProjectConstants;
 import io.ballerina.projects.util.ProjectPaths;
 
@@ -60,6 +61,14 @@ public class BalaProject extends Project {
     private BalaProject(ProjectEnvironmentBuilder environmentBuilder, Path balaPath) {
         super(ProjectKind.BALA_PROJECT, balaPath, environmentBuilder);
         this.platform = BalaFiles.readPackageJson(balaPath).getPlatform();
+    }
+
+    @Override
+    public Project duplicate() {
+        ProjectEnvironmentBuilder projectEnvironmentBuilder = ProjectEnvironmentBuilder.getDefaultBuilder();
+        projectEnvironmentBuilder.addCompilationCacheFactory(TempDirCompilationCache::from);
+        BalaProject balaProject = new BalaProject(projectEnvironmentBuilder, this.sourceRoot);
+        return cloneProject(balaProject);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/directory/BuildProject.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/directory/BuildProject.java
@@ -156,6 +156,13 @@ public class BuildProject extends Project {
     }
 
     @Override
+    public Project duplicate() {
+        BuildProject buildProject = new BuildProject(
+                ProjectEnvironmentBuilder.getDefaultBuilder(), this.sourceRoot, buildOptions());
+        return cloneProject(buildProject);
+    }
+
+    @Override
     public DocumentId documentId(Path file) {
         if (isFilePathInProject(file)) {
             Path parent = Optional.of(file.toAbsolutePath().getParent()).get();

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/directory/BuildProject.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/directory/BuildProject.java
@@ -157,8 +157,9 @@ public class BuildProject extends Project {
 
     @Override
     public Project duplicate() {
+        BuildOptions duplicateBuildOptions = new BuildOptionsBuilder().build().acceptTheirs(buildOptions());
         BuildProject buildProject = new BuildProject(
-                ProjectEnvironmentBuilder.getDefaultBuilder(), this.sourceRoot, buildOptions());
+                ProjectEnvironmentBuilder.getDefaultBuilder(), this.sourceRoot, duplicateBuildOptions);
         return cloneProject(buildProject);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/directory/SingleFileProject.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/directory/SingleFileProject.java
@@ -73,6 +73,13 @@ public class SingleFileProject extends Project {
     }
 
     @Override
+    public Project duplicate() {
+        SingleFileProject singleFileProject = new SingleFileProject(
+                ProjectEnvironmentBuilder.getDefaultBuilder(), this.sourceRoot, buildOptions());
+        return cloneProject(singleFileProject);
+    }
+
+    @Override
     public DocumentId documentId(Path file) {
         if (!this.sourceRoot.toAbsolutePath().normalize().toString().equals(
                 file.toAbsolutePath().normalize().toString())) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/directory/SingleFileProject.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/directory/SingleFileProject.java
@@ -74,8 +74,9 @@ public class SingleFileProject extends Project {
 
     @Override
     public Project duplicate() {
+        BuildOptions duplicateBuildOptions = new BuildOptionsBuilder().build().acceptTheirs(buildOptions());
         SingleFileProject singleFileProject = new SingleFileProject(
-                ProjectEnvironmentBuilder.getDefaultBuilder(), this.sourceRoot, buildOptions());
+                ProjectEnvironmentBuilder.getDefaultBuilder(), this.sourceRoot, duplicateBuildOptions);
         return cloneProject(singleFileProject);
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/PackageCache.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/PackageCache.java
@@ -82,6 +82,17 @@ public class PackageCache {
         packageSymbolMap.remove(packageElements[0]);
     }
 
+    public void flush() {
+        packageMap.clear();
+        for (String idStr : packageSymbolMap.keySet()) {
+            PackageID pkgID = getSymbol(idStr).pkgID;
+            if (PackageID.isLangLibPackageID(pkgID)) {
+                continue;
+            }
+            packageSymbolMap.remove(pkgID);
+        }
+    }
+
     public static String getCacheID(PackageID packageID) {
         String bvmAlias = packageID.toString();
         if (packageID.sourceFileName != null) {

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBalaProject.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBalaProject.java
@@ -265,7 +265,7 @@ public class TestBalaProject {
         int errorCount2 = project.currentPackage().getCompilation().diagnosticResult().errorCount();
         Assert.assertEquals(errorCount2, 3);
 
-        project.refresh();
+        project.clearCaches();
         int errorCount3 = project.currentPackage().getCompilation().diagnosticResult().errorCount();
         Assert.assertEquals(errorCount3, 0);
     }

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBalaProject.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBalaProject.java
@@ -47,6 +47,8 @@ import io.ballerina.projects.repos.TempDirCompilationCache;
 import org.ballerinalang.test.BCompileUtil;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import org.wso2.ballerinalang.compiler.PackageCache;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -266,5 +268,73 @@ public class TestBalaProject {
         project.refresh();
         int errorCount3 = project.currentPackage().getCompilation().diagnosticResult().errorCount();
         Assert.assertEquals(errorCount3, 0);
+    }
+
+    @Test
+    public void testProjectDuplicate() {
+        Path projectDirPath = RESOURCE_DIRECTORY.resolve("projects_for_refresh_tests").resolve("package_refresh_bala");
+        Project project = TestUtils.loadProject(projectDirPath);
+        Assert.assertEquals(project.kind(), ProjectKind.BALA_PROJECT);
+        Project duplicate = project.duplicate();
+        Assert.assertEquals(project.kind(), ProjectKind.BALA_PROJECT);
+
+        Assert.assertNotSame(project, duplicate);
+        Assert.assertNotSame(project.currentPackage().project(), duplicate.currentPackage().project());
+
+        Assert.assertNotSame(project.currentPackage(), duplicate.currentPackage());
+        Assert.assertEquals(project.currentPackage().packageId(), duplicate.currentPackage().packageId());
+        Assert.assertTrue(project.currentPackage().moduleIds().containsAll(duplicate.currentPackage().moduleIds())
+                && duplicate.currentPackage().moduleIds().containsAll(project.currentPackage().moduleIds()));
+        Assert.assertEquals(project.currentPackage().packageMd().isPresent(),
+                duplicate.currentPackage().packageMd().isPresent());
+        if (project.currentPackage().packageMd().isPresent()) {
+            Assert.assertEquals(project.currentPackage().packageMd().get().content(),
+                    duplicate.currentPackage().packageMd().get().content());
+        }
+
+        for (ModuleId moduleId : project.currentPackage().moduleIds()) {
+            Assert.assertNotSame(project.currentPackage().module(moduleId),
+                    duplicate.currentPackage().module(moduleId));
+            Assert.assertNotSame(project.currentPackage().module(moduleId).project(),
+                    duplicate.currentPackage().module(moduleId).project());
+            Assert.assertNotSame(project.currentPackage().module(moduleId).packageInstance(),
+                    duplicate.currentPackage().module(moduleId).packageInstance());
+
+            Assert.assertEquals(project.currentPackage().module(moduleId).descriptor(),
+                    duplicate.currentPackage().module(moduleId).descriptor());
+            Assert.assertEquals(project.currentPackage().module(moduleId).moduleMd().isPresent(),
+                    duplicate.currentPackage().module(moduleId).moduleMd().isPresent());
+            if (project.currentPackage().module(moduleId).moduleMd().isPresent()) {
+                Assert.assertEquals(project.currentPackage().module(moduleId).moduleMd().get().content(),
+                        duplicate.currentPackage().module(moduleId).moduleMd().get().content());
+            }
+
+            Assert.assertTrue(project.currentPackage().module(moduleId).documentIds().containsAll(
+                    duplicate.currentPackage().module(moduleId).documentIds())
+                    && duplicate.currentPackage().module(moduleId).documentIds().containsAll(
+                    project.currentPackage().module(moduleId).documentIds()));
+            for (DocumentId documentId : project.currentPackage().module(moduleId).documentIds()) {
+                Assert.assertNotSame(project.currentPackage().module(moduleId).document(documentId),
+                        duplicate.currentPackage().module(moduleId).document(documentId));
+                Assert.assertNotSame(project.currentPackage().module(moduleId).document(documentId).module(),
+                        duplicate.currentPackage().module(moduleId).document(documentId).module());
+                Assert.assertNotSame(project.currentPackage().module(moduleId).document(documentId).syntaxTree(),
+                        duplicate.currentPackage().module(moduleId).document(documentId).syntaxTree());
+
+                Assert.assertEquals(project.currentPackage().module(moduleId).document(documentId).name(),
+                        duplicate.currentPackage().module(moduleId).document(documentId).name());
+                Assert.assertEquals(
+                        project.currentPackage().module(moduleId).document(documentId).syntaxTree().toSourceCode(),
+                        duplicate.currentPackage().module(moduleId).document(documentId).syntaxTree().toSourceCode());
+            }
+        }
+        Assert.assertNotSame(project.projectEnvironmentContext().getService(CompilerContext.class),
+                duplicate.projectEnvironmentContext().getService(CompilerContext.class));
+        Assert.assertNotSame(
+                PackageCache.getInstance(project.projectEnvironmentContext().getService(CompilerContext.class)),
+                PackageCache.getInstance(duplicate.projectEnvironmentContext().getService(CompilerContext.class)));
+
+        project.currentPackage().getCompilation();
+        duplicate.currentPackage().getCompilation();
     }
 }

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBalaProject.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBalaProject.java
@@ -37,12 +37,14 @@ import io.ballerina.projects.PackageResolution;
 import io.ballerina.projects.Project;
 import io.ballerina.projects.ProjectEnvironmentBuilder;
 import io.ballerina.projects.ProjectException;
+import io.ballerina.projects.ProjectKind;
 import io.ballerina.projects.ResolvedPackageDependency;
 import io.ballerina.projects.bala.BalaProject;
 import io.ballerina.projects.directory.BuildProject;
 import io.ballerina.projects.internal.model.CompilerPluginDescriptor;
 import io.ballerina.projects.internal.model.Target;
 import io.ballerina.projects.repos.TempDirCompilationCache;
+import org.ballerinalang.test.BCompileUtil;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -246,5 +248,23 @@ public class TestBalaProject {
         } catch (ProjectException e) {
             // ignore
         }
+    }
+
+    @Test
+    public void testProjectRefresh() {
+        Path projectDirPath = RESOURCE_DIRECTORY.resolve("projects_for_refresh_tests").resolve("package_refresh_bala");
+        Project project = TestUtils.loadProject(projectDirPath);
+        Assert.assertEquals(project.kind(), ProjectKind.BALA_PROJECT);
+        PackageCompilation compilation = project.currentPackage().getCompilation();
+        int errorCount = compilation.diagnosticResult().errorCount();
+        Assert.assertEquals(errorCount, 3);
+
+        BCompileUtil.compileAndCacheBala("projects_for_refresh_tests/package_refresh_two_v3");
+        int errorCount2 = project.currentPackage().getCompilation().diagnosticResult().errorCount();
+        Assert.assertEquals(errorCount2, 3);
+
+        project.refresh();
+        int errorCount3 = project.currentPackage().getCompilation().diagnosticResult().errorCount();
+        Assert.assertEquals(errorCount3, 0);
     }
 }

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProject.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProject.java
@@ -1556,7 +1556,7 @@ public class TestBuildProject extends BaseTest {
     }
 
     @Test
-    public void testProjectRefresh() {
+    public void testProjectClearCaches() {
         Path projectDirPath = RESOURCE_DIRECTORY.resolve("projects_for_refresh_tests").resolve("package_refresh_one");
         BuildProject buildProject = TestUtils.loadBuildProject(projectDirPath);
         PackageCompilation compilation = buildProject.currentPackage().getCompilation();
@@ -1567,7 +1567,7 @@ public class TestBuildProject extends BaseTest {
         int errorCount2 = buildProject.currentPackage().getCompilation().diagnosticResult().errorCount();
         Assert.assertEquals(errorCount2, 3);
 
-        buildProject.refresh();
+        buildProject.clearCaches();
         int errorCount3 = buildProject.currentPackage().getCompilation().diagnosticResult().errorCount();
         Assert.assertEquals(errorCount3, 0);
     }
@@ -1581,6 +1581,15 @@ public class TestBuildProject extends BaseTest {
         Project duplicate = project.duplicate();
         Assert.assertNotSame(project, duplicate);
         Assert.assertNotSame(project.currentPackage().project(), duplicate.currentPackage().project());
+        Assert.assertNotSame(
+                project.currentPackage().project().buildOptions(), duplicate.currentPackage().project().buildOptions());
+        Assert.assertNotSame(project.projectEnvironmentContext(),
+                duplicate.projectEnvironmentContext());
+        Assert.assertNotSame(project.projectEnvironmentContext().getService(CompilerContext.class),
+                duplicate.projectEnvironmentContext().getService(CompilerContext.class));
+        Assert.assertNotSame(
+                PackageCache.getInstance(project.projectEnvironmentContext().getService(CompilerContext.class)),
+                PackageCache.getInstance(duplicate.projectEnvironmentContext().getService(CompilerContext.class)));
 
         Assert.assertEquals(project.sourceRoot().toString(), duplicate.sourceRoot().toString());
         Assert.assertTrue(duplicate.buildOptions().codeCoverage());
@@ -1649,11 +1658,6 @@ public class TestBuildProject extends BaseTest {
                         duplicate.currentPackage().module(moduleId).document(documentId).syntaxTree().toSourceCode());
             }
         }
-        Assert.assertNotSame(project.projectEnvironmentContext().getService(CompilerContext.class),
-                duplicate.projectEnvironmentContext().getService(CompilerContext.class));
-        Assert.assertNotSame(
-                PackageCache.getInstance(project.projectEnvironmentContext().getService(CompilerContext.class)),
-                PackageCache.getInstance(duplicate.projectEnvironmentContext().getService(CompilerContext.class)));
 
         project.currentPackage().getCompilation();
         duplicate.currentPackage().getCompilation();

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProject.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProject.java
@@ -56,6 +56,7 @@ import io.ballerina.projects.util.ProjectUtils;
 import io.ballerina.toml.semantic.ast.TomlTableArrayNode;
 import io.ballerina.toml.semantic.ast.TomlTableNode;
 import io.ballerina.tools.text.LinePosition;
+import org.ballerinalang.test.BCompileUtil;
 import org.testng.Assert;
 import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
@@ -1549,6 +1550,23 @@ public class TestBuildProject extends BaseTest {
             Assert.fail(e.getMessage());
         }
         return buildProject;
+    }
+
+    @Test
+    public void testProjectRefresh() {
+        Path projectDirPath = RESOURCE_DIRECTORY.resolve("projects_for_refresh_tests").resolve("package_refresh_one");
+        BuildProject buildProject = TestUtils.loadBuildProject(projectDirPath);
+        PackageCompilation compilation = buildProject.currentPackage().getCompilation();
+        int errorCount = compilation.diagnosticResult().errorCount();
+        Assert.assertEquals(errorCount, 3);
+
+        BCompileUtil.compileAndCacheBala("projects_for_refresh_tests/package_refresh_two");
+        int errorCount2 = buildProject.currentPackage().getCompilation().diagnosticResult().errorCount();
+        Assert.assertEquals(errorCount2, 3);
+
+        buildProject.refresh();
+        int errorCount3 = buildProject.currentPackage().getCompilation().diagnosticResult().errorCount();
+        Assert.assertEquals(errorCount3, 0);
     }
 
     @AfterClass (alwaysRun = true)

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestSingleFileProject.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestSingleFileProject.java
@@ -29,6 +29,7 @@ import io.ballerina.projects.Package;
 import io.ballerina.projects.PackageCompilation;
 import io.ballerina.projects.ProjectException;
 import io.ballerina.projects.directory.SingleFileProject;
+import org.ballerinalang.test.BCompileUtil;
 import org.testng.Assert;
 import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
@@ -236,6 +237,24 @@ public class TestSingleFileProject {
         Assert.assertEquals(
                 compilation.diagnosticResult().diagnostics().stream().findFirst().get().location().lineRange()
                         .filePath(), "main_with_error.bal");
+    }
+
+    @Test
+    public void testProjectRefresh() {
+        Path projectDirPath = RESOURCE_DIRECTORY.resolve("projects_for_refresh_tests").resolve("single-file")
+                .resolve("main.bal");
+        SingleFileProject singleFileProject = TestUtils.loadSingleFileProject(projectDirPath);
+        PackageCompilation compilation = singleFileProject.currentPackage().getCompilation();
+        int errorCount = compilation.diagnosticResult().errorCount();
+        Assert.assertEquals(errorCount, 3);
+
+        BCompileUtil.compileAndCacheBala("projects_for_refresh_tests/package_refresh_two_v2");
+        int errorCount2 = singleFileProject.currentPackage().getCompilation().diagnosticResult().errorCount();
+        Assert.assertEquals(errorCount2, 3);
+
+        singleFileProject.refresh();
+        int errorCount3 = singleFileProject.currentPackage().getCompilation().diagnosticResult().errorCount();
+        Assert.assertEquals(errorCount3, 0);
     }
 
     @AfterClass(alwaysRun = true)

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestSingleFileProject.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestSingleFileProject.java
@@ -27,13 +27,17 @@ import io.ballerina.projects.Module;
 import io.ballerina.projects.ModuleId;
 import io.ballerina.projects.Package;
 import io.ballerina.projects.PackageCompilation;
+import io.ballerina.projects.Project;
 import io.ballerina.projects.ProjectException;
+import io.ballerina.projects.ProjectKind;
 import io.ballerina.projects.directory.SingleFileProject;
 import org.ballerinalang.test.BCompileUtil;
 import org.testng.Assert;
 import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
+import org.wso2.ballerinalang.compiler.PackageCache;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -255,6 +259,61 @@ public class TestSingleFileProject {
         singleFileProject.refresh();
         int errorCount3 = singleFileProject.currentPackage().getCompilation().diagnosticResult().errorCount();
         Assert.assertEquals(errorCount3, 0);
+    }
+
+    @Test
+    public void testProjectDuplicate() {
+        Path projectDirPath = RESOURCE_DIRECTORY.resolve("projects_for_refresh_tests").resolve("single-file")
+                .resolve("main.bal");
+        SingleFileProject project = TestUtils.loadSingleFileProject(projectDirPath);
+        Project duplicate = project.duplicate();
+        Assert.assertEquals(duplicate.kind(), ProjectKind.SINGLE_FILE_PROJECT);
+
+        Assert.assertNotSame(project, duplicate);
+        Assert.assertNotSame(project.currentPackage().project(), duplicate.currentPackage().project());
+
+        Assert.assertNotSame(project.currentPackage(), duplicate.currentPackage());
+        Assert.assertEquals(project.currentPackage().packageId(), duplicate.currentPackage().packageId());
+        Assert.assertEquals(project.currentPackage().getDefaultModule().moduleId(),
+                duplicate.currentPackage().getDefaultModule().moduleId());
+
+        Assert.assertNotSame(project.currentPackage().getDefaultModule(),
+                duplicate.currentPackage().getDefaultModule());
+        Assert.assertNotSame(project.currentPackage().getDefaultModule().project(),
+                duplicate.currentPackage().getDefaultModule().project());
+        Assert.assertNotSame(project.currentPackage().getDefaultModule().packageInstance(),
+                duplicate.currentPackage().getDefaultModule().packageInstance());
+
+        Assert.assertEquals(project.currentPackage().getDefaultModule().descriptor(),
+                duplicate.currentPackage().getDefaultModule().descriptor());
+        Assert.assertEquals(project.currentPackage().getDefaultModule().moduleMd().isPresent(),
+                duplicate.currentPackage().getDefaultModule().moduleMd().isPresent());
+
+        DocumentId documentId = project.currentPackage().getDefaultModule().documentIds().stream().findFirst().get();
+        Assert.assertEquals(documentId,
+                duplicate.currentPackage().getDefaultModule().documentIds().stream().findFirst().get());
+
+        Assert.assertNotSame(project.currentPackage().getDefaultModule().document(documentId),
+                duplicate.currentPackage().getDefaultModule().document(documentId));
+        Assert.assertNotSame(project.currentPackage().getDefaultModule().document(documentId).module(),
+                duplicate.currentPackage().getDefaultModule().document(documentId).module());
+        Assert.assertNotSame(project.currentPackage().getDefaultModule().document(documentId).syntaxTree(),
+                duplicate.currentPackage().getDefaultModule().document(documentId).syntaxTree());
+
+        Assert.assertEquals(project.currentPackage().getDefaultModule().document(documentId).name(),
+                duplicate.currentPackage().getDefaultModule().document(documentId).name());
+        Assert.assertEquals(
+                project.currentPackage().getDefaultModule().document(documentId).syntaxTree().toSourceCode(),
+                duplicate.currentPackage().getDefaultModule().document(documentId).syntaxTree().toSourceCode());
+
+        Assert.assertNotSame(project.projectEnvironmentContext().getService(CompilerContext.class),
+                duplicate.projectEnvironmentContext().getService(CompilerContext.class));
+        Assert.assertNotSame(
+                PackageCache.getInstance(project.projectEnvironmentContext().getService(CompilerContext.class)),
+                PackageCache.getInstance(duplicate.projectEnvironmentContext().getService(CompilerContext.class)));
+
+        project.currentPackage().getCompilation();
+        duplicate.currentPackage().getCompilation();
     }
 
     @AfterClass(alwaysRun = true)

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestSingleFileProject.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestSingleFileProject.java
@@ -256,7 +256,7 @@ public class TestSingleFileProject {
         int errorCount2 = singleFileProject.currentPackage().getCompilation().diagnosticResult().errorCount();
         Assert.assertEquals(errorCount2, 3);
 
-        singleFileProject.refresh();
+        singleFileProject.clearCaches();
         int errorCount3 = singleFileProject.currentPackage().getCompilation().diagnosticResult().errorCount();
         Assert.assertEquals(errorCount3, 0);
     }
@@ -271,6 +271,15 @@ public class TestSingleFileProject {
 
         Assert.assertNotSame(project, duplicate);
         Assert.assertNotSame(project.currentPackage().project(), duplicate.currentPackage().project());
+        Assert.assertNotSame(
+                project.currentPackage().project().buildOptions(), duplicate.currentPackage().project().buildOptions());
+        Assert.assertNotSame(project.projectEnvironmentContext(),
+                duplicate.projectEnvironmentContext());
+        Assert.assertNotSame(project.projectEnvironmentContext().getService(CompilerContext.class),
+                duplicate.projectEnvironmentContext().getService(CompilerContext.class));
+        Assert.assertNotSame(
+                PackageCache.getInstance(project.projectEnvironmentContext().getService(CompilerContext.class)),
+                PackageCache.getInstance(duplicate.projectEnvironmentContext().getService(CompilerContext.class)));
 
         Assert.assertNotSame(project.currentPackage(), duplicate.currentPackage());
         Assert.assertEquals(project.currentPackage().packageId(), duplicate.currentPackage().packageId());
@@ -305,12 +314,6 @@ public class TestSingleFileProject {
         Assert.assertEquals(
                 project.currentPackage().getDefaultModule().document(documentId).syntaxTree().toSourceCode(),
                 duplicate.currentPackage().getDefaultModule().document(documentId).syntaxTree().toSourceCode());
-
-        Assert.assertNotSame(project.projectEnvironmentContext().getService(CompilerContext.class),
-                duplicate.projectEnvironmentContext().getService(CompilerContext.class));
-        Assert.assertNotSame(
-                PackageCache.getInstance(project.projectEnvironmentContext().getService(CompilerContext.class)),
-                PackageCache.getInstance(duplicate.projectEnvironmentContext().getService(CompilerContext.class)));
 
         project.currentPackage().getCompilation();
         duplicate.currentPackage().getCompilation();

--- a/project-api/project-api-test/src/test/resources/projects_for_refresh_tests/package_refresh_bala/bala.json
+++ b/project-api/project-api-test/src/test/resources/projects_for_refresh_tests/package_refresh_bala/bala.json
@@ -1,0 +1,4 @@
+{
+  "bala_version": "2.0.0",
+  "built_by": "WSO2"
+}

--- a/project-api/project-api-test/src/test/resources/projects_for_refresh_tests/package_refresh_bala/dependency-graph.json
+++ b/project-api/project-api-test/src/test/resources/projects_for_refresh_tests/package_refresh_bala/dependency-graph.json
@@ -1,0 +1,75 @@
+{
+  "packages": [
+    {
+      "org": "asmaj",
+      "name": "package_refresh_bala",
+      "version": "0.1.0",
+      "transitive": false,
+      "dependencies": [
+        {
+          "org": "asmaj",
+          "name": "package_refresh_two_v3",
+          "version": "0.1.0",
+          "transitive": false,
+          "dependencies": [],
+          "modules": []
+        }
+      ],
+      "modules": []
+    },
+    {
+      "org": "asmaj",
+      "name": "package_refresh_two_v3",
+      "version": "0.1.0",
+      "transitive": false,
+      "dependencies": [],
+      "modules": []
+    }
+  ],
+  "modules": [
+    {
+      "org": "asmaj",
+      "package_name": "package_refresh_bala",
+      "version": "0.1.0",
+      "module_name": "package_refresh_bala.mod1",
+      "dependencies": [
+        {
+          "org": "asmaj",
+          "package_name": "package_refresh_two_v3",
+          "version": "0.1.0",
+          "module_name": "package_refresh_two_v3",
+          "dependencies": []
+        }
+      ]
+    },
+    {
+      "org": "asmaj",
+      "package_name": "package_refresh_bala",
+      "version": "0.1.0",
+      "module_name": "package_refresh_bala.mod2",
+      "dependencies": []
+    },
+    {
+      "org": "asmaj",
+      "package_name": "package_refresh_bala",
+      "version": "0.1.0",
+      "module_name": "package_refresh_bala",
+      "dependencies": [
+        {
+          "org": "asmaj",
+          "package_name": "package_refresh_bala",
+          "version": "0.1.0",
+          "module_name": "package_refresh_bala.mod2",
+          "dependencies": []
+        },
+        {
+          "org": "asmaj",
+          "package_name": "package_refresh_bala",
+          "version": "0.1.0",
+          "module_name": "package_refresh_bala.mod1",
+          "dependencies": []
+        }
+      ]
+    }
+  ]
+}

--- a/project-api/project-api-test/src/test/resources/projects_for_refresh_tests/package_refresh_bala/modules/package_refresh_bala.mod1/mod1.bal
+++ b/project-api/project-api-test/src/test/resources/projects_for_refresh_tests/package_refresh_bala/modules/package_refresh_bala.mod1/mod1.bal
@@ -1,0 +1,5 @@
+import asmaj/package_refresh_two_v3;
+
+public function func1() {
+    package_refresh_two_v3:func();
+}

--- a/project-api/project-api-test/src/test/resources/projects_for_refresh_tests/package_refresh_bala/modules/package_refresh_bala.mod2/mod2.bal
+++ b/project-api/project-api-test/src/test/resources/projects_for_refresh_tests/package_refresh_bala/modules/package_refresh_bala.mod2/mod2.bal
@@ -1,0 +1,2 @@
+public function func2() {
+}

--- a/project-api/project-api-test/src/test/resources/projects_for_refresh_tests/package_refresh_bala/modules/package_refresh_bala/main.bal
+++ b/project-api/project-api-test/src/test/resources/projects_for_refresh_tests/package_refresh_bala/modules/package_refresh_bala/main.bal
@@ -1,0 +1,7 @@
+import asmaj/package_refresh_bala.mod1;
+import asmaj/package_refresh_bala.mod2;
+
+public function main() {
+   mod1:func1();
+   mod2:func2();
+}

--- a/project-api/project-api-test/src/test/resources/projects_for_refresh_tests/package_refresh_bala/package.json
+++ b/project-api/project-api-test/src/test/resources/projects_for_refresh_tests/package_refresh_bala/package.json
@@ -1,0 +1,13 @@
+{
+  "organization": "asmaj",
+  "name": "package_refresh_bala",
+  "version": "0.1.0",
+  "export": [
+    "package_refresh_bala"
+  ],
+  "ballerina_version": "slbeta4",
+  "implementation_vendor": "WSO2",
+  "language_spec_version": "2021R1",
+  "platform": "any",
+  "template": false
+}

--- a/project-api/project-api-test/src/test/resources/projects_for_refresh_tests/package_refresh_one/Ballerina.toml
+++ b/project-api/project-api-test/src/test/resources/projects_for_refresh_tests/package_refresh_one/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "asmaj"
+name = "package_refresh_one"
+version = "0.1.0"

--- a/project-api/project-api-test/src/test/resources/projects_for_refresh_tests/package_refresh_one/main.bal
+++ b/project-api/project-api-test/src/test/resources/projects_for_refresh_tests/package_refresh_one/main.bal
@@ -1,0 +1,7 @@
+import asmaj/package_refresh_one.mod1;
+import asmaj/package_refresh_one.mod2;
+
+public function main() {
+   mod1:func1();
+   mod2:func2();
+}

--- a/project-api/project-api-test/src/test/resources/projects_for_refresh_tests/package_refresh_one/modules/mod1/mod1.bal
+++ b/project-api/project-api-test/src/test/resources/projects_for_refresh_tests/package_refresh_one/modules/mod1/mod1.bal
@@ -1,0 +1,5 @@
+import asmaj/package_refresh_two;
+
+public function func1() {
+    package_refresh_two:func();
+}

--- a/project-api/project-api-test/src/test/resources/projects_for_refresh_tests/package_refresh_one/modules/mod2/mod2.bal
+++ b/project-api/project-api-test/src/test/resources/projects_for_refresh_tests/package_refresh_one/modules/mod2/mod2.bal
@@ -1,0 +1,2 @@
+public function func2() {
+}

--- a/project-api/project-api-test/src/test/resources/projects_for_refresh_tests/package_refresh_two/Ballerina.toml
+++ b/project-api/project-api-test/src/test/resources/projects_for_refresh_tests/package_refresh_two/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "asmaj"
+name = "package_refresh_two"
+version = "0.1.0"

--- a/project-api/project-api-test/src/test/resources/projects_for_refresh_tests/package_refresh_two/main.bal
+++ b/project-api/project-api-test/src/test/resources/projects_for_refresh_tests/package_refresh_two/main.bal
@@ -1,0 +1,2 @@
+public function func() {
+}

--- a/project-api/project-api-test/src/test/resources/projects_for_refresh_tests/package_refresh_two_v2/Ballerina.toml
+++ b/project-api/project-api-test/src/test/resources/projects_for_refresh_tests/package_refresh_two_v2/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "asmaj"
+name = "package_refresh_two_v2"
+version = "0.1.0"

--- a/project-api/project-api-test/src/test/resources/projects_for_refresh_tests/package_refresh_two_v2/main.bal
+++ b/project-api/project-api-test/src/test/resources/projects_for_refresh_tests/package_refresh_two_v2/main.bal
@@ -1,0 +1,2 @@
+public function func() {
+}

--- a/project-api/project-api-test/src/test/resources/projects_for_refresh_tests/package_refresh_two_v3/Ballerina.toml
+++ b/project-api/project-api-test/src/test/resources/projects_for_refresh_tests/package_refresh_two_v3/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "asmaj"
+name = "package_refresh_two_v3"
+version = "0.1.0"

--- a/project-api/project-api-test/src/test/resources/projects_for_refresh_tests/package_refresh_two_v3/main.bal
+++ b/project-api/project-api-test/src/test/resources/projects_for_refresh_tests/package_refresh_two_v3/main.bal
@@ -1,0 +1,2 @@
+public function func() {
+}

--- a/project-api/project-api-test/src/test/resources/projects_for_refresh_tests/single-file/main.bal
+++ b/project-api/project-api-test/src/test/resources/projects_for_refresh_tests/single-file/main.bal
@@ -1,0 +1,5 @@
+import asmaj/package_refresh_two_v2;
+
+public function func1() {
+    package_refresh_two_v2:func();
+}


### PR DESCRIPTION
## Purpose
> Introduce Project.clearCaches and Project.duplicate
Fixes #33073

## Approach
> Describe how you are implementing the solutions along with the design details.
Introduces the following public instance method in Project class
```
public void clearCaches();
public Project duplicate();
```
> This will discard the old contexts which includes clearing of compilation caches and diagnostics.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [x] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
