### PR TITLE
Fix a bug in `is-expr` with readonly arrays

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -2511,9 +2511,8 @@ public class TypeChecker {
             }
         }
 
-        int targetTypeSize = targetType.getSize();
         int sourceSize = source.size();
-        if ((targetTypeSize != -1) && (sourceSize != targetTypeSize)) {
+        if ((targetType.getState() != ArrayState.OPEN) && (sourceSize != targetType.getSize())) {
             return false;
         }
         for (int i = 0; i < sourceSize; i++) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -2511,7 +2511,12 @@ public class TypeChecker {
             }
         }
 
-        for (int i = 0; i < source.size(); i++) {
+        int targetTypeSize = targetType.getSize();
+        int sourceSize = source.size();
+        if ((targetTypeSize != -1) && (sourceSize != targetTypeSize)) {
+            return false;
+        }
+        for (int i = 0; i < sourceSize; i++) {
             if (!checkIsLikeType(null, source.get(i), targetTypeElementType, unresolvedValues,
                     allowNumericConversion, null)) {
                 return false;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/TypeTestExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/TypeTestExprTest.java
@@ -747,7 +747,8 @@ public class TypeTestExprTest {
                 "testRecordIntersectionWithFunctionFields",
                 "testBuiltInSubTypeTypeTestAgainstFiniteType",
                 "testIntSubtypes",
-                "testRecordsWithOptionalFields"
+                "testRecordsWithOptionalFields",
+                "testReadOnlyArrays"
         };
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/type-test-expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/type-test-expr.bal
@@ -711,6 +711,21 @@ public function testEmptyArrayType() {
     test:assertEquals(c is int[], true);
 }
 
+function testReadOnlyArrays() {
+    anydata & readonly arr1 = [2, 2, 3];
+    test:assertTrue(arr1 is int[3]);
+    test:assertTrue(arr1 is int[]);
+    test:assertFalse(arr1 is int[2]);
+    test:assertFalse(arr1 is boolean[3]);
+
+    anydata arr2 = ["a", "b", "c"];
+    anydata & readonly arr3 = arr2.cloneReadOnly();
+    test:assertTrue(arr3 is string[3]);
+    test:assertTrue(arr3 is string[]);
+    test:assertFalse(arr3 is string[2]);
+    test:assertTrue(arr3 is anydata[3]);
+}
+
 // ========================== Tuples ==========================
 
 function testSimpleTuples() returns [boolean, boolean, boolean, boolean, boolean] {


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues.

$title
Fixes #34879

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
