### PR TITLE
Fix symbol lookup issues in type refs

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeReferenceTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeReferenceTypeSymbol.java
@@ -25,8 +25,9 @@ import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.tools.diagnostics.Location;
-import org.wso2.ballerinalang.compiler.semantics.model.symbols.BPackageSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.Scope;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BParameterizedType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BTypeReferenceType;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
@@ -94,7 +95,15 @@ public class BallerinaTypeReferenceTypeSymbol extends AbstractTypeSymbol impleme
         }
 
         SymbolFactory symbolFactory = SymbolFactory.getInstance(this.context);
-        this.definition = symbolFactory.getBCompiledSymbol(tSymbol, this.name());
+
+        if (this.getReferredType(this.getBType()).tag == TypeTags.PARAMETERIZED_TYPE) {
+            this.definition = symbolFactory.getBCompiledSymbol(((BParameterizedType) this.tSymbol.type).paramSymbol,
+                                                               this.name());
+        } else {
+            Scope.ScopeEntry scopeEntry = tSymbol.owner.scope.lookup(Names.fromString(this.name()));
+            this.definition = symbolFactory.getBCompiledSymbol(scopeEntry.symbol, this.name());
+        }
+
         return this.definition;
     }
 
@@ -110,20 +119,13 @@ public class BallerinaTypeReferenceTypeSymbol extends AbstractTypeSymbol impleme
         }
 
         this.moduleEvaluated = true;
-        BSymbol symbol = this.getBType().tsymbol.owner;
-        while (symbol != null) {
-            if (symbol instanceof BPackageSymbol) {
-                break;
-            }
-            symbol = symbol.owner;
-        }
+        Symbol definition = this.definition();
 
