### PR TITLE
Fix support for braced expressions in add check code action

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/MatchedExpressionNodeResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/MatchedExpressionNodeResolver.java
@@ -16,6 +16,7 @@
 package org.ballerinalang.langserver.codeaction;
 
 import io.ballerina.compiler.syntax.tree.AssignmentStatementNode;
+import io.ballerina.compiler.syntax.tree.BracedExpressionNode;
 import io.ballerina.compiler.syntax.tree.ExpressionNode;
 import io.ballerina.compiler.syntax.tree.FromClauseNode;
 import io.ballerina.compiler.syntax.tree.LetVariableDeclarationNode;
@@ -89,6 +90,11 @@ public class MatchedExpressionNodeResolver extends NodeTransformer<Optional<Expr
     @Override
     public Optional<ExpressionNode> transform(FromClauseNode fromClauseNode) {
         return Optional.of(fromClauseNode.expression());
+    }
+
+    @Override
+    public Optional<ExpressionNode> transform(BracedExpressionNode node) {
+        return Optional.of(node);
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/AddCheckCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/AddCheckCodeAction.java
@@ -18,6 +18,7 @@ package org.ballerinalang.langserver.codeaction.providers;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
+import io.ballerina.compiler.syntax.tree.BracedExpressionNode;
 import io.ballerina.compiler.syntax.tree.ExpressionNode;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.tools.diagnostics.Diagnostic;
@@ -31,6 +32,7 @@ import org.ballerinalang.langserver.commons.CodeActionContext;
 import org.ballerinalang.langserver.commons.codeaction.CodeActionNodeType;
 import org.ballerinalang.langserver.commons.codeaction.spi.DiagBasedPositionDetails;
 import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.TextEdit;
 
 import java.util.ArrayList;
@@ -93,10 +95,18 @@ public class AddCheckCodeAction extends TypeCastCodeAction {
             return Collections.emptyList();
         }
 
+        Position pos = CommonUtil.toRange(diagnostic.location().lineRange()).getStart();
+        // The following code may sound odd. But as per the diagnostic, when the error is in the expr of a braced 
+        // expression, the diagnostic location points to the braced expression itself. To overcome that, here we
+        // treat braced expressions specially and add 'check' within the parentheses.
+        if (expressionNode.get().kind() == SyntaxKind.BRACED_EXPRESSION) {
+            BracedExpressionNode bracedExpressionNode = (BracedExpressionNode) expressionNode.get();
+            pos = CommonUtil.toRange(bracedExpressionNode.expression().location().lineRange()).getStart();
+        }
+
         List<TextEdit> edits = new ArrayList<>();
         edits.addAll(CodeActionUtil.getAddCheckTextEdits(
-                CommonUtil.toRange(diagnostic.location().lineRange()).getStart(),
-                positionDetails.matchedNode(), context));
+                pos, positionDetails.matchedNode(), context));
         if (edits.isEmpty()) {
             return Collections.emptyList();
         }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/AddCheckCodeActionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/AddCheckCodeActionTest.java
@@ -47,6 +47,7 @@ public class AddCheckCodeActionTest extends AbstractCodeActionTest {
                 {"add_check_codeaction_config3.json", "add_check_codeaction_source3.bal"},
                 {"add_check_codeaction_config4.json", "add_check_codeaction_source4.bal"},
                 {"add_check_codeaction_config5.json", "add_check_codeaction_source4.bal"},
+                {"add_check_with_parantheses_config1.json", "add_check_with_parantheses_source1.bal"},
         };
     }
 

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/add-check/config/add_check_with_parantheses_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/add-check/config/add_check_with_parantheses_config1.json
@@ -1,0 +1,37 @@
+{
+  "line": 1,
+  "character": 39,
+  "expected": [
+    {
+      "title": "Add 'check' error",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 31
+            },
+            "end": {
+              "line": 1,
+              "character": 31
+            }
+          },
+          "newText": "check "
+        },
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 33
+            },
+            "end": {
+              "line": 0,
+              "character": 33
+            }
+          },
+          "newText": " returns error?"
+        }
+      ]
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/add-check/source/add_check_with_parantheses_source1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/add-check/source/add_check_with_parantheses_source1.bal
@@ -1,0 +1,3 @@
+public function myFunc(json data) {
+    json myJson = {firstName: (data.firstName).toString()};
+}


### PR DESCRIPTION
## Purpose
$subject

Fixes #34212

## Approach
Now,
```
public function myFunc(json data) returns error? {
    json myJson = {firstName: (data.firstName).toString()};
}
```
will result in:
```
public function myFunc(json data) returns error? {
    json myJson = {firstName: (check data.firstName).toString()};
}
```

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
