### PR TITLE
Fix table lookup doesn't check when there is only one candidate issue

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TableValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TableValueImpl.java
@@ -585,14 +585,14 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
             if (entryList == null) {
                 return null;
             }
-            if (entryList.size() > 1) {
+            if (entryList.size() >= 1) {
                 for (Map.Entry<K, V> entry: entryList) {
                     if (TypeChecker.isEqual(key, entry.getKey())) {
                         return entry.getValue();
                     }
                 }
             }
-            return entryList.get(0).getValue();
+            return null;
         }
 
         public V putData(K key, V data) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TableValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TableValueImpl.java
@@ -585,11 +585,9 @@ public class TableValueImpl<K, V> implements TableValue<K, V> {
             if (entryList == null) {
                 return null;
             }
-            if (entryList.size() >= 1) {
-                for (Map.Entry<K, V> entry: entryList) {
-                    if (TypeChecker.isEqual(key, entry.getKey())) {
-                        return entry.getValue();
-                    }
+            for (Map.Entry<K, V> entry: entryList) {
+                if (TypeChecker.isEqual(key, entry.getKey())) {
+                    return entry.getValue();
                 }
             }
             return null;

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibTableTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibTableTest.java
@@ -109,6 +109,11 @@ public class LangLibTableTest {
     }
 
     @Test
+    public void testGetValue() {
+        BRunUtil.invoke(compileResult, "testGetValue");
+    }
+
+    @Test
     public void testHashCollisionHandlingScenarios() {
         BRunUtil.invoke(compileResult, "testHashCollisionHandlingScenarios");
     }

--- a/langlib/langlib-test/src/test/resources/test-src/tablelib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/tablelib_test.bal
@@ -783,6 +783,30 @@ function testGetKeysFromUnionConstrained() returns any[] {
     return tab.keys();
 }
 
+type R record {|
+    readonly int|float|decimal|boolean v;
+    int code;
+|};
+
+type Tab table<R> key(v);
+
+function testGetValue() {
+    Tab t = table [
+            {v: 0, code: 0},
+            {v: 1d, code: 1},
+            {v: false, code: 3},
+            {v: 2.0, code: 4}
+        ];
+
+    R r1 = {"v":1d,"code":1};
+    R r2 = {v: false, code: 3};
+
+    assertEquals(t[0f], ());
+    assertEquals(t[1d], r1);
+    assertEquals(t[false], r2);
+    assertEquals(t[2], ());
+}
+
 const ASSERTION_ERROR_REASON = "AssertionError";
 
 function assertTrue(boolean actual) {


### PR DESCRIPTION
## Purpose
> $subject

Fixes #34712

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
