### PR TITLE
Fix bug in multi-level type referencing chains

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeReferenceTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeReferenceTypeSymbol.java
@@ -25,10 +25,10 @@ import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.tools.diagnostics.Location;
-import org.wso2.ballerinalang.compiler.semantics.analyzer.Types;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BPackageSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BTypeReferenceType;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Names;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
@@ -59,8 +59,7 @@ public class BallerinaTypeReferenceTypeSymbol extends AbstractTypeSymbol impleme
     public BallerinaTypeReferenceTypeSymbol(CompilerContext context, ModuleID moduleID, BType bType,
                                             BSymbol tSymbol, boolean fromIntersectionType) {
         super(context, TypeDescKind.TYPE_REFERENCE, bType);
-        Types types = Types.getInstance(this.context);
-        referredType =  types.getReferredType(this.getBType());
+        referredType = getReferredType(bType);
         this.definitionName = tSymbol.getOriginalName().getValue();
         this.tSymbol = tSymbol;
         this.fromIntersectionType = fromIntersectionType;
@@ -170,5 +169,13 @@ public class BallerinaTypeReferenceTypeSymbol extends AbstractTypeSymbol impleme
 
     private boolean isAnonOrg(ModuleID moduleID) {
         return ANON_ORG.equals(moduleID.orgName());
+    }
+
+    private BType getReferredType(BType type) {
+        if (type.tag == TypeTags.TYPEREFDESC) {
+            return ((BTypeReferenceType) type).referredType;
+        }
+
+        return type;
     }
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config55.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config55.json
@@ -17,7 +17,7 @@
       "label": "rec2",
       "kind": "Variable",
       "detail": "TestRecord2",
-      "sortText": "AB",
+      "sortText": "BB",
       "insertText": "rec2",
       "insertTextFormat": "Snippet"
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config56.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config56.json
@@ -17,7 +17,7 @@
       "label": "rec2",
       "kind": "Variable",
       "detail": "TestRecord2",
-      "sortText": "AB",
+      "sortText": "BB",
       "insertText": "rec2",
       "insertTextFormat": "Snippet"
     },

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typedescriptors/TypeReferenceTSymbolTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typedescriptors/TypeReferenceTSymbolTest.java
@@ -112,6 +112,41 @@ public class TypeReferenceTSymbolTest {
         assertEquals(((TypeReferenceTypeSymbol) (recordFieldSymbol).typeDescriptor()).definition(), typeSymbol.get());
         assertEquals(((recordFieldSymbol).typeDescriptor()).typeKind(), TypeDescKind.TYPE_REFERENCE);
         assertEquals(((recordFieldSymbol).typeDescriptor()).getName().get().toString(), "Age");
+    }
 
+    @Test
+    public void testReferringATypeRef1() {
+        Optional<Symbol> symbol = model.symbol(srcFile, from(46, 8));
+        TypeSymbol type = ((VariableSymbol) symbol.get()).typeDescriptor();
+
+        assertEquals(type.typeKind(), TypeDescKind.TYPE_REFERENCE);
+        assertEquals(type.getName().get(), "Foo");
+
+        type = ((TypeReferenceTypeSymbol) type).typeDescriptor();
+        assertEquals(type.typeKind(), TypeDescKind.TYPE_REFERENCE);
+        assertEquals(type.getName().get(), "Person");
+
+        type = ((TypeReferenceTypeSymbol) type).typeDescriptor();
+        assertEquals(type.typeKind(), TypeDescKind.RECORD);
+    }
+
+    @Test
+    public void testReferringATypeRef2() {
+        Optional<Symbol> symbol = model.symbol(srcFile, from(47, 8));
+        TypeSymbol type = ((VariableSymbol) symbol.get()).typeDescriptor();
+
+        assertEquals(type.typeKind(), TypeDescKind.TYPE_REFERENCE);
+        assertEquals(type.getName().get(), "Bar");
+
+        type = ((TypeReferenceTypeSymbol) type).typeDescriptor();
+        assertEquals(type.typeKind(), TypeDescKind.TYPE_REFERENCE);
+        assertEquals(type.getName().get(), "Foo");
+
+        type = ((TypeReferenceTypeSymbol) type).typeDescriptor();
+        assertEquals(type.typeKind(), TypeDescKind.TYPE_REFERENCE);
+        assertEquals(type.getName().get(), "Person");
+
+        type = ((TypeReferenceTypeSymbol) type).typeDescriptor();
+        assertEquals(type.typeKind(), TypeDescKind.RECORD);
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/typedescriptors/typeref_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/typedescriptors/typeref_test.bal
@@ -43,4 +43,12 @@ function test() {
     record {|
         Age age;
     |} p;
+
+    Foo f;
+    Bar b;
 }
+
+// utils
+type Foo Person;
+
+type Bar Foo;


### PR DESCRIPTION
## Purpose
This PR fixes an issue in how the type refs were being modelled. Previously, if there were multiple levels of referencing, those intermediate levels were ignored and the referred type was incorrectly set as the referred type at the lowest level.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
