### PR TITLE
Fix incorrect type checking with numeric singletons

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/JsonUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/JsonUtils.java
@@ -376,7 +376,7 @@ public class JsonUtils {
                     if (jsonValue == valueSpaceItem) {
                         return convertJSON(jsonValue, inputValueType);
                     }
-                    if (TypeChecker.isFiniteTypeValue(jsonValue, inputValueType, valueSpaceItem)) {
+                    if (TypeChecker.isFiniteTypeValue(jsonValue, inputValueType, valueSpaceItem, true)) {
                         matchedValues.add(valueSpaceItem);
                     }
                 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -2740,29 +2740,42 @@ public class TypeChecker {
         switch (sourceType.getTag()) {
             case TypeTags.BYTE_TAG:
             case TypeTags.INT_TAG:
-                if (valueSpaceItemType.getTag() == TypeTags.DECIMAL_TAG) {
-                    return ((Number) sourceValue).longValue() == ((DecimalValue) valueSpaceItem).intValue() &&
-                            allowNumericConversion;
+                switch (valueSpaceItemType.getTag()) {
+                    case TypeTags.BYTE_TAG:
+                    case TypeTags.INT_TAG:
+                        return ((Number) sourceValue).longValue() == ((Number) valueSpaceItem).longValue();
+                    case TypeTags.FLOAT_TAG:
+                        return ((Number) sourceValue).longValue() == ((Number) valueSpaceItem).longValue() &&
+                                allowNumericConversion;
+                    case TypeTags.DECIMAL_TAG:
+                        return ((Number) sourceValue).longValue() == ((DecimalValue) valueSpaceItem).intValue() &&
+                                allowNumericConversion;
                 }
-                return ((Number) sourceValue).longValue() == ((Number) valueSpaceItem).longValue() &&
-                        (valueSpaceItemType.getTag() != TypeTags.FLOAT_TAG || allowNumericConversion);
             case TypeTags.FLOAT_TAG:
-                if (valueSpaceItemType.getTag() == TypeTags.DECIMAL_TAG) {
-                    return ((Number) sourceValue).doubleValue() == ((DecimalValue) valueSpaceItem).floatValue();
+                switch (valueSpaceItemType.getTag()) {
+                    case TypeTags.BYTE_TAG:
+                    case TypeTags.INT_TAG:
+                        return ((Number) sourceValue).doubleValue() == ((Number) valueSpaceItem).doubleValue()
+                                && allowNumericConversion;
+                    case TypeTags.FLOAT_TAG:
+                        return (((Number) sourceValue).doubleValue() == ((Number) valueSpaceItem).doubleValue() ||
+                                (Double.isNaN((Double) sourceValue) && Double.isNaN((Double) valueSpaceItem)));
+                    case TypeTags.DECIMAL_TAG:
+                        return ((Number) sourceValue).doubleValue() == ((DecimalValue) valueSpaceItem).floatValue()
+                                && allowNumericConversion;
                 }
-                return (((Number) sourceValue).doubleValue() == ((Number) valueSpaceItem).doubleValue() ||
-                        (Double.isNaN((Double) sourceValue) && Double.isNaN((Double) valueSpaceItem))) &&
-                        sourceType.getTag() == valueSpaceItemType.getTag();
             case TypeTags.DECIMAL_TAG:
-                if (valueSpaceItemType.getTag() == TypeTags.INT_TAG ||
-                        valueSpaceItemType.getTag() == TypeTags.BYTE_TAG) {
-                    return checkDecimalEqual((DecimalValue) sourceValue,
-                            DecimalValue.valueOf(((Number) valueSpaceItem).longValue())) && allowNumericConversion;
-                } else if (valueSpaceItemType.getTag() == TypeTags.FLOAT_TAG) {
-                    return checkDecimalEqual((DecimalValue) sourceValue,
+                switch (valueSpaceItemType.getTag()) {
+                    case TypeTags.BYTE_TAG:
+                    case TypeTags.INT_TAG:
+                        return checkDecimalEqual((DecimalValue) sourceValue,
+                                DecimalValue.valueOf(((Number) valueSpaceItem).longValue())) && allowNumericConversion;
+                    case TypeTags.FLOAT_TAG:
+                        return checkDecimalEqual((DecimalValue) sourceValue,
                             DecimalValue.valueOf(((Number) valueSpaceItem).doubleValue())) && allowNumericConversion;
+                    case TypeTags.DECIMAL_TAG:
+                        return checkDecimalEqual((DecimalValue) sourceValue, (DecimalValue) valueSpaceItem);
                 }
-                return checkDecimalEqual((DecimalValue) sourceValue, (DecimalValue) valueSpaceItem);
             default:
                 if (sourceType.getTag() != valueSpaceItemType.getTag()) {
                     return false;

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -2722,37 +2722,30 @@ public class TypeChecker {
 
         for (Object valueSpaceItem : targetType.valueSpace) {
             // TODO: 8/13/19 Maryam fix for conversion
-            if (isFiniteTypeValue(sourceValue, sourceType, valueSpaceItem)) {
+            if (isFiniteTypeValue(sourceValue, sourceType, valueSpaceItem, allowNumericConversion)) {
                 return true;
             }
         }
         return false;
     }
 
-    protected static boolean isFiniteTypeValue(Object sourceValue, Type sourceType, Object valueSpaceItem) {
+    protected static boolean isFiniteTypeValue(Object sourceValue, Type sourceType, Object valueSpaceItem,
+                                               boolean allowNumericConversion) {
         Type valueSpaceItemType = getType(valueSpaceItem);
         if (valueSpaceItemType.getTag() > TypeTags.FLOAT_TAG) {
             return valueSpaceItemType.getTag() == sourceType.getTag() &&
                     (valueSpaceItem == sourceValue || valueSpaceItem.equals(sourceValue));
         }
 
-        switch (sourceType.getTag()) {
-            case TypeTags.BYTE_TAG:
-            case TypeTags.INT_TAG:
-                return ((Number) sourceValue).longValue() == ((Number) valueSpaceItem).longValue();
-            case TypeTags.FLOAT_TAG:
-                if (sourceType.getTag() != valueSpaceItemType.getTag()) {
-                    return false;
-                }
-
-                return ((Number) sourceValue).doubleValue() == ((Number) valueSpaceItem).doubleValue();
-            case TypeTags.DECIMAL_TAG:
-                // falls through
-            default:
-                if (sourceType.getTag() != valueSpaceItemType.getTag()) {
-                    return false;
-                }
-                return valueSpaceItem.equals(sourceValue);
+        if (sourceType.getTag() < TypeTags.FLOAT_TAG) {
+            return ((Number) sourceValue).longValue() == ((Number) valueSpaceItem).longValue() &&
+                    (valueSpaceItemType.getTag() != TypeTags.FLOAT_TAG || allowNumericConversion);
+        } else {
+            if (valueSpaceItemType.getTag() != sourceType.getTag()) {
+                return false;
+            }
+            return ((Number) sourceValue).doubleValue() == ((Number) valueSpaceItem).doubleValue() ||
+                    (Double.isNaN((Double) sourceValue) && Double.isNaN((Double) valueSpaceItem));
         }
     }
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeConverter.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeConverter.java
@@ -345,7 +345,7 @@ public class TypeConverter {
                     if (inputValue == valueSpaceItem) {
                         return Set.of(inputValueType);
                     }
-                    if (TypeChecker.isFiniteTypeValue(inputValue, inputValueType, valueSpaceItem)) {
+                    if (TypeChecker.isFiniteTypeValue(inputValue, inputValueType, valueSpaceItem, true)) {
                         convertibleTypes.add(TypeChecker.getType(valueSpaceItem));
                     }
                 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeConverter.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeConverter.java
@@ -266,10 +266,10 @@ public class TypeConverter {
 
         Type inputValueType;
         int targetTypeTag = targetType.getTag();
+        int initialErrorCount = errors.size();
 
         switch (targetTypeTag) {
             case TypeTags.UNION_TAG:
-                int initialErrorCount = errors.size();
                 inputValueType = TypeChecker.getType(inputValue);
                 for (Type memType : ((BUnionType) targetType).getMemberTypes()) {
                     if ((inputValueType == memType) || isIntegerSubtypeAndConvertible(inputValue, memType)) {
@@ -348,6 +348,13 @@ public class TypeConverter {
                     if (TypeChecker.isFiniteTypeValue(inputValue, inputValueType, valueSpaceItem, true)) {
                         convertibleTypes.add(TypeChecker.getType(valueSpaceItem));
                     }
+                }
+                if (!allowAmbiguity && (convertibleTypes.size() > 1) && !convertibleTypes.contains(inputValueType) &&
+                        !hasIntegerSubTypes(convertibleTypes)) {
+                    errors.subList(initialErrorCount, errors.size()).clear();
+                    addErrorMessage(0, errors, "value '" + getShortSourceValue(inputValue)
+                            + "' cannot be converted to '" + targetType + "': ambiguous target type");
+                    return new LinkedHashSet<>();
                 }
                 break;
             default:

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -3435,30 +3435,37 @@ public class Types {
 
     private boolean isFiniteTypeAssignable(BFiniteType finiteType, BType targetType, Set<TypePair> unresolvedTypes) {
         BType expType = getReferredType(targetType);
-        for (BLangExpression expression : finiteType.getValueSpace()) {
-            if (expType.tag != TypeTags.FINITE && expType.tag != TypeTags.UNION) {
-                if (!isLiteralCompatibleWithBuiltinTypeWithSubTypes((BLangLiteral) expression, targetType) &&
-                        !isAssignable(expression.getBType(), expType, unresolvedTypes)) {
-                    return false;
-                }
-            }
-
-            ((BLangLiteral) expression).isFiniteContext = true;
-            if (expType.tag == TypeTags.FINITE) {
+        if (expType.tag == TypeTags.FINITE) {
+            for (BLangExpression expression : finiteType.getValueSpace()) {
+                ((BLangLiteral) expression).isFiniteContext = true;
                 if (!isAssignableToFiniteType(expType, (BLangLiteral) expression)) {
                     return false;
                 }
-            } else {
-                List<BType> unionMemberTypes = getAllTypes(targetType, true);
+            }
+            return true;
+        }
+
+        if (targetType.tag == TypeTags.UNION) {
+            List<BType> unionMemberTypes = getAllTypes(targetType, true);
+            for (BLangExpression valueExpr : finiteType.getValueSpace()) {
+                ((BLangLiteral) valueExpr).isFiniteContext = true;
                 if (unionMemberTypes.stream()
                         .noneMatch(targetMemType ->
                                 getReferredType(targetMemType).tag == TypeTags.FINITE ?
-                                        isAssignableToFiniteType(targetMemType, (BLangLiteral) expression) :
-                                        isAssignable(expression.getBType(), targetMemType, unresolvedTypes) ||
+                                        isAssignableToFiniteType(targetMemType, (BLangLiteral) valueExpr) :
+                                        isAssignable(valueExpr.getBType(), targetMemType, unresolvedTypes) ||
                                                 isLiteralCompatibleWithBuiltinTypeWithSubTypes(
-                                                        (BLangLiteral) expression, targetMemType))) {
+                                                        (BLangLiteral) valueExpr, targetMemType))) {
                     return false;
                 }
+            }
+            return true;
+        }
+
+        for (BLangExpression expression : finiteType.getValueSpace()) {
+            if (!isLiteralCompatibleWithBuiltinTypeWithSubTypes((BLangLiteral) expression, targetType) &&
+                    !isAssignable(expression.getBType(), expType, unresolvedTypes)) {
+                return false;
             }
         }
         return true;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -3435,31 +3435,31 @@ public class Types {
 
     private boolean isFiniteTypeAssignable(BFiniteType finiteType, BType targetType, Set<TypePair> unresolvedTypes) {
         BType expType = getReferredType(targetType);
-        if (expType.tag == TypeTags.FINITE) {
-            return finiteType.getValueSpace().stream()
-                    .allMatch(expression -> isAssignableToFiniteType(expType, (BLangLiteral) expression));
-        }
-
-        if (targetType.tag == TypeTags.UNION) {
-            List<BType> unionMemberTypes = getAllTypes(targetType, true);
-            for (BLangExpression valueExpr : finiteType.getValueSpace()) {
-                if (unionMemberTypes.stream()
-                        .noneMatch(targetMemType ->
-                                getReferredType(targetMemType).tag == TypeTags.FINITE ?
-                                        isAssignableToFiniteType(targetMemType, (BLangLiteral) valueExpr) :
-                                        isAssignable(valueExpr.getBType(), targetMemType, unresolvedTypes) ||
-                                                isLiteralCompatibleWithBuiltinTypeWithSubTypes(
-                                                        (BLangLiteral) valueExpr, targetMemType))) {
+        for (BLangExpression expression : finiteType.getValueSpace()) {
+            if (expType.tag != TypeTags.FINITE && expType.tag != TypeTags.UNION) {
+                if (!isLiteralCompatibleWithBuiltinTypeWithSubTypes((BLangLiteral) expression, targetType) &&
+                        !isAssignable(expression.getBType(), expType, unresolvedTypes)) {
                     return false;
                 }
             }
-            return true;
-        }
 
-        for (BLangExpression expression : finiteType.getValueSpace()) {
-            if (!isLiteralCompatibleWithBuiltinTypeWithSubTypes((BLangLiteral) expression, targetType) &&
-                    !isAssignable(expression.getBType(), expType, unresolvedTypes)) {
-                return false;
+            ((BLangLiteral) expression).isFiniteContext = true;
+            if (expType.tag == TypeTags.FINITE) {
+                boolean foundMember = isAssignableToFiniteType(expType, (BLangLiteral) expression);
+                if (!foundMember) {
+                    return false;
+                }
+            } else {
+                List<BType> unionMemberTypes = getAllTypes(targetType, true);
+                if (unionMemberTypes.stream()
+                        .noneMatch(targetMemType ->
+                                getReferredType(targetMemType).tag == TypeTags.FINITE ?
+                                        isAssignableToFiniteType(targetMemType, (BLangLiteral) expression) :
+                                        isAssignable(expression.getBType(), targetMemType, unresolvedTypes) ||
+                                                isLiteralCompatibleWithBuiltinTypeWithSubTypes(
+                                                        (BLangLiteral) expression, targetMemType))) {
+                    return false;
+                }
             }
         }
         return true;
@@ -3558,7 +3558,8 @@ public class Types {
                 }
                 double baseDoubleVal = Double.parseDouble(baseValueStr);
                 double candidateDoubleVal;
-                if (candidateTypeTag == TypeTags.INT && !candidateLiteral.isConstant) {
+                if (candidateTypeTag == TypeTags.INT && !candidateLiteral.isConstant &&
+                        !candidateLiteral.isFiniteContext) {
                     candidateDoubleVal = ((Long) candidateValue).doubleValue();
                     return baseDoubleVal == candidateDoubleVal;
                 } else if (candidateTypeTag == TypeTags.FLOAT) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -3482,6 +3482,12 @@ public class Types {
             if (((BLangLiteral) memberLiteral).value == null) {
                 return literalExpr.value == null;
             }
+
+            // If the literal which needs to be tested is from finite type and the type of the any member literal
+            // is not the same type, the literal cannot be assignable to finite type.
+            if (literalExpr.isFiniteContext && memberLiteral.getBType().tag != literalExpr.getBType().tag) {
+                return false;
+            }
             // Check whether the literal that needs to be tested is assignable to any of the member literal in the
             // value space.
             return checkLiteralAssignabilityBasedOnType((BLangLiteral) memberLiteral, literalExpr);
@@ -3564,8 +3570,7 @@ public class Types {
                 }
                 double baseDoubleVal = Double.parseDouble(baseValueStr);
                 double candidateDoubleVal;
-                if (candidateTypeTag == TypeTags.INT && !candidateLiteral.isConstant &&
-                        !candidateLiteral.isFiniteContext) {
+                if (candidateTypeTag == TypeTags.INT && !candidateLiteral.isConstant) {
                     candidateDoubleVal = ((Long) candidateValue).doubleValue();
                     return baseDoubleVal == candidateDoubleVal;
                 } else if (candidateTypeTag == TypeTags.FLOAT) {
@@ -3576,12 +3581,11 @@ public class Types {
             case TypeTags.DECIMAL:
                 BigDecimal baseDecimalVal = NumericLiteralSupport.parseBigDecimal(baseValue);
                 BigDecimal candidateDecimalVal;
-                if (candidateTypeTag == TypeTags.INT && !candidateLiteral.isConstant &&
-                        !candidateLiteral.isFiniteContext) {
+                if (candidateTypeTag == TypeTags.INT && !candidateLiteral.isConstant) {
                     candidateDecimalVal = new BigDecimal((long) candidateValue, MathContext.DECIMAL128);
                     return baseDecimalVal.compareTo(candidateDecimalVal) == 0;
-                } else if (candidateTypeTag == TypeTags.FLOAT && !candidateLiteral.isConstant &&
-                        !candidateLiteral.isFiniteContext || candidateTypeTag == TypeTags.DECIMAL) {
+                } else if (candidateTypeTag == TypeTags.FLOAT && !candidateLiteral.isConstant ||
+                        candidateTypeTag == TypeTags.DECIMAL) {
                     if (NumericLiteralSupport.isFloatDiscriminated(String.valueOf(candidateValue))) {
                         return false;
                     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -3445,8 +3445,7 @@ public class Types {
 
             ((BLangLiteral) expression).isFiniteContext = true;
             if (expType.tag == TypeTags.FINITE) {
-                boolean foundMember = isAssignableToFiniteType(expType, (BLangLiteral) expression);
-                if (!foundMember) {
+                if (!isAssignableToFiniteType(expType, (BLangLiteral) expression)) {
                     return false;
                 }
             } else {
@@ -3570,11 +3569,12 @@ public class Types {
             case TypeTags.DECIMAL:
                 BigDecimal baseDecimalVal = NumericLiteralSupport.parseBigDecimal(baseValue);
                 BigDecimal candidateDecimalVal;
-                if (candidateTypeTag == TypeTags.INT && !candidateLiteral.isConstant) {
+                if (candidateTypeTag == TypeTags.INT && !candidateLiteral.isConstant &&
+                        !candidateLiteral.isFiniteContext) {
                     candidateDecimalVal = new BigDecimal((long) candidateValue, MathContext.DECIMAL128);
                     return baseDecimalVal.compareTo(candidateDecimalVal) == 0;
-                } else if (candidateTypeTag == TypeTags.FLOAT && !candidateLiteral.isConstant ||
-                        candidateTypeTag == TypeTags.DECIMAL) {
+                } else if (candidateTypeTag == TypeTags.FLOAT && !candidateLiteral.isConstant &&
+                        !candidateLiteral.isFiniteContext || candidateTypeTag == TypeTags.DECIMAL) {
                     if (NumericLiteralSupport.isFloatDiscriminated(String.valueOf(candidateValue))) {
                         return false;
                     }

--- a/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
@@ -1387,6 +1387,9 @@ function testCloneWithTypeImmutableStructuredTypes() {
     assert(person4.id, 14);
 }
 
+type IntOne 1;
+type FloatOne 1.0;
+type DecimalOne 1d;
 type IntOneOrTwo 1|2;
 type IntTwoOrThree 2|3;
 type IntThreeOrFour 3|4;
@@ -1395,6 +1398,7 @@ type FloatTwoOrThree 2.0|3.0;
 type FloatThreeOrFour 3.0|4.0;
 type IntOneOrFloatTwo 1|2.0;
 type IntTwoOrFloatTwo 2|2.0;
+type DecimalOneOrTwo 1d|2d;
 
 function testCloneWithTypeWithFiniteType() {
     int x = 2;
@@ -1419,6 +1423,34 @@ function testCloneWithTypeWithFiniteType() {
     assert(g is error, false);
     IntTwoOrFloatTwo h = checkpanic g;
     assert(h, 2.0);
+
+    int z = 1;
+    float w = 1.0;
+    decimal v = 1d;
+
+    DecimalOne|error i = z.cloneWithType();
+    assert(checkpanic i, 1.0d);
+    DecimalOneOrTwo|error j = z.cloneWithType();
+    assert(checkpanic j, 1.0d);
+    DecimalOne|error k = w.cloneWithType();
+    assert(checkpanic k, 1.0d);
+    DecimalOneOrTwo|error l = w.cloneWithType();
+    assert(checkpanic l, 1.0d);
+
+    IntOne|error m = v.cloneWithType();
+    assert(checkpanic m, 1);
+    FloatOne|error n = v.cloneWithType();
+    assert(checkpanic n, 1.0);
+    IntOneOrTwo|error p = v.cloneWithType();
+    assert(checkpanic p, 1);
+
+    DecimalOneOrTwo decimalOneOrTwo = 2d;
+    IntTwoOrFloatTwo|error q = decimalOneOrTwo.cloneWithType();
+    assert(q is error, true);
+    error err = <error> q;
+    assert(err.message(), "{ballerina/lang.value}ConversionError");
+    assert(<string> checkpanic err.detail()["message"],
+            "'decimal' value cannot be converted to 'IntTwoOrFloatTwo': ambiguous target type");
 }
 
 function testCloneWithTypeWithUnionOfFiniteType() {
@@ -1439,6 +1471,9 @@ function testCloneWithTypeWithUnionOfFiniteType() {
     assert(e is error, false);
     IntOneOrFloatTwo|IntTwoOrThree f = checkpanic e;
     assert(f, 2);
+
+    (DecimalOneOrTwo|FloatThreeOrFour)|error g = y.cloneWithType();
+    assert(checkpanic g, 2d);
 }
 
 function testCloneWithTypeWithFiniteArrayTypeFromIntArray() {

--- a/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
@@ -1450,7 +1450,8 @@ function testCloneWithTypeWithFiniteType() {
     error err = <error> q;
     assert(err.message(), "{ballerina/lang.value}ConversionError");
     assert(<string> checkpanic err.detail()["message"],
-            "'decimal' value cannot be converted to 'IntTwoOrFloatTwo': ambiguous target type");
+            "'decimal' value cannot be converted to 'IntTwoOrFloatTwo': " +
+            "\n\t\tvalue '2' cannot be converted to 'IntTwoOrFloatTwo': ambiguous target type");
 }
 
 function testCloneWithTypeWithUnionOfFiniteType() {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/TypeTestExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/TypeTestExprTest.java
@@ -767,7 +767,8 @@ public class TypeTestExprTest {
                 "testBuiltInSubTypeTypeTestAgainstFiniteType",
                 "testIntSubtypes",
                 "testRecordsWithOptionalFields",
-                "testReadOnlyArrays"
+                "testReadOnlyArrays",
+                "testTypeTestExprWithSingletons"
         };
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/finite/FiniteTypeNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/finite/FiniteTypeNegativeTest.java
@@ -46,7 +46,7 @@ public class FiniteTypeNegativeTest {
     public void testInvalidLiteralAssignment() {
 
         CompileResult result = BCompileUtil.compile("test-src/types/finite/finite_type_negative.bal");
-        Assert.assertEquals(result.getErrorCount(), 71, "Error count mismatch");
+        Assert.assertEquals(result.getErrorCount(), 77, "Error count mismatch");
         int i = 0;
         validateError(result, i++, "incompatible types: expected 'Finite', found 'string'", 33, 16);
         validateError(result, i++, "incompatible types: expected 'ByteType', found '5'", 40, 18);
@@ -118,6 +118,12 @@ public class FiniteTypeNegativeTest {
         validateError(result, i++, "incompatible types: expected 'IntOrNullStr', found '(int|null)'", 226, 22);
         validateError(result, i++, "incompatible types: expected 'IntOrNullStr', found 'null'", 228, 22);
         validateError(result, i++, "incompatible types: expected 'null', found 'string'", 231, 14);
-        validateError(result, i, "incompatible types: expected '\"null\"', found '()'", 232, 16);
+        validateError(result, i++, "incompatible types: expected '\"null\"', found '()'", 232, 16);
+        validateError(result, i++, "incompatible types: expected 'FloatOne', found 'IntOne'", 241, 18);
+        validateError(result, i++, "incompatible types: expected '1.0f', found 'IntOne'", 242, 13);
+        validateError(result, i++, "incompatible types: expected 'float', found 'IntOne'", 243, 15);
+        validateError(result, i++, "incompatible types: expected 'IntOne', found 'FloatOne'", 246, 16);
+        validateError(result, i++, "incompatible types: expected '1', found 'FloatOne'", 247, 11);
+        validateError(result, i, "incompatible types: expected '(FloatOne|StringA)', found 'IntOne'", 248, 26);
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/finite/FiniteTypeNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/finite/FiniteTypeNegativeTest.java
@@ -46,7 +46,7 @@ public class FiniteTypeNegativeTest {
     public void testInvalidLiteralAssignment() {
 
         CompileResult result = BCompileUtil.compile("test-src/types/finite/finite_type_negative.bal");
-        Assert.assertEquals(result.getErrorCount(), 77, "Error count mismatch");
+        Assert.assertEquals(result.getErrorCount(), 83, "Error count mismatch");
         int i = 0;
         validateError(result, i++, "incompatible types: expected 'Finite', found 'string'", 33, 16);
         validateError(result, i++, "incompatible types: expected 'ByteType', found '5'", 40, 18);
@@ -119,11 +119,17 @@ public class FiniteTypeNegativeTest {
         validateError(result, i++, "incompatible types: expected 'IntOrNullStr', found 'null'", 228, 22);
         validateError(result, i++, "incompatible types: expected 'null', found 'string'", 231, 14);
         validateError(result, i++, "incompatible types: expected '\"null\"', found '()'", 232, 16);
-        validateError(result, i++, "incompatible types: expected 'FloatOne', found 'IntOne'", 241, 18);
-        validateError(result, i++, "incompatible types: expected '1.0f', found 'IntOne'", 242, 13);
-        validateError(result, i++, "incompatible types: expected 'float', found 'IntOne'", 243, 15);
-        validateError(result, i++, "incompatible types: expected 'IntOne', found 'FloatOne'", 246, 16);
-        validateError(result, i++, "incompatible types: expected '1', found 'FloatOne'", 247, 11);
-        validateError(result, i, "incompatible types: expected '(FloatOne|StringA)', found 'IntOne'", 248, 26);
+        validateError(result, i++, "incompatible types: expected 'FloatOne', found 'IntOne'", 242, 18);
+        validateError(result, i++, "incompatible types: expected '1.0f', found 'IntOne'", 243, 13);
+        validateError(result, i++, "incompatible types: expected 'float', found 'IntOne'", 244, 15);
+        validateError(result, i++, "incompatible types: expected 'DecimalOne', found 'IntOne'", 245, 20);
+        validateError(result, i++, "incompatible types: expected 'IntOne', found 'FloatOne'", 248, 16);
+        validateError(result, i++, "incompatible types: expected '1', found 'FloatOne'", 249, 11);
+        validateError(result, i++, "incompatible types: expected 'DecimalOne', found 'FloatOne'", 250, 20);
+        validateError(result, i++, "incompatible types: expected 'DecimalOne', found 'float'", 251, 20);
+        validateError(result, i++, "incompatible types: expected '(FloatOne|StringA)', found 'IntOne'", 252, 26);
+        validateError(result, i++, "incompatible types: expected 'IntOne', found 'DecimalOne'", 256, 16);
+        validateError(result, i++, "incompatible types: expected 'FloatOne', found 'DecimalOne'", 257, 18);
+        validateError(result, i, "incompatible types: expected '(FloatOne|IntOne)', found 'DecimalOne'", 258, 25);
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/type-test-expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/type-test-expr.bal
@@ -920,13 +920,16 @@ function testFiniteTypeAsBroaderType_1() returns boolean {
 type IntOne 1;
 type FloatOne 1.0;
 type FloatNaN float:NaN;
+type DecimalOne 1d;
 
 function testTypeTestExprWithSingletons() {
     IntOne intOne = 1;
     FloatOne floatOne = 1.0;
+    DecimalOne decimalOne = 1d;
 
     any a = intOne;
     test:assertFalse(a is FloatOne);
+    test:assertFalse(a is DecimalOne);
     test:assertFalse(a is 1f);
     test:assertFalse(a is float);
     test:assertTrue(a is FloatOne|IntOne);
@@ -940,6 +943,11 @@ function testTypeTestExprWithSingletons() {
     any c = floatNaN;
     test:assertTrue(c is FloatNaN);
     test:assertTrue(c is float:NaN);
+
+    any d = decimalOne;
+    test:assertFalse(d is IntOne);
+    test:assertFalse(d is FloatOne);
+    test:assertFalse(d is 1);
 }
 
 type FRUIT_OR_COUNT "apple"|2|"grape"|10;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/type-test-expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/type-test-expr.bal
@@ -917,6 +917,31 @@ function testFiniteTypeAsBroaderType_1() returns boolean {
     return a is string;
 }
 
+type IntOne 1;
+type FloatOne 1.0;
+type FloatNaN float:NaN;
+
+function testTypeTestExprWithSingletons() {
+    IntOne intOne = 1;
+    FloatOne floatOne = 1.0;
+
+    any a = intOne;
+    test:assertFalse(a is FloatOne);
+    test:assertFalse(a is 1f);
+    test:assertFalse(a is float);
+    test:assertTrue(a is FloatOne|IntOne);
+
+    any b = floatOne;
+    test:assertFalse(b is IntOne);
+    test:assertFalse(b is 1);
+    test:assertFalse(b is int);
+
+    FloatNaN floatNaN = float:NaN;
+    any c = floatNaN;
+    test:assertTrue(c is FloatNaN);
+    test:assertTrue(c is float:NaN);
+}
+
 type FRUIT_OR_COUNT "apple"|2|"grape"|10;
 
 function testFiniteTypeAsBroaderType_2() returns [boolean, boolean] {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/finite/finite_type_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/finite/finite_type_negative.bal
@@ -231,3 +231,20 @@ function testNullFiniteType() {
     null _ = "null"; // error
     "null" _ = null; // error
 }
+
+type IntOne 1;
+type FloatOne 1.0;
+type StringA "A";
+
+function testFiniteTypeAssignableNegative() {
+    IntOne intOne = 1;
+    FloatOne _ = intOne;
+    1.0 _ = intOne;
+    float _ = intOne;
+
+    FloatOne floatOne = 1.0;
+    IntOne _ = floatOne;
+    1 _ = floatOne;
+    FloatOne|StringA _ = intOne;
+    FloatOne|StringA _ = floatOne;
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/finite/finite_type_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/finite/finite_type_negative.bal
@@ -234,6 +234,7 @@ function testNullFiniteType() {
 
 type IntOne 1;
 type FloatOne 1.0;
+type DecimalOne 1.0d;
 type StringA "A";
 
 function testFiniteTypeAssignableNegative() {
@@ -241,10 +242,18 @@ function testFiniteTypeAssignableNegative() {
     FloatOne _ = intOne;
     1.0 _ = intOne;
     float _ = intOne;
+    DecimalOne _ = intOne;
 
     FloatOne floatOne = 1.0;
     IntOne _ = floatOne;
     1 _ = floatOne;
+    DecimalOne _ = floatOne;
+    DecimalOne _ = 1.0f;
     FloatOne|StringA _ = intOne;
     FloatOne|StringA _ = floatOne;
+
+    DecimalOne decimalOne = 1.0d;
+    IntOne _ = decimalOne;
+    FloatOne _ = decimalOne;
+    FloatOne|IntOne _ = decimalOne;
 }


### PR DESCRIPTION
## Purpose
> This PR fixes some incorrect type checking and conversion of decimal singletons.

Fixes #34885
Fixes https://github.com/ballerina-platform/ballerina-lang/issues/35168

## Samples
```ballerina
type DecimalOne 1.0d;
type DecimalOneOrTwo 1.0d|2d;

public function main() {
    int x = 1;

    DecimalOne|error z2 = x.cloneWithType();
    io:println(z2); // 1.0

    DecimalOneOrTwo|error z3 = x.cloneWithType();
    io:println(z3); // 1.0

}
```
## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
