### PR TITLE
Fix removing ignored imports in syntaxtree modify

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/visitor/UnusedSymbolsVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/visitor/UnusedSymbolsVisitor.java
@@ -127,6 +127,13 @@ public class UnusedSymbolsVisitor extends NodeVisitor {
                 availableOutSideDeleteRange = true;
             }
         }
+
+        // If import has the prefix `_` then treat is as an used import.
+        if (importDeclarationNode.prefix().isPresent()
+                && "_".equals(importDeclarationNode.prefix().get().prefix().text())) {
+            availableOutSideDeleteRange = true;
+        }
+
         if (availableOutSideDeleteRange) {
             this.unusedImports.remove(getImportModuleName(importDeclarationNode.orgName().isPresent()
                     ? importDeclarationNode.orgName().get() : null, importDeclarationNode.moduleName()));
@@ -134,8 +141,6 @@ public class UnusedSymbolsVisitor extends NodeVisitor {
                             ? importDeclarationNode.orgName().get() : null, importDeclarationNode.moduleName()),
                     importDeclarationNode);
         }
-
-
     }
 
     private void decideVariablesToBeDeleted(LineRange lineRange) {

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/document/SyntaxTreeModifyTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/document/SyntaxTreeModifyTest.java
@@ -76,6 +76,41 @@ public class SyntaxTreeModifyTest {
             .resolve("modify")
             .resolve("mainHttpCallWithPrint.bal");
 
+    private Path removeImport = FileUtils.RES_DIR.resolve("extensions")
+            .resolve("document")
+            .resolve("ast")
+            .resolve("modify")
+            .resolve("removeImport.bal");
+
+    private Path removeImportExpected = FileUtils.RES_DIR.resolve("extensions")
+            .resolve("document")
+            .resolve("ast")
+            .resolve("modify")
+            .resolve("removeImportExpected.bal");
+
+    private Path notRemoveIgnoredImports = FileUtils.RES_DIR.resolve("extensions")
+            .resolve("document")
+            .resolve("ast")
+            .resolve("modify")
+            .resolve("notRemoveIgnoredImports.bal");
+
+    private Path notRemoveIgnoredImportsExpected = FileUtils.RES_DIR.resolve("extensions")
+            .resolve("document")
+            .resolve("ast")
+            .resolve("modify")
+            .resolve("notRemoveIgnoredImportsExpected.bal");
+
+    private Path notRemoveUsedImports = FileUtils.RES_DIR.resolve("extensions")
+            .resolve("document")
+            .resolve("ast")
+            .resolve("modify")
+            .resolve("notRemoveUsedImports.bal");
+
+    private Path notRemoveUsedImportsExpected = FileUtils.RES_DIR.resolve("extensions")
+            .resolve("document")
+            .resolve("ast")
+            .resolve("modify")
+            .resolve("notRemoveUsedImportsExpected.bal");
 //    private Path serviceNatsFile = FileUtils.RES_DIR.resolve("extensions")
 //            .resolve("document")
 //            .resolve("ast")
@@ -135,6 +170,72 @@ public class SyntaxTreeModifyTest {
         BallerinaSyntaxTreeResponse astModifyResponse = LSExtensionTestUtil
                 .modifyAndGetBallerinaSyntaxTree(inputFile.toString(),
                         new ASTModification[]{modification1, modification2, modification3}, this.serviceEndpoint);
+        BallerinaSyntaxTreeResponse astResponse = LSExtensionTestUtil.getBallerinaSyntaxTree(
+                expectedFile.toString(), this.serviceEndpoint);
+        Assert.assertEquals(astModifyResponse.getSyntaxTree(), astResponse.getSyntaxTree());
+        TestUtil.closeDocument(this.serviceEndpoint, inputFile);
+        TestUtil.closeDocument(this.serviceEndpoint, expectedFile);
+    }
+
+    @Test(description = "Remove unused import from file on modification.")
+    public void testRemoveUnusedImport() throws IOException {
+        skipOnWindows();
+        Path inputFile = LSExtensionTestUtil.createTempFile(removeImport);
+        TestUtil.openDocument(serviceEndpoint, inputFile);
+        Path expectedFile = LSExtensionTestUtil.createTempFile(removeImportExpected);
+        TestUtil.openDocument(serviceEndpoint, expectedFile);
+        Gson gson = new Gson();
+        ASTModification modification1 = new ASTModification(3, 0, 3, 0, false,
+                "INSERT",
+                gson.fromJson("{\"TYPE\":\"ballerina/http\", \"STATEMENT\":\"int a = 0;\"}",
+                        JsonObject.class));
+        BallerinaSyntaxTreeResponse astModifyResponse = LSExtensionTestUtil
+                .modifyAndGetBallerinaSyntaxTree(inputFile.toString(),
+                        new ASTModification[]{modification1}, this.serviceEndpoint);
+        BallerinaSyntaxTreeResponse astResponse = LSExtensionTestUtil.getBallerinaSyntaxTree(
+                expectedFile.toString(), this.serviceEndpoint);
+        Assert.assertEquals(astModifyResponse.getSyntaxTree(), astResponse.getSyntaxTree());
+        TestUtil.closeDocument(this.serviceEndpoint, inputFile);
+        TestUtil.closeDocument(this.serviceEndpoint, expectedFile);
+    }
+
+    @Test(description = "Not remove ignored imports from file on modification.")
+    public void testNotRemoveIgnoredImport() throws IOException {
+        skipOnWindows();
+        Path inputFile = LSExtensionTestUtil.createTempFile(notRemoveIgnoredImports);
+        TestUtil.openDocument(serviceEndpoint, inputFile);
+        Path expectedFile = LSExtensionTestUtil.createTempFile(notRemoveIgnoredImportsExpected);
+        TestUtil.openDocument(serviceEndpoint, expectedFile);
+        Gson gson = new Gson();
+        ASTModification modification1 = new ASTModification(3, 0, 3, 0, false,
+                "INSERT",
+                gson.fromJson("{\"TYPE\":\"ballerina/http\", \"STATEMENT\":\"int a = 0;\"}",
+                        JsonObject.class));
+        BallerinaSyntaxTreeResponse astModifyResponse = LSExtensionTestUtil
+                .modifyAndGetBallerinaSyntaxTree(inputFile.toString(),
+                        new ASTModification[]{modification1}, this.serviceEndpoint);
+        BallerinaSyntaxTreeResponse astResponse = LSExtensionTestUtil.getBallerinaSyntaxTree(
+                expectedFile.toString(), this.serviceEndpoint);
+        Assert.assertEquals(astModifyResponse.getSyntaxTree(), astResponse.getSyntaxTree());
+        TestUtil.closeDocument(this.serviceEndpoint, inputFile);
+        TestUtil.closeDocument(this.serviceEndpoint, expectedFile);
+    }
+
+    @Test(description = "Not remove used imports from file on modification.")
+    public void testNotRemoveUsedImport() throws IOException {
+        skipOnWindows();
+        Path inputFile = LSExtensionTestUtil.createTempFile(notRemoveUsedImports);
+        TestUtil.openDocument(serviceEndpoint, inputFile);
+        Path expectedFile = LSExtensionTestUtil.createTempFile(notRemoveUsedImportsExpected);
+        TestUtil.openDocument(serviceEndpoint, expectedFile);
+        Gson gson = new Gson();
+        ASTModification modification1 = new ASTModification(5, 0, 5, 0, false,
+                "INSERT",
+                gson.fromJson("{\"TYPE\":\"ballerina/http\", \"STATEMENT\":\"int a = 0;\"}",
+                        JsonObject.class));
+        BallerinaSyntaxTreeResponse astModifyResponse = LSExtensionTestUtil
+                .modifyAndGetBallerinaSyntaxTree(inputFile.toString(),
+                        new ASTModification[]{modification1}, this.serviceEndpoint);
         BallerinaSyntaxTreeResponse astResponse = LSExtensionTestUtil.getBallerinaSyntaxTree(
                 expectedFile.toString(), this.serviceEndpoint);
         Assert.assertEquals(astModifyResponse.getSyntaxTree(), astResponse.getSyntaxTree());

--- a/language-server/modules/langserver-core/src/test/resources/extensions/document/ast/modify/notRemoveIgnoredImports.bal
+++ b/language-server/modules/langserver-core/src/test/resources/extensions/document/ast/modify/notRemoveIgnoredImports.bal
@@ -1,0 +1,5 @@
+import ballerina/lang.array as _;
+
+public function main() {
+
+}

--- a/language-server/modules/langserver-core/src/test/resources/extensions/document/ast/modify/notRemoveIgnoredImportsExpected.bal
+++ b/language-server/modules/langserver-core/src/test/resources/extensions/document/ast/modify/notRemoveIgnoredImportsExpected.bal
@@ -1,0 +1,5 @@
+import ballerina/lang.array as _;
+
+public function main() {
+    int a = 0;
+}

--- a/language-server/modules/langserver-core/src/test/resources/extensions/document/ast/modify/notRemoveUsedImports.bal
+++ b/language-server/modules/langserver-core/src/test/resources/extensions/document/ast/modify/notRemoveUsedImports.bal
@@ -1,0 +1,7 @@
+import ballerina/lang.array;
+
+public function main() {
+    int[] a = [0];
+    int count = array:length(a);
+
+}

--- a/language-server/modules/langserver-core/src/test/resources/extensions/document/ast/modify/notRemoveUsedImportsExpected.bal
+++ b/language-server/modules/langserver-core/src/test/resources/extensions/document/ast/modify/notRemoveUsedImportsExpected.bal
@@ -1,0 +1,7 @@
+import ballerina/lang.array;
+
+public function main() {
+    int[] a = [0];
+    int count = array:length(a);
+    int a = 0;
+}

--- a/language-server/modules/langserver-core/src/test/resources/extensions/document/ast/modify/removeImport.bal
+++ b/language-server/modules/langserver-core/src/test/resources/extensions/document/ast/modify/removeImport.bal
@@ -1,0 +1,5 @@
+import ballerina/lang.array;
+
+public function main() {
+
+}

--- a/language-server/modules/langserver-core/src/test/resources/extensions/document/ast/modify/removeImportExpected.bal
+++ b/language-server/modules/langserver-core/src/test/resources/extensions/document/ast/modify/removeImportExpected.bal
@@ -1,0 +1,4 @@
+
+public function main() {
+    int a = 0;
+}

--- a/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/SyntaxTreeDiagnosticsUtil.java
+++ b/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/SyntaxTreeDiagnosticsUtil.java
@@ -21,6 +21,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import io.ballerina.tools.diagnostics.Diagnostic;
 import io.ballerina.tools.diagnostics.DiagnosticInfo;
+import io.ballerina.tools.diagnostics.Location;
 
 /**
  * This is the SyntaxTreeDiagnosticsUtil class for diagnostics related utils used in the syntax tree generation.
@@ -34,6 +35,7 @@ public class SyntaxTreeDiagnosticsUtil {
         for (Diagnostic diagnostic : diagnostics) {
             JsonObject diagnosticJson = new JsonObject();
             diagnosticJson.addProperty("message", diagnostic.message());
+            diagnosticJson.add("range" , getLocation(diagnostic.location()));
             DiagnosticInfo diagnosticInfo = diagnostic.diagnosticInfo();
             if (diagnosticInfo != null) {
                 JsonObject diagnosticInfoJson = new JsonObject();
@@ -45,5 +47,14 @@ public class SyntaxTreeDiagnosticsUtil {
         }
 
         return diagnosticsArray;
+    }
+
+    public static JsonObject getLocation(Location location) {
+        JsonObject jsonLocation = new JsonObject();
+        jsonLocation.addProperty("startLine", location.lineRange().startLine().line());
+        jsonLocation.addProperty("endLine", location.lineRange().endLine().line());
+        jsonLocation.addProperty("startColumn", location.textRange().startOffset());
+        jsonLocation.addProperty("endColumn", location.textRange().endOffset());
+        return jsonLocation;
     }
 }


### PR DESCRIPTION
## Purpose
Fix removing ignored imports in syntax tree modify

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
