### PR TITLE
Fix change-return-type code action for union types that includes functions

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaUnionTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaUnionTypeSymbol.java
@@ -38,6 +38,7 @@ import java.util.Set;
 import java.util.StringJoiner;
 import java.util.regex.Pattern;
 
+import static io.ballerina.compiler.api.symbols.TypeDescKind.FUNCTION;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.INTERSECTION;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.NIL;
 
@@ -168,6 +169,11 @@ public class BallerinaUnionTypeSymbol extends AbstractTypeSymbol implements Unio
             StringJoiner joiner = new StringJoiner("|");
             unionType.resolvingToString = true;
             for (TypeSymbol typeDescriptor : memberTypes) {
+                // If the member is a function and not the last element, add surrounding parenthesis
+                if (typeDescriptor.typeKind() == FUNCTION && !memberTypes.get(memberTypes.size() - 1).equals(typeDescriptor)) {
+                    joiner.add("(" + typeDescriptor.signature() + ")");
+                    continue;
+                }
                 joiner.add(getSignatureForIntersectionType(typeDescriptor));
             }
             unionType.resolvingToString = false;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaUnionTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaUnionTypeSymbol.java
@@ -170,7 +170,8 @@ public class BallerinaUnionTypeSymbol extends AbstractTypeSymbol implements Unio
             unionType.resolvingToString = true;
             for (TypeSymbol typeDescriptor : memberTypes) {
                 // If the member is a function and not the last element, add surrounding parenthesis
-                if (typeDescriptor.typeKind() == FUNCTION && !memberTypes.get(memberTypes.size() - 1).equals(typeDescriptor)) {
+                if (typeDescriptor.typeKind() == FUNCTION &&
+                        !memberTypes.get(memberTypes.size() - 1).equals(typeDescriptor)) {
                     joiner.add("(" + typeDescriptor.signature() + ")");
                     continue;
                 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
@@ -349,6 +349,27 @@ public class TypedescriptorTest {
         };
     }
 
+    @Test(dataProvider = "UnionWithFunctionTypePos")
+    public void testUnionTypeWithFunctionType(int line, int col, String signature) {
+        Symbol symbol = getSymbol(line, col);
+        TypeSymbol type = ((VariableSymbol) symbol).typeDescriptor();
+        assertEquals(type.typeKind(), UNION);
+        assertEquals(type.signature(), signature);
+    }
+
+    @DataProvider(name = "UnionWithFunctionTypePos")
+    public Object[][] getUnionWithFunctionTypePos() {
+        return new Object[][]{
+                {259, 34, "(function () returns int)|10|20"},
+                {260, 37, "(function () returns int)|string"},
+                {261, 35, "string|function () returns int"},
+                {262, 36, "(function () returns int)|10|20"},
+                {263, 37, "(function () returns int|string)|3"},
+                {264, 34, "ReturnIntFunctionType?|string"},
+                {265, 57, "(function () returns string)|function () returns int"},
+        };
+    }
+
     @Test(dataProvider = "FiniteTypeDataProvider")
     public void testFiniteType(int line, int column, String typeName, List<String> expSignatures) {
         Symbol symbol = getSymbol(line, column);

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/typedesc_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/typedesc_test.bal
@@ -255,3 +255,20 @@ function testObjectTypeSignature() {
         remote function testRFunc();
     } obj;
 }
+
+function testUnionTypeWithFunctionType() {
+    10|20|function () returns int aVar = 10;
+    (function () returns int)|string bVar = "10";
+    string|function () returns int cVar = "10";
+    10|(function () returns int)|20 dVar = 10;
+    3|function () returns int|string eVar = 3;
+    ReturnIntFunctionType?|string fVar = returnIntFunc;
+    (function () returns string)|function () returns int gVar = returnIntFunc;
+}
+
+// utils
+type ReturnIntFunctionType function () returns int;
+
+function returnIntFunc() returns int {
+    return 1;
+}


### PR DESCRIPTION
## Purpose
$title

Fixes #34382

## Approach
If the member is a function and not the last element, add surrounding parenthesis

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
