### PR TITLE
Update ls simulator workflow to not fail fast

### DIFF
--- a/.github/workflows/language_server_simulator.yml
+++ b/.github/workflows/language_server_simulator.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 240
     strategy:
+      fail-fast: false
       matrix: 
         branch: ["master", "stage-swan-lake"]
 


### PR DESCRIPTION
## Purpose
$subject

Without this, if there's a memory leak in only one branch (say `master`), job to simulate on other branch (`stage-swan-lake`) gets cancelled.

## Approach
Added fail fast property to job strategy

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
