### PR TITLE
Fix `annotations()` API of `WorkerSymbol`

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -19,6 +19,7 @@ package org.wso2.ballerinalang.compiler.semantics.analyzer;
 
 import io.ballerina.compiler.api.symbols.DiagnosticState;
 import io.ballerina.tools.diagnostics.Location;
+import io.ballerina.tools.text.LineRange;
 import org.ballerinalang.compiler.CompilerOptionName;
 import org.ballerinalang.compiler.CompilerPhase;
 import org.ballerinalang.model.TreeBuilder;
@@ -64,6 +65,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BTypeDefinitionSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BVarSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BWorkerSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BXMLAttributeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BXMLNSSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.SymTag;
@@ -4412,6 +4414,10 @@ public class SymbolEnter extends BLangNodeVisitor {
             varSymbol = new BInvokableSymbol(SymTag.VARIABLE, flags, varName, env.enclPkg.symbol.pkgID, type,
                                              env.scope.owner, location, isInternal ? VIRTUAL : getOrigin(varName));
             varSymbol.kind = SymbolKind.FUNCTION;
+        } else if (Symbols.isFlagOn(flags, Flags.WORKER)) {
+            varSymbol = new BWorkerSymbol(flags, varName, env.enclPkg.symbol.pkgID, type, env.scope.owner, location,
+                                          isInternal ? VIRTUAL : getOrigin(varName));
+            resolveAssociatedWorkerFunc((BWorkerSymbol) varSymbol, env);
         } else {
             varSymbol = new BVarSymbol(flags, varName, env.enclPkg.symbol.pkgID, type, env.scope.owner, location,
                                        isInternal ? VIRTUAL : getOrigin(varName));
@@ -4420,6 +4426,24 @@ public class SymbolEnter extends BLangNodeVisitor {
             }
         }
         return varSymbol;
+    }
+
+    private void resolveAssociatedWorkerFunc(BWorkerSymbol worker, SymbolEnv env) {
+        LineRange workerVarPos = worker.pos.lineRange();
+
+        for (BLangLambdaFunction lambdaFn : env.enclPkg.lambdaFunctions) {
+            LineRange workerBodyPos = lambdaFn.function.pos.lineRange();
+
+            if (worker.name.value.equals(lambdaFn.function.defaultWorkerName.value)
+                    && withinRange(workerVarPos, env.node.pos.lineRange())
+                    && withinRange(workerBodyPos, env.node.pos.lineRange())) {
+                worker.setAssociatedFuncSymbol(lambdaFn.function.symbol);
+                return;
+            }
+        }
+
+        throw new IllegalStateException(
+                "Matching function node not found for worker: " + worker.name.value + " at " + worker.pos);
     }
 
     private void defineObjectInitFunction(BLangObjectTypeNode object, SymbolEnv conEnv) {
@@ -5029,6 +5053,22 @@ public class SymbolEnter extends BLangNodeVisitor {
             }
         }
         return false;
