### PR TITLE
Fix debugger ExpressionEvaluationTest

### DIFF
--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/evaluation/ExpressionEvaluationTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/evaluation/ExpressionEvaluationTest.java
@@ -172,7 +172,9 @@ public class ExpressionEvaluationTest extends ExpressionEvaluationBaseTest {
 
         debugTestRunner.assertExpression(context, "nameWithType", "\"Ballerina\"", "string");
         debugTestRunner.assertExpression(context, "nameWithoutType", "\"Ballerina\"", "string");
-        debugTestRunner.assertExpression(context, GLOBAL_VAR_03, "map (size = 1)", "map");
+        debugTestRunner.assertExpression(context, GLOBAL_VAR_03,
+                                         "(debug_test_resources/evaluation_tests:0:$anonType$_10 & readonly)",
+                                         "record");
         debugTestRunner.assertExpression(context, GLOBAL_VAR_04, "()", "nil");
         debugTestRunner.assertExpression(context, GLOBAL_VAR_05, "()", "nil");
         // global variables
@@ -185,7 +187,9 @@ public class ExpressionEvaluationTest extends ExpressionEvaluationBaseTest {
 
         // with qualified literals (i.e. imported modules)
         debugTestRunner.assertExpression(context, "other:publicConstant", "\"Ballerina\"", "string");
-        debugTestRunner.assertExpression(context, "other:constMap", "map (size = 1)", "map");
+        debugTestRunner.assertExpression(context, "other:constMap",
+                                         "(debug_test_resources/evaluation_tests.other:0:$anonType$_3 & readonly)",
+                                         "record");
         debugTestRunner.assertExpression(context, "int:MAX_VALUE", "9223372036854775807", "int");
         // qualified name references with import alias
         debugTestRunner.assertExpression(context, "langFloat:PI", "3.141592653589793", "float");


### PR DESCRIPTION
## Purpose
$title.

Verified using VSCode also.

Where the source is

```ballerina
const map<int> M = {a: 1};

record {int i;} x = {i: 1};
```

Previously we got
```cmd
x
record {| int i; anydata...; |}
i:1
M
map (size = 1)
a:1
```

Now it is

```cmd
x
record {| int i; anydata...; |}
i:1
M
record {| readonly 1 a; |} & readonly
a:1
```