### PR TITLE
Fix create variable code actions with tuple with a rest type descriptor

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTupleTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTupleTypeSymbol.java
@@ -90,7 +90,7 @@ public class BallerinaTupleTypeSymbol extends AbstractTypeSymbol implements Tupl
         }
         tupleType.resolvingToString = false;
         if (restTypeDescriptor().isPresent()) {
-            joiner.add("..." + restTypeDescriptor().get().signature());
+            joiner.add(restTypeDescriptor().get().signature() + "...");
         }
         return "[" + joiner.toString() + "]";
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionUtil.java
@@ -76,7 +76,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.StringJoiner;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -226,7 +225,7 @@ public class CodeActionUtil {
             }
 
             // Anon Record
-            String rType = FunctionGenerator.generateTypeDefinition(importsAcceptor, typeDescriptor, context);
+            String rType = FunctionGenerator.generateTypeSignature(importsAcceptor, typeDescriptor, context);
             RecordTypeSymbol recordLiteral = (RecordTypeSymbol) typeDescriptor;
             types.add((recordLiteral.fieldDescriptors().size() > 0) ? rType : "record {}");
 
@@ -254,7 +253,7 @@ public class CodeActionUtil {
                 prevType = recordField.typeDescriptor();
             }
             if (isConstrainedMap && prevType != null) {
-                String type = FunctionGenerator.generateTypeDefinition(importsAcceptor, prevType, context);
+                String type = FunctionGenerator.generateTypeSignature(importsAcceptor, prevType, context);
                 types.add("map<" + type + ">");
             } else {
                 types.add("map<any>");
@@ -266,7 +265,6 @@ public class CodeActionUtil {
             TypeSymbol prevType = null;
             TypeSymbol prevInnerType = null;
             boolean isArrayCandidate = tupleType.restTypeDescriptor().isEmpty();
-            StringJoiner tupleJoiner = new StringJoiner(", ");
             for (TypeSymbol memberType : tupleType.memberTypeDescriptors()) {
                 // Here we check previous member-type with current member-type for equality
                 // 1. Check type-kind is differs Tuple vs int
@@ -292,23 +290,22 @@ public class CodeActionUtil {
                         prevInnerType = innerType;
                     }
                     if (isSameInnerType && prevInnerType != null) {
-                        String type = FunctionGenerator.generateTypeDefinition(importsAcceptor, prevInnerType, context);
+                        String type = FunctionGenerator.generateTypeSignature(importsAcceptor, prevInnerType, context);
                         arrayType = type + "[]";
                     }
                 }
-                String type = FunctionGenerator.generateTypeDefinition(importsAcceptor, memberType, context);
-                tupleJoiner.add(type);
+                String type = FunctionGenerator.generateTypeSignature(importsAcceptor, memberType, context);
                 prevType = memberType;
                 if (arrayType == null) {
                     arrayType = type;
                 }
             }
-            // Array
+            // Add Array type if valid
             if (isArrayCandidate) {
                 types.add(arrayType + "[]");
             }
-            // Tuple
-            types.add("[" + tupleJoiner.toString() + "]");
+            // Add tuple type
+            types.add(FunctionGenerator.generateTypeSignature(importsAcceptor, tupleType, context));
         } else if (typeDescriptor.typeKind() == TypeDescKind.ARRAY) {
             // Handle ambiguous array element types eg. record[], json[], map[]
             ArrayTypeSymbol arrayTypeSymbol = (ArrayTypeSymbol) typeDescriptor;
@@ -325,7 +322,7 @@ public class CodeActionUtil {
                     })
                     .collect(Collectors.toList());
         } else {
-            types.add(FunctionGenerator.generateTypeDefinition(importsAcceptor, typeDescriptor, context));
+            types.add(FunctionGenerator.generateTypeSignature(importsAcceptor, typeDescriptor, context));
         }
 
         importEdits.addAll(importsAcceptor.getNewImportTextEdits());
