### PR TITLE
Change diagnostic message for remote qualifier

### DIFF
--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -812,7 +812,7 @@ error.service.service.type.required.anonymous=\
   cannot infer type of the anonymous endpoint, requires a valid service type for service {0}
 
 error.remote.function.in.non.network.object=\
-  remote qualifier only allowed in client and service objects
+  remote qualifier only allowed in clients and services
 
 error.unsupported.path.param.type=\
   only ''int'', ''string'', ''float'', ''boolean'', ''decimal'' types are supported as path params, found ''{0}''

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/object/ObjectConstructorTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/object/ObjectConstructorTest.java
@@ -95,7 +95,7 @@ public class ObjectConstructorTest {
         validateError(negativeResult, index++, "incompatible types: 'SampleRec' is not an object", 19, 39);
         validateError(negativeResult, index++, "remote method has a visibility qualifier", 22, 5);
         validateError(negativeResult, index++,
-                "remote qualifier only allowed in client and service objects", 22, 13);
+                "remote qualifier only allowed in clients and services", 22, 13);
         validateError(negativeResult, index++, "object constructor 'init' method cannot have parameters",
                 26, 5);
         validateError(negativeResult, index++, "object initializer function can not be declared as " +

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectTypeReferenceTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectTypeReferenceTest.java
@@ -182,7 +182,7 @@ public class ObjectTypeReferenceTest {
                 " in the referencing object", 60, 6);
         BAssertUtil.validateError(negativeResult, i++, "invalid object type inclusion: missing 'isolated client' " +
                 "qualifier(s) in the referencing object", 61, 6);
-        BAssertUtil.validateError(negativeResult, i++, "remote qualifier only allowed in client and service objects",
+        BAssertUtil.validateError(negativeResult, i++, "remote qualifier only allowed in clients and services",
                                   68, 5);
         BAssertUtil.validateError(negativeResult, i++, "invalid object type inclusion: missing 'isolated' qualifier" +
                 "(s) in the referencing object", 74, 6);
@@ -198,7 +198,7 @@ public class ObjectTypeReferenceTest {
                 "the referencing object constructor expression", 80, 18);
         BAssertUtil.validateError(negativeResult, i++, "invalid type reference: missing 'client' qualifier(s) in the " +
                 "referencing object constructor expression", 84, 24);
-        BAssertUtil.validateError(negativeResult, i++, "remote qualifier only allowed in client and service objects",
+        BAssertUtil.validateError(negativeResult, i++, "remote qualifier only allowed in clients and services",
                                   87, 5);
         BAssertUtil.validateError(negativeResult, i++, "invalid type reference: missing 'isolated client' " +
                 "qualifier(s) in the referencing object constructor expression", 93, 21);


### PR DESCRIPTION
## Purpose

Consider the error given for the below scenario. This is a class and not a object.

```Ballerina
import ballerina/jballerina.java;

class ClientObjImpl {
    remote isolated function createBoxedLongFromBInt(int value) returns handle = @java:Constructor {
        'class: "java.lang.Long",
        paramTypes: ["long"]
    } external;
}
```

```LogTalk
ERROR [t3.bal:(4:5,7:16)] remote qualifier only allowed in client and service objects
```

#### Suggestion

```LogTalk
ERROR [t3.bal:(4:5,7:16)] remote qualifier only allowed in clients and services
```

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
