### PR TITLE
Fix map creation for user defined type that refers to a predefined union

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TypedescValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TypedescValueImpl.java
@@ -18,7 +18,6 @@
 package io.ballerina.runtime.internal.values;
 
 import io.ballerina.runtime.api.TypeTags;
-import io.ballerina.runtime.api.creators.TypeCreator;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.values.BInitialValueEntry;
 import io.ballerina.runtime.api.values.BLink;
@@ -84,21 +83,11 @@ public class TypedescValueImpl implements  TypedescValue {
 
     @Override
     public Object instantiate(Strand s, BInitialValueEntry[] initialValues) {
-        return new MapValueImpl(getMapType(describingType), (BMapInitialValueEntry[]) initialValues);
-    }
-
-    private Type getMapType(Type describingType) {
-        switch (describingType.getTag()) {
-            case TypeTags.MAP_TAG:
-                return describingType;
-            case TypeTags.JSON_TAG:
-            case TypeTags.ANYDATA_TAG:
-            case TypeTags.ANY_TAG:
-                return TypeCreator.createMapType(describingType);
-            default:
-                // This method will be overridden for user-defined types, therefore this line shouldn't be reached.
-                throw new BallerinaException("Given type can't be instantiated at runtime : " + describingType);
+        if (describingType.getTag() == TypeTags.MAP_TAG) {
+            return new MapValueImpl(describingType, (BMapInitialValueEntry[]) initialValues);
         }
+        // This method will be overridden for user-defined types, therefore this line shouldn't be reached.
+        throw new BallerinaException("Given type can't be instantiated at runtime : " + describingType);
     }
 
     @Override

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TypedescValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TypedescValueImpl.java
@@ -18,6 +18,7 @@
 package io.ballerina.runtime.internal.values;
 
 import io.ballerina.runtime.api.TypeTags;
+import io.ballerina.runtime.api.creators.TypeCreator;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.values.BInitialValueEntry;
 import io.ballerina.runtime.api.values.BLink;
@@ -83,11 +84,21 @@ public class TypedescValueImpl implements  TypedescValue {
 
     @Override
     public Object instantiate(Strand s, BInitialValueEntry[] initialValues) {
-        if (describingType.getTag() == TypeTags.MAP_TAG) {
-            return new MapValueImpl(describingType, (BMapInitialValueEntry[]) initialValues);
+        return new MapValueImpl(getMapType(describingType), (BMapInitialValueEntry[]) initialValues);
+    }
+
+    private Type getMapType(Type describingType) {
+        switch (describingType.getTag()) {
+            case TypeTags.MAP_TAG:
+                return describingType;
+            case TypeTags.JSON_TAG:
+            case TypeTags.ANYDATA_TAG:
+            case TypeTags.ANY_TAG:
+                return TypeCreator.createMapType(describingType);
+            default:
+                // This method will be overridden for user-defined types, therefore this line shouldn't be reached.
+                throw new BallerinaException("Given type can't be instantiated at runtime : " + describingType);
         }
-        // This method will be overridden for user-defined types, therefor this line shouldn't be reached.
-        throw new BallerinaException("Given type can't be instantiated at runtime : " + describingType);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/emit/TypeEmitter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/emit/TypeEmitter.java
@@ -36,6 +36,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BStreamType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BTableType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BTupleType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BTypeReferenceType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BTypedescType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BUnionType;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
@@ -144,6 +145,8 @@ class TypeEmitter {
                 return emitBTypeHandle((BHandleType) bType, tabs);
             case TypeTags.STREAM:
                 return emitBStreamType((BStreamType) bType, tabs);
+            case TypeTags.TYPEREFDESC:
+                return emitTypeRefDesc((BTypeReferenceType) bType, tabs);
             default:
                 throw new IllegalStateException("Invalid type");
         }
@@ -375,6 +378,14 @@ class TypeEmitter {
         String str = "typeDesc";
         str += "<";
         str += emitTypeRef(bType.constraint, 0);
+        str += ">";
+        return str;
+    }
+
+    private static String emitTypeRefDesc(BTypeReferenceType bType, int tabs) {
+        String str = "typeRefDesc";
+        str += "<";
+        str += emitTypeRef(bType.referredType, 0);
         str += ">";
         return str;
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -2051,7 +2051,7 @@ public class TypeChecker extends BLangNodeVisitor {
         if (tag == TypeTags.TYPEREFDESC) {
             BType refType = Types.getReferredType(bType);
             BType compatibleType = checkMappingConstructorCompatibility(refType, mappingConstructor);
-            return (refType.tag != TypeTags.UNION && refType.tag != TypeTags.INTERSECTION) ? bType : compatibleType;
+            return (!isUnionType(refType.tag) && refType.tag != TypeTags.INTERSECTION) ? bType : compatibleType;
         }
 
         if (tag == TypeTags.INTERSECTION) {
@@ -2078,6 +2078,11 @@ public class TypeChecker extends BLangNodeVisitor {
         reportIncompatibleMappingConstructorError(mappingConstructor, bType);
         validateSpecifiedFields(mappingConstructor, symTable.semanticError);
         return symTable.semanticError;
+    }
+
+    private boolean isUnionType(int refTypeTag) {
+        return refTypeTag == TypeTags.UNION || refTypeTag == TypeTags.ANY || refTypeTag == TypeTags.ANYDATA ||
+                refTypeTag == TypeTags.JSON;
     }
 
     private BType checkReadOnlyMappingType(BLangRecordLiteral mappingConstructor) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -2051,7 +2051,8 @@ public class TypeChecker extends BLangNodeVisitor {
         if (tag == TypeTags.TYPEREFDESC) {
             BType refType = Types.getReferredType(bType);
             BType compatibleType = checkMappingConstructorCompatibility(refType, mappingConstructor);
-            return (!isUnionType(refType.tag) && refType.tag != TypeTags.INTERSECTION) ? bType : compatibleType;
+            return (!TypeTags.isUnionTypeTag(refType.tag) && refType.tag != TypeTags.INTERSECTION) ? bType :
+                    compatibleType;
         }
 
         if (tag == TypeTags.INTERSECTION) {
@@ -2078,11 +2079,6 @@ public class TypeChecker extends BLangNodeVisitor {
         reportIncompatibleMappingConstructorError(mappingConstructor, bType);
         validateSpecifiedFields(mappingConstructor, symTable.semanticError);
         return symTable.semanticError;
-    }
-
-    private boolean isUnionType(int refTypeTag) {
-        return refTypeTag == TypeTags.UNION || refTypeTag == TypeTags.ANY || refTypeTag == TypeTags.ANYDATA ||
-                refTypeTag == TypeTags.JSON;
     }
 
     private BType checkReadOnlyMappingType(BLangRecordLiteral mappingConstructor) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/TypeTags.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/TypeTags.java
@@ -159,4 +159,16 @@ public class TypeTags {
         }
     }
 
+    public static boolean isUnionTypeTag(int tag) {
+        switch (tag) {
+            case TypeTags.UNION:
+            case TypeTags.ANY:
+            case TypeTags.ANYDATA:
+            case TypeTags.JSON:
+                return true;
+            default:
+                return false;
+        }
+    }
+
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/typereftype/TypeReferenceTests.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/typereftype/TypeReferenceTests.java
@@ -20,18 +20,31 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.ballerinalang.test.BAssertUtil.validateError;
+
 /**
  * This class contains type reference type related test cases.
  */
 public class TypeReferenceTests {
 
+    private CompileResult result;
+
+    @BeforeClass
+    public void setup() {
+        result = BCompileUtil.compile("test-src/types/typereftype/type_reference.bal");
+    }
+
     @Test
     public void testTypeRef() {
-        CompileResult positiveCompileResult = BCompileUtil.compile("test-src/types/typereftype/type_reference.bal");
-        BRunUtil.invoke(positiveCompileResult, "testTypeRef");
+        BRunUtil.invoke(result, "testTypeRef");
+    }
+
+    @Test
+    public void testUnionTypeRefWithMap() {
+        BRunUtil.invoke(result, "testUnionTypeRefWithMap");
     }
 
     @Test(description = "Test basics types")

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/typereftype/type_reference.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/typereftype/type_reference.bal
@@ -226,9 +226,34 @@ function getImmutable(ImmutableIntArrayOrStringArray x) returns ImmutableIntArra
     return [];
 }
 
+type AnyDataType anydata;
+
+type JsonType json;
+
+type AnyType any;
+
+function testUnionTypeRefWithMap() {
+    AnyDataType map1 = {"a": 1};
+    JsonType map2 = {"b": 2};
+    AnyType map3 = {"c": 3};
+
+    assertTrue(map1 is anydata);
+    assertEqual(map1.toString(), "{\"a\":1}");
+
+    assertTrue(map2 is json);
+    assertEqual(map2.toString(), "{\"b\":2}");
+
+    assertTrue(map3 is any);
+    assertEqual(map3.toString(), "{\"c\":3}");
+}
+
+function assertTrue(anydata actual) {
+    return assertEqual(actual, true);
+}
+
 function assertEqual(anydata actual, anydata expected) {
     if expected == actual {
         return;
     }
-    panic error(string `expected '${expected.toBalString()}', found '${actual.toBalString()}'`);
+    panic error(string `expected '${expected.toString()}', found '${actual.toString()}'`);
 }


### PR DESCRIPTION
## Purpose
$subject
Fixes #35105 

## Approach
When creating a map value from the user-defined type which refers to the Ballerina in-built unions (`anydata`, `json`, `any`), it fails at runtime as the union type is not a proper map type. This PR fixes it by providing the correct type when creating such a map.

## Samples
```ballerina
type AnyDataType anydata;
AnyDataType map1 = {"a": 1};
```
## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