@@ -400,10 +397,11 @@ public class CodeActionUtil {
         String spaces = StringUtils.repeat(' ', range.getStart().getCharacter());
         String padding = LINE_SEPARATOR + LINE_SEPARATOR + spaces;
 
-        boolean hasError = unionType.memberTypeDescriptors().stream().anyMatch(s -> s.typeKind() == TypeDescKind.ERROR);
+        boolean hasError = CodeActionUtil.hasErrorMemberType(unionType);
 
         List<TypeSymbol> members = new ArrayList<>(unionType.memberTypeDescriptors());
         long errorTypesCount = unionType.memberTypeDescriptors().stream()
+                .map(CommonUtil::getRawType)
                 .filter(t -> t.typeKind() == TypeDescKind.ERROR)
                 .count();
         if (members.size() == 1) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/FunctionGenerator.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/FunctionGenerator.java
@@ -41,15 +41,15 @@ public class FunctionGenerator {
             Pattern.compile("([\\w]+)\\/([\\w.]+):([^:]+):([\\w]+)[\\|]?");
 
     /**
-     * Returns signature of the return type.
+     * Returns signature of the provided type.
      *
      * @param importsAcceptor imports acceptor
      * @param typeDescriptor  {@link BLangNode}
      * @param context         {@link DocumentServiceContext}
      * @return return type signature
      */
-    public static String generateTypeDefinition(ImportsAcceptor importsAcceptor,
-                                                TypeSymbol typeDescriptor, DocumentServiceContext context) {
+    public static String generateTypeSignature(ImportsAcceptor importsAcceptor,
+                                               TypeSymbol typeDescriptor, DocumentServiceContext context) {
         return processModuleIDsInText(importsAcceptor, typeDescriptor.signature(), context);
     }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/CreateVariableTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/CreateVariableTest.java
@@ -102,6 +102,9 @@ public class CreateVariableTest extends AbstractCodeActionTest {
                 {"createVariableForOptionalFieldAccess2.json", "createVariableForOptionalFieldAccess2.bal"},
                 {"createVariableWithTypeDesc.json", "createVariableWithTypeDesc.bal"},
 
+                // Tuple related
+                {"createVariableWithTuple1.json", "createVariableWithTuple1.bal"},
+
                 // Create variables of function/invocable type
                 {"createVariableWithFunctionType1.json", "createVariableWithFunctionType1.bal"},
                 {"createVariableWithFunctionType2.json", "createVariableWithFunctionType1.bal"},

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/TypeGuardTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/TypeGuardTest.java
@@ -51,6 +51,7 @@ public class TypeGuardTest extends AbstractCodeActionTest {
                 {"typeGuardVariableCodeAction1.json", "typeGuardVariable1.bal"},
                 {"typeGuardVariableCodeAction2.json", "typeGuardVariable1.bal"},
                 {"typeGuardVariableCodeAction3.json", "typeGuardVariable2.bal"},
+                {"typeGuardWithTuple1.json", "typeGuardWithTuple1.bal"},
         };
     }
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithTuple1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithTuple1.json
@@ -1,0 +1,24 @@
+{
+    "line": 1,
+    "character": 7,
+    "expected": [
+        {
+            "title": "Create variable with 'json[]'",
+            "edits": [
+                {
+                    "range": {
+                        "start": {
+                            "line": 68,
+                            "character": 4
+                        },
+                        "end": {
+                            "line": 68,
+                            "character": 4
+                        }
+                    },
+                    "newText": "json[] listResult = "
+                }
+            ]
+        }
+    ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithTuple1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithTuple1.json
@@ -1,24 +1,99 @@
 {
-    "line": 1,
-    "character": 7,
-    "expected": [
+  "line": 1,
+  "character": 7,
+  "expected": [
+    {
+      "title": "Create variable",
+      "edits": [
         {
-            "title": "Create variable with 'json[]'",
-            "edits": [
-                {
-                    "range": {
-                        "start": {
-                            "line": 68,
-                            "character": 4
-                        },
-                        "end": {
-                            "line": 68,
-                            "character": 4
-                        }
-                    },
-                    "newText": "json[] listResult = "
-                }
-            ]
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 4
+            },
+            "end": {
+              "line": 1,
+              "character": 4
+            }
+          },
+          "newText": "[int, string...]|error tuple \u003d "
         }
-    ]
+      ]
+    },
+    {
+      "title": "Create variable and type guard",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 15
+            },
+            "end": {
+              "line": 1,
+              "character": 15
+            }
+          },
+          "newText": "\n    if tuple is [int, string...] {\n\n    }"
+        },
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 4
+            },
+            "end": {
+              "line": 1,
+              "character": 4
+            }
+          },
+          "newText": "[int, string...]|error tuple \u003d "
+        }
+      ]
+    },
+    {
+      "title": "Create variable and check error",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 4
+            },
+            "end": {
+              "line": 1,
+              "character": 4
+            }
+          },
+          "newText": "[int, string...] tuple \u003d "
+        },
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 4
+            },
+            "end": {
+              "line": 1,
+              "character": 4
+            }
+          },
+          "newText": "check "
+        },
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 22
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": " returns error?"
+        }
+      ]
+    }
+  ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/source/createVariableWithTuple1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/source/createVariableWithTuple1.bal
@@ -1,0 +1,5 @@
+public function main() {
+    getTuple();
+}
+
+function getTuple() returns [int, string...]|error => [1, "hello"];

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/type-guard/config/typeGuardWithTuple1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/type-guard/config/typeGuardWithTuple1.json
@@ -1,0 +1,37 @@
+{
+  "line": 1,
+  "character": 9,
+  "expected": [
+    {
+      "title": "Create variable and type guard",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 15
+            },
+            "end": {
+              "line": 1,
+              "character": 15
+            }
+          },
+          "newText": "\n    if tuple is [int, string...] {\n\n    }"
+        },
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 4
+            },
+            "end": {
+              "line": 1,
+              "character": 4
+            }
+          },
+          "newText": "[int, string...]|error tuple \u003d "
+        }
+      ]
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/type-guard/source/typeGuardWithTuple1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/type-guard/source/typeGuardWithTuple1.bal
@@ -1,0 +1,5 @@
+public function main() {
+    getTuple();
+}
+
+function getTuple() returns [int, string...]|error => [1, "hello"];


### PR DESCRIPTION
## Purpose
$subject

Fixes #34098

## Approach
Fixed an issue in `BallerinaTupleTypeSymbol` signature where `...` to represent rest type descriptor was being added at the beginning of the type name.

![tuple_with_create_var_codeaction](https://user-images.githubusercontent.com/11285165/145020489-67f4b94c-d4ad-46ad-9e64-89271f2bdc1c.gif)

## Samples

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
