### PR TITLE
Remove special case handling in Semantic API of keywords used in lang libs

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
@@ -583,7 +583,7 @@ public class SymbolFactory {
                 if (mthd instanceof BResourceFunction) {
                     return ((BResourceFunction) mthd).accessor.value;
                 }
-                return mthd.funcName.value;
+                return mthd.symbol.getOriginalName().getValue();
             }
         }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaClassSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaClassSymbol.java
@@ -103,7 +103,8 @@ public class BallerinaClassSymbol extends BallerinaSymbol implements ClassSymbol
         if (this.initMethod == null && this.internalSymbol.initializerFunc != null) {
             SymbolFactory symbolFactory = SymbolFactory.getInstance(this.context);
             this.initMethod = symbolFactory.createMethodSymbol(internalSymbol.initializerFunc.symbol,
-                                                               internalSymbol.initializerFunc.funcName.value);
+                                                               internalSymbol.initializerFunc.symbol
+                                                                       .getOriginalName().value);
         }
 
         return Optional.ofNullable(this.initMethod);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaModule.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaModule.java
@@ -158,7 +158,7 @@ public class BallerinaModule extends BallerinaSymbol implements ModuleSymbol {
             ScopeEntry scopeEntry = entry.getValue();
             if (scopeEntry.symbol instanceof BClassSymbol &&
                     (scopeEntry.symbol.flags & Flags.PUBLIC) == Flags.PUBLIC) {
-                String constName = scopeEntry.symbol.getName().getValue();
+                String constName = scopeEntry.symbol.getOriginalName().getValue();
                 classes.add(symbolFactory.createClassSymbol((BClassSymbol) scopeEntry.symbol, constName));
             }
         }
@@ -186,7 +186,7 @@ public class BallerinaModule extends BallerinaSymbol implements ModuleSymbol {
 
             if (scopeEntry.symbol instanceof BConstantSymbol &&
                     (scopeEntry.symbol.flags & Flags.PUBLIC) == Flags.PUBLIC) {
-                String constName = scopeEntry.symbol.getName().getValue();
+                String constName = scopeEntry.symbol.getOriginalName().getValue();
                 constants.add(symbolFactory.createConstantSymbol((BConstantSymbol) scopeEntry.symbol, constName));
             }
         }
@@ -208,7 +208,7 @@ public class BallerinaModule extends BallerinaSymbol implements ModuleSymbol {
             ScopeEntry scopeEntry = entry.getValue();
 
             if (scopeEntry.symbol instanceof BEnumSymbol && Symbols.isFlagOn(scopeEntry.symbol.flags, Flags.PUBLIC)) {
-                String constName = scopeEntry.symbol.getName().getValue();
+                String constName = scopeEntry.symbol.getOriginalName().getValue();
                 enums.add(symbolFactory.createEnumSymbol((BEnumSymbol) scopeEntry.symbol, constName));
             }
         }
@@ -235,8 +235,8 @@ public class BallerinaModule extends BallerinaSymbol implements ModuleSymbol {
                         && scopeEntry.symbol.origin != BUILTIN)) {
                     continue;
                 }
-                symbols.add(
-                        symbolFactory.getBCompiledSymbol(scopeEntry.symbol, scopeEntry.symbol.getName().getValue()));
+                symbols.add(symbolFactory.getBCompiledSymbol(scopeEntry.symbol,
+                                                             scopeEntry.symbol.getOriginalName().getValue()));
             }
 
             this.allSymbols = Collections.unmodifiableList(symbols);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectTypeSymbol.java
@@ -116,7 +116,8 @@ public class BallerinaObjectTypeSymbol extends AbstractTypeSymbol implements Obj
                             symbolFactory.createResourceMethodSymbol(attachedFunc.symbol));
             } else {
                 methods.put(attachedFunc.funcName.value,
-                            symbolFactory.createMethodSymbol(attachedFunc.symbol, attachedFunc.funcName.getValue()));
+                            symbolFactory.createMethodSymbol(attachedFunc.symbol,
+                                                             attachedFunc.symbol.getOriginalName().getValue()));
             }
         }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaServiceDeclarationSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaServiceDeclarationSymbol.java
@@ -147,7 +147,7 @@ public class BallerinaServiceDeclarationSymbol extends BallerinaSymbol implement
                             symbolFactory.createResourceMethodSymbol(method.symbol));
             } else {
                 methods.put(method.funcName.value,
-                            symbolFactory.createMethodSymbol(method.symbol, method.funcName.value));
+                            symbolFactory.createMethodSymbol(method.symbol, method.symbol.getOriginalName().value));
             }
         }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSymbol.java
@@ -17,7 +17,6 @@
  */
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.impl.BallerinaKeywordsProvider;
 import io.ballerina.compiler.api.impl.SymbolFactory;
 import io.ballerina.compiler.api.symbols.Documentation;
