### PR TITLE
Change return type `String[]` from `string[]` to `string[]?` 

### DIFF
--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JField.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JField.java
@@ -72,9 +72,13 @@ public class JField extends BFunction {
         if (type.isArray()) {
             isArray = true;
             returnError = true;
-            if (!type.getComponentType().isPrimitive() && !isStringArray) {
+            if (!type.getComponentType().isPrimitive()) {
                 isObject = false;
-                isObjectArray = true;
+                if (type.getComponentType().equals(String.class)) {
+                    isStringArray = true;
+                } else {
+                    isObjectArray = true;
+                }
             }
             javaArraysModule = true;
         }
@@ -117,7 +121,7 @@ public class JField extends BFunction {
         StringBuilder returnString = new StringBuilder();
         if (super.getKind() == BFunctionKind.FIELD_GET) {
             returnString.append(fieldObj.getShortTypeName());
-            if (isString) {
+            if (isString || isStringArray) {
                 returnString.append("?");
             }
             if (returnError) {

--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JMethod.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JMethod.java
@@ -300,7 +300,7 @@ public class JMethod extends BFunction {
         StringBuilder returnString = new StringBuilder();
         if (getHasReturn()) {
             returnString.append(this.returnType);
-            if (getIsStringReturn()) {
+            if (getIsStringReturn() || isStringArrayReturn()) {
                 returnString.append("?");
             }
             if (getHasException()) {

--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/utils/BindgenNodeFactory.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/utils/BindgenNodeFactory.java
@@ -771,18 +771,6 @@ class BindgenNodeFactory {
                     )
                 )
             );
-//        List<StatementNode> statementNodes = new LinkedList<>();
-//
-//        statementNodes.add(getExternalFunctionCallStatement("handle|error", jMethod));
-//        statementNodes.add(createIfElseStatementNode(
-//                createBracedExpressionNode(createSimpleNameReferenceNode("externalObj is error")),
-//                getCheckExceptionBlock(jMethod.getExceptionName(), jMethod.getExceptionConstName()),
-//                createElseBlockNode(createBlockStatementNode(AbstractNodeFactory.createNodeList(
-//                        createReturnStatementNode(createTypeCastExpressionNode("string[]",
-//                                createCheckExpressionNode(createFunctionCallExpressionNode("jarrays:fromHandle",
-//                                        new LinkedList<>(Arrays.asList("externalObj", "\"string\"")))))))))));
-//
-//        return statementNodes;
     }
 
     private static List<StatementNode> getPrimitiveReturnWithException(JMethod jMethod) {

--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/utils/BindgenNodeFactory.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/utils/BindgenNodeFactory.java
@@ -733,18 +733,56 @@ class BindgenNodeFactory {
     }
 
     private static List<StatementNode> getStringArrayWithException(JMethod jMethod) {
-        List<StatementNode> statementNodes = new LinkedList<>();
-
-        statementNodes.add(getExternalFunctionCallStatement("handle|error", jMethod));
-        statementNodes.add(createIfElseStatementNode(
-                createBracedExpressionNode(createSimpleNameReferenceNode("externalObj is error")),
-                getCheckExceptionBlock(jMethod.getExceptionName(), jMethod.getExceptionConstName()),
-                createElseBlockNode(createBlockStatementNode(AbstractNodeFactory.createNodeList(
-                        createReturnStatementNode(createTypeCastExpressionNode("string[]",
-                                createCheckExpressionNode(createFunctionCallExpressionNode("jarrays:fromHandle",
-                                        new LinkedList<>(Arrays.asList("externalObj", "\"string\"")))))))))));
-
-        return statementNodes;
+        return List.of(
+                //   handle externalObj = <call external method>;
+                getExternalFunctionCallStatement("handle|error", jMethod),
+                //   if java:isNull(externalObj) {
+                //       return null;
+                //   }
+                createReturnIfHandleIsNullStatement("externalObj"),
+                //  if (externalObj is error) {
+                //      InterruptedException e = error InterruptedException(INTERRUPTEDEXCEPTION, externalObj,
+                //           message = externalObj.message());
+                //      return e;
+                //  } else {
+                //      return <string[]>check jarrays:fromHandle(externalObj, "string");
+                //  }
+                createIfElseStatementNode(
+                    createBracedExpressionNode(
+                        createSimpleNameReferenceNode("externalObj is error")
+                    ),
+                    getCheckExceptionBlock(jMethod.getExceptionName(), jMethod.getExceptionConstName()),
+                    createElseBlockNode(
+                        createBlockStatementNode(
+                            AbstractNodeFactory.createNodeList(
+                                createReturnStatementNode(
+                                    createTypeCastExpressionNode(
+                                        "string[]",
+                                        createCheckExpressionNode(
+                                            createFunctionCallExpressionNode(
+                                                    "jarrays:fromHandle",
+                                                    new LinkedList<>(Arrays.asList("externalObj", "\"string\""))
+                                            )
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            );
+//        List<StatementNode> statementNodes = new LinkedList<>();
+//
+//        statementNodes.add(getExternalFunctionCallStatement("handle|error", jMethod));
+//        statementNodes.add(createIfElseStatementNode(
+//                createBracedExpressionNode(createSimpleNameReferenceNode("externalObj is error")),
+//                getCheckExceptionBlock(jMethod.getExceptionName(), jMethod.getExceptionConstName()),
+//                createElseBlockNode(createBlockStatementNode(AbstractNodeFactory.createNodeList(
+//                        createReturnStatementNode(createTypeCastExpressionNode("string[]",
+//                                createCheckExpressionNode(createFunctionCallExpressionNode("jarrays:fromHandle",
+//                                        new LinkedList<>(Arrays.asList("externalObj", "\"string\"")))))))))));
+//
+//        return statementNodes;
     }
 
     private static List<StatementNode> getPrimitiveReturnWithException(JMethod jMethod) {

--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/utils/BindgenNodeFactory.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/utils/BindgenNodeFactory.java
@@ -98,8 +98,6 @@ import static org.ballerinalang.bindgen.utils.BindgenConstants.HANDLE;
 import static org.ballerinalang.bindgen.utils.BindgenConstants.NAME;
 import static org.ballerinalang.bindgen.utils.BindgenConstants.PARAM_TYPES;
 
-//import static org.ballerinalang.bindgen.utils.BindgenConstants.*;
-
 /**
  * Class for generating the Ballerina syntax tree util nodes and tokens.
  *

--- a/misc/ballerina-bindgen/src/test/resources/unit-test-resources/fields.bal
+++ b/misc/ballerina-bindgen/src/test/resources/unit-test-resources/fields.bal
@@ -61,8 +61,11 @@ distinct class FieldsTestResource {
     # The function that maps to the `returnStringArray` method of `org.ballerinalang.bindgen.FieldsTestResource`.
     #
     # + return - The `string[]` value returning from the Java mapping.
-    function returnStringArray() returns string[]|error {
+    function returnStringArray() returns string[]?|error {
         handle externalObj = org_ballerinalang_bindgen_FieldsTestResource_returnStringArray(self.jObj);
+        if java:isNull(externalObj) {
+            return null;
+        }
         return <string[]>check jarrays:fromHandle(externalObj, "string");
     }
 
@@ -359,8 +362,12 @@ distinct class FieldsTestResource {
     # The function that retrieves the value of the public field `getInstanceStringArray`.
     #
     # + return - The `string[]` value of the field.
-    function getGetInstanceStringArray() returns string[]|error {
-        return <string[]>check jarrays:fromHandle(org_ballerinalang_bindgen_FieldsTestResource_getGetInstanceStringArray(self.jObj), "string");
+    function getGetInstanceStringArray() returns string[]?|error {
+        handle externalObj = org_ballerinalang_bindgen_FieldsTestResource_getGetInstanceStringArray(self.jObj);
+        if java:isNull(externalObj) {
+            return null;
+        }
+        return <string[]>check jarrays:fromHandle(externalObj, "string");
     }
 
     # The function to set the value of the public field `getInstanceStringArray`.
@@ -921,8 +928,12 @@ function FieldsTestResource_setGetStaticBooleanArray(boolean[] arg) {
 # The function that retrieves the value of the public field `getStaticStringArray`.
 #
 # + return - The `string[]` value of the field.
-function FieldsTestResource_getGetStaticStringArray() returns string[]|error {
-    return <string[]>check jarrays:fromHandle(org_ballerinalang_bindgen_FieldsTestResource_getGetStaticStringArray(), "string");
+function FieldsTestResource_getGetStaticStringArray() returns string[]?|error {
+    handle externalObj = org_ballerinalang_bindgen_FieldsTestResource_getGetStaticStringArray();
+    if java:isNull(externalObj) {
+        return null;
+    }
+    return <string[]>check jarrays:fromHandle(externalObj, "string");
 }
 
 # The function to set the value of the public field `getStaticStringArray`.

--- a/misc/ballerina-bindgen/src/test/resources/unit-test-resources/interfaceMapping.bal
+++ b/misc/ballerina-bindgen/src/test/resources/unit-test-resources/interfaceMapping.bal
@@ -26,8 +26,11 @@ public distinct class InterfaceTestResource {
     # The function that maps to the `returnStringArray` method of `org.ballerinalang.bindgen.InterfaceTestResource`.
     #
     # + return - The `string[]` value returning from the Java mapping.
-    public function returnStringArray() returns string[]|error {
+    public function returnStringArray() returns string[]?|error {
         handle externalObj = org_ballerinalang_bindgen_InterfaceTestResource_returnStringArray(self.jObj);
+        if java:isNull(externalObj) {
+            return null;
+        }
         return <string[]>check jarrays:fromHandle(externalObj, "string");
     }
 

--- a/misc/ballerina-bindgen/src/test/resources/unit-test-resources/methods.bal
+++ b/misc/ballerina-bindgen/src/test/resources/unit-test-resources/methods.bal
@@ -488,8 +488,11 @@ distinct class MethodsTestResource {
     # The function that maps to the `returnStringArray` method of `org.ballerinalang.bindgen.MethodsTestResource`.
     #
     # + return - The `string[]` value returning from the Java mapping.
-    function returnStringArray() returns string[]|error {
+    function returnStringArray() returns string[]?|error {
         handle externalObj = org_ballerinalang_bindgen_MethodsTestResource_returnStringArray(self.jObj);
+        if java:isNull(externalObj) {
+            return null;
+        }
         return <string[]>check jarrays:fromHandle(externalObj, "string");
     }
 
@@ -499,8 +502,11 @@ distinct class MethodsTestResource {
     # + arg1 - The `StringBuffer` value required to map with the Java method parameter.
     # + arg2 - The `int` value required to map with the Java method parameter.
     # + return - The `string[]` value returning from the Java mapping.
-    function returnStringArray1(string[] arg0, StringBuffer arg1, int arg2) returns string[]|error {
+    function returnStringArray1(string[] arg0, StringBuffer arg1, int arg2) returns string[]?|error {
         handle externalObj = org_ballerinalang_bindgen_MethodsTestResource_returnStringArray1(self.jObj, check jarrays:toHandle(arg0, "java.lang.String"), arg1.jObj, arg2);
+        if java:isNull(externalObj) {
+            return null;
+        }
         return <string[]>check jarrays:fromHandle(externalObj, "string");
     }
 
@@ -510,7 +516,7 @@ distinct class MethodsTestResource {
     # + arg1 - The `StringBuffer` value required to map with the Java method parameter.
     # + arg2 - The `int` value required to map with the Java method parameter.
     # + return - The `string[]` or the `InterruptedException` value returning from the Java mapping.
-    function returnStringArray2(string[] arg0, StringBuffer arg1, int arg2) returns string[]|InterruptedException|error {
+    function returnStringArray2(string[] arg0, StringBuffer arg1, int arg2) returns string[]?|InterruptedException|error {
         handle|error externalObj = org_ballerinalang_bindgen_MethodsTestResource_returnStringArray2(self.jObj, check jarrays:toHandle(arg0, "java.lang.String"), arg1.jObj, arg2);
         if (externalObj is error) {
             InterruptedException e = error InterruptedException(INTERRUPTEDEXCEPTION, externalObj, message = externalObj.message());

--- a/misc/ballerina-bindgen/src/test/resources/unit-test-resources/methods.bal
+++ b/misc/ballerina-bindgen/src/test/resources/unit-test-resources/methods.bal
@@ -518,6 +518,9 @@ distinct class MethodsTestResource {
     # + return - The `string[]` or the `InterruptedException` value returning from the Java mapping.
     function returnStringArray2(string[] arg0, StringBuffer arg1, int arg2) returns string[]?|InterruptedException|error {
         handle|error externalObj = org_ballerinalang_bindgen_MethodsTestResource_returnStringArray2(self.jObj, check jarrays:toHandle(arg0, "java.lang.String"), arg1.jObj, arg2);
+        if java:isNull(externalObj) {
+            return null;
+        }
         if (externalObj is error) {
             InterruptedException e = error InterruptedException(INTERRUPTEDEXCEPTION, externalObj, message = externalObj.message());
             return e;


### PR DESCRIPTION
## Purpose
In Java, 
* a method with return type `String[]` can return `null`
* a field of type `String[]` can be set to `null`

A real world example can be found in the open source Java library [opencsv](http://opencsv.sourceforge.net/). The method [CSVReader.readNext()](https://github.com/cygri/opencsv/blob/f9b23175a887238ab9422cbeb072f3ea56592adc/src/main/java/com/opencsv/CSVReader.java#L271) replies `null` if there are no more rows to read from a CSV file. 

Currently, with the code generated by `bindgen` in Swan Lake Beta6, this case can not be handled in ballerina code, because the return type is currently mapped to `string[]`. This pull requests includes a patch for the `bindgen` code which changes the return types for the generated methods in this case to `string[]?`.
 

## Check List 
- [ x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
