### PR TITLE
Fix codegen for int subtype field in records

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/values/JvmRecordGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/values/JvmRecordGen.java
@@ -27,6 +27,7 @@ import org.wso2.ballerinalang.compiler.bir.codegen.split.JvmCreateTypeGen;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BField;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BTypeReferenceType;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -854,6 +855,8 @@ public class JvmRecordGen {
             case FLOAT:
             case BYTE:
                 return false;
+            case TYPEREFDESC:
+                return checkIfValueIsJReferenceType(((BTypeReferenceType) bType).referredType);
             default:
                 return true;
         }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/integer/BIntegerValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/integer/BIntegerValueTest.java
@@ -173,6 +173,11 @@ public class BIntegerValueTest {
         Assert.assertEquals(intValue.intValue(), 1, "Invalid int value returned.");
     }
 
+    @Test(description = "Test record fields with int:subtypes")
+    public void testIntSubtypeField() {
+        BRunUtil.invoke(result, "testIntSubtypeField");
+    }
+
     @AfterClass
     public void tearDown() {
         result = null;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/integer/integer-value.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/integer/integer-value.bal
@@ -1,3 +1,4 @@
+import ballerina/test;
 function testIntegerValue () returns (int) {
     int b;
     b = 10;
@@ -91,4 +92,20 @@ function testIntegerParameter (int a) returns (int) {
     int b;
     b = a;
     return b;
+}
+
+public type IntervalDayToSecond record {|
+    int sign = +1;
+    int:Unsigned32 days?;
+    int:Unsigned32 hours?;
+    int:Unsigned32 minutes?;
+    decimal seconds?;
+|};
+
+function testIntSubtypeField() {
+    IntervalDayToSecond val = {days: 11, hours: 10, minutes: 9, seconds: 8.555};
+    test:assertEquals(val?.days, 11);
+    test:assertEquals(val?.hours, 10);
+    test:assertEquals(val?.minutes, 9);
+    test:assertEquals(val?.seconds, <decimal>8.555);
 }


### PR DESCRIPTION
## Purpose
$subject
Fixes #34175

## Approach
Add `TypeReferenceType` check for record generation

## Samples
```ballerina
public type Rec record {
    int:Unsigned32 days?;
};

public function main() {
    Rec _ = {};
}
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