@@ -50,7 +49,6 @@ public class BallerinaSymbol implements Symbol {
     private final BSymbol internalSymbol;
     private ModuleSymbol module;
     private boolean moduleEvaluated;
-    private String unEscapedName;
 
     protected BallerinaSymbol(String name, SymbolKind symbolKind, BSymbol symbol, CompilerContext context) {
         this.name = name;
@@ -75,23 +73,6 @@ public class BallerinaSymbol implements Symbol {
 
     @Override
     public Optional<String> getName() {
-        // In the langlib context, reserved keywords can be used as regular identifiers. Therefore, they will not be
-        // escaped.
-        if (this.unEscapedName != null) {
-            return Optional.of(this.unEscapedName);
-        }
-        if (getModule().isPresent()) {
-            ModuleID moduleID = getModule().get().id();
-            if (moduleID.moduleName().startsWith("lang.")
-                    && moduleID.orgName().startsWith("ballerina") && this.name.startsWith("'")) {
-                if (!(moduleID.moduleName().equals("lang.string") && this.name.equals("'join"))) {
-                    // Related discussion: https://github.com/ballerina-platform/ballerina-lang/discussions/31830
-                    this.unEscapedName = Utils.unescapeUnicodeCodepoints(this.name.substring(1));
-                    return Optional.ofNullable(this.unEscapedName);
-                }
-            }
-        }
-        this.unEscapedName = this.name;
         return Optional.ofNullable(this.name);
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ASTBuilderUtil.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ASTBuilderUtil.java
@@ -868,7 +868,10 @@ public class ASTBuilderUtil {
                                                                       PackageID newPkgID,
                                                                       Location location,
                                                                       SymbolOrigin origin) {
-        BInvokableSymbol dupFuncSymbol = Symbols.createFunctionSymbol(invokableSymbol.flags, newName, newName, newPkgID,
+        // Since this is a duplicate, there's no reason for the original name to change. The name changes since we're
+        // taking the name as AttachedType'sName.methodName
+        BInvokableSymbol dupFuncSymbol = Symbols.createFunctionSymbol(invokableSymbol.flags, newName,
+                                                                      invokableSymbol.getOriginalName(), newPkgID,
                                                                       null, owner, invokableSymbol.bodyExist,
                                                                       location, origin);
         dupFuncSymbol.receiverSymbol = invokableSymbol.receiverSymbol;

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/check_expression_ctx_config9.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/check_expression_ctx_config9.json
@@ -93,25 +93,6 @@
       }
     },
     {
-      "label": "map(function () func)",
-      "kind": "Function",
-      "detail": "stream<stream:Type1, stream:CompletionType>",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.stream:0.0.0_  \n  \nApplies a function to each member of a stream and returns a stream of the results.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Return** `stream<stream:Type1, stream:CompletionType>`   \n- new stream containing result of applying function `func` to each member of parameter `stm` in order  \n  \n"
-        }
-      },
-      "sortText": "CA",
-      "filterText": "map",
-      "insertText": "map(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
       "label": "close()",
       "kind": "Function",
       "detail": "stream:CompletionType?",
@@ -174,6 +155,25 @@
       "filterText": "toString",
       "insertText": "toString()",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "'map(function () func)",
+      "kind": "Function",
+      "detail": "stream<stream:Type1, stream:CompletionType>",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.stream:0.0.0_  \n  \nApplies a function to each member of a stream and returns a stream of the results.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Return** `stream<stream:Type1, stream:CompletionType>`   \n- new stream containing result of applying function `func` to each member of parameter `stm` in order  \n  \n"
+        }
+      },
+      "sortText": "CA",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/xml_attribute_access_expr_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/xml_attribute_access_expr_ctx_config1.json
@@ -525,25 +525,6 @@
       }
     },
     {
-      "label": "map(function () func)",
-      "kind": "Function",
-      "detail": "xml<xml:XmlType>",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml:0.0.0_  \n  \nApplies a function to each item in an xml sequence, and returns an xml sequence of the results.\n\nEach item is represented as a singleton value.\n  \n**Params**  \n- `function ()` func: a function to apply to each child or parameter `item`  \n  \n**Return** `xml<xml:XmlType>`   \n- new xml value containing result of applying function `func` to each child or parameter `item`  \n  \n"
-        }
-      },
-      "sortText": "CD",
-      "filterText": "map",
-      "insertText": "map(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
       "label": "cloneWithType(typedesc<anydata> t)",
       "kind": "Function",
       "detail": "t|error",
@@ -685,6 +666,25 @@
       "filterText": "toJsonString",
       "insertText": "toJsonString()",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "'map(function () func)",
+      "kind": "Function",
+      "detail": "xml<xml:XmlType>",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.xml:0.0.0_  \n  \nApplies a function to each item in an xml sequence, and returns an xml sequence of the results.\n\nEach item is represented as a singleton value.\n  \n**Params**  \n- `function ()` func: a function to apply to each child or parameter `item`  \n  \n**Return** `xml<xml:XmlType>`   \n- new xml value containing result of applying function `func` to each child or parameter `item`  \n  \n"
+        }
+      },
+      "sortText": "CD",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/xml_attribute_access_expr_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/xml_attribute_access_expr_ctx_config2.json
@@ -525,25 +525,6 @@
       }
     },
     {
-      "label": "map(function () func)",
-      "kind": "Function",
-      "detail": "xml<xml:XmlType>",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml:0.0.0_  \n  \nApplies a function to each item in an xml sequence, and returns an xml sequence of the results.\n\nEach item is represented as a singleton value.\n  \n**Params**  \n- `function ()` func: a function to apply to each child or parameter `item`  \n  \n**Return** `xml<xml:XmlType>`   \n- new xml value containing result of applying function `func` to each child or parameter `item`  \n  \n"
-        }
-      },
-      "sortText": "CD",
-      "filterText": "map",
-      "insertText": "map(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
       "label": "cloneWithType(typedesc<anydata> t)",
       "kind": "Function",
       "detail": "t|error",
@@ -685,6 +666,25 @@
       "filterText": "toJsonString",
       "insertText": "toJsonString()",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "'map(function () func)",
+      "kind": "Function",
+      "detail": "xml<xml:XmlType>",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.xml:0.0.0_  \n  \nApplies a function to each item in an xml sequence, and returns an xml sequence of the results.\n\nEach item is represented as a singleton value.\n  \n**Params**  \n- `function ()` func: a function to apply to each child or parameter `item`  \n  \n**Return** `xml<xml:XmlType>`   \n- new xml value containing result of applying function `func` to each child or parameter `item`  \n  \n"
+        }
+      },
+      "sortText": "CD",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config1.json
@@ -432,7 +432,15 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)",
+      "label": "testOptional",
+      "kind": "Field",
+      "detail": "int?",
+      "sortText": "CA",
+      "insertText": "testOptional",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "'map(function () func)",
       "kind": "Function",
       "detail": "map<map:Type1>",
       "documentation": {
@@ -442,21 +450,13 @@
         }
       },
       "sortText": "CD",
-      "filterText": "map",
-      "insertText": "map(${1})",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
         "command": "editor.action.triggerParameterHints"
       }
-    },
-    {
-      "label": "testOptional",
-      "kind": "Field",
-      "detail": "int?",
-      "sortText": "CA",
-      "insertText": "testOptional",
-      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config11.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config11.json
@@ -388,7 +388,7 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)",
+      "label": "'map(function () func)",
       "kind": "Function",
       "detail": "map<map:Type1>",
       "documentation": {
@@ -398,8 +398,8 @@
         }
       },
       "sortText": "CD",
-      "filterText": "map",
-      "insertText": "map(${1})",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config1a.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config1a.json
@@ -380,7 +380,15 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)",
+      "label": "testOptional",
+      "kind": "Field",
+      "detail": "int?",
+      "sortText": "CA",
+      "insertText": "testOptional",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "'map(function () func)",
       "kind": "Function",
       "detail": "map<map:Type1>",
       "documentation": {
@@ -390,21 +398,13 @@
         }
       },
       "sortText": "CD",
-      "filterText": "map",
-      "insertText": "map(${1})",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
         "command": "editor.action.triggerParameterHints"
       }
-    },
-    {
-      "label": "testOptional",
-      "kind": "Field",
-      "detail": "int?",
-      "sortText": "CA",
-      "insertText": "testOptional",
-      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config2.json
@@ -432,7 +432,15 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)",
+      "label": "testOptional",
+      "kind": "Field",
+      "detail": "int?",
+      "sortText": "CA",
+      "insertText": "testOptional",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "'map(function () func)",
       "kind": "Function",
       "detail": "map<map:Type1>",
       "documentation": {
@@ -442,21 +450,13 @@
         }
       },
       "sortText": "CD",
-      "filterText": "map",
-      "insertText": "map(${1})",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
         "command": "editor.action.triggerParameterHints"
       }
-    },
-    {
-      "label": "testOptional",
-      "kind": "Field",
-      "detail": "int?",
-      "sortText": "CA",
-      "insertText": "testOptional",
-      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config28.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config28.json
@@ -568,7 +568,7 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)",
+      "label": "'map(function () func)",
       "kind": "Function",
       "detail": "array:Type1[]",
       "documentation": {
@@ -578,8 +578,8 @@
         }
       },
       "sortText": "CD",
