### PR TITLE
[Debugger] Add missing variable visibility tests

### DIFF
--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/LanguageConstructDebugTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/LanguageConstructDebugTest.java
@@ -118,8 +118,8 @@ public class LanguageConstructDebugTest extends BaseTestCase {
         String testModuleFileName = "main.bal";
         debugTestRunner = new DebugTestRunner(testProjectName, testModuleFileName, true);
 
-        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 19));
-        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 25));
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 22));
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 28));
         debugTestRunner.initDebugSession(DebugUtils.DebuggeeExecutionKind.RUN);
 
         // Test for debug engage when worker `w1`

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/variables/VariableVisibilityTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/variables/VariableVisibilityTest.java
@@ -207,7 +207,7 @@ public class VariableVisibilityTest extends BaseTestCase {
 
         // variable visibility test for closure
         // A closure is an inner anonymous function that has visibility to the scope of its enclosing environment.
-        // It can access its own scope, its enclosing environment’s scope, and variables defined in the global scope
+        // It can access its own scope, its enclosing environment’s scope, and variables defined in the global scope.
         debugTestRunner.assertVariable(localVariables, "a", "3", "int");
         debugTestRunner.assertVariable(localVariables, "b", "3", "int");
         debugTestRunner.assertVariable(localVariables, "c", "34", "int");

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/variables/VariableVisibilityTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/variables/VariableVisibilityTest.java
@@ -71,7 +71,7 @@ public class VariableVisibilityTest extends BaseTestCase {
     @Test(description = "Variable visibility test in the middle of the main() method for a new variable")
     public void newVariableVisibilityTest() throws BallerinaTestException {
         debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 243));
-        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 308));
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 313));
         debugTestRunner.initDebugSession(DebugUtils.DebuggeeExecutionKind.RUN);
         debugHitInfo = debugTestRunner.waitForDebugHit(20000);
         localVariables = debugTestRunner.fetchVariables(debugHitInfo.getRight(), DebugTestRunner.VariableScope.LOCAL);
@@ -105,12 +105,12 @@ public class VariableVisibilityTest extends BaseTestCase {
 
     @Test(description = "Variable visibility test in control flows")
     public void controlFlowVariableVisibilityTest() throws BallerinaTestException {
-        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 262));
-        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 269));
-        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 276));
-        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 285));
-        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 291));
-        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 298));
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 267));
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 274));
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 281));
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 290));
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 296));
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 303));
         // Todo - enable after fixing https://github.com/ballerina-platform/ballerina-lang/issues/27738
         // debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 266));
 
@@ -119,25 +119,25 @@ public class VariableVisibilityTest extends BaseTestCase {
         localVariables = debugTestRunner.fetchVariables(debugHitInfo.getRight(), DebugTestRunner.VariableScope.LOCAL);
 
         // local variable visibility test inside `if` statement.
-        Assert.assertEquals(localVariables.size(), 47);
+        Assert.assertEquals(localVariables.size(), 50);
 
         // local variable visibility test inside `else` statement.
         debugTestRunner.resumeProgram(debugHitInfo.getRight(), DebugTestRunner.DebugResumeKind.NEXT_BREAKPOINT);
         debugHitInfo = debugTestRunner.waitForDebugHit(10000);
         localVariables = debugTestRunner.fetchVariables(debugHitInfo.getRight(), DebugTestRunner.VariableScope.LOCAL);
-        Assert.assertEquals(localVariables.size(), 47);
+        Assert.assertEquals(localVariables.size(), 50);
 
         // local variable visibility test inside `else-if` statement.
         debugTestRunner.resumeProgram(debugHitInfo.getRight(), DebugTestRunner.DebugResumeKind.NEXT_BREAKPOINT);
         debugHitInfo = debugTestRunner.waitForDebugHit(10000);
         localVariables = debugTestRunner.fetchVariables(debugHitInfo.getRight(), DebugTestRunner.VariableScope.LOCAL);
-        Assert.assertEquals(localVariables.size(), 47);
+        Assert.assertEquals(localVariables.size(), 50);
 
         // local variable visibility test inside `while` loop.
         debugTestRunner.resumeProgram(debugHitInfo.getRight(), DebugTestRunner.DebugResumeKind.NEXT_BREAKPOINT);
         debugHitInfo = debugTestRunner.waitForDebugHit(10000);
         localVariables = debugTestRunner.fetchVariables(debugHitInfo.getRight(), DebugTestRunner.VariableScope.LOCAL);
-        Assert.assertEquals(localVariables.size(), 47);
+        Assert.assertEquals(localVariables.size(), 50);
 
         // local variable visibility test inside `foreach` loop.
         debugTestRunner.resumeProgram(debugHitInfo.getRight(), DebugTestRunner.DebugResumeKind.NEXT_BREAKPOINT);
@@ -149,7 +149,7 @@ public class VariableVisibilityTest extends BaseTestCase {
         debugTestRunner.resumeProgram(debugHitInfo.getRight(), DebugTestRunner.DebugResumeKind.NEXT_BREAKPOINT);
         debugHitInfo = debugTestRunner.waitForDebugHit(10000);
         localVariables = debugTestRunner.fetchVariables(debugHitInfo.getRight(), DebugTestRunner.VariableScope.LOCAL);
-        Assert.assertEquals(localVariables.size(), 48);
+        Assert.assertEquals(localVariables.size(), 51);
 
         // Todo - enable after fixing https://github.com/ballerina-platform/ballerina-lang/issues/27738
         // local variable visibility test inside `foreach` statement + lambda function.
@@ -162,8 +162,8 @@ public class VariableVisibilityTest extends BaseTestCase {
 
     @Test(description = "Variable visibility test for global variables")
     public void globalVariableVisibilityTest() throws BallerinaTestException {
-        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 335));
-        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 310));
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 343));
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 318));
         debugTestRunner.initDebugSession(DebugUtils.DebuggeeExecutionKind.RUN);
         debugHitInfo = debugTestRunner.waitForDebugHit(20000);
         globalVariables = debugTestRunner.fetchVariables(debugHitInfo.getRight(), VariableScope.GLOBAL);
