### PR TITLE
Fix issue in toString() for decimal zero

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/DecimalValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/DecimalValue.java
@@ -253,7 +253,7 @@ public class DecimalValue implements SimpleValue, BDecimal {
      * @param parent The link to the parent node
      */
     public String stringValue(BLink parent) {
-        if (this.valueKind != DecimalValueKind.OTHER) {
+        if (this.valueKind != DecimalValueKind.OTHER && this.valueKind != DecimalValueKind.ZERO) {
             return this.valueKind.getValue();
         }
         return value.toString();

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibValueTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibValueTest.java
@@ -484,6 +484,11 @@ public class LangLibValueTest {
         };
     }
 
+    @Test
+    public void testDecimalZeroToStringWithDifferentPrecisions() {
+        BRunUtil.invokeFunction(compileResult, "testDecimalZeroToStringWithDifferentPrecisions");
+    }
+
     @AfterClass
     public void tearDown() {
         compileResult = null;

--- a/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
@@ -2259,27 +2259,27 @@ function testUsingCloneableReturnType() {
     assertEquality("dummyVal", caller.getAttribute("dummy"));
 }
 
-function testDecimalZeroToStringWithDifferentPrecisions() returns error? {
+function testDecimalZeroToStringWithDifferentPrecisions() {
     decimal d1 = 0.0d;
     decimal d2 = 0d;
 
     assertFalse(d1.toString() == d2.toString());
-    assertTrue(check decimal:fromString(d1.toString()) == check decimal:fromString(d2.toString()));
-    assertFalse(decimal:fromString(d1.toString()) === decimal:fromString(d2.toString()));
+    assertTrue(checkpanic decimal:fromString(d1.toString()) == checkpanic decimal:fromString(d2.toString()));
+    assertFalse(checkpanic decimal:fromString(d1.toString()) === checkpanic decimal:fromString(d2.toString()));
 
     d1 = 0.00000000d;
     d2 = 0.0d;
 
     assertFalse(d1.toString() == d2.toString());
-    assertTrue(check decimal:fromString(d1.toString()) == check decimal:fromString(d2.toString()));
-    assertFalse(decimal:fromString(d1.toString()) === decimal:fromString(d2.toString()));
+    assertTrue(checkpanic decimal:fromString(d1.toString()) == checkpanic decimal:fromString(d2.toString()));
+    assertFalse(checkpanic decimal:fromString(d1.toString()) === checkpanic decimal:fromString(d2.toString()));
     
     d1 = 0.0000d;
     d2 = 0.0000d;
 
     assertEquality(d1.toString(), d2.toString());
-    assertTrue(check decimal:fromString(d1.toString()) == check decimal:fromString(d2.toString()));
-    assertTrue(decimal:fromString(d1.toString()) === decimal:fromString(d2.toString()));
+    assertTrue(checkpanic decimal:fromString(d1.toString()) == checkpanic decimal:fromString(d2.toString()));
+    assertTrue(checkpanic decimal:fromString(d1.toString()) === checkpanic decimal:fromString(d2.toString()));
 }
 
 type AssertionError distinct error;

--- a/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
@@ -508,25 +508,6 @@ public function xmlSequenceFragmentToString() returns string {
    return (x/*).toString();
 }
 
-type AssertionError distinct error;
-
-const ASSERTION_ERROR_REASON = "AssertionError";
-
-function assertEquality(any|error expected, any|error actual) {
-    if expected is anydata && actual is anydata && expected == actual {
-        return;
-    }
-
-    if expected === actual {
-        return;
-    }
-
-    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
-    string actualValAsString = actual is error ? actual.toString() : actual.toString();
-    panic error AssertionError(ASSERTION_ERROR_REASON,
-            message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
-}
-
 type Person2 record {
     string name;
     int age;
@@ -2278,3 +2259,52 @@ function testUsingCloneableReturnType() {
     assertEquality("dummyVal", caller.getAttribute("dummy"));
 }
 
+function testDecimalZeroToStringWithDifferentPrecisions() returns error? {
+    decimal d1 = 0.0d;
+    decimal d2 = 0d;
+
+    assertFalse(d1.toString() == d2.toString());
+    assertTrue(check decimal:fromString(d1.toString()) == check decimal:fromString(d2.toString()));
+    assertFalse(decimal:fromString(d1.toString()) === decimal:fromString(d2.toString()));
+
+    d1 = 0.00000000d;
+    d2 = 0.0d;
+
+    assertFalse(d1.toString() == d2.toString());
+    assertTrue(check decimal:fromString(d1.toString()) == check decimal:fromString(d2.toString()));
+    assertFalse(decimal:fromString(d1.toString()) === decimal:fromString(d2.toString()));
+    
+    d1 = 0.0000d;
+    d2 = 0.0000d;
+
+    assertEquality(d1.toString(), d2.toString());
+    assertTrue(check decimal:fromString(d1.toString()) == check decimal:fromString(d2.toString()));
+    assertTrue(decimal:fromString(d1.toString()) === decimal:fromString(d2.toString()));
+}
+
+type AssertionError distinct error;
+
+const ASSERTION_ERROR_REASON = "AssertionError";
+
+function assertFalse(any|error actual) {
+    assertEquality(false, actual);
+}
+
+function assertTrue(any|error actual) {
+    assertEquality(true, actual);
+}
+
+function assertEquality(any|error expected, any|error actual) {
+    if expected is anydata && actual is anydata && expected == actual {
+        return;
+    }
+
+    if expected === actual {
+        return;
+    }
+
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
+    panic error AssertionError(ASSERTION_ERROR_REASON,
+            message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
+}

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/evaluation/ExpressionEvaluationTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/evaluation/ExpressionEvaluationTest.java
@@ -531,7 +531,7 @@ public class ExpressionEvaluationTest extends ExpressionEvaluationBaseTest {
         // float % float
         debugTestRunner.assertExpression(context, String.format("%s %% %s", FLOAT_VAR, FLOAT_VAR), "-0.0", "float");
         // decimal % decimal
-        debugTestRunner.assertExpression(context, String.format("%s %% %s", DECIMAL_VAR, DECIMAL_VAR), "0",
+        debugTestRunner.assertExpression(context, String.format("%s %% %s", DECIMAL_VAR, DECIMAL_VAR), "0.0",
                 "decimal");
     }
 
@@ -568,7 +568,7 @@ public class ExpressionEvaluationTest extends ExpressionEvaluationBaseTest {
         // float - float
         debugTestRunner.assertExpression(context, String.format("%s - %s", FLOAT_VAR, FLOAT_VAR), "0.0", "float");
         // decimal - decimal
-        debugTestRunner.assertExpression(context, String.format("%s - %s", DECIMAL_VAR, DECIMAL_VAR), "0", "decimal");
+        debugTestRunner.assertExpression(context, String.format("%s - %s", DECIMAL_VAR, DECIMAL_VAR), "0.0", "decimal");
     }
 
     @Override


### PR DESCRIPTION
## Purpose
Fix issue in toString() for decimal zero with different precisions

Fixes #34472

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
