### PR TITLE
Fix wrong enclosed node picking issue in NodeFinder

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/NodeFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/NodeFinder.java
@@ -653,6 +653,7 @@ class NodeFinder extends BaseVisitor {
     public void visit(BLangTypeInit typeInit) {
         lookupNode(typeInit.userDefinedType);
         lookupNodes(typeInit.argsExpr);
+        setEnclosingNode(typeInit, typeInit.pos);
     }
 
     @Override
@@ -1369,7 +1370,8 @@ class NodeFinder extends BaseVisitor {
     }
 
     private boolean setEnclosingNode(BLangNode node, Location pos) {
-        if (PositionUtil.withinRange(this.range, pos) && this.enclosingNode == null) {
+        if (PositionUtil.withinRange(this.range, pos)
+                && (this.enclosingNode == null || PositionUtil.withinRange(pos.lineRange(), this.enclosingNode.pos))) {
             this.enclosingNode = node;
             return true;
         }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/PositionUtil.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/PositionUtil.java
@@ -59,6 +59,7 @@ class PositionUtil {
         return true;
     }
 
+    // Checks whether the specified range falls within the node
     static boolean withinRange(LineRange specifiedRange, Location nodePosition) {
 
         //TODO: Remove this check

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typeof/TypeOfRegressionTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typeof/TypeOfRegressionTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.semantic.api.test.typeof;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.ClassSymbol;
+import io.ballerina.compiler.api.symbols.SymbolKind;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.semantic.api.test.util.SemanticAPITestUtils;
+import io.ballerina.tools.text.LinePosition;
+import io.ballerina.tools.text.LineRange;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Regression tests for typeOf().
+ */
+public class TypeOfRegressionTest {
+
+    private SemanticModel model;
+
+    @BeforeClass
+    public void setup() {
+        model = SemanticAPITestUtils.getDefaultModulesSemanticModel(
+                "test-src/regression-tests/typeof_listener_test.bal");
+    }
+
+    @Test
+    public void testListenerType() {
+        Optional<TypeSymbol> type = model.typeOf(
+                LineRange.from("typeof_listener_test.bal",
+                               LinePosition.from(16, 19), LinePosition.from(16, 35)));
+
+        assertTrue(type.isPresent());
+        assertEquals(type.get().kind(), SymbolKind.TYPE);
+        assertEquals(type.get().typeKind(), TypeDescKind.TYPE_REFERENCE);
+
+        ClassSymbol clazz = (ClassSymbol) ((TypeReferenceTypeSymbol) type.get()).definition();
+        assertEquals(clazz.kind(), SymbolKind.CLASS);
+        assertEquals(clazz.typeKind(), TypeDescKind.OBJECT);
+        assertEquals(clazz.getName().get(), "Listener");
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/regression-tests/typeof_listener_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/regression-tests/typeof_listener_test.bal
@@ -1,0 +1,44 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+service Service on new Listener({}) {
+    remote function onMessage(string s) returns int {
+        return 0;
+    }
+}
+
+public type Config record {|
+    int field1;
+    int field2;
+|};
+
+public type Service service object {
+    remote function onMessage(string s) returns int;
+};
+
+public class Listener {
+    function init(Config config) {}
+
+    public function attach(Service s, string|string[]? name = ()) returns error? {}
+
+    public function detach(Service s) returns error? {}
+
+    public function 'start() returns error? {}
+
+    public function gracefulStop() returns error? {}
+
+    public function immediateStop() returns error? {}
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
+++ b/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
@@ -168,6 +168,7 @@
             <!--Type Of-->
             <class name="io.ballerina.semantic.api.test.typeof.TypeOfInCallStatementsTest" />
             <class name="io.ballerina.semantic.api.test.typeof.TypeOfQueryExprTest" />
+            <class name="io.ballerina.semantic.api.test.typeof.TypeOfRegressionTest" />
 
         </classes>
     </test>


### PR DESCRIPTION
## Purpose
Fixes an issue with the `NodeFinder` which caused it to ignore the immediate node which encloses the given range. 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
