### PR TITLE
Improve the sorting order of completion items in from clause context

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FromClauseNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FromClauseNodeContext.java
@@ -16,6 +16,8 @@
 package org.ballerinalang.langserver.completions.providers.context;
 
 import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.syntax.tree.BindingPatternNode;
 import io.ballerina.compiler.syntax.tree.FromClauseNode;
 import io.ballerina.compiler.syntax.tree.Node;
@@ -26,13 +28,19 @@ import io.ballerina.compiler.syntax.tree.Token;
 import io.ballerina.compiler.syntax.tree.TypeDescriptorNode;
 import io.ballerina.compiler.syntax.tree.TypedBindingPatternNode;
 import org.ballerinalang.annotation.JavaSPIService;
+import org.ballerinalang.langserver.common.utils.CommonUtil;
+import org.ballerinalang.langserver.common.utils.SymbolUtil;
 import org.ballerinalang.langserver.common.utils.completion.QNameReferenceUtil;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.SnippetCompletionItem;
+import org.ballerinalang.langserver.completions.SymbolCompletionItem;
 import org.ballerinalang.langserver.completions.util.Snippet;
+import org.ballerinalang.langserver.completions.util.SortingUtil;
+import org.eclipse.lsp4j.CompletionItemKind;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -107,6 +115,47 @@ public class FromClauseNodeContext extends IntermediateClauseNodeContext<FromCla
     @Override
     public boolean onPreValidation(BallerinaCompletionContext context, FromClauseNode node) {
         return !node.fromKeyword().isMissing();
+    }
+    
+    @Override
+    public void sort(BallerinaCompletionContext context,
+                     FromClauseNode node,
+                     List<LSCompletionItem> completionItems) {
+
+        completionItems.forEach(lsCItem -> {
+            if (isIterableCompletionItem(lsCItem)) {
+                lsCItem.getCompletionItem().setSortText(SortingUtil.genSortText(1)
+                        + SortingUtil.genSortText(SortingUtil.toRank(context, lsCItem)));
+                return;
+            } else if (lsCItem.getType() == LSCompletionItem.CompletionItemType.SYMBOL &&
+                    lsCItem.getCompletionItem().getKind() == CompletionItemKind.Function) {
+                lsCItem.getCompletionItem().setSortText(SortingUtil.genSortText(2));
+                return;
+            }
+            lsCItem.getCompletionItem().setSortText(SortingUtil.genSortText(3) +
+                    SortingUtil.genSortText(SortingUtil.toRank(context, lsCItem)));
+        });
+    }
+
+    private boolean isIterableCompletionItem(LSCompletionItem lsCItem) {
+        
+        if (lsCItem.getType() != LSCompletionItem.CompletionItemType.SYMBOL) {
+            return false;
+        }
+        
+        Symbol symbol = ((SymbolCompletionItem) lsCItem).getSymbol().orElse(null);
+        Optional<TypeSymbol> typeDesc = SymbolUtil.getTypeDescriptor(symbol);
+
+        List<TypeDescKind> ITERABLES = Arrays.asList(
+                TypeDescKind.STRING, TypeDescKind.ARRAY,
+                TypeDescKind.MAP, TypeDescKind.TABLE,
+                TypeDescKind.STREAM, TypeDescKind.XML);
+
+        if (typeDesc.isPresent()) {
+            TypeSymbol rawType = CommonUtil.getRawType(typeDesc.get());
+            return ITERABLES.contains(rawType.typeKind());
+        }
+        return false;
     }
 
     private boolean onTypedBindingPatternContext(BallerinaCompletionContext context, FromClauseNode node) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FromClauseNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FromClauseNodeContext.java
@@ -146,14 +146,14 @@ public class FromClauseNodeContext extends IntermediateClauseNodeContext<FromCla
         Symbol symbol = ((SymbolCompletionItem) lsCItem).getSymbol().orElse(null);
         Optional<TypeSymbol> typeDesc = SymbolUtil.getTypeDescriptor(symbol);
 
-        List<TypeDescKind> ITERABLES = Arrays.asList(
+        List<TypeDescKind> iterables = Arrays.asList(
                 TypeDescKind.STRING, TypeDescKind.ARRAY,
                 TypeDescKind.MAP, TypeDescKind.TABLE,
                 TypeDescKind.STREAM, TypeDescKind.XML);
 
         if (typeDesc.isPresent()) {
             TypeSymbol rawType = CommonUtil.getRawType(typeDesc.get());
-            return ITERABLES.contains(rawType.typeKind());
+            return iterables.contains(rawType.typeKind());
         }
         return false;
     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config12.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config12.json
@@ -9,7 +9,7 @@
       "label": "in",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "CQ",
       "filterText": "in",
       "insertText": "in ",
       "insertTextFormat": "Snippet"

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config13.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config13.json
@@ -9,7 +9,7 @@
       "label": "in",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "CQ",
       "filterText": "in",
       "insertText": "in ",
       "insertTextFormat": "Snippet"

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config14.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config14.json
@@ -9,7 +9,7 @@
       "label": "module1",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "O",
+      "sortText": "CO",
       "filterText": "module1",
       "insertText": "module1",
       "insertTextFormat": "Snippet"
@@ -18,7 +18,7 @@
       "label": "ballerina/lang.array",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "R",
+      "sortText": "CR",
       "filterText": "array",
       "insertText": "array",
       "insertTextFormat": "Snippet",
@@ -42,7 +42,7 @@
       "label": "ballerina/jballerina.java",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "R",
+      "sortText": "CR",
       "filterText": "java",
       "insertText": "java",
       "insertTextFormat": "Snippet",
@@ -66,7 +66,7 @@
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "R",
+      "sortText": "CR",
       "filterText": "runtime",
       "insertText": "runtime",
       "insertTextFormat": "Snippet",
@@ -90,7 +90,7 @@
       "label": "boolean",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "boolean",
       "insertTextFormat": "Snippet"
     },
@@ -98,7 +98,7 @@
       "label": "decimal",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "decimal",
       "insertTextFormat": "Snippet"
     },
@@ -106,7 +106,7 @@
       "label": "error",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "error",
       "insertTextFormat": "Snippet"
     },
@@ -114,7 +114,7 @@
       "label": "float",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "float",
       "insertTextFormat": "Snippet"
     },
@@ -122,7 +122,7 @@
       "label": "future",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "future",
       "insertTextFormat": "Snippet"
     },
