### PR TITLE
Backport fix overriding class symbol with type alias info #34468

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -428,18 +428,16 @@ public class BIRGen extends BLangNodeVisitor {
                                                           displayName,
                                                           astTypeDefinition.symbol.originalName);
         if (astTypeDefinition.symbol.tag == SymTag.TYPE_DEF) {
-            if (type.tsymbol.owner == astTypeDefinition.symbol.owner) {
-                typeDefs.put(astTypeDefinition.symbol.type.tsymbol, typeDef);
-                typeDef.referenceType = ((BTypeDefinitionSymbol) astTypeDefinition.symbol).referenceType;
+            BTypeReferenceType referenceType = ((BTypeDefinitionSymbol) astTypeDefinition.symbol).referenceType;
+            typeDef.referenceType = referenceType;
+            BTypeSymbol typeSymbol = astTypeDefinition.symbol.type.tsymbol;
+            if (type.tsymbol.owner == astTypeDefinition.symbol.owner
+                    && !(Symbols.isFlagOn(typeSymbol.flags, Flags.CLASS))) {
+                typeDefs.put(typeSymbol, typeDef);
             } else {
-                BTypeReferenceType referenceType = ((BTypeDefinitionSymbol) astTypeDefinition.symbol).referenceType;
-                typeDef.referenceType = referenceType;
-
                 if (referenceType != null) {
                     typeDef.type = referenceType;
                 }
-
-                typeDefs.put(astTypeDefinition.symbol, typeDef);
             }
         } else {
             //enum symbols

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCodeGenUtil.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCodeGenUtil.java
@@ -527,7 +527,7 @@ public class JvmCodeGenUtil {
             return IdentifierUtils.encodeNonFunctionIdentifier(((BStructureTypeSymbol) typeSymbol)
                     .typeDefinitionSymbol.name.value);
         }
-        return IdentifierUtils.encodeNonFunctionIdentifier(t.tsymbol.name.value);
+        return IdentifierUtils.encodeNonFunctionIdentifier(typeSymbol.name.value);
     }
 
     public static boolean isBallerinaBuiltinModule(String orgName, String moduleName) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmDesugarPhase.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmDesugarPhase.java
@@ -43,7 +43,6 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BInvokableType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BObjectType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BRecordType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
-import org.wso2.ballerinalang.compiler.semantics.model.types.BTypeReferenceType;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.Names;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
@@ -266,17 +265,11 @@ public class JvmDesugarPhase {
     private static void encodeTypeDefIdentifiers(List<BIRTypeDefinition> typeDefs,
                                                  HashMap<String, String> encodedVsInitialIds) {
         for (BIRTypeDefinition typeDefinition : typeDefs) {
-            if (typeDefinition.referenceType != null) {
-                typeDefinition.type.tsymbol.name = Names.fromString(encodeNonFunctionIdentifier(
-                        ((BTypeReferenceType) typeDefinition.referenceType).definitionName, encodedVsInitialIds));
-            } else {
-                typeDefinition.type.tsymbol.name = Names.fromString(encodeNonFunctionIdentifier(
-                        typeDefinition.type.tsymbol.name.value, encodedVsInitialIds));
-            }
-
+            typeDefinition.type.tsymbol.name = Names.fromString(encodeNonFunctionIdentifier(
+                    typeDefinition.type.tsymbol.name.value, encodedVsInitialIds));
             typeDefinition.internalName =
                     Names.fromString(encodeNonFunctionIdentifier(typeDefinition.internalName.value,
-                                                                 encodedVsInitialIds));
+                            encodedVsInitialIds));
 
             encodeFunctionIdentifiers(typeDefinition.attachedFuncs, encodedVsInitialIds);
             BType bType = JvmCodeGenUtil.getReferredType(typeDefinition.type);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -1548,8 +1548,10 @@ public class SymbolEnter extends BLangNodeVisitor {
             }
         }
 
-        if ((definedType.tsymbol.kind == SymbolKind.OBJECT || definedType.tsymbol.kind == SymbolKind.RECORD) &&
-                typeDefSymbol.owner == definedType.tsymbol.owner) {
+        if ((((definedType.tsymbol.kind == SymbolKind.OBJECT
+                && !Symbols.isFlagOn(definedType.tsymbol.flags, Flags.CLASS))
+                || definedType.tsymbol.kind == SymbolKind.RECORD))
+                && ((BStructureTypeSymbol) definedType.tsymbol).typeDefinitionSymbol == null) {
             ((BStructureTypeSymbol) definedType.tsymbol).typeDefinitionSymbol = (BTypeDefinitionSymbol) typeDefSymbol;
         }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/typedefs/TypeDefinitionsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/typedefs/TypeDefinitionsTest.java
@@ -161,6 +161,11 @@ public class TypeDefinitionsTest {
         BRunUtil.invoke(compileResult, "testFuncInvocation");
     }
 
+    @Test
+    public void testClassDefinition() {
+        BRunUtil.invoke(compileResult, "testClassDefn");
+    }
+
 //    @Test
 //    public void testRecordTypeResolving() {
 //        BRunUtil.invoke(recordFieldRes, "testRecordTypeResolving");

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/types/type_reference_type_bala_test_2.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/types/type_reference_type_bala_test_2.bal
@@ -22,10 +22,21 @@ type Module record {|
     map<StringDefn> stringDefns = {};
 |};
 
+type FooFunctionDecl tr:FunctionDecl;
+
 function testFn() {
     Module m = {stringDefns: {a: new (1234)}};
     assertEquality(1, m.stringDefns.length());
     assertEquality(1234, m.stringDefns.get("a").i);
+
+    tr:FooFunction fn1 = new ("llvmFunction1");
+    assertEquality("llvmFunction1", fn1.getFuncName());
+
+    tr:FunctionDecl fn2 = new ("llvmFunction2");
+    assertEquality("llvmFunction2", fn2.getFuncName());
+
+    FooFunctionDecl fn3 = new ("llvmFunction3");
+    assertEquality("llvmFunction3", fn3.getFuncName());
 }
 
 function assertEquality(anydata expected, anydata actual) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/test_project_type_reference_types_2/types.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/test_project_type_reference_types_2/types.bal
@@ -21,3 +21,16 @@ public readonly class ConstPointerValue {
         self.i = i;
     }
 }
+
+public type FunctionDecl FooFunction;
+
+public class FooFunction {
+    string functionName;
+    public function init(string functionName) {
+        self.functionName = functionName;
+    }
+
+    public function getFuncName() returns string {
+        return self.functionName;
+    }
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/typedefs/type-definitions.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/typedefs/type-definitions.bal
@@ -250,6 +250,24 @@ function testFuncInvocation() {
     assertEquality(104, obj.sum());
 }
 
+function testClassDefn() {
+    FooFunction fn = new ("llvmFunction");
+    assertEquality("llvmFunction", fn.getFuncName());
+}
+
+type FunctionDecl FooFunction;
+
+class FooFunction {
+    string functionName;
+    function init(string functionName) {
+        self.functionName = functionName;
+    }
+
+    function getFuncName() returns string {
+        return self.functionName;
+    }
+}
+
 const ASSERTION_ERROR_REASON = "AssertionError";
 
 function assertTrue(any|error actual) {


### PR DESCRIPTION
## Purpose
> Backport fix overriding class symbol with type alias info #34468

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
