### PR TITLE
Add default `.gitignore` and `devcontainer.json` files  when creating new projects using central templates

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/CommandUtil.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/CommandUtil.java
@@ -210,6 +210,11 @@ public class CommandUtil {
             Files.copy(packageMDFilePath, toPackageMdPath, StandardCopyOption.REPLACE_EXISTING);
         }
 
+        // Create default .gitignore
+        createDefaultGitignore(projectPath);
+        // Create default devcontainer.json
+        createDefaultDevContainer(projectPath);
+
         // Create modules
         String templatePkgName = packageJson.getName();
         Path modulesRoot = balaPath.resolve(ProjectConstants.MODULES_ROOT);
@@ -471,22 +476,27 @@ public class CommandUtil {
         } else {
             initPackage(path);
         }
+        createDefaultGitignore(path);
+        createDefaultDevContainer(path);
+    }
+
+    private static void createDefaultGitignore(Path path) throws IOException {
         Path gitignore = path.resolve(ProjectConstants.GITIGNORE_FILE_NAME);
         if (Files.notExists(gitignore)) {
             Files.createFile(gitignore);
         }
         String defaultGitignore = FileUtils.readFileAsString(NEW_CMD_DEFAULTS + "/" + GITIGNORE);
         Files.write(gitignore, defaultGitignore.getBytes(StandardCharsets.UTF_8));
-        // Create dev container
-        Path devcontainer = path.resolve(ProjectConstants.DEVCONTAINER);
-        if (Files.notExists(devcontainer)) {
-            Files.createFile(devcontainer);
+    }
+
+    private static void createDefaultDevContainer(Path path) throws IOException {
+        Path devContainer = path.resolve(ProjectConstants.DEVCONTAINER);
+        if (Files.notExists(devContainer)) {
+            Files.createFile(devContainer);
         }
-
-
-        String defaultDevcontainer = FileUtils.readFileAsString(NEW_CMD_DEFAULTS + "/" + DEVCONTAINER);
-        defaultDevcontainer = defaultDevcontainer.replace("latest", RepoUtils.getBallerinaVersion());
-        Files.write(devcontainer, defaultDevcontainer.getBytes(StandardCharsets.UTF_8));
+        String defaultDevContainer = FileUtils.readFileAsString(NEW_CMD_DEFAULTS + "/" + DEVCONTAINER);
+        defaultDevContainer = defaultDevContainer.replace("latest", RepoUtils.getBallerinaVersion());
+        Files.write(devContainer, defaultDevContainer.getBytes(StandardCharsets.UTF_8));
     }
 
     /**

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/NewCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/NewCommandTest.java
@@ -260,7 +260,8 @@ public class NewCommandTest extends BaseCommandTest {
         Assert.assertTrue(tomlContent.contains(expectedTomlContent));
 
         Assert.assertTrue(Files.exists(packageDir.resolve(ProjectConstants.PACKAGE_MD_FILE_NAME)));
-
+        Assert.assertTrue(Files.exists(packageDir.resolve(ProjectConstants.GITIGNORE_FILE_NAME)));
+        Assert.assertTrue(Files.exists(packageDir.resolve(ProjectConstants.DEVCONTAINER)));
         Assert.assertTrue(readOutput().contains("Created new Ballerina package"));
     }
 
@@ -291,6 +292,8 @@ public class NewCommandTest extends BaseCommandTest {
                 "observabilityIncluded = true\n";
         Assert.assertTrue(tomlContent.contains(expectedTomlContent));
         Assert.assertTrue(Files.exists(packageDir.resolve(ProjectConstants.PACKAGE_MD_FILE_NAME)));
+        Assert.assertTrue(Files.exists(packageDir.resolve(ProjectConstants.GITIGNORE_FILE_NAME)));
+        Assert.assertTrue(Files.exists(packageDir.resolve(ProjectConstants.DEVCONTAINER)));
         Assert.assertTrue(readOutput().contains("Created new Ballerina package"));
     }
 


### PR DESCRIPTION
## Purpose
> $Title
- Fixes https://github.com/ballerina-platform/ballerina-lang/issues/34414

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
