### PR TITLE
Add missing completions inside ternary conditional expression

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/completion/QNameReferenceUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/completion/QNameReferenceUtil.java
@@ -51,6 +51,18 @@ public class QNameReferenceUtil {
     public static List<Symbol> getExpressionContextEntries(BallerinaCompletionContext ctx,
                                                            QualifiedNameReferenceNode qNameRef) {
         String moduleAlias = QNameReferenceUtil.getAlias(qNameRef);
+        return getExpressionContextEntries(ctx, moduleAlias);
+    }
+
+    /**
+     * Get the completions for the qualified name reference context.
+     *
+     * @param ctx           language server operation context
+     * @param moduleAlias   module alias of the qualified name reference
+     * @return {@link List} of completion items
+     */
+    public static List<Symbol> getExpressionContextEntries(BallerinaCompletionContext ctx, String moduleAlias) {
+
         Optional<ModuleSymbol> moduleSymbol = CommonUtil.searchModuleForAlias(ctx, moduleAlias);
 
         return moduleSymbol.map(value -> value.allSymbols().stream()

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/completion/QNameReferenceUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/completion/QNameReferenceUtil.java
@@ -84,7 +84,7 @@ public class QNameReferenceUtil {
     }
 
     /**
-     * Get the unquoted module alias identifier if the module alias is a quoted identifier
+     * Get the unquoted module alias identifier if the module alias is a quoted identifier.
      *
      * @param alias qualified name reference
      * @return {@link String} extracted alias

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/completion/QNameReferenceUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/completion/QNameReferenceUtil.java
@@ -50,8 +50,7 @@ public class QNameReferenceUtil {
      */
     public static List<Symbol> getExpressionContextEntries(BallerinaCompletionContext ctx,
                                                            QualifiedNameReferenceNode qNameRef) {
-        String moduleAlias = QNameReferenceUtil.getAlias(qNameRef);
-        return getExpressionContextEntries(ctx, moduleAlias);
+        return getExpressionContextEntries(ctx, qNameRef.modulePrefix().text());
     }
 
     /**
@@ -62,8 +61,8 @@ public class QNameReferenceUtil {
      * @return {@link List} of completion items
      */
     public static List<Symbol> getExpressionContextEntries(BallerinaCompletionContext ctx, String moduleAlias) {
-
-        Optional<ModuleSymbol> moduleSymbol = CommonUtil.searchModuleForAlias(ctx, moduleAlias);
+        String alias = getAlias(moduleAlias);
+        Optional<ModuleSymbol> moduleSymbol = CommonUtil.searchModuleForAlias(ctx, alias);
 
         return moduleSymbol.map(value -> value.allSymbols().stream()
                 .filter(symbol -> symbol.kind() == SymbolKind.FUNCTION
@@ -81,6 +80,16 @@ public class QNameReferenceUtil {
      */
     public static String getAlias(QualifiedNameReferenceNode qNameRef) {
         String alias = qNameRef.modulePrefix().text();
+        return getAlias(alias);
+    }
+
+    /**
+     * Get the unquoted module alias identifier if the module alias is a quoted identifier
+     *
+     * @param alias qualified name reference
+     * @return {@link String} extracted alias
+     */
+    public static String getAlias(String alias) {
         return alias.startsWith("'") ? alias.substring(1) : alias;
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ConditionalExpressionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ConditionalExpressionNodeContext.java
@@ -15,7 +15,6 @@
  */
 package org.ballerinalang.langserver.completions.providers.context;
 
-import io.ballerina.compiler.api.symbols.ModuleSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.syntax.tree.ConditionalExpressionNode;
@@ -25,7 +24,6 @@ import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
 import io.ballerina.compiler.syntax.tree.SimpleNameReferenceNode;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import org.ballerinalang.annotation.JavaSPIService;
-import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.common.utils.completion.QNameReferenceUtil;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
 import org.ballerinalang.langserver.commons.completion.LSCompletionException;
@@ -61,12 +59,11 @@ public class ConditionalExpressionNodeContext extends AbstractCompletionProvider
             eg: int n = true ? module1:
              */
             String middleExprName = ((SimpleNameReferenceNode) node.middleExpression()).name().text();
-            String alias = middleExprName.startsWith("'") ? middleExprName.substring(1) : middleExprName;
-            Optional<ModuleSymbol> moduleSymbol = CommonUtil.searchModuleForAlias(context, alias);
-            if (moduleSymbol.isEmpty()) {
+            List<Symbol> expressionContextSymbols = 
+                    QNameReferenceUtil.getExpressionContextEntries(context, middleExprName);
+            if (expressionContextSymbols.isEmpty()) {
                 completionItems.addAll(this.expressionCompletions(context));
             } else {
-                List<Symbol> expressionContextSymbols = QNameReferenceUtil.getExpressionContextEntries(context, alias);
                 completionItems.addAll(this.getCompletionItemList(expressionContextSymbols, context));
             }
         } else if (QNameReferenceUtil.onQualifiedNameIdentifier(context, nodeAtCursor)) {
@@ -103,6 +100,4 @@ public class ConditionalExpressionNodeContext extends AbstractCompletionProvider
                     .setSortText(SortingUtil.genSortTextByAssignability(context, completionItem, symbol));
         }
     }
-//    QualifiedNameReferenceNode qualifiedNameReferenceNode = (QualifiedNameReferenceNode) node.middleExpression();
-//    qualifiedNameReferenceNode.identifier()
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ConditionalExpressionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ConditionalExpressionNodeContext.java
@@ -19,6 +19,7 @@ import io.ballerina.compiler.api.symbols.ModuleSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.syntax.tree.ConditionalExpressionNode;
+import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.compiler.syntax.tree.NonTerminalNode;
 import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
 import io.ballerina.compiler.syntax.tree.SimpleNameReferenceNode;
@@ -52,12 +53,9 @@ public class ConditionalExpressionNodeContext extends AbstractCompletionProvider
     public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, ConditionalExpressionNode node)
             throws LSCompletionException {
         NonTerminalNode nodeAtCursor = context.getNodeAtCursor();
-        int cursor = context.getCursorPositionInTree();
-        int colonTokenPos = node.colonToken().textRange().startOffset();
         List<LSCompletionItem> completionItems = new ArrayList<>();
 
-        if (cursor > colonTokenPos && node.middleExpression().kind() == SyntaxKind.SIMPLE_NAME_REFERENCE 
-                && node.endExpression().kind() == SyntaxKind.SIMPLE_NAME_REFERENCE) {
+        if (isMiddleExpressionQNameRef(node)) {
             /*
             Covers the following context
             eg: int n = true ? module1:
@@ -81,6 +79,13 @@ public class ConditionalExpressionNodeContext extends AbstractCompletionProvider
         this.sort(context, node, completionItems);
         return completionItems;
     }
+    
+    private boolean isMiddleExpressionQNameRef(ConditionalExpressionNode node) {
+        Node middleExpression = node.middleExpression();
+        Node endExpression = node.endExpression();
+        return !middleExpression.isMissing() && middleExpression.kind() == SyntaxKind.SIMPLE_NAME_REFERENCE 
+                && !endExpression.isMissing() && endExpression.kind() == SyntaxKind.SIMPLE_NAME_REFERENCE;
+    }
 
     @Override
     public void sort(BallerinaCompletionContext context, ConditionalExpressionNode node,
@@ -98,4 +103,6 @@ public class ConditionalExpressionNodeContext extends AbstractCompletionProvider
                     .setSortText(SortingUtil.genSortTextByAssignability(context, completionItem, symbol));
         }
     }
+//    QualifiedNameReferenceNode qualifiedNameReferenceNode = (QualifiedNameReferenceNode) node.middleExpression();
+//    qualifiedNameReferenceNode.identifier()
 }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/ExpressionContextTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/ExpressionContextTest.java
@@ -56,6 +56,7 @@ public class ExpressionContextTest extends CompletionTest {
                 "object_constructor_expr_ctx_config6.json", // LS fix needed
                 "object_constructor_expr_ctx_config11.json", // LS fix needed
                 "error_constructor_expr_ctx_config11.json", //#33027
+                "conditional_expr_ctx_config12.json", //#34145
                 
                 // TODO ContextTypeResolver's context type for method call expressions should be revisited
                 "method_call_expression_ctx_config9.json"

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config1.json
@@ -9,6 +9,7 @@
       "label": "module1",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "S",
       "filterText": "module1",
       "insertText": "module1",
       "insertTextFormat": "Snippet"
@@ -17,6 +18,7 @@
       "label": "ballerina/lang.test",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "R",
       "filterText": "test",
       "insertText": "test",
       "insertTextFormat": "Snippet",
@@ -40,6 +42,7 @@
       "label": "ballerina/lang.array",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "R",
       "filterText": "array",
       "insertText": "array",
       "insertTextFormat": "Snippet",
@@ -63,6 +66,7 @@
       "label": "ballerina/jballerina.java",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "R",
       "filterText": "java",
       "insertText": "java",
       "insertTextFormat": "Snippet",
@@ -86,6 +90,7 @@
       "label": "ballerina/lang.value",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "R",
       "filterText": "value",
       "insertText": "value",
       "insertTextFormat": "Snippet",
@@ -109,6 +114,7 @@
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "R",
       "filterText": "runtime",
       "insertText": "runtime",
       "insertTextFormat": "Snippet",
@@ -132,6 +138,7 @@
       "label": "boolean",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "boolean",
       "insertTextFormat": "Snippet"
     },
@@ -139,6 +146,7 @@
       "label": "decimal",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "decimal",
       "insertTextFormat": "Snippet"
     },
@@ -146,6 +154,7 @@
       "label": "error",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "error",
       "insertTextFormat": "Snippet"
     },
@@ -153,6 +162,7 @@
       "label": "float",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "float",
       "insertTextFormat": "Snippet"
     },
@@ -160,6 +170,7 @@
       "label": "future",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "future",
       "insertTextFormat": "Snippet"
     },
@@ -167,6 +178,7 @@
       "label": "int",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "int",
       "insertTextFormat": "Snippet"
     },
@@ -174,6 +186,7 @@
       "label": "map",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "map",
       "insertTextFormat": "Snippet"
     },
@@ -181,6 +194,7 @@
       "label": "object",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "object",
       "insertTextFormat": "Snippet"
     },
@@ -188,6 +202,7 @@
       "label": "stream",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "stream",
       "insertTextFormat": "Snippet"
     },
@@ -195,6 +210,7 @@
       "label": "string",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "string",
       "insertTextFormat": "Snippet"
     },
@@ -202,6 +218,7 @@
       "label": "table",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "table",
       "insertTextFormat": "Snippet"
     },
@@ -209,6 +226,7 @@
       "label": "transaction",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "transaction",
       "insertTextFormat": "Snippet"
     },
@@ -216,6 +234,7 @@
       "label": "typedesc",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "typedesc",
       "insertTextFormat": "Snippet"
     },
@@ -223,6 +242,7 @@
       "label": "xml",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
     },
@@ -230,6 +250,7 @@
       "label": "service",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "service",
       "insertText": "service",
       "insertTextFormat": "Snippet"
@@ -238,6 +259,7 @@
       "label": "new",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "new",
       "insertText": "new ",
       "insertTextFormat": "Snippet"
@@ -246,6 +268,7 @@
       "label": "isolated",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "isolated",
       "insertText": "isolated ",
       "insertTextFormat": "Snippet"
@@ -254,6 +277,7 @@
       "label": "transactional",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "transactional",
       "insertText": "transactional",
       "insertTextFormat": "Snippet"
@@ -262,6 +286,7 @@
       "label": "function",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "function",
       "insertText": "function ",
       "insertTextFormat": "Snippet"
@@ -270,6 +295,7 @@
       "label": "let",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "let",
       "insertText": "let",
       "insertTextFormat": "Snippet"
@@ -278,6 +304,7 @@
       "label": "typeof",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "typeof",
       "insertText": "typeof ",
       "insertTextFormat": "Snippet"
@@ -286,6 +313,7 @@
       "label": "trap",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "trap",
       "insertText": "trap",
       "insertTextFormat": "Snippet"
@@ -294,6 +322,7 @@
       "label": "client",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "client",
       "insertText": "client ",
       "insertTextFormat": "Snippet"
@@ -302,6 +331,7 @@
       "label": "true",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "true",
       "insertText": "true",
       "insertTextFormat": "Snippet"
@@ -310,6 +340,7 @@
       "label": "false",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "false",
       "insertText": "false",
       "insertTextFormat": "Snippet"
@@ -318,6 +349,7 @@
       "label": "check",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "check",
       "insertText": "check ",
       "insertTextFormat": "Snippet"
@@ -326,6 +358,7 @@
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "checkpanic",
       "insertText": "checkpanic ",
       "insertTextFormat": "Snippet"
@@ -334,6 +367,7 @@
       "label": "is",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "is",
       "insertText": "is",
       "insertTextFormat": "Snippet"
@@ -342,6 +376,7 @@
       "label": "error constructor",
       "kind": "Snippet",
       "detail": "Snippet",
+      "sortText": "T",
       "filterText": "error",
       "insertText": "error(\"${1}\")",
       "insertTextFormat": "Snippet"
@@ -350,6 +385,7 @@
       "label": "object constructor",
       "kind": "Snippet",
       "detail": "Snippet",
+      "sortText": "T",
       "filterText": "object",
       "insertText": "object {${1}}",
       "insertTextFormat": "Snippet"
@@ -358,6 +394,7 @@
       "label": "base16",
       "kind": "Snippet",
       "detail": "Snippet",
+      "sortText": "T",
       "filterText": "base16",
       "insertText": "base16 `${1}`",
       "insertTextFormat": "Snippet"
@@ -366,6 +403,7 @@
       "label": "base64",
       "kind": "Snippet",
       "detail": "Snippet",
+      "sortText": "T",
       "filterText": "base64",
       "insertText": "base64 `${1}`",
       "insertTextFormat": "Snippet"
@@ -374,6 +412,7 @@
       "label": "from",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "from",
       "insertText": "from ",
       "insertTextFormat": "Snippet"
@@ -382,6 +421,7 @@
       "label": "Thread",
       "kind": "TypeParameter",
       "detail": "Union",
+      "sortText": "R",
       "insertText": "Thread",
       "insertTextFormat": "Snippet"
     },
@@ -395,6 +435,7 @@
           "value": "**Package:** _._  \n  \n  \n"
         }
       },
+      "sortText": "G",
       "filterText": "name",
       "insertText": "name()",
       "insertTextFormat": "Snippet"
@@ -406,6 +447,7 @@
       "documentation": {
         "left": "Describes Strand execution details for the runtime.\n"
       },
+      "sortText": "Q",
       "insertText": "StrandData",
       "insertTextFormat": "Snippet"
     },
@@ -413,6 +455,7 @@
       "label": "flag",
       "kind": "Variable",
       "detail": "boolean",
+      "sortText": "F",
       "insertText": "flag",
       "insertTextFormat": "Snippet"
     },
@@ -420,6 +463,7 @@
       "label": "n",
       "kind": "Variable",
       "detail": "int",
+      "sortText": "AB",
       "insertText": "n",
       "insertTextFormat": "Snippet"
     },
@@ -427,6 +471,7 @@
       "label": "readonly",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "readonly",
       "insertTextFormat": "Snippet"
     },
@@ -434,6 +479,7 @@
       "label": "handle",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "handle",
       "insertTextFormat": "Snippet"
     },
@@ -441,6 +487,7 @@
       "label": "never",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "never",
       "insertTextFormat": "Snippet"
     },
@@ -448,6 +495,7 @@
       "label": "json",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "json",
       "insertTextFormat": "Snippet"
     },
@@ -455,6 +503,7 @@
       "label": "anydata",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "anydata",
       "insertTextFormat": "Snippet"
     },
@@ -462,6 +511,7 @@
       "label": "any",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "any",
       "insertTextFormat": "Snippet"
     },
@@ -469,6 +519,7 @@
       "label": "byte",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
     },
@@ -476,6 +527,7 @@
       "label": "null",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "null",
       "insertText": "null",
       "insertTextFormat": "Snippet"

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config10.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config10.json
@@ -1,0 +1,495 @@
+{
+  "position": {
+    "line": 4,
+    "character": 26
+  },
+  "source": "expression_context/source/conditional_expr_ctx_source10.bal",
+  "items": [
+    {
+      "label": "module1",
+      "kind": "Module",
+      "detail": "Module",
+      "filterText": "module1",
+      "insertText": "module1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.array",
+      "kind": "Module",
+      "detail": "Module",
+      "filterText": "array",
+      "insertText": "array",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.array;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/jballerina.java",
+      "kind": "Module",
+      "detail": "Module",
+      "filterText": "java",
+      "insertText": "java",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/jballerina.java;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "filterText": "value",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.runtime",
+      "kind": "Module",
+      "detail": "Module",
+      "filterText": "runtime",
+      "insertText": "runtime",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.runtime;\n"
+        }
+      ]
+    },
+    {
+      "label": "boolean",
+      "kind": "Unit",
+      "detail": "type",
+      "insertText": "boolean",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "decimal",
+      "kind": "Unit",
+      "detail": "type",
+      "insertText": "decimal",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "error",
+      "kind": "Unit",
+      "detail": "type",
+      "insertText": "error",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "float",
+      "kind": "Unit",
+      "detail": "type",
+      "insertText": "float",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "future",
+      "kind": "Unit",
+      "detail": "type",
+      "insertText": "future",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "int",
+      "kind": "Unit",
+      "detail": "type",
+      "insertText": "int",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "map",
+      "kind": "Unit",
+      "detail": "type",
+      "insertText": "map",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "object",
+      "kind": "Unit",
+      "detail": "type",
+      "insertText": "object",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "stream",
+      "kind": "Unit",
+      "detail": "type",
+      "insertText": "stream",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string",
+      "kind": "Unit",
+      "detail": "type",
+      "insertText": "string",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "table",
+      "kind": "Unit",
+      "detail": "type",
+      "insertText": "table",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "transaction",
+      "kind": "Unit",
+      "detail": "type",
+      "insertText": "transaction",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "typedesc",
+      "kind": "Unit",
+      "detail": "type",
+      "insertText": "typedesc",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml",
+      "kind": "Unit",
+      "detail": "type",
+      "insertText": "xml",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "service",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "filterText": "service",
+      "insertText": "service",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "new",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "filterText": "new",
+      "insertText": "new ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "isolated",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "filterText": "isolated",
+      "insertText": "isolated ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "transactional",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "filterText": "transactional",
+      "insertText": "transactional",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "function",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "filterText": "function",
+      "insertText": "function ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "let",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "filterText": "let",
+      "insertText": "let",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "typeof",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "filterText": "typeof",
+      "insertText": "typeof ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "trap",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "filterText": "trap",
+      "insertText": "trap",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "client",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "filterText": "client",
+      "insertText": "client ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "true",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "filterText": "true",
+      "insertText": "true",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "false",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "filterText": "false",
+      "insertText": "false",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "check",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "filterText": "check",
+      "insertText": "check ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "checkpanic",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "filterText": "checkpanic",
+      "insertText": "checkpanic ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "is",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "filterText": "is",
+      "insertText": "is",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "filterText": "error",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "object constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "filterText": "object",
+      "insertText": "object {${1}}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "base16",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "filterText": "base16",
+      "insertText": "base16 `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "base64",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "filterText": "base64",
+      "insertText": "base64 `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "from",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "filterText": "from",
+      "insertText": "from ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Thread",
+      "kind": "TypeParameter",
+      "detail": "Union",
+      "insertText": "Thread",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "StrandData",
+      "kind": "Struct",
+      "detail": "Record",
+      "documentation": {
+        "left": "Describes Strand execution details for the runtime.\n"
+      },
+      "insertText": "StrandData",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "flag",
+      "kind": "Variable",
+      "detail": "boolean",
+      "insertText": "flag",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "n",
+      "kind": "Variable",
+      "detail": "int",
+      "insertText": "n",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "readonly",
+      "kind": "Unit",
+      "detail": "type",
+      "insertText": "readonly",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "handle",
+      "kind": "Unit",
+      "detail": "type",
+      "insertText": "handle",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "never",
+      "kind": "Unit",
+      "detail": "type",
+      "insertText": "never",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "json",
+      "kind": "Unit",
+      "detail": "type",
+      "insertText": "json",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "anydata",
+      "kind": "Unit",
+      "detail": "type",
+      "insertText": "anydata",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "any",
+      "kind": "Unit",
+      "detail": "type",
+      "insertText": "any",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "byte",
+      "kind": "Unit",
+      "detail": "type",
+      "insertText": "byte",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "null",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "filterText": "null",
+      "insertText": "null",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.test",
+      "kind": "Module",
+      "detail": "Module",
+      "filterText": "test",
+      "insertText": "test1",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.test as test1 ;\n"
+        }
+      ]
+    },
+    {
+      "label": "name(boolean test)",
+      "kind": "Function",
+      "detail": "()",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _._  \n  \n  \n**Params**  \n- `boolean` test"
+        }
+      },
+      "filterText": "name",
+      "insertText": "name(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "test",
+      "kind": "Variable",
+      "detail": "boolean",
+      "insertText": "test",
+      "insertTextFormat": "Snippet"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config10.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config10.json
@@ -9,6 +9,7 @@
       "label": "module1",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "S",
       "filterText": "module1",
       "insertText": "module1",
       "insertTextFormat": "Snippet"
@@ -17,6 +18,7 @@
       "label": "ballerina/lang.array",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "R",
       "filterText": "array",
       "insertText": "array",
       "insertTextFormat": "Snippet",
@@ -40,6 +42,7 @@
       "label": "ballerina/jballerina.java",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "R",
       "filterText": "java",
       "insertText": "java",
       "insertTextFormat": "Snippet",
@@ -63,6 +66,7 @@
       "label": "ballerina/lang.value",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "R",
       "filterText": "value",
       "insertText": "value",
       "insertTextFormat": "Snippet",
@@ -86,6 +90,7 @@
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "R",
       "filterText": "runtime",
       "insertText": "runtime",
       "insertTextFormat": "Snippet",
@@ -109,6 +114,7 @@
       "label": "boolean",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "boolean",
       "insertTextFormat": "Snippet"
     },
@@ -116,6 +122,7 @@
       "label": "decimal",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "decimal",
       "insertTextFormat": "Snippet"
     },
@@ -123,6 +130,7 @@
       "label": "error",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "error",
       "insertTextFormat": "Snippet"
     },
@@ -130,6 +138,7 @@
       "label": "float",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "float",
       "insertTextFormat": "Snippet"
     },
@@ -137,6 +146,7 @@
       "label": "future",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "future",
       "insertTextFormat": "Snippet"
     },
@@ -144,6 +154,7 @@
       "label": "int",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "int",
       "insertTextFormat": "Snippet"
     },
@@ -151,6 +162,7 @@
       "label": "map",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "map",
       "insertTextFormat": "Snippet"
     },
@@ -158,6 +170,7 @@
       "label": "object",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "object",
       "insertTextFormat": "Snippet"
     },
@@ -165,6 +178,7 @@
       "label": "stream",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "stream",
       "insertTextFormat": "Snippet"
     },
@@ -172,6 +186,7 @@
       "label": "string",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "string",
       "insertTextFormat": "Snippet"
     },
@@ -179,6 +194,7 @@
       "label": "table",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "table",
       "insertTextFormat": "Snippet"
     },
@@ -186,6 +202,7 @@
       "label": "transaction",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "transaction",
       "insertTextFormat": "Snippet"
     },
@@ -193,6 +210,7 @@
       "label": "typedesc",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "typedesc",
       "insertTextFormat": "Snippet"
     },
@@ -200,6 +218,7 @@
       "label": "xml",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
     },
@@ -207,6 +226,7 @@
       "label": "service",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "service",
       "insertText": "service",
       "insertTextFormat": "Snippet"
@@ -215,6 +235,7 @@
       "label": "new",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "new",
       "insertText": "new ",
       "insertTextFormat": "Snippet"
@@ -223,6 +244,7 @@
       "label": "isolated",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "isolated",
       "insertText": "isolated ",
       "insertTextFormat": "Snippet"
@@ -231,6 +253,7 @@
       "label": "transactional",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "transactional",
       "insertText": "transactional",
       "insertTextFormat": "Snippet"
@@ -239,6 +262,7 @@
       "label": "function",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "function",
       "insertText": "function ",
       "insertTextFormat": "Snippet"
@@ -247,6 +271,7 @@
       "label": "let",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "let",
       "insertText": "let",
       "insertTextFormat": "Snippet"
@@ -255,6 +280,7 @@
       "label": "typeof",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "typeof",
       "insertText": "typeof ",
       "insertTextFormat": "Snippet"
@@ -263,6 +289,7 @@
       "label": "trap",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "trap",
       "insertText": "trap",
       "insertTextFormat": "Snippet"
@@ -271,6 +298,7 @@
       "label": "client",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "client",
       "insertText": "client ",
       "insertTextFormat": "Snippet"
@@ -279,6 +307,7 @@
       "label": "true",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "true",
       "insertText": "true",
       "insertTextFormat": "Snippet"
@@ -287,6 +316,7 @@
       "label": "false",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "false",
       "insertText": "false",
       "insertTextFormat": "Snippet"
@@ -295,6 +325,7 @@
       "label": "check",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "check",
       "insertText": "check ",
       "insertTextFormat": "Snippet"
@@ -303,6 +334,7 @@
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "checkpanic",
       "insertText": "checkpanic ",
       "insertTextFormat": "Snippet"
@@ -311,6 +343,7 @@
       "label": "is",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "is",
       "insertText": "is",
       "insertTextFormat": "Snippet"
@@ -319,6 +352,7 @@
       "label": "error constructor",
       "kind": "Snippet",
       "detail": "Snippet",
+      "sortText": "T",
       "filterText": "error",
       "insertText": "error(\"${1}\")",
       "insertTextFormat": "Snippet"
@@ -327,6 +361,7 @@
       "label": "object constructor",
       "kind": "Snippet",
       "detail": "Snippet",
+      "sortText": "T",
       "filterText": "object",
       "insertText": "object {${1}}",
       "insertTextFormat": "Snippet"
@@ -335,6 +370,7 @@
       "label": "base16",
       "kind": "Snippet",
       "detail": "Snippet",
+      "sortText": "T",
       "filterText": "base16",
       "insertText": "base16 `${1}`",
       "insertTextFormat": "Snippet"
@@ -343,6 +379,7 @@
       "label": "base64",
       "kind": "Snippet",
       "detail": "Snippet",
+      "sortText": "T",
       "filterText": "base64",
       "insertText": "base64 `${1}`",
       "insertTextFormat": "Snippet"
@@ -351,6 +388,7 @@
       "label": "from",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "from",
       "insertText": "from ",
       "insertTextFormat": "Snippet"
@@ -359,6 +397,7 @@
       "label": "Thread",
       "kind": "TypeParameter",
       "detail": "Union",
+      "sortText": "R",
       "insertText": "Thread",
       "insertTextFormat": "Snippet"
     },
@@ -369,6 +408,7 @@
       "documentation": {
         "left": "Describes Strand execution details for the runtime.\n"
       },
+      "sortText": "Q",
       "insertText": "StrandData",
       "insertTextFormat": "Snippet"
     },
@@ -376,6 +416,7 @@
       "label": "flag",
       "kind": "Variable",
       "detail": "boolean",
+      "sortText": "F",
       "insertText": "flag",
       "insertTextFormat": "Snippet"
     },
@@ -383,6 +424,7 @@
       "label": "n",
       "kind": "Variable",
       "detail": "int",
+      "sortText": "AB",
       "insertText": "n",
       "insertTextFormat": "Snippet"
     },
@@ -390,6 +432,7 @@
       "label": "readonly",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "readonly",
       "insertTextFormat": "Snippet"
     },
@@ -397,6 +440,7 @@
       "label": "handle",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "handle",
       "insertTextFormat": "Snippet"
     },
@@ -404,6 +448,7 @@
       "label": "never",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "never",
       "insertTextFormat": "Snippet"
     },
@@ -411,6 +456,7 @@
       "label": "json",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "json",
       "insertTextFormat": "Snippet"
     },
@@ -418,6 +464,7 @@
       "label": "anydata",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "anydata",
       "insertTextFormat": "Snippet"
     },
@@ -425,6 +472,7 @@
       "label": "any",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "any",
       "insertTextFormat": "Snippet"
     },
@@ -432,6 +480,7 @@
       "label": "byte",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
     },
@@ -439,6 +488,7 @@
       "label": "null",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "null",
       "insertText": "null",
       "insertTextFormat": "Snippet"
@@ -447,6 +497,7 @@
       "label": "ballerina/lang.test",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "R",
       "filterText": "test",
       "insertText": "test1",
       "insertTextFormat": "Snippet",
@@ -476,6 +527,7 @@
           "value": "**Package:** _._  \n  \n  \n**Params**  \n- `boolean` test"
         }
       },
+      "sortText": "G",
       "filterText": "name",
       "insertText": "name(${1})",
       "insertTextFormat": "Snippet",
@@ -488,6 +540,7 @@
       "label": "test",
       "kind": "Variable",
       "detail": "boolean",
+      "sortText": "F",
       "insertText": "test",
       "insertTextFormat": "Snippet"
     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config11.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config11.json
@@ -1,0 +1,251 @@
+{
+  "position": {
+    "line": 4,
+    "character": 28
+  },
+  "source": "expression_context/source/conditional_expr_ctx_source11.bal",
+  "items": [
+    {
+      "label": "ENUM1_FIELD1",
+      "kind": "EnumMember",
+      "detail": "ENUM1_FIELD1",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": ""
+        }
+      },
+      "sortText": "L",
+      "insertText": "ENUM1_FIELD1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TEST_INT_CONST1",
+      "kind": "Variable",
+      "detail": "1",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": ""
+        }
+      },
+      "sortText": "AC",
+      "insertText": "TEST_INT_CONST1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TEST_STRING_CONST1",
+      "kind": "Variable",
+      "detail": "HELLO WORLD",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": ""
+        }
+      },
+      "sortText": "G",
+      "insertText": "TEST_STRING_CONST1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "AnnotationType",
+      "kind": "Struct",
+      "detail": "Record",
+      "sortText": "Q",
+      "insertText": "AnnotationType",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ResponseMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
+      },
+      "sortText": "M",
+      "insertText": "ResponseMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "RequestMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
+      },
+      "sortText": "M",
+      "insertText": "RequestMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestRecord1",
+      "kind": "Struct",
+      "detail": "Record",
+      "sortText": "Q",
+      "insertText": "TestRecord1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestRecord2",
+      "kind": "Struct",
+      "detail": "Record",
+      "sortText": "Q",
+      "insertText": "TestRecord2",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestMap2",
+      "kind": "TypeParameter",
+      "detail": "Map",
+      "sortText": "R",
+      "insertText": "TestMap2",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestMap3",
+      "kind": "TypeParameter",
+      "detail": "Map",
+      "sortText": "R",
+      "insertText": "TestMap3",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestObject1",
+      "kind": "Interface",
+      "detail": "Object",
+      "sortText": "O",
+      "insertText": "TestObject1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ErrorOne",
+      "kind": "Event",
+      "detail": "Error",
+      "sortText": "P",
+      "insertText": "ErrorOne",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ErrorTwo",
+      "kind": "Event",
+      "detail": "Error",
+      "sortText": "P",
+      "insertText": "ErrorTwo",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Listener",
+      "kind": "Interface",
+      "detail": "Class",
+      "sortText": "O",
+      "insertText": "Listener",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Client",
+      "kind": "Interface",
+      "detail": "Class",
+      "documentation": {
+        "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs."
+      },
+      "sortText": "O",
+      "insertText": "Client",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Response",
+      "kind": "Interface",
+      "detail": "Class",
+      "documentation": {
+        "left": "Represents a response.\n"
+      },
+      "sortText": "O",
+      "insertText": "Response",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestClass1",
+      "kind": "Interface",
+      "detail": "Class",
+      "sortText": "O",
+      "insertText": "TestClass1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "listener1",
+      "kind": "Variable",
+      "detail": "module1:Listener",
+      "sortText": "G",
+      "insertText": "listener1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "function1()",
+      "kind": "Function",
+      "detail": "()",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \n  \n"
+        }
+      },
+      "sortText": "E",
+      "filterText": "function1",
+      "insertText": "function1()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "function2()",
+      "kind": "Function",
+      "detail": "()",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function2  \n"
+        }
+      },
+      "sortText": "E",
+      "filterText": "function2",
+      "insertText": "function2()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "function3(int param1, int param2, float... param3)",
+      "kind": "Function",
+      "detail": "int",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function3 with input parameters\n  \n**Params**  \n- `int` param1: param1 Parameter Description   \n- `int` param2: param2 Parameter Description  \n- `float[]` param3: param3 Parameter Description  \n  \n**Return** `int`   \n- Return Value Description  \n  \n"
+        }
+      },
+      "sortText": "AA",
+      "filterText": "function3",
+      "insertText": "function3(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "function4(int param1, int param2, string param3, float... param4)",
+      "kind": "Function",
+      "detail": "()",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function4 with input parameters\n  \n**Params**  \n- `int` param1: param1 Parameter Description   \n- `int` param2: param2 Parameter Description  \n- `string` param3: param3 Parameter Description(Defaultable)  \n- `float[]` param4: param4 Parameter Description"
+        }
+      },
+      "sortText": "E",
+      "filterText": "function4",
+      "insertText": "function4(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config11.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config11.json
@@ -246,6 +246,14 @@
         "title": "editor.action.triggerParameterHints",
         "command": "editor.action.triggerParameterHints"
       }
+    },
+    {
+      "label": "TEST_FUTURE_INT",
+      "kind": "Variable",
+      "detail": "future<int>",
+      "sortText": "G",
+      "insertText": "TEST_FUTURE_INT",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config12.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config12.json
@@ -1,0 +1,251 @@
+{
+  "position": {
+    "line": 4,
+    "character": 27
+  },
+  "source": "expression_context/source/conditional_expr_ctx_source12.bal",
+  "items": [
+    {
+      "label": "ENUM1_FIELD1",
+      "kind": "EnumMember",
+      "detail": "ENUM1_FIELD1",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": ""
+        }
+      },
+      "sortText": "L",
+      "insertText": "ENUM1_FIELD1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TEST_INT_CONST1",
+      "kind": "Variable",
+      "detail": "1",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": ""
+        }
+      },
+      "sortText": "AC",
+      "insertText": "TEST_INT_CONST1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TEST_STRING_CONST1",
+      "kind": "Variable",
+      "detail": "HELLO WORLD",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": ""
+        }
+      },
+      "sortText": "G",
+      "insertText": "TEST_STRING_CONST1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "AnnotationType",
+      "kind": "Struct",
+      "detail": "Record",
+      "sortText": "Q",
+      "insertText": "AnnotationType",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ResponseMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
+      },
+      "sortText": "M",
+      "insertText": "ResponseMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "RequestMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
+      },
+      "sortText": "M",
+      "insertText": "RequestMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestRecord1",
+      "kind": "Struct",
+      "detail": "Record",
+      "sortText": "Q",
+      "insertText": "TestRecord1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestRecord2",
+      "kind": "Struct",
+      "detail": "Record",
+      "sortText": "Q",
+      "insertText": "TestRecord2",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestMap2",
+      "kind": "TypeParameter",
+      "detail": "Map",
+      "sortText": "R",
+      "insertText": "TestMap2",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestMap3",
+      "kind": "TypeParameter",
+      "detail": "Map",
+      "sortText": "R",
+      "insertText": "TestMap3",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestObject1",
+      "kind": "Interface",
+      "detail": "Object",
+      "sortText": "O",
+      "insertText": "TestObject1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ErrorOne",
+      "kind": "Event",
+      "detail": "Error",
+      "sortText": "P",
+      "insertText": "ErrorOne",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ErrorTwo",
+      "kind": "Event",
+      "detail": "Error",
+      "sortText": "P",
+      "insertText": "ErrorTwo",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Listener",
+      "kind": "Interface",
+      "detail": "Class",
+      "sortText": "O",
+      "insertText": "Listener",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Client",
+      "kind": "Interface",
+      "detail": "Class",
+      "documentation": {
+        "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs."
+      },
+      "sortText": "O",
+      "insertText": "Client",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Response",
+      "kind": "Interface",
+      "detail": "Class",
+      "documentation": {
+        "left": "Represents a response.\n"
+      },
+      "sortText": "O",
+      "insertText": "Response",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestClass1",
+      "kind": "Interface",
+      "detail": "Class",
+      "sortText": "O",
+      "insertText": "TestClass1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "listener1",
+      "kind": "Variable",
+      "detail": "module1:Listener",
+      "sortText": "G",
+      "insertText": "listener1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "function1()",
+      "kind": "Function",
+      "detail": "()",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \n  \n"
+        }
+      },
+      "sortText": "E",
+      "filterText": "function1",
+      "insertText": "function1()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "function2()",
+      "kind": "Function",
+      "detail": "()",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function2  \n"
+        }
+      },
+      "sortText": "E",
+      "filterText": "function2",
+      "insertText": "function2()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "function3(int param1, int param2, float... param3)",
+      "kind": "Function",
+      "detail": "int",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function3 with input parameters\n  \n**Params**  \n- `int` param1: param1 Parameter Description   \n- `int` param2: param2 Parameter Description  \n- `float[]` param3: param3 Parameter Description  \n  \n**Return** `int`   \n- Return Value Description  \n  \n"
+        }
+      },
+      "sortText": "AA",
+      "filterText": "function3",
+      "insertText": "function3(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "function4(int param1, int param2, string param3, float... param4)",
+      "kind": "Function",
+      "detail": "()",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function4 with input parameters\n  \n**Params**  \n- `int` param1: param1 Parameter Description   \n- `int` param2: param2 Parameter Description  \n- `string` param3: param3 Parameter Description(Defaultable)  \n- `float[]` param4: param4 Parameter Description"
+        }
+      },
+      "sortText": "E",
+      "filterText": "function4",
+      "insertText": "function4(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config2.json
@@ -9,6 +9,7 @@
       "label": "module1",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "S",
       "filterText": "module1",
       "insertText": "module1",
       "insertTextFormat": "Snippet"
@@ -17,6 +18,7 @@
       "label": "ballerina/lang.test",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "R",
       "filterText": "test",
       "insertText": "test",
       "insertTextFormat": "Snippet",
@@ -40,6 +42,7 @@
       "label": "ballerina/lang.array",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "R",
       "filterText": "array",
       "insertText": "array",
       "insertTextFormat": "Snippet",
@@ -63,6 +66,7 @@
       "label": "ballerina/jballerina.java",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "R",
       "filterText": "java",
       "insertText": "java",
       "insertTextFormat": "Snippet",
@@ -86,6 +90,7 @@
       "label": "ballerina/lang.value",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "R",
       "filterText": "value",
       "insertText": "value",
       "insertTextFormat": "Snippet",
@@ -109,6 +114,7 @@
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "R",
       "filterText": "runtime",
       "insertText": "runtime",
       "insertTextFormat": "Snippet",
@@ -132,6 +138,7 @@
       "label": "boolean",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "boolean",
       "insertTextFormat": "Snippet"
     },
@@ -139,6 +146,7 @@
       "label": "decimal",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "decimal",
       "insertTextFormat": "Snippet"
     },
@@ -146,6 +154,7 @@
       "label": "error",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "error",
       "insertTextFormat": "Snippet"
     },
@@ -153,6 +162,7 @@
       "label": "float",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "float",
       "insertTextFormat": "Snippet"
     },
@@ -160,6 +170,7 @@
       "label": "future",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "future",
       "insertTextFormat": "Snippet"
     },
@@ -167,6 +178,7 @@
       "label": "int",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "int",
       "insertTextFormat": "Snippet"
     },
@@ -174,6 +186,7 @@
       "label": "map",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "map",
       "insertTextFormat": "Snippet"
     },
@@ -181,6 +194,7 @@
       "label": "object",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "object",
       "insertTextFormat": "Snippet"
     },
@@ -188,6 +202,7 @@
       "label": "stream",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "stream",
       "insertTextFormat": "Snippet"
     },
@@ -195,6 +210,7 @@
       "label": "string",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "string",
       "insertTextFormat": "Snippet"
     },
@@ -202,6 +218,7 @@
       "label": "table",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "table",
       "insertTextFormat": "Snippet"
     },
@@ -209,6 +226,7 @@
       "label": "transaction",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "transaction",
       "insertTextFormat": "Snippet"
     },
@@ -216,6 +234,7 @@
       "label": "typedesc",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "typedesc",
       "insertTextFormat": "Snippet"
     },
@@ -223,6 +242,7 @@
       "label": "xml",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
     },
@@ -230,6 +250,7 @@
       "label": "service",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "service",
       "insertText": "service",
       "insertTextFormat": "Snippet"
@@ -238,6 +259,7 @@
       "label": "new",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "new",
       "insertText": "new ",
       "insertTextFormat": "Snippet"
@@ -246,6 +268,7 @@
       "label": "isolated",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "isolated",
       "insertText": "isolated ",
       "insertTextFormat": "Snippet"
@@ -254,6 +277,7 @@
       "label": "transactional",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "transactional",
       "insertText": "transactional",
       "insertTextFormat": "Snippet"
@@ -262,6 +286,7 @@
       "label": "function",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "function",
       "insertText": "function ",
       "insertTextFormat": "Snippet"
@@ -270,6 +295,7 @@
       "label": "let",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "let",
       "insertText": "let",
       "insertTextFormat": "Snippet"
@@ -278,6 +304,7 @@
       "label": "typeof",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "typeof",
       "insertText": "typeof ",
       "insertTextFormat": "Snippet"
@@ -286,6 +313,7 @@
       "label": "trap",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "trap",
       "insertText": "trap",
       "insertTextFormat": "Snippet"
@@ -294,6 +322,7 @@
       "label": "client",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "client",
       "insertText": "client ",
       "insertTextFormat": "Snippet"
@@ -302,6 +331,7 @@
       "label": "true",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "true",
       "insertText": "true",
       "insertTextFormat": "Snippet"
@@ -310,6 +340,7 @@
       "label": "false",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "false",
       "insertText": "false",
       "insertTextFormat": "Snippet"
@@ -318,6 +349,7 @@
       "label": "check",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "check",
       "insertText": "check ",
       "insertTextFormat": "Snippet"
@@ -326,6 +358,7 @@
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "checkpanic",
       "insertText": "checkpanic ",
       "insertTextFormat": "Snippet"
@@ -334,6 +367,7 @@
       "label": "is",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "is",
       "insertText": "is",
       "insertTextFormat": "Snippet"
@@ -342,6 +376,7 @@
       "label": "error constructor",
       "kind": "Snippet",
       "detail": "Snippet",
+      "sortText": "T",
       "filterText": "error",
       "insertText": "error(\"${1}\")",
       "insertTextFormat": "Snippet"
@@ -350,6 +385,7 @@
       "label": "object constructor",
       "kind": "Snippet",
       "detail": "Snippet",
+      "sortText": "T",
       "filterText": "object",
       "insertText": "object {${1}}",
       "insertTextFormat": "Snippet"
@@ -358,6 +394,7 @@
       "label": "base16",
       "kind": "Snippet",
       "detail": "Snippet",
+      "sortText": "T",
       "filterText": "base16",
       "insertText": "base16 `${1}`",
       "insertTextFormat": "Snippet"
@@ -366,6 +403,7 @@
       "label": "base64",
       "kind": "Snippet",
       "detail": "Snippet",
+      "sortText": "T",
       "filterText": "base64",
       "insertText": "base64 `${1}`",
       "insertTextFormat": "Snippet"
@@ -374,6 +412,7 @@
       "label": "from",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "from",
       "insertText": "from ",
       "insertTextFormat": "Snippet"
@@ -382,6 +421,7 @@
       "label": "Thread",
       "kind": "TypeParameter",
       "detail": "Union",
+      "sortText": "R",
       "insertText": "Thread",
       "insertTextFormat": "Snippet"
     },
@@ -395,6 +435,7 @@
           "value": "**Package:** _._  \n  \n  \n"
         }
       },
+      "sortText": "G",
       "filterText": "name",
       "insertText": "name()",
       "insertTextFormat": "Snippet"
@@ -406,6 +447,7 @@
       "documentation": {
         "left": "Describes Strand execution details for the runtime.\n"
       },
+      "sortText": "Q",
       "insertText": "StrandData",
       "insertTextFormat": "Snippet"
     },
@@ -413,6 +455,7 @@
       "label": "flag",
       "kind": "Variable",
       "detail": "boolean",
+      "sortText": "F",
       "insertText": "flag",
       "insertTextFormat": "Snippet"
     },
@@ -420,6 +463,7 @@
       "label": "n",
       "kind": "Variable",
       "detail": "int",
+      "sortText": "AB",
       "insertText": "n",
       "insertTextFormat": "Snippet"
     },
@@ -427,6 +471,7 @@
       "label": "readonly",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "readonly",
       "insertTextFormat": "Snippet"
     },
@@ -434,6 +479,7 @@
       "label": "handle",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "handle",
       "insertTextFormat": "Snippet"
     },
@@ -441,6 +487,7 @@
       "label": "never",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "never",
       "insertTextFormat": "Snippet"
     },
@@ -448,6 +495,7 @@
       "label": "json",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "json",
       "insertTextFormat": "Snippet"
     },
@@ -455,6 +503,7 @@
       "label": "anydata",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "anydata",
       "insertTextFormat": "Snippet"
     },
@@ -462,6 +511,7 @@
       "label": "any",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "any",
       "insertTextFormat": "Snippet"
     },
@@ -469,6 +519,7 @@
       "label": "byte",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
     },
@@ -476,6 +527,7 @@
       "label": "null",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "null",
       "insertText": "null",
       "insertTextFormat": "Snippet"

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config3.json
@@ -9,6 +9,7 @@
       "label": "module1",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "S",
       "filterText": "module1",
       "insertText": "module1",
       "insertTextFormat": "Snippet"
@@ -17,6 +18,7 @@
       "label": "ballerina/lang.test",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "R",
       "filterText": "test",
       "insertText": "test",
       "insertTextFormat": "Snippet",
@@ -40,6 +42,7 @@
       "label": "ballerina/lang.array",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "R",
       "filterText": "array",
       "insertText": "array",
       "insertTextFormat": "Snippet",
@@ -63,6 +66,7 @@
       "label": "ballerina/jballerina.java",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "R",
       "filterText": "java",
       "insertText": "java",
       "insertTextFormat": "Snippet",
@@ -86,6 +90,7 @@
       "label": "ballerina/lang.value",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "R",
       "filterText": "value",
       "insertText": "value",
       "insertTextFormat": "Snippet",
@@ -109,6 +114,7 @@
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "R",
       "filterText": "runtime",
       "insertText": "runtime",
       "insertTextFormat": "Snippet",
@@ -132,6 +138,7 @@
       "label": "boolean",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "boolean",
       "insertTextFormat": "Snippet"
     },
@@ -139,6 +146,7 @@
       "label": "decimal",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "decimal",
       "insertTextFormat": "Snippet"
     },
@@ -146,6 +154,7 @@
       "label": "error",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "error",
       "insertTextFormat": "Snippet"
     },
@@ -153,6 +162,7 @@
       "label": "float",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "float",
       "insertTextFormat": "Snippet"
     },
@@ -160,6 +170,7 @@
       "label": "future",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "future",
       "insertTextFormat": "Snippet"
     },
@@ -167,6 +178,7 @@
       "label": "int",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "int",
       "insertTextFormat": "Snippet"
     },
@@ -174,6 +186,7 @@
       "label": "map",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "map",
       "insertTextFormat": "Snippet"
     },
@@ -181,6 +194,7 @@
       "label": "object",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "object",
       "insertTextFormat": "Snippet"
     },
@@ -188,6 +202,7 @@
       "label": "stream",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "stream",
       "insertTextFormat": "Snippet"
     },
@@ -195,6 +210,7 @@
       "label": "string",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "string",
       "insertTextFormat": "Snippet"
     },
@@ -202,6 +218,7 @@
       "label": "table",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "table",
       "insertTextFormat": "Snippet"
     },
@@ -209,6 +226,7 @@
       "label": "transaction",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "transaction",
       "insertTextFormat": "Snippet"
     },
@@ -216,6 +234,7 @@
       "label": "typedesc",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "typedesc",
       "insertTextFormat": "Snippet"
     },
@@ -223,6 +242,7 @@
       "label": "xml",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
     },
@@ -230,6 +250,7 @@
       "label": "service",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "service",
       "insertText": "service",
       "insertTextFormat": "Snippet"
@@ -238,6 +259,7 @@
       "label": "new",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "new",
       "insertText": "new ",
       "insertTextFormat": "Snippet"
@@ -246,6 +268,7 @@
       "label": "isolated",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "isolated",
       "insertText": "isolated ",
       "insertTextFormat": "Snippet"
@@ -254,6 +277,7 @@
       "label": "transactional",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "transactional",
       "insertText": "transactional",
       "insertTextFormat": "Snippet"
@@ -262,6 +286,7 @@
       "label": "function",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "function",
       "insertText": "function ",
       "insertTextFormat": "Snippet"
@@ -270,6 +295,7 @@
       "label": "let",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "let",
       "insertText": "let",
       "insertTextFormat": "Snippet"
@@ -278,6 +304,7 @@
       "label": "typeof",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "typeof",
       "insertText": "typeof ",
       "insertTextFormat": "Snippet"
@@ -286,6 +313,7 @@
       "label": "trap",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "trap",
       "insertText": "trap",
       "insertTextFormat": "Snippet"
@@ -294,6 +322,7 @@
       "label": "client",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "client",
       "insertText": "client ",
       "insertTextFormat": "Snippet"
@@ -302,6 +331,7 @@
       "label": "true",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "true",
       "insertText": "true",
       "insertTextFormat": "Snippet"
@@ -310,6 +340,7 @@
       "label": "false",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "false",
       "insertText": "false",
       "insertTextFormat": "Snippet"
@@ -318,6 +349,7 @@
       "label": "check",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "check",
       "insertText": "check ",
       "insertTextFormat": "Snippet"
@@ -326,6 +358,7 @@
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "checkpanic",
       "insertText": "checkpanic ",
       "insertTextFormat": "Snippet"
@@ -334,6 +367,7 @@
       "label": "is",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "is",
       "insertText": "is",
       "insertTextFormat": "Snippet"
@@ -342,6 +376,7 @@
       "label": "error constructor",
       "kind": "Snippet",
       "detail": "Snippet",
+      "sortText": "T",
       "filterText": "error",
       "insertText": "error(\"${1}\")",
       "insertTextFormat": "Snippet"
@@ -350,6 +385,7 @@
       "label": "object constructor",
       "kind": "Snippet",
       "detail": "Snippet",
+      "sortText": "T",
       "filterText": "object",
       "insertText": "object {${1}}",
       "insertTextFormat": "Snippet"
@@ -358,6 +394,7 @@
       "label": "base16",
       "kind": "Snippet",
       "detail": "Snippet",
+      "sortText": "T",
       "filterText": "base16",
       "insertText": "base16 `${1}`",
       "insertTextFormat": "Snippet"
@@ -366,6 +403,7 @@
       "label": "base64",
       "kind": "Snippet",
       "detail": "Snippet",
+      "sortText": "T",
       "filterText": "base64",
       "insertText": "base64 `${1}`",
       "insertTextFormat": "Snippet"
@@ -374,6 +412,7 @@
       "label": "from",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "from",
       "insertText": "from ",
       "insertTextFormat": "Snippet"
@@ -382,6 +421,7 @@
       "label": "Thread",
       "kind": "TypeParameter",
       "detail": "Union",
+      "sortText": "R",
       "insertText": "Thread",
       "insertTextFormat": "Snippet"
     },
@@ -395,6 +435,7 @@
           "value": "**Package:** _._  \n  \n  \n"
         }
       },
+      "sortText": "G",
       "filterText": "name",
       "insertText": "name()",
       "insertTextFormat": "Snippet"
@@ -406,6 +447,7 @@
       "documentation": {
         "left": "Describes Strand execution details for the runtime.\n"
       },
+      "sortText": "Q",
       "insertText": "StrandData",
       "insertTextFormat": "Snippet"
     },
@@ -413,6 +455,7 @@
       "label": "flag",
       "kind": "Variable",
       "detail": "boolean",
+      "sortText": "F",
       "insertText": "flag",
       "insertTextFormat": "Snippet"
     },
@@ -420,6 +463,7 @@
       "label": "n",
       "kind": "Variable",
       "detail": "int",
+      "sortText": "AB",
       "insertText": "n",
       "insertTextFormat": "Snippet"
     },
@@ -427,6 +471,7 @@
       "label": "readonly",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "readonly",
       "insertTextFormat": "Snippet"
     },
@@ -434,6 +479,7 @@
       "label": "handle",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "handle",
       "insertTextFormat": "Snippet"
     },
@@ -441,6 +487,7 @@
       "label": "never",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "never",
       "insertTextFormat": "Snippet"
     },
@@ -448,6 +495,7 @@
       "label": "json",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "json",
       "insertTextFormat": "Snippet"
     },
@@ -455,6 +503,7 @@
       "label": "anydata",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "anydata",
       "insertTextFormat": "Snippet"
     },
@@ -462,6 +511,7 @@
       "label": "any",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "any",
       "insertTextFormat": "Snippet"
     },
@@ -469,6 +519,7 @@
       "label": "byte",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
     },
@@ -476,6 +527,7 @@
       "label": "null",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "null",
       "insertText": "null",
       "insertTextFormat": "Snippet"

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config4.json
@@ -9,6 +9,7 @@
       "label": "module1",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "S",
       "filterText": "module1",
       "insertText": "module1",
       "insertTextFormat": "Snippet"
@@ -17,6 +18,7 @@
       "label": "ballerina/lang.test",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "R",
       "filterText": "test",
       "insertText": "test",
       "insertTextFormat": "Snippet",
@@ -40,6 +42,7 @@
       "label": "ballerina/lang.array",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "R",
       "filterText": "array",
       "insertText": "array",
       "insertTextFormat": "Snippet",
@@ -63,6 +66,7 @@
       "label": "ballerina/jballerina.java",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "R",
       "filterText": "java",
       "insertText": "java",
       "insertTextFormat": "Snippet",
@@ -86,6 +90,7 @@
       "label": "ballerina/lang.value",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "R",
       "filterText": "value",
       "insertText": "value",
       "insertTextFormat": "Snippet",
@@ -109,6 +114,7 @@
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "R",
       "filterText": "runtime",
       "insertText": "runtime",
       "insertTextFormat": "Snippet",
@@ -132,6 +138,7 @@
       "label": "boolean",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "boolean",
       "insertTextFormat": "Snippet"
     },
@@ -139,6 +146,7 @@
       "label": "decimal",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "decimal",
       "insertTextFormat": "Snippet"
     },
@@ -146,6 +154,7 @@
       "label": "error",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "error",
       "insertTextFormat": "Snippet"
     },
@@ -153,6 +162,7 @@
       "label": "float",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "float",
       "insertTextFormat": "Snippet"
     },
@@ -160,6 +170,7 @@
       "label": "future",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "future",
       "insertTextFormat": "Snippet"
     },
@@ -167,6 +178,7 @@
       "label": "int",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "int",
       "insertTextFormat": "Snippet"
     },
@@ -174,6 +186,7 @@
       "label": "map",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "map",
       "insertTextFormat": "Snippet"
     },
@@ -181,6 +194,7 @@
       "label": "object",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "object",
       "insertTextFormat": "Snippet"
     },
@@ -188,6 +202,7 @@
       "label": "stream",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "stream",
       "insertTextFormat": "Snippet"
     },
@@ -195,6 +210,7 @@
       "label": "string",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "string",
       "insertTextFormat": "Snippet"
     },
@@ -202,6 +218,7 @@
       "label": "table",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "table",
       "insertTextFormat": "Snippet"
     },
@@ -209,6 +226,7 @@
       "label": "transaction",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "transaction",
       "insertTextFormat": "Snippet"
     },
@@ -216,6 +234,7 @@
       "label": "typedesc",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "typedesc",
       "insertTextFormat": "Snippet"
     },
@@ -223,6 +242,7 @@
       "label": "xml",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
     },
@@ -230,6 +250,7 @@
       "label": "service",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "service",
       "insertText": "service",
       "insertTextFormat": "Snippet"
@@ -238,6 +259,7 @@
       "label": "new",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "new",
       "insertText": "new ",
       "insertTextFormat": "Snippet"
@@ -246,6 +268,7 @@
       "label": "isolated",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "isolated",
       "insertText": "isolated ",
       "insertTextFormat": "Snippet"
@@ -254,6 +277,7 @@
       "label": "transactional",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "transactional",
       "insertText": "transactional",
       "insertTextFormat": "Snippet"
@@ -262,6 +286,7 @@
       "label": "function",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "function",
       "insertText": "function ",
       "insertTextFormat": "Snippet"
@@ -270,6 +295,7 @@
       "label": "let",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "let",
       "insertText": "let",
       "insertTextFormat": "Snippet"
@@ -278,6 +304,7 @@
       "label": "typeof",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "typeof",
       "insertText": "typeof ",
       "insertTextFormat": "Snippet"
@@ -286,6 +313,7 @@
       "label": "trap",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "trap",
       "insertText": "trap",
       "insertTextFormat": "Snippet"
@@ -294,6 +322,7 @@
       "label": "client",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "client",
       "insertText": "client ",
       "insertTextFormat": "Snippet"
@@ -302,6 +331,7 @@
       "label": "true",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "true",
       "insertText": "true",
       "insertTextFormat": "Snippet"
@@ -310,6 +340,7 @@
       "label": "false",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "false",
       "insertText": "false",
       "insertTextFormat": "Snippet"
@@ -318,6 +349,7 @@
       "label": "check",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "check",
       "insertText": "check ",
       "insertTextFormat": "Snippet"
@@ -326,6 +358,7 @@
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "checkpanic",
       "insertText": "checkpanic ",
       "insertTextFormat": "Snippet"
@@ -334,6 +367,7 @@
       "label": "is",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "is",
       "insertText": "is",
       "insertTextFormat": "Snippet"
@@ -342,6 +376,7 @@
       "label": "error constructor",
       "kind": "Snippet",
       "detail": "Snippet",
+      "sortText": "T",
       "filterText": "error",
       "insertText": "error(\"${1}\")",
       "insertTextFormat": "Snippet"
@@ -350,6 +385,7 @@
       "label": "object constructor",
       "kind": "Snippet",
       "detail": "Snippet",
+      "sortText": "T",
       "filterText": "object",
       "insertText": "object {${1}}",
       "insertTextFormat": "Snippet"
@@ -358,6 +394,7 @@
       "label": "base16",
       "kind": "Snippet",
       "detail": "Snippet",
+      "sortText": "T",
       "filterText": "base16",
       "insertText": "base16 `${1}`",
       "insertTextFormat": "Snippet"
@@ -366,6 +403,7 @@
       "label": "base64",
       "kind": "Snippet",
       "detail": "Snippet",
+      "sortText": "T",
       "filterText": "base64",
       "insertText": "base64 `${1}`",
       "insertTextFormat": "Snippet"
@@ -374,6 +412,7 @@
       "label": "from",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "from",
       "insertText": "from ",
       "insertTextFormat": "Snippet"
@@ -382,6 +421,7 @@
       "label": "Thread",
       "kind": "TypeParameter",
       "detail": "Union",
+      "sortText": "R",
       "insertText": "Thread",
       "insertTextFormat": "Snippet"
     },
@@ -395,6 +435,7 @@
           "value": "**Package:** _._  \n  \n  \n"
         }
       },
+      "sortText": "G",
       "filterText": "name",
       "insertText": "name()",
       "insertTextFormat": "Snippet"
@@ -406,6 +447,7 @@
       "documentation": {
         "left": "Describes Strand execution details for the runtime.\n"
       },
+      "sortText": "Q",
       "insertText": "StrandData",
       "insertTextFormat": "Snippet"
     },
@@ -413,6 +455,7 @@
       "label": "flag",
       "kind": "Variable",
       "detail": "boolean",
+      "sortText": "F",
       "insertText": "flag",
       "insertTextFormat": "Snippet"
     },
@@ -420,6 +463,7 @@
       "label": "n",
       "kind": "Variable",
       "detail": "int",
+      "sortText": "AB",
       "insertText": "n",
       "insertTextFormat": "Snippet"
     },
@@ -427,6 +471,7 @@
       "label": "readonly",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "readonly",
       "insertTextFormat": "Snippet"
     },
@@ -434,6 +479,7 @@
       "label": "handle",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "handle",
       "insertTextFormat": "Snippet"
     },
@@ -441,6 +487,7 @@
       "label": "never",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "never",
       "insertTextFormat": "Snippet"
     },
@@ -448,6 +495,7 @@
       "label": "json",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "json",
       "insertTextFormat": "Snippet"
     },
@@ -455,6 +503,7 @@
       "label": "anydata",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "anydata",
       "insertTextFormat": "Snippet"
     },
@@ -462,6 +511,7 @@
       "label": "any",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "any",
       "insertTextFormat": "Snippet"
     },
@@ -469,6 +519,7 @@
       "label": "byte",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
     },
@@ -476,6 +527,7 @@
       "label": "null",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "null",
       "insertText": "null",
       "insertTextFormat": "Snippet"

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config5.json
@@ -15,6 +15,7 @@
           "value": ""
         }
       },
+      "sortText": "L",
       "insertText": "ENUM1_FIELD1",
       "insertTextFormat": "Snippet"
     },
@@ -28,6 +29,7 @@
           "value": ""
         }
       },
+      "sortText": "AC",
       "insertText": "TEST_INT_CONST1",
       "insertTextFormat": "Snippet"
     },
@@ -41,6 +43,7 @@
           "value": ""
         }
       },
+      "sortText": "G",
       "insertText": "TEST_STRING_CONST1",
       "insertTextFormat": "Snippet"
     },
@@ -48,6 +51,7 @@
       "label": "AnnotationType",
       "kind": "Struct",
       "detail": "Record",
+      "sortText": "Q",
       "insertText": "AnnotationType",
       "insertTextFormat": "Snippet"
     },
@@ -58,6 +62,7 @@
       "documentation": {
         "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
       },
+      "sortText": "M",
       "insertText": "ResponseMessage",
       "insertTextFormat": "Snippet"
     },
@@ -68,6 +73,7 @@
       "documentation": {
         "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
       },
+      "sortText": "M",
       "insertText": "RequestMessage",
       "insertTextFormat": "Snippet"
     },
@@ -75,6 +81,7 @@
       "label": "TestRecord1",
       "kind": "Struct",
       "detail": "Record",
+      "sortText": "Q",
       "insertText": "TestRecord1",
       "insertTextFormat": "Snippet"
     },
@@ -82,6 +89,7 @@
       "label": "TestRecord2",
       "kind": "Struct",
       "detail": "Record",
+      "sortText": "Q",
       "insertText": "TestRecord2",
       "insertTextFormat": "Snippet"
     },
@@ -89,6 +97,7 @@
       "label": "TestMap2",
       "kind": "TypeParameter",
       "detail": "Map",
+      "sortText": "R",
       "insertText": "TestMap2",
       "insertTextFormat": "Snippet"
     },
@@ -96,6 +105,7 @@
       "label": "TestMap3",
       "kind": "TypeParameter",
       "detail": "Map",
+      "sortText": "R",
       "insertText": "TestMap3",
       "insertTextFormat": "Snippet"
     },
@@ -103,6 +113,7 @@
       "label": "TestObject1",
       "kind": "Interface",
       "detail": "Object",
+      "sortText": "O",
       "insertText": "TestObject1",
       "insertTextFormat": "Snippet"
     },
@@ -110,6 +121,7 @@
       "label": "ErrorOne",
       "kind": "Event",
       "detail": "Error",
+      "sortText": "P",
       "insertText": "ErrorOne",
       "insertTextFormat": "Snippet"
     },
@@ -117,6 +129,7 @@
       "label": "ErrorTwo",
       "kind": "Event",
       "detail": "Error",
+      "sortText": "P",
       "insertText": "ErrorTwo",
       "insertTextFormat": "Snippet"
     },
@@ -124,6 +137,7 @@
       "label": "Listener",
       "kind": "Interface",
       "detail": "Class",
+      "sortText": "O",
       "insertText": "Listener",
       "insertTextFormat": "Snippet"
     },
@@ -134,6 +148,7 @@
       "documentation": {
         "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs."
       },
+      "sortText": "O",
       "insertText": "Client",
       "insertTextFormat": "Snippet"
     },
@@ -144,6 +159,7 @@
       "documentation": {
         "left": "Represents a response.\n"
       },
+      "sortText": "O",
       "insertText": "Response",
       "insertTextFormat": "Snippet"
     },
@@ -151,6 +167,7 @@
       "label": "TestClass1",
       "kind": "Interface",
       "detail": "Class",
+      "sortText": "O",
       "insertText": "TestClass1",
       "insertTextFormat": "Snippet"
     },
@@ -158,6 +175,7 @@
       "label": "listener1",
       "kind": "Variable",
       "detail": "module1:Listener",
+      "sortText": "G",
       "insertText": "listener1",
       "insertTextFormat": "Snippet"
     },
@@ -171,6 +189,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \n  \n"
         }
       },
+      "sortText": "E",
       "filterText": "function1",
       "insertText": "function1()",
       "insertTextFormat": "Snippet"
@@ -185,6 +204,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function2  \n"
         }
       },
+      "sortText": "E",
       "filterText": "function2",
       "insertText": "function2()",
       "insertTextFormat": "Snippet"
@@ -199,6 +219,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function3 with input parameters\n  \n**Params**  \n- `int` param1: param1 Parameter Description   \n- `int` param2: param2 Parameter Description  \n- `float[]` param3: param3 Parameter Description  \n  \n**Return** `int`   \n- Return Value Description  \n  \n"
         }
       },
+      "sortText": "AA",
       "filterText": "function3",
       "insertText": "function3(${1})",
       "insertTextFormat": "Snippet",
@@ -217,6 +238,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function4 with input parameters\n  \n**Params**  \n- `int` param1: param1 Parameter Description   \n- `int` param2: param2 Parameter Description  \n- `string` param3: param3 Parameter Description(Defaultable)  \n- `float[]` param4: param4 Parameter Description"
         }
       },
+      "sortText": "E",
       "filterText": "function4",
       "insertText": "function4(${1})",
       "insertTextFormat": "Snippet",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config5.json
@@ -251,6 +251,7 @@
       "label": "TEST_FUTURE_INT",
       "kind": "Variable",
       "detail": "future<int>",
+      "sortText": "G",
       "insertText": "TEST_FUTURE_INT",
       "insertTextFormat": "Snippet"
     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config6.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config6.json
@@ -1,0 +1,251 @@
+{
+  "position": {
+    "line": 4,
+    "character": 28
+  },
+  "source": "expression_context/source/conditional_expr_ctx_source6.bal",
+  "items": [
+    {
+      "label": "ENUM1_FIELD1",
+      "kind": "EnumMember",
+      "detail": "ENUM1_FIELD1",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": ""
+        }
+      },
+      "sortText": "L",
+      "insertText": "ENUM1_FIELD1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TEST_INT_CONST1",
+      "kind": "Variable",
+      "detail": "1",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": ""
+        }
+      },
+      "sortText": "AC",
+      "insertText": "TEST_INT_CONST1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TEST_STRING_CONST1",
+      "kind": "Variable",
+      "detail": "HELLO WORLD",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": ""
+        }
+      },
+      "sortText": "G",
+      "insertText": "TEST_STRING_CONST1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "AnnotationType",
+      "kind": "Struct",
+      "detail": "Record",
+      "sortText": "Q",
+      "insertText": "AnnotationType",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ResponseMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
+      },
+      "sortText": "M",
+      "insertText": "ResponseMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "RequestMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
+      },
+      "sortText": "M",
+      "insertText": "RequestMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestRecord1",
+      "kind": "Struct",
+      "detail": "Record",
+      "sortText": "Q",
+      "insertText": "TestRecord1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestRecord2",
+      "kind": "Struct",
+      "detail": "Record",
+      "sortText": "Q",
+      "insertText": "TestRecord2",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestMap2",
+      "kind": "TypeParameter",
+      "detail": "Map",
+      "sortText": "R",
+      "insertText": "TestMap2",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestMap3",
+      "kind": "TypeParameter",
+      "detail": "Map",
+      "sortText": "R",
+      "insertText": "TestMap3",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestObject1",
+      "kind": "Interface",
+      "detail": "Object",
+      "sortText": "O",
+      "insertText": "TestObject1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ErrorOne",
+      "kind": "Event",
+      "detail": "Error",
+      "sortText": "P",
+      "insertText": "ErrorOne",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ErrorTwo",
+      "kind": "Event",
+      "detail": "Error",
+      "sortText": "P",
+      "insertText": "ErrorTwo",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Listener",
+      "kind": "Interface",
+      "detail": "Class",
+      "sortText": "O",
+      "insertText": "Listener",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Client",
+      "kind": "Interface",
+      "detail": "Class",
+      "documentation": {
+        "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs."
+      },
+      "sortText": "O",
+      "insertText": "Client",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Response",
+      "kind": "Interface",
+      "detail": "Class",
+      "documentation": {
+        "left": "Represents a response.\n"
+      },
+      "sortText": "O",
+      "insertText": "Response",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestClass1",
+      "kind": "Interface",
+      "detail": "Class",
+      "sortText": "O",
+      "insertText": "TestClass1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "listener1",
+      "kind": "Variable",
+      "detail": "module1:Listener",
+      "sortText": "G",
+      "insertText": "listener1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "function1()",
+      "kind": "Function",
+      "detail": "()",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \n  \n"
+        }
+      },
+      "sortText": "E",
+      "filterText": "function1",
+      "insertText": "function1()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "function2()",
+      "kind": "Function",
+      "detail": "()",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function2  \n"
+        }
+      },
+      "sortText": "E",
+      "filterText": "function2",
+      "insertText": "function2()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "function3(int param1, int param2, float... param3)",
+      "kind": "Function",
+      "detail": "int",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function3 with input parameters\n  \n**Params**  \n- `int` param1: param1 Parameter Description   \n- `int` param2: param2 Parameter Description  \n- `float[]` param3: param3 Parameter Description  \n  \n**Return** `int`   \n- Return Value Description  \n  \n"
+        }
+      },
+      "sortText": "AA",
+      "filterText": "function3",
+      "insertText": "function3(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "function4(int param1, int param2, string param3, float... param4)",
+      "kind": "Function",
+      "detail": "()",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function4 with input parameters\n  \n**Params**  \n- `int` param1: param1 Parameter Description   \n- `int` param2: param2 Parameter Description  \n- `string` param3: param3 Parameter Description(Defaultable)  \n- `float[]` param4: param4 Parameter Description"
+        }
+      },
+      "sortText": "E",
+      "filterText": "function4",
+      "insertText": "function4(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config6.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config6.json
@@ -246,6 +246,14 @@
         "title": "editor.action.triggerParameterHints",
         "command": "editor.action.triggerParameterHints"
       }
+    },
+    {
+      "label": "TEST_FUTURE_INT",
+      "kind": "Variable",
+      "detail": "future<int>",
+      "sortText": "G",
+      "insertText": "TEST_FUTURE_INT",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config7.json
@@ -1,0 +1,229 @@
+{
+  "position": {
+    "line": 4,
+    "character": 27
+  },
+  "source": "expression_context/source/conditional_expr_ctx_source7.bal",
+  "items": [
+    {
+      "label": "ENUM1_FIELD1",
+      "kind": "EnumMember",
+      "detail": "ENUM1_FIELD1",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": ""
+        }
+      },
+      "insertText": "ENUM1_FIELD1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TEST_INT_CONST1",
+      "kind": "Variable",
+      "detail": "1",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": ""
+        }
+      },
+      "insertText": "TEST_INT_CONST1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TEST_STRING_CONST1",
+      "kind": "Variable",
+      "detail": "HELLO WORLD",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": ""
+        }
+      },
+      "insertText": "TEST_STRING_CONST1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "AnnotationType",
+      "kind": "Struct",
+      "detail": "Record",
+      "insertText": "AnnotationType",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ResponseMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
+      },
+      "insertText": "ResponseMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "RequestMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
+      },
+      "insertText": "RequestMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestRecord1",
+      "kind": "Struct",
+      "detail": "Record",
+      "insertText": "TestRecord1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestRecord2",
+      "kind": "Struct",
+      "detail": "Record",
+      "insertText": "TestRecord2",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestMap2",
+      "kind": "TypeParameter",
+      "detail": "Map",
+      "insertText": "TestMap2",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestMap3",
+      "kind": "TypeParameter",
+      "detail": "Map",
+      "insertText": "TestMap3",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestObject1",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "TestObject1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ErrorOne",
+      "kind": "Event",
+      "detail": "Error",
+      "insertText": "ErrorOne",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ErrorTwo",
+      "kind": "Event",
+      "detail": "Error",
+      "insertText": "ErrorTwo",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Listener",
+      "kind": "Interface",
+      "detail": "Class",
+      "insertText": "Listener",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Client",
+      "kind": "Interface",
+      "detail": "Class",
+      "documentation": {
+        "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs."
+      },
+      "insertText": "Client",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Response",
+      "kind": "Interface",
+      "detail": "Class",
+      "documentation": {
+        "left": "Represents a response.\n"
+      },
+      "insertText": "Response",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestClass1",
+      "kind": "Interface",
+      "detail": "Class",
+      "insertText": "TestClass1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "listener1",
+      "kind": "Variable",
+      "detail": "module1:Listener",
+      "insertText": "listener1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "function1()",
+      "kind": "Function",
+      "detail": "()",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \n  \n"
+        }
+      },
+      "filterText": "function1",
+      "insertText": "function1()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "function2()",
+      "kind": "Function",
+      "detail": "()",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function2  \n"
+        }
+      },
+      "filterText": "function2",
+      "insertText": "function2()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "function3(int param1, int param2, float... param3)",
+      "kind": "Function",
+      "detail": "int",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function3 with input parameters\n  \n**Params**  \n- `int` param1: param1 Parameter Description   \n- `int` param2: param2 Parameter Description  \n- `float[]` param3: param3 Parameter Description  \n  \n**Return** `int`   \n- Return Value Description  \n  \n"
+        }
+      },
+      "filterText": "function3",
+      "insertText": "function3(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "function4(int param1, int param2, string param3, float... param4)",
+      "kind": "Function",
+      "detail": "()",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function4 with input parameters\n  \n**Params**  \n- `int` param1: param1 Parameter Description   \n- `int` param2: param2 Parameter Description  \n- `string` param3: param3 Parameter Description(Defaultable)  \n- `float[]` param4: param4 Parameter Description"
+        }
+      },
+      "filterText": "function4",
+      "insertText": "function4(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config7.json
@@ -15,6 +15,7 @@
           "value": ""
         }
       },
+      "sortText": "L",
       "insertText": "ENUM1_FIELD1",
       "insertTextFormat": "Snippet"
     },
@@ -28,6 +29,7 @@
           "value": ""
         }
       },
+      "sortText": "AB",
       "insertText": "TEST_INT_CONST1",
       "insertTextFormat": "Snippet"
     },
@@ -41,6 +43,7 @@
           "value": ""
         }
       },
+      "sortText": "F",
       "insertText": "TEST_STRING_CONST1",
       "insertTextFormat": "Snippet"
     },
@@ -48,6 +51,7 @@
       "label": "AnnotationType",
       "kind": "Struct",
       "detail": "Record",
+      "sortText": "Q",
       "insertText": "AnnotationType",
       "insertTextFormat": "Snippet"
     },
@@ -58,6 +62,7 @@
       "documentation": {
         "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
       },
+      "sortText": "M",
       "insertText": "ResponseMessage",
       "insertTextFormat": "Snippet"
     },
@@ -68,6 +73,7 @@
       "documentation": {
         "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
       },
+      "sortText": "M",
       "insertText": "RequestMessage",
       "insertTextFormat": "Snippet"
     },
@@ -75,6 +81,7 @@
       "label": "TestRecord1",
       "kind": "Struct",
       "detail": "Record",
+      "sortText": "Q",
       "insertText": "TestRecord1",
       "insertTextFormat": "Snippet"
     },
@@ -82,6 +89,7 @@
       "label": "TestRecord2",
       "kind": "Struct",
       "detail": "Record",
+      "sortText": "Q",
       "insertText": "TestRecord2",
       "insertTextFormat": "Snippet"
     },
@@ -89,6 +97,7 @@
       "label": "TestMap2",
       "kind": "TypeParameter",
       "detail": "Map",
+      "sortText": "R",
       "insertText": "TestMap2",
       "insertTextFormat": "Snippet"
     },
@@ -96,6 +105,7 @@
       "label": "TestMap3",
       "kind": "TypeParameter",
       "detail": "Map",
+      "sortText": "R",
       "insertText": "TestMap3",
       "insertTextFormat": "Snippet"
     },
@@ -103,6 +113,7 @@
       "label": "TestObject1",
       "kind": "Interface",
       "detail": "Object",
+      "sortText": "O",
       "insertText": "TestObject1",
       "insertTextFormat": "Snippet"
     },
@@ -110,6 +121,7 @@
       "label": "ErrorOne",
       "kind": "Event",
       "detail": "Error",
+      "sortText": "P",
       "insertText": "ErrorOne",
       "insertTextFormat": "Snippet"
     },
@@ -117,6 +129,7 @@
       "label": "ErrorTwo",
       "kind": "Event",
       "detail": "Error",
+      "sortText": "P",
       "insertText": "ErrorTwo",
       "insertTextFormat": "Snippet"
     },
@@ -124,6 +137,7 @@
       "label": "Listener",
       "kind": "Interface",
       "detail": "Class",
+      "sortText": "O",
       "insertText": "Listener",
       "insertTextFormat": "Snippet"
     },
@@ -134,6 +148,7 @@
       "documentation": {
         "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs."
       },
+      "sortText": "O",
       "insertText": "Client",
       "insertTextFormat": "Snippet"
     },
@@ -144,6 +159,7 @@
       "documentation": {
         "left": "Represents a response.\n"
       },
+      "sortText": "O",
       "insertText": "Response",
       "insertTextFormat": "Snippet"
     },
@@ -151,6 +167,7 @@
       "label": "TestClass1",
       "kind": "Interface",
       "detail": "Class",
+      "sortText": "O",
       "insertText": "TestClass1",
       "insertTextFormat": "Snippet"
     },
@@ -158,6 +175,7 @@
       "label": "listener1",
       "kind": "Variable",
       "detail": "module1:Listener",
+      "sortText": "F",
       "insertText": "listener1",
       "insertTextFormat": "Snippet"
     },
@@ -171,6 +189,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \n  \n"
         }
       },
+      "sortText": "G",
       "filterText": "function1",
       "insertText": "function1()",
       "insertTextFormat": "Snippet"
@@ -185,6 +204,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function2  \n"
         }
       },
+      "sortText": "G",
       "filterText": "function2",
       "insertText": "function2()",
       "insertTextFormat": "Snippet"
@@ -199,6 +219,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function3 with input parameters\n  \n**Params**  \n- `int` param1: param1 Parameter Description   \n- `int` param2: param2 Parameter Description  \n- `float[]` param3: param3 Parameter Description  \n  \n**Return** `int`   \n- Return Value Description  \n  \n"
         }
       },
+      "sortText": "AC",
       "filterText": "function3",
       "insertText": "function3(${1})",
       "insertTextFormat": "Snippet",
@@ -217,6 +238,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function4 with input parameters\n  \n**Params**  \n- `int` param1: param1 Parameter Description   \n- `int` param2: param2 Parameter Description  \n- `string` param3: param3 Parameter Description(Defaultable)  \n- `float[]` param4: param4 Parameter Description"
         }
       },
+      "sortText": "G",
       "filterText": "function4",
       "insertText": "function4(${1})",
       "insertTextFormat": "Snippet",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config7.json
@@ -246,6 +246,14 @@
         "title": "editor.action.triggerParameterHints",
         "command": "editor.action.triggerParameterHints"
       }
+    },
+    {
+      "label": "TEST_FUTURE_INT",
+      "kind": "Variable",
+      "detail": "future<int>",
+      "sortText": "F",
+      "insertText": "TEST_FUTURE_INT",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config8.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config8.json
@@ -9,6 +9,7 @@
       "label": "module1",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "S",
       "filterText": "module1",
       "insertText": "module1",
       "insertTextFormat": "Snippet"
@@ -17,6 +18,7 @@
       "label": "ballerina/lang.test",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "R",
       "filterText": "test",
       "insertText": "test",
       "insertTextFormat": "Snippet",
@@ -40,6 +42,7 @@
       "label": "ballerina/lang.array",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "R",
       "filterText": "array",
       "insertText": "array",
       "insertTextFormat": "Snippet",
@@ -63,6 +66,7 @@
       "label": "ballerina/jballerina.java",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "R",
       "filterText": "java",
       "insertText": "java",
       "insertTextFormat": "Snippet",
@@ -86,6 +90,7 @@
       "label": "ballerina/lang.value",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "R",
       "filterText": "value",
       "insertText": "value",
       "insertTextFormat": "Snippet",
@@ -109,6 +114,7 @@
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
+      "sortText": "R",
       "filterText": "runtime",
       "insertText": "runtime",
       "insertTextFormat": "Snippet",
@@ -132,6 +138,7 @@
       "label": "boolean",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "boolean",
       "insertTextFormat": "Snippet"
     },
@@ -139,6 +146,7 @@
       "label": "decimal",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "decimal",
       "insertTextFormat": "Snippet"
     },
@@ -146,6 +154,7 @@
       "label": "error",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "error",
       "insertTextFormat": "Snippet"
     },
@@ -153,6 +162,7 @@
       "label": "float",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "float",
       "insertTextFormat": "Snippet"
     },
@@ -160,6 +170,7 @@
       "label": "future",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "future",
       "insertTextFormat": "Snippet"
     },
@@ -167,6 +178,7 @@
       "label": "int",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "int",
       "insertTextFormat": "Snippet"
     },
@@ -174,6 +186,7 @@
       "label": "map",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "map",
       "insertTextFormat": "Snippet"
     },
@@ -181,6 +194,7 @@
       "label": "object",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "object",
       "insertTextFormat": "Snippet"
     },
@@ -188,6 +202,7 @@
       "label": "stream",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "stream",
       "insertTextFormat": "Snippet"
     },
@@ -195,6 +210,7 @@
       "label": "string",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "string",
       "insertTextFormat": "Snippet"
     },
@@ -202,6 +218,7 @@
       "label": "table",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "table",
       "insertTextFormat": "Snippet"
     },
@@ -209,6 +226,7 @@
       "label": "transaction",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "transaction",
       "insertTextFormat": "Snippet"
     },
@@ -216,6 +234,7 @@
       "label": "typedesc",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "typedesc",
       "insertTextFormat": "Snippet"
     },
@@ -223,6 +242,7 @@
       "label": "xml",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
     },
@@ -230,6 +250,7 @@
       "label": "service",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "service",
       "insertText": "service",
       "insertTextFormat": "Snippet"
@@ -238,6 +259,7 @@
       "label": "new",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "new",
       "insertText": "new ",
       "insertTextFormat": "Snippet"
@@ -246,6 +268,7 @@
       "label": "isolated",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "isolated",
       "insertText": "isolated ",
       "insertTextFormat": "Snippet"
@@ -254,6 +277,7 @@
       "label": "transactional",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "transactional",
       "insertText": "transactional",
       "insertTextFormat": "Snippet"
@@ -262,6 +286,7 @@
       "label": "function",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "function",
       "insertText": "function ",
       "insertTextFormat": "Snippet"
@@ -270,6 +295,7 @@
       "label": "let",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "let",
       "insertText": "let",
       "insertTextFormat": "Snippet"
@@ -278,6 +304,7 @@
       "label": "typeof",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "typeof",
       "insertText": "typeof ",
       "insertTextFormat": "Snippet"
@@ -286,6 +313,7 @@
       "label": "trap",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "trap",
       "insertText": "trap",
       "insertTextFormat": "Snippet"
@@ -294,6 +322,7 @@
       "label": "client",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "client",
       "insertText": "client ",
       "insertTextFormat": "Snippet"
@@ -302,6 +331,7 @@
       "label": "true",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "true",
       "insertText": "true",
       "insertTextFormat": "Snippet"
@@ -310,6 +340,7 @@
       "label": "false",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "false",
       "insertText": "false",
       "insertTextFormat": "Snippet"
@@ -318,6 +349,7 @@
       "label": "null",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "null",
       "insertText": "null",
       "insertTextFormat": "Snippet"
@@ -326,6 +358,7 @@
       "label": "check",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "check",
       "insertText": "check ",
       "insertTextFormat": "Snippet"
@@ -334,6 +367,7 @@
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "checkpanic",
       "insertText": "checkpanic ",
       "insertTextFormat": "Snippet"
@@ -342,6 +376,7 @@
       "label": "is",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "is",
       "insertText": "is",
       "insertTextFormat": "Snippet"
@@ -350,6 +385,7 @@
       "label": "error constructor",
       "kind": "Snippet",
       "detail": "Snippet",
+      "sortText": "T",
       "filterText": "error",
       "insertText": "error(\"${1}\")",
       "insertTextFormat": "Snippet"
@@ -358,6 +394,7 @@
       "label": "object constructor",
       "kind": "Snippet",
       "detail": "Snippet",
+      "sortText": "T",
       "filterText": "object",
       "insertText": "object {${1}}",
       "insertTextFormat": "Snippet"
@@ -366,6 +403,7 @@
       "label": "base16",
       "kind": "Snippet",
       "detail": "Snippet",
+      "sortText": "T",
       "filterText": "base16",
       "insertText": "base16 `${1}`",
       "insertTextFormat": "Snippet"
@@ -374,6 +412,7 @@
       "label": "base64",
       "kind": "Snippet",
       "detail": "Snippet",
+      "sortText": "T",
       "filterText": "base64",
       "insertText": "base64 `${1}`",
       "insertTextFormat": "Snippet"
@@ -382,6 +421,7 @@
       "label": "from",
       "kind": "Keyword",
       "detail": "Keyword",
+      "sortText": "U",
       "filterText": "from",
       "insertText": "from ",
       "insertTextFormat": "Snippet"
@@ -390,6 +430,7 @@
       "label": "n",
       "kind": "Variable",
       "detail": "int",
+      "sortText": "AB",
       "insertText": "n",
       "insertTextFormat": "Snippet"
     },
@@ -403,6 +444,7 @@
           "value": "**Package:** _._  \n  \n  \n"
         }
       },
+      "sortText": "G",
       "filterText": "name",
       "insertText": "name()",
       "insertTextFormat": "Snippet"
@@ -411,6 +453,7 @@
       "label": "flag",
       "kind": "Variable",
       "detail": "boolean",
+      "sortText": "F",
       "insertText": "flag",
       "insertTextFormat": "Snippet"
     },
@@ -418,6 +461,7 @@
       "label": "Thread",
       "kind": "TypeParameter",
       "detail": "Union",
+      "sortText": "R",
       "insertText": "Thread",
       "insertTextFormat": "Snippet"
     },
@@ -428,6 +472,7 @@
       "documentation": {
         "left": "Describes Strand execution details for the runtime.\n"
       },
+      "sortText": "Q",
       "insertText": "StrandData",
       "insertTextFormat": "Snippet"
     },
@@ -435,6 +480,7 @@
       "label": "readonly",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "readonly",
       "insertTextFormat": "Snippet"
     },
@@ -442,6 +488,7 @@
       "label": "handle",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "handle",
       "insertTextFormat": "Snippet"
     },
@@ -449,6 +496,7 @@
       "label": "never",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "never",
       "insertTextFormat": "Snippet"
     },
@@ -456,6 +504,7 @@
       "label": "json",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "json",
       "insertTextFormat": "Snippet"
     },
@@ -463,6 +512,7 @@
       "label": "anydata",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "anydata",
       "insertTextFormat": "Snippet"
     },
@@ -470,6 +520,7 @@
       "label": "any",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "any",
       "insertTextFormat": "Snippet"
     },
@@ -477,6 +528,7 @@
       "label": "byte",
       "kind": "Unit",
       "detail": "type",
+      "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config8.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config8.json
@@ -1,0 +1,484 @@
+{
+  "position": {
+    "line": 4,
+    "character": 26
+  },
+  "source": "expression_context/source/conditional_expr_ctx_source8.bal",
+  "items": [
+    {
+      "label": "module1",
+      "kind": "Module",
+      "detail": "Module",
+      "filterText": "module1",
+      "insertText": "module1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.test",
+      "kind": "Module",
+      "detail": "Module",
+      "filterText": "test",
+      "insertText": "test",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.test;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.array",
+      "kind": "Module",
+      "detail": "Module",
+      "filterText": "array",
+      "insertText": "array",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.array;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/jballerina.java",
+      "kind": "Module",
+      "detail": "Module",
+      "filterText": "java",
+      "insertText": "java",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/jballerina.java;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "filterText": "value",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.runtime",
+      "kind": "Module",
+      "detail": "Module",
+      "filterText": "runtime",
+      "insertText": "runtime",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.runtime;\n"
+        }
+      ]
+    },
+    {
+      "label": "boolean",
+      "kind": "Unit",
+      "detail": "type",
+      "insertText": "boolean",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "decimal",
+      "kind": "Unit",
+      "detail": "type",
+      "insertText": "decimal",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "error",
+      "kind": "Unit",
+      "detail": "type",
+      "insertText": "error",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "float",
+      "kind": "Unit",
+      "detail": "type",
+      "insertText": "float",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "future",
+      "kind": "Unit",
+      "detail": "type",
+      "insertText": "future",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "int",
+      "kind": "Unit",
+      "detail": "type",
+      "insertText": "int",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "map",
+      "kind": "Unit",
+      "detail": "type",
+      "insertText": "map",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "object",
+      "kind": "Unit",
+      "detail": "type",
+      "insertText": "object",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "stream",
+      "kind": "Unit",
+      "detail": "type",
+      "insertText": "stream",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string",
+      "kind": "Unit",
+      "detail": "type",
+      "insertText": "string",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "table",
+      "kind": "Unit",
+      "detail": "type",
+      "insertText": "table",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "transaction",
+      "kind": "Unit",
+      "detail": "type",
+      "insertText": "transaction",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "typedesc",
+      "kind": "Unit",
+      "detail": "type",
+      "insertText": "typedesc",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml",
+      "kind": "Unit",
+      "detail": "type",
+      "insertText": "xml",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "service",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "filterText": "service",
+      "insertText": "service",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "new",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "filterText": "new",
+      "insertText": "new ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "isolated",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "filterText": "isolated",
+      "insertText": "isolated ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "transactional",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "filterText": "transactional",
+      "insertText": "transactional",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "function",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "filterText": "function",
+      "insertText": "function ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "let",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "filterText": "let",
+      "insertText": "let",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "typeof",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "filterText": "typeof",
+      "insertText": "typeof ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "trap",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "filterText": "trap",
+      "insertText": "trap",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "client",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "filterText": "client",
+      "insertText": "client ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "true",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "filterText": "true",
+      "insertText": "true",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "false",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "filterText": "false",
+      "insertText": "false",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "null",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "filterText": "null",
+      "insertText": "null",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "check",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "filterText": "check",
+      "insertText": "check ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "checkpanic",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "filterText": "checkpanic",
+      "insertText": "checkpanic ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "is",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "filterText": "is",
+      "insertText": "is",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "filterText": "error",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "object constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "filterText": "object",
+      "insertText": "object {${1}}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "base16",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "filterText": "base16",
+      "insertText": "base16 `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "base64",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "filterText": "base64",
+      "insertText": "base64 `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "from",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "filterText": "from",
+      "insertText": "from ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "n",
+      "kind": "Variable",
+      "detail": "int",
+      "insertText": "n",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "name()",
+      "kind": "Function",
+      "detail": "()",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _._  \n  \n  \n"
+        }
+      },
+      "filterText": "name",
+      "insertText": "name()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "flag",
+      "kind": "Variable",
+      "detail": "boolean",
+      "insertText": "flag",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Thread",
+      "kind": "TypeParameter",
+      "detail": "Union",
+      "insertText": "Thread",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "StrandData",
+      "kind": "Struct",
+      "detail": "Record",
+      "documentation": {
+        "left": "Describes Strand execution details for the runtime.\n"
+      },
+      "insertText": "StrandData",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "readonly",
+      "kind": "Unit",
+      "detail": "type",
+      "insertText": "readonly",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "handle",
+      "kind": "Unit",
+      "detail": "type",
+      "insertText": "handle",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "never",
+      "kind": "Unit",
+      "detail": "type",
+      "insertText": "never",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "json",
+      "kind": "Unit",
+      "detail": "type",
+      "insertText": "json",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "anydata",
+      "kind": "Unit",
+      "detail": "type",
+      "insertText": "anydata",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "any",
+      "kind": "Unit",
+      "detail": "type",
+      "insertText": "any",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "byte",
+      "kind": "Unit",
+      "detail": "type",
+      "insertText": "byte",
+      "insertTextFormat": "Snippet"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config9.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config9.json
@@ -15,6 +15,7 @@
           "value": ""
         }
       },
+      "sortText": "L",
       "insertText": "ENUM1_FIELD1",
       "insertTextFormat": "Snippet"
     },
@@ -28,6 +29,7 @@
           "value": ""
         }
       },
+      "sortText": "AC",
       "insertText": "TEST_INT_CONST1",
       "insertTextFormat": "Snippet"
     },
@@ -41,6 +43,7 @@
           "value": ""
         }
       },
+      "sortText": "G",
       "insertText": "TEST_STRING_CONST1",
       "insertTextFormat": "Snippet"
     },
@@ -48,6 +51,7 @@
       "label": "AnnotationType",
       "kind": "Struct",
       "detail": "Record",
+      "sortText": "Q",
       "insertText": "AnnotationType",
       "insertTextFormat": "Snippet"
     },
@@ -58,6 +62,7 @@
       "documentation": {
         "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
       },
+      "sortText": "M",
       "insertText": "ResponseMessage",
       "insertTextFormat": "Snippet"
     },
@@ -68,6 +73,7 @@
       "documentation": {
         "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
       },
+      "sortText": "M",
       "insertText": "RequestMessage",
       "insertTextFormat": "Snippet"
     },
@@ -75,6 +81,7 @@
       "label": "TestRecord1",
       "kind": "Struct",
       "detail": "Record",
+      "sortText": "Q",
       "insertText": "TestRecord1",
       "insertTextFormat": "Snippet"
     },
@@ -82,6 +89,7 @@
       "label": "TestRecord2",
       "kind": "Struct",
       "detail": "Record",
+      "sortText": "Q",
       "insertText": "TestRecord2",
       "insertTextFormat": "Snippet"
     },
@@ -89,6 +97,7 @@
       "label": "TestMap2",
       "kind": "TypeParameter",
       "detail": "Map",
+      "sortText": "R",
       "insertText": "TestMap2",
       "insertTextFormat": "Snippet"
     },
@@ -96,6 +105,7 @@
       "label": "TestMap3",
       "kind": "TypeParameter",
       "detail": "Map",
+      "sortText": "R",
       "insertText": "TestMap3",
       "insertTextFormat": "Snippet"
     },
@@ -103,6 +113,7 @@
       "label": "TestObject1",
       "kind": "Interface",
       "detail": "Object",
+      "sortText": "O",
       "insertText": "TestObject1",
       "insertTextFormat": "Snippet"
     },
@@ -110,6 +121,7 @@
       "label": "ErrorOne",
       "kind": "Event",
       "detail": "Error",
+      "sortText": "P",
       "insertText": "ErrorOne",
       "insertTextFormat": "Snippet"
     },
@@ -117,6 +129,7 @@
       "label": "ErrorTwo",
       "kind": "Event",
       "detail": "Error",
+      "sortText": "P",
       "insertText": "ErrorTwo",
       "insertTextFormat": "Snippet"
     },
@@ -124,6 +137,7 @@
       "label": "Listener",
       "kind": "Interface",
       "detail": "Class",
+      "sortText": "O",
       "insertText": "Listener",
       "insertTextFormat": "Snippet"
     },
@@ -134,6 +148,7 @@
       "documentation": {
         "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs."
       },
+      "sortText": "O",
       "insertText": "Client",
       "insertTextFormat": "Snippet"
     },
@@ -144,6 +159,7 @@
       "documentation": {
         "left": "Represents a response.\n"
       },
+      "sortText": "O",
       "insertText": "Response",
       "insertTextFormat": "Snippet"
     },
@@ -151,6 +167,7 @@
       "label": "TestClass1",
       "kind": "Interface",
       "detail": "Class",
+      "sortText": "O",
       "insertText": "TestClass1",
       "insertTextFormat": "Snippet"
     },
@@ -158,6 +175,7 @@
       "label": "listener1",
       "kind": "Variable",
       "detail": "module1:Listener",
+      "sortText": "G",
       "insertText": "listener1",
       "insertTextFormat": "Snippet"
     },
@@ -171,6 +189,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \n  \n"
         }
       },
+      "sortText": "E",
       "filterText": "function1",
       "insertText": "function1()",
       "insertTextFormat": "Snippet"
@@ -185,6 +204,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function2  \n"
         }
       },
+      "sortText": "E",
       "filterText": "function2",
       "insertText": "function2()",
       "insertTextFormat": "Snippet"
@@ -199,6 +219,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function3 with input parameters\n  \n**Params**  \n- `int` param1: param1 Parameter Description   \n- `int` param2: param2 Parameter Description  \n- `float[]` param3: param3 Parameter Description  \n  \n**Return** `int`   \n- Return Value Description  \n  \n"
         }
       },
+      "sortText": "AA",
       "filterText": "function3",
       "insertText": "function3(${1})",
       "insertTextFormat": "Snippet",
@@ -217,6 +238,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function4 with input parameters\n  \n**Params**  \n- `int` param1: param1 Parameter Description   \n- `int` param2: param2 Parameter Description  \n- `string` param3: param3 Parameter Description(Defaultable)  \n- `float[]` param4: param4 Parameter Description"
         }
       },
+      "sortText": "E",
       "filterText": "function4",
       "insertText": "function4(${1})",
       "insertTextFormat": "Snippet",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config9.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config9.json
@@ -1,0 +1,229 @@
+{
+  "position": {
+    "line": 4,
+    "character": 34
+  },
+  "source": "expression_context/source/conditional_expr_ctx_source9.bal",
+  "items": [
+    {
+      "label": "ENUM1_FIELD1",
+      "kind": "EnumMember",
+      "detail": "ENUM1_FIELD1",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": ""
+        }
+      },
+      "insertText": "ENUM1_FIELD1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TEST_INT_CONST1",
+      "kind": "Variable",
+      "detail": "1",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": ""
+        }
+      },
+      "insertText": "TEST_INT_CONST1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TEST_STRING_CONST1",
+      "kind": "Variable",
+      "detail": "HELLO WORLD",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": ""
+        }
+      },
+      "insertText": "TEST_STRING_CONST1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "AnnotationType",
+      "kind": "Struct",
+      "detail": "Record",
+      "insertText": "AnnotationType",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ResponseMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
+      },
+      "insertText": "ResponseMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "RequestMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
+      },
+      "insertText": "RequestMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestRecord1",
+      "kind": "Struct",
+      "detail": "Record",
+      "insertText": "TestRecord1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestRecord2",
+      "kind": "Struct",
+      "detail": "Record",
+      "insertText": "TestRecord2",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestMap2",
+      "kind": "TypeParameter",
+      "detail": "Map",
+      "insertText": "TestMap2",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestMap3",
+      "kind": "TypeParameter",
+      "detail": "Map",
+      "insertText": "TestMap3",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestObject1",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "TestObject1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ErrorOne",
+      "kind": "Event",
+      "detail": "Error",
+      "insertText": "ErrorOne",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ErrorTwo",
+      "kind": "Event",
+      "detail": "Error",
+      "insertText": "ErrorTwo",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Listener",
+      "kind": "Interface",
+      "detail": "Class",
+      "insertText": "Listener",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Client",
+      "kind": "Interface",
+      "detail": "Class",
+      "documentation": {
+        "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs."
+      },
+      "insertText": "Client",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Response",
+      "kind": "Interface",
+      "detail": "Class",
+      "documentation": {
+        "left": "Represents a response.\n"
+      },
+      "insertText": "Response",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestClass1",
+      "kind": "Interface",
+      "detail": "Class",
+      "insertText": "TestClass1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "listener1",
+      "kind": "Variable",
+      "detail": "module1:Listener",
+      "insertText": "listener1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "function1()",
+      "kind": "Function",
+      "detail": "()",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \n  \n"
+        }
+      },
+      "filterText": "function1",
+      "insertText": "function1()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "function2()",
+      "kind": "Function",
+      "detail": "()",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function2  \n"
+        }
+      },
+      "filterText": "function2",
+      "insertText": "function2()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "function3(int param1, int param2, float... param3)",
+      "kind": "Function",
+      "detail": "int",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function3 with input parameters\n  \n**Params**  \n- `int` param1: param1 Parameter Description   \n- `int` param2: param2 Parameter Description  \n- `float[]` param3: param3 Parameter Description  \n  \n**Return** `int`   \n- Return Value Description  \n  \n"
+        }
+      },
+      "filterText": "function3",
+      "insertText": "function3(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "function4(int param1, int param2, string param3, float... param4)",
+      "kind": "Function",
+      "detail": "()",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function4 with input parameters\n  \n**Params**  \n- `int` param1: param1 Parameter Description   \n- `int` param2: param2 Parameter Description  \n- `string` param3: param3 Parameter Description(Defaultable)  \n- `float[]` param4: param4 Parameter Description"
+        }
+      },
+      "filterText": "function4",
+      "insertText": "function4(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config9.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config9.json
@@ -246,6 +246,14 @@
         "title": "editor.action.triggerParameterHints",
         "command": "editor.action.triggerParameterHints"
       }
+    },
+    {
+      "label": "TEST_FUTURE_INT",
+      "kind": "Variable",
+      "detail": "future<int>",
+      "sortText": "G",
+      "insertText": "TEST_FUTURE_INT",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/conditional_expr_ctx_source10.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/conditional_expr_ctx_source10.bal
@@ -1,0 +1,6 @@
+import ballerina/module1;
+
+function name(boolean test) {
+    boolean flag = true;
+    int n = test ? flag : 
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/conditional_expr_ctx_source11.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/conditional_expr_ctx_source11.bal
@@ -1,0 +1,6 @@
+import ballerina/module1;
+
+function name(boolean test) {
+    boolean flag = true;
+    int n = test ? module1:f : module1:function3(1, 1, 1.0);
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/conditional_expr_ctx_source12.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/conditional_expr_ctx_source12.bal
@@ -1,0 +1,6 @@
+import ballerina/module1;
+
+function name(boolean test) {
+    boolean flag = true;
+    int n = test ? module1: : module1:function3(1, 1, 1.0);
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/conditional_expr_ctx_source6.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/conditional_expr_ctx_source6.bal
@@ -1,0 +1,6 @@
+import ballerina/module1;
+
+function name() {
+    boolean flag = true;
+    int n = flag ?: module1:
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/conditional_expr_ctx_source7.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/conditional_expr_ctx_source7.bal
@@ -1,0 +1,6 @@
+import ballerina/module1;
+
+function name() {
+    boolean flag = true;
+    int n = flag ? module1:
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/conditional_expr_ctx_source8.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/conditional_expr_ctx_source8.bal
@@ -1,0 +1,6 @@
+import ballerina/module1;
+
+function name() {
+    boolean flag = true;
+    int n = flag ? true : 
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/conditional_expr_ctx_source9.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/conditional_expr_ctx_source9.bal
@@ -1,0 +1,6 @@
+import ballerina/module1;
+
+function name() {
+    boolean flag = true;
+    int n = flag ? true : module1:
+}


### PR DESCRIPTION
## Purpose
> Inside the ternary conditional expression after the `?` token, NoSpaceColon is identified as the colon token of the ternary conditional expression by the parser. Hence, qualified name reference completions are missing. 
> In addition to that this PR improves the sorting in conditional expression.

Fixes #33199 
Fixes #33791
Fixes #33622 

## Approach
> If the middleExpression and the endExpression are of the syntaxKind Simple Name Reference, and middleExpression is  a module alias we give completions for qualified name reference.

## Samples
<img width="593" alt="Screenshot 2021-12-02 at 19 07 37" src="https://user-images.githubusercontent.com/46120162/144785258-fe060171-13f9-4ea9-a3e1-5cf99be64688.png">

<img width="544" alt="Screenshot 2021-12-06 at 11 09 17" src="https://user-images.githubusercontent.com/46120162/144793252-6024ca2d-a8a0-4604-84c5-baace34d2a72.png">

## Remarks

> [Ambiguity between ternary conditional expression and qualified identifier](https://github.com/ballerina-platform/ballerina-spec/issues/970)

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
