### PR TITLE
Add guard against multiple calls to ObserveUtils.stopObservationWithContext

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/ObserveUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/ObserveUtils.java
@@ -291,12 +291,14 @@ public class ObserveUtils {
      * @param observerContext Observer context
      */
     public static void stopObservationWithContext(ObserverContext observerContext) {
-        if (observerContext.isServer()) {
-            observers.forEach(observer -> observer.stopServerObservation(observerContext));
-        } else {
-            observers.forEach(observer -> observer.stopClientObservation(observerContext));
+        if (!observerContext.isFinished()) {
+            if (observerContext.isServer()) {
+                observers.forEach(observer -> observer.stopServerObservation(observerContext));
+            } else {
+                observers.forEach(observer -> observer.stopClientObservation(observerContext));
+            }
+            observerContext.setFinished();
         }
-        observerContext.setFinished();
     }
 
     /**


### PR DESCRIPTION
## Purpose
> If ObserveUtils.stopObservationWithContext is called more than once for a single observation, it can lead to errors in metrics. Therefore a gaurd against that was added.

Fixes https://github.com/ballerina-platform/module-ballerinax-prometheus/issues/111

## Approach
> A gaurd was added against calling `ObserveUtils.stopObservationWithContext` twice

## Samples
> N/A

## Remarks
> N/A

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
