### PR TITLE
Fix issue with missing annotations in var symbols

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -1510,6 +1510,14 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
                 if (simpleVariable.symbol.type == symTable.semanticError) {
                     simpleVariable.symbol.state = DiagnosticState.UNKNOWN_TYPE;
                 }
+
+                variable.annAttachments.forEach(annotationAttachment -> {
+                    annotationAttachment.attachPoints.add(AttachPoint.Point.VAR);
+                    annotationAttachment.accept(this);
+                    variable.symbol.addAnnotation(annotationAttachment.annotationSymbol);
+                });
+
+                validateAnnotationAttachmentCount(variable.annAttachments);
                 break;
             case TUPLE_VARIABLE:
                 if (varRefExpr == null) {

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/VarDeclSymbolTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/VarDeclSymbolTest.java
@@ -104,8 +104,8 @@ public class VarDeclSymbolTest {
                         List.of(Qualifier.FINAL, Qualifier.CONFIGURABLE)},
                 {26, 13, "s3", TypeDescKind.STRING, "String 3", "varDecl",
                         List.of(Qualifier.FINAL)},
-//                {30, 10, "s4", TypeDescKind.STRING, "String 4", "varDecl",
-//                        List.of(Qualifier.FINAL)},      // TODO: Uncomment after fixing #32709
+                {30, 10, "s4", TypeDescKind.STRING, "String 4", "varDecl",
+                        List.of(Qualifier.FINAL)},
                 {34, 13, "s5", TypeDescKind.ANY, "String 5", "varDecl",
                         List.of(Qualifier.ISOLATED)},
                 {38, 13, "i1", TypeDescKind.INT, "Int 1", "varDecl",
@@ -140,6 +140,8 @@ public class VarDeclSymbolTest {
                         List.of()},
                 {74, 11, "str", TypeDescKind.STRING, null, "varDecl",
                         List.of()},
+                {77, 14, "str2", TypeDescKind.STRING, null, "varDecl",
+                        List.of(Qualifier.FINAL)},
         };
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbols/var_decl_symbol_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbols/var_decl_symbol_test.bal
@@ -73,6 +73,9 @@ var {a: valueA, b: valueB} = {a: "A", b: 2};
 function test() {
     @varDecl
     string str = "foo";
+
+    @varDecl
+    final var str2 = "value";
 }
 
 public annotation varDecl;


### PR DESCRIPTION
## Purpose
Annotations were not being added to local vars when it was declared using `var`. This PR addresses that.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
