### PR TITLE
Check array capacity before `unshift()`

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ArrayValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ArrayValueImpl.java
@@ -656,32 +656,36 @@ public class ArrayValueImpl extends AbstractArrayValue {
                 }
                 break;
             default:
-                for (int i = 0; i < size; i++) {
-                    if (refValues[i] == null) {
-                        sj.add("null");
-                    } else {
-                        Type type = TypeChecker.getType(refValues[i]);
-                        switch (type.getTag()) {
-                            case TypeTags.STRING_TAG:
-                            case TypeTags.XML_TAG:
-                            case TypeTags.XML_ELEMENT_TAG:
-                            case TypeTags.XML_ATTRIBUTES_TAG:
-                            case TypeTags.XML_COMMENT_TAG:
-                            case TypeTags.XML_PI_TAG:
-                            case TypeTags.XMLNS_TAG:
-                            case TypeTags.XML_TEXT_TAG:
-                                sj.add(((BValue) (refValues[i])).informalStringValue(new CycleUtils
-                                        .Node(this, parent)));
-                                break;
-                            default:
-                                sj.add(StringUtils.getStringValue(refValues[i], new CycleUtils.Node(this, parent)));
-                                break;
-                        }
-                    }
-                }
+                getRefValuesString(parent, sj);
                 break;
         }
         return "[" + sj + "]";
+    }
+
+    private void getRefValuesString(BLink parent, StringJoiner sj) {
+        for (int i = 0; i < size; i++) {
+            if (refValues[i] == null) {
+                sj.add("null");
+            } else {
+                Type type = TypeChecker.getType(refValues[i]);
+                switch (type.getTag()) {
+                    case TypeTags.STRING_TAG:
+                    case TypeTags.XML_TAG:
+                    case TypeTags.XML_ELEMENT_TAG:
+                    case TypeTags.XML_ATTRIBUTES_TAG:
+                    case TypeTags.XML_COMMENT_TAG:
+                    case TypeTags.XML_PI_TAG:
+                    case TypeTags.XMLNS_TAG:
+                    case TypeTags.XML_TEXT_TAG:
+                        sj.add(((BValue) (refValues[i])).informalStringValue(new CycleUtils
+                                .Node(this, parent)));
+                        break;
+                    default:
+                        sj.add(StringUtils.getStringValue(refValues[i], new CycleUtils.Node(this, parent)));
+                        break;
+                }
+            }
+        }
     }
 
     @Override
@@ -1206,15 +1210,14 @@ public class ArrayValueImpl extends AbstractArrayValue {
     private void unshiftArray(long index, int unshiftByN, int arrLength) {
         int lastIndex = size() + unshiftByN - 1;
         prepareForConsecutiveMultiAdd(lastIndex, arrLength);
-        Object arr = getArrayFromType(elementType.getTag());
-
         if (index > lastIndex) {
             throw BLangExceptionHelper.getRuntimeException(
                     getModulePrefixedReason(ARRAY_LANG_LIB, INDEX_OUT_OF_RANGE_ERROR_IDENTIFIER),
                     RuntimeErrors.INDEX_NUMBER_TOO_LARGE, index);
         }
-
         int i = (int) index;
+        ensureCapacity(this.size - i + 1, this.size);
+        Object arr = getArrayFromType(elementType.getTag());
         System.arraycopy(arr, i, arr, i + unshiftByN, this.size - i);
     }
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ArrayValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ArrayValueImpl.java
@@ -1216,7 +1216,7 @@ public class ArrayValueImpl extends AbstractArrayValue {
                     RuntimeErrors.INDEX_NUMBER_TOO_LARGE, index);
         }
         int i = (int) index;
-        ensureCapacity(this.size - i + 1, this.size);
+        ensureCapacity(this.size + unshiftByN, this.size);
         Object arr = getArrayFromType(elementType.getTag());
         System.arraycopy(arr, i, arr, i + unshiftByN, this.size - i);
     }

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibArrayTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibArrayTest.java
@@ -510,7 +510,8 @@ public class LangLibArrayTest {
                 "testReverseMap",
                 "testReverseRecord",
                 "testArrayReverseEquality",
-                "testPushAfterSliceOnTuple"
+                "testPushAfterSliceOnTuple",
+                "testUnshiftLargeValues"
         };
     }
 }

--- a/langlib/langlib-test/src/test/resources/test-src/arraylib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/arraylib_test.bal
@@ -1447,3 +1447,14 @@ function testToStreamOnImmutableArray() {
     stream<byte[] & readonly> castedstrm = <stream<byte[] & readonly>>strm;
     assertValueEquality([1, 2], castedstrm.next()?.value);
 }
+
+function testUnshiftLargeValues() {
+    int[] list = [];
+    foreach int i in 0 ..< 400 {
+        list.unshift(i);
+    }
+    assertValueEquality(400, list.length());
+    assertValueEquality(399, list[0]);
+    assertValueEquality(199, list[200]);
+    assertValueEquality(0, list[399]);
+}


### PR DESCRIPTION
## Purpose
Fixing the index out of bounds bug in array `unshift()` function. 

Fixes #34394 

## Approach
Add a check for array capacity before shifting the internal array.

## Samples
```ballerina
public function main() {
    int[] list = [];
    foreach int i in 0 ..< 200 {
        list.unshift(i);
    }
}
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
