### PR TITLE
Add `decodeIdentifier()` runtime API for log module

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/utils/IdentifierUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/utils/IdentifierUtils.java
@@ -1,0 +1,43 @@
+/*
+ *   Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.runtime.api.utils;
+
+import io.ballerina.identifier.Utils;
+
+/**
+ * Utils class that provides methods to decode identifiers with special characters.
+ *
+ * @since 2.0.0
+ */
+public class IdentifierUtils {
+
+    private IdentifierUtils() {
+    }
+
+    /**
+     * Decode the encoded identifiers for runtime calls.
+     *
+     * @param encodedIdentifier encoded identifier string
+     * @return decoded identifier
+     */
+    public static String decodeIdentifier(String encodedIdentifier) {
+        return Utils.decodeIdentifier(encodedIdentifier);
+    }
+
+}

--- a/misc/identifier-util/src/main/java/module-info.java
+++ b/misc/identifier-util/src/main/java/module-info.java
@@ -4,5 +4,5 @@ module io.ballerina.identifier {
 
     exports io.ballerina.identifier to io.ballerina.lang, io.ballerina.runtime, io.ballerina.shell,
             io.ballerina.testerina.runtime, io.ballerina.lang.runtime, io.ballerina.lang.error, io.ballerina.cli,
-            ballerina.debug.adapter.core;
+            ballerina.debug.adapter.core, io.ballerina.stdlib.log, io.ballerina.stdlib.http;
 }

--- a/misc/identifier-util/src/main/java/module-info.java
+++ b/misc/identifier-util/src/main/java/module-info.java
@@ -4,5 +4,5 @@ module io.ballerina.identifier {
 
     exports io.ballerina.identifier to io.ballerina.lang, io.ballerina.runtime, io.ballerina.shell,
             io.ballerina.testerina.runtime, io.ballerina.lang.runtime, io.ballerina.lang.error, io.ballerina.cli,
-            ballerina.debug.adapter.core, io.ballerina.stdlib.log;
+            ballerina.debug.adapter.core;
 }

--- a/misc/identifier-util/src/main/java/module-info.java
+++ b/misc/identifier-util/src/main/java/module-info.java
@@ -4,5 +4,5 @@ module io.ballerina.identifier {
 
     exports io.ballerina.identifier to io.ballerina.lang, io.ballerina.runtime, io.ballerina.shell,
             io.ballerina.testerina.runtime, io.ballerina.lang.runtime, io.ballerina.lang.error, io.ballerina.cli,
-            ballerina.debug.adapter.core, io.ballerina.stdlib.log, io.ballerina.stdlib.http;
+            ballerina.debug.adapter.core, io.ballerina.stdlib.log;
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
@@ -33,6 +33,7 @@ import io.ballerina.runtime.api.types.ServiceType;
 import io.ballerina.runtime.api.types.TupleType;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.types.TypeId;
+import io.ballerina.runtime.api.utils.IdentifierUtils;
 import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.values.BArray;
 import io.ballerina.runtime.api.values.BFunctionPointer;
@@ -147,5 +148,9 @@ public class Values {
             index++;
         }
         return arrayValue;
+    }
+
+    public static BString decodeIdentifier(BString identifier) {
+        return StringUtils.fromString(IdentifierUtils.decodeIdentifier(identifier.getValue()));
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/runtime/api/RuntimeAPITest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/runtime/api/RuntimeAPITest.java
@@ -52,4 +52,10 @@ public class RuntimeAPITest {
         CompileResult result = BCompileUtil.compile("test-src/runtime/api/async");
         BRunUtil.invoke(result, "main");
     }
+
+    @Test
+    public void utilsTest() {
+        CompileResult result = BCompileUtil.compile("test-src/runtime/api/util");
+        BRunUtil.invoke(result, "main");
+    }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/util/Ballerina.toml
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/util/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org= "testorg"
+name="runtime_api"
+version= "1.0.0"

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/util/main.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/util/main.bal
@@ -1,0 +1,33 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+import ballerina/jballerina.java;
+
+public function main() {
+    testIdentifierDecoding();
+}
+
+function testIdentifierDecoding() {
+    test:assertEquals(decodeIdentifier("üňĩćőđę_ƈȏɳʂʈ_IL"), "üňĩćőđę_ƈȏɳʂʈ_IL");
+    test:assertEquals(decodeIdentifier("const_IL_123"), "const_IL_123");
+    test:assertEquals(decodeIdentifier(" $0047$0058@$0091`{~_IL"), " /:@[`{~_IL");
+}
+
+function decodeIdentifier(string s) returns string = @java:Method {
+    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
+} external;
+


### PR DESCRIPTION
## Purpose
$subject
Fixes #34325

## Remarks
As `log` & `http` standard libraries use identifier util methods, we need to export them.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
