### PR TITLE
Fix missing completions for field names in MappingConstructorExpressionNodeContext

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/ContextTypeResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/ContextTypeResolver.java
@@ -91,7 +91,7 @@ import java.util.function.Predicate;
 import javax.annotation.Nonnull;
 
 /**
- * This visitor is used to resolve a type of a given context.
+ * This visitor is used to resolve a type of given context.
  * For example, consider the following example,
  * <pre>
  *     function sayHello() returns int {
@@ -198,7 +198,7 @@ public class ContextTypeResolver extends NodeTransformer<Optional<TypeSymbol>> {
                 && symbol.getName().get().equals(node.identifier().text());
         List<Symbol> moduleContent = QNameReferenceUtil.getModuleContent(context, node, predicate);
         if (moduleContent.size() != 1) {
-            // At the moment we do not handle the ambiguity. Hence consider only single item
+            // At the moment we do not handle the ambiguity. Hence, consider only single item
             return Optional.empty();
         }
 
@@ -661,9 +661,8 @@ public class ContextTypeResolver extends NodeTransformer<Optional<TypeSymbol>> {
 
     @Override
     public Optional<TypeSymbol> transform(MatchStatementNode matchStatementNode) {
-        Optional<TypeSymbol> typeSymbol = context.currentSemanticModel()
+        return context.currentSemanticModel()
                 .flatMap(semanticModel -> semanticModel.typeOf(matchStatementNode.condition()));
-        return typeSymbol;
     }
 
     //    @Override
@@ -679,7 +678,7 @@ public class ContextTypeResolver extends NodeTransformer<Optional<TypeSymbol>> {
     private Optional<Symbol> getTypeFromQNameReference(QualifiedNameReferenceNode node, Predicate<Symbol> predicate) {
         List<Symbol> moduleContent = QNameReferenceUtil.getModuleContent(context, node, predicate);
         if (moduleContent.size() != 1) {
-            // At the moment we do not handle the ambiguity. Hence consider only single item
+            // At the moment we do not handle the ambiguity. Hence, consider only single item
             return Optional.empty();
         }
 
@@ -825,7 +824,7 @@ public class ContextTypeResolver extends NodeTransformer<Optional<TypeSymbol>> {
      * @param positionalArgumentNode Positional arg node
      * @param argumentNodes          Argument nodes
      * @param newExpressionNode      Implicit/explicit new expression node
-     * @return Optiona type symbol of the parameter
+     * @return Optional type symbol of the parameter
      */
     private Optional<TypeSymbol> getPositionalArgumentTypeForNewExpr(PositionalArgumentNode positionalArgumentNode,
                                                                      NodeList<FunctionArgumentNode> argumentNodes,

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config64.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config64.json
@@ -1,0 +1,43 @@
+{
+  "position": {
+    "line": 10,
+    "character": 10
+  },
+  "source": "expression_context/source/mapping_expr_ctx_source64.bal",
+  "items": [
+    {
+      "label": "readonly",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "readonly",
+      "insertText": "readonly ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "name",
+      "kind": "Field",
+      "detail": "Person.name",
+      "sortText": "K",
+      "insertText": "name: \"${1}\"",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "age",
+      "kind": "Field",
+      "detail": "Person.age",
+      "sortText": "K",
+      "insertText": "age: ${2:0}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Fill Person Required Fields",
+      "kind": "Property",
+      "detail": "Person",
+      "sortText": "R",
+      "filterText": "fill",
+      "insertText": "name: \"\",\nage: 0",
+      "insertTextFormat": "Snippet"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/mapping_expr_ctx_source64.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/mapping_expr_ctx_source64.bal
@@ -1,0 +1,13 @@
+type Person record {
+    readonly string name;
+    int age;
+};
+
+type PersonTable table<Person> key(name);
+
+public function main() {
+    PersonTable t1 = table [
+        {name: "A", age: 2},
+        {n}
+    ];
+}


### PR DESCRIPTION
## Purpose
>$Subject

Fixes #34822 

## Samples
> ![Screenshot from 2022-02-08 12-35-22](https://user-images.githubusercontent.com/46120162/152935505-d8db45b3-1efb-43ee-9b01-54ebba4a0fa3.png)

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
