### PR TITLE
[`master`] Fix bug in named arg reference finding

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/ReferenceFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/ReferenceFinder.java
@@ -986,8 +986,8 @@ public class ReferenceFinder extends BaseVisitor {
 
     @Override
     public void visit(BLangNamedArgsExpression bLangNamedArgsExpression) {
-        // TODO: create issue. Missing symbol info.
         find(bLangNamedArgsExpression.expr);
+        addIfSameSymbol(bLangNamedArgsExpression.varSymbol, bLangNamedArgsExpression.name.pos);
     }
 
     @Override

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsInErrorConstructorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsInErrorConstructorTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.semantic.api.test.allreferences;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+/**
+ * Test cases for the find all references API related to error constructor exprs.
+ *
+ * @since 2201.0.1
+ */
+@Test
+public class FindRefsInErrorConstructorTest extends FindAllReferencesTest {
+
+    @DataProvider(name = "PositionProvider")
+    public Object[][] getLookupPositions() {
+        return new Object[][]{
+                {18, 11, location(18, 11, 13),
+                        List.of(location(18, 11, 13),
+                                location(24, 58, 60))
+                },
+                {24, 58, location(18, 11, 13),
+                        List.of(location(18, 11, 13),
+                                location(24, 58, 60))
+                },
+        };
+    }
+
+    @Override
+    public String getTestSourcePath() {
+        return "test-src/find-all-ref/find_ref_in_error_ctr.bal";
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/find-all-ref/find_ref_in_error_ctr.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/find-all-ref/find_ref_in_error_ctr.bal
@@ -1,0 +1,26 @@
+// Copyright (c) 2022 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+type ErrorDetail record {|
+    int code = 10;
+    string st;
+|};
+
+type MyError error<ErrorDetail>;
+
+function test() {
+    MyError errName = error MyError("message", code = 10, st = "st");
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
+++ b/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
@@ -41,27 +41,28 @@
             <class name="io.ballerina.semantic.api.test.TypedescriptorTest" />
             <class name="io.ballerina.semantic.api.test.WorkspaceSymbolLookupTest" />
 
-            <class name="io.ballerina.semantic.api.test.allreferences.FindRefsWithinTargetDocumentTest" />
             <class name="io.ballerina.semantic.api.test.allreferences.AnnotationRefsTest" />
             <class name="io.ballerina.semantic.api.test.allreferences.FindModulePrefixRefsTest" />
             <class name="io.ballerina.semantic.api.test.allreferences.FindRefsAcrossFilesTest" />
             <class name="io.ballerina.semantic.api.test.allreferences.FindRefsInBindingPatternsTest" />
+            <class name="io.ballerina.semantic.api.test.allreferences.FindRefsInClassObjectTest" />
+            <class name="io.ballerina.semantic.api.test.allreferences.FindRefsInConditionalStmtTest" />
             <class name="io.ballerina.semantic.api.test.allreferences.FindRefsInDoStmtTest" />
+            <class name="io.ballerina.semantic.api.test.allreferences.FindRefsInErrorConstructorTest" />
             <class name="io.ballerina.semantic.api.test.allreferences.FindRefsInExprsTest" />
+            <class name="io.ballerina.semantic.api.test.allreferences.FindRefsInFailTrtryStmtTest" />
             <class name="io.ballerina.semantic.api.test.allreferences.FindRefsInLambdasTest" />
             <class name="io.ballerina.semantic.api.test.allreferences.FindRefsInMatchStmtTest" />
+            <class name="io.ballerina.semantic.api.test.allreferences.FindRefsInRecordTypeDefTest" />
+            <class name="io.ballerina.semantic.api.test.allreferences.FindRefsInRegCompoundStmtTest" />
             <class name="io.ballerina.semantic.api.test.allreferences.FindRefsInServiceDeclTest" />
             <class name="io.ballerina.semantic.api.test.allreferences.FindRefsInTestsTest" />
+            <class name="io.ballerina.semantic.api.test.allreferences.FindRefsInTransactionalStmtTest" />
             <class name="io.ballerina.semantic.api.test.allreferences.FindRefsInWorkersTest" />
-            <class name="io.ballerina.semantic.api.test.allreferences.FindRefsInRecordTypeDefTest" />
             <class name="io.ballerina.semantic.api.test.allreferences.FindRefsOfEnumsTest" />
+            <class name="io.ballerina.semantic.api.test.allreferences.FindRefsWithinTargetDocumentTest" />
             <class name="io.ballerina.semantic.api.test.allreferences.XMLRefsTest" />
             <class name="io.ballerina.semantic.api.test.allreferences.CyclicUnionRefsTest" />
-            <class name="io.ballerina.semantic.api.test.allreferences.FindRefsInConditionalStmtTest" />
-            <class name="io.ballerina.semantic.api.test.allreferences.FindRefsInRegCompoundStmtTest" />
-            <class name="io.ballerina.semantic.api.test.allreferences.FindRefsInTransactionalStmtTest" />
-            <class name="io.ballerina.semantic.api.test.allreferences.FindRefsInFailTrtryStmtTest" />
-            <class name="io.ballerina.semantic.api.test.allreferences.FindRefsInClassObjectTest" />
 
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByAnnotationTest" />
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByClassTest" />


### PR DESCRIPTION
## Purpose
Properly implements the visit() method for named args in the reference finder.

Fixes #33067

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