@@ -130,7 +130,7 @@
       "label": "int",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "int",
       "insertTextFormat": "Snippet"
     },
@@ -138,7 +138,7 @@
       "label": "map",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "map",
       "insertTextFormat": "Snippet"
     },
@@ -146,7 +146,7 @@
       "label": "object",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "object",
       "insertTextFormat": "Snippet"
     },
@@ -154,7 +154,7 @@
       "label": "stream",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "stream",
       "insertTextFormat": "Snippet"
     },
@@ -162,7 +162,7 @@
       "label": "string",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "string",
       "insertTextFormat": "Snippet"
     },
@@ -170,7 +170,7 @@
       "label": "table",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "table",
       "insertTextFormat": "Snippet"
     },
@@ -178,7 +178,7 @@
       "label": "transaction",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "transaction",
       "insertTextFormat": "Snippet"
     },
@@ -186,7 +186,7 @@
       "label": "typedesc",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "typedesc",
       "insertTextFormat": "Snippet"
     },
@@ -194,7 +194,7 @@
       "label": "xml",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
     },
@@ -202,7 +202,7 @@
       "label": "service",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "CQ",
       "filterText": "service",
       "insertText": "service",
       "insertTextFormat": "Snippet"
@@ -211,7 +211,7 @@
       "label": "new",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "CQ",
       "filterText": "new",
       "insertText": "new ",
       "insertTextFormat": "Snippet"
@@ -220,7 +220,7 @@
       "label": "isolated",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "CQ",
       "filterText": "isolated",
       "insertText": "isolated ",
       "insertTextFormat": "Snippet"
@@ -229,7 +229,7 @@
       "label": "transactional",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "CQ",
       "filterText": "transactional",
       "insertText": "transactional",
       "insertTextFormat": "Snippet"
@@ -238,7 +238,7 @@
       "label": "function",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "CQ",
       "filterText": "function",
       "insertText": "function ",
       "insertTextFormat": "Snippet"
@@ -247,7 +247,7 @@
       "label": "let",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "CQ",
       "filterText": "let",
       "insertText": "let",
       "insertTextFormat": "Snippet"
@@ -256,7 +256,7 @@
       "label": "typeof",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "CQ",
       "filterText": "typeof",
       "insertText": "typeof ",
       "insertTextFormat": "Snippet"
@@ -265,7 +265,7 @@
       "label": "trap",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "CQ",
       "filterText": "trap",
       "insertText": "trap",
       "insertTextFormat": "Snippet"
@@ -274,7 +274,7 @@
       "label": "client",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "CQ",
       "filterText": "client",
       "insertText": "client ",
       "insertTextFormat": "Snippet"
@@ -283,7 +283,7 @@
       "label": "true",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "CQ",
       "filterText": "true",
       "insertText": "true",
       "insertTextFormat": "Snippet"
@@ -292,7 +292,7 @@
       "label": "false",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "CQ",
       "filterText": "false",
       "insertText": "false",
       "insertTextFormat": "Snippet"
@@ -301,7 +301,7 @@
       "label": "check",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "CQ",
       "filterText": "check",
       "insertText": "check ",
       "insertTextFormat": "Snippet"
@@ -310,7 +310,7 @@
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "CQ",
       "filterText": "checkpanic",
       "insertText": "checkpanic ",
       "insertTextFormat": "Snippet"
@@ -319,7 +319,7 @@
       "label": "is",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "CQ",
       "filterText": "is",
       "insertText": "is",
       "insertTextFormat": "Snippet"
@@ -328,7 +328,7 @@
       "label": "error constructor",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "CP",
       "filterText": "error",
       "insertText": "error(\"${1}\")",
       "insertTextFormat": "Snippet"
@@ -337,7 +337,7 @@
       "label": "object constructor",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "CP",
       "filterText": "object",
       "insertText": "object {${1}}",
       "insertTextFormat": "Snippet"
@@ -346,7 +346,7 @@
       "label": "base16",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "CP",
       "filterText": "base16",
       "insertText": "base16 `${1}`",
       "insertTextFormat": "Snippet"
@@ -355,7 +355,7 @@
       "label": "base64",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "CP",
       "filterText": "base64",
       "insertText": "base64 `${1}`",
       "insertTextFormat": "Snippet"
@@ -364,7 +364,7 @@
       "label": "from",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "CQ",
       "filterText": "from",
       "insertText": "from ",
       "insertTextFormat": "Snippet"
@@ -379,7 +379,7 @@
           "value": "**Package:** _._  \n  \n  \n**Params**  \n- `int` a  \n- `int` c"
         }
       },
-      "sortText": "C",
+      "sortText": "B",
       "filterText": "doTask",
       "insertText": "doTask(${1})",
       "insertTextFormat": "Snippet",
@@ -392,7 +392,7 @@
       "label": "Thread",
       "kind": "TypeParameter",
       "detail": "Union",
-      "sortText": "N",
+      "sortText": "CN",
       "insertText": "Thread",
       "insertTextFormat": "Snippet"
     },
@@ -406,7 +406,7 @@
           "value": "**Package:** _._  \n  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "B",
       "filterText": "testFunction",
       "insertText": "testFunction()",
       "insertTextFormat": "Snippet"
@@ -415,7 +415,7 @@
       "label": "list1",
       "kind": "Variable",
       "detail": "int[]",
-      "sortText": "B",
+      "sortText": "AB",
       "insertText": "list1",
       "insertTextFormat": "Snippet"
     },
@@ -423,7 +423,7 @@
       "label": "value2",
       "kind": "Variable",
       "detail": "int",
-      "sortText": "B",
+      "sortText": "CB",
       "insertText": "value2",
       "insertTextFormat": "Snippet"
     },
@@ -434,7 +434,7 @@
       "documentation": {
         "left": "Describes Strand execution details for the runtime.\n"
       },
-      "sortText": "M",
+      "sortText": "CM",
       "insertText": "StrandData",
       "insertTextFormat": "Snippet"
     },
@@ -442,7 +442,7 @@
       "label": "readonly",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "readonly",
       "insertTextFormat": "Snippet"
     },
@@ -450,7 +450,7 @@
       "label": "handle",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "handle",
       "insertTextFormat": "Snippet"
     },
@@ -458,7 +458,7 @@
       "label": "never",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "never",
       "insertTextFormat": "Snippet"
     },
@@ -466,7 +466,7 @@
       "label": "json",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "json",
       "insertTextFormat": "Snippet"
     },