-        if (symbol == null) {
+        if (definition.getModule().isEmpty()) {
             return Optional.empty();
         }
 
-        SymbolFactory symbolFactory = SymbolFactory.getInstance(this.context);
-        this.module = symbolFactory.createModuleSymbol((BPackageSymbol) symbol, symbol.name.value);
+        this.module = definition.getModule().get();
         return Optional.of(this.module);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/TypesFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/TypesFactory.java
@@ -327,7 +327,7 @@ public class TypesFactory {
         }
 
         final TypeKind kind = bType.getKind();
-        return kind == PARAMETERIZED || tSymbol.kind == SymbolKind.TYPE_DEF
+        return kind == PARAMETERIZED
                 || tSymbol.kind == SymbolKind.ENUM || isCustomError(tSymbol);
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/ErrorTypeSymbolTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/ErrorTypeSymbolTest.java
@@ -22,6 +22,7 @@ import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.Documentable;
 import io.ballerina.compiler.api.symbols.Documentation;
 import io.ballerina.compiler.api.symbols.ErrorTypeSymbol;
+import io.ballerina.compiler.api.symbols.ModuleSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeDefinitionSymbol;
@@ -99,15 +100,31 @@ public class ErrorTypeSymbolTest {
 
         for (TypeSymbol typeSymbol : memberTypeSymbols) {
             assertEquals(((TypeReferenceTypeSymbol) typeSymbol).typeDescriptor().typeKind(), TypeDescKind.ERROR);
-            assertEquals(((typeSymbol).getModule().get()).id().orgName(), Names.ANON_ORG.toString());
-            assertEquals(((typeSymbol).getModule().get()).id().moduleName(), PackageID.DEFAULT.toString());
+            assertModuleInfo(typeSymbol.getModule().get());
         }
 
         assertTrue(distinctErrorSymbol.isPresent());
         ErrorTypeSymbol errorTypeSymbol =
                 (ErrorTypeSymbol) ((TypeDefinitionSymbol) distinctErrorSymbol.get()).typeDescriptor();
         assertEquals(errorTypeSymbol.typeKind(), TypeDescKind.ERROR);
-        assertEquals(errorTypeSymbol.getModule().get().id().moduleName(), PackageID.DEFAULT.toString());
-        assertEquals(errorTypeSymbol.getModule().get().id().orgName(), Names.ANON_ORG.toString());
+        assertModuleInfo(errorTypeSymbol.getModule().get());
+    }
+
+    @Test
+    public void testErrorTypeRef() {
+        Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(32, 4));
+
+        assertTrue(symbol.isPresent());
+        assertEquals(symbol.get().kind(), SymbolKind.TYPE);
+
+        TypeSymbol type = (TypeSymbol) symbol.get();
+        assertEquals(type.typeKind(), TypeDescKind.TYPE_REFERENCE);
+        assertEquals(type.getName().get(), "SendError");
+        assertModuleInfo(type.getModule().get());
+    }
+
+    private void assertModuleInfo(ModuleSymbol module) {
+        assertEquals(module.id().orgName(), Names.ANON_ORG.toString());
+        assertEquals(module.id().moduleName(), PackageID.DEFAULT.toString());
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typedescriptors/TypeReferenceTSymbolTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typedescriptors/TypeReferenceTSymbolTest.java
@@ -24,6 +24,7 @@ import io.ballerina.compiler.api.symbols.EnumSymbol;
 import io.ballerina.compiler.api.symbols.RecordFieldSymbol;
 import io.ballerina.compiler.api.symbols.RecordTypeSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeDefinitionSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
@@ -31,9 +32,13 @@ import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.VariableSymbol;
 import io.ballerina.projects.Document;
 import io.ballerina.projects.Project;
+import io.ballerina.tools.text.LinePosition;
+import org.ballerinalang.model.elements.PackageID;
 import org.ballerinalang.test.BCompileUtil;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.wso2.ballerinalang.compiler.util.Names;
 
 import java.util.Map;
 import java.util.Optional;
@@ -46,6 +51,7 @@ import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDocume
 import static io.ballerina.tools.text.LinePosition.from;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
 
 /**
  * Test cases for the type reference type descriptor.
@@ -148,5 +154,27 @@ public class TypeReferenceTSymbolTest {
 
         type = ((TypeReferenceTypeSymbol) type).typeDescriptor();
         assertEquals(type.typeKind(), TypeDescKind.RECORD);
+    }
+
+    @Test(dataProvider = "TypeRefPos")
+    public void testTypeRefLookup(int line, int col, String expName) {
+        Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, col));
+
+        assertTrue(symbol.isPresent());
+        assertEquals(symbol.get().kind(), SymbolKind.TYPE);
+
+        TypeSymbol type = (TypeSymbol) symbol.get();
+        assertEquals(type.typeKind(), TypeDescKind.TYPE_REFERENCE);
+        assertEquals(type.getName().get(), expName);
+        assertEquals(type.getModule().get().id().orgName(), Names.ANON_ORG.toString());
+        assertEquals(type.getModule().get().id().moduleName(), PackageID.DEFAULT.toString());
+    }
+
+    @DataProvider(name = "TypeRefPos")
+    public Object[][] getTypeRefPos() {
+        return new Object[][]{
+                {46, 4, "Foo"},
+                {48, 4, "Baz"},
+        };
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbols/error_type_symbol_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbols/error_type_symbol_test.bal
@@ -28,3 +28,7 @@ public type EmailError SendError|ReadClientInitError|ReadError;
 
 # Represents the operation canceled(typically by the caller) error.
 public type CancelledError distinct error;
+
+function test() {
+    SendError err;
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/typedescriptors/typeref_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/typedescriptors/typeref_test.bal
@@ -46,9 +46,12 @@ function test() {
 
     Foo f;
     Bar b;
+    Baz z;
 }
 
 // utils
 type Foo Person;
 
 type Bar Foo;
+
+type Baz decimal;


### PR DESCRIPTION
## Purpose
This PR fixes a couple of issues related to type refs that were there when one tries to lookup the symbol of a type ref.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
