### PR TITLE
Fix missing in-scope symbols issue for expressions/actions with scope

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/EnvironmentResolver.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/EnvironmentResolver.java
@@ -52,6 +52,8 @@ import org.wso2.ballerinalang.compiler.tree.clauses.BLangOrderByClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangSelectClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangWhereClause;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangBinaryExpr;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangCheckPanickedExpr;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangCheckedExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangConstant;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangErrorConstructorExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
@@ -65,6 +67,7 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangQueryAction;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangQueryExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangStatementExpression;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangTrapExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangTypeConversionExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangTypeInit;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangAssignment;
@@ -283,9 +286,6 @@ public class EnvironmentResolver extends BaseVisitor {
 
     @Override
     public void visit(BLangExpressionStmt exprStmtNode) {
-        if (!(exprStmtNode.expr instanceof BLangInvocation)) {
-            return;
-        }
         this.acceptNode(exprStmtNode.expr, symbolEnv);
     }
 
@@ -613,6 +613,21 @@ public class EnvironmentResolver extends BaseVisitor {
             this.scope = blockEnv;
             this.acceptNode(matchClause.blockStmt, blockEnv);
         }
+    }
+
+    @Override
+    public void visit(BLangCheckedExpr checkedExpr) {
+        this.acceptNode(checkedExpr.expr, this.symbolEnv);
+    }
+
+    @Override
+    public void visit(BLangCheckPanickedExpr checkPanickedExpr) {
+        this.acceptNode(checkPanickedExpr.expr, this.symbolEnv);
+    }
+
+    @Override
+    public void visit(BLangTrapExpr trapExpr) {
+        this.acceptNode(trapExpr.expr, this.symbolEnv);
     }
 
     private void acceptNode(BLangNode node, SymbolEnv env) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/EnvironmentResolver.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/EnvironmentResolver.java
