### PR TITLE
Fix CCE issue when checking the lang lib methods of XML sub types

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/LangLibrary.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/LangLibrary.java
@@ -39,6 +39,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BXMLType;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.Names;
+import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.util.Flags;
 
 import java.util.ArrayList;
@@ -213,7 +214,10 @@ public class LangLibrary {
             case STREAM:
                 return ((BStreamType) type).constraint;
             case XML:
-                return ((BXMLType) type).constraint;
+                if (type.tag == TypeTags.XML) {
+                    return ((BXMLType) type).constraint;
+                }
+                return type;
             // The following explicitly mentioned type kinds should be supported, but they are not for the moment.
             case ERROR:
             default:

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/LangLibFunctionTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/LangLibFunctionTest.java
@@ -25,6 +25,7 @@ import io.ballerina.compiler.api.symbols.FunctionTypeSymbol;
 import io.ballerina.compiler.api.symbols.RecordFieldSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.TypeDefinitionSymbol;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
@@ -59,6 +60,7 @@ import static io.ballerina.compiler.api.symbols.TypeDescKind.STRING;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.TABLE;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.TUPLE;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.TYPEDESC;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.TYPE_REFERENCE;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.UNION;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.XML;
 import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDefaultModulesSemanticModel;
@@ -225,10 +227,10 @@ public class LangLibFunctionTest {
     }
 
     @Test(dataProvider = "XMLInfoProvider")
-    public void testXMLLangLib(int line, int column, List<String> expFunctions) {
-        Symbol symbol = getSymbol(67, 8);
+    public void testXMLLangLib(int line, int column, TypeDescKind expTypeKind, List<String> expFunctions) {
+        Symbol symbol = getSymbol(line, column);
         TypeSymbol type = ((VariableSymbol) symbol).typeDescriptor();
-        assertEquals(type.typeKind(), XML);
+        assertEquals(type.typeKind(), expTypeKind);
         assertLangLibList(type.langLibMethods(), expFunctions);
     }
 
@@ -239,11 +241,18 @@ public class LangLibFunctionTest {
                                             "cloneWithType", "isReadOnly", "toString", "toBalString", "toJson",
                                             "toJsonString", "ensureType", "text", "data");
 
-//        List<String> additionalFuncs = List.of("getName", "setName", "getChildren", "setChildren", "getAttributes");
+        List<String> elementFuncs = List.of("getName", "setName", "getChildren", "setChildren", "getAttributes",
+                                            "getDescendants");
+        List<String> piFuncs = List.of("getTarget");
 
         return new Object[][]{
-                {67, 8, expFunctions},
-//                {68, 17, Stream.concat(expFunctions.stream(), additionalFuncs.stream()).collect(Collectors.toList())}
+                {67, 8, XML, expFunctions},
+                {68, 17, TYPE_REFERENCE, Stream.concat(expFunctions.stream(), elementFuncs.stream())
+                        .collect(Collectors.toList())},
+                {76, 31, TYPE_REFERENCE, Stream.concat(expFunctions.stream(), piFuncs.stream())
+                        .collect(Collectors.toList())},
+                {77, 17, TYPE_REFERENCE, expFunctions},
+                {78, 14, TYPE_REFERENCE, expFunctions},
         };
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/langlib_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/langlib_test.bal
@@ -73,6 +73,10 @@ function test() {
     T1 t1 = 2;
 
     T2 t2 = "a";
+
+    'xml:ProcessingInstruction pi = xml `<?target data?>`;
+    'xml:Comment cmnt;
+    'xml:Text txt;
 }
 
 type T1 1|2|3;


### PR DESCRIPTION
## Purpose
This PR fixes a bug in lang lib calculation logic for subtypes of XML type. 

## Remarks
Came across #34646 while fixing this.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