@@ -474,7 +474,7 @@
       "label": "anydata",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "anydata",
       "insertTextFormat": "Snippet"
     },
@@ -482,7 +482,7 @@
       "label": "any",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "any",
       "insertTextFormat": "Snippet"
     },
@@ -490,7 +490,7 @@
       "label": "byte",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
     },
@@ -498,7 +498,7 @@
       "label": "ballerina/lang.value",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "R",
+      "sortText": "CR",
       "filterText": "value",
       "insertText": "value",
       "insertTextFormat": "Snippet",
@@ -522,7 +522,7 @@
       "label": "ballerina/lang.test",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "R",
+      "sortText": "CR",
       "filterText": "test",
       "insertText": "test",
       "insertTextFormat": "Snippet",
@@ -546,7 +546,7 @@
       "label": "null",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "CQ",
       "filterText": "null",
       "insertText": "null",
       "insertTextFormat": "Snippet"

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config15.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config15.json
@@ -15,7 +15,7 @@
           "value": ""
         }
       },
-      "sortText": "H",
+      "sortText": "CH",
       "insertText": "ENUM1_FIELD1",
       "insertTextFormat": "Snippet"
     },
@@ -29,7 +29,7 @@
           "value": ""
         }
       },
-      "sortText": "C",
+      "sortText": "CC",
       "insertText": "TEST_INT_CONST1",
       "insertTextFormat": "Snippet"
     },
@@ -43,7 +43,7 @@
           "value": ""
         }
       },
-      "sortText": "C",
+      "sortText": "CC",
       "insertText": "TEST_STRING_CONST1",
       "insertTextFormat": "Snippet"
     },
@@ -51,7 +51,7 @@
       "label": "AnnotationType",
       "kind": "Struct",
       "detail": "Record",
-      "sortText": "M",
+      "sortText": "CM",
       "insertText": "AnnotationType",
       "insertTextFormat": "Snippet"
     },
@@ -62,7 +62,7 @@
       "documentation": {
         "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
       },
-      "sortText": "I",
+      "sortText": "CI",
       "insertText": "ResponseMessage",
       "insertTextFormat": "Snippet"
     },
@@ -73,7 +73,7 @@
       "documentation": {
         "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
       },
-      "sortText": "I",
+      "sortText": "CI",
       "insertText": "RequestMessage",
       "insertTextFormat": "Snippet"
     },
@@ -81,7 +81,7 @@
       "label": "TestRecord1",
       "kind": "Struct",
       "detail": "Record",
-      "sortText": "M",
+      "sortText": "CM",
       "insertText": "TestRecord1",
       "insertTextFormat": "Snippet"
     },
@@ -89,7 +89,7 @@
       "label": "TestRecord2",
       "kind": "Struct",
       "detail": "Record",
-      "sortText": "M",
+      "sortText": "CM",
       "insertText": "TestRecord2",
       "insertTextFormat": "Snippet"
     },
@@ -97,7 +97,7 @@
       "label": "TestMap2",
       "kind": "TypeParameter",
       "detail": "Map",
-      "sortText": "N",
+      "sortText": "AN",
       "insertText": "TestMap2",
       "insertTextFormat": "Snippet"
     },
@@ -105,7 +105,7 @@
       "label": "TestMap3",
       "kind": "TypeParameter",
       "detail": "Map",
-      "sortText": "N",
+      "sortText": "AN",
       "insertText": "TestMap3",
       "insertTextFormat": "Snippet"
     },
@@ -113,7 +113,7 @@
       "label": "TestObject1",
       "kind": "Interface",
       "detail": "Object",
-      "sortText": "K",
+      "sortText": "CK",
       "insertText": "TestObject1",
       "insertTextFormat": "Snippet"
     },
@@ -121,7 +121,7 @@
       "label": "ErrorOne",
       "kind": "Event",
       "detail": "Error",
-      "sortText": "L",
+      "sortText": "CL",
       "insertText": "ErrorOne",
       "insertTextFormat": "Snippet"
     },
@@ -129,7 +129,7 @@
       "label": "ErrorTwo",
       "kind": "Event",
       "detail": "Error",
-      "sortText": "L",
+      "sortText": "CL",
       "insertText": "ErrorTwo",
       "insertTextFormat": "Snippet"
     },
@@ -137,7 +137,7 @@
       "label": "Listener",
       "kind": "Interface",
       "detail": "Class",
-      "sortText": "K",
+      "sortText": "CK",
       "insertText": "Listener",
       "insertTextFormat": "Snippet"
     },
@@ -148,7 +148,7 @@
       "documentation": {
         "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs."
       },
-      "sortText": "K",
+      "sortText": "CK",
       "insertText": "Client",
       "insertTextFormat": "Snippet"
     },
@@ -159,7 +159,7 @@
       "documentation": {
         "left": "Represents a response.\n"
       },
-      "sortText": "K",
+      "sortText": "CK",
       "insertText": "Response",
       "insertTextFormat": "Snippet"
     },
@@ -167,7 +167,7 @@
       "label": "TestClass1",
       "kind": "Interface",
       "detail": "Class",
-      "sortText": "K",
+      "sortText": "CK",
       "insertText": "TestClass1",
       "insertTextFormat": "Snippet"
     },
@@ -175,7 +175,7 @@
       "label": "listener1",
       "kind": "Variable",
       "detail": "module1:Listener",
-      "sortText": "C",
+      "sortText": "CC",
       "insertText": "listener1",
       "insertTextFormat": "Snippet"
     },
@@ -189,7 +189,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \n  \n"
         }
       },
-      "sortText": "A",
+      "sortText": "B",
       "filterText": "function1",
       "insertText": "function1()",
       "insertTextFormat": "Snippet"
@@ -204,7 +204,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function2  \n"
         }
       },
-      "sortText": "A",
+      "sortText": "B",
       "filterText": "function2",
       "insertText": "function2()",
       "insertTextFormat": "Snippet"
@@ -219,7 +219,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function3 with input parameters\n  \n**Params**  \n- `int` param1: param1 Parameter Description   \n- `int` param2: param2 Parameter Description  \n- `float[]` param3: param3 Parameter Description  \n  \n**Return** `int`   \n- Return Value Description  \n  \n"
         }
       },
-      "sortText": "A",
+      "sortText": "B",
       "filterText": "function3",
       "insertText": "function3(${1})",
       "insertTextFormat": "Snippet",
