### PR TITLE
Wrap working directory with quotes

### DIFF
--- a/distribution/zip/jballerina/bin/bal
+++ b/distribution/zip/jballerina/bin/bal
@@ -218,7 +218,7 @@ BALLERINA_CLASSPATH=$BALLERINA_CLASSPATH:$BALLERINA_CLASSPATH_EXT
 CMD_LINE_ARGS="-Xbootclasspath/a:"$BALLERINA_XBOOTCLASSPATH" \
                -Xms256m -Xmx1024m \
                -XX:+HeapDumpOnOutOfMemoryError \
-               -XX:HeapDumpPath="$(pwd)" \
+               -XX:HeapDumpPath="'$(pwd)'" \
                $JAVA_OPTS \
                -classpath "$BALLERINA_CLASSPATH" \
                -Dballerina.home="$BALLERINA_HOME" \


### PR DESCRIPTION
## Purpose
Fix `bal` command not working in a directory name with spaces

## Fixes 
https://github.com/ballerina-platform/ballerina-lang/issues/32557

## Approach
Wrap the `$pwd` (current directory) with quotes.