-      "filterText": "map",
-      "insertText": "map(${1})",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config2a.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config2a.json
@@ -380,25 +380,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)",
-      "kind": "Function",
-      "detail": "map<map:Type1>",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:0.0.0_  \n  \nApplies a function each member of a map and returns a map of the result.\n\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Return** `map<map:Type1>`   \n- new map containing result of applying function `func` to each member  \n  \n"
-        }
-      },
-      "sortText": "CD",
-      "filterText": "map",
-      "insertText": "map(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
       "label": "strField1",
       "kind": "Field",
       "detail": "string",
@@ -421,6 +402,25 @@
       "sortText": "AA",
       "insertText": "testOptional",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "'map(function () func)",
+      "kind": "Function",
+      "detail": "map<map:Type1>",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:0.0.0_  \n  \nApplies a function each member of a map and returns a map of the result.\n\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Return** `map<map:Type1>`   \n- new map containing result of applying function `func` to each member  \n  \n"
+        }
+      },
+      "sortText": "CD",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config3.json
@@ -440,7 +440,15 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)",
+      "label": "optionalInt",
+      "kind": "Field",
+      "detail": "int?",
+      "sortText": "CA",
+      "insertText": "optionalInt",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "'map(function () func)",
       "kind": "Function",
       "detail": "map<map:Type1>",
       "documentation": {
@@ -450,21 +458,13 @@
         }
       },
       "sortText": "CD",
-      "filterText": "map",
-      "insertText": "map(${1})",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
         "command": "editor.action.triggerParameterHints"
       }
-    },
-    {
-      "label": "optionalInt",
-      "kind": "Field",
-      "detail": "int?",
-      "sortText": "CA",
-      "insertText": "optionalInt",
-      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config34.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config34.json
@@ -297,25 +297,6 @@
       }
     },
     {
-      "label": "map(function () func)",
-      "kind": "Function",
-      "detail": "array:Type1[]",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.array:0.0.0_  \n  \nApplies a function to each member of an array and returns an array of the results.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Return** `array:Type1[]`   \n- new array containing result of applying parameter `func` to each member of parameter `arr` in order  \n  \n"
-        }
-      },
-      "sortText": "CD",
-      "filterText": "map",
-      "insertText": "map(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
       "label": "toBalString()",
       "kind": "Function",
       "detail": "string",
@@ -533,6 +514,25 @@
       "filterText": "toJsonString",
       "insertText": "toJsonString()",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "'map(function () func)",
+      "kind": "Function",
+      "detail": "array:Type1[]",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.array:0.0.0_  \n  \nApplies a function to each member of an array and returns an array of the results.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Return** `array:Type1[]`   \n- new array containing result of applying parameter `func` to each member of parameter `arr` in order  \n  \n"
+        }
+      },
+      "sortText": "CD",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config38.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config38.json
@@ -552,25 +552,6 @@
       }
     },
     {
-      "label": "map(function () func)",
-      "kind": "Function",
-      "detail": "xml<xml:XmlType>",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml:0.0.0_  \n  \nApplies a function to each item in an xml sequence, and returns an xml sequence of the results.\n\nEach item is represented as a singleton value.\n  \n**Params**  \n- `function ()` func: a function to apply to each child or parameter `item`  \n  \n**Return** `xml<xml:XmlType>`   \n- new xml value containing result of applying function `func` to each child or parameter `item`  \n  \n"
-        }
-      },
-      "sortText": "CD",
-      "filterText": "map",
-      "insertText": "map(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
       "label": "cloneWithType(typedesc<anydata> t)",
       "kind": "Function",
       "detail": "t|error",
@@ -633,6 +614,25 @@
       "filterText": "toJsonString",
       "insertText": "toJsonString()",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "'map(function () func)",
+      "kind": "Function",
+      "detail": "xml<xml:XmlType>",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.xml:0.0.0_  \n  \nApplies a function to each item in an xml sequence, and returns an xml sequence of the results.\n\nEach item is represented as a singleton value.\n  \n**Params**  \n- `function ()` func: a function to apply to each child or parameter `item`  \n  \n**Return** `xml<xml:XmlType>`   \n- new xml value containing result of applying function `func` to each child or parameter `item`  \n  \n"
+        }
+      },
+      "sortText": "CD",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config39.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config39.json
@@ -552,25 +552,6 @@
       }
     },
     {
-      "label": "map(function () func)",
-      "kind": "Function",
-      "detail": "xml<xml:XmlType>",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml:0.0.0_  \n  \nApplies a function to each item in an xml sequence, and returns an xml sequence of the results.\n\nEach item is represented as a singleton value.\n  \n**Params**  \n- `function ()` func: a function to apply to each child or parameter `item`  \n  \n**Return** `xml<xml:XmlType>`   \n- new xml value containing result of applying function `func` to each child or parameter `item`  \n  \n"
-        }
-      },
-      "sortText": "CD",
-      "filterText": "map",
-      "insertText": "map(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
       "label": "cloneWithType(typedesc<anydata> t)",
       "kind": "Function",
       "detail": "t|error",
@@ -633,6 +614,25 @@
       "filterText": "toJsonString",
       "insertText": "toJsonString()",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "'map(function () func)",
+      "kind": "Function",
+      "detail": "xml<xml:XmlType>",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.xml:0.0.0_  \n  \nApplies a function to each item in an xml sequence, and returns an xml sequence of the results.\n\nEach item is represented as a singleton value.\n  \n**Params**  \n- `function ()` func: a function to apply to each child or parameter `item`  \n  \n**Return** `xml<xml:XmlType>`   \n- new xml value containing result of applying function `func` to each child or parameter `item`  \n  \n"
+        }
+      },
+      "sortText": "CD",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config3a.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config3a.json
@@ -388,7 +388,15 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)",
+      "label": "optionalInt",
+      "kind": "Field",
+      "detail": "int?",
+      "sortText": "AA",
+      "insertText": "optionalInt",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "'map(function () func)",
       "kind": "Function",
       "detail": "map<map:Type1>",
       "documentation": {
@@ -398,21 +406,13 @@
         }
       },
       "sortText": "CD",
-      "filterText": "map",
-      "insertText": "map(${1})",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
         "command": "editor.action.triggerParameterHints"
       }
-    },
-    {
-      "label": "optionalInt",
-      "kind": "Field",
-      "detail": "int?",
-      "sortText": "AA",
-      "insertText": "optionalInt",
-      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config4.json
@@ -518,25 +518,6 @@
       }
     },
     {
-      "label": "map(function () func)",
-      "kind": "Function",
-      "detail": "xml<xml:XmlType>",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml:0.0.0_  \n  \nApplies a function to each item in an xml sequence, and returns an xml sequence of the results.\n\nEach item is represented as a singleton value.\n  \n**Params**  \n- `function ()` func: a function to apply to each child or parameter `item`  \n  \n**Return** `xml<xml:XmlType>`   \n- new xml value containing result of applying function `func` to each child or parameter `item`  \n  \n"
-        }
-      },
-      "sortText": "CD",
-      "filterText": "map",
-      "insertText": "map(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
       "label": "cloneWithType(typedesc<anydata> t)",
       "kind": "Function",
       "detail": "t|error",
