### PR TITLE
Add runtime error for out of range exponents in decimal values

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/cli/CliUtil.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/cli/CliUtil.java
@@ -124,7 +124,7 @@ public class CliUtil {
     private static DecimalValue getDecimalValue(String argument, String parameterName) {
         try {
             return new DecimalValue(argument);
-        } catch (NumberFormatException e) {
+        } catch (NumberFormatException | BError e) {
             throw ErrorCreator.createError(
                     StringUtils.fromString(String.format(INVALID_ARGUMENT_ERROR, argument, parameterName, "decimal")));
         }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/configurable/providers/cli/CliProvider.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/configurable/providers/cli/CliProvider.java
@@ -162,7 +162,7 @@ public class CliProvider implements ConfigProvider {
         }
         try {
             return getCliConfigValue(TypeConverter.stringToDecimal(cliArg.value));
-        } catch (NumberFormatException e) {
+        } catch (NumberFormatException | BError e) {
             throw new ConfigException(CONFIG_INCOMPATIBLE_TYPE, cliArg, key.variable, key.type, cliArg.value);
         }
     }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/util/exceptions/BallerinaErrorReasons.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/util/exceptions/BallerinaErrorReasons.java
@@ -50,6 +50,8 @@ public class BallerinaErrorReasons {
     public static final String NUMBER_OVERFLOW_ERROR_IDENTIFIER = "NumberOverflow";
     public static final BString NUMBER_OVERFLOW =
             StringUtils.fromString(BALLERINA_PREFIX.concat(NUMBER_OVERFLOW_ERROR_IDENTIFIER));
+    public static final BString LARGE_EXPONENT_ERROR = StringUtils.fromString(BALLERINA_PREFIX.concat(
+            "DecimalExponentError"));
     public static final BString ARITHMETIC_OPERATION_ERROR =
             StringUtils.fromString(BALLERINA_PREFIX.concat("ArithmeticOperationError"));
     public static final BString JAVA_NULL_REFERENCE_ERROR =

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/util/exceptions/RuntimeErrors.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/util/exceptions/RuntimeErrors.java
@@ -120,7 +120,8 @@ public enum RuntimeErrors implements DiagnosticCode {
     CONFIG_CLI_TYPE_NOT_SUPPORTED("config.cli.type.not.supported", "RUNTIME_0092"),
     CONFIG_CLI_VARIABLE_AMBIGUITY("config.cli.variable.ambiguity", "RUNTIME_0093"),
     CONFIG_CLI_ARGS_AMBIGUITY("config.cli.args.ambiguity", "RUNTIME_0094"),
-    CONFIG_CLI_UNUSED_CLI_ARGS("config.cli.unused.args", "RUNTIME_0095");
+    CONFIG_CLI_UNUSED_CLI_ARGS("config.cli.unused.args", "RUNTIME_0095"),
+    LARGE_EXPONENTS_IN_DECIMAL("large.number.of.exponents.in.decimal", "RUNTIME_0096");
 
     private String errorMsgKey;
     private String errorCode;

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/DecimalValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/DecimalValue.java
@@ -75,8 +75,12 @@ public class DecimalValue implements SimpleValue, BDecimal {
             try {
                 this.value = new BigDecimal(value, MathContext.DECIMAL128);
             } catch (NumberFormatException exception) {
-                throw ErrorCreator.createError(BallerinaErrorReasons.LARGE_EXPONENT_ERROR,
-                        BLangExceptionHelper.getErrorDetails(RuntimeErrors.LARGE_EXPONENTS_IN_DECIMAL, value));
+                String message = exception.getMessage();
+                if (message.equals("Too many nonzero exponent digits.") || message.equals("Exponent overflow.")) {
+                    throw ErrorCreator.createError(BallerinaErrorReasons.LARGE_EXPONENT_ERROR,
+                            BLangExceptionHelper.getErrorDetails(RuntimeErrors.LARGE_EXPONENTS_IN_DECIMAL, value));
+                }
+                throw exception;
             }
         }
         if (!this.booleanValue()) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/DecimalValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/DecimalValue.java
@@ -20,11 +20,15 @@ package io.ballerina.runtime.internal.values;
 
 import io.ballerina.runtime.api.PredefinedTypes;
 import io.ballerina.runtime.api.constants.RuntimeConstants;
+import io.ballerina.runtime.api.creators.ErrorCreator;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.values.BDecimal;
 import io.ballerina.runtime.api.values.BLink;
 import io.ballerina.runtime.internal.DecimalValueKind;
 import io.ballerina.runtime.internal.ErrorUtils;
+import io.ballerina.runtime.internal.util.exceptions.BLangExceptionHelper;
+import io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons;
+import io.ballerina.runtime.internal.util.exceptions.RuntimeErrors;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -68,7 +72,12 @@ public class DecimalValue implements SimpleValue, BDecimal {
         if (isHexValueString(value)) {
             this.value = hexToDecimalFloatingPointNumber(value);
         } else {
-            this.value = new BigDecimal(value, MathContext.DECIMAL128);
+            try {
+                this.value = new BigDecimal(value, MathContext.DECIMAL128);
+            } catch (NumberFormatException exception) {
+                throw ErrorCreator.createError(BallerinaErrorReasons.LARGE_EXPONENT_ERROR,
+                        BLangExceptionHelper.getErrorDetails(RuntimeErrors.LARGE_EXPONENTS_IN_DECIMAL, value));
+            }
         }
         if (!this.booleanValue()) {
             this.valueKind = DecimalValueKind.ZERO;

--- a/bvm/ballerina-runtime/src/main/resources/MessagesBundle.properties
+++ b/bvm/ballerina-runtime/src/main/resources/MessagesBundle.properties
@@ -233,3 +233,4 @@ config.cli.variable.ambiguity = configurable value for variable ''{0}'' clashes 
   provide the command line argument as ''[{2}]''
 config.cli.args.ambiguity = configurable value for variable ''{0}'' clashes with multiple command line arguments {1}
 config.cli.unused.args = [{0}] unused command line argument
+large.number.of.exponents.in.decimal = too many exponents found in decimal value ''{0}''

--- a/bvm/ballerina-runtime/src/test/java/io/ballerina/runtime/test/cli/OptionTest.java
+++ b/bvm/ballerina-runtime/src/test/java/io/ballerina/runtime/test/cli/OptionTest.java
@@ -300,6 +300,12 @@ public class OptionTest {
                     "invalid argument 'name' for parameter 'val', expected " + typeStr + " value");
     }
 
+    @Test()
+    public void testInvalidDecimal() {
+        testInvalid(PredefinedTypes.TYPE_DECIMAL, new String[]{"--val=99999999.9e9999999999"},
+                "invalid argument '99999999.9e9999999999' for parameter 'val', expected decimal value");
+    }
+
     @DataProvider(name = "invalid")
     public Object[][] testInvalidOption() {
         return new Object[][]{{PredefinedTypes.TYPE_STRING, new String[]{"-val"}, "undefined CLI argument: '-val'"},

--- a/bvm/ballerina-runtime/src/test/java/io/ballerina/runtime/test/config/negative/CliProviderNegativeTest.java
+++ b/bvm/ballerina-runtime/src/test/java/io/ballerina/runtime/test/config/negative/CliProviderNegativeTest.java
@@ -93,6 +93,10 @@ public class CliProviderNegativeTest {
                 {new String[]{"-Cmyorg.mod.x = 27.5 "}, "myorg", "mod", "x", PredefinedTypes.TYPE_DECIMAL,
                         "error: [myorg.mod.x= 27.5 ] configurable variable 'x' is expected to be of type 'decimal', " +
                                 "but found ' 27.5 '"},
+                {new String[]{"-Cmyorg.mod.x =99999999.9e9999999999"}, "myorg", "mod", "x",
+                        PredefinedTypes.TYPE_DECIMAL,
+                        "error: [myorg.mod.x=99999999.9e9999999999] configurable variable 'x' is expected to be of " +
+                                "type 'decimal', but found '99999999.9e9999999999'"},
                 // Config byte value with invalid byte range
                 {new String[]{"-Cmyorg.mod.x=345"}, "myorg", "mod", "x", PredefinedTypes.TYPE_BYTE,
                         "error: [myorg.mod.x=345] value provided for byte variable 'x' is out of range. Expected " +

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/decimaltype/BDecimalUsageTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/decimaltype/BDecimalUsageTest.java
@@ -145,6 +145,11 @@ public class BDecimalUsageTest {
         BRunUtil.invoke(result, "testDecimalDefaultable");
     }
 
+    @Test(description = "Test decimal values with too many exponents")
+    public void testDecimalNegativeLargeExponents() {
+        BRunUtil.invoke(result, "testDecimalNegativeLargeExponents");
+    }
+
     @AfterClass
     public void tearDown() {
         result = null;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/decimal/decimal_usage.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/decimal/decimal_usage.bal
@@ -42,7 +42,7 @@ function testDecimalRecord() returns [decimal, decimal] {
 
 // Test object with decimal fields
 function testDecimalObject() returns [string, int, decimal, decimal] {
-    Student s = new(57.25, 168.67);
+    Student s = new (57.25, 168.67);
     return [s.name, s.age, s.weight, s.height];
 }
 
@@ -78,4 +78,31 @@ function decimalDefaultable(decimal fixedPrice, decimal tax = 10.28, decimal dis
     decimal discount = fixedPrice * discountRate;
     decimal price = fixedPrice + tax - discount;
     return price;
+}
+
+// Decimal exponents 
+function testDecimalNegativeLargeExponents() {
+    decimal|error value = trap getDecimal1();
+    test:assertTrue(value is error);
+    error err = <error>value;
+    test:assertEquals(err.message(), "{ballerina}DecimalExponentError");
+    var message = err.detail()["message"];
+    string messageString = message is error ? message.toString() : message.toString();
+    test:assertEquals(messageString, "too many exponents found in decimal value '99999999.9e99999999999999'");
+
+    value = trap getDecimal2();
+    test:assertTrue(value is error);
+    err = <error>value;
+    test:assertEquals(err.message(), "{ballerina}DecimalExponentError");
+    message = err.detail()["message"];
+    messageString = message is error ? message.toString() : message.toString();
+    test:assertEquals(messageString, "too many exponents found in decimal value '99999999.9e9999999999'");
+}
+
+function getDecimal1() returns decimal {
+    return 99999999.9e99999999999999;
+}
+
+function getDecimal2() returns decimal {
+    return 99999999.9e9999999999;
 }


### PR DESCRIPTION
## Purpose
$subject

Fixes #33878 

## Approach
Added validation to panic when there are out of range exponents in the decimal value.

## Samples
```ballerina
public function main() {
    decimal _ = 99999999.9e99999999999;
}
```

error message : 
```
error: {ballerina}DecimalExponentError {"message":"too many exponents found in decimal value '99999999.9e99999999999'"}
        at hinduja.foo.0:main(main.bal:2)
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
