### PR TITLE
Avoid calls to the AI backends when there is no data in performance analyzer

### DIFF
--- a/misc/ls-extensions/modules/performance-analyzer-services/src/main/java/io/ballerina/Constants.java
+++ b/misc/ls-extensions/modules/performance-analyzer-services/src/main/java/io/ballerina/Constants.java
@@ -23,4 +23,14 @@ package io.ballerina;
 public class Constants {
 
     public static final String CAPABILITY_NAME = "performanceAnalyzer";
+    static final String ERROR = "error";
+    static final String SUCCESS = "Success";
+    static final String CONNECTION_ERROR = "CONNECTION_ERROR";
+    static final String AUTHENTICATION_ERROR = "AUTHENTICATION_ERROR";
+    static final String SOME_ERROR = "SOME_ERROR_OCCURRED";
+    static final String ENDPOINT_RESOLVE_ERROR = "ENDPOINT_RESOLVE_ERROR";
+    static final String TYPE = "type";
+    static final String MESSAGE = "message";
+    static final String NO_DATA = "NO_DATA";
+
 }

--- a/misc/ls-extensions/modules/performance-analyzer-services/src/main/java/io/ballerina/PerformanceAnalyzerService.java
+++ b/misc/ls-extensions/modules/performance-analyzer-services/src/main/java/io/ballerina/PerformanceAnalyzerService.java
@@ -37,6 +37,8 @@ import java.net.http.HttpResponse;
 import java.util.HashMap;
 import java.util.concurrent.CompletableFuture;
 