@@ -678,6 +659,25 @@
       "filterText": "toJsonString",
       "insertText": "toJsonString()",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "'map(function () func)",
+      "kind": "Function",
+      "detail": "xml<xml:XmlType>",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.xml:0.0.0_  \n  \nApplies a function to each item in an xml sequence, and returns an xml sequence of the results.\n\nEach item is represented as a singleton value.\n  \n**Params**  \n- `function ()` func: a function to apply to each child or parameter `item`  \n  \n**Return** `xml<xml:XmlType>`   \n- new xml value containing result of applying function `func` to each child or parameter `item`  \n  \n"
+        }
+      },
+      "sortText": "CD",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config40.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config40.json
@@ -552,25 +552,6 @@
       }
     },
     {
-      "label": "map(function () func)",
-      "kind": "Function",
-      "detail": "xml<xml:XmlType>",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml:0.0.0_  \n  \nApplies a function to each item in an xml sequence, and returns an xml sequence of the results.\n\nEach item is represented as a singleton value.\n  \n**Params**  \n- `function ()` func: a function to apply to each child or parameter `item`  \n  \n**Return** `xml<xml:XmlType>`   \n- new xml value containing result of applying function `func` to each child or parameter `item`  \n  \n"
-        }
-      },
-      "sortText": "CD",
-      "filterText": "map",
-      "insertText": "map(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
       "label": "cloneWithType(typedesc<anydata> t)",
       "kind": "Function",
       "detail": "t|error",
@@ -633,6 +614,25 @@
       "filterText": "toJsonString",
       "insertText": "toJsonString()",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "'map(function () func)",
+      "kind": "Function",
+      "detail": "xml<xml:XmlType>",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.xml:0.0.0_  \n  \nApplies a function to each item in an xml sequence, and returns an xml sequence of the results.\n\nEach item is represented as a singleton value.\n  \n**Params**  \n- `function ()` func: a function to apply to each child or parameter `item`  \n  \n**Return** `xml<xml:XmlType>`   \n- new xml value containing result of applying function `func` to each child or parameter `item`  \n  \n"
+        }
+      },
+      "sortText": "CD",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config41.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config41.json
@@ -552,25 +552,6 @@
       }
     },
     {
-      "label": "map(function () func)",
-      "kind": "Function",
-      "detail": "xml<xml:XmlType>",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml:0.0.0_  \n  \nApplies a function to each item in an xml sequence, and returns an xml sequence of the results.\n\nEach item is represented as a singleton value.\n  \n**Params**  \n- `function ()` func: a function to apply to each child or parameter `item`  \n  \n**Return** `xml<xml:XmlType>`   \n- new xml value containing result of applying function `func` to each child or parameter `item`  \n  \n"
-        }
-      },
-      "sortText": "CD",
-      "filterText": "map",
-      "insertText": "map(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
       "label": "cloneWithType(typedesc<anydata> t)",
       "kind": "Function",
       "detail": "t|error",
@@ -633,6 +614,25 @@
       "filterText": "toJsonString",
       "insertText": "toJsonString()",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "'map(function () func)",
+      "kind": "Function",
+      "detail": "xml<xml:XmlType>",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.xml:0.0.0_  \n  \nApplies a function to each item in an xml sequence, and returns an xml sequence of the results.\n\nEach item is represented as a singleton value.\n  \n**Params**  \n- `function ()` func: a function to apply to each child or parameter `item`  \n  \n**Return** `xml<xml:XmlType>`   \n- new xml value containing result of applying function `func` to each child or parameter `item`  \n  \n"
+        }
+      },
+      "sortText": "CD",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config5.json
@@ -380,7 +380,15 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)",
+      "label": "testOptional",
+      "kind": "Field",
+      "detail": "int?",
+      "sortText": "CA",
+      "insertText": "testOptional",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "'map(function () func)",
       "kind": "Function",
       "detail": "map<map:Type1>",
       "documentation": {
@@ -390,21 +398,13 @@
         }
       },
       "sortText": "CD",
-      "filterText": "map",
-      "insertText": "map(${1})",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
         "command": "editor.action.triggerParameterHints"
       }
-    },
-    {
-      "label": "testOptional",
-      "kind": "Field",
-      "detail": "int?",
-      "sortText": "CA",
-      "insertText": "testOptional",
-      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config50.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config50.json
@@ -237,25 +237,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)",
-      "kind": "Function",
-      "detail": "map<map:Type1>",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:0.0.0_  \n  \nApplies a function each member of a map and returns a map of the result.\n\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Return** `map<map:Type1>`   \n- new map containing result of applying function `func` to each member  \n  \n"
-        }
-      },
-      "sortText": "CD",
-      "filterText": "map",
-      "insertText": "map(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
       "label": "cloneWithType(typedesc<anydata> t)",
       "kind": "Function",
       "detail": "t|error",
@@ -435,6 +416,25 @@
       "filterText": "toJsonString",
       "insertText": "toJsonString()",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "'map(function () func)",
+      "kind": "Function",
+      "detail": "map<map:Type1>",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:0.0.0_  \n  \nApplies a function each member of a map and returns a map of the result.\n\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Return** `map<map:Type1>`   \n- new map containing result of applying function `func` to each member  \n  \n"
+        }
+      },
+      "sortText": "CD",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config5a.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config5a.json
@@ -380,7 +380,15 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)",
+      "label": "testOptional",
+      "kind": "Field",
+      "detail": "int?",
+      "sortText": "AA",
+      "insertText": "testOptional",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "'map(function () func)",
       "kind": "Function",
       "detail": "map<map:Type1>",
       "documentation": {
@@ -390,21 +398,13 @@
         }
       },
       "sortText": "CD",
-      "filterText": "map",
-      "insertText": "map(${1})",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
         "command": "editor.action.triggerParameterHints"
       }
-    },
-    {
-      "label": "testOptional",
-      "kind": "Field",
-      "detail": "int?",
-      "sortText": "AA",
-      "insertText": "testOptional",
-      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config5b.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config5b.json
@@ -380,7 +380,15 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)",
+      "label": "testOptional",
+      "kind": "Field",
+      "detail": "int?",
+      "sortText": "CA",
+      "insertText": "testOptional",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "'map(function () func)",
       "kind": "Function",
       "detail": "map<map:Type1>",
       "documentation": {
@@ -390,21 +398,13 @@
         }
       },
       "sortText": "CD",
-      "filterText": "map",
-      "insertText": "map(${1})",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
         "command": "editor.action.triggerParameterHints"
       }
