### PR TITLE
Improve filler value check for xml sub-types

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -3220,7 +3220,7 @@ public class TypeChecker {
 
         int typeTag = type.getTag();
         if (TypeTags.isXMLTypeTag(typeTag)) {
-            return (typeTag == TypeTags.XML_TAG || typeTag == TypeTags.XML_TEXT_TAG);
+            return typeTag == TypeTags.XML_TAG || typeTag == TypeTags.XML_TEXT_TAG;
         }
 
         if (typeTag < TypeTags.RECORD_TYPE_TAG &&

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -3217,11 +3217,20 @@ public class TypeChecker {
         if (type == null) {
             return true;
         }
-        if (type.getTag() < TypeTags.RECORD_TYPE_TAG &&
-                !(type.getTag() == TypeTags.CHAR_STRING_TAG || type.getTag() == TypeTags.NEVER_TAG)) {
+
+        int typeTag = type.getTag();
+        if (TypeTags.isXMLTypeTag(typeTag)) {
+            if (typeTag == TypeTags.XML_TAG || typeTag == TypeTags.XML_TEXT_TAG) {
+                return true;
+            }
+            return false;
+        }
+
+        if (typeTag < TypeTags.RECORD_TYPE_TAG &&
+                !(typeTag == TypeTags.CHAR_STRING_TAG || typeTag == TypeTags.NEVER_TAG)) {
             return true;
         }
-        switch (type.getTag()) {
+        switch (typeTag) {
             case TypeTags.STREAM_TAG:
             case TypeTags.MAP_TAG:
             case TypeTags.ANY_TAG:

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -3220,10 +3220,7 @@ public class TypeChecker {
 
         int typeTag = type.getTag();
         if (TypeTags.isXMLTypeTag(typeTag)) {
-            if (typeTag == TypeTags.XML_TAG || typeTag == TypeTags.XML_TEXT_TAG) {
-                return true;
-            }
-            return false;
+            return (typeTag == TypeTags.XML_TAG || typeTag == TypeTags.XML_TEXT_TAG);
         }
 
         if (typeTag < TypeTags.RECORD_TYPE_TAG &&

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayFillTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayFillTest.java
@@ -613,6 +613,11 @@ public class ArrayFillTest {
         }
     }
 
+    @Test
+    public void testXMLSubtypesArrayFill() {
+        BRunUtil.invokeFunction(compileResult, "testXMLSubtypesArrayFill");
+    }
+
     @AfterClass
     public void tearDown() {
         compileResult = null;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayFillTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayFillTest.java
@@ -615,7 +615,7 @@ public class ArrayFillTest {
 
     @Test
     public void testXMLSubtypesArrayFill() {
-        BRunUtil.invokeFunction(compileResult, "testXMLSubtypesArrayFill");
+        BRunUtil.invoke(compileResult, "testXMLSubtypesArrayFill");
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array-fill-test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array-fill-test.bal
@@ -329,38 +329,38 @@ function testXMLSubtypesArrayFill() {
     " filler values\"}";
 
     xml:Element[] a = [];
-    error? result = trap addXmlElement(a, xml `<foo/>`);
+    error? result = trap setXmlArraySecondElement(a, xml `<foo/>`);
     assertEquality(result is error, true);
     error err = <error>result;
     assertEquality(errorMsg, err.message());
     assertEquality(errorDetails, err.detail().toString());
 
     xml:Comment[] b = [];
-    result = trap addXmlElement(b, xml `<!-- this is a comment text -->`);
+    result = trap setXmlArraySecondElement(b, xml `<!-- this is a comment text -->`);
     assertEquality(result is error, true);
     err = <error>result;
     assertEquality(errorMsg, err.message());
     assertEquality(errorDetails, err.detail().toString());
 
     xml:ProcessingInstruction[] c = [];
-    result = trap addXmlElement(c, xml `<?xml-stylesheet href="mystyle.css" type="text/css"?>`);
+    result = trap setXmlArraySecondElement(c, xml `<?xml-stylesheet href="mystyle.css" type="text/css"?>`);
     assertEquality(result is error, true);
     err = <error>result;
     assertEquality(errorMsg, err.message());
     assertEquality(errorDetails, err.detail().toString());
 
     xml:Text[] d = [];
-    result = trap addXmlElement(d, xml `Hello World`);
+    result = trap setXmlArraySecondElement(d, xml `Hello World`);
     assertEquality(result is (), true);
     assertEquality("[``,`Hello World`]", d.toString());
 
     xml[] e = [];
-    result = trap addXmlElement(e, xml `Hello World`);
+    result = trap setXmlArraySecondElement(e, xml `Hello World`);
     assertEquality(result is (), true);
     assertEquality("[``,`Hello World`]", e.toString());
 }
 
-function addXmlElement(xml[] arr, xml element) {
+function setXmlArraySecondElement(xml[] arr, xml element) {
     arr[1] = element;
 }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array-fill-test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array-fill-test.bal
@@ -323,6 +323,47 @@ function testFiniteTypeArrayFill() returns DEC[] {
     return ar;
 }
 
+function testXMLSubtypesArrayFill() {
+    string errorMsg = "{ballerina/lang.array}IllegalListInsertion";
+    string errorDetails = "{\"message\":\"array of length 0 cannot be expanded into array of length 2 without" +
+    " filler values\"}";
+
+    xml:Element[] a = [];
+    error? result = trap addXmlElement(a, xml `<foo/>`);
+    assertEquality(result is error, true);
+    error err = <error>result;
+    assertEquality(errorMsg, err.message());
+    assertEquality(errorDetails, err.detail().toString());
+
+    xml:Comment[] b = [];
+    result = trap addXmlElement(b, xml `<!-- this is a comment text -->`);
+    assertEquality(result is error, true);
+    err = <error>result;
+    assertEquality(errorMsg, err.message());
+    assertEquality(errorDetails, err.detail().toString());
+
+    xml:ProcessingInstruction[] c = [];
+    result = trap addXmlElement(c, xml `<?xml-stylesheet href="mystyle.css" type="text/css"?>`);
+    assertEquality(result is error, true);
+    err = <error>result;
+    assertEquality(errorMsg, err.message());
+    assertEquality(errorDetails, err.detail().toString());
+
+    xml:Text[] d = [];
+    result = trap addXmlElement(d, xml `Hello World`);
+    assertEquality(result is (), true);
+    assertEquality("[``,`Hello World`]", d.toString());
+
+    xml[] e = [];
+    result = trap addXmlElement(e, xml `Hello World`);
+    assertEquality(result is (), true);
+    assertEquality("[``,`Hello World`]", e.toString());
+}
+
+function addXmlElement(xml[] arr, xml element) {
+    arr[1] = element;
+}
+
 type AssertionError distinct error;
 
 const ASSERTION_ERROR_REASON = "AssertionError";


### PR DESCRIPTION
## Purpose
$subject

Fixes #35221 

## Approach
As per the spec, the only XML subtype that has a filler value is `xml:Text`. Currently, an empty XML value is added a filler value for all XML subtypes. This PR improves the filler value check for XML type depending on the subtype information.

## Samples
```ballerina
    xml:Element[] x = [];
    x[1] = xml `<foo/>`;
```
This will throw the following runtime error after the fix. 
```
error: {ballerina/lang.array}IllegalListInsertion {"message":"array of length 0 cannot be expanded into array of length 2 without filler values"}
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
