### PR TITLE
Fix `slice()` returning fixed size array for tuples 

### DIFF
--- a/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Slice.java
+++ b/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Slice.java
@@ -78,7 +78,7 @@ public class Slice {
                 }
 
                 UnionType unionType = TypeCreator.createUnionType(memTypes);
-                ArrayType slicedArrType = TypeCreator.createArrayType(unionType, (int) (endIndex - startIndex));
+                ArrayType slicedArrType = TypeCreator.createArrayType(unionType);
                 slicedArr = ValueCreator.createArrayValue(slicedArrType);
 
                 for (long i = startIndex, j = 0; i < endIndex; i++, j++) {

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibArrayTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibArrayTest.java
@@ -162,39 +162,6 @@ public class LangLibArrayTest {
         Assert.fail();
     }
 
-    @Test
-    public void testPushAfterSlice() {
-        BValue[] returns = BRunUtil.invokeFunction(compileResult, "testPushAfterSlice");
-        BValueArray result = (BValueArray) returns[0];
-
-        assertEquals(((BInteger) result.getRefValue(0)).intValue(), 3);
-        assertEquals(((BInteger) result.getRefValue(1)).intValue(), 4);
-
-        BValueArray arr = (BValueArray) result.getRefValue(2);
-        assertEquals(arr.elementType.getTag(), TypeTags.FLOAT_TAG);
-        assertEquals(arr.size(), 4);
-        assertEquals(arr.getFloat(0), 23.45);
-        assertEquals(arr.getFloat(1), 34.56);
-        assertEquals(arr.getFloat(2), 45.67);
-        assertEquals(arr.getFloat(3), 20.1);
-    }
-
-    @Test
-    public void testPushAfterSliceFixed() {
-        BValue[] returns = BRunUtil.invokeFunction(compileResult, "testPushAfterSliceFixed");
-        BValueArray result = (BValueArray) returns[0];
-
-        assertEquals(((BInteger) result.getRefValue(0)).intValue(), 2);
-        assertEquals(((BInteger) result.getRefValue(1)).intValue(), 3);
-
-        BValueArray arr = (BValueArray) result.getRefValue(2);
-        assertEquals(arr.elementType.getTag(), TypeTags.INT_TAG);
-        assertEquals(arr.size(), 3);
-        assertEquals(arr.getInt(0), 4);
-        assertEquals(arr.getInt(1), 5);
-        assertEquals(arr.getInt(2), 88);
-    }
-
     @Test(expectedExceptions = BLangRuntimeException.class,
             expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.array}InherentTypeViolation " +
                     "\\{\"message\":\"incompatible types: expected '\\(map<string> & readonly\\)', " +
@@ -242,51 +209,6 @@ public class LangLibArrayTest {
         BValue[] returns = BRunUtil.invoke(compileResult, "testIndexOf");
         assertEquals(((BInteger) returns[0]).intValue(), 4);
         assertNull(returns[1]);
-    }
-
-    @Test
-    public void testLastIndexOf() {
-        BRunUtil.invoke(compileResult, "testLastIndexOf");
-    }
-
-    @Test
-    public void testReverseInt() {
-        BRunUtil.invoke(compileResult, "testReverseInt");
-    } 
-
-    @Test
-    public void testReverseFloat() {
-        BRunUtil.invoke(compileResult, "testReverseFloat");
-    }
-
-    @Test
-    public void testReverseStr() {
-        BRunUtil.invoke(compileResult, "testReverseStr");
-    }
-
-    @Test
-    public void testReverseBool() {
-        BRunUtil.invoke(compileResult, "testReverseBool");
-    }
-
-    @Test
-    public void testReverseByte() {
-        BRunUtil.invoke(compileResult, "testReverseByte");
-    }
-
-    @Test
-    public void testReverseMap() {
-        BRunUtil.invoke(compileResult, "testReverseMap");
-    }
-
-    @Test
-    public void testReverseRecord() {
-        BRunUtil.invoke(compileResult, "testReverseRecord");
-    }
-
-    @Test
-    public void testArrayReverseEquality() {
-        BRunUtil.invoke(compileResult, "testArrayReverseEquality");
     }
 
     @Test
@@ -559,7 +481,7 @@ public class LangLibArrayTest {
 
     @DataProvider(name = "FunctionList")
     public Object[] testFunctions() {
-        return new Object[]{
+        return new String[]{
                 "testSliceOnTupleWithRestDesc",
                 "testLastIndexOf",
                 "testPush",
@@ -576,7 +498,19 @@ public class LangLibArrayTest {
                 "testReadOnlyArrayFilter",
                 "testTupleFilter",
                 "testTupleReverse",
-                "testToStreamOnImmutableArray"
+                "testToStreamOnImmutableArray",
+                "testPushAfterSlice",
+                "testPushAfterSliceFixed",
+                "testLastIndexOf",
+                "testReverseInt",
+                "testReverseFloat",
+                "testReverseStr",
+                "testReverseBool",
+                "testReverseByte",
+                "testReverseMap",
+                "testReverseRecord",
+                "testArrayReverseEquality",
+                "testPushAfterSliceOnTuple"
         };
     }
 }


### PR DESCRIPTION
## Purpose
$subject

Fixes #24349

## Approach
Removed sliced array size when creating result array type. 

## Samples
```ballerina
public function main() {
    [int, int, int] x = [1, 2, 3];
    int[] y = x.slice(1);
    
    y.push(4);
}
```

## Remarks
- fixed some indentation formatting in the test `.bal` file.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
