### PR TITLE
Add icon property to connectors and packages

### DIFF
--- a/cli/central-client/src/main/java/org/ballerinalang/central/client/model/Package.java
+++ b/cli/central-client/src/main/java/org/ballerinalang/central/client/model/Package.java
@@ -82,6 +82,9 @@ public class Package {
     public static final String JSON_PROPERTY_SUMMARY = "summary";
     @SerializedName(JSON_PROPERTY_SUMMARY) private String summary;
 
+    public static final String JSON_PROPERTY_ICON = "icon";
+    @SerializedName(JSON_PROPERTY_ICON) private String icon;
+
     public Package organization(String organization) {
         this.organization = organization;
         return this;
@@ -351,6 +354,19 @@ public class Package {
 
     public void setModules(List<Module> modules) {
         this.modules = modules;
+    }
+
+    public Package icon(String icon) {
+        this.icon = icon;
+        return this;
+    }
+
+    public String getIcon() {
+        return icon;
+    }
+
+    public void setIcon(String icon) {
+        this.icon = icon;
     }
 
     @Override

--- a/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/connector/models/connector/Connector.java
+++ b/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/connector/models/connector/Connector.java
@@ -43,6 +43,8 @@ public class Connector {
     @Expose
     public String name;
     @Expose
+    public String icon;
+    @Expose
     public String documentation;
     @Expose
     public String platform;

--- a/misc/diagram-util/src/test/java/org/ballerinalang/diagramutil/TestConnectorGenerator.java
+++ b/misc/diagram-util/src/test/java/org/ballerinalang/diagramutil/TestConnectorGenerator.java
@@ -74,7 +74,7 @@ public class TestConnectorGenerator {
         Assert.assertTrue(connector.displayAnnotation.containsKey("iconPath"));
         Assert.assertEquals(connector.displayAnnotation.get("label"), "Test Client");
         Assert.assertEquals(connector.displayAnnotation.get("iconPath"), "logo.svg");
-        Assert.assertEquals(connector.icon, "");
+        Assert.assertEquals(connector.icon, null);
 
         Assert.assertEquals(connector.functions.size(), 5);
         List<Function> functionList = connector.functions;

--- a/misc/diagram-util/src/test/java/org/ballerinalang/diagramutil/TestConnectorGenerator.java
+++ b/misc/diagram-util/src/test/java/org/ballerinalang/diagramutil/TestConnectorGenerator.java
@@ -74,6 +74,7 @@ public class TestConnectorGenerator {
         Assert.assertTrue(connector.displayAnnotation.containsKey("iconPath"));
         Assert.assertEquals(connector.displayAnnotation.get("label"), "Test Client");
         Assert.assertEquals(connector.displayAnnotation.get("iconPath"), "logo.svg");
+        Assert.assertEquals(connector.icon, "");
 
         Assert.assertEquals(connector.functions.size(), 5);
         List<Function> functionList = connector.functions;


### PR DESCRIPTION
## Purpose
Connector and trigger API has changed with package icons.
Here I have updated the connector and package classes with the `icon` property to match new responses.

## Related PR
- https://github.com/ballerina-platform/ballerina-lang/pull/34352

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
