### PR TITLE
Fix issue in tracking field references in index-based access exprs

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/ReferenceFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/ReferenceFinder.java
@@ -19,9 +19,11 @@
 package io.ballerina.compiler.api.impl;
 
 import io.ballerina.tools.diagnostics.Location;
+import io.ballerina.tools.text.LineRange;
 import org.ballerinalang.model.clauses.OrderKeyNode;
 import org.ballerinalang.model.elements.Flag;
 import org.ballerinalang.model.tree.expressions.RecordLiteralNode;
+import org.wso2.ballerinalang.compiler.diagnostic.BLangDiagnosticLocation;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 import org.wso2.ballerinalang.compiler.tree.BLangAnnotation;
 import org.wso2.ballerinalang.compiler.tree.BLangAnnotationAttachment;
@@ -91,6 +93,7 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangIsLikeExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangLambdaFunction;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangLetExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangListConstructorExpr;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangLiteral;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangMatchGuard;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangNamedArgsExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangObjectConstructorExpression;
@@ -793,8 +796,13 @@ public class ReferenceFinder extends BaseVisitor {
 
     @Override
     public void visit(BLangIndexBasedAccess indexAccessExpr) {
-        find(indexAccessExpr.indexExpr);
         find(indexAccessExpr.expr);
+
+        if (indexAccessExpr.indexExpr instanceof BLangLiteral) {
+            addIfSameSymbol(indexAccessExpr.symbol, getLocationForLiteral(indexAccessExpr.indexExpr.pos));
+        } else {
+            find(indexAccessExpr.indexExpr);
+        }
     }
 
     @Override
@@ -1282,5 +1290,22 @@ public class ReferenceFinder extends BaseVisitor {
 
     private boolean isGeneratedClassDefForService(BLangClassDefinition clazz) {
         return clazz.flagSet.contains(Flag.ANONYMOUS) && clazz.flagSet.contains(Flag.SERVICE);
+    }
+
+    /**
+     * This method is intended to be used for getting the location of a string value with the surrounding quotes
+     * disregarded. If we give the original location, it'd be problematic for use cases such as renaming since we only
+     * return a list of locations of references. Without further contextual info, it'll be hard to determine whether a
+     * particular reference location is a string value.
+     *
+     * @param location Location of the string
+     * @return The modified location with the quotes diregarded
+     */
+    private Location getLocationForLiteral(Location location) {
+        LineRange lineRange = location.lineRange();
+        return new BLangDiagnosticLocation(lineRange.filePath(),
+                                           lineRange.startLine().line(), lineRange.endLine().line(),
+                                           lineRange.startLine().offset() + 1, lineRange.endLine().offset() - 1,
+                                           location.textRange().startOffset(), location.textRange().length());
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsInExprsTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsInExprsTest.java
@@ -106,7 +106,8 @@ public class FindRefsInExprsTest extends FindAllReferencesTest {
                 {92, 15, location(92, 15, 19),
                         List.of(location(92, 15, 19),
                                 location(94, 17, 21),
-                                location(95, 18, 22))
+                                location(95, 18, 22),
+                                location(98, 27, 31))
                 },
                 {93, 12, location(93, 12, 15),
                         List.of(location(93, 12, 15),
@@ -121,7 +122,8 @@ public class FindRefsInExprsTest extends FindAllReferencesTest {
                 {98, 26, location(92, 15, 19),
                         List.of(location(92, 15, 19),
                                 location(94, 17, 21),
-                                location(95, 18, 22))
+                                location(95, 18, 22),
+                                location(98, 27, 31))
                 },
                 // Query exprs
                 {114, 22, location(114, 21, 23),


### PR DESCRIPTION
## Purpose
This PR fixes an issue we had in identifying references of a field when used in an index-baed access expression.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