-    },
-    {
-      "label": "testOptional",
-      "kind": "Field",
-      "detail": "int?",
-      "sortText": "CA",
-      "insertText": "testOptional",
-      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config5c.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config5c.json
@@ -380,7 +380,15 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)",
+      "label": "testOptional",
+      "kind": "Field",
+      "detail": "int?",
+      "sortText": "CA",
+      "insertText": "testOptional",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "'map(function () func)",
       "kind": "Function",
       "detail": "map<map:Type1>",
       "documentation": {
@@ -390,21 +398,13 @@
         }
       },
       "sortText": "CD",
-      "filterText": "map",
-      "insertText": "map(${1})",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",
         "command": "editor.action.triggerParameterHints"
       }
-    },
-    {
-      "label": "testOptional",
-      "kind": "Field",
-      "detail": "int?",
-      "sortText": "CA",
-      "insertText": "testOptional",
-      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config7.json
@@ -388,7 +388,7 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)",
+      "label": "'map(function () func)",
       "kind": "Function",
       "detail": "map<map:Type1>",
       "documentation": {
@@ -398,8 +398,8 @@
         }
       },
       "sortText": "CD",
-      "filterText": "map",
-      "insertText": "map(${1})",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config8.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config8.json
@@ -388,7 +388,7 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)",
+      "label": "'map(function () func)",
       "kind": "Function",
       "detail": "map<map:Type1>",
       "documentation": {
@@ -398,8 +398,8 @@
         }
       },
       "sortText": "CD",
-      "filterText": "map",
-      "insertText": "map(${1})",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_within_param_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_within_param_config1.json
@@ -372,25 +372,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)",
-      "kind": "Function",
-      "detail": "map<map:Type1>",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:0.0.0_  \n  \nApplies a function each member of a map and returns a map of the result.\n\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Return** `map<map:Type1>`   \n- new map containing result of applying function `func` to each member  \n  \n"
-        }
-      },
-      "sortText": "CD",
-      "filterText": "map",
-      "insertText": "map(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
       "label": "name",
       "kind": "Field",
       "detail": "string",
@@ -483,6 +464,25 @@
       "sortText": "CA",
       "insertText": "goals",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "'map(function () func)",
+      "kind": "Function",
+      "detail": "map<map:Type1>",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:0.0.0_  \n  \nApplies a function each member of a map and returns a map of the result.\n\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Return** `map<map:Type1>`   \n- new map containing result of applying function `func` to each member  \n  \n"
+        }
+      },
+      "sortText": "CD",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/foreach_stmt_ctx_config10.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/foreach_stmt_ctx_config10.json
@@ -568,7 +568,7 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)",
+      "label": "'map(function () func)",
       "kind": "Function",
       "detail": "array:Type1[]",
       "documentation": {
@@ -578,8 +578,8 @@
         }
       },
       "sortText": "CD",
-      "filterText": "map",
-      "insertText": "map(${1})",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/foreach_stmt_ctx_config11.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/foreach_stmt_ctx_config11.json
@@ -568,7 +568,7 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)",
+      "label": "'map(function () func)",
       "kind": "Function",
       "detail": "array:Type1[]",
       "documentation": {
@@ -578,8 +578,8 @@
         }
       },
       "sortText": "CD",
-      "filterText": "map",
-      "insertText": "map(${1})",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/foreach_stmt_ctx_config12.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/foreach_stmt_ctx_config12.json
@@ -568,7 +568,7 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)",
+      "label": "'map(function () func)",
       "kind": "Function",
       "detail": "array:Type1[]",
       "documentation": {
@@ -578,8 +578,8 @@
         }
       },
       "sortText": "CD",
-      "filterText": "map",
-      "insertText": "map(${1})",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/foreach_stmt_ctx_config14.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/foreach_stmt_ctx_config14.json
@@ -568,7 +568,7 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)",
+      "label": "'map(function () func)",
       "kind": "Function",
       "detail": "array:Type1[]",
       "documentation": {
@@ -578,8 +578,8 @@
         }
       },
       "sortText": "CD",
-      "filterText": "map",
-      "insertText": "map(${1})",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/foreach_stmt_ctx_config15.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/foreach_stmt_ctx_config15.json
@@ -478,7 +478,7 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)",
+      "label": "'map(function () func)",
       "kind": "Function",
       "detail": "map<map:Type1>",
       "documentation": {
@@ -488,8 +488,8 @@
         }
       },
       "sortText": "CD",
-      "filterText": "map",
-      "insertText": "map(${1})",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/foreach_stmt_ctx_config16.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/foreach_stmt_ctx_config16.json
@@ -478,7 +478,7 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)",
+      "label": "'map(function () func)",
       "kind": "Function",
       "detail": "map<map:Type1>",
       "documentation": {
@@ -488,8 +488,8 @@
         }
       },
       "sortText": "CD",
-      "filterText": "map",
-      "insertText": "map(${1})",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/foreach_stmt_ctx_config17.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/foreach_stmt_ctx_config17.json
@@ -462,7 +462,7 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)",
+      "label": "'map(function () func)",
       "kind": "Function",
       "detail": "map<map:Type1>",
       "documentation": {
@@ -472,8 +472,8 @@
         }
       },
       "sortText": "CD",
-      "filterText": "map",
-      "insertText": "map(${1})",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/foreach_stmt_ctx_config18.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/foreach_stmt_ctx_config18.json
@@ -337,7 +337,7 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)",
+      "label": "'map(function () func)",
       "kind": "Function",
       "detail": "table<table:MapType1>",
       "documentation": {
@@ -347,8 +347,8 @@
         }
       },
       "sortText": "CD",
-      "filterText": "map",
-      "insertText": "map(${1})",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/foreach_stmt_ctx_config19.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/foreach_stmt_ctx_config19.json
@@ -183,7 +183,7 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)",
+      "label": "'map(function () func)",
       "kind": "Function",
       "detail": "stream<stream:Type1, stream:CompletionType>",
       "documentation": {
@@ -193,8 +193,8 @@
         }
       },
       "sortText": "CD",
-      "filterText": "map",
-      "insertText": "map(${1})",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/foreach_stmt_ctx_config20.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/foreach_stmt_ctx_config20.json
@@ -518,25 +518,6 @@
       }
     },
     {
-      "label": "map(function () func)",
-      "kind": "Function",
-      "detail": "xml<xml:XmlType>",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml:0.0.0_  \n  \nApplies a function to each item in an xml sequence, and returns an xml sequence of the results.\n\nEach item is represented as a singleton value.\n  \n**Params**  \n- `function ()` func: a function to apply to each child or parameter `item`  \n  \n**Return** `xml<xml:XmlType>`   \n- new xml value containing result of applying function `func` to each child or parameter `item`  \n  \n"
-        }
-      },
-      "sortText": "CD",
-      "filterText": "map",
-      "insertText": "map(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
       "label": "cloneWithType(typedesc<anydata> t)",
       "kind": "Function",
       "detail": "t|error",
