### PR TITLE
Fix the code-gen crash for value creation of not defined types

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/creators/JvmErrorCreatorGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/creators/JvmErrorCreatorGen.java
@@ -89,7 +89,7 @@ public class JvmErrorCreatorGen {
                 CREATE_ERROR, null, null);
         mv.visitCode();
         if (errorTypeDefList.isEmpty()) {
-            createDefaultCase(mv, new Label(), 1, "No such error: ");
+            createDefaultCase(mv, new Label(), 0, "No such error: ");
         } else {
             mv.visitVarInsn(ALOAD, 0);
             mv.visitVarInsn(ALOAD, 1);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/creators/JvmObjectCreatorGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/creators/JvmObjectCreatorGen.java
@@ -117,7 +117,7 @@ public class JvmObjectCreatorGen {
                 CREATE_OBJECT, null, null);
         mv.visitCode();
         if (objectTypeDefList.isEmpty()) {
-            createDefaultCase(mv, new Label(), 1, "No such object: ");
+            createDefaultCase(mv, new Label(), 0, "No such object: ");
         } else {
             mv.visitVarInsn(ALOAD, 0);
             mv.visitVarInsn(ALOAD, 1);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/creators/JvmRecordCreatorGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/creators/JvmRecordCreatorGen.java
@@ -105,7 +105,7 @@ public class JvmRecordCreatorGen {
                 CREATE_RECORD_WITH_MAP, null);
         mv.visitCode();
         if (recordTypeDefList.isEmpty()) {
-            createDefaultCase(mv, new Label(), 1, "No such record: ");
+            createDefaultCase(mv, new Label(), 0, "No such record: ");
         } else {
             mv.visitVarInsn(ALOAD, 0);
             mv.visitMethodInsn(INVOKESTATIC, typeOwnerClass, CREATE_RECORD_VALUE + 0,

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
@@ -20,6 +20,7 @@ package org.ballerinalang.nativeimpl.jvm.runtime.api.tests;
 
 import io.ballerina.runtime.api.Module;
 import io.ballerina.runtime.api.PredefinedTypes;
+import io.ballerina.runtime.api.creators.ErrorCreator;
 import io.ballerina.runtime.api.creators.TypeCreator;
 import io.ballerina.runtime.api.creators.ValueCreator;
 import io.ballerina.runtime.api.types.IntersectableReferenceType;
@@ -35,6 +36,7 @@ import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.types.TypeId;
 import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.values.BArray;
+import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.api.values.BFunctionPointer;
 import io.ballerina.runtime.api.values.BListInitialValueEntry;
 import io.ballerina.runtime.api.values.BMap;
@@ -56,6 +58,7 @@ public class Values {
 
     private static final Module objectModule = new Module("testorg", "runtime_api.objects", "1");
     private static final Module recordModule = new Module("testorg", "runtime_api.records", "1");
+    private static final Module invalidValueModule = new Module("testorg", "invalid_values", "1");
 
     public static BMap<BString, Object> getRecord(BString recordName) {
         HashMap<String, Object> address = new HashMap<>();
@@ -147,5 +150,19 @@ public class Values {
             index++;
         }
         return arrayValue;
+    }
+
+    public static BObject getInvalidObject(BString objectName) {
+        return ValueCreator.createObjectValue(invalidValueModule, objectName.getValue());
+    }
+
+    public static BMap<BString, Object> getInvalidRecord(BString recordName) {
+        return ValueCreator.createRecordValue(invalidValueModule, recordName.getValue());
+    }
+
+    public static BError getInvalidError(BString errorName) {
+        BString errorMsg = StringUtils.fromString("error message!");
+        return ErrorCreator.createError(invalidValueModule, errorName.getValue(), errorMsg,
+                ErrorCreator.createError(errorMsg), ValueCreator.createMapValue());
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/runtime/api/RuntimeAPITest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/runtime/api/RuntimeAPITest.java
@@ -20,6 +20,7 @@ package org.ballerinalang.test.runtime.api;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 /**
@@ -29,27 +30,20 @@ import org.testng.annotations.Test;
  */
 public class RuntimeAPITest {
 
-    @Test
-    public void valueCreatorTest() {
-        CompileResult result = BCompileUtil.compile("test-src/runtime/api/values");
+    @Test(dataProvider = "packageNameProvider")
+    public void testRuntimeAPIs(String packageName) {
+        CompileResult result = BCompileUtil.compile("test-src/runtime/api/" + packageName);
         BRunUtil.invoke(result, "main");
     }
 
-    @Test
-    public void errorCreatorTest() {
-        CompileResult result = BCompileUtil.compile("test-src/runtime/api/errors");
-        BRunUtil.invoke(result, "main");
-    }
-
-    @Test
-    public void methodTypeTest() {
-        CompileResult result = BCompileUtil.compile("test-src/runtime/api/types");
-        BRunUtil.invoke(result, "main");
-    }
-
-    @Test
-    public void asyncCallTest() {
-        CompileResult result = BCompileUtil.compile("test-src/runtime/api/async");
-        BRunUtil.invoke(result, "main");
+    @DataProvider
+    public Object[] packageNameProvider() {
+        return new String[]{
+                "values",
+                "errors",
+                "types",
+                "async",
+                "invalid_values",
+        };
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/invalid_values/Ballerina.toml
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/invalid_values/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org= "testorg"
+name="invalid_values"
+version= "1.0.0"

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/invalid_values/main.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/invalid_values/main.bal
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+// Copyright (c) 2022 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 //
 // WSO2 Inc. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/invalid_values/main.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/invalid_values/main.bal
@@ -1,0 +1,48 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+// Prints `Hello, World!`.
+
+import ballerina/jballerina.java;
+import ballerina/lang.test as test;
+
+public function main() {
+
+    object {}|error invalidObject = trap getInvalidObject("Object");
+    anydata|error invalidRecord = trap getInvalidRecord("Record");
+    error invalidError = trap getInvalidError("Error");
+
+    test:assertTrue(invalidObject is error);
+    test:assertTrue(invalidRecord is error);
+
+    error e1 = <error>invalidObject;
+    error e2 = <error>invalidRecord;
+
+    test:assertValueEqual("No such object: Object", e1.message());
+    test:assertValueEqual("No such record: Record", e2.message());
+    test:assertValueEqual("No such error: Error", invalidError.message());
+}
+
+function getInvalidObject(string objectName) returns object {} = @java:Method {
+    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
+} external;
+
+function getInvalidRecord(string recordName) returns record {} = @java:Method {
+    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
+} external;
+
+function getInvalidError(string errorName) returns error = @java:Method {
+    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
+} external;


### PR DESCRIPTION
## Purpose
$subject
Fixes #34157 

## Approach
A code generation error occurs when calling the generated createValue APIs for errors, records and objects when there are no such types defined.
Fixed by providing the correct parameter index for the type name to create the `No such type` error.

## Samples
```ballerina
import ballerina/jballerina.java;

public function main() {
    object {} invalidObject = getInvalidObject("Object");
    anydata invalidRecord = getInvalidRecord("Record");
    error invalidError = getInvalidError("Error");
}

function getInvalidObject(string objectName) returns object {} = @java:Method {
    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
} external;

function getInvalidRecord(string recordName) returns record {} = @java:Method {
    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
} external;

function getInvalidError(string errorName) returns error = @java:Method {
    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
} external;
```


In `Values.java`
```java
    private static final Module invalidValueModule = new Module("testorg", "invalid_values", "1");

    public static BObject getInvalidObject(BString objectName) {
        return ValueCreator.createObjectValue(invalidValueModule, objectName.getValue());
    }

    public static BMap<BString, Object> getInvalidRecord(BString recordName) {
        return ValueCreator.createRecordValue(invalidValueModule, recordName.getValue());
    }

    public static BError getInvalidError(BString errorName) {
        BString errorMsg = StringUtils.fromString("error message!");
        return ErrorCreator.createError(invalidValueModule, errorName.getValue(), errorMsg,
                ErrorCreator.createError(errorMsg), ValueCreator.createMapValue());
    }
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