@@ -238,7 +238,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function4 with input parameters\n  \n**Params**  \n- `int` param1: param1 Parameter Description   \n- `int` param2: param2 Parameter Description  \n- `string` param3: param3 Parameter Description(Defaultable)  \n- `float[]` param4: param4 Parameter Description"
         }
       },
-      "sortText": "A",
+      "sortText": "B",
       "filterText": "function4",
       "insertText": "function4(${1})",
       "insertTextFormat": "Snippet",
@@ -251,7 +251,7 @@
       "label": "TEST_FUTURE_INT",
       "kind": "Variable",
       "detail": "future<int>",
-      "sortText": "C",
+      "sortText": "CC",
       "insertText": "TEST_FUTURE_INT",
       "insertTextFormat": "Snippet"
     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config16.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config16.json
@@ -15,7 +15,7 @@
           "value": ""
         }
       },
-      "sortText": "H",
+      "sortText": "CH",
       "insertText": "ENUM1_FIELD1",
       "insertTextFormat": "Snippet"
     },
@@ -29,7 +29,7 @@
           "value": ""
         }
       },
-      "sortText": "C",
+      "sortText": "CC",
       "insertText": "TEST_INT_CONST1",
       "insertTextFormat": "Snippet"
     },
@@ -43,7 +43,7 @@
           "value": ""
         }
       },
-      "sortText": "C",
+      "sortText": "CC",
       "insertText": "TEST_STRING_CONST1",
       "insertTextFormat": "Snippet"
     },
@@ -51,7 +51,7 @@
       "label": "AnnotationType",
       "kind": "Struct",
       "detail": "Record",
-      "sortText": "M",
+      "sortText": "CM",
       "insertText": "AnnotationType",
       "insertTextFormat": "Snippet"
     },
@@ -62,7 +62,7 @@
       "documentation": {
         "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
       },
-      "sortText": "I",
+      "sortText": "CI",
       "insertText": "ResponseMessage",
       "insertTextFormat": "Snippet"
     },
@@ -73,7 +73,7 @@
       "documentation": {
         "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
       },
-      "sortText": "I",
+      "sortText": "CI",
       "insertText": "RequestMessage",
       "insertTextFormat": "Snippet"
     },
@@ -81,7 +81,7 @@
       "label": "TestRecord1",
       "kind": "Struct",
       "detail": "Record",
-      "sortText": "M",
+      "sortText": "CM",
       "insertText": "TestRecord1",
       "insertTextFormat": "Snippet"
     },
@@ -89,7 +89,7 @@
       "label": "TestRecord2",
       "kind": "Struct",
       "detail": "Record",
-      "sortText": "M",
+      "sortText": "CM",
       "insertText": "TestRecord2",
       "insertTextFormat": "Snippet"
     },
@@ -97,7 +97,7 @@
       "label": "TestMap2",
       "kind": "TypeParameter",
       "detail": "Map",
-      "sortText": "N",
+      "sortText": "AN",
       "insertText": "TestMap2",
       "insertTextFormat": "Snippet"
     },
@@ -105,7 +105,7 @@
       "label": "TestMap3",
       "kind": "TypeParameter",
       "detail": "Map",
-      "sortText": "N",
+      "sortText": "AN",
       "insertText": "TestMap3",
       "insertTextFormat": "Snippet"
     },
@@ -113,7 +113,7 @@
       "label": "TestObject1",
       "kind": "Interface",
       "detail": "Object",
-      "sortText": "K",
+      "sortText": "CK",
       "insertText": "TestObject1",
       "insertTextFormat": "Snippet"
     },
@@ -121,7 +121,7 @@
       "label": "ErrorOne",
       "kind": "Event",
       "detail": "Error",
-      "sortText": "L",
+      "sortText": "CL",
       "insertText": "ErrorOne",
       "insertTextFormat": "Snippet"
     },
@@ -129,7 +129,7 @@
       "label": "ErrorTwo",
       "kind": "Event",
       "detail": "Error",
-      "sortText": "L",
+      "sortText": "CL",
       "insertText": "ErrorTwo",
       "insertTextFormat": "Snippet"
     },
@@ -137,7 +137,7 @@
       "label": "Listener",
       "kind": "Interface",
       "detail": "Class",
-      "sortText": "K",
+      "sortText": "CK",
       "insertText": "Listener",
       "insertTextFormat": "Snippet"
     },
@@ -148,7 +148,7 @@
       "documentation": {
         "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs."
       },
-      "sortText": "K",
+      "sortText": "CK",
       "insertText": "Client",
       "insertTextFormat": "Snippet"
     },
@@ -159,7 +159,7 @@
       "documentation": {
         "left": "Represents a response.\n"
       },
-      "sortText": "K",
+      "sortText": "CK",
       "insertText": "Response",
       "insertTextFormat": "Snippet"
     },
@@ -167,7 +167,7 @@
       "label": "TestClass1",
       "kind": "Interface",
       "detail": "Class",
-      "sortText": "K",
+      "sortText": "CK",
       "insertText": "TestClass1",
       "insertTextFormat": "Snippet"
     },
@@ -175,7 +175,7 @@
       "label": "listener1",
       "kind": "Variable",
       "detail": "module1:Listener",
-      "sortText": "C",
+      "sortText": "CC",
       "insertText": "listener1",
       "insertTextFormat": "Snippet"
     },
@@ -189,7 +189,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \n  \n"
         }
       },
-      "sortText": "A",
+      "sortText": "B",
       "filterText": "function1",
       "insertText": "function1()",
       "insertTextFormat": "Snippet"
@@ -204,7 +204,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function2  \n"
         }
       },
-      "sortText": "A",
+      "sortText": "B",
       "filterText": "function2",
       "insertText": "function2()",
       "insertTextFormat": "Snippet"
@@ -219,7 +219,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function3 with input parameters\n  \n**Params**  \n- `int` param1: param1 Parameter Description   \n- `int` param2: param2 Parameter Description  \n- `float[]` param3: param3 Parameter Description  \n  \n**Return** `int`   \n- Return Value Description  \n  \n"
         }
       },
-      "sortText": "A",
+      "sortText": "B",
       "filterText": "function3",
       "insertText": "function3(${1})",
       "insertTextFormat": "Snippet",