@@ -678,6 +659,25 @@
       "filterText": "toJsonString",
       "insertText": "toJsonString()",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "'map(function () func)",
+      "kind": "Function",
+      "detail": "xml<xml:XmlType>",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.xml:0.0.0_  \n  \nApplies a function to each item in an xml sequence, and returns an xml sequence of the results.\n\nEach item is represented as a singleton value.\n  \n**Params**  \n- `function ()` func: a function to apply to each child or parameter `item`  \n  \n**Return** `xml<xml:XmlType>`   \n- new xml value containing result of applying function `func` to each child or parameter `item`  \n  \n"
+        }
+      },
+      "sortText": "CD",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/foreach_stmt_ctx_config21.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/foreach_stmt_ctx_config21.json
@@ -568,7 +568,7 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)",
+      "label": "'map(function () func)",
       "kind": "Function",
       "detail": "array:Type1[]",
       "documentation": {
@@ -578,8 +578,8 @@
         }
       },
       "sortText": "CD",
-      "filterText": "map",
-      "insertText": "map(${1})",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/foreach_stmt_ctx_config22.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/foreach_stmt_ctx_config22.json
@@ -530,7 +530,7 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)",
+      "label": "'map(function () func)",
       "kind": "Function",
       "detail": "array:Type1[]",
       "documentation": {
@@ -540,8 +540,8 @@
         }
       },
       "sortText": "CD",
-      "filterText": "map",
-      "insertText": "map(${1})",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/foreach_stmt_ctx_config23.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/foreach_stmt_ctx_config23.json
@@ -456,7 +456,7 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)",
+      "label": "'map(function () func)",
       "kind": "Function",
       "detail": "map<map:Type1>",
       "documentation": {
@@ -466,8 +466,8 @@
         }
       },
       "sortText": "CD",
-      "filterText": "map",
-      "insertText": "map(${1})",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/foreach_stmt_ctx_config24.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/foreach_stmt_ctx_config24.json
@@ -518,25 +518,6 @@
       }
     },
     {
-      "label": "map(function () func)",
-      "kind": "Function",
-      "detail": "xml<xml:XmlType>",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.xml:0.0.0_  \n  \nApplies a function to each item in an xml sequence, and returns an xml sequence of the results.\n\nEach item is represented as a singleton value.\n  \n**Params**  \n- `function ()` func: a function to apply to each child or parameter `item`  \n  \n**Return** `xml<xml:XmlType>`   \n- new xml value containing result of applying function `func` to each child or parameter `item`  \n  \n"
-        }
-      },
-      "sortText": "CD",
-      "filterText": "map",
-      "insertText": "map(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
       "label": "cloneWithType(typedesc<anydata> t)",
       "kind": "Function",
       "detail": "t|error",
@@ -678,6 +659,25 @@
       "filterText": "toJsonString",
       "insertText": "toJsonString()",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "'map(function () func)",
+      "kind": "Function",
+      "detail": "xml<xml:XmlType>",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.xml:0.0.0_  \n  \nApplies a function to each item in an xml sequence, and returns an xml sequence of the results.\n\nEach item is represented as a singleton value.\n  \n**Params**  \n- `function ()` func: a function to apply to each child or parameter `item`  \n  \n**Return** `xml<xml:XmlType>`   \n- new xml value containing result of applying function `func` to each child or parameter `item`  \n  \n"
+        }
+      },
+      "sortText": "CD",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/foreach_stmt_ctx_config25.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/foreach_stmt_ctx_config25.json
@@ -93,25 +93,6 @@
       }
     },
     {
-      "label": "map(function () func)",
-      "kind": "Function",
-      "detail": "stream<stream:Type1, stream:CompletionType>",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.stream:0.0.0_  \n  \nApplies a function to each member of a stream and returns a stream of the results.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Return** `stream<stream:Type1, stream:CompletionType>`   \n- new stream containing result of applying function `func` to each member of parameter `stm` in order  \n  \n"
-        }
-      },
-      "sortText": "CD",
-      "filterText": "map",
-      "insertText": "map(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
       "label": "close()",
       "kind": "Function",
       "detail": "stream:CompletionType?",
@@ -174,6 +155,25 @@
       "filterText": "toString",
       "insertText": "toString()",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "'map(function () func)",
+      "kind": "Function",
+      "detail": "stream<stream:Type1, stream:CompletionType>",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.stream:0.0.0_  \n  \nApplies a function to each member of a stream and returns a stream of the results.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Return** `stream<stream:Type1, stream:CompletionType>`   \n- new stream containing result of applying function `func` to each member of parameter `stm` in order  \n  \n"
+        }
+      },
+      "sortText": "CD",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/foreach_stmt_ctx_config9.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/foreach_stmt_ctx_config9.json
@@ -568,7 +568,7 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)",
+      "label": "'map(function () func)",
       "kind": "Function",
       "detail": "array:Type1[]",
       "documentation": {
@@ -578,8 +578,8 @@
         }
       },
       "sortText": "CD",
-      "filterText": "map",
-      "insertText": "map(${1})",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/optional_field_access_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/optional_field_access_ctx_config1.json
@@ -194,25 +194,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)",
-      "kind": "Function",
-      "detail": "map<map:Type1>",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:0.0.0_  \n  \nApplies a function each member of a map and returns a map of the result.\n\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Return** `map<map:Type1>`   \n- new map containing result of applying function `func` to each member  \n  \n"
-        }
-      },
-      "sortText": "CD",
-      "filterText": "map",
-      "insertText": "map(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
       "label": "filter(function () func)",
       "kind": "Function",
       "detail": "map<map:Type>",
@@ -400,6 +381,25 @@
       "sortText": "CD",
       "filterText": "ensureType",
       "insertText": "ensureType(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "'map(function () func)",
+      "kind": "Function",
+      "detail": "map<map:Type1>",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:0.0.0_  \n  \nApplies a function each member of a map and returns a map of the result.\n\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Return** `map<map:Type1>`   \n- new map containing result of applying function `func` to each member  \n  \n"
+        }
+      },
+      "sortText": "CD",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/optional_field_access_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/optional_field_access_ctx_config2.json
@@ -194,25 +194,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)",
-      "kind": "Function",
-      "detail": "map<map:Type1>",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:0.0.0_  \n  \nApplies a function each member of a map and returns a map of the result.\n\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Return** `map<map:Type1>`   \n- new map containing result of applying function `func` to each member  \n  \n"
-        }
-      },
-      "sortText": "CD",
-      "filterText": "map",
-      "insertText": "map(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
       "label": "filter(function () func)",
       "kind": "Function",
       "detail": "map<map:Type>",
@@ -400,6 +381,25 @@
       "sortText": "CD",
       "filterText": "ensureType",
       "insertText": "ensureType(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "'map(function () func)",
