### PR TITLE
Update bal.bat to run cli commands for project paths with spaces - windows

### DIFF
--- a/distribution/zip/jballerina/bin/bal.bat
+++ b/distribution/zip/jballerina/bin/bal.bat
@@ -151,7 +151,7 @@ set CMD_LINE_ARGS=-Xbootclasspath/a:%BALLERINA_XBOOTCLASSPATH% -Xms256m -Xmx1024
 set jar=%~2
 if "%1" == "run" if "%jar:~-4%" == ".jar" goto runJar
 
-set jar=%4
+set jar=%~4
 if "%1" == "run" if "%~2" == "--debug" if "%jar:~-4%" == ".jar" goto debugJar
 
 :runJava

--- a/distribution/zip/jballerina/bin/bal.bat
+++ b/distribution/zip/jballerina/bin/bal.bat
@@ -148,11 +148,11 @@ if not "%BALLERINA_CLASSPATH_EXT%" == "" set BALLERINA_CLASSPATH=!BALLERINA_CLAS
 
 set CMD_LINE_ARGS=-Xbootclasspath/a:%BALLERINA_XBOOTCLASSPATH% -Xms256m -Xmx1024m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=""  -Dcom.sun.management.jmxremote -classpath "%BALLERINA_CLASSPATH%" %JAVA_OPTS% -Dballerina.home="%BALLERINA_HOME%" -Dballerina.target="jvm" -Djava.command="%JAVA_HOME%\bin\java" -Djava.opts="%JAVA_OPTS%" -Denable.nonblocking=false -Dfile.encoding=UTF8 -Dballerina.version=${project.version}
 
-set jar=%2
+set jar=%~2
 if "%1" == "run" if "%jar:~-4%" == ".jar" goto runJar
 
 set jar=%4
-if "%1" == "run" if "%2" == "--debug" if "%jar:~-4%" == ".jar" goto debugJar
+if "%1" == "run" if "%~2" == "--debug" if "%jar:~-4%" == ".jar" goto debugJar
 
 :runJava
 "%JAVA_HOME%\bin\java" %CMD_LINE_ARGS% io.ballerina.cli.launcher.Main %CMD%


### PR DESCRIPTION
## Purpose
>  fix https://github.com/ballerina-platform/ballerina-lang/issues/34692

## Approach
> getting rid of surrounding quotes when expanding cmd arguments with `%~2`

## Sample runs
![cli-pass](https://user-images.githubusercontent.com/57571152/149899893-c55db72b-ca71-4d00-8128-111404344f54.PNG)

## Related PRs
> https://github.com/ballerina-platform/ballerina-update-tool/pull/200