### PR TITLE
Fix MatchedExpressionNodeResolver returning null

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/MatchedExpressionNodeResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/MatchedExpressionNodeResolver.java
@@ -36,6 +36,9 @@ import java.util.Optional;
 /**
  * Node Transformer to find the container expression node for a given node.
  *
+ * <strong>Note</strong>: Rather than doing {@code node.apply(expressionResolver)}, 
+ * please use {@link #findExpression(Node)} since the {@code node.apply()} method may return {@code null}.
+ *
  * @since 2.0.0
  */
 public class MatchedExpressionNodeResolver extends NodeTransformer<Optional<ExpressionNode>> {
@@ -46,6 +49,26 @@ public class MatchedExpressionNodeResolver extends NodeTransformer<Optional<Expr
         this.matchedNode = matchedNode;
     }
 
+    /**
+     * Given the node, this method returns the optional expression in which the provided node is located.
+     *
+     * @param node Node
+     * @return Optional enclosing expression node
+     */
+    public Optional<ExpressionNode> findExpression(Node node) {
+        if (node == null) {
+            return Optional.empty();
+        }
+
+        Optional<ExpressionNode> exprNode = node.apply(this);
+        // Due to the way apply() method is implemented in some cases, this can return null
+        if (exprNode == null) {
+            return Optional.empty();
+        }
+        
+        return exprNode;
+    }
+    
     @Override
     protected Optional<ExpressionNode> transformSyntaxNode(Node node) {
         if (node.parent() == null) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/MatchedExpressionNodeResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/MatchedExpressionNodeResolver.java
@@ -62,11 +62,7 @@ public class MatchedExpressionNodeResolver extends NodeTransformer<Optional<Expr
 
         Optional<ExpressionNode> exprNode = node.apply(this);
         // Due to the way apply() method is implemented in some cases, this can return null
-        if (exprNode == null) {
-            return Optional.empty();
-        }
-        
-        return exprNode;
+        return exprNode == null ? Optional.empty() : exprNode;
     }
     
     @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/AddCheckCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/AddCheckCodeAction.java
@@ -69,7 +69,7 @@ public class AddCheckCodeAction extends TypeCastCodeAction {
         //Check if there is a check expression already present.
         MatchedExpressionNodeResolver expressionResolver =
                 new MatchedExpressionNodeResolver(positionDetails.matchedNode());
-        Optional<ExpressionNode> expressionNode = positionDetails.matchedNode().apply(expressionResolver);
+        Optional<ExpressionNode> expressionNode = expressionResolver.findExpression(positionDetails.matchedNode());
         if (expressionNode.isEmpty() || expressionNode.get().kind() == SyntaxKind.CHECK_EXPRESSION) {
             return Collections.emptyList();
         }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/TypeCastCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/TypeCastCodeAction.java
@@ -73,7 +73,7 @@ public class TypeCastCodeAction extends AbstractCodeActionProvider {
         //Check if there is a type cast expression already present.
         MatchedExpressionNodeResolver expressionResolver = 
                 new MatchedExpressionNodeResolver(positionDetails.matchedNode());
-        Optional<ExpressionNode> expressionNode = positionDetails.matchedNode().apply(expressionResolver);
+        Optional<ExpressionNode> expressionNode = expressionResolver.findExpression(positionDetails.matchedNode());
         if (expressionNode.isEmpty() || expressionNode.get().kind() == SyntaxKind.TYPE_CAST_EXPRESSION) {
             return Collections.emptyList();
         }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/HoverUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/HoverUtil.java
@@ -91,7 +91,7 @@ public class HoverUtil {
             NonTerminalNode nodeAtCursor = CommonUtil.findNode(nodeRange, srcFile.get().syntaxTree());
             if (nodeAtCursor != null) {
                 MatchedExpressionNodeResolver expressionResolver = new MatchedExpressionNodeResolver(nodeAtCursor);
-                Optional<ExpressionNode> expr = nodeAtCursor.apply(expressionResolver);
+                Optional<ExpressionNode> expr = expressionResolver.findExpression(nodeAtCursor);
                 if (expr.isPresent()) {
                     return getHoverForExpression(context, expr.get());
                 }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/AddCheckCodeActionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/AddCheckCodeActionTest.java
@@ -55,6 +55,7 @@ public class AddCheckCodeActionTest extends AbstractCodeActionTest {
     public Object[][] negativeDataProvider() {
         return new Object[][]{
                 {"negative_add_check_codeaction_config1.json", "negative_add_check_codeaction_source1.bal"},
+                {"negative_add_check_external_treenode_list.json", "negative_add_check_external_treenode_list.bal"},
         };
     }
 

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/add-check/config/negative_add_check_external_treenode_list.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/add-check/config/negative_add_check_external_treenode_list.json
@@ -1,0 +1,9 @@
+{
+  "line": 9,
+  "character": 19,
+  "expected": [
+    {
+      "title": "Add 'check' error"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/add-check/source/negative_add_check_external_treenode_list.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/add-check/source/negative_add_check_external_treenode_list.bal
@@ -1,0 +1,10 @@
+type Foo object {
+    string name;
+};
+
+type A object {
+    *Foo;
+    int z;
+};
+
+A x = object {123, ""}


### PR DESCRIPTION
## Purpose
$subject

The `apply()` method of `ExternalTreeNodeList` returns `null` causing the `Optional` to be null in `MatchedExpressionNodeResolver` case. Changed the behavior of `MatchedExpressionNodeResolver` to not expose this behavior to the outside.

Fixes #34318

## Approach
See description

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
