### PR TITLE
Add missing signature help for union typed expressions

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
@@ -498,7 +498,7 @@ public class SignatureHelpUtil {
         }
         NonTerminalNode nodeAtCursor = context.getNodeAtCursor().get();
         if (nodeAtCursor.kind() == SyntaxKind.FUNCTION_CALL) {
-            return getFunctionSymbol(nodeAtCursor, context);
+            return getFunctionSymbol((FunctionCallExpressionNode) nodeAtCursor, context);
         }
         return getFunctionSymbol(nodeAtCursor, context);
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
@@ -498,13 +498,13 @@ public class SignatureHelpUtil {
         }
         NonTerminalNode nodeAtCursor = context.getNodeAtCursor().get();
         if (nodeAtCursor.kind() == SyntaxKind.FUNCTION_CALL) {
-            return getFunctionSymbol(((FunctionCallExpressionNode) nodeAtCursor), context);
+            return getFunctionSymbol(nodeAtCursor, context);
         }
         return getFunctionSymbol(nodeAtCursor, context);
 
     }
 
-    private static Optional<? extends Symbol> getFunctionSymbol(FunctionCallExpressionNode node, 
+    private static Optional<? extends Symbol> getFunctionSymbol(FunctionCallExpressionNode node,
                                                                 SignatureContext context) {
         NameReferenceNode nameReferenceNode = node.functionName();
         String funcName;
@@ -522,7 +522,7 @@ public class SignatureHelpUtil {
             funcName = ((SimpleNameReferenceNode) nameReferenceNode).name().text();
             List<Symbol> visibleSymbols = context.visibleSymbols(context.getCursorPosition());
             filteredContent = visibleSymbols.stream()
-                    .filter(symbolPredicate.and(symbol -> symbol.getName().get().equals(funcName)))
+                    .filter(symbolPredicate.and(symbol -> symbol.getName().isPresent() && symbol.getName().get().equals(funcName)))
                     .collect(Collectors.toList());
         }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
@@ -522,7 +522,8 @@ public class SignatureHelpUtil {
             funcName = ((SimpleNameReferenceNode) nameReferenceNode).name().text();
             List<Symbol> visibleSymbols = context.visibleSymbols(context.getCursorPosition());
             filteredContent = visibleSymbols.stream()
-                    .filter(symbolPredicate.and(symbol -> symbol.getName().isPresent() && symbol.getName().get().equals(funcName)))
+                    .filter(symbolPredicate.and(symbol -> symbol.getName().isPresent() 
+                            && symbol.getName().get().equals(funcName)))
                     .collect(Collectors.toList());
         }
 

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/expressions.bal
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/expressions.bal
@@ -303,7 +303,7 @@ public client class Stub {
     public Child obj = new Child();
 
     # Create a new Stub
-    public function init(any arg1,string arg2) returns error?{
+    public function init(any arg1, string arg2) returns error? {
         
     }
 

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/expressions.bal
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/expressions.bal
@@ -303,8 +303,8 @@ public client class Stub {
     public Child obj = new Child();
 
     # Create a new Stub
-    public function init(any arg1,string arg2) {
-
+    public function init(any arg1,string arg2) returns error?{
+        
     }
 
     # Returns name


### PR DESCRIPTION
## Purpose
$subject to add signature help when a new expression's type is a union. 

Fixes #34391 


## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
