### PR TITLE
Fix bal command issue in "C:\" and "D:\"

### DIFF
--- a/distribution/zip/jballerina/bin/bal.bat
+++ b/distribution/zip/jballerina/bin/bal.bat
@@ -146,7 +146,7 @@ rem BALLERINA_CLASSPATH_EXT is for outsiders to additionally add
 rem classpath locations, e.g. AWS Lambda function libraries.
 if not "%BALLERINA_CLASSPATH_EXT%" == "" set BALLERINA_CLASSPATH=!BALLERINA_CLASSPATH!;%BALLERINA_CLASSPATH_EXT%
 
-set CMD_LINE_ARGS=-Xbootclasspath/a:%BALLERINA_XBOOTCLASSPATH% -Xms256m -Xmx1024m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath="%cd%"  -Dcom.sun.management.jmxremote -classpath "%BALLERINA_CLASSPATH%" %JAVA_OPTS% -Dballerina.home="%BALLERINA_HOME%" -Dballerina.target="jvm" -Djava.command="%JAVA_HOME%\bin\java" -Djava.opts="%JAVA_OPTS%" -Denable.nonblocking=false -Dfile.encoding=UTF8 -Dballerina.version=${project.version}
+set CMD_LINE_ARGS=-Xbootclasspath/a:%BALLERINA_XBOOTCLASSPATH% -Xms256m -Xmx1024m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=""  -Dcom.sun.management.jmxremote -classpath "%BALLERINA_CLASSPATH%" %JAVA_OPTS% -Dballerina.home="%BALLERINA_HOME%" -Dballerina.target="jvm" -Djava.command="%JAVA_HOME%\bin\java" -Djava.opts="%JAVA_OPTS%" -Denable.nonblocking=false -Dfile.encoding=UTF8 -Dballerina.version=${project.version}
 
 set jar=%2
 if "%1" == "run" if "%jar:~-4%" == ".jar" goto runJar


### PR DESCRIPTION
## Purpose
Fix bal command issue in "C:\" and "D:\" directories. (Unless it opens bal help window in the command line)

Fixes #https://github.com/ballerina-platform/ballerina-lang/issues/33841

## Approach
Changed the heap-dump.hprof path from `"%cd%"` to `""`.

