### PR TITLE
Improve service type inference to type-ids

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
@@ -753,7 +753,6 @@ public enum DiagnosticErrorCode implements DiagnosticCode {
     INVALID_NON_ISOLATED_CALL_IN_MATCH_GUARD("BCE4018", "invalid.non.isolated.call.in.match.guard"),
     INVALID_CALL_WITH_MUTABLE_ARGS_IN_MATCH_GUARD("BCE4019", "invalid.call.with.mutable.args.in.match.guard"),
     ERROR_CONSTRUCTOR_COMPATIBLE_TYPE_NOT_FOUND("BCE4020", "error.constructor.compatible.type.not.found"),
-    CANNOT_INFER_SERVICE_TYPES_FROM_LISTENERS("BCE4021", "cannot.infer.service.type.from.listeners"),
     SERVICE_DOES_NOT_IMPLEMENT_REQUIRED_CONSTRUCTS("BCE4022", "service.decl.does.not.implement.required.constructs")
     ;
 

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -793,9 +793,6 @@ error.object.type.required=\
 error.service.invalid.object.type=\
   given type ''{0}'' does not match with service type interface
 
-error.cannot.infer.service.type.from.listeners=\
-  cannot infer service type from listener attachments
-
 error.service.decl.does.not.implement.required.constructs=\
   service declaration does not implement all required constructs of type: ''{0}''
 

--- a/langlib/lang.typedesc/src/main/java/org/ballerinalang/langlib/typedesc/TypeIds.java
+++ b/langlib/lang.typedesc/src/main/java/org/ballerinalang/langlib/typedesc/TypeIds.java
@@ -87,6 +87,7 @@ public class TypeIds {
                 typeIdSet = errorType.typeIdSet;
                 break;
             case TypeTags.OBJECT_TYPE_TAG:
+            case TypeTags.SERVICE_TAG:
                 BObjectType objectType = (BObjectType) describingType;
                 typeIdSet = objectType.typeIdSet;
                 break;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/services/service_decl_distinct_listener_arg.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/services/service_decl_distinct_listener_arg.bal
@@ -56,11 +56,6 @@ isolated function externLInit(object {} o) returns error? = @java:Method {
     name: "listenerInit"
 } external;
 
-function getService() returns object {} = @java:Method {
-    'class: "org/ballerinalang/nativeimpl/jvm/servicetests/ServiceValue",
-    name: "getService"
-} external;
-
 function reset() = @java:Method {
     'class: "org/ballerinalang/nativeimpl/jvm/servicetests/ServiceValue",
     name: "reset"
@@ -69,6 +64,11 @@ function reset() = @java:Method {
 public function callMethod(service object {} s, string name) returns future<any|error>  = @java:Method {
     'class:"org/ballerinalang/nativeimpl/jvm/servicetests/ServiceValue",
     name:"callMethod"
+} external;
+
+function getService() returns ServiceType = @java:Method {
+    'class: "org/ballerinalang/nativeimpl/jvm/servicetests/ServiceValue",
+    name: "getService"
 } external;
 
 listener lsn = new Listener();
@@ -89,6 +89,16 @@ service / on lsn {
 
 function testServiceDecl() {
     any|error v = wait callMethod(<service object {}> getService(), "$get$processRequest");
+    ServiceType s = getService();
+    var td = typeof s;
+    var tIds = td.typeIds();
+    if (tIds != ()) {
+        assertEquality(tIds.length(), 1);
+        assertEquality(tIds[0].localId, "ServiceType");
+    } else {
+        panic error("Expected to have type-ids");
+    }
+
     reset();
     assertEquality(v, <json> { output: "Hello" });
 }


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/33992

Current type inference is a hack to get someting similar to type-inference, we need to change the way we represent service-decl to have proper type inference for the service-decl. Issue to track this https://github.com/ballerina-platform/ballerina-lang/issues/34092
## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
