### PR TITLE
Fix missing compile error when the array size cannot be inferred from the list constructor

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
@@ -170,6 +170,7 @@ public enum DiagnosticErrorCode implements DiagnosticCode {
     INVALID_ARRAY_LENGTH("BCE2126", "invalid.array.length"),
     CANNOT_RESOLVE_CONST("BCE2127", "cannot.resolve.const"),
     ALREADY_INITIALIZED_SYMBOL_WITH_ANOTHER("BCE2128", "already.initialized.symbol.with.another"),
+    CANNOT_INFER_ARRAY_SIZE("BCE2129", "cannot.infer.array.size"),
 
     //Transaction related error codes
     ROLLBACK_CANNOT_BE_OUTSIDE_TRANSACTION_BLOCK("BCE2300", "rollback.cannot.be.outside.transaction.block"),

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -1410,7 +1410,7 @@ public class TypeChecker extends BLangNodeVisitor {
 
             List<BType> compatibleTypes = new ArrayList<>();
             boolean erroredExpType = false;
-            boolean CannotInferArraySize = false;
+            boolean cannotInferArraySize = false;
             for (BType memberType : ((BUnionType) bType).getMemberTypes()) {
                 if (memberType == symTable.semanticError) {
                     if (!erroredExpType) {
@@ -1436,11 +1436,11 @@ public class TypeChecker extends BLangNodeVisitor {
                     dlog.error(listCompatibleMemType.tsymbol.pos, DiagnosticErrorCode.CANNOT_INFER_ARRAY_SIZE,
                             listCompatibleMemType);
                     this.dlog.mute();
-                    CannotInferArraySize = true;
+                    cannotInferArraySize = true;
                 }
             }
 
-            if (CannotInferArraySize) {
+            if (cannotInferArraySize) {
                 this.dlog.unmute();
                 return symTable.semanticError;
             }

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -444,6 +444,9 @@ error.already.initialized.symbol=\
 error.already.initialized.symbol.with.another=\
   symbol ''{0}'' is already initialized with ''{1}''
 
+error.cannot.infer.array.size=\
+  cannot infer array size of ''{0}''
+
 error.type.cast.not.yet.supported.for.type=\
   type cast not yet supported for type ''{0}''
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArraySizeDefinitionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArraySizeDefinitionTest.java
@@ -38,6 +38,8 @@ public class ArraySizeDefinitionTest {
     private static final String INVALID_ARRAY_LENGTH_ERROR =
             "invalid array length: array length should be a non-negative integer";
     private static final String SIZE_LIMIT_ERROR = "array length greater that '2147483637' not yet supported";
+    private static final String CANNOT_INFER_ARRAY_SIZE_STRING = "cannot infer array size of 'string[*]'";
+    private static final String CANNOT_INFER_ARRAY_SIZE_BYTE = "cannot infer array size of 'byte[*]'";
 
     @Test
     public void testCompilationSizeReferenceErrors() {
@@ -75,6 +77,9 @@ public class ArraySizeDefinitionTest {
         BAssertUtil.validateError(resultNegative, index++, SIZE_LIMIT_ERROR, 48, 9);
         BAssertUtil.validateError(resultNegative, index++, INVALID_ARRAY_LENGTH_ERROR, 50, 9);
         BAssertUtil.validateError(resultNegative, index++, INVALID_ARRAY_LENGTH_ERROR, 51, 9);
+        BAssertUtil.validateError(resultNegative, index++, CANNOT_INFER_ARRAY_SIZE_STRING, 55, 12);
+        BAssertUtil.validateError(resultNegative, index++, CANNOT_INFER_ARRAY_SIZE_BYTE, 55, 22);
+        BAssertUtil.validateError(resultNegative, index++, incompatibleTypeError, 56, 18);
         Assert.assertEquals(resultNegative.getDiagnostics().length, index);
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array_size_test_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array_size_test_negative.bal
@@ -50,3 +50,8 @@ function arraySizeTest() {
     int[9223372036854775808] w = [];
     int[0x001234567890abcdef01] x = [];
 }
+
+function inferArraySize() {
+    int[*]|string[*]|byte[*]  y = [1000];
+    int[*]  z = ["1"];
+}


### PR DESCRIPTION
## Purpose
> $title.

Fixes #33938

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
