### PR TITLE
Fix no field completions within mapping constructor inside a new expression

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MappingConstructorExpressionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MappingConstructorExpressionNodeContext.java
@@ -15,8 +15,6 @@
  */
 package org.ballerinalang.langserver.completions.providers.context;
 
-import io.ballerina.compiler.api.symbols.RecordFieldSymbol;
-import io.ballerina.compiler.api.symbols.RecordTypeSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.VariableSymbol;
@@ -34,9 +32,7 @@ import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -107,20 +103,11 @@ public class MappingConstructorExpressionNodeContext extends
     }
 
     @Override
-    protected Map<String, RecordFieldSymbol> getValidFields(MappingConstructorExpressionNode node,
-                                                            RecordTypeSymbol recordTypeSymbol) {
-        List<String> missingFields = node.fields().stream()
+    protected List<String> getFields(MappingConstructorExpressionNode node) {
+        return node.fields().stream()
                 .filter(field -> !field.isMissing() && field.kind() == SyntaxKind.SPECIFIC_FIELD
                         && ((SpecificFieldNode) field).fieldName().kind() == SyntaxKind.IDENTIFIER_TOKEN)
                 .map(field -> ((IdentifierToken) ((SpecificFieldNode) field).fieldName()).text())
                 .collect(Collectors.toList());
-        Map<String, RecordFieldSymbol> fieldSymbols = new HashMap<>();
-        recordTypeSymbol.fieldDescriptors().forEach((name, symbol) -> {
-            if (!missingFields.contains(name)) {
-                fieldSymbols.put(name, symbol);
-            }
-        });
-
-        return fieldSymbols;
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MappingMatchPatternNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MappingMatchPatternNodeContext.java
@@ -15,8 +15,6 @@
  */
 package org.ballerinalang.langserver.completions.providers.context;
 
-import io.ballerina.compiler.api.symbols.RecordFieldSymbol;
-import io.ballerina.compiler.api.symbols.RecordTypeSymbol;
 import io.ballerina.compiler.syntax.tree.FieldMatchPatternNode;
 import io.ballerina.compiler.syntax.tree.MappingMatchPatternNode;
 import io.ballerina.compiler.syntax.tree.NonTerminalNode;
@@ -28,9 +26,7 @@ import org.ballerinalang.langserver.commons.completion.LSCompletionException;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -61,21 +57,12 @@ public class MappingMatchPatternNodeContext extends MappingContextProvider<Mappi
     }
 
     @Override
-    protected Map<String, RecordFieldSymbol> getValidFields(MappingMatchPatternNode node,
-                                                            RecordTypeSymbol recordTypeSymbol) {
-        List<String> missingFields = node.fieldMatchPatterns().stream()
+    protected List<String> getFields(MappingMatchPatternNode node) {
+        return node.fieldMatchPatterns().stream()
                 .filter(field -> !field.isMissing() && field.kind() == SyntaxKind.FIELD_MATCH_PATTERN
                         && ((FieldMatchPatternNode) field).fieldNameNode().kind() == SyntaxKind.IDENTIFIER_TOKEN)
                 .map(field -> ((FieldMatchPatternNode) field).fieldNameNode().text())
                 .collect(Collectors.toList());
-        Map<String, RecordFieldSymbol> fieldSymbols = new HashMap<>();
-        recordTypeSymbol.fieldDescriptors().forEach((name, symbol) -> {
-            if (!missingFields.contains(name)) {
-                fieldSymbols.put(name, symbol);
-            }
-        });
-
-        return fieldSymbols;
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/ContextTypeResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/ContextTypeResolver.java
@@ -643,7 +643,10 @@ public class ContextTypeResolver extends NodeTransformer<Optional<TypeSymbol>> {
 
     @Override
     public Optional<TypeSymbol> transform(MappingConstructorExpressionNode mappingConstructorExpressionNode) {
-        return mappingConstructorExpressionNode.parent().apply(this);
+        return context.currentSemanticModel()
+                .flatMap(semanticModel -> semanticModel.typeOf(mappingConstructorExpressionNode))
+                .filter(typeSymbol -> typeSymbol.typeKind() != TypeDescKind.COMPILATION_ERROR)
+                .or(() -> mappingConstructorExpressionNode.parent().apply(this));
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config38_negative.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config38_negative.json
@@ -18,7 +18,7 @@
       "label": "c",
       "kind": "Variable",
       "detail": "Outer",
-      "sortText": "AB",
+      "sortText": "F",
       "insertText": "c",
       "insertTextFormat": "Snippet"
     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config51.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config51.json
@@ -18,7 +18,7 @@
       "label": "a",
       "kind": "Variable",
       "detail": "int",
-      "sortText": "AB",
+      "sortText": "F",
       "insertText": "a",
       "insertTextFormat": "Snippet"
     },
@@ -32,7 +32,7 @@
           "value": ""
         }
       },
-      "sortText": "AB",
+      "sortText": "F",
       "insertText": "CONST1",
       "insertTextFormat": "Snippet"
     },
@@ -40,7 +40,7 @@
       "label": "param2",
       "kind": "Variable",
       "detail": "int",
-      "sortText": "AB",
+      "sortText": "F",
       "insertText": "param2",
       "insertTextFormat": "Snippet"
     },