+    }
+
+    private boolean withinRange(LineRange srcRange, LineRange targetRange) {
+        int startLine = srcRange.startLine().line();
+        int startOffset = srcRange.startLine().offset();
+        int endLine = srcRange.endLine().line();
+        int endOffset = srcRange.endLine().offset();
+
+        int enclStartLine = targetRange.startLine().line();
+        int enclEndLine = targetRange.endLine().line();
+        int enclStartOffset = targetRange.startLine().offset();
+        int enclEndOffset = targetRange.endLine().offset();
+
+        return targetRange.filePath().equals(srcRange.filePath())
+                && (startLine == enclStartLine && startOffset >= enclStartOffset || startLine > enclStartLine)
+                && (endLine == enclEndLine && endOffset <= enclEndOffset || endLine < enclEndLine);
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BWorkerSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BWorkerSymbol.java
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.wso2.ballerinalang.compiler.semantics.model.symbols;
+
+import io.ballerina.tools.diagnostics.Location;
+import org.ballerinalang.model.elements.PackageID;
+import org.ballerinalang.model.symbols.SymbolKind;
+import org.ballerinalang.model.symbols.SymbolOrigin;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
+import org.wso2.ballerinalang.compiler.util.Name;
+
+/**
+ * A simple wrapper symbol for representing a worker symbol so that we can keep track of the symbol of the function
+ * associated with the worker as well.
+ *
+ * @since 2.0.0
+ */
+public class BWorkerSymbol extends BVarSymbol {
+
+    private BInvokableSymbol associatedFn;
+
+    public BWorkerSymbol(long flags, Name varName, PackageID pkgID, BType type, BSymbol owner, Location location,
+                         SymbolOrigin symbolOrigin) {
+        super(flags, varName, pkgID, type, owner, location, symbolOrigin);
+        this.kind = SymbolKind.WORKER;
+    }
+
+    public void setAssociatedFuncSymbol(BInvokableSymbol symbol) {
+        this.associatedFn = symbol;
+    }
+
+    public BInvokableSymbol getAssociatedFuncSymbol() {
+        return this.associatedFn;
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/AnnotationSymbolTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/AnnotationSymbolTest.java
@@ -45,6 +45,8 @@ import static io.ballerina.compiler.api.symbols.SymbolKind.METHOD;
 import static io.ballerina.compiler.api.symbols.SymbolKind.PARAMETER;
 import static io.ballerina.compiler.api.symbols.SymbolKind.RECORD_FIELD;
 import static io.ballerina.compiler.api.symbols.SymbolKind.RESOURCE_METHOD;
+import static io.ballerina.compiler.api.symbols.SymbolKind.TYPE_DEFINITION;
+import static io.ballerina.compiler.api.symbols.SymbolKind.WORKER;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.TYPE_REFERENCE;
 import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.assertBasicsAndGetSymbol;
 import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDefaultModulesSemanticModel;
@@ -88,7 +90,7 @@ public class AnnotationSymbolTest {
     public Object[][] getPos() {
         return new Object[][]{
                 {30, 6, CONSTANT, of("v1")},
-//                {36, 12, TYPE_DEFINITION, of("v1")}, // TODO: Uncomment after fixing #27461
+                {36, 12, TYPE_DEFINITION, of("v1")},
                 {37, 15, RECORD_FIELD, of("v5")},
                 {49, 6, CLASS, of("v1", "v2", "v2")},
                 {50, 15, CLASS_FIELD, of("v5")},
@@ -98,7 +100,7 @@ public class AnnotationSymbolTest {
                 {70, 11, ANNOTATION, of("v1")},
                 {82, 18, CLASS_FIELD, of("v5")},
                 {87, 22, RESOURCE_METHOD, of("v3")},
-//                {96, 11, WORKER, of("v1")} // TODO: Uncomment after fixing #27461
+                {96, 11, WORKER, of("v1")},
                 {105, 5, ENUM, of("v1", "v5")},
                 {109, 4, ENUM_MEMBER, of("v1")}
         };

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/WorkerSymbolTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/WorkerSymbolTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.semantic.api.test.symbols;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.AnnotationSymbol;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.SymbolKind;
+import io.ballerina.compiler.api.symbols.WorkerSymbol;
+import io.ballerina.projects.Document;
+import io.ballerina.projects.Project;
+import io.ballerina.tools.text.LinePosition;
+import org.ballerinalang.test.BCompileUtil;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDefaultModulesSemanticModel;
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDocumentForSingleSource;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Test cases for worker symbols.
+ *
+ * @since 2.0.0
+ */
+public class WorkerSymbolTest {
+
+    private SemanticModel model;
+    private Document srcFile;
+
+    @BeforeClass
+    public void setup() {
+        Project project = BCompileUtil.loadProject("test-src/symbols/worker_symbol_test.bal");
+        model = getDefaultModulesSemanticModel(project);
+        srcFile = getDocumentForSingleSource(project);
+    }
+
+    @Test(dataProvider = "WorkerPos")
+    public void testWorkerAnnots(int line, int col, String expName, List<String> expAnnots) {
+        Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, col));
+        assertTrue(symbol.isPresent());
+        assertEquals(symbol.get().kind(), SymbolKind.WORKER);
+        assertEquals(symbol.get().getName().get(), expName);
+
+        List<AnnotationSymbol> annots = ((WorkerSymbol) symbol.get()).annotations();
+        assertEquals(annots.size(), expAnnots.size());
+
+        for (AnnotationSymbol annot : annots) {
+            assertTrue(expAnnots.contains(annot.getName().get()));
+        }
+    }
+
+    @DataProvider(name = "WorkerPos")
+    public Object[][] getErrorType() {
+        return new Object[][]{
+                {19, 11, "w1", List.of("a1", "strand")},
+                {23, 11, "w2", List.of("a2")},
+                {27, 11, "w3", List.of("a3")},
+                {33, 11, "w2", List.of("a4")},
+                {37, 11, "w3", List.of("a5")},
+        };
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbols/worker_symbol_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbols/worker_symbol_test.bal
@@ -1,0 +1,47 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+function test1() {
+    @strand{thread:"any"}
+    @a1
+    worker w1 {
+    }
+
+    @a2
+    worker w2 {
+    }
+
+    @a3
+    worker w3 {
+    }
+}
+
+function test2() {
+    @a4
+    worker w2 {
+    }
+
+    @a5
+    worker w3 {
+    }
+}
+
+// utils
+annotation a1;
+annotation a2;
+annotation a3;
+annotation a4;
+annotation a5;

--- a/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
+++ b/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
@@ -149,6 +149,7 @@
             <class name="io.ballerina.semantic.api.test.symbols.TypeSymbolTest" />
             <class name="io.ballerina.semantic.api.test.symbols.UnionTypeSymbolTest" />
             <class name="io.ballerina.semantic.api.test.symbols.VarDeclSymbolTest" />
+            <class name="io.ballerina.semantic.api.test.symbols.WorkerSymbolTest" />
             <class name="io.ballerina.semantic.api.test.symbols.XMLNamespaceDeclSymbolTest" />
 
             <!--Langlib-->


### PR DESCRIPTION
## Purpose
The `annotations()` API of `WorkerSymbol` was broken due to the way we model a worker internally. This PR addresses this by introducing a new internal symbol for workers which also keeps track of the function symbol of the generated function for workers.

Fixes #27461 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
