### PR TITLE
Fix change var type code action for record fields

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/ChangeVariableTypeCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/ChangeVariableTypeCodeAction.java
@@ -117,18 +117,21 @@ public class ChangeVariableTypeCodeAction extends TypeCastCodeAction {
 
     private Optional<NonTerminalNode> getVariableNode(NonTerminalNode sNode) {
         // Find var node
-        while (sNode != null &&
-                sNode.kind() != SyntaxKind.LOCAL_VAR_DECL &&
-                sNode.kind() != SyntaxKind.MODULE_VAR_DECL &&
-                sNode.kind() != SyntaxKind.ASSIGNMENT_STATEMENT) {
-            // The cursor can be within a positional/named arg. If so, don't show this code action
-            if (sNode.kind() == SyntaxKind.POSITIONAL_ARG || sNode.kind() == SyntaxKind.NAMED_ARG) {
-                return Optional.empty();
-            }
-            sNode = sNode.parent();
+        if (isVariableNode(sNode)) {
+            return Optional.of(sNode);
+        } else if (isVariableNode(sNode.parent())) {
+            return Optional.of(sNode.parent());
         }
 
-        return Optional.ofNullable(sNode);
+        return Optional.empty();
+    }
+    
+    boolean isVariableNode (NonTerminalNode sNode) {
+        return sNode != null &&
+                (sNode.kind() == SyntaxKind.LOCAL_VAR_DECL ||
+                sNode.kind() == SyntaxKind.MODULE_VAR_DECL ||
+                sNode.kind() == SyntaxKind.ASSIGNMENT_STATEMENT) &&
+                (sNode.kind() != SyntaxKind.POSITIONAL_ARG || sNode.kind() != SyntaxKind.NAMED_ARG);
     }
 
     private Optional<String> getTypeNodeStr(ExpressionNode expressionNode) {

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ChangeVariableTypeCodeActionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ChangeVariableTypeCodeActionTest.java
@@ -61,6 +61,7 @@ public class ChangeVariableTypeCodeActionTest extends AbstractCodeActionTest {
         return new Object[][]{
                 {"negative_changeVarType1.json", "negative_changeVarType1.bal"},
                 {"negative_changeVarType2.json", "negative_changeVarType2.bal"},
+                {"negative_changeVarType3.json", "negative_changeVarType3.bal"},
         };
     }
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/config/negative_changeVarType3.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/config/negative_changeVarType3.json
@@ -1,0 +1,9 @@
+{
+    "line": 2,
+    "character": 67,
+    "expected": [
+        {
+            "title": "Change variable 'val' type to 'float'"
+        }
+    ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/source/negative_changeVarType3.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/source/negative_changeVarType3.bal
@@ -1,0 +1,4 @@
+
+public function main() {
+    record {|int field1; int field2;|} val = {field1: 0, field2: 1.0}; 
+}


### PR DESCRIPTION
## Purpose
This PR fixes showing the change var type code action for record fields in order to avoid inaccurate code action edits.

Fixes #33780

## Approach
Modified the logic to find variable node to check only upto parent.

## Samples
<img width="618" alt="Screenshot 2021-12-01 at 11 21 09" src="https://user-images.githubusercontent.com/27485094/144179290-39e47a16-67bc-4709-96fe-f5479395b02d.png">

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