@@ -48,7 +48,7 @@
       "label": "param1",
       "kind": "Variable",
       "detail": "int",
-      "sortText": "AB",
+      "sortText": "F",
       "insertText": "param1",
       "insertTextFormat": "Snippet"
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config52.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config52.json
@@ -15,14 +15,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "a",
-      "kind": "Variable",
-      "detail": "int",
-      "sortText": "AB",
-      "insertText": "a",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "CONST1",
       "kind": "Variable",
       "detail": "\"Test\"",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config54.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config54.json
@@ -6,14 +6,6 @@
   "source": "expression_context/source/mapping_expr_ctx_source54.bal",
   "items": [
     {
-      "label": "a",
-      "kind": "Variable",
-      "detail": "int",
-      "sortText": "AB",
-      "insertText": "a",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "CONST1",
       "kind": "Variable",
       "detail": "\"Test\"",
@@ -23,7 +15,7 @@
           "value": ""
         }
       },
-      "sortText": "AB",
+      "sortText": "F",
       "insertText": "CONST1",
       "insertTextFormat": "Snippet"
     },
@@ -47,7 +39,7 @@
       "label": "b",
       "kind": "Variable",
       "detail": "map<any>",
-      "sortText": "AB",
+      "sortText": "F",
       "insertText": "b",
       "insertTextFormat": "Snippet"
     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config63.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config63.json
@@ -1,0 +1,59 @@
+{
+  "position": {
+    "line": 27,
+    "character": 28
+  },
+  "source": "expression_context/source/mapping_expr_ctx_source63.bal",
+  "items": [
+    {
+      "label": "readonly",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "readonly",
+      "insertText": "readonly ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "scheme",
+      "kind": "Field",
+      "detail": "ClientConfig.scheme",
+      "sortText": "K",
+      "insertText": "scheme: \"${1}\"",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "port",
+      "kind": "Field",
+      "detail": "ClientConfig.port",
+      "sortText": "K",
+      "insertText": "port: ${2:0}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "host",
+      "kind": "Field",
+      "detail": "ClientConfig.host",
+      "sortText": "K",
+      "insertText": "host: \"${3}\"",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "timeout",
+      "kind": "Field",
+      "detail": "ClientConfig.timeout",
+      "sortText": "K",
+      "insertText": "timeout: ${4:0}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Fill ClientConfig Required Fields",
+      "kind": "Property",
+      "detail": "ClientConfig",
+      "sortText": "R",
+      "filterText": "fill",
+      "insertText": "scheme: \"\",\nport: 0,\nhost: \"\",\ntimeout: 0",
+      "insertTextFormat": "Snippet"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/mapping_expr_ctx_source63.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/mapping_expr_ctx_source63.bal
@@ -1,0 +1,29 @@
+type ClientConfig record {|
+    string host;
+    int port;
+    string scheme;
+
+    int timeout;
+|};
+
+public type Error distinct error;
+
+client class Client {
+
+    private ClientConfig config;
+
+    public function init(ClientConfig config) returns error? {
+        self.config = config;
+    }
+
+    remote function findByName(string name) returns json|Error {
+        return {
+            id: "123",
+            name: "Test"
+        };
+    }
+}
+
+public function main() returns error? {
+    Client cl = check new ({});
+}


### PR DESCRIPTION
## Purpose
$subject

Fixes #34841

## Approach
Updated `ContextTypeResolver` to first check the type of mapping constructor node before looking up the parent.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
