### PR TITLE
Add package attributes from template `package.json` to `Ballerina.toml`

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/CommandUtil.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/CommandUtil.java
@@ -347,14 +347,17 @@ public class CommandUtil {
             stringJoiner.add("\"" + newModuleName + "\"");
         }
 
-        Files.writeString(balTomlPath, "\nexport = [" + stringJoiner.toString() + "]"
+        Files.writeString(balTomlPath, "\nexport = [" + stringJoiner + "]"
                 .replaceFirst(packageJson.getName(), packageName), StandardOpenOption.APPEND);
-        Files.writeString(balTomlPath, "\nballerina_version = \"" + packageJson.getBallerinaVersion()
+        Files.writeString(balTomlPath, "\ndistribution = \"" + packageJson.getBallerinaVersion()
                 + "\"", StandardOpenOption.APPEND);
-        Files.writeString(balTomlPath, "\nimplementation_vendor = \"" + packageJson.getImplementationVendor()
-                + "\"", StandardOpenOption.APPEND);
-        Files.writeString(balTomlPath, "\nlanguage_spec_version = \"" + packageJson.getLanguageSpecVersion()
-                + "\"", StandardOpenOption.APPEND);
+
+        writePackageAttributeArray(balTomlPath, packageJson.getLicenses(), "license");
+        writePackageAttributeArray(balTomlPath, packageJson.getAuthors(), "authors");
+        writePackageAttributeArray(balTomlPath, packageJson.getKeywords(), "keywords");
+        writePackageAttributeValue(balTomlPath, packageJson.getSourceRepository(), "repository");
+        writePackageAttributeValue(balTomlPath, packageJson.getVisibility(), "visibility");
+        writePackageAttributeValue(balTomlPath, packageJson.getIcon(), "icon");
 
         Files.writeString(balTomlPath, "\n\n[build-options]", StandardOpenOption.APPEND);
         Files.writeString(balTomlPath, "\nobservabilityIncluded = true\n", StandardOpenOption.APPEND);
@@ -365,26 +368,62 @@ public class CommandUtil {
         }
         Files.writeString(balTomlPath, "\n[[platform." + platform + ".dependency]]", StandardOpenOption.APPEND);
         for (Object dependencies : platformLibraries) {
-            JsonObject dependeciesObj = (JsonObject) dependencies;
-            String libPath = dependeciesObj.get("path").getAsString();
+            JsonObject dependenciesObj = (JsonObject) dependencies;
+            String libPath = dependenciesObj.get("path").getAsString();
             Path libName = Optional.of(Paths.get(libPath).getFileName()).get();
             Path libRelPath = Paths.get("libs", libName.toString());
             Files.writeString(balTomlPath, "\npath = \"" + libRelPath + "\"", StandardOpenOption.APPEND);
 
-            if (dependeciesObj.get("artifactId") != null) {
-                String artifactId = dependeciesObj.get("artifactId").getAsString();
+            if (dependenciesObj.get("artifactId") != null) {
+                String artifactId = dependenciesObj.get("artifactId").getAsString();
                 Files.writeString(balTomlPath, "\nartifactId = \"" + artifactId + "\"",
                         StandardOpenOption.APPEND);
             }
-            if (dependeciesObj.get("groupId") != null) {
-                String groupId = dependeciesObj.get("groupId").getAsString();
+            if (dependenciesObj.get("groupId") != null) {
+                String groupId = dependenciesObj.get("groupId").getAsString();
                 Files.writeString(balTomlPath, "\ngroupId = \"" + groupId + "\"", StandardOpenOption.APPEND);
             }
-            if (dependeciesObj.get("version") != null) {
-                String dependencyVersion = dependeciesObj.get("version").getAsString();
+            if (dependenciesObj.get("version") != null) {
+                String dependencyVersion = dependenciesObj.get("version").getAsString();
                 Files.writeString(balTomlPath, "\nversion = \"" + dependencyVersion + "\"\n",
                         StandardOpenOption.APPEND);
             }
+        }
+    }
+
+    /**
+     * Write Ballerina.toml package attribute array from template package.json to new project Ballerina.toml.
+     *
+     * @param balTomlPath    Ballerina.toml path of the new project
+     * @param attributeArray package attribute values array
+     * @param attributeName  package attribute name
+     * @throws IOException when error occurs writing to the Ballerina.toml
+     */
+    private static void writePackageAttributeArray(Path balTomlPath, List<String> attributeArray, String attributeName)
+            throws IOException {
+        if (attributeArray != null && !attributeArray.isEmpty()) {
+            StringJoiner stringJoiner = new StringJoiner(",");
+            for (String attributeElement : attributeArray) {
+                stringJoiner.add("\"" + attributeElement + "\"");
+            }
+            Files.writeString(balTomlPath, "\n" + attributeName + " = [" + stringJoiner + "]",
+                    StandardOpenOption.APPEND);
+        }
+    }
+
+    /**
+     * Write Ballerina.toml package attribute from template package.json to new project Ballerina.toml.
+     *
+     * @param balTomlPath    Ballerina.toml path of the new project
+     * @param attributeValue package attribute value
+     * @param attributeName  package attribute name
+     * @throws IOException when error occurs writing to the Ballerina.toml
+     */
+    private static void writePackageAttributeValue(Path balTomlPath, String attributeValue, String attributeName)
+            throws IOException {
+        if (attributeValue != null && !attributeValue.isEmpty()) {
+            Files.writeString(balTomlPath, "\n" + attributeName + " = \"" + attributeValue + "\"",
+                    StandardOpenOption.APPEND);
         }
     }
 

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/CommandUtilTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/CommandUtilTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.cli.cmd;
+
+import com.google.gson.Gson;
+import io.ballerina.projects.internal.bala.PackageJson;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static io.ballerina.cli.cmd.CommandOutputUtils.readFileAsString;
+import static io.ballerina.cli.cmd.CommandUtil.writeBallerinaToml;
+import static io.ballerina.projects.util.ProjectConstants.BALLERINA_TOML;
+
+/**
+ * Unit tests for @code{CommandUtil} class used in commands.
+ *
+ * @since 2.0.0
+ */
+public class CommandUtilTest {
+
+    private static final Path COMMAND_UTIL_RESOURCE_DIR = Paths
+            .get("src", "test", "resources", "test-resources", "command-util");
+
+    @Test(description = "Test write new project Ballerina.toml from template package.json")
+    public void testWriteBallerinaToml() throws IOException {
+        // Read sample package.json
+        PackageJson packageJson;
+        try (InputStream inputStream = new FileInputStream(
+                String.valueOf(COMMAND_UTIL_RESOURCE_DIR.resolve("sample-package.json")))) {
+            Reader fileReader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
+            packageJson = new Gson().fromJson(fileReader, PackageJson.class);
+        }
+
+        // Create empty Ballerina.toml
+        Path ballerinaTomlPath = Files.createFile(COMMAND_UTIL_RESOURCE_DIR.resolve(BALLERINA_TOML));
+
+        // Test writeBallerinaToml method
+        writeBallerinaToml(ballerinaTomlPath, packageJson, "gsheet_new_row_to_github_new_issue", "any");
+        Assert.assertEquals(readFileAsString(COMMAND_UTIL_RESOURCE_DIR.resolve(BALLERINA_TOML)),
+                readFileAsString(COMMAND_UTIL_RESOURCE_DIR.resolve("expected-ballerina.toml")));
+    }
+
+    @AfterMethod
+    public void tearDown() throws IOException {
+        Files.deleteIfExists(COMMAND_UTIL_RESOURCE_DIR.resolve(BALLERINA_TOML));
+    }
+}

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/NewCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/NewCommandTest.java
@@ -37,6 +37,7 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
 
+import static io.ballerina.cli.cmd.CommandOutputUtils.readFileAsString;
 
 /**
  * Test cases for bal new command.
@@ -245,19 +246,16 @@ public class NewCommandTest extends BaseCommandTest {
         Assert.assertTrue(Files.exists(packageDir));
 
         Assert.assertTrue(Files.exists(packageDir.resolve(ProjectConstants.BALLERINA_TOML)));
-        String tomlContent = Files.readString(
-                packageDir.resolve(ProjectConstants.BALLERINA_TOML), StandardCharsets.UTF_8);
         String expectedTomlContent = "[package]\n" +
                 "org = \"admin\"\n" +
                 "name = \"sample_pull_local\"\n" +
                 "version = \"0.1.5\"\n" +
                 "export = [\"sample_pull_local\"]\n" +
-                "ballerina_version = \"slbeta4\"\n" +
-                "implementation_vendor = \"WSO2\"\n" +
-                "language_spec_version = \"2021R1\"\n" +
+                "distribution = \"slbeta4\"\n" +
                 "\n[build-options]\n" +
                 "observabilityIncluded = true\n";
-        Assert.assertTrue(tomlContent.contains(expectedTomlContent));
+        Assert.assertEquals(
+                readFileAsString(packageDir.resolve(ProjectConstants.BALLERINA_TOML)), expectedTomlContent);
 
         Assert.assertTrue(Files.exists(packageDir.resolve(ProjectConstants.PACKAGE_MD_FILE_NAME)));
         Assert.assertTrue(Files.exists(packageDir.resolve(ProjectConstants.GITIGNORE_FILE_NAME)));
@@ -278,19 +276,16 @@ public class NewCommandTest extends BaseCommandTest {
         Assert.assertTrue(Files.exists(packageDir));
 
         Assert.assertTrue(Files.exists(packageDir.resolve(ProjectConstants.BALLERINA_TOML)));
-        String tomlContent = Files.readString(
-                packageDir.resolve(ProjectConstants.BALLERINA_TOML), StandardCharsets.UTF_8);
         String expectedTomlContent = "[package]\n" +
                 "org = \"parkavik\"\n" +
                 "name = \"sample_pull_WO_Module_Version\"\n" +
                 "version = \"1.0.1\"\n" +
                 "export = [\"sample_pull_WO_Module_Version\"]\n" +
-                "ballerina_version = \"slbeta4\"\n" +
-                "implementation_vendor = \"WSO2\"\n" +
-                "language_spec_version = \"2021R1\"\n" +
+                "distribution = \"slbeta4\"\n" +
                 "\n[build-options]\n" +
                 "observabilityIncluded = true\n";
-        Assert.assertTrue(tomlContent.contains(expectedTomlContent));
+        Assert.assertEquals(
+                readFileAsString(packageDir.resolve(ProjectConstants.BALLERINA_TOML)), expectedTomlContent);
         Assert.assertTrue(Files.exists(packageDir.resolve(ProjectConstants.PACKAGE_MD_FILE_NAME)));
         Assert.assertTrue(Files.exists(packageDir.resolve(ProjectConstants.GITIGNORE_FILE_NAME)));
         Assert.assertTrue(Files.exists(packageDir.resolve(ProjectConstants.DEVCONTAINER)));
@@ -310,19 +305,16 @@ public class NewCommandTest extends BaseCommandTest {
         Assert.assertTrue(Files.exists(packageDir));
 
         Assert.assertTrue(Files.exists(packageDir.resolve(ProjectConstants.BALLERINA_TOML)));
-        String tomlContent = Files.readString(
-                packageDir.resolve(ProjectConstants.BALLERINA_TOML), StandardCharsets.UTF_8);
         String expectedTomlContent = "[package]\n" +
                 "org = \"parkavik\"\n" +
                 "name = \"sample_pull\"\n" +
                 "version = \"1.0.0\"\n" +
                 "export = [\"sample_pull\"]\n" +
-                "ballerina_version = \"slbeta4\"\n" +
-                "implementation_vendor = \"WSO2\"\n" +
-                "language_spec_version = \"2021R1\"\n" +
+                "distribution = \"slbeta4\"\n" +
                 "\n[build-options]\n" +
                 "observabilityIncluded = true\n";
-        Assert.assertTrue(tomlContent.contains(expectedTomlContent));
+        Assert.assertEquals(
+                readFileAsString(packageDir.resolve(ProjectConstants.BALLERINA_TOML)), expectedTomlContent);
         Assert.assertTrue(Files.exists(packageDir.resolve(ProjectConstants.PACKAGE_MD_FILE_NAME)));
         Assert.assertTrue(readOutput().contains("Created new package"));
     }
@@ -348,22 +340,23 @@ public class NewCommandTest extends BaseCommandTest {
         Assert.assertTrue(Files.exists(packageDir.resolve("modules/types.wrappers/string.bal")));
 
         Assert.assertTrue(Files.exists(packageDir.resolve(ProjectConstants.BALLERINA_TOML)));
-        String tomlContent = Files.readString(
-                packageDir.resolve(ProjectConstants.BALLERINA_TOML), StandardCharsets.UTF_8);
         String expectedTomlContent = "[package]\n" +
                 "org = \"ballerina\"\n" +
                 "name = \"sample_multi_module\"\n" +
                 "version = \"1.0.1\"\n" +
                 "export = [\"sample_multi_module\",\"sample_multi_module.types.timestamp\"," +
                 "\"sample_multi_module.types.wrappers\"]\n" +
-                "ballerina_version = \"slbeta4\"\n" +
-                "implementation_vendor = \"WSO2\"\n" +
-                "language_spec_version = \"2021R1\"\n" +
+                "distribution = \"slbeta4\"\n" +
+                "license = [\"Apache-2.0\"]\n" +
+                "authors = [\"Ballerina\"]\n" +
+                "keywords = [\"wrappers\"]\n" +
+                "repository = \"https://github.com/ballerina-platform/module-ballerina-protobuf\"\n" +
                 "\n[build-options]\n" +
                 "observabilityIncluded = true\n" +
                 "\n[[platform.java11.dependency]]\n" +
                 "path = \"libs" + File.separator + "protobuf-native-1.0.1.jar\"";
-        Assert.assertTrue(tomlContent.contains(expectedTomlContent));
+        Assert.assertEquals(
+                readFileAsString(packageDir.resolve(ProjectConstants.BALLERINA_TOML)), expectedTomlContent);
         Assert.assertTrue(readOutput().contains("Created new package"));
     }
 
@@ -400,9 +393,7 @@ public class NewCommandTest extends BaseCommandTest {
                 "name = \"sample_pull_libs\"\n" +
                 "version = \"0.1.0\"\n" +
                 "export = [\"sample_pull_libs\"]\n" +
-                "ballerina_version = \"slbeta4\"\n" +
-                "implementation_vendor = \"WSO2\"\n" +
-                "language_spec_version = \"2021R1\"\n";
+                "distribution = \"slbeta4\"\n";
         String expectedTomlLibContent =
                 "artifactId = \"snakeyaml\"\n" +
                 "groupId = \"org.yaml\"\n" +

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/PrintUtilsTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/PrintUtilsTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package io.ballerina.cli.cmd;
 
 import com.google.gson.Gson;

--- a/cli/ballerina-cli/src/test/resources/test-resources/command-util/expected-ballerina.toml
+++ b/cli/ballerina-cli/src/test/resources/test-resources/command-util/expected-ballerina.toml
@@ -1,0 +1,11 @@
+[package]
+org = "choreo"
+name = "gsheet_new_row_to_github_new_issue"
+version = "1.0.1"
+export = ["gsheet_new_row_to_github_new_issue"]
+distribution = "slbeta6"
+keywords = ["Type/Webhook","Category/Integration","Internal/http"]
+icon = "docs/icon.png"
+
+[build-options]
+observabilityIncluded = true

--- a/cli/ballerina-cli/src/test/resources/test-resources/command-util/sample-package.json
+++ b/cli/ballerina-cli/src/test/resources/test-resources/command-util/sample-package.json
@@ -1,0 +1,19 @@
+{
+  "organization": "choreo",
+  "name": "gsheet_new_row_to_github_new_issue",
+  "version": "1.0.1",
+  "keywords": [
+    "Type/Webhook",
+    "Category/Integration",
+    "Internal/http"
+  ],
+  "export": [
+    "gsheet_new_row_to_github_new_issue"
+  ],
+  "icon": "docs/icon.png",
+  "ballerina_version": "slbeta6",
+  "implementation_vendor": "WSO2",
+  "language_spec_version": "2021R1",
+  "platform": "any",
+  "template": true
+}

--- a/cli/ballerina-cli/src/test/resources/testng.xml
+++ b/cli/ballerina-cli/src/test/resources/testng.xml
@@ -37,6 +37,7 @@ under the License.
             <class name="io.ballerina.cli.cmd.ShellCommandTest" />
             <class name="io.ballerina.cli.cmd.TestCommandTest" />
             <class name="io.ballerina.cli.cmd.PackCommandTest" />
+            <class name="io.ballerina.cli.cmd.CommandUtilTest" />
         </classes>
     </test>
 </suite>

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageManifest.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageManifest.java
@@ -19,8 +19,6 @@ package io.ballerina.projects;
 
 import io.ballerina.projects.internal.DefaultDiagnosticResult;
 import io.ballerina.projects.internal.model.CompilerPluginDescriptor;
-import io.ballerina.projects.internal.model.Dependency;
-import org.ballerinalang.toml.model.Platform;
 
 import java.util.Collections;
 import java.util.List;


### PR DESCRIPTION


## Purpose
> Adding package attributes from template package.json to new project
Ballerina.toml. Also When creating new project from template,
remove adding implementation_vendor and language_spec_version
fields to Ballerina.toml of newly created project.

Fixes #34807

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