+      "kind": "Function",
+      "detail": "map<map:Type1>",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:0.0.0_  \n  \nApplies a function each member of a map and returns a map of the result.\n\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Return** `map<map:Type1>`   \n- new map containing result of applying function `func` to each member  \n  \n"
+        }
+      },
+      "sortText": "CD",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/optional_field_access_ctx_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/optional_field_access_ctx_config3.json
@@ -194,25 +194,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)",
-      "kind": "Function",
-      "detail": "map<map:Type1>",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:0.0.0_  \n  \nApplies a function each member of a map and returns a map of the result.\n\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Return** `map<map:Type1>`   \n- new map containing result of applying function `func` to each member  \n  \n"
-        }
-      },
-      "sortText": "CD",
-      "filterText": "map",
-      "insertText": "map(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
       "label": "filter(function () func)",
       "kind": "Function",
       "detail": "map<map:Type>",
@@ -408,6 +389,25 @@
       "sortText": "CD",
       "filterText": "ensureType",
       "insertText": "ensureType(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "'map(function () func)",
+      "kind": "Function",
+      "detail": "map<map:Type1>",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:0.0.0_  \n  \nApplies a function each member of a map and returns a map of the result.\n\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Return** `map<map:Type1>`   \n- new map containing result of applying function `func` to each member  \n  \n"
+        }
+      },
+      "sortText": "CD",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/optional_field_access_ctx_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/optional_field_access_ctx_config4.json
@@ -194,25 +194,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map(function () func)",
-      "kind": "Function",
-      "detail": "map<map:Type1>",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.map:0.0.0_  \n  \nApplies a function each member of a map and returns a map of the result.\n\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Return** `map<map:Type1>`   \n- new map containing result of applying function `func` to each member  \n  \n"
-        }
-      },
-      "sortText": "CD",
-      "filterText": "map",
-      "insertText": "map(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
       "label": "filter(function () func)",
       "kind": "Function",
       "detail": "map<map:Type>",
@@ -408,6 +389,25 @@
       "sortText": "CD",
       "filterText": "ensureType",
       "insertText": "ensureType(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "'map(function () func)",