@@ -238,7 +238,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function4 with input parameters\n  \n**Params**  \n- `int` param1: param1 Parameter Description   \n- `int` param2: param2 Parameter Description  \n- `string` param3: param3 Parameter Description(Defaultable)  \n- `float[]` param4: param4 Parameter Description"
         }
       },
-      "sortText": "A",
+      "sortText": "B",
       "filterText": "function4",
       "insertText": "function4(${1})",
       "insertTextFormat": "Snippet",
@@ -251,7 +251,7 @@
       "label": "TEST_FUTURE_INT",
       "kind": "Variable",
       "detail": "future<int>",
-      "sortText": "C",
+      "sortText": "CC",
       "insertText": "TEST_FUTURE_INT",
       "insertTextFormat": "Snippet"
     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config18.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config18.json
@@ -9,7 +9,7 @@
       "label": "Thread",
       "kind": "TypeParameter",
       "detail": "Union",
-      "sortText": "N",
+      "sortText": "CN",
       "insertText": "Thread",
       "insertTextFormat": "Snippet"
     },
@@ -20,7 +20,7 @@
       "documentation": {
         "left": "Describes Strand execution details for the runtime.\n"
       },
-      "sortText": "M",
+      "sortText": "CM",
       "insertText": "StrandData",
       "insertTextFormat": "Snippet"
     },
@@ -28,7 +28,7 @@
       "label": "Customer",
       "kind": "Struct",
       "detail": "Record",
-      "sortText": "M",
+      "sortText": "CM",
       "insertText": "Customer",
       "insertTextFormat": "Snippet"
     },
@@ -36,7 +36,7 @@
       "label": "readonly",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "readonly",
       "insertTextFormat": "Snippet"
     },
@@ -44,7 +44,7 @@
       "label": "handle",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "handle",
       "insertTextFormat": "Snippet"
     },
@@ -52,7 +52,7 @@
       "label": "never",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "never",
       "insertTextFormat": "Snippet"
     },
@@ -60,7 +60,7 @@
       "label": "json",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "json",
       "insertTextFormat": "Snippet"
     },
@@ -68,7 +68,7 @@
       "label": "anydata",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "anydata",
       "insertTextFormat": "Snippet"
     },
@@ -76,7 +76,7 @@
       "label": "any",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "any",
       "insertTextFormat": "Snippet"
     },
@@ -84,7 +84,7 @@
       "label": "byte",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
     },
@@ -92,7 +92,7 @@
       "label": "service",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "service",
       "insertTextFormat": "Snippet"
     },
@@ -100,7 +100,7 @@
       "label": "record",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "CQ",
       "filterText": "record",
       "insertText": "record ",
       "insertTextFormat": "Snippet"
@@ -109,7 +109,7 @@
       "label": "function",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "CQ",
       "filterText": "function",
       "insertText": "function ",
       "insertTextFormat": "Snippet"
@@ -118,7 +118,7 @@
       "label": "record {}",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "CP",
       "filterText": "record",
       "insertText": "record {${1}}",
       "insertTextFormat": "Snippet"
@@ -127,7 +127,7 @@
       "label": "record {||}",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "CP",
       "filterText": "record",
       "insertText": "record {|${1}|}",
       "insertTextFormat": "Snippet"
@@ -136,7 +136,7 @@
       "label": "distinct",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "CQ",
       "filterText": "distinct",
       "insertText": "distinct",
       "insertTextFormat": "Snippet"
@@ -145,7 +145,7 @@
       "label": "object {}",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "CP",
       "filterText": "object",
       "insertText": "object {${1}}",
       "insertTextFormat": "Snippet"
@@ -154,7 +154,7 @@
       "label": "true",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "CQ",
       "filterText": "true",
       "insertText": "true",
       "insertTextFormat": "Snippet"
@@ -163,7 +163,7 @@
       "label": "false",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "CQ",
       "filterText": "false",
       "insertText": "false",
       "insertTextFormat": "Snippet"
@@ -172,7 +172,7 @@
       "label": "ballerina/lang.array",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "R",
+      "sortText": "CR",
       "filterText": "array",
       "insertText": "array",
       "insertTextFormat": "Snippet",
@@ -196,7 +196,7 @@
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "R",
+      "sortText": "CR",
       "filterText": "runtime",
       "insertText": "runtime",
       "insertTextFormat": "Snippet",
@@ -220,7 +220,7 @@
       "label": "ballerina/module1",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "R",
+      "sortText": "CR",
       "filterText": "module1",
       "insertText": "module1",
       "insertTextFormat": "Snippet",
@@ -244,7 +244,7 @@
       "label": "ballerina/lang.test",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "R",
+      "sortText": "CR",
       "filterText": "test",
       "insertText": "test",
       "insertTextFormat": "Snippet",
@@ -268,7 +268,7 @@
       "label": "ballerina/jballerina.java",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "R",
+      "sortText": "CR",
       "filterText": "java",
       "insertText": "java",
       "insertTextFormat": "Snippet",
@@ -292,7 +292,7 @@
       "label": "ballerina/lang.value",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "R",
+      "sortText": "CR",
       "filterText": "value",
       "insertText": "value",
       "insertTextFormat": "Snippet",
@@ -316,7 +316,7 @@
       "label": "boolean",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "boolean",
       "insertTextFormat": "Snippet"
     },
@@ -324,7 +324,7 @@
       "label": "decimal",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "decimal",
       "insertTextFormat": "Snippet"
     },
@@ -332,7 +332,7 @@
       "label": "error",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "error",
       "insertTextFormat": "Snippet"
     },
@@ -340,7 +340,7 @@
       "label": "float",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "float",
       "insertTextFormat": "Snippet"
     },
@@ -348,7 +348,7 @@
       "label": "future",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "future",
       "insertTextFormat": "Snippet"
     },
@@ -356,7 +356,7 @@
       "label": "int",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "int",
       "insertTextFormat": "Snippet"
     },
@@ -364,7 +364,7 @@
       "label": "map",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "map",
       "insertTextFormat": "Snippet"
     },
@@ -372,7 +372,7 @@
       "label": "object",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "object",
       "insertTextFormat": "Snippet"
     },
@@ -380,7 +380,7 @@
       "label": "stream",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "stream",
       "insertTextFormat": "Snippet"
     },
@@ -388,7 +388,7 @@
       "label": "string",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "string",
       "insertTextFormat": "Snippet"
     },
@@ -396,7 +396,7 @@
       "label": "table",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "table",
       "insertTextFormat": "Snippet"
     },