@@ -198,9 +198,23 @@ public class VariableVisibilityTest extends BaseTestCase {
 
     @Test(description = "Variable visibility test for local variables at the last line of main() method")
     public void localVariableVisibilityTest() throws BallerinaTestException {
-        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 310));
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 318));
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 351));
         debugTestRunner.initDebugSession(DebugUtils.DebuggeeExecutionKind.RUN);
         debugHitInfo = debugTestRunner.waitForDebugHit(20000);
+        localVariables = debugTestRunner.fetchVariables(debugHitInfo.getRight(), VariableScope.LOCAL);
+        globalVariables = debugTestRunner.fetchVariables(debugHitInfo.getRight(), VariableScope.GLOBAL);
+
+        // variable visibility test for closure
+        // A closure is an inner anonymous function that has visibility to the scope of its enclosing environment.
+        // It can access its own scope, its enclosing environment’s scope, and variables defined in the global scope
+        debugTestRunner.assertVariable(localVariables, "a", "3", "int");
+        debugTestRunner.assertVariable(localVariables, "b", "3", "int");
+        debugTestRunner.assertVariable(localVariables, "c", "34", "int");
+        debugTestRunner.assertVariable(globalVariables, "port", "9090", "int");
+
+        debugTestRunner.resumeProgram(debugHitInfo.getRight(), DebugTestRunner.DebugResumeKind.NEXT_BREAKPOINT);
+        debugHitInfo = debugTestRunner.waitForDebugHit(10000);
         localVariables = debugTestRunner.fetchVariables(debugHitInfo.getRight(), VariableScope.LOCAL);
 
         // var variable visibility test
@@ -294,11 +308,14 @@ public class VariableVisibilityTest extends BaseTestCase {
 
         // service variable visibility test
         debugTestRunner.assertVariable(localVariables, "serviceVar", "service", "service");
+
+        // let expression visibility test
+        debugTestRunner.assertVariable(localVariables, "letVar", "\"Hello Ballerina!\"", "string");
     }
 
     @Test(description = "Child variable visibility test for local variables at the last line of main() method")
     public void localVariableChildrenVisibilityTest() throws BallerinaTestException {
-        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 310));
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 318));
         debugTestRunner.initDebugSession(DebugUtils.DebuggeeExecutionKind.RUN);
         debugHitInfo = debugTestRunner.waitForDebugHit(20000);
         localVariables = debugTestRunner.fetchVariables(debugHitInfo.getRight(), VariableScope.LOCAL);
