### PR TITLE
Remove adding the line number for `$init$` function

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmPackageGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmPackageGen.java
@@ -662,7 +662,7 @@ public class JvmPackageGen {
         } catch (MethodTooLargeException e) {
             String funcName = e.getMethodName();
             BIRFunction func = findFunction(node, funcName);
-            if (func != null) {
+            if (func != null && func.pos != null) {
                 dlog.error(func.pos, DiagnosticErrorCode.METHOD_TOO_LARGE,
                         Utils.decodeIdentifier(func.name.value));
             } else {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -9932,13 +9932,12 @@ public class Desugar extends BLangNodeVisitor {
         }
 
         BLangFunction initFunction =
-                TypeDefBuilderHelper.createInitFunctionForStructureType(classDefinition.pos, classDefinition.symbol,
-                                                                        env, names, GENERATED_INIT_SUFFIX,
-                                                                        classDefinition.getBType(), returnType);
+                TypeDefBuilderHelper.createInitFunctionForStructureType(null, classDefinition.symbol,
+                        env, names, GENERATED_INIT_SUFFIX,
+                        classDefinition.getBType(), returnType);
         BObjectTypeSymbol typeSymbol = ((BObjectTypeSymbol) classDefinition.getBType().tsymbol);
         typeSymbol.generatedInitializerFunc = new BAttachedFunction(GENERATED_INIT_SUFFIX, initFunction.symbol,
-                                                                    (BInvokableType) initFunction.getBType(),
-                                                                    classDefinition.pos);
+                (BInvokableType) initFunction.getBType(), null);
         classDefinition.generatedInitFunction = initFunction;
         initFunction.returnTypeNode.setBType(returnType);
         return rewrite(initFunction, env);


### PR DESCRIPTION
## Purpose
$subject
Fixes #35193 

## Approach
With the fix we added in https://github.com/ballerina-platform/ballerina-lang/pull/35082, the line number of the last line of a function is added to the line number table. As we pass the position of a class definition when creating the `$init$` function, it will end up in the line number table with the above fix. 

As `$init$` is a generated function, we do not need the position information of it for debugging purpose. This PR removes this information. 
 
## Samples
For the following bal source, 
![bal_src](https://user-images.githubusercontent.com/28644893/155295206-d88a1a4c-bd31-474d-9799-113649b554f6.png)

before fix 
![before_fix](https://user-images.githubusercontent.com/28644893/155295239-9699e68f-0774-46dc-90b2-fea915e87489.png)

after fix
![after_fix](https://user-images.githubusercontent.com/28644893/155295260-509d80c2-662e-418d-b778-8dc1ab1844ad.png)

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