@@ -404,7 +404,7 @@
       "label": "transaction",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "transaction",
       "insertTextFormat": "Snippet"
     },
@@ -412,7 +412,7 @@
       "label": "typedesc",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "typedesc",
       "insertTextFormat": "Snippet"
     },
@@ -420,7 +420,7 @@
       "label": "xml",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
     },
@@ -428,7 +428,7 @@
       "label": "var",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "CQ",
       "filterText": "var",
       "insertText": "var ",
       "insertTextFormat": "Snippet"

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config29.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config29.json
@@ -1,0 +1,605 @@
+{
+  "position": {
+    "line": 19,
+    "character": 36
+  },
+  "source": "query_expression/source/query_expr_ctx_source29.bal",
+  "items": [
+    {
+      "label": "let",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "CQ",
+      "filterText": "let",
+      "insertText": "let",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.test",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "CR",
+      "filterText": "test",
+      "insertText": "test",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.test;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.array",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "CR",
+      "filterText": "array",
+      "insertText": "array",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.array;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/jballerina.java",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "CR",
+      "filterText": "java",
+      "insertText": "java",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/jballerina.java;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "CR",
+      "filterText": "value",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/module1",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "CR",
+      "filterText": "module1",
+      "insertText": "module1",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/module1;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.runtime",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "CR",
+      "filterText": "runtime",
+      "insertText": "runtime",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.runtime;\n"
+        }
+      ]
+    },
+    {
+      "label": "boolean",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "CR",
+      "insertText": "boolean",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "decimal",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "CR",
+      "insertText": "decimal",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "error",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "CR",
+      "insertText": "error",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "float",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "CR",
+      "insertText": "float",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "future",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "CR",
+      "insertText": "future",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "int",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "CR",
+      "insertText": "int",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "map",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "CR",
+      "insertText": "map",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "object",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "CR",
+      "insertText": "object",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "stream",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "CR",
+      "insertText": "stream",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "CR",
+      "insertText": "string",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "table",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "CR",
+      "insertText": "table",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "transaction",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "CR",
+      "insertText": "transaction",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "typedesc",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "CR",
+      "insertText": "typedesc",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "CR",
+      "insertText": "xml",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "service",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "CQ",
+      "filterText": "service",
+      "insertText": "service",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "new",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "CQ",
+      "filterText": "new",
+      "insertText": "new ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "isolated",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "CQ",
+      "filterText": "isolated",
+      "insertText": "isolated ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "transactional",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "CQ",
+      "filterText": "transactional",
+      "insertText": "transactional",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "function",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "CQ",
+      "filterText": "function",
+      "insertText": "function ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "typeof",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "CQ",
+      "filterText": "typeof",
+      "insertText": "typeof ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "trap",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "CQ",
+      "filterText": "trap",
+      "insertText": "trap",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "client",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "CQ",
+      "filterText": "client",
+      "insertText": "client ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "true",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "CQ",
+      "filterText": "true",
+      "insertText": "true",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "false",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "CQ",
+      "filterText": "false",
+      "insertText": "false",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "null",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "CQ",
+      "filterText": "null",
+      "insertText": "null",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "check",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "CQ",
+      "filterText": "check",
+      "insertText": "check ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "checkpanic",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "CQ",
+      "filterText": "checkpanic",
+      "insertText": "checkpanic ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "is",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "CQ",
+      "filterText": "is",
+      "insertText": "is",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "CP",
+      "filterText": "error",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "object constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "CP",
+      "filterText": "object",
+      "insertText": "object {${1}}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "base16",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "CP",
+      "filterText": "base16",
+      "insertText": "base16 `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "base64",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "CP",
+      "filterText": "base64",
+      "insertText": "base64 `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "from",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "CQ",
+      "filterText": "from",
+      "insertText": "from ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getIntArr()",
+      "kind": "Function",
+      "detail": "int[]",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _._  \n  \n  \n  \n  \n**Return** `int[]`   \n  \n"
+        }
+      },
+      "sortText": "B",
+      "filterText": "getIntArr",
+      "insertText": "getIntArr()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "stringValue",
+      "kind": "Variable",
+      "detail": "string",
+      "sortText": "AB",
+      "insertText": "stringValue",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "intValue",
+      "kind": "Variable",
+      "detail": "int",
+      "sortText": "CB",
+      "insertText": "intValue",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "intArray",
+      "kind": "Variable",
+      "detail": "int[]",
+      "sortText": "AB",
+      "insertText": "intArray",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getStrArr()",
+      "kind": "Function",
+      "detail": "string[]",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _._  \n  \n  \n  \n  \n**Return** `string[]`   \n  \n"
+        }
+      },
+      "sortText": "B",
+      "filterText": "getStrArr",
+      "insertText": "getStrArr()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "StrandData",
+      "kind": "Struct",
+      "detail": "Record",
+      "documentation": {
+        "left": "Describes Strand execution details for the runtime.\n"
+      },
+      "sortText": "CM",
+      "insertText": "StrandData",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Thread",
+      "kind": "TypeParameter",
+      "detail": "Union",
+      "sortText": "CN",
+      "insertText": "Thread",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getMedalStats()",
+      "kind": "Function",
+      "detail": "stream<MedalStatsRecord, error?>|error",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _._  \n  \n  \n  \n  \n**Return** `stream<MedalStatsRecord, error?>|error`   \n  \n"
+        }
+      },
+      "sortText": "B",
+      "filterText": "getMedalStats",
+      "insertText": "getMedalStats()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "MedalStatsRecord",
+      "kind": "Struct",
+      "detail": "Record",
+      "sortText": "CM",
+      "insertText": "MedalStatsRecord",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "tsvStream",
+      "kind": "Variable",
+      "detail": "stream<string[], error?>",
+      "sortText": "AB",
+      "insertText": "tsvStream",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "readonly",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "CR",
+      "insertText": "readonly",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "handle",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "CR",
+      "insertText": "handle",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "never",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "CR",
+      "insertText": "never",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "json",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "CR",
+      "insertText": "json",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "anydata",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "CR",
+      "insertText": "anydata",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "any",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "CR",
+      "insertText": "any",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "byte",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "CR",
+      "insertText": "byte",
+      "insertTextFormat": "Snippet"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config7.json
@@ -9,7 +9,7 @@
       "label": "Thread",
       "kind": "TypeParameter",
       "detail": "Union",
-      "sortText": "N",
+      "sortText": "CN",
       "insertText": "Thread",
       "insertTextFormat": "Snippet"
     },
