### PR TITLE
[Shell] Allow multiple expressions in the same line

### DIFF
--- a/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/parser/SerialTreeParser.java
+++ b/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/parser/SerialTreeParser.java
@@ -23,7 +23,17 @@ import io.ballerina.compiler.syntax.tree.ModuleMemberDeclarationNode;
 import io.ballerina.compiler.syntax.tree.ModulePartNode;
 import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.shell.exceptions.TreeParserException;
-import io.ballerina.shell.parser.trials.*;
+import io.ballerina.shell.parser.trials.EmptyExpressionTrial;
+import io.ballerina.shell.parser.trials.ExpressionListTrial;
+import io.ballerina.shell.parser.trials.ExpressionTrial;
+import io.ballerina.shell.parser.trials.GetErrorMessageTrial;
+import io.ballerina.shell.parser.trials.InvalidMethodException;
+import io.ballerina.shell.parser.trials.ModuleMemberTrial;
+import io.ballerina.shell.parser.trials.ModulePartTrial;
+import io.ballerina.shell.parser.trials.ParserRejectedException;
+import io.ballerina.shell.parser.trials.ParserTrialFailedException;
+import io.ballerina.shell.parser.trials.StatementTrial;
+import io.ballerina.shell.parser.trials.TreeParserTrial;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/parser/SerialTreeParser.java
+++ b/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/parser/SerialTreeParser.java
@@ -23,16 +23,7 @@ import io.ballerina.compiler.syntax.tree.ModuleMemberDeclarationNode;
 import io.ballerina.compiler.syntax.tree.ModulePartNode;
 import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.shell.exceptions.TreeParserException;
-import io.ballerina.shell.parser.trials.EmptyExpressionTrial;
-import io.ballerina.shell.parser.trials.ExpressionTrial;
-import io.ballerina.shell.parser.trials.GetErrorMessageTrial;
-import io.ballerina.shell.parser.trials.InvalidMethodException;
-import io.ballerina.shell.parser.trials.ModuleMemberTrial;
-import io.ballerina.shell.parser.trials.ModulePartTrial;
-import io.ballerina.shell.parser.trials.ParserRejectedException;
-import io.ballerina.shell.parser.trials.ParserTrialFailedException;
-import io.ballerina.shell.parser.trials.StatementTrial;
-import io.ballerina.shell.parser.trials.TreeParserTrial;
+import io.ballerina.shell.parser.trials.*;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -57,6 +48,7 @@ public class SerialTreeParser extends TrialTreeParser {
         this.nodeParserTrials = List.of(
                 new ModuleMemberTrial(this),
                 new ExpressionTrial(this),
+                new ExpressionListTrial(this),
                 new StatementTrial(this),
                 new EmptyExpressionTrial(this),
                 new GetErrorMessageTrial(this)

--- a/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/parser/trials/ExpressionListTrial.java
+++ b/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/parser/trials/ExpressionListTrial.java
@@ -25,7 +25,6 @@ import io.ballerina.shell.parser.TrialTreeParser;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
 
 /**
  * Attempts to parse source as list of expressions.

--- a/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/parser/trials/ExpressionListTrial.java
+++ b/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/parser/trials/ExpressionListTrial.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.shell.parser.trials;
+
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NodeParser;
+import io.ballerina.shell.parser.TrialTreeParser;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Attempts to parse source as list of expressions.
+ *
+ * @since 2.0.0
+ */
+public class ExpressionListTrial extends TreeParserTrial {
+
+    private static final String SEMICOLON = ";";
+
+    public ExpressionListTrial(TrialTreeParser parentParser) {
+        super(parentParser);
+    }
+
+    @Override
+    public Collection<Node> parse(String source) throws ParserTrialFailedException {
+        Collection<Node> nodes = new ArrayList<>();
+        Collection<Node> parsedNodes =  new ArrayList<>();
+        Collection<String> expressionList;
+        if (!source.endsWith(SEMICOLON)) {
+            source = source + ";";
+        }
+
+        expressionList = new ArrayList<>(Arrays.asList(source.split(";")));
+        for (String element: expressionList) {
+            parsedNodes.add(NodeParser.parseActionOrExpression(element.trim()));
+        }
+
+        for (Node parsedNode : parsedNodes) {
+            if (parsedNode.hasDiagnostics()) {
+                throw new ParserTrialFailedException("Error occurred during parsing node as an expression.");
+            }
+            nodes.add(parsedNode);
+        }
+
+        return nodes;
+    }
+}

--- a/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/parser/trials/ExpressionListTrial.java
+++ b/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/parser/trials/ExpressionListTrial.java
@@ -48,7 +48,7 @@ public class ExpressionListTrial extends TreeParserTrial {
             source = source + ";";
         }
 
-        expressionList = new ArrayList<>(Arrays.asList(source.split(";")));
+        expressionList = Arrays.asList(source.split(";"));
         for (String element: expressionList) {
             parsedNodes.add(NodeParser.parseActionOrExpression(element.trim()));
         }

--- a/ballerina-shell/modules/shell-core/src/test/resources/testcases/evaluator/basics.modules.json
+++ b/ballerina-shell/modules/shell-core/src/test/resources/testcases/evaluator/basics.modules.json
@@ -30,5 +30,33 @@
     "description": "Import different module with io prefix.",
     "code": "import ballerina/io;",
     "error": "InvokerException"
+  },
+  {
+    "description": "Add multiple statements.",
+    "code": "int x = 1; int y = 2; int z = 3;"
+  },
+  {
+    "description": "input multiple variables in one-line.",
+    "code": "x;y;z;",
+    "expr": 3
+  },
+  {
+    "description": "input multiple variables in one-line.",
+    "code": "x;y;z;",
+    "expr": 3
+  },
+  {
+    "description": "input a function",
+    "code": "\n\nfunction add(int x, int y) returns int {\n\n    int sum = x + y;\n\n    return sum;\n\n}"
+  },
+  {
+    "description": "Calling function multiple times in the same line.",
+    "code": "add(1,2); add(2,3); add(3,4)",
+    "expr": 7
+  },
+  {
+    "description": "Call multiple expressions in one-line",
+    "code": "add(1,2); add(2,3); add(3,4); x",
+    "expr": 1
   }
 ]

--- a/ballerina-shell/modules/shell-core/src/test/resources/testcases/evaluator/basics.modules.json
+++ b/ballerina-shell/modules/shell-core/src/test/resources/testcases/evaluator/basics.modules.json
@@ -42,8 +42,8 @@
   },
   {
     "description": "input multiple variables in one-line.",
-    "code": "x;y;z;",
-    "expr": 3
+    "code": "x;y;",
+    "expr": 2
   },
   {
     "description": "input a function",


### PR DESCRIPTION
## Purpose

Fixes #34096 
Allow user to input multiple expressions in a one line and outputs the last expression value.

- Added new parser Trial to parse multiple expressions.

Example :

`x ; y ; z;` will output `z` value

![Screenshot from 2021-12-08 11-17-04](https://user-images.githubusercontent.com/31839712/145155187-27b33828-38d9-46df-a013-25aebccada6a.png)

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
