### PR TITLE
Fix issue in tracking record fields in a wait-for-all expression

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
@@ -1563,6 +1563,10 @@ class SymbolFinder extends BaseVisitor {
 
     @Override
     public void visit(BLangWaitForAllExpr.BLangWaitKeyValue waitKeyValue) {
+        if (waitKeyValue.keyExpr == null && setEnclosingNode(waitKeyValue.keySymbol, waitKeyValue.key.pos)) {
+            return;
+        }
+
         lookupNode(waitKeyValue.valueExpr != null ? waitKeyValue.valueExpr : waitKeyValue.keyExpr);
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -3903,6 +3903,7 @@ public class TypeChecker extends BLangNodeVisitor {
                 }
             } else {
                 checkWaitKeyValExpr(keyVal, lhsFields.get(key).type);
+                keyVal.keySymbol = lhsFields.get(key).symbol;
             }
         }
         // If the record literal is of record type and types are validated for the fields, check if there are any

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangWaitForAllExpr.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangWaitForAllExpr.java
@@ -20,6 +20,7 @@ package org.wso2.ballerinalang.compiler.tree.expressions;
 import org.ballerinalang.model.tree.NodeKind;
 import org.ballerinalang.model.tree.expressions.WaitForAllExpressionNode;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BAttachedFunction;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BVarSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.tree.BLangIdentifier;
 import org.wso2.ballerinalang.compiler.tree.BLangNode;
@@ -78,6 +79,7 @@ public class BLangWaitForAllExpr extends BLangExpression implements WaitForAllEx
         public BLangIdentifier key;
         public BLangExpression valueExpr;
         public BLangExpression keyExpr;
+        public BVarSymbol keySymbol; // Only applicable when a record type is contextually expected
 
         @Override
         public BLangIdentifier getKey() {

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/actions/SymbolsInWaitActionsTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/actions/SymbolsInWaitActionsTest.java
@@ -17,17 +17,22 @@
 package io.ballerina.semantic.api.test.actions;
 
 import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.projects.Document;
 import io.ballerina.projects.Project;
+import io.ballerina.tools.text.LinePosition;
 import org.ballerinalang.test.BCompileUtil;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.assertBasicsAndGetSymbol;
+import java.util.Optional;
+
 import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDefaultModulesSemanticModel;
 import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDocumentForSingleSource;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 /**
  * Test cases for use of symbol() with wait action.
@@ -47,7 +52,17 @@ public class SymbolsInWaitActionsTest {
 
     @Test(dataProvider = "PosInWaitAction")
     public void testSymbolsInWaitAction(int line, int col, String name, SymbolKind symbolKind) {
-        assertBasicsAndGetSymbol(model, srcFile, line, col, name, symbolKind);
+        Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, col));
+
+        if (name == null) {
+            assertTrue(symbol.isEmpty());
+            return;
+        }
+
+        assertTrue(symbol.isPresent());
+        assertEquals(symbol.get().kind(), symbolKind);
+        assertTrue(symbol.get().getName().isPresent());
+        assertEquals(symbol.get().getName().get(), name);
     }
 
     @DataProvider(name = "PosInWaitAction")
@@ -61,16 +76,20 @@ public class SymbolsInWaitActionsTest {
                 {25, 25, "W1", SymbolKind.WORKER},
 
                 // Multiple Wait Action
-//                {43, 51, "a", SymbolKind.RECORD_FIELD},   // TODO: Fix 33388
+                {43, 51, null, null},
                 {43, 54, "WA", SymbolKind.WORKER},
-//                {43, 58, "a", SymbolKind.RECORD_FIELD},   // TODO: Fix 33388
+                {43, 58, null, null},
                 {43, 61, "WB", SymbolKind.WORKER},
                 {44, 51, "WC", SymbolKind.WORKER},
                 {44, 55, "WD", SymbolKind.WORKER},
+                {45, 63, "a", SymbolKind.RECORD_FIELD},
+                {45, 66, "WA", SymbolKind.WORKER},
+                {45, 70, "b", SymbolKind.RECORD_FIELD},
+                {45, 73, "WB", SymbolKind.WORKER},
 
                 // Alternate Wait Action
-                {56, 29, "WA", SymbolKind.WORKER},
-                {56, 34, "WB", SymbolKind.WORKER},
+                {57, 29, "WA", SymbolKind.WORKER},
+                {57, 34, "WB", SymbolKind.WORKER},
         };
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/actions/symbols_in_wait_actions_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/actions/symbols_in_wait_actions_test.bal
@@ -43,6 +43,7 @@ function testMultipleWaitAction() returns error? {
 
     map<string|error|string|error> result1 = wait {a: WA, b: WB};
     map<string|error|string|error> result2 = wait {WC, WD};
+    record {|string|error a; string|error b;|} result3 = wait {a: WA, b: WB};
 }
 
 function testAlternateWaitAction() {


### PR DESCRIPTION
## Purpose
This modifies the AST node for wait-for-all expr to keep track of the record field symbol as well when the contextually expected type is a record type.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