@@ -464,6 +481,31 @@ public class VariableVisibilityTest extends BaseTestCase {
         // `self` child variable visibility test inside object method.
         selfChildVariables = debugTestRunner.fetchChildVariables(localVariables.get("self"));
         debugTestRunner.assertVariable(selfChildVariables, "name", "\"John\"", "string");
+    }
+
+    @Test(description = "Worker related variable visibility test")
+    public void workerVariableVisibilityTest() throws BallerinaTestException {
+        String testProjectName = "worker-tests";
+        String testModuleFileName = "main.bal";
+        debugTestRunner = new DebugTestRunner(testProjectName, testModuleFileName, true);
+
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 23));
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 31));
+        debugTestRunner.initDebugSession(DebugUtils.DebuggeeExecutionKind.RUN);
+        Pair<BallerinaTestDebugPoint, StoppedEventArguments> debugHitInfo = debugTestRunner.waitForDebugHit(20000);
+
+        // variable visibility test for workers outside fork (workers are visible outside fork() as futures).
+        localVariables = debugTestRunner.fetchVariables(debugHitInfo.getRight(), DebugTestRunner.VariableScope.LOCAL);
+        debugTestRunner.assertVariable(localVariables, "w1", "future<()>", "future");
+
+        // variable visibility test inside worker (only worker's variables should be visible).
+        debugTestRunner.resumeProgram(debugHitInfo.getRight(), DebugTestRunner.DebugResumeKind.NEXT_BREAKPOINT);
+        debugHitInfo = debugTestRunner.waitForDebugHit(10000);
+        localVariables = debugTestRunner.fetchVariables(debugHitInfo.getRight(), DebugTestRunner.VariableScope.LOCAL);
+        debugTestRunner.assertVariable(localVariables, "x", "10", "int");
+
+        // variables outside worker should not be visible
+        Assert.assertFalse(localVariables.containsKey("a"));
     }
 
     @AfterMethod(alwaysRun = true)

--- a/tests/jballerina-debugger-integration-test/src/test/resources/project-based-tests/variable-tests/main.bal
+++ b/tests/jballerina-debugger-integration-test/src/test/resources/project-based-tests/variable-tests/main.bal
@@ -259,8 +259,8 @@ public function main() {
 
     // let expression
     string letVar = let string hello = "Hello ",
-                          string ballerina = "Ballerina!"
-                      in hello + ballerina;    
+                        string ballerina = "Ballerina!"
+                    in hello + ballerina;
 
     // variable visibility in 'if' statement
     if (true) {

--- a/tests/jballerina-debugger-integration-test/src/test/resources/project-based-tests/variable-tests/main.bal
+++ b/tests/jballerina-debugger-integration-test/src/test/resources/project-based-tests/variable-tests/main.bal
@@ -257,6 +257,11 @@ public function main() {
         }
     };
 
+    // let expression
+    string letVar = let string hello = "Hello ",
+                          string ballerina = "Ballerina!"
+                      in hello + ballerina;    
+
     // variable visibility in 'if' statement
     if (true) {
         intVar = 1;
@@ -307,6 +312,9 @@ public function main() {
 
     intVar = addition(2, 3);
     intVar = addition(3, 4);
+
+    var foo = basicClosure();
+    int result = foo(3);
 }
 
 function printSalaryDetails(int baseSalary, int annualIncrement = 20, float bonusRate = 0.02) returns string {
@@ -333,4 +341,16 @@ function printDetails(string name, int age = 18, string... modules) returns stri
 
 function addition(int a, int b) returns int {
     return a + b;
+}
+
+function basicClosure() returns (function (int) returns int) {
+    int a = 3;
+    var foo = function (int b) returns int {
+        int c = 34;
+        if (b == 3) {
+            c = c + b + a + port;
+        }
+        return c + a;
+    };
+    return foo;
 }

--- a/tests/jballerina-debugger-integration-test/src/test/resources/project-based-tests/worker-tests/main.bal
+++ b/tests/jballerina-debugger-integration-test/src/test/resources/project-based-tests/worker-tests/main.bal
@@ -15,13 +15,17 @@
 // under the License.
 
 public function main() {
-    worker w1 {
-        int x = 10;
-        x -> w2;
-    }
+    int a = 5;
 
-    worker w2 {
-        int y = <- w1;
-        int z = y;
+    fork {
+        worker w1 {
+            int x = 10;
+            x -> w2;
+        }
+
+        worker w2 {
+            int y = <- w1;
+            int z = y;
+        }
     }
 }


### PR DESCRIPTION
## Purpose
This PR will add some missing variable visibility tests.
- [x] Language constructs
    - [x] Worker
        - [x] Inside a particular worker, only its variables are visible. Variables outside workers are not visible.
        - [x] Worker status is visible in the main strand
- [x] fork() - workers are visible outside fork() as futures
- [x]  Closure() - a closure is an inner anonymous function that has visibility to the scope of its enclosing environment. It can access its own scope, its enclosing environment’s scope, and variables defined in the module scope.
- [x] Variable visibility test
    - [x] Let expression

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/28832