+import static io.ballerina.PerformanceAnalyzerNodeVisitor.ACTION_INVOCATION_KEY;
+
 /**
  * The extended service for the performance analyzer.
  *
@@ -52,8 +54,11 @@ public class PerformanceAnalyzerService implements ExtendedLanguageServerService
     static final String AUTHENTICATION_ERROR = "AUTHENTICATION_ERROR";
     static final String SOME_ERROR = "SOME_ERROR_OCCURRED";
     static final String ENDPOINT_RESOLVE_ERROR = "ENDPOINT_RESOLVE_ERROR";
+    static final String TYPE = "type";
+    static final String MESSAGE = "message";
     private static final HashMap<JsonObject, JsonObject> realTimeCachedResponses = new HashMap<>();
     private static final HashMap<JsonObject, JsonObject> advancedCachedResponses = new HashMap<>();
+    public static final String NO_DATA = "NO_DATA";
 
     private WorkspaceManager workspaceManager;
 
@@ -74,7 +79,27 @@ public class PerformanceAnalyzerService implements ExtendedLanguageServerService
 
         return CompletableFuture.supplyAsync(() -> {
             String fileUri = request.getDocumentIdentifier().getUri();
-            return EndpointsFinder.getEndpoints(fileUri, this.workspaceManager, request.getRange());
+            JsonObject data = EndpointsFinder.getEndpoints(fileUri, this.workspaceManager, request.getRange());
+
+            if (data.entrySet().isEmpty()) {
+                JsonObject obj = new JsonObject();
+                obj.addProperty(TYPE, ERROR);
+                obj.addProperty(MESSAGE, ENDPOINT_RESOLVE_ERROR);
+                return obj;
+            }
+
+            if (data.get(ACTION_INVOCATION_KEY).getAsJsonObject().get("nextNode").isJsonNull()) {
+                JsonObject obj = new JsonObject();
+                obj.addProperty(TYPE, ERROR);
+                obj.addProperty(MESSAGE, NO_DATA);
+                return obj;
+            }
+
+            if (data.get(TYPE) == null) {
+                data.addProperty(TYPE, SUCCESS);
+                data.addProperty(MESSAGE, SUCCESS);
+            }
+            return data;
         });
     }
 
@@ -92,8 +117,8 @@ public class PerformanceAnalyzerService implements ExtendedLanguageServerService
             JsonObject data = EndpointsFinder.getEndpoints(fileUri, this.workspaceManager, request.getRange());
             if (data.entrySet().isEmpty()) {
                 JsonObject obj = new JsonObject();
-                obj.addProperty("type", ERROR);
-                obj.addProperty("message", ENDPOINT_RESOLVE_ERROR);
+                obj.addProperty(TYPE, ERROR);
+                obj.addProperty(MESSAGE, ENDPOINT_RESOLVE_ERROR);
                 return obj;
             }
 
@@ -108,9 +133,9 @@ public class PerformanceAnalyzerService implements ExtendedLanguageServerService
                     return null;
                 }
 
-                if (graphData.get("type") == null) {
-                    graphData.addProperty("type", SUCCESS);
-                    graphData.addProperty("message", SUCCESS);
+                if (graphData.get(TYPE) == null) {
+                    graphData.addProperty(TYPE, SUCCESS);
+                    graphData.addProperty(MESSAGE, SUCCESS);
                     advancedCachedResponses.put(data, graphData);
                 }
             }
@@ -134,8 +159,15 @@ public class PerformanceAnalyzerService implements ExtendedLanguageServerService
 
             if (data.entrySet().isEmpty()) {
                 JsonObject obj = new JsonObject();
-                obj.addProperty("type", ERROR);
-                obj.addProperty("message", ENDPOINT_RESOLVE_ERROR);
+                obj.addProperty(TYPE, ERROR);
+                obj.addProperty(MESSAGE, ENDPOINT_RESOLVE_ERROR);
+                return obj;
+            }
+
+            if (data.get(ACTION_INVOCATION_KEY).getAsJsonObject().get("nextNode").isJsonNull()) {
+                JsonObject obj = new JsonObject();
+                obj.addProperty(TYPE, ERROR);
+                obj.addProperty(MESSAGE, NO_DATA);
                 return obj;
             }
 
@@ -146,9 +178,9 @@ public class PerformanceAnalyzerService implements ExtendedLanguageServerService
                 realTimeData = getDataFromChoreo(request.getChoreoAPI(), data, AnalyzeType.REALTIME,
                         request.getChoreoToken(), request.getChoreoCookie());
 
-                if (realTimeData.get("type") == null) {
-                    realTimeData.addProperty("type", SUCCESS);
-                    realTimeData.addProperty("message", SUCCESS);
+                if (realTimeData.get(TYPE) == null) {
+                    realTimeData.addProperty(TYPE, SUCCESS);
+                    realTimeData.addProperty(MESSAGE, SUCCESS);
                     realTimeCachedResponses.put(data, realTimeData);
                 }
             }
@@ -188,27 +220,27 @@ public class PerformanceAnalyzerService implements ExtendedLanguageServerService
                 return gson.fromJson(response.body(), JsonObject.class);
             } else if (response.statusCode() == 401) {
                 JsonObject obj = new JsonObject();
-                obj.addProperty("type", ERROR);
-                obj.addProperty("message", AUTHENTICATION_ERROR);
+                obj.addProperty(TYPE, ERROR);
+                obj.addProperty(MESSAGE, AUTHENTICATION_ERROR);
                 return obj;
             }
             JsonObject obj = new JsonObject();
-            obj.addProperty("type", ERROR);
-            obj.addProperty("message", SOME_ERROR);
+            obj.addProperty(TYPE, ERROR);
+            obj.addProperty(MESSAGE, SOME_ERROR);
             return obj;
 
         } catch (IOException e) {
             // No connection
             data.remove("analyzeType");
             JsonObject obj = new JsonObject();
-            obj.addProperty("type", ERROR);
-            obj.addProperty("message", CONNECTION_ERROR);
+            obj.addProperty(TYPE, ERROR);
+            obj.addProperty(MESSAGE, CONNECTION_ERROR);
             return obj;
         } catch (InterruptedException | URISyntaxException e) {
             data.remove("analyzeType");
             JsonObject obj = new JsonObject();
-            obj.addProperty("type", ERROR);
-            obj.addProperty("message", e.getMessage());
+            obj.addProperty(TYPE, ERROR);
+            obj.addProperty(MESSAGE, e.getMessage());
             return obj;
         }
     }

--- a/misc/ls-extensions/modules/performance-analyzer-services/src/main/java/io/ballerina/PerformanceAnalyzerService.java
+++ b/misc/ls-extensions/modules/performance-analyzer-services/src/main/java/io/ballerina/PerformanceAnalyzerService.java
@@ -37,6 +37,15 @@ import java.net.http.HttpResponse;
 import java.util.HashMap;
 import java.util.concurrent.CompletableFuture;
 
+import static io.ballerina.Constants.AUTHENTICATION_ERROR;
+import static io.ballerina.Constants.CONNECTION_ERROR;
+import static io.ballerina.Constants.ENDPOINT_RESOLVE_ERROR;
+import static io.ballerina.Constants.ERROR;
+import static io.ballerina.Constants.MESSAGE;
+import static io.ballerina.Constants.NO_DATA;
+import static io.ballerina.Constants.SOME_ERROR;
+import static io.ballerina.Constants.SUCCESS;
+import static io.ballerina.Constants.TYPE;
 import static io.ballerina.PerformanceAnalyzerNodeVisitor.ACTION_INVOCATION_KEY;
 
 /**
@@ -48,17 +57,8 @@ import static io.ballerina.PerformanceAnalyzerNodeVisitor.ACTION_INVOCATION_KEY;
 @JsonSegment("performanceAnalyzer")
 public class PerformanceAnalyzerService implements ExtendedLanguageServerService {
 
-    static final String ERROR = "error";
-    static final String SUCCESS = "Success";
-    static final String CONNECTION_ERROR = "CONNECTION_ERROR";
-    static final String AUTHENTICATION_ERROR = "AUTHENTICATION_ERROR";
-    static final String SOME_ERROR = "SOME_ERROR_OCCURRED";
-    static final String ENDPOINT_RESOLVE_ERROR = "ENDPOINT_RESOLVE_ERROR";
-    static final String TYPE = "type";
-    static final String MESSAGE = "message";
     private static final HashMap<JsonObject, JsonObject> realTimeCachedResponses = new HashMap<>();
     private static final HashMap<JsonObject, JsonObject> advancedCachedResponses = new HashMap<>();
-    public static final String NO_DATA = "NO_DATA";
 
     private WorkspaceManager workspaceManager;
 

--- a/misc/ls-extensions/modules/performance-analyzer-services/src/test/java/io/ballerina/PerformanceAnalyzerTest.java
+++ b/misc/ls-extensions/modules/performance-analyzer-services/src/test/java/io/ballerina/PerformanceAnalyzerTest.java
@@ -38,11 +38,11 @@ import java.nio.file.Paths;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
+import static io.ballerina.Constants.MESSAGE;
+import static io.ballerina.Constants.SUCCESS;
+import static io.ballerina.Constants.TYPE;
 import static io.ballerina.PerformanceAnalyzerNodeVisitor.ACTION_INVOCATION_KEY;
 import static io.ballerina.PerformanceAnalyzerNodeVisitor.ENDPOINTS_KEY;
-import static io.ballerina.PerformanceAnalyzerService.MESSAGE;
-import static io.ballerina.PerformanceAnalyzerService.SUCCESS;
-import static io.ballerina.PerformanceAnalyzerService.TYPE;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 
 /**
@@ -50,8 +50,8 @@ import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
  */
 public class PerformanceAnalyzerTest {
 
-    public static final String BALLERINA = "ballerina";
-    public static final String RESULT = "result";
+    private static final String BALLERINA = "ballerina";
+    private static final String RESULT = "result";
     private static final String PERFORMANCE_ANALYZE = "performanceAnalyzer/getEndpoints";
     private static final Path RES_DIR = Paths.get("src", "test", "resources").toAbsolutePath();
 

--- a/misc/ls-extensions/modules/performance-analyzer-services/src/test/resources/ballerina/noData.bal
+++ b/misc/ls-extensions/modules/performance-analyzer-services/src/test/resources/ballerina/noData.bal
@@ -1,0 +1,30 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import project.http as http;
+
+listener http:Listener helloEp4 = new (8081);
+
+service /test on helloEp4 {
+
+    resource function get .(int tag) returns string {
+        return "sss";
+    }
+    resource function get v1/[int id]/v2/[string name]() returns string {
+        return (id.toString()) + name;
+    }
+}
+

--- a/misc/ls-extensions/modules/performance-analyzer-services/src/test/resources/result/ifElse.json
+++ b/misc/ls-extensions/modules/performance-analyzer-services/src/test/resources/result/ifElse.json
@@ -89,5 +89,7 @@
         "nextNode": null
       }
     }
-  }
+  },
+  "type": "Success",
+  "message": "Success"
 }

--- a/misc/ls-extensions/modules/performance-analyzer-services/src/test/resources/result/main.json
+++ b/misc/ls-extensions/modules/performance-analyzer-services/src/test/resources/result/main.json
@@ -79,5 +79,7 @@
         }
       }
     }
-  }
+  },
+  "type": "Success",
+  "message": "Success"
 }

--- a/misc/ls-extensions/modules/performance-analyzer-services/src/test/resources/result/noData.json
+++ b/misc/ls-extensions/modules/performance-analyzer-services/src/test/resources/result/noData.json
@@ -1,0 +1,4 @@
+{
+  "type": "error",
+  "message": "NO_DATA"
+}


### PR DESCRIPTION
## Purpose
> Currently, NO_DATA pop is showing always when there is no endpoint invocations in the function. This happens because there is no client calls to predict the performance. This PR fixes that issue and avoid the API calls to the API backend when there is no client endpoints.

Fixes https://github.com/wso2/ballerina-plugin-vscode/issues/131

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
