### PR TITLE
Fix stream return type selection

### DIFF
--- a/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/connector/models/connector/Type.java
+++ b/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/connector/models/connector/Type.java
@@ -23,6 +23,7 @@ import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.ArrayTypeSymbol;
 import io.ballerina.compiler.api.symbols.ErrorTypeSymbol;
 import io.ballerina.compiler.api.symbols.IntersectionTypeSymbol;
+import io.ballerina.compiler.api.symbols.ObjectTypeSymbol;
 import io.ballerina.compiler.api.symbols.RecordTypeSymbol;
 import io.ballerina.compiler.api.symbols.StreamTypeSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
@@ -44,7 +45,9 @@ import io.ballerina.compiler.syntax.tree.UnionTypeDescriptorNode;
 import org.ballerinalang.diagramutil.connector.models.connector.types.ArrayType;
 import org.ballerinalang.diagramutil.connector.models.connector.types.EnumType;
 import org.ballerinalang.diagramutil.connector.models.connector.types.ErrorType;
+import org.ballerinalang.diagramutil.connector.models.connector.types.InclusionType;
 import org.ballerinalang.diagramutil.connector.models.connector.types.IntersectionType;
+import org.ballerinalang.diagramutil.connector.models.connector.types.ObjectType;
 import org.ballerinalang.diagramutil.connector.models.connector.types.PrimitiveType;
 import org.ballerinalang.diagramutil.connector.models.connector.types.RecordType;
 import org.ballerinalang.diagramutil.connector.models.connector.types.StreamType;
@@ -290,6 +293,22 @@ public class Type {
         } else if (symbol instanceof StreamTypeSymbol) {
             StreamTypeSymbol streamTypeSymbol = (StreamTypeSymbol) symbol;
             type = fromSemanticSymbol(streamTypeSymbol.typeParameter());
+        } else if (symbol instanceof ObjectTypeSymbol) {
+            ObjectTypeSymbol objectTypeSymbol = (ObjectTypeSymbol) symbol;
+            ObjectType objectType = new ObjectType();
+            objectTypeSymbol.fieldDescriptors().forEach((typeName, typeSymbol) -> {
+                Type semanticSymbol = fromSemanticSymbol(typeSymbol);
+                if (semanticSymbol != null) {
+                    objectType.fields.add(semanticSymbol);
+                }
+            });
+            objectTypeSymbol.typeInclusions().forEach(typeSymbol -> {
+                Type semanticSymbol = fromSemanticSymbol(typeSymbol);
+                if (semanticSymbol != null) {
+                    objectType.fields.add(new InclusionType(semanticSymbol));
+                }
+            });
+            type = objectType;
         } else if (symbol instanceof TypeSymbol) {
             type = new PrimitiveType(((TypeSymbol) symbol).signature());
         }

--- a/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/connector/models/connector/Type.java
+++ b/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/connector/models/connector/Type.java
@@ -24,6 +24,7 @@ import io.ballerina.compiler.api.symbols.ArrayTypeSymbol;
 import io.ballerina.compiler.api.symbols.ErrorTypeSymbol;
 import io.ballerina.compiler.api.symbols.IntersectionTypeSymbol;
 import io.ballerina.compiler.api.symbols.RecordTypeSymbol;
+import io.ballerina.compiler.api.symbols.StreamTypeSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
@@ -286,6 +287,9 @@ public class Type {
                 }
             });
             type = intersectionType;
+        } else if (symbol instanceof StreamTypeSymbol) {
+            StreamTypeSymbol streamTypeSymbol = (StreamTypeSymbol) symbol;
+            type = fromSemanticSymbol(streamTypeSymbol.typeParameter());
         } else if (symbol instanceof TypeSymbol) {
             type = new PrimitiveType(((TypeSymbol) symbol).signature());
         }

--- a/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/connector/models/connector/types/ObjectType.java
+++ b/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/connector/models/connector/types/ObjectType.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.diagramutil.connector.models.connector.types;
+
+import com.google.gson.annotations.Expose;
+import org.ballerinalang.diagramutil.connector.models.connector.Type;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Object type model.
+ */
+public class ObjectType extends Type {
+    @Expose
+    public List<Type> fields;
+
+    public ObjectType() {
+        this.typeName = "object";
+        this.fields = new ArrayList<>();
+    }
+}


### PR DESCRIPTION
## Purpose
Update connector metadata generation logic to capture 

- `rowType` stream returns
- `rowTemplate` parameters

## Approach
Add `StreamTypeSymbol` and `ObjectTypeSymbol` filters, when getting type symbols form semantic API 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
