### PR TITLE
Update type narrowing to consider readonly difference - phase I

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -4417,6 +4417,11 @@ public class Types {
                 break;
             case TypeTags.TYPEREFDESC:
                 BType refType = getReferredType(originalType);
+
+                if (refType.tag == TypeTags.INTERSECTION) {
+                    refType = ((BIntersectionType) refType).effectiveType;
+                }
+
                 if (refType.tag != TypeTags.UNION && refType.tag != TypeTags.FINITE) {
                     return originalType;
                 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -4469,6 +4469,8 @@ public class Types {
 
         remainingType = getReferredType(remainingType);
         switch (remainingType.tag) {
+            case TypeTags.MAP:
+                return false;
             case RECORD:
                 BRecordType recordType = (BRecordType) remainingType;
                 if (!recordType.sealed && recordType.restFieldType != symTable.neverType) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -4434,9 +4434,6 @@ public class Types {
             return remainingType;
         }
 
-//        if (isAssignable(originalType, typeToRemove)) {
-//        }
-
         if (isClosedRecordTypes(getReferredType(typeToRemove)) && removesDistinctRecords(typeToRemove, remainingType)) {
             return remainingType;
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -4403,9 +4403,10 @@ public class Types {
 
                 BType typeRemovedFromOriginalType = getReferredType(getRemainingType((BUnionType) originalType,
                                                                       getAllTypes(remainingType, true)));
-                if (isInherentlyImmutableType(typeRemovedFromOriginalType) ||
+                if (typeRemovedFromOriginalType == symTable.nullSet ||
+                        (isInherentlyImmutableType(typeRemovedFromOriginalType) ||
                         (isSelectivelyImmutableType(typeRemovedFromOriginalType) &&
-                                Symbols.isFlagOn(typeRemovedFromOriginalType.flags, Flags.READONLY))) {
+                                Symbols.isFlagOn(typeRemovedFromOriginalType.flags, Flags.READONLY)))) {
                     return remainingType;
                 }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/TypeGuardTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/TypeGuardTest.java
@@ -741,6 +741,31 @@ public class TypeGuardTest {
         BRunUtil.invoke(result, "testIfElseWithTypeTestMultipleVariablesInNestedBlocks");
     }
 
+    @Test
+    public void testTypeGuardsAccountingForSemTypes1() {
+        CompileResult result = BCompileUtil.compile("test-src/statements/ifelse/test_type_guard_sem_types_1.bal");
+        int index = 0;
+        BAssertUtil.validateError(result, index++, "incompatible types: expected 'B', found '(A|B)'", 29, 15);
+        BAssertUtil.validateError(result, index++, "incompatible types: expected 'B', found '(A|B)'", 37, 11);
+        BAssertUtil.validateError(result, index++, "incompatible types: expected 'D', found 'E'", 54, 15);
+        BAssertUtil.validateError(result, index++, "incompatible types: expected 'O', found '((N|O) & readonly)'",
+                                  122, 15);
+        Assert.assertEquals(result.getDiagnostics().length, index);
+    }
+
+    @Test
+    public void testTypeGuardsAccountingForSemTypes2() {
+        CompileResult result = BCompileUtil.compile("test-src/statements/ifelse/test_type_guard_sem_types_2.bal");
+        int index = 0;
+        BAssertUtil.validateHint(result, index++, "unnecessary condition: expression will always evaluate to 'true'",
+                                 30, 8);
+        BAssertUtil.validateError(result, index++, "unreachable code", 33, 9);
+        BAssertUtil.validateError(result, index++,
+                                  "expression of type 'never' or equivalent to type 'never' not allowed here",
+                      33, 13);
+        Assert.assertEquals(result.getDiagnostics().length, index);
+    }
+
     @AfterClass
     public void tearDown() {
         result = null;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/TypeGuardTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/TypeGuardTest.java
@@ -81,10 +81,10 @@ public class TypeGuardTest {
                                   "incompatible types: '(Person|Student)' will not be matched to 'float'", 138, 40);
         BAssertUtil.validateError(negativeResult, i++,
                                   "incompatible types: '(Person|Student)' will not be matched to 'boolean'", 138, 56);
-        BAssertUtil.validateError(negativeResult, i++,
-                "incompatible types: '(Baz|int)' will not be matched to 'Bar'", 150, 15);
-        BAssertUtil.validateError(negativeResult, i++,
-                "incompatible types: '(Baz|int)' will not be matched to 'Qux'", 156, 15);
+//        BAssertUtil.validateError(negativeResult, i++,
+//                "incompatible types: '(Baz|int)' will not be matched to 'Bar'", 150, 15);
+//        BAssertUtil.validateError(negativeResult, i++,
+//                "incompatible types: '(Baz|int)' will not be matched to 'Qux'", 156, 15);
         BAssertUtil.validateError(negativeResult, i++,
                 "incompatible types: 'record {| int i; boolean b; |}' will not be matched to 'ClosedRec'", 187, 8);
         BAssertUtil.validateError(negativeResult, i++,

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/ifelse/test_type_guard_sem_types_1.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/ifelse/test_type_guard_sem_types_1.bal
@@ -1,0 +1,182 @@
+// Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+type A record {|
+    string a;
+|};
+
+type B record {|
+    int a;
+|};
+
+function f1(A|B x) {
+    if x is A {
+        return;
+    } else {
+        B _ = x; // error
+    }
+}
+
+function f2(A|B x) {
+    if x is A {
+        return;
+    }
+    B _ = x; // error
+}
+
+type C record {|
+    int i;
+|};
+
+type D record {|
+    string i;
+|};
+
+type E C|D;
+
+function f3(E v) {
+    if v is C {
+
+    } else {
+        D _ = v; // error
+    }
+}
+
+type F readonly & record {|
+    int i;
+|};
+
+type G readonly & record {|
+    string i;
+|};
+
+type H F|G;
+
+function f4(H v) {
+    if v is F {
+
+    } else {
+        G _ = v; // OK
+    }
+}
+
+type I readonly & record {|
+    int i;
+|};
+
+type J readonly & record {|
+    string i;
+|};
+
+function f5(I|J v) {
+    if v is I {
+
+    } else {
+        J _ = v; // OK
+    }
+}
+
+type K record {|
+    int i;
+|};
+
+type L record {|
+    string i;
+|};
+
+type M readonly & (K|L);
+
+function f6(M v) {
+    if v is K {
+
+    } else {
+        L _ = v; // OK
+    }
+}
+
+type N record {|
+    int i;
+|};
+
+type O record {|
+    string i;
+|};
+
+function f7(readonly & (N|O) v) {
+    if v is N {
+
+    } else {
+        O _ = v; // OK, but not supported yet (snapshot 1)
+    }
+}
+
+type P record {|
+    int i;
+|};
+
+type Q record {|
+    string i;
+|};
+
+type R record {|
+    anydata i;
+|};
+
+function f8(P|Q v) {
+    if v is R {
+
+    } else {
+        _ = v; // unreachable
+    }
+}
+
+type S record {|
+    int i;
+|};
+
+type T record {|
+    int j;
+|};
+
+type U R|T;
+
+function f9(U v) {
+    if v is R {
+
+    } else {
+        T _ = v; // OK
+    }
+}
+
+function f10() {
+    int[]|error res = [];
+
+    if res is int[] {
+        int[] _ = res;
+    } else {
+        error x = res; // OK
+    }
+}
+
+function f11() {
+    int[] & readonly|string[] x = [1];
+
+    if x is int[] {
+
+    } else {
+        string[] _ = x; // OK
+    }
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/ifelse/test_type_guard_sem_types_2.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/ifelse/test_type_guard_sem_types_2.bal
@@ -1,0 +1,35 @@
+// Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+type P record {|
+    int i;
+|};
+
+type Q record {|
+    string i;
+|};
+
+type R record {|
+    anydata i;
+|};
+
+function f1(P|Q v) {
+    if v is R {
+
+    } else {
+        _ = v; // unreachable
+    }
+}


### PR DESCRIPTION
## Purpose
$title. In the interest of time, doesn't fully implement read-only difference, but performs several checks to arrive at the narrowed types.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
