### PR TITLE
Fix type reference types across modules

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -77,6 +77,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BObjectType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BRecordType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BTableType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BTypeReferenceType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BUnionType;
 import org.wso2.ballerinalang.compiler.tree.BLangAnnotation;
 import org.wso2.ballerinalang.compiler.tree.BLangAnnotationAttachment;
@@ -427,8 +428,19 @@ public class BIRGen extends BLangNodeVisitor {
                                                           displayName,
                                                           astTypeDefinition.symbol.originalName);
         if (astTypeDefinition.symbol.tag == SymTag.TYPE_DEF) {
-            typeDefs.put(astTypeDefinition.symbol.type.tsymbol, typeDef);
-            typeDef.referenceType = ((BTypeDefinitionSymbol) astTypeDefinition.symbol).referenceType;
+            if (type.tsymbol.owner == astTypeDefinition.symbol.owner) {
+                typeDefs.put(astTypeDefinition.symbol.type.tsymbol, typeDef);
+                typeDef.referenceType = ((BTypeDefinitionSymbol) astTypeDefinition.symbol).referenceType;
+            } else {
+                BTypeReferenceType referenceType = ((BTypeDefinitionSymbol) astTypeDefinition.symbol).referenceType;
+                typeDef.referenceType = referenceType;
+
+                if (referenceType != null) {
+                    typeDef.type = referenceType;
+                }
+
+                typeDefs.put(astTypeDefinition.symbol, typeDef);
+            }
         } else {
             //enum symbols
             typeDefs.put(astTypeDefinition.symbol, typeDef);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -1548,7 +1548,8 @@ public class SymbolEnter extends BLangNodeVisitor {
             }
         }
 
-        if (definedType.tsymbol.kind == SymbolKind.OBJECT || definedType.tsymbol.kind == SymbolKind.RECORD) {
+        if ((definedType.tsymbol.kind == SymbolKind.OBJECT || definedType.tsymbol.kind == SymbolKind.RECORD) &&
+                typeDefSymbol.owner == definedType.tsymbol.owner) {
             ((BStructureTypeSymbol) definedType.tsymbol).typeDefinitionSymbol = (BTypeDefinitionSymbol) typeDefSymbol;
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -961,7 +961,7 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
                 entry = entry.next;
                 continue;
             }
-            symTable.errorType = (BErrorType) entry.symbol.type;
+            symTable.errorType = (BErrorType) types.getReferredType(entry.symbol.type);
             symTable.detailType = (BMapType) symTable.errorType.detailType;
             return;
         }
@@ -979,7 +979,7 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
                 entry = entry.next;
                 continue;
             }
-            BUnionType type = (BUnionType) entry.symbol.type;
+            BUnionType type = (BUnionType) types.getReferredType(entry.symbol.type);
             symTable.anydataType = new BAnydataType(type);
             symTable.anydataOrReadonly = BUnionType.create(null, symTable.anydataType, symTable.readonlyType);
             entry.symbol.type = symTable.anydataType;
@@ -999,7 +999,7 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
                 entry = entry.next;
                 continue;
             }
-            BUnionType type = (BUnionType) entry.symbol.type;
+            BUnionType type = (BUnionType) types.getReferredType(entry.symbol.type);
             symTable.jsonType = new BJSONType(type);
             symTable.jsonType.tsymbol = new BTypeSymbol(SymTag.TYPE, Flags.PUBLIC, Names.JSON, PackageID.ANNOTATIONS,
                     symTable.jsonType, symTable.langAnnotationModuleSymbol, symTable.builtinPos, BUILTIN);
@@ -1018,7 +1018,7 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
                     entry = entry.next;
                     continue;
                 }
-                symTable.cloneableType = (BUnionType) entry.symbol.type;
+                symTable.cloneableType = (BUnionType) types.getReferredType(entry.symbol.type);
                 symTable.cloneableType.tsymbol =
                         new BTypeSymbol(SymTag.TYPE, Flags.PUBLIC, Names.CLONEABLE,
                                 PackageID.VALUE, symTable.cloneableType, symTable.langValueModuleSymbol,
@@ -1078,7 +1078,7 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
                 entry = entry.next;
                 continue;
             }
-            symTable.iterableType = (BObjectType) entry.symbol.type;
+            symTable.iterableType = (BObjectType) types.getReferredType(entry.symbol.type);
             return;
         }
         throw new IllegalStateException("built-in distinct Iterable type not found ?");

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/types/TypeReferenceTypeBalaTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/types/TypeReferenceTypeBalaTest.java
@@ -36,11 +36,19 @@ public class TypeReferenceTypeBalaTest {
     @BeforeClass
     public void setup() {
         BCompileUtil.compileAndCacheBala("test-src/bala/test_projects/test_project_type_reference_types");
+        BCompileUtil.compileAndCacheBala("test-src/bala/test_projects/test_project_type_reference_types_2");
     }
 
     @Test
     public void testTypeReferenceTypeViaBala() {
         CompileResult result = BCompileUtil.compile("test-src/bala/test_bala/types/type_reference_type_bala_test.bal");
+        BRunUtil.invoke(result, "testFn");
+    }
+
+    @Test
+    public void testTypeReferenceTypeViaBala2() {
+        CompileResult result = BCompileUtil.compile(
+                "test-src/bala/test_bala/types/type_reference_type_bala_test_2.bal");
         BRunUtil.invoke(result, "testFn");
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/types/type_reference_type_bala_test_2.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/types/type_reference_type_bala_test_2.bal
@@ -1,0 +1,37 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import testorg/typereftypes2 as tr;
+
+type StringDefn tr:ConstPointerValue;
+
+type Module record {|
+    map<StringDefn> stringDefns = {};
+|};
+
+function testFn() {
+    Module m = {stringDefns: {a: new (1234)}};
+    assertEquality(1, m.stringDefns.length());
+    assertEquality(1234, m.stringDefns.get("a").i);
+}
+
+function assertEquality(anydata expected, anydata actual) {
+    if expected == actual {
+        return;
+    }
+
+    panic error("expected '" + expected.toString() + "', found '" + actual.toString() + "'");
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/test_project_type_reference_types_2/Ballerina.toml
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/test_project_type_reference_types_2/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "testorg"
+name ="typereftypes2"
+version = "1.0.0"

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/test_project_type_reference_types_2/types.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/test_project_type_reference_types_2/types.bal
@@ -1,0 +1,23 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+public readonly class ConstPointerValue {
+    public int i;
+
+    public function init(int i) {
+        self.i = i;
+    }
+}


### PR DESCRIPTION
## Purpose
$title. When type reference types are used across modules, types in imported modules get updated with details from the modules in which they are imported.

This PR adds a temporary fix for slbeta6 by adding a check for the owner. But we need to properly revisit how we model such type definitions and how they are handled in the BIR.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/34241

## Remarks
https://github.com/ballerina-platform/ballerina-lang/issues/34247

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