@@ -20,7 +20,7 @@
       "documentation": {
         "left": "Describes Strand execution details for the runtime.\n"
       },
-      "sortText": "M",
+      "sortText": "CM",
       "insertText": "StrandData",
       "insertTextFormat": "Snippet"
     },
@@ -28,7 +28,7 @@
       "label": "readonly",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "readonly",
       "insertTextFormat": "Snippet"
     },
@@ -36,7 +36,7 @@
       "label": "handle",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "handle",
       "insertTextFormat": "Snippet"
     },
@@ -44,7 +44,7 @@
       "label": "never",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "never",
       "insertTextFormat": "Snippet"
     },
@@ -52,7 +52,7 @@
       "label": "json",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "json",
       "insertTextFormat": "Snippet"
     },
@@ -60,7 +60,7 @@
       "label": "anydata",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "anydata",
       "insertTextFormat": "Snippet"
     },
@@ -68,7 +68,7 @@
       "label": "any",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "any",
       "insertTextFormat": "Snippet"
     },
@@ -76,7 +76,7 @@
       "label": "byte",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
     },
@@ -84,7 +84,7 @@
       "label": "service",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "service",
       "insertTextFormat": "Snippet"
     },
@@ -92,7 +92,7 @@
       "label": "record",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "CQ",
       "filterText": "record",
       "insertText": "record ",
       "insertTextFormat": "Snippet"
@@ -101,7 +101,7 @@
       "label": "function",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "CQ",
       "filterText": "function",
       "insertText": "function ",
       "insertTextFormat": "Snippet"
@@ -110,7 +110,7 @@
       "label": "record {}",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "CP",
       "filterText": "record",
       "insertText": "record {${1}}",
       "insertTextFormat": "Snippet"
@@ -119,7 +119,7 @@
       "label": "record {||}",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "CP",
       "filterText": "record",
       "insertText": "record {|${1}|}",
       "insertTextFormat": "Snippet"
@@ -128,7 +128,7 @@
       "label": "distinct",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "CQ",
       "filterText": "distinct",
       "insertText": "distinct",
       "insertTextFormat": "Snippet"
@@ -137,7 +137,7 @@
       "label": "object {}",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "CP",
       "filterText": "object",
       "insertText": "object {${1}}",
       "insertTextFormat": "Snippet"
@@ -146,7 +146,7 @@
       "label": "true",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "CQ",
       "filterText": "true",
       "insertText": "true",
       "insertTextFormat": "Snippet"
@@ -155,7 +155,7 @@
       "label": "false",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "CQ",
       "filterText": "false",
       "insertText": "false",
       "insertTextFormat": "Snippet"
@@ -164,7 +164,7 @@
       "label": "module1",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "O",
+      "sortText": "CO",
       "filterText": "module1",
       "insertText": "module1",
       "insertTextFormat": "Snippet"
@@ -173,7 +173,7 @@
       "label": "ballerina/lang.array",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "R",
+      "sortText": "CR",
       "filterText": "array",
       "insertText": "array",
       "insertTextFormat": "Snippet",
@@ -197,7 +197,7 @@
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "R",
+      "sortText": "CR",
       "filterText": "runtime",
       "insertText": "runtime",
       "insertTextFormat": "Snippet",
@@ -221,7 +221,7 @@
       "label": "ballerina/lang.test",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "R",
+      "sortText": "CR",
       "filterText": "test",
       "insertText": "test1",
       "insertTextFormat": "Snippet",
@@ -245,7 +245,7 @@
       "label": "ballerina/jballerina.java",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "R",
+      "sortText": "CR",
       "filterText": "java",
       "insertText": "java",
       "insertTextFormat": "Snippet",
@@ -269,7 +269,7 @@
       "label": "boolean",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "boolean",
       "insertTextFormat": "Snippet"
     },
@@ -277,7 +277,7 @@
       "label": "decimal",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "decimal",
       "insertTextFormat": "Snippet"
     },
@@ -285,7 +285,7 @@
       "label": "error",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "error",
       "insertTextFormat": "Snippet"
     },
@@ -293,7 +293,7 @@
       "label": "float",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "float",
       "insertTextFormat": "Snippet"
     },
@@ -301,7 +301,7 @@
       "label": "future",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "future",
       "insertTextFormat": "Snippet"
     },
@@ -309,7 +309,7 @@
       "label": "int",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "int",
       "insertTextFormat": "Snippet"
     },
@@ -317,7 +317,7 @@
       "label": "map",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "map",
       "insertTextFormat": "Snippet"
     },
@@ -325,7 +325,7 @@
       "label": "object",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "object",
       "insertTextFormat": "Snippet"
     },
@@ -333,7 +333,7 @@
       "label": "stream",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "stream",
       "insertTextFormat": "Snippet"
     },
@@ -341,7 +341,7 @@
       "label": "string",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "string",
       "insertTextFormat": "Snippet"
     },
@@ -349,7 +349,7 @@
       "label": "table",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "table",
       "insertTextFormat": "Snippet"
     },
@@ -357,7 +357,7 @@
       "label": "transaction",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "transaction",
       "insertTextFormat": "Snippet"
     },
@@ -365,7 +365,7 @@
       "label": "typedesc",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "typedesc",
       "insertTextFormat": "Snippet"
     },
@@ -373,7 +373,7 @@
       "label": "xml",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
     },
@@ -381,7 +381,7 @@
       "label": "var",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "CQ",
       "filterText": "var",
       "insertText": "var ",
       "insertTextFormat": "Snippet"
@@ -390,7 +390,7 @@
       "label": "ballerina/lang.value",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "R",
+      "sortText": "CR",
       "filterText": "value",
       "insertText": "value",
       "insertTextFormat": "Snippet",

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config8.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config8.json
@@ -9,7 +9,7 @@
       "label": "Thread",
       "kind": "TypeParameter",
       "detail": "Union",
-      "sortText": "N",
+      "sortText": "CN",
       "insertText": "Thread",
       "insertTextFormat": "Snippet"
     },
@@ -20,7 +20,7 @@
       "documentation": {
         "left": "Describes Strand execution details for the runtime.\n"
       },
-      "sortText": "M",
+      "sortText": "CM",
       "insertText": "StrandData",
       "insertTextFormat": "Snippet"
     },
@@ -28,7 +28,7 @@
       "label": "readonly",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "readonly",
       "insertTextFormat": "Snippet"
     },