@@ -51,25 +51,39 @@ import org.wso2.ballerinalang.compiler.tree.clauses.BLangOnFailClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangOrderByClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangSelectClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangWhereClause;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangAnnotAccessExpr;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangArrowFunction;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangBinaryExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangCheckPanickedExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangCheckedExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangConstant;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangElvisExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangErrorConstructorExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangFieldBasedAccess;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangGroupExpr;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangIndexBasedAccess;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangInvocation;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangLambdaFunction;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangLetExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangListConstructorExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangNamedArgsExpression;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangObjectConstructorExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangQueryAction;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangQueryExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangRestArgsExpression;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangServiceConstructorExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangStatementExpression;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangTableConstructorExpr;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangTernaryExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangTrapExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangTypeConversionExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangTypeInit;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangTypeTestExpr;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangWaitExpr;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangWaitForAllExpr;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangWorkerSyncSendExpr;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangAssignment;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangBlockStmt;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangCompoundAssignment;
@@ -260,7 +274,7 @@ public class EnvironmentResolver extends BaseVisitor {
 
     @Override
     public void visit(BLangExprFunctionBody exprFuncBody) {
-        if (PositionUtil.withinBlock(this.linePosition, exprFuncBody.getPosition())
+        if (PositionUtil.withinRightInclusive(this.linePosition, exprFuncBody.getPosition())
                 && isNarrowerEnclosure(exprFuncBody.getPosition())) {
             SymbolEnv exprBodyEnv = SymbolEnv.createFuncBodyEnv(exprFuncBody, symbolEnv);
             this.scope = exprBodyEnv;
@@ -615,6 +629,8 @@ public class EnvironmentResolver extends BaseVisitor {
         }
     }
 
+    // Expressions. Need to implement these since there can be some expressions which may contain query
+    // expressions/actions within them.
     @Override
     public void visit(BLangCheckedExpr checkedExpr) {
         this.acceptNode(checkedExpr.expr, this.symbolEnv);
@@ -628,6 +644,88 @@ public class EnvironmentResolver extends BaseVisitor {
     @Override
     public void visit(BLangTrapExpr trapExpr) {
         this.acceptNode(trapExpr.expr, this.symbolEnv);
+    }
+
+    @Override
+    public void visit(BLangFieldBasedAccess fieldAccessExpr) {
+        this.acceptNode(fieldAccessExpr.expr, this.symbolEnv);
+    }
+
+    @Override
+    public void visit(BLangIndexBasedAccess indexAccessExpr) {
+        this.acceptNode(indexAccessExpr.expr, this.symbolEnv);
+        this.acceptNode(indexAccessExpr.indexExpr, this.symbolEnv);
+    }
+
+    @Override
+    public void visit(BLangTernaryExpr ternaryExpr) {
+        this.acceptNode(ternaryExpr.expr, this.symbolEnv);
+        this.acceptNode(ternaryExpr.thenExpr, this.symbolEnv);
+        this.acceptNode(ternaryExpr.elseExpr, this.symbolEnv);
+    }
+
+    @Override
+    public void visit(BLangWaitExpr awaitExpr) {
+        this.acceptNodes(awaitExpr.exprList, this.symbolEnv);
+    }
+
+    @Override
+    public void visit(BLangElvisExpr elvisExpr) {
+        this.acceptNode(elvisExpr.lhsExpr, this.symbolEnv);
+        this.acceptNode(elvisExpr.rhsExpr, this.symbolEnv);
+    }
+
+    @Override
+    public void visit(BLangTableConstructorExpr tableConstructorExpr) {
+        this.acceptNodes(tableConstructorExpr.recordLiteralList, this.symbolEnv);
+    }
+
+    @Override
+    public void visit(BLangRestArgsExpression bLangVarArgsExpression) {
+        this.acceptNode(bLangVarArgsExpression.expr, this.symbolEnv);
+    }
+
+    @Override
+    public void visit(BLangServiceConstructorExpr serviceConstructorExpr) {
+        this.acceptNode(serviceConstructorExpr.serviceNode, this.symbolEnv);
+    }
+
+    @Override
+    public void visit(BLangTypeTestExpr typeTestExpr) {
+        this.acceptNode(typeTestExpr.expr, this.symbolEnv);
+        this.acceptNode(typeTestExpr.typeNode, this.symbolEnv);
+    }
+
+    @Override
+    public void visit(BLangAnnotAccessExpr annotAccessExpr) {
+        this.acceptNode(annotAccessExpr.expr, this.symbolEnv);
+    }
+
+    @Override
+    public void visit(BLangObjectConstructorExpression bLangObjectConstructorExpression) {
+        this.acceptNode(bLangObjectConstructorExpression.classNode, this.symbolEnv);
+    }
+
+    @Override
+    public void visit(BLangWorkerSyncSendExpr syncSendExpr) {
+        this.acceptNode(syncSendExpr.expr, this.symbolEnv);
+    }
+
+    @Override
+    public void visit(BLangWaitForAllExpr waitForAllExpr) {
+        this.acceptNodes(waitForAllExpr.keyValuePairs, this.symbolEnv);
+    }
+
+    @Override
+    public void visit(BLangArrowFunction bLangArrowFunction) {
+        this.acceptNodes(bLangArrowFunction.params, this.symbolEnv);
+        this.acceptNode(bLangArrowFunction.body, this.symbolEnv);
+    }
+
+    private void acceptNodes(List<? extends BLangNode> nodes, SymbolEnv env) {
+        for (BLangNode node : nodes) {
+            this.acceptNode(node, env);
+        }
     }
 
     private void acceptNode(BLangNode node, SymbolEnv env) {

--- a/language-server/modules/langserver-core/src/test/resources/completion/let_expression_context/config/let_expr_ctx_config11.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/let_expression_context/config/let_expr_ctx_config11.json
@@ -558,6 +558,14 @@
       "sortText": "F",
       "insertText": "b",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "x1",
+      "kind": "Variable",
+      "detail": "float",
+      "sortText": "AB",
+      "insertText": "x1",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/let_expression_context/config/let_expr_ctx_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/let_expression_context/config/let_expr_ctx_config3.json
@@ -578,6 +578,14 @@
       "filterText": "from",
       "insertText": "from ${1:var} ${2:item} in ${3}",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "x2",
+      "kind": "Variable",
+      "detail": "float",
+      "sortText": "AB",
+      "insertText": "x2",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/let_expression_context/config/let_expr_ctx_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/let_expression_context/config/let_expr_ctx_config4.json
@@ -542,6 +542,14 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "x2",
+      "kind": "Variable",
+      "detail": "float",
+      "sortText": "AB",
+      "insertText": "x2",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/let_expression_context/config/let_expr_ctx_config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/let_expression_context/config/let_expr_ctx_config7.json
@@ -578,6 +578,14 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "x2",
+      "kind": "Variable",
+      "detail": "float",
+      "sortText": "AB",
+      "insertText": "x2",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/visiblesymbols/VisibleSymbolsInExpressionsTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/visiblesymbols/VisibleSymbolsInExpressionsTest.java
@@ -140,6 +140,35 @@ public class VisibleSymbolsInExpressionsTest extends BaseVisibleSymbolsTest {
                                 from("strTemp", VARIABLE),
                                 from("rawTemp", VARIABLE)
                 )},
+                {54, 31, concat(expModuleSymbols,
+                                from("b", VARIABLE),
+                                from("strTemp", VARIABLE),
+                                from("rawTemp", VARIABLE),
+                                from("y", VARIABLE)
+                )},
+                {56, 61, concat(expModuleSymbols,
+                                from("b", VARIABLE),
+                                from("strTemp", VARIABLE),
+                                from("rawTemp", VARIABLE),
+                                from("p", PARAMETER),
+                                from("fn", VARIABLE),
+                                from("y", VARIABLE)
+                )},
+                {58, 32, concat(expModuleSymbols,
+                                from("b", VARIABLE),
+                                from("strTemp", VARIABLE),
+                                from("rawTemp", VARIABLE),
+                                from("fn", VARIABLE),
+                                from("z", VARIABLE)
+                )},
+                // TODO: https://github.com/ballerina-platform/ballerina-lang/issues/34109
+//                {58, 56, concat(expModuleSymbols,
+//                                from("b", VARIABLE),
+//                                from("strTemp", VARIABLE),
+//                                from("rawTemp", VARIABLE),
+//                                from("fn", VARIABLE),
+//                                from("y", VARIABLE)
+//                )},
         };
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/visiblesymbols/VisibleSymbolsInQueryActionsTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/visiblesymbols/VisibleSymbolsInQueryActionsTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.semantic.api.test.visiblesymbols;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static io.ballerina.compiler.api.symbols.SymbolKind.FUNCTION;
+import static io.ballerina.compiler.api.symbols.SymbolKind.VARIABLE;
+import static io.ballerina.semantic.api.test.visiblesymbols.BaseVisibleSymbolsTest.ExpectedSymbolInfo.from;
+
+/**
+ * Test cases for symbols visible at various points in query actions.
+ */
+@Test
+public class VisibleSymbolsInQueryActionsTest extends BaseVisibleSymbolsTest {
+
+    @Override
+    String getTestSourcePath() {
+        return "test-src/visiblesymbols/symbol_lookup_in_query_actions.bal";
+    }
+
+    @DataProvider(name = "PositionProvider")
+    @Override
+    public Object[][] getLookupPositions() {
+        List<ExpectedSymbolInfo> expCommonSymbols =
+                List.of(
+                        from("arr1", VARIABLE),
+                        from("arr2", VARIABLE),
+                        from("test", FUNCTION),
+                        from("result", VARIABLE)
+                );
+        return new Object[][]{
+                {25, 33, concat(expCommonSymbols,
+                                from("i", VARIABLE),
+                                from("j", VARIABLE),
+                                from("res1", VARIABLE)
+                )},
+                {30, 43, concat(expCommonSymbols,
+                                from("i", VARIABLE),
+                                from("j", VARIABLE),
+                                from("stringVal", VARIABLE),
+                                from("intVal", VARIABLE),
+                                from("res1", VARIABLE),
+                                from("res2", VARIABLE)
+                )},
+                {35, 20, concat(expCommonSymbols,
+                                from("i", VARIABLE),
+                                from("j", VARIABLE),
+                                from("res1", VARIABLE),
+                                from("res2", VARIABLE)
+                )},
+                {38, 20, concat(expCommonSymbols,
+                                from("i", VARIABLE),
+                                from("res1", VARIABLE),
+                                from("res2", VARIABLE)
+                )},
+        };
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/visiblesymbols/symbol_lookup_in_query_actions.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/visiblesymbols/symbol_lookup_in_query_actions.bal
@@ -1,0 +1,40 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+int [] arr1 = [1, 2, 3];
+int [] arr2 = [1, 2, 3];
+
+function test() {
+    int result = 0;
+
+    error? res1 = from int i in arr1
+                   from int j in arr2
+                   where i == j
+                   do { result = i + j; };
+
+    var res2 = trap from int i in arr1
+              from int j in arr2
+              let string stringVal = "abc", int intVal = -1
+              do { result = i + j + intVal; };
+
+    check from int i in arr1
+                join int j in arr2
+                on i equals j
+                do { };
+
+    checkpanic from int i in (from int k in arr1 select k)
+                do { };
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/visiblesymbols/visible_symbols_in_exprs_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/visiblesymbols/visible_symbols_in_exprs_test.bal
@@ -51,6 +51,12 @@ function testMiscExprs() {
     string strTemp = string `a string template: ${x}`;
 
     'object:RawTemplate rawTemp = `a raw template: ${b}`;
+
+    b = 10 + let int y = 20 in ;
+
+    function (int) returns int fn = (p) => let int y = 20 in ;
+
+    b = true ? (let int z = 0 in z) : (let int y = 1 in y);
 }
 
 // utils

--- a/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
+++ b/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
@@ -162,6 +162,7 @@
             <class name="io.ballerina.semantic.api.test.visiblesymbols.VisibleSymbolsInCompoundStatementsTest" />
             <class name="io.ballerina.semantic.api.test.visiblesymbols.VisibleSymbolsInExpressionsTest" />
             <class name="io.ballerina.semantic.api.test.visiblesymbols.VisibleSymbolsInModuleLevelDeclsTest" />
+            <class name="io.ballerina.semantic.api.test.visiblesymbols.VisibleSymbolsInQueryActionsTest" />
             <class name="io.ballerina.semantic.api.test.visiblesymbols.VisibleSymbolsInQueryExprsTest" />
             <class name="io.ballerina.semantic.api.test.visiblesymbols.VisibleSymbolsInStatementsTest" />
             <class name="io.ballerina.semantic.api.test.visiblesymbols.VisibleSymbolsInWorkersTest" />


### PR DESCRIPTION
## Purpose
This PR fixes an issue that was there in the `EnvironmentResolver`, which caused some in-scope symbols to be dropped when applied to expressions/actions which have a notion of scoping (e.g., let expr, query action). 

## Remarks
The check for right inclusive range check is buggy. Need to address it: #34109 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
