### PR TITLE
Fix performance forecaster caching issue

### DIFF
--- a/misc/ls-extensions/modules/performance-analyzer-services/src/main/java/io/ballerina/PerformanceAnalyzerNodeVisitor.java
+++ b/misc/ls-extensions/modules/performance-analyzer-services/src/main/java/io/ballerina/PerformanceAnalyzerNodeVisitor.java
@@ -64,7 +64,6 @@ import org.eclipse.lsp4j.Range;
 
 import java.util.HashMap;
 import java.util.Optional;
-import java.util.UUID;
 
 /**
  * Visitor to discover the program structure.
@@ -88,6 +87,7 @@ public class PerformanceAnalyzerNodeVisitor extends NodeVisitor {
     private Node currentNode;
     private Document document;
     private boolean withinRange = false;
+    private int uuid;
 
     public PerformanceAnalyzerNodeVisitor(SemanticModel model, String file, Range range) {
 
@@ -435,7 +435,7 @@ public class PerformanceAnalyzerNodeVisitor extends NodeVisitor {
             return referenceMap.get(lineRange);
         }
 
-        String uuid = UUID.randomUUID().toString();
+        String uuid = String.valueOf(this.uuid++);
         referenceMap.put(lineRange, uuid);
         return uuid;
     }


### PR DESCRIPTION
## Purpose
> Performance forecaster caching is not working due to the usage of the UUID. This PR implements alternative way and fix the issue.

## Approach
> Removed the UUID usage and added an incremental integer value for the endpoint ID.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