@@ -36,7 +36,7 @@
       "label": "handle",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "handle",
       "insertTextFormat": "Snippet"
     },
@@ -44,7 +44,7 @@
       "label": "never",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "never",
       "insertTextFormat": "Snippet"
     },
@@ -52,7 +52,7 @@
       "label": "json",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "json",
       "insertTextFormat": "Snippet"
     },
@@ -60,7 +60,7 @@
       "label": "anydata",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "anydata",
       "insertTextFormat": "Snippet"
     },
@@ -68,7 +68,7 @@
       "label": "any",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "any",
       "insertTextFormat": "Snippet"
     },
@@ -76,7 +76,7 @@
       "label": "byte",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
     },
@@ -84,7 +84,7 @@
       "label": "service",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "service",
       "insertTextFormat": "Snippet"
     },
@@ -92,7 +92,7 @@
       "label": "record",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "CQ",
       "filterText": "record",
       "insertText": "record ",
       "insertTextFormat": "Snippet"
@@ -101,7 +101,7 @@
       "label": "function",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "CQ",
       "filterText": "function",
       "insertText": "function ",
       "insertTextFormat": "Snippet"
@@ -110,7 +110,7 @@
       "label": "record {}",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "CP",
       "filterText": "record",
       "insertText": "record {${1}}",
       "insertTextFormat": "Snippet"
@@ -119,7 +119,7 @@
       "label": "record {||}",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "CP",
       "filterText": "record",
       "insertText": "record {|${1}|}",
       "insertTextFormat": "Snippet"
@@ -128,7 +128,7 @@
       "label": "distinct",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "CQ",
       "filterText": "distinct",
       "insertText": "distinct",
       "insertTextFormat": "Snippet"
@@ -137,7 +137,7 @@
       "label": "object {}",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "CP",
       "filterText": "object",
       "insertText": "object {${1}}",
       "insertTextFormat": "Snippet"
@@ -146,7 +146,7 @@
       "label": "true",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "CQ",
       "filterText": "true",
       "insertText": "true",
       "insertTextFormat": "Snippet"
@@ -155,7 +155,7 @@
       "label": "false",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "CQ",
       "filterText": "false",
       "insertText": "false",
       "insertTextFormat": "Snippet"
@@ -164,7 +164,7 @@
       "label": "module1",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "O",
+      "sortText": "CO",
       "filterText": "module1",
       "insertText": "module1",
       "insertTextFormat": "Snippet"
@@ -173,7 +173,7 @@
       "label": "ballerina/lang.array",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "R",
+      "sortText": "CR",
       "filterText": "array",
       "insertText": "array",
       "insertTextFormat": "Snippet",
@@ -197,7 +197,7 @@
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "R",
+      "sortText": "CR",
       "filterText": "runtime",
       "insertText": "runtime",
       "insertTextFormat": "Snippet",
@@ -221,7 +221,7 @@
       "label": "ballerina/jballerina.java",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "R",
+      "sortText": "CR",
       "filterText": "java",
       "insertText": "java",
       "insertTextFormat": "Snippet",
@@ -245,7 +245,7 @@
       "label": "boolean",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "boolean",
       "insertTextFormat": "Snippet"
     },
@@ -253,7 +253,7 @@
       "label": "decimal",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "decimal",
       "insertTextFormat": "Snippet"
     },
@@ -261,7 +261,7 @@
       "label": "error",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "error",
       "insertTextFormat": "Snippet"
     },
@@ -269,7 +269,7 @@
       "label": "float",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "float",
       "insertTextFormat": "Snippet"
     },
@@ -277,7 +277,7 @@
       "label": "future",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "future",
       "insertTextFormat": "Snippet"
     },
@@ -285,7 +285,7 @@
       "label": "int",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "int",
       "insertTextFormat": "Snippet"
     },
@@ -293,7 +293,7 @@
       "label": "map",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "map",
       "insertTextFormat": "Snippet"
     },
@@ -301,7 +301,7 @@
       "label": "object",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "object",
       "insertTextFormat": "Snippet"
     },
@@ -309,7 +309,7 @@
       "label": "stream",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "stream",
       "insertTextFormat": "Snippet"
     },
@@ -317,7 +317,7 @@
       "label": "string",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "string",
       "insertTextFormat": "Snippet"
     },
@@ -325,7 +325,7 @@
       "label": "table",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "table",
       "insertTextFormat": "Snippet"
     },
@@ -333,7 +333,7 @@
       "label": "transaction",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "transaction",
       "insertTextFormat": "Snippet"
     },
@@ -341,7 +341,7 @@
       "label": "typedesc",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "typedesc",
       "insertTextFormat": "Snippet"
     },
@@ -349,7 +349,7 @@
       "label": "xml",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "R",
+      "sortText": "CR",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
     },
@@ -357,7 +357,7 @@
       "label": "var",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "CQ",
       "filterText": "var",
       "insertText": "var ",
       "insertTextFormat": "Snippet"
@@ -366,7 +366,7 @@
       "label": "ballerina/lang.value",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "R",
+      "sortText": "CR",
       "filterText": "value",
       "insertText": "value",
       "insertTextFormat": "Snippet",
@@ -390,7 +390,7 @@
       "label": "ballerina/lang.test",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "R",
+      "sortText": "CR",
       "filterText": "test",
       "insertText": "test",
       "insertTextFormat": "Snippet",

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/source/query_expr_ctx_source29.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/source/query_expr_ctx_source29.bal
@@ -1,0 +1,21 @@
+function getIntArr() returns int[] { 
+    return [];
+}
+
+function getStrArr() returns string[] { 
+    return [];
+}
+
+type MedalStatsRecord record {
+
+}; 
+
+function getMedalStats() returns stream<MedalStatsRecord, error?> | error {
+    int intValue;
+    string stringValue; 
+    int[] intArray;
+
+    stream<string[], error?> tsvStream;
+
+    return stream from var entry in 
+}


### PR DESCRIPTION
## Purpose
This PR improves the sorting order of completion items in from clause context giving priority to,
1. Iterables
2. Function call expressions
3. Default sorting to the rest of the completion items

Fixes #33861

## Samples
<img width="730" alt="Screenshot 2021-12-09 at 18 53 56" src="https://user-images.githubusercontent.com/27485094/145563676-866c72f0-1f0a-4c88-b193-b68aa23e3696.png">


## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
