### PR TITLE
Fix create function in return statement and fail expression

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/visitors/FunctionCallExpressionTypeFinder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/visitors/FunctionCallExpressionTypeFinder.java
@@ -35,8 +35,11 @@ import io.ballerina.compiler.syntax.tree.AssignmentStatementNode;
 import io.ballerina.compiler.syntax.tree.BinaryExpressionNode;
 import io.ballerina.compiler.syntax.tree.ErrorConstructorExpressionNode;
 import io.ballerina.compiler.syntax.tree.ExplicitNewExpressionNode;
+import io.ballerina.compiler.syntax.tree.FailStatementNode;
 import io.ballerina.compiler.syntax.tree.FunctionArgumentNode;
+import io.ballerina.compiler.syntax.tree.FunctionBodyBlockNode;
 import io.ballerina.compiler.syntax.tree.FunctionCallExpressionNode;
+import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
 import io.ballerina.compiler.syntax.tree.IfElseStatementNode;
 import io.ballerina.compiler.syntax.tree.ImplicitNewExpressionNode;
 import io.ballerina.compiler.syntax.tree.LetExpressionNode;
@@ -49,6 +52,7 @@ import io.ballerina.compiler.syntax.tree.NodeVisitor;
 import io.ballerina.compiler.syntax.tree.ParenthesizedArgList;
 import io.ballerina.compiler.syntax.tree.PositionalArgumentNode;
 import io.ballerina.compiler.syntax.tree.RemoteMethodCallActionNode;
+import io.ballerina.compiler.syntax.tree.ReturnStatementNode;
 import io.ballerina.compiler.syntax.tree.SeparatedNodeList;
 import io.ballerina.compiler.syntax.tree.SimpleNameReferenceNode;
 import io.ballerina.compiler.syntax.tree.SpecificFieldNode;
@@ -346,6 +350,35 @@ public class FunctionCallExpressionTypeFinder extends NodeVisitor {
     }
 
     @Override
+    public void visit(FunctionDefinitionNode node) {
+        semanticModel.symbol(node)
+                .flatMap(SymbolUtil::getTypeDescriptor)
+                .ifPresent(this::checkAndSetTypeResult);
+    }
+
+    @Override
+    public void visit(FunctionBodyBlockNode node) {
+        node.parent().accept(this);
+    }
+
+    @Override
+    public void visit(ReturnStatementNode returnStatementNode) {
+        this.semanticModel.typeOf(returnStatementNode).ifPresent(this::checkAndSetTypeResult);
+        if (resultFound) {
+            return;
+        }
+
+        // Get function type symbol and get return type descriptor from it
+        returnStatementNode.parent().accept(this);
+        if (resultFound && returnTypeSymbol.typeKind() == TypeDescKind.FUNCTION) {
+            FunctionTypeSymbol functionTypeSymbol = (FunctionTypeSymbol) returnTypeSymbol;
+            functionTypeSymbol.returnTypeDescriptor().ifPresentOrElse(this::checkAndSetTypeResult, this::resetResult);
+        } else {
+            resetResult();
+        }
+    }
+
+    @Override
     public void visit(UnaryExpressionNode unaryExpressionNode) {
         semanticModel.typeOf(unaryExpressionNode).ifPresent(this::checkAndSetTypeResult);
 
@@ -357,6 +390,11 @@ public class FunctionCallExpressionTypeFinder extends NodeVisitor {
     @Override
     public void visit(IfElseStatementNode ifElseStatementNode) {
         checkAndSetTypeDescResult(TypeDescKind.BOOLEAN);
+    }
+
+    @Override
+    public void visit(FailStatementNode failStatementNode) {
+        checkAndSetTypeDescResult(TypeDescKind.ERROR);
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/command/CreateFunctionCommandExecTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/command/CreateFunctionCommandExecTest.java
@@ -132,7 +132,9 @@ public class CreateFunctionCommandExecTest extends AbstractCommandExecutionTest 
                 // TODO Blocked by #34448
                 // {"create_function_in_var_decl14.json", "create_function_in_var_decl4.bal"}
                 
-                 {"create_function_which_returns_error1.json", "create_function_which_returns_error1.bal"},
+                {"create_function_which_returns_error1.json", "create_function_which_returns_error1.bal"},
+                {"create_function_in_fail1.json", "create_function_in_fail1.bal"},
+                {"create_function_in_return1.json", "create_function_in_return1.bal"},
         };
     }
 

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/create_function_in_fail1.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/create_function_in_fail1.json
@@ -1,0 +1,40 @@
+{
+  "arguments": {
+    "node.range": {
+      "start": {
+        "line": 1,
+        "character": 9
+      },
+      "end": {
+        "line": 1,
+        "character": 21
+      }
+    }
+  },
+  "expected": {
+    "result": {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "range": {
+                  "start": {
+                    "line": 2,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 2,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction getFailure() returns error {\n    \n}\n"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "jsonrpc": "2.0"
+  }
+}

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/create_function_in_return1.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/create_function_in_return1.json
@@ -1,0 +1,40 @@
+{
+  "arguments": {
+    "node.range": {
+      "start": {
+        "line": 1,
+        "character": 11
+      },
+      "end": {
+        "line": 1,
+        "character": 22
+      }
+    }
+  },
+  "expected": {
+    "result": {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "range": {
+                  "start": {
+                    "line": 2,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 2,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction getReturn() returns int {\n    return 0;\n}\n"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "jsonrpc": "2.0"
+  }
+}

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/source/create_function_in_fail1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/source/create_function_in_fail1.bal
@@ -1,0 +1,3 @@
+function test1() {
+    fail getFailure();
+}

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/source/create_function_in_return1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/source/create_function_in_return1.bal
@@ -1,0 +1,3 @@
+function test2() returns int {
+    return getReturn();
+}


### PR DESCRIPTION
## Purpose
$subject

Fixes #34767

## Approach
Overridden required methods in the `FunctionCallExpressionTypeFinder`.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
