### PR TITLE
Improve SymbolFinder to visit onfail clause

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
@@ -722,6 +722,7 @@ class SymbolFinder extends BaseVisitor {
     public void visit(BLangWhile whileNode) {
         lookupNode(whileNode.expr);
         lookupNode(whileNode.body);
+        lookupNode(whileNode.onFailClause);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
@@ -641,6 +641,7 @@ class SymbolFinder extends BaseVisitor {
         lookupNode((BLangNode) foreach.variableDefinitionNode);
         lookupNode(foreach.collection);
         lookupNode(foreach.body);
+        lookupNode(foreach.onFailClause);
     }
 
     @Override
@@ -728,6 +729,7 @@ class SymbolFinder extends BaseVisitor {
     @Override
     public void visit(BLangLock lockNode) {
         lookupNode(lockNode.body);
+        lookupNode(lockNode.onFailClause);
     }
 
     @Override

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsInFailTrtryStmtTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsInFailTrtryStmtTest.java
@@ -53,6 +53,10 @@ public class FindRefsInFailTrtryStmtTest extends FindAllReferencesTest {
                                 location(45, 13, 18),
                                 location(52, 9, 14))
                 },
+                {70, 21, location(70, 20, 22),
+                        List.of(location(70, 20, 22),
+                                location(71, 20, 22))
+                }
         };
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsInFailTrtryStmtTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsInFailTrtryStmtTest.java
@@ -56,6 +56,14 @@ public class FindRefsInFailTrtryStmtTest extends FindAllReferencesTest {
                 {70, 21, location(70, 20, 22),
                         List.of(location(70, 20, 22),
                                 location(71, 20, 22))
+                },
+                {79, 21, location(79, 20, 22),
+                        List.of(location(79, 20, 22),
+                                location(80, 20, 22))
+                },
+                {87, 21, location(87, 20, 22),
+                        List.of(location(87, 20, 22),
+                                location(88, 20, 22))
                 }
         };
     }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/statements/SymbolsInFailRetryStatements.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/statements/SymbolsInFailRetryStatements.java
@@ -66,6 +66,7 @@ public class SymbolsInFailRetryStatements {
                 {42, 12, "value", SymbolKind.VARIABLE},
                 {44, 20, "e", SymbolKind.VARIABLE},
                 {45, 13, "func2", SymbolKind.FUNCTION},
+                {70, 21, "ee", SymbolKind.VARIABLE}
         };
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/statements/SymbolsInFailRetryStatements.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/statements/SymbolsInFailRetryStatements.java
@@ -66,7 +66,9 @@ public class SymbolsInFailRetryStatements {
                 {42, 12, "value", SymbolKind.VARIABLE},
                 {44, 20, "e", SymbolKind.VARIABLE},
                 {45, 13, "func2", SymbolKind.FUNCTION},
-                {70, 21, "ee", SymbolKind.VARIABLE}
+                {70, 21, "ee", SymbolKind.VARIABLE},
+                {79, 21, "ee", SymbolKind.VARIABLE},
+                {86, 21, "ee", SymbolKind.VARIABLE},
         };
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/find-all-ref/find_refs_in_fail_retry_stmt.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/find-all-ref/find_refs_in_fail_retry_stmt.bal
@@ -72,3 +72,20 @@ function testWhileOnFail(){
         error ref = ee;
     }
 }
+
+function testForEachOnFail() {
+    int[] arr = [1,2,3];
+    foreach int item in arr {
+        fail getError();
+    } on fail error ee {
+        error ref = ee;
+    }
+}
+
+function testLockOnFail(){
+    lock {
+        fail getError();
+    } on fail error ee {
+        error ref = ee;
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/find-all-ref/find_refs_in_fail_retry_stmt.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/find-all-ref/find_refs_in_fail_retry_stmt.bal
@@ -63,3 +63,12 @@ class RetryMgr {
         return true;
     }
 }
+
+function testWhileOnFail(){
+    int iter = 0;
+    while (iter < 3) {
+
+    } on fail error ee { 
+        error ref = ee;
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/statements/symbols_in_fail_retry_stmt.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/statements/symbols_in_fail_retry_stmt.bal
@@ -72,3 +72,18 @@ function testWhileOnFail(){
 
     }
 }
+
+function testForEachOnFail() {
+    int[] arr = [1,2,3];
+    foreach int item in arr {
+        fail getError();
+    } on fail error ee {
+    }
+}
+
+function testLockOnFail(){
+    lock {
+        fail getError();
+    } on fail error ee {
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/statements/symbols_in_fail_retry_stmt.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/statements/symbols_in_fail_retry_stmt.bal
@@ -63,3 +63,12 @@ class RetryMgr {
         return true;
     }
 }
+
+function testWhileOnFail(){
+    int iter = 0;
+    while (iter < 3) {
+
+    } on fail error ee { 
+
+    }
+}


### PR DESCRIPTION
## Purpose
$subject to add missing `while-on-fail clause` visiting implementation.

Fixes #34857 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
