### PR TITLE
Introduce new API for getting string representation of a constant

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaConstantSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaConstantSymbol.java
@@ -24,10 +24,17 @@ import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
+import org.wso2.ballerinalang.compiler.tree.BLangConstantValue;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
+import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.util.Flags;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.StringJoiner;
 
 import static io.ballerina.compiler.api.symbols.SymbolKind.CONSTANT;
 import static io.ballerina.compiler.api.symbols.SymbolKind.ENUM_MEMBER;
@@ -40,7 +47,7 @@ import static org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols.is
  */
 public class BallerinaConstantSymbol extends BallerinaVariableSymbol implements ConstantSymbol {
 
-    private final Object constValue;
+    private final String constValue;
     private TypeSymbol broaderType;
 
     private BallerinaConstantSymbol(String name, List<Qualifier> qualifiers, List<AnnotationSymbol> annots,
@@ -48,7 +55,7 @@ public class BallerinaConstantSymbol extends BallerinaVariableSymbol implements 
                                     BSymbol bSymbol, CompilerContext context) {
         super(name, isFlagOn(bSymbol.flags, Flags.ENUM_MEMBER) ? ENUM_MEMBER : CONSTANT, qualifiers, annots,
               typeDescriptor, bSymbol, context);
-        this.constValue = constValue;
+        this.constValue = stringValueOf((BLangConstantValue) constValue);
         this.broaderType = broaderType;
     }
 
@@ -59,7 +66,18 @@ public class BallerinaConstantSymbol extends BallerinaVariableSymbol implements 
      */
     @Override
     public Object constValue() {
-        return constValue;
+        // explicitly returning null here since this will be deprecated and this anyways used to return null always
+        // since the corresponding internal API for this wasn't implemented before.
+        return null;
+    }
+
+    @Override
+    public Optional<String> resolvedValue() {
+        if (this.constValue == null) {
+            return Optional.empty();
+        }
+
+        return Optional.of(this.constValue);
     }
 
     @Override
@@ -90,6 +108,46 @@ public class BallerinaConstantSymbol extends BallerinaVariableSymbol implements 
     @Override
     public boolean subtypeOf(TypeSymbol targetType) {
         return this.typeDescriptor().subtypeOf(targetType);
+    }
+
+    private String stringValueOf(BLangConstantValue value) {
+        if (value == null) {
+            return null;
+        }
+
+        if (value.value instanceof BLangConstantValue) {
+            return stringValueOf((BLangConstantValue) value.value);
+        }
+
+        if (value.value instanceof HashMap) {
+            StringJoiner joiner = new StringJoiner(", ", "{", "}");
+            Map map = (Map) value.value;
+
+            map.forEach((k, v) -> {
+                StringBuilder builder = new StringBuilder();
+                builder.append(k).append(": ");
+
+                if (v instanceof BLangConstantValue) {
+                    builder.append(stringValueOf((BLangConstantValue) v));
+                } else {
+                    builder.append(toStringVal(v, value.type));
+                }
+
+                joiner.add(builder.toString());
+            });
+
+            return joiner.toString();
+        }
+
+        return toStringVal(value.value, value.type);
+    }
+
+    private String toStringVal(Object obj, BType valType) {
+        if (obj instanceof String && TypeTags.isStringTypeTag(valType.tag)) {
+            return String.format("\"%s\"", obj);
+        }
+
+        return String.valueOf(obj);
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/ConstantSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/ConstantSymbol.java
@@ -17,6 +17,8 @@
  */
 package io.ballerina.compiler.api.symbols;
 
+import java.util.Optional;
+
 /**
  * Represent Constant Symbol.
  *
@@ -30,6 +32,13 @@ public interface ConstantSymbol extends VariableSymbol, SingletonTypeSymbol, Ann
      * @return {@link Object} value of the constant
      */
     Object constValue();
+
+    /**
+     * Gives a string representation of the resolved constant value.
+     *
+     * @return A string representation of the constant
+     */
+    Optional<String> resolvedValue();
 
     /**
      * Gets the broader type of constant expression associated with this symbol.

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ConstantValueResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ConstantValueResolver.java
@@ -75,6 +75,7 @@ import java.math.MathContext;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
@@ -207,7 +208,7 @@ public class ConstantValueResolver extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangRecordLiteral recordLiteral) {
-        Map<String, BLangConstantValue> mapConstVal = new HashMap<>();
+        Map<String, BLangConstantValue> mapConstVal = new LinkedHashMap<>();
         for (RecordLiteralNode.RecordField field : recordLiteral.fields) {
             String key;
             BLangConstantValue value;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BConstantSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BConstantSymbol.java
@@ -53,4 +53,9 @@ public class BConstantSymbol extends BVarSymbol implements ConstantSymbol {
     public SymbolKind getKind() {
         return SymbolKind.CONSTANT;
     }
+
+    @Override
+    public Object getConstValue() {
+        return value;
+    }
 }

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbols/const_decl_symbol_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbols/const_decl_symbol_test.bal
@@ -35,4 +35,9 @@ const byte byteConst = 2;
 @constDecl
 const boolean boolConst = true;
 
+const int A = constValue + intConst;
+const map<string> B = {foo: strConst, bar: "BAR"};
+const map<map<int>> C = {foo: {a: intConst, b: 100}};
+const D = ;
+
 annotation constDecl;


### PR DESCRIPTION
## Purpose
Introduces a new API for getting a string representation of a constant from its symbol since the original API added for this it not quite suited as an API and wasn't implemented properly

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
