### PR TITLE
Fix incorrect behaviour in bitwise-expr when the contexual expected type set to byte

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -4107,6 +4107,7 @@ public class TypeChecker extends BLangNodeVisitor {
         BType rhsType;
 
         if (binaryExpr.expectedType.tag == TypeTags.FLOAT || binaryExpr.expectedType.tag == TypeTags.DECIMAL ||
+                                                             binaryExpr.expectedType.tag == TypeTags.BYTE ||
                 isOptionalFloatOrDecimal(binaryExpr.expectedType)) {
             rhsType = checkAndGetType(binaryExpr.rhsExpr, rhsExprEnv, binaryExpr);
         } else {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -4089,6 +4089,7 @@ public class TypeChecker extends BLangNodeVisitor {
         SymbolEnv rhsExprEnv;
         BType lhsType;
         if (binaryExpr.expectedType.tag == TypeTags.FLOAT || binaryExpr.expectedType.tag == TypeTags.DECIMAL ||
+                                                             binaryExpr.expectedType.tag == TypeTags.BYTE ||
                 isOptionalFloatOrDecimal(binaryExpr.expectedType)) {
             lhsType = checkAndGetType(binaryExpr.lhsExpr, env, binaryExpr);
         } else {

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibSubTypeTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibSubTypeTest.java
@@ -206,7 +206,6 @@ public class LangLibSubTypeTest {
         BAssertUtil.validateError(result, err++, "incompatible types: expected 'decimal'," + FOUND_UNSIGNED_32, 237,
                                   17);
 
-        BAssertUtil.validateError(result, err++, EXPECT_BYTE + FOUND_INT, 251, 14);
         BAssertUtil.validateError(result, err++, "incompatible types: expected 'float'," + FOUND_INT, 252, 15);
         BAssertUtil.validateError(result, err++, EXPECT_SIGNED_32 + FOUND_INT, 253, 23);
         BAssertUtil.validateError(result, err++, "incompatible types: expected 'decimal'," + FOUND_BYTE, 254, 17);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/bytetype/BByteValueNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/bytetype/BByteValueNegativeTest.java
@@ -78,23 +78,18 @@ public class BByteValueNegativeTest {
         BAssertUtil.validateError(result, 22, msg4, 40, 87);
     }
 
-    @Test(description = "Test byte shift operators negative", groups = { "disableOnOldParser" })
+    @Test(description = "Test byte shift operators negative")
     public void invalidByteShiftOperators() {
         CompileResult result = BCompileUtil.compile("test-src/types/byte/byte-shift-operators-negative.bal");
-        Assert.assertEquals(result.getErrorCount(), 13);
+        Assert.assertEquals(result.getErrorCount(), 8);
         int i = 0;
-        BAssertUtil.validateError(result, i++, "incompatible types: expected 'byte', found 'int'", 2, 14);
         BAssertUtil.validateError(result, i++, "no whitespaces allowed in right shift op", 2, 16);
         BAssertUtil.validateError(result, i++, "incompatible types: expected 'byte', found 'boolean'", 3, 13);
         BAssertUtil.validateError(result, i++, "missing gt token", 3, 20);
         BAssertUtil.validateError(result, i++, "missing identifier", 3, 20);
-        BAssertUtil.validateError(result, i++, "incompatible types: expected 'byte', found 'int'", 4, 13);
         BAssertUtil.validateError(result, i++, "no whitespaces allowed in unsigned right shift op", 4, 15);
-        BAssertUtil.validateError(result, i++, "incompatible types: expected 'byte', found 'int'", 5, 12);
         BAssertUtil.validateError(result, i++, "no whitespaces allowed in unsigned right shift op", 5, 14);
-        BAssertUtil.validateError(result, i++, "incompatible types: expected 'byte', found 'int'", 6, 11);
         BAssertUtil.validateError(result, i++, "no whitespaces allowed in unsigned right shift op", 6, 13);
-        BAssertUtil.validateError(result, i++, "incompatible types: expected 'byte', found 'int'", 7, 9);
         BAssertUtil.validateError(result, i++, "no whitespaces allowed in unsigned right shift op", 7, 11);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/bytetype/BByteValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/bytetype/BByteValueTest.java
@@ -383,13 +383,20 @@ public class BByteValueTest {
     private void invokeBitwiseAndTestFunction(byte a, byte b, int i, int j) {
         BValue[] args = {new BByte(a), new BByte(b), new BInteger(i), new BInteger(j)};
         BValue[] returns = BRunUtil.invoke(result, "testBitwiseAndOperator", args);
-        Assert.assertEquals(returns.length, 5);
+        Assert.assertEquals(returns.length, 8);
         BByte bByte1 = (BByte) returns[0];
-        BInteger bInteger1 = (BInteger) returns[1];
-        BInteger bInteger2 = (BInteger) returns[2];
-        BInteger bInteger3 = (BInteger) returns[3];
-        BInteger bInteger4 = (BInteger) returns[4];
+        BByte bByte2 = (BByte) returns[1];
+        BByte bByte3 = (BByte) returns[2];
+        BByte bByte4 = (BByte) returns[3];
+        BInteger bInteger1 = (BInteger) returns[4];
+        BInteger bInteger2 = (BInteger) returns[5];
+        BInteger bInteger3 = (BInteger) returns[6];
+        BInteger bInteger4 = (BInteger) returns[7];
         Assert.assertEquals(bByte1.value().byteValue(), a & b, "Invalid result");
+        Assert.assertEquals(bByte2.value().byteValue(), Byte.valueOf("7F", 16) & i, "Invalid result");
+        Assert.assertEquals(bByte3.value().byteValue(), i & Byte.valueOf("7F", 16), "Invalid result");
+        Assert.assertEquals(bByte4.value().byteValue(), Byte.valueOf("A", 16) & Byte.valueOf("A", 16) ,
+                            "Invalid result");
         Assert.assertEquals(bInteger1.intValue(), Byte.toUnsignedInt(a) & Byte.toUnsignedInt(b), "Invalid result");
         Assert.assertEquals(bInteger2.intValue(), Byte.toUnsignedInt(a) & i, "Invalid result");
         Assert.assertEquals(bInteger3.intValue(), i & j, "Invalid result");

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/byte/byte-value.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/byte/byte-value.bal
@@ -197,13 +197,16 @@ function testWorkerWithByteVariable() {
   }
 }
 
-function testBitwiseAndOperator(byte a, byte b, int i, int j) returns [byte, int, int, int, int]{
+function testBitwiseAndOperator(byte a, byte b, int i, int j) returns [byte, byte, byte, byte, int, int, int, int]{
     byte b1 = a & b;
+    byte b2 = 0x7F & i;
+    byte b3 = i & 0x7F;
+    byte b4 = 10 & 10;
     int r1 = <int>(a & b);
     int r2 = <int>a & i;
     int r3 = i & j;
     int r4 = <int>a & i & <int>b & j;
-    return [b1, r1, r2, r3, r4];
+    return [b1, b2, b3, b4, r1, r2, r3, r4];
 }
 
 function testBitwiseOrOperator(byte a, byte b, int i, int j) returns [byte, int, int, int, int]{


### PR DESCRIPTION
## Purpose
> $title

Fixes #33818 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