+      "kind": "Function",
+      "detail": "map<map:Type1>",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:0.0.0_  \n  \nApplies a function each member of a map and returns a map of the result.\n\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Return** `map<map:Type1>`   \n- new map containing result of applying function `func` to each member  \n  \n"
+        }
+      },
+      "sortText": "CD",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
       "insertTextFormat": "Snippet",
       "command": {
         "title": "editor.action.triggerParameterHints",

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/LangLibFunctionTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/LangLibFunctionTest.java
@@ -201,7 +201,7 @@ public class LangLibFunctionTest {
         TypeSymbol type = ((VariableSymbol) symbol).typeDescriptor();
         assertEquals(type.typeKind(), ARRAY);
 
-        List<String> expFunctions = List.of("length", "iterator", "enumerate", "map", "forEach", "filter",
+        List<String> expFunctions = List.of("length", "iterator", "enumerate", "'map", "forEach", "filter",
                                             "reduce", "slice", "remove", "removeAll", "setLength", "reverse",
                                             "sort", "pop", "push", "shift", "unshift", "toString",
                                             "toBalString", "toStream", "ensureType");
@@ -215,7 +215,7 @@ public class LangLibFunctionTest {
         TypeSymbol type = ((VariableSymbol) symbol).typeDescriptor();
         assertEquals(type.typeKind(), MAP);
 
-        List<String> expFunctions = List.of("length", "iterator", "get", "entries", "map", "forEach", "filter",
+        List<String> expFunctions = List.of("length", "iterator", "get", "entries", "'map", "forEach", "filter",
                                             "reduce", "removeIfHasKey", "remove", "removeAll", "hasKey", "keys",
                                             "toArray", "clone", "cloneReadOnly", "cloneWithType", "isReadOnly",
                                             "toString", "toBalString", "toJson", "toJsonString", "fromJsonWithType",
@@ -234,7 +234,7 @@ public class LangLibFunctionTest {
 
     @DataProvider(name = "XMLInfoProvider")
     public Object[][] getXMLInfo() {
-        List<String> expFunctions = List.of("length", "iterator", "forEach", "map", "filter", "get", "slice", "strip",
+        List<String> expFunctions = List.of("length", "iterator", "forEach", "'map", "filter", "get", "slice", "strip",
                                             "elements", "children", "elementChildren", "clone", "cloneReadOnly",
                                             "cloneWithType", "isReadOnly", "toString", "toBalString", "toJson",
                                             "toJsonString", "ensureType", "text", "data");
@@ -276,7 +276,7 @@ public class LangLibFunctionTest {
         TypeSymbol type = ((TypeDefinitionSymbol) symbol).typeDescriptor();
         assertEquals(type.typeKind(), RECORD);
 
-        List<String> expFunctions = List.of("length", "iterator", "get", "entries", "map", "forEach", "filter",
+        List<String> expFunctions = List.of("length", "iterator", "get", "entries", "'map", "forEach", "filter",
                                             "reduce", "removeIfHasKey", "remove", "removeAll", "hasKey", "keys",
                                             "toArray", "clone", "cloneReadOnly", "cloneWithType", "isReadOnly",
                                             "toString", "toBalString", "toJson", "toJsonString", "fromJsonWithType",
@@ -291,7 +291,7 @@ public class LangLibFunctionTest {
         TypeSymbol type = ((VariableSymbol) symbol).typeDescriptor();
         assertEquals(type.typeKind(), TUPLE);
 
-        List<String> expFunctions = List.of("length", "iterator", "enumerate", "map", "forEach", "filter", "reduce",
+        List<String> expFunctions = List.of("length", "iterator", "enumerate", "'map", "forEach", "filter", "reduce",
                                             "slice", "remove", "removeAll", "setLength", "indexOf", "lastIndexOf",
                                             "reverse", "sort", "pop", "push", "shift", "unshift", "toStream", "clone",
                                             "cloneReadOnly", "cloneWithType", "isReadOnly", "toString", "toBalString",
@@ -342,7 +342,7 @@ public class LangLibFunctionTest {
         TypeSymbol type = ((VariableSymbol) symbol).typeDescriptor();
         assertEquals(type.typeKind(), STREAM);
 
-        List<String> expFunctions = List.of("filter", "next", "map", "reduce", "forEach", "iterator", "close",
+        List<String> expFunctions = List.of("filter", "next", "'map", "reduce", "forEach", "iterator", "close",
                                             "toString", "toBalString", "ensureType");
 
         assertLangLibList(type.langLibMethods(), expFunctions);
@@ -358,7 +358,7 @@ public class LangLibFunctionTest {
 
     @DataProvider(name = "TableInfoProvider")
     public Object[][] getTableInfo() {
-        List<String> expFunctions = List.of("length", "put", "add", "removeAll", "toArray", "map", "reduce", "forEach",
+        List<String> expFunctions = List.of("length", "put", "add", "removeAll", "toArray", "'map", "reduce", "forEach",
                                             "iterator", "toString", "toBalString", "clone", "cloneReadOnly",
                                             "cloneWithType", "isReadOnly", "toJson", "toJsonString", "ensureType");
 
@@ -378,7 +378,7 @@ public class LangLibFunctionTest {
 
         List<String> expFunctions = List.of("reduce", "forEach", "shift", "length", "sort", "reverse", "toStream",
                                             "remove", "push", "filter", "pop", "lastIndexOf", "iterator", "removeAll",
-                                            "setLength", "slice", "enumerate", "unshift", "map", "indexOf",
+                                            "setLength", "slice", "enumerate", "unshift", "'map", "indexOf",
                                             "cloneWithType", "cloneReadOnly", "toBalString", "toJson", "isReadOnly",
                                             "fromJsonWithType", "mergeJson", "clone", "ensureType", "toString",
                                             "toJsonString");

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolBIRTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolBIRTest.java
@@ -254,10 +254,10 @@ public class SymbolBIRTest {
     private List<SymbolInfo> getModuleSymbolInfo() {
         return createSymbolInfoList(
                 new Object[][]{
-                        {"xml", MODULE}, {"testproject", MODULE}, {"object", MODULE}, {"error", MODULE},
-                        {"boolean", MODULE}, {"decimal", MODULE}, {"typedesc", MODULE}, {"float", MODULE},
-                        {"future", MODULE}, {"int", MODULE}, {"map", MODULE}, {"stream", MODULE},
-                        {"string", MODULE}, {"table", MODULE}, {"transaction", MODULE}
+                        {"lang.xml", MODULE}, {"testproject", MODULE}, {"lang.object", MODULE}, {"lang.error", MODULE},
+                        {"lang.boolean", MODULE}, {"lang.decimal", MODULE}, {"lang.typedesc", MODULE}, {"lang.float", MODULE},
+                        {"lang.future", MODULE}, {"lang.int", MODULE}, {"lang.map", MODULE}, {"lang.stream", MODULE},
+                        {"lang.string", MODULE}, {"lang.table", MODULE}, {"lang.transaction", MODULE}
                 });
     }
 
@@ -295,6 +295,11 @@ public class SymbolBIRTest {
         @Override
         public int hashCode() {
             return Objects.hash(this.name, this.kind);
+        }
+
+        @Override
+        public String toString() {
+            return "Symbol {name='" + name + '\'' + ", kind=" + kind + '}';
         }
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolBIRTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolBIRTest.java
@@ -254,10 +254,10 @@ public class SymbolBIRTest {
     private List<SymbolInfo> getModuleSymbolInfo() {
         return createSymbolInfoList(
                 new Object[][]{
-                        {"lang.xml", MODULE}, {"testproject", MODULE}, {"lang.object", MODULE}, {"lang.error", MODULE},
-                        {"lang.boolean", MODULE}, {"lang.decimal", MODULE}, {"lang.typedesc", MODULE}, {"lang.float", MODULE},
-                        {"lang.future", MODULE}, {"lang.int", MODULE}, {"lang.map", MODULE}, {"lang.stream", MODULE},
-                        {"lang.string", MODULE}, {"lang.table", MODULE}, {"lang.transaction", MODULE}
+                        {"xml", MODULE}, {"testproject", MODULE}, {"object", MODULE}, {"error", MODULE},
+                        {"boolean", MODULE}, {"decimal", MODULE}, {"typedesc", MODULE}, {"float", MODULE},
+                        {"future", MODULE}, {"int", MODULE}, {"map", MODULE}, {"stream", MODULE},
+                        {"string", MODULE}, {"table", MODULE}, {"transaction", MODULE}
                 });
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/langlib/TypeParamBoundArrayFunctionsTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/langlib/TypeParamBoundArrayFunctionsTest.java
@@ -99,7 +99,7 @@ public class TypeParamBoundArrayFunctionsTest {
 
     @Test
     public void testMap() {
-        FunctionTypeSymbol mapFnType = assertFnNameAndGetParams("map");
+        FunctionTypeSymbol mapFnType = assertFnNameAndGetParams("'map");
         List<ParameterSymbol> params = mapFnType.params().get();
 
         assertEquals(params.size(), 2);

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/langlib/TypeParamBoundMapFunctionsTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/langlib/TypeParamBoundMapFunctionsTest.java
@@ -114,7 +114,7 @@ public class TypeParamBoundMapFunctionsTest {
 
     @Test
     public void testMap() {
-        FunctionTypeSymbol mapFnType = assertFnNameAndGetParams("map");
+        FunctionTypeSymbol mapFnType = assertFnNameAndGetParams("'map");
         List<ParameterSymbol> params = mapFnType.params().get();
 
         assertEquals(params.size(), 2);

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/langlib/TypeParamBoundStreamFunctionsTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/langlib/TypeParamBoundStreamFunctionsTest.java
@@ -90,7 +90,7 @@ public class TypeParamBoundStreamFunctionsTest {
 
     @Test
     public void testMap() {
-        FunctionTypeSymbol mapFnType = assertFnNameAndGetParams("map");
+        FunctionTypeSymbol mapFnType = assertFnNameAndGetParams("'map");
         List<ParameterSymbol> params = mapFnType.params().get();
 
         assertEquals(params.size(), 2);

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/langlib/TypeParamBoundTableFunctionsTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/langlib/TypeParamBoundTableFunctionsTest.java
@@ -109,7 +109,7 @@ public class TypeParamBoundTableFunctionsTest {
 
     @Test
     public void testMap() {
-        FunctionTypeSymbol mapFnType = assertFnNameAndGetParams("map");
+        FunctionTypeSymbol mapFnType = assertFnNameAndGetParams("'map");
         List<ParameterSymbol> params = mapFnType.params().get();
 
         assertEquals(params.size(), 2);

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/langlib/TypeParamBoundXMLFunctionsTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/langlib/TypeParamBoundXMLFunctionsTest.java
@@ -103,7 +103,7 @@ public class TypeParamBoundXMLFunctionsTest {
 
     @Test
     public void testMap() {
-        FunctionTypeSymbol mapFnType = assertFnNameAndGetParams("map");
+        FunctionTypeSymbol mapFnType = assertFnNameAndGetParams("'map");
         List<ParameterSymbol> params = mapFnType.params().get();
 
         assertEquals(params.size(), 2);


### PR DESCRIPTION
## Purpose
This PR removes all the special case handling we did at the Semantic API level for keywords used in lang libs. The major impact of this is on how completions behave. Refer to the following images for how it behaves with this change. Previously, it didn't show the quote.

<img width="459" alt="Screenshot 2022-01-05 at 18 44 15" src="https://user-images.githubusercontent.com/6260009/148282629-a96735ef-b32a-4fbd-a900-b58873f46eeb.png">

<img width="459" alt="Screenshot 2022-01-05 at 18 44 55" src="https://user-images.githubusercontent.com/6260009/148282647-e7870dd1-4ae8-482e-89f6-8e46a6519bbd.png">

## Remarks
Note that this nor the previous behaviour had no effect on features such as find all refs, renaming and goto def since we do support comparing quoted and unquoted symbol names.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
