### PR TITLE
Add validation for runtime APIs

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/creators/ErrorCreator.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/creators/ErrorCreator.java
@@ -60,7 +60,7 @@ public class ErrorCreator {
      * @return new error
      */
     public static BError createError(BString message, BMap<BString, Object> details) {
-        RuntimeUtils.validateErrorDetails(details);
+        details = RuntimeUtils.validateErrorDetails(details);
         return new ErrorValue(message, details);
     }
 
@@ -106,7 +106,7 @@ public class ErrorCreator {
      * @return new error
      */
     public static BError createError(Type type, BString message, BError cause, BMap<BString, Object> details) {
-        RuntimeUtils.validateErrorDetails(details);
+        details = RuntimeUtils.validateErrorDetails(details);
         return new ErrorValue(type, message, cause, details);
     }
 
@@ -156,7 +156,7 @@ public class ErrorCreator {
      */
     public static BError createError(Module module, String errorTypeName,
                                      BString message, BError cause, BMap<BString, Object> details) {
-        RuntimeUtils.validateErrorDetails(details);
+        details = RuntimeUtils.validateErrorDetails(details);
         ValueCreator valueCreator = ValueCreator.getValueCreator(ValueCreator.getLookupKey(module));
         return valueCreator.createErrorValue(errorTypeName, message, cause, details);
     }
@@ -189,7 +189,7 @@ public class ErrorCreator {
     @Deprecated
     public static BError createDistinctError(String typeIdName, Module typeIdPkg, BString message,
                                              BMap<BString, Object> details) {
-        RuntimeUtils.validateErrorDetails(details);
+        details = RuntimeUtils.validateErrorDetails(details);
         return new ErrorValue(new BErrorType(TypeConstants.ERROR, PredefinedTypes.TYPE_ERROR.getPackage(), TypeChecker
                 .getType(details)), message, null, details, typeIdName, typeIdPkg);
     }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/creators/ErrorCreator.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/creators/ErrorCreator.java
@@ -60,6 +60,9 @@ public class ErrorCreator {
      * @return new error
      */
     public static BError createError(BString message, BMap<BString, Object> details) {
+        if (details == null) {
+            details = new MapValueImpl<>(PredefinedTypes.TYPE_ERROR_DETAIL);
+        }
         RuntimeUtils.validateObjectAssignabilityToBType(details);
         return new ErrorValue(message, details);
     }
@@ -106,6 +109,9 @@ public class ErrorCreator {
      * @return new error
      */
     public static BError createError(Type type, BString message, BError cause, BMap<BString, Object> details) {
+        if (details == null) {
+            details = new MapValueImpl<>(PredefinedTypes.TYPE_ERROR_DETAIL);
+        }
         RuntimeUtils.validateObjectAssignabilityToBType(details);
         return new ErrorValue(type, message, cause, details);
     }
@@ -192,6 +198,9 @@ public class ErrorCreator {
     @Deprecated
     public static BError createDistinctError(String typeIdName, Module typeIdPkg, BString message,
                                              BMap<BString, Object> details) {
+        if (details == null) {
+            details = new MapValueImpl<>(PredefinedTypes.TYPE_ERROR_DETAIL);
+        }
         RuntimeUtils.validateObjectAssignabilityToBType(details);
         return new ErrorValue(new BErrorType(TypeConstants.ERROR, PredefinedTypes.TYPE_ERROR.getPackage(), TypeChecker
                 .getType(details)), message, null, details, typeIdName, typeIdPkg);

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/creators/ErrorCreator.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/creators/ErrorCreator.java
@@ -60,10 +60,7 @@ public class ErrorCreator {
      * @return new error
      */
     public static BError createError(BString message, BMap<BString, Object> details) {
-        if (details == null) {
-            details = new MapValueImpl<>(PredefinedTypes.TYPE_ERROR_DETAIL);
-        }
-        RuntimeUtils.validateObjectAssignabilityToBType(details);
+        RuntimeUtils.validateErrorDetails(details);
         return new ErrorValue(message, details);
     }
 
@@ -109,10 +106,7 @@ public class ErrorCreator {
      * @return new error
      */
     public static BError createError(Type type, BString message, BError cause, BMap<BString, Object> details) {
-        if (details == null) {
-            details = new MapValueImpl<>(PredefinedTypes.TYPE_ERROR_DETAIL);
-        }
-        RuntimeUtils.validateObjectAssignabilityToBType(details);
+        RuntimeUtils.validateErrorDetails(details);
         return new ErrorValue(type, message, cause, details);
     }
 
@@ -162,10 +156,7 @@ public class ErrorCreator {
      */
     public static BError createError(Module module, String errorTypeName,
                                      BString message, BError cause, BMap<BString, Object> details) {
-        if (details == null) {
-            details = new MapValueImpl<>(PredefinedTypes.TYPE_ERROR_DETAIL);
-        }
-        RuntimeUtils.validateObjectAssignabilityToBType(details);
+        RuntimeUtils.validateErrorDetails(details);
         ValueCreator valueCreator = ValueCreator.getValueCreator(ValueCreator.getLookupKey(module));
         return valueCreator.createErrorValue(errorTypeName, message, cause, details);
     }
@@ -198,10 +189,7 @@ public class ErrorCreator {
     @Deprecated
     public static BError createDistinctError(String typeIdName, Module typeIdPkg, BString message,
                                              BMap<BString, Object> details) {
-        if (details == null) {
-            details = new MapValueImpl<>(PredefinedTypes.TYPE_ERROR_DETAIL);
-        }
-        RuntimeUtils.validateObjectAssignabilityToBType(details);
+        RuntimeUtils.validateErrorDetails(details);
         return new ErrorValue(new BErrorType(TypeConstants.ERROR, PredefinedTypes.TYPE_ERROR.getPackage(), TypeChecker
                 .getType(details)), message, null, details, typeIdName, typeIdPkg);
     }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/creators/ErrorCreator.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/creators/ErrorCreator.java
@@ -27,6 +27,7 @@ import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BString;
 import io.ballerina.runtime.internal.TypeChecker;
 import io.ballerina.runtime.internal.types.BErrorType;
+import io.ballerina.runtime.internal.util.RuntimeUtils;
 import io.ballerina.runtime.internal.values.ErrorValue;
 import io.ballerina.runtime.internal.values.MapValueImpl;
 import io.ballerina.runtime.internal.values.MappingInitialValueEntry;
@@ -59,6 +60,7 @@ public class ErrorCreator {
      * @return new error
      */
     public static BError createError(BString message, BMap<BString, Object> details) {
+        RuntimeUtils.validateObjectAssignabilityToBType(details);
         return new ErrorValue(message, details);
     }
 
@@ -104,6 +106,7 @@ public class ErrorCreator {
      * @return new error
      */
     public static BError createError(Type type, BString message, BError cause, BMap<BString, Object> details) {
+        RuntimeUtils.validateObjectAssignabilityToBType(details);
         return new ErrorValue(type, message, cause, details);
     }
 
@@ -153,6 +156,10 @@ public class ErrorCreator {
      */
     public static BError createError(Module module, String errorTypeName,
                                      BString message, BError cause, BMap<BString, Object> details) {
+        if (details == null) {
+            details = new MapValueImpl<>(PredefinedTypes.TYPE_ERROR_DETAIL);
+        }
+        RuntimeUtils.validateObjectAssignabilityToBType(details);
         ValueCreator valueCreator = ValueCreator.getValueCreator(ValueCreator.getLookupKey(module));
         return valueCreator.createErrorValue(errorTypeName, message, cause, details);
     }
@@ -185,6 +192,7 @@ public class ErrorCreator {
     @Deprecated
     public static BError createDistinctError(String typeIdName, Module typeIdPkg, BString message,
                                              BMap<BString, Object> details) {
+        RuntimeUtils.validateObjectAssignabilityToBType(details);
         return new ErrorValue(new BErrorType(TypeConstants.ERROR, PredefinedTypes.TYPE_ERROR.getPackage(), TypeChecker
                 .getType(details)), message, null, details, typeIdName, typeIdPkg);
     }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/creators/ValueCreator.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/creators/ValueCreator.java
@@ -49,6 +49,7 @@ import io.ballerina.runtime.internal.DecimalValueKind;
 import io.ballerina.runtime.internal.JsonDataSource;
 import io.ballerina.runtime.internal.ValueUtils;
 import io.ballerina.runtime.internal.XmlFactory;
+import io.ballerina.runtime.internal.util.RuntimeUtils;
 import io.ballerina.runtime.internal.values.ArrayValue;
 import io.ballerina.runtime.internal.values.ArrayValueImpl;
 import io.ballerina.runtime.internal.values.DecimalValue;
@@ -799,6 +800,8 @@ public class ValueCreator {
      */
     public static BMap<BString, Object> createRecordValue(Module packageId, String recordTypeName,
                                                           Map<String, Object> valueMap) {
+
+        RuntimeUtils.validateObjectAssignabilityToBType(valueMap);
         return ValueUtils.createRecordValue(packageId, recordTypeName, valueMap);
     }
 
@@ -814,6 +817,7 @@ public class ValueCreator {
      */
     public static BMap<BString, Object> createReadonlyRecordValue(Module packageId, String recordTypeName,
                                                                   Map<String, Object> valueMap) {
+        RuntimeUtils.validateObjectAssignabilityToBType(valueMap);
         MapValueImpl<BString, Object> bmap = (MapValueImpl<BString, Object>) ValueUtils.createRecordValue(
                 packageId, recordTypeName, valueMap);
         bmap.freezeDirect();
@@ -828,6 +832,7 @@ public class ValueCreator {
      * @return value of the record.
      */
     public static BMap<BString, Object> createRecordValue(BMap<BString, Object> record, Object... values) {
+        RuntimeUtils.validateObjectAssignabilityToBType(record);
         return ValueUtils.createRecordValue(record, values);
     }
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/creators/ValueCreator.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/creators/ValueCreator.java
@@ -801,7 +801,7 @@ public class ValueCreator {
     public static BMap<BString, Object> createRecordValue(Module packageId, String recordTypeName,
                                                           Map<String, Object> valueMap) {
 
-        RuntimeUtils.validateBMapValues(valueMap);
+        valueMap = RuntimeUtils.validateBMapValues(valueMap);
         return ValueUtils.createRecordValue(packageId, recordTypeName, valueMap);
     }
 
@@ -817,7 +817,7 @@ public class ValueCreator {
      */
     public static BMap<BString, Object> createReadonlyRecordValue(Module packageId, String recordTypeName,
                                                                   Map<String, Object> valueMap) {
-        RuntimeUtils.validateBMapValues(valueMap);
+        valueMap = RuntimeUtils.validateBMapValues(valueMap);
         MapValueImpl<BString, Object> bmap = (MapValueImpl<BString, Object>) ValueUtils.createRecordValue(
                 packageId, recordTypeName, valueMap);
         bmap.freezeDirect();
@@ -832,7 +832,7 @@ public class ValueCreator {
      * @return value of the record.
      */
     public static BMap<BString, Object> createRecordValue(BMap<BString, Object> record, Object... values) {
-        RuntimeUtils.validateBMapValues(record);
+        record = RuntimeUtils.validateBMapValues(record);
         return ValueUtils.createRecordValue(record, values);
     }
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/creators/ValueCreator.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/creators/ValueCreator.java
@@ -801,7 +801,7 @@ public class ValueCreator {
     public static BMap<BString, Object> createRecordValue(Module packageId, String recordTypeName,
                                                           Map<String, Object> valueMap) {
 
-        RuntimeUtils.validateObjectAssignabilityToBType(valueMap);
+        RuntimeUtils.validateBMapValues(valueMap);
         return ValueUtils.createRecordValue(packageId, recordTypeName, valueMap);
     }
 
@@ -817,7 +817,7 @@ public class ValueCreator {
      */
     public static BMap<BString, Object> createReadonlyRecordValue(Module packageId, String recordTypeName,
                                                                   Map<String, Object> valueMap) {
-        RuntimeUtils.validateObjectAssignabilityToBType(valueMap);
+        RuntimeUtils.validateBMapValues(valueMap);
         MapValueImpl<BString, Object> bmap = (MapValueImpl<BString, Object>) ValueUtils.createRecordValue(
                 packageId, recordTypeName, valueMap);
         bmap.freezeDirect();
@@ -832,7 +832,7 @@ public class ValueCreator {
      * @return value of the record.
      */
     public static BMap<BString, Object> createRecordValue(BMap<BString, Object> record, Object... values) {
-        RuntimeUtils.validateObjectAssignabilityToBType(record);
+        RuntimeUtils.validateBMapValues(record);
         return ValueUtils.createRecordValue(record, values);
     }
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/ErrorUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/ErrorUtils.java
@@ -136,6 +136,11 @@ public class ErrorUtils {
                 getErrorMessage(RuntimeErrors.TYPE_ASSIGNABLE_ERROR, sourceVal, targetType));
     }
 
+    public static BError createJToBTypeCastError(Object value) {
+        throw createError(BLangExceptionHelper.
+                getErrorMessage(RuntimeErrors.J_TYPE_ASSIGNABLE_ERROR, value));
+    }
+
     public static BError createNumericConversionError(Object inputValue, Type targetType) {
         throw createError(BallerinaErrorReasons.NUMBER_CONVERSION_ERROR,
                           BLangExceptionHelper.getErrorDetails(

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/util/RuntimeUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/util/RuntimeUtils.java
@@ -18,6 +18,7 @@
 
 package io.ballerina.runtime.internal.util;
 
+import io.ballerina.runtime.api.PredefinedTypes;
 import io.ballerina.runtime.api.TypeTags;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.utils.StringUtils;
@@ -31,6 +32,7 @@ import io.ballerina.runtime.internal.types.BArrayType;
 import io.ballerina.runtime.internal.values.ArrayValue;
 import io.ballerina.runtime.internal.values.ArrayValueImpl;
 import io.ballerina.runtime.internal.values.ErrorValue;
+import io.ballerina.runtime.internal.values.MapValueImpl;
 
 import java.io.PrintStream;
 import java.util.Map;
@@ -202,7 +204,10 @@ public class RuntimeUtils {
         return version.split("\\.")[0];
     }
 
-    public static void validateObjectAssignabilityToBType(BMap<BString, Object> bMap) {
+    public static void validateBMapValues(BMap<BString, Object> bMap) {
+        if (bMap == null) {
+            bMap = new MapValueImpl<>();
+        }
         for (Object value : bMap.values()) {
             if (isInvalidBallerinaValue(value)) {
                 throw ErrorUtils.createJToBTypeCastError(value.getClass());
@@ -210,9 +215,23 @@ public class RuntimeUtils {
         }
     }
 
-    public static void validateObjectAssignabilityToBType(Map<String, Object> bMap) {
+    public static void validateBMapValues(Map<String, Object> bMap) {
+        if (bMap == null) {
+            bMap = new MapValueImpl<>();
+        }
         for (Object value : bMap.values()) {
             if (isInvalidBallerinaValue(value) && !(value instanceof String)) {
+                throw ErrorUtils.createJToBTypeCastError(value.getClass());
+            }
+        }
+    }
+
+    public static void validateErrorDetails(BMap<BString, Object> details) {
+        if (details == null) {
+            details = new MapValueImpl<>(PredefinedTypes.TYPE_ERROR_DETAIL);
+        }
+        for (Object value : details.values()) {
+            if (isInvalidBallerinaValue(value)) {
                 throw ErrorUtils.createJToBTypeCastError(value.getClass());
             }
         }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/util/RuntimeUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/util/RuntimeUtils.java
@@ -204,37 +204,40 @@ public class RuntimeUtils {
         return version.split("\\.")[0];
     }
 
-    public static void validateBMapValues(BMap<BString, Object> bMap) {
+    public static BMap<BString, Object> validateBMapValues(BMap<BString, Object> bMap) {
         if (bMap == null) {
-            bMap = new MapValueImpl<>();
+            return new MapValueImpl<>();
         }
         for (Object value : bMap.values()) {
             if (isInvalidBallerinaValue(value)) {
                 throw ErrorUtils.createJToBTypeCastError(value.getClass());
             }
         }
+        return bMap;
     }
 
-    public static void validateBMapValues(Map<String, Object> bMap) {
+    public static Map<String, Object> validateBMapValues(Map<String, Object> bMap) {
         if (bMap == null) {
-            bMap = new MapValueImpl<>();
+            return new MapValueImpl<>();
         }
         for (Object value : bMap.values()) {
             if (isInvalidBallerinaValue(value) && !(value instanceof String)) {
                 throw ErrorUtils.createJToBTypeCastError(value.getClass());
             }
         }
+        return bMap;
     }
 
-    public static void validateErrorDetails(BMap<BString, Object> details) {
+    public static BMap<BString, Object> validateErrorDetails(BMap<BString, Object> details) {
         if (details == null) {
-            details = new MapValueImpl<>(PredefinedTypes.TYPE_ERROR_DETAIL);
+            return new MapValueImpl<>(PredefinedTypes.TYPE_ERROR_DETAIL);
         }
         for (Object value : details.values()) {
             if (isInvalidBallerinaValue(value)) {
                 throw ErrorUtils.createJToBTypeCastError(value.getClass());
             }
         }
+        return details;
     }
 
     private static boolean isInvalidBallerinaValue(Object value) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/util/RuntimeUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/util/RuntimeUtils.java
@@ -21,6 +21,10 @@ package io.ballerina.runtime.internal.util;
 import io.ballerina.runtime.api.TypeTags;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.utils.StringUtils;
+import io.ballerina.runtime.api.values.BMap;
+import io.ballerina.runtime.api.values.BString;
+import io.ballerina.runtime.api.values.BValue;
+import io.ballerina.runtime.internal.ErrorUtils;
 import io.ballerina.runtime.internal.TypeConverter;
 import io.ballerina.runtime.internal.diagnostics.RuntimeDiagnosticLog;
 import io.ballerina.runtime.internal.types.BArrayType;
@@ -29,6 +33,7 @@ import io.ballerina.runtime.internal.values.ArrayValueImpl;
 import io.ballerina.runtime.internal.values.ErrorValue;
 
 import java.io.PrintStream;
+import java.util.Map;
 import java.util.logging.ConsoleHandler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -195,6 +200,27 @@ public class RuntimeUtils {
 
     public static String getMajorVersion(String version) {
         return version.split("\\.")[0];
+    }
+
+    public static void validateObjectAssignabilityToBType(BMap<BString, Object> bMap) {
+        for (Object value : bMap.values()) {
+            if (isInvalidBallerinaValue(value)) {
+                throw ErrorUtils.createJToBTypeCastError(value.getClass());
+            }
+        }
+    }
+
+    public static void validateObjectAssignabilityToBType(Map<String, Object> bMap) {
+        for (Object value : bMap.values()) {
+            if (isInvalidBallerinaValue(value) && !(value instanceof String)) {
+                throw ErrorUtils.createJToBTypeCastError(value.getClass());
+            }
+        }
+    }
+
+    private static boolean isInvalidBallerinaValue(Object value) {
+        return (value != null && !(value instanceof Number) && !(value instanceof Boolean) &&
+                !(value instanceof BValue));
     }
 
     private RuntimeUtils() {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/util/exceptions/RuntimeErrors.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/util/exceptions/RuntimeErrors.java
@@ -66,7 +66,7 @@ public enum RuntimeErrors implements DiagnosticCode {
     CYCLIC_VALUE_REFERENCE("cyclic.value.reference", "RUNTIME_0038"),
     CANNOT_CONVERT_NIL("cannot.convert.nil", "RUNTIME_0039"),
     INCOMPATIBLE_CONVERT_OPERATION("incompatible.convert.operation", "RUNTIME_0040"),
-
+    J_TYPE_ASSIGNABLE_ERROR("incompatible.java.object.type.assignment", "RUNTIME_0041"),
     INCOMPATIBLE_SIMPLE_TYPE_CONVERT_OPERATION("incompatible.simple.type.convert.operation", "RUNTIME_0042"),
     TUPLE_INDEX_OUT_OF_RANGE("tuple.index.out.of.range", "RUNTIME_0043"),
     ILLEGAL_ARRAY_INSERTION("illegal.array.insertion", "RUNTIME_0044"),

--- a/bvm/ballerina-runtime/src/main/resources/MessagesBundle.properties
+++ b/bvm/ballerina-runtime/src/main/resources/MessagesBundle.properties
@@ -182,6 +182,8 @@ object.invalid.final.field.update = cannot update ''final'' field ''{0}'' in obj
 unsupported.comparison.operation = cannot compare ''{0}'' and ''{1}''
 unordered.types.in.comparison = ''{0}'' is unordered with respect to ''{1}''
 incompatible.type.assignment = ''{0}'' cannot be assigned to type ''{1}''
+incompatible.java.object.type.assignment = ''{0}'' is not from a valid java runtime class. It should be a subclass of \
+  one of the following: java.lang.Number, java.lang.Boolean or from the package ''io.ballerina.runtime.api.values''
 int.range.overflow = int range overflow
 invalid.value.for.object.field = invalid value for object field ''{0}'': expected value of type ''{1}'', found ''{2}''
 key.not.found = cannot find key ''{0}''

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Errors.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Errors.java
@@ -97,4 +97,9 @@ public class Errors {
         return ErrorCreator.createError(errorModule, errorName.getValue(), StringUtils.fromString("msg"),
                 null, null);
     }
+
+    public static BError getDistinctErrorWithNullDetailNegative2(BString msg) {
+        ErrorType bErrorType = createErrorType(TypeConstants.ERROR, PredefinedTypes.TYPE_ERROR.getPackage());
+        return ErrorCreator.createError(bErrorType, msg, null, null);
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Errors.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Errors.java
@@ -97,4 +97,13 @@ public class Errors {
         return ErrorCreator.createError(errorModule, errorName.getValue(), StringUtils.fromString("msg"),
                 null, null);
     }
+
+    public static BError getErrorWithNullDetailNegative(BString msg) {
+        return ErrorCreator.createError(msg, (BMap<BString, Object>) null);
+    }
+
+    public static BError getDistinctErrorWithNullDetailNegative2(BString msg) {
+        String typeIdName = "RuntimeError";
+        return ErrorCreator.createDistinctError(typeIdName, errorModule, msg, (BMap<BString, Object>) null);
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Errors.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Errors.java
@@ -20,6 +20,7 @@ package org.ballerinalang.nativeimpl.jvm.runtime.api.tests;
 
 import io.ballerina.runtime.api.Module;
 import io.ballerina.runtime.api.PredefinedTypes;
+import io.ballerina.runtime.api.constants.TypeConstants;
 import io.ballerina.runtime.api.creators.ErrorCreator;
 import io.ballerina.runtime.api.creators.TypeCreator;
 import io.ballerina.runtime.api.creators.ValueCreator;
@@ -32,6 +33,8 @@ import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BString;
 
 import java.util.List;
+
+import static io.ballerina.runtime.api.creators.TypeCreator.createErrorType;
 
 /**
  * This class contains a set of utility methods required for runtime api @{@link ErrorCreator} testing.
@@ -61,5 +64,37 @@ public class Errors {
             index++;
         }
         return arrayValue;
+    }
+
+    public static BError getDistinctErrorNegative(BString errorName) {
+        BMap<BString, Object> errorDetails = ValueCreator.createMapValue();
+        errorDetails.put(StringUtils.fromString("detail"), "detail error message");
+        return ErrorCreator.createError(errorModule, errorName.getValue(), StringUtils.fromString("msg"),
+                null, errorDetails);
+    }
+
+    public static BError getErrorNegative1(BString msg) {
+        BMap<BString, Object> errorDetails = ValueCreator.createMapValue();
+        errorDetails.put(StringUtils.fromString("detail"), "detail error message");
+        return ErrorCreator.createError(msg, errorDetails);
+    }
+
+    public static BError getErrorWithTypeNegative(BString msg) {
+        ErrorType bErrorType = createErrorType(TypeConstants.ERROR, PredefinedTypes.TYPE_ERROR.getPackage());
+        BMap<BString, Object> errorDetails = ValueCreator.createMapValue();
+        errorDetails.put(StringUtils.fromString("detail"), "detail error message");
+        return ErrorCreator.createError(bErrorType, msg, null, errorDetails);
+    }
+
+    public static BError getErrorNegative2(BString msg) {
+        String typeIdName = "RuntimeError";
+        BMap<BString, Object> errorDetails = ValueCreator.createMapValue();
+        errorDetails.put(StringUtils.fromString("detail"), "this is runtime failure");
+        return ErrorCreator.createDistinctError(typeIdName, errorModule, msg, errorDetails);
+    }
+
+    public static BError getDistinctErrorWithNullDetailNegative(BString errorName) {
+        return ErrorCreator.createError(errorModule, errorName.getValue(), StringUtils.fromString("msg"),
+                null, null);
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Errors.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Errors.java
@@ -97,9 +97,4 @@ public class Errors {
         return ErrorCreator.createError(errorModule, errorName.getValue(), StringUtils.fromString("msg"),
                 null, null);
     }
-
-    public static BError getDistinctErrorWithNullDetailNegative2(BString msg) {
-        ErrorType bErrorType = createErrorType(TypeConstants.ERROR, PredefinedTypes.TYPE_ERROR.getPackage());
-        return ErrorCreator.createError(bErrorType, msg, null, null);
-    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
@@ -243,11 +243,4 @@ public class Values {
         values[1] = "abc";
         return ValueCreator.createRecordValue(map, values);
     }
-
-    public static BMap<BString, Object> getRecordWithRestFieldsNegative2() {
-        Object[] values = new Object[2];
-        values[0] = 1;
-        values[1] = "abc";
-        return ValueCreator.createRecordValue(null, values);
-    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
@@ -49,6 +49,7 @@ import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
 import io.ballerina.runtime.internal.types.BFunctionType;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -213,5 +214,33 @@ public class Values {
 
     public static BString decodeIdentifier(BString identifier) {
         return StringUtils.fromString(IdentifierUtils.decodeIdentifier(identifier.getValue()));
+    }
+
+    public static BMap<BString, Object> getRecordNegative(BString recordName) {
+        ArrayList<Integer> arrayList = new ArrayList<>(Arrays.asList(1, 2, 3, 4, 5));
+        Map<String, Object> map = Map.ofEntries(
+                Map.entry("arrList", arrayList)
+        );
+        return ValueCreator.createRecordValue(recordModule, recordName.getValue(), map);
+    }
+
+    public static BMap<BString, Object> getReadonlyRecordNegative(BString recordName) {
+        Map<String, Integer> map = Map.ofEntries(
+                Map.entry("a", 1),
+                Map.entry("b", 2)
+        );
+        Map<String, Object> valueMap = Map.ofEntries(
+                Map.entry("valueMap", map)
+        );
+        return ValueCreator.createRecordValue(recordModule, recordName.getValue(), valueMap);
+    }
+
+    public static BMap<BString, Object> getRecordWithRestFieldsNegative() {
+        BMap<BString, Object> map = ValueCreator.createMapValue();
+        map.put(StringUtils.fromString("key"), "map value");
+        Object[] values = new Object[2];
+        values[0] = 1;
+        values[1] = "abc";
+        return ValueCreator.createRecordValue(map, values);
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
@@ -243,4 +243,11 @@ public class Values {
         values[1] = "abc";
         return ValueCreator.createRecordValue(map, values);
     }
+
+    public static BMap<BString, Object> getRecordWithRestFieldsNegative2() {
+        Object[] values = new Object[2];
+        values[0] = 1;
+        values[1] = "abc";
+        return ValueCreator.createRecordValue(null, values);
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
@@ -224,6 +224,14 @@ public class Values {
         return ValueCreator.createRecordValue(recordModule, recordName.getValue(), map);
     }
 
+    public static BMap<BString, Object> getRecordNegative2(BString recordName) {
+        ArrayList<Integer> arrayList = new ArrayList<>(Arrays.asList(1, 2, 3, 4, 5));
+        Map<String, Object> map = Map.ofEntries(
+                Map.entry("arrList", arrayList)
+        );
+        return ValueCreator.createRecordValue(recordModule, recordName.getValue(), null);
+    }
+
     public static BMap<BString, Object> getReadonlyRecordNegative(BString recordName) {
         Map<String, Integer> map = Map.ofEntries(
                 Map.entry("a", 1),

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/errors/main.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/errors/main.bal
@@ -57,6 +57,9 @@ public function main() {
 
     err = trap errors:getDistinctErrorWithNullDetailNegative("error message");
     test:assertValueEqual(err.message(), "No such error: error message");
+
+    err = trap errors:getDistinctErrorWithNullDetailNegative2("error message");
+    test:assertValueEqual(err.message(), "java.lang.NullPointerException");
 }
 
 function testTypeIds() {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/errors/main.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/errors/main.bal
@@ -57,6 +57,12 @@ public function main() {
 
     err = trap errors:getDistinctErrorWithNullDetailNegative("error message");
     test:assertValueEqual(err.message(), "No such error: error message");
+
+    err = trap errors:getErrorWithNullDetailNegative("error message");
+    test:assertValueEqual(err.message(), "error message");
+
+    err = trap errors:getDistinctErrorWithNullDetailNegative2("error message");
+    test:assertValueEqual(err.message(), "error message");
 }
 
 function testTypeIds() {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/errors/main.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/errors/main.bal
@@ -32,6 +32,31 @@ public function main() {
     test:assertValueEqual(invalidError.message(), "No such error: UserError2");
 
     testTypeIds();
+
+    errors:IOError|error res = trap errors:getDistinctErrorNegative("UserError");
+    test:assertTrue(res is error);
+    error e = <error> res;
+    test:assertValueEqual(e.message(), "'class java.lang.String' is not from a valid java runtime class. " +
+        "It should be a subclass of one of the following: java.lang.Number, java.lang.Boolean or " +
+        "from the package 'io.ballerina.runtime.api.values'");
+
+    error err = trap errors:getErrorNegative1("error message");
+    test:assertValueEqual(err.message(), "'class java.lang.String' is not from a valid java runtime class. " +
+        "It should be a subclass of one of the following: java.lang.Number, java.lang.Boolean or " +
+        "from the package 'io.ballerina.runtime.api.values'");
+
+    err = trap errors:getErrorWithTypeNegative("error message");
+    test:assertValueEqual(err.message(), "'class java.lang.String' is not from a valid java runtime class. " +
+        "It should be a subclass of one of the following: java.lang.Number, java.lang.Boolean or " +
+        "from the package 'io.ballerina.runtime.api.values'");
+
+    err = trap errors:getErrorNegative2("error message");
+    test:assertValueEqual(err.message(), "'class java.lang.String' is not from a valid java runtime class. " +
+            "It should be a subclass of one of the following: java.lang.Number, java.lang.Boolean or " +
+            "from the package 'io.ballerina.runtime.api.values'");
+
+    err = trap errors:getDistinctErrorWithNullDetailNegative("error message");
+    test:assertValueEqual(err.message(), "No such error: error message");
 }
 
 function testTypeIds() {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/errors/main.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/errors/main.bal
@@ -57,9 +57,6 @@ public function main() {
 
     err = trap errors:getDistinctErrorWithNullDetailNegative("error message");
     test:assertValueEqual(err.message(), "No such error: error message");
-
-    err = trap errors:getDistinctErrorWithNullDetailNegative2("error message");
-    test:assertValueEqual(err.message(), "java.lang.NullPointerException");
 }
 
 function testTypeIds() {
@@ -69,4 +66,3 @@ function testTypeIds() {
     test:assertValueEqual(types[0], "UserError");
     test:assertValueEqual(types[1], "GenericError");
 }
-

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/errors/modules/errors/errors.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/errors/modules/errors/errors.bal
@@ -49,3 +49,11 @@ public function getErrorWithTypeNegative(string msg) returns error = @java:Metho
 public function getDistinctErrorWithNullDetailNegative(string msg) returns error = @java:Method {
     'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Errors"
 } external;
+
+public function getErrorWithNullDetailNegative(string msg) returns error = @java:Method {
+    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Errors"
+} external;
+
+public function getDistinctErrorWithNullDetailNegative2(string msg) returns error = @java:Method {
+    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Errors"
+} external;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/errors/modules/errors/errors.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/errors/modules/errors/errors.bal
@@ -49,3 +49,7 @@ public function getErrorWithTypeNegative(string msg) returns error = @java:Metho
 public function getDistinctErrorWithNullDetailNegative(string msg) returns error = @java:Method {
     'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Errors"
 } external;
+
+public function getDistinctErrorWithNullDetailNegative2(string msg) returns error = @java:Method {
+    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Errors"
+} external;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/errors/modules/errors/errors.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/errors/modules/errors/errors.bal
@@ -27,3 +27,25 @@ public function getError(string errorName) returns error = @java:Method {
 public function getTypeIds(error errorVal) returns string[] = @java:Method {
     'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Errors"
 } external;
+
+public type IOError distinct error;
+
+public function getDistinctErrorNegative(string msg) returns IOError = @java:Method {
+    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Errors"
+} external;
+
+public function getErrorNegative1(string msg) returns error = @java:Method {
+    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Errors"
+} external;
+
+public function getErrorNegative2(string msg) returns error = @java:Method {
+    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Errors"
+} external;
+
+public function getErrorWithTypeNegative(string msg) returns error = @java:Method {
+    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Errors"
+} external;
+
+public function getDistinctErrorWithNullDetailNegative(string msg) returns error = @java:Method {
+    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Errors"
+} external;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/errors/modules/errors/errors.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/errors/modules/errors/errors.bal
@@ -49,7 +49,3 @@ public function getErrorWithTypeNegative(string msg) returns error = @java:Metho
 public function getDistinctErrorWithNullDetailNegative(string msg) returns error = @java:Method {
     'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Errors"
 } external;
-
-public function getDistinctErrorWithNullDetailNegative2(string msg) returns error = @java:Method {
-    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Errors"
-} external;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/values/main.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/values/main.bal
@@ -61,6 +61,11 @@ public function main() {
         "It should be a subclass of one of the following: java.lang.Number, java.lang.Boolean or " +
         "from the package 'io.ballerina.runtime.api.values'");
 
+    record{}|error res2 = trap records:getRecordWithRestFieldsNegative2();
+    test:assertTrue(res2 is error);
+    error e6 = <error> res2;
+    test:assertValueEqual(e6.message(), "java.lang.NullPointerException");
+
     maps:validateAPI();
     records:validateAPI();
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/values/main.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/values/main.bal
@@ -61,11 +61,6 @@ public function main() {
         "It should be a subclass of one of the following: java.lang.Number, java.lang.Boolean or " +
         "from the package 'io.ballerina.runtime.api.values'");
 
-    record{}|error res2 = trap records:getRecordWithRestFieldsNegative2();
-    test:assertTrue(res2 is error);
-    error e6 = <error> res2;
-    test:assertValueEqual(e6.message(), "java.lang.NullPointerException");
-
     maps:validateAPI();
     records:validateAPI();
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/values/main.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/values/main.bal
@@ -40,6 +40,27 @@ public function main() {
     test:assertValueEqual(e1.message(), "No such object: Person2");
     test:assertValueEqual(e2.message(), "No such record: Address2");
 
+    records:Foo|error fooOrError =  trap <records:Foo> records:getRecordNegative("Foo");
+    test:assertTrue(fooOrError is error);
+    error e3 = <error> fooOrError;
+    test:assertValueEqual(e3.message(), "'class java.util.ArrayList' is not from a valid java runtime class. " +
+        "It should be a subclass of one of the following: java.lang.Number, java.lang.Boolean or " +
+        "from the package 'io.ballerina.runtime.api.values'");
+
+    records:Bar|error barOrError = trap <records:Bar> records:getReadonlyRecordNegative("Bar");
+    test:assertTrue(barOrError is error);
+    error e4 = <error> barOrError;
+    test:assertValueEqual(e4.message(), "'class java.util.ImmutableCollections$MapN' is not from a valid java runtime class. " +
+        "It should be a subclass of one of the following: java.lang.Number, java.lang.Boolean or " +
+        "from the package 'io.ballerina.runtime.api.values'");
+
+    record{}|error res = trap records:getRecordWithRestFieldsNegative();
+    test:assertTrue(res is error);
+    error e5 = <error> res;
+    test:assertValueEqual(e5.message(), "'class java.lang.String' is not from a valid java runtime class. " +
+        "It should be a subclass of one of the following: java.lang.Number, java.lang.Boolean or " +
+        "from the package 'io.ballerina.runtime.api.values'");
+
     maps:validateAPI();
     records:validateAPI();
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/values/modules/records/records.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/values/modules/records/records.bal
@@ -36,6 +36,14 @@ type Student record {|
     string name;
 |};
 
+public type Foo record {
+    int[] y;
+};
+
+public type Bar readonly & record {|
+    int[] x;
+|};
+
 public function validateAPI() {
     anydata recordVal1 = getRecordValue();
     test:assertTrue(recordVal1 is Student);
@@ -50,5 +58,17 @@ function getRecordValue() returns anydata = @java:Method {
 } external;
 
 function getRecordValueWithInitialValues() returns Details = @java:Method {
+    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
+} external;
+
+public function getRecordNegative(string recordName) returns record{} = @java:Method {
+    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
+} external;
+
+public function getReadonlyRecordNegative(string recordName) returns record{} = @java:Method {
+    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
+} external;
+
+public function getRecordWithRestFieldsNegative() returns record{} = @java:Method {
     'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
 } external;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/values/modules/records/records.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/values/modules/records/records.bal
@@ -72,7 +72,3 @@ public function getReadonlyRecordNegative(string recordName) returns record{} = 
 public function getRecordWithRestFieldsNegative() returns record{} = @java:Method {
     'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
 } external;
-
-public function getRecordWithRestFieldsNegative2() returns record{} = @java:Method {
-    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
-} external;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/values/modules/records/records.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/values/modules/records/records.bal
@@ -65,6 +65,10 @@ public function getRecordNegative(string recordName) returns record{} = @java:Me
     'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
 } external;
 
+public function getRecordNegative2(string recordName) returns record{} = @java:Method {
+    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
+} external;
+
 public function getReadonlyRecordNegative(string recordName) returns record{} = @java:Method {
     'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
 } external;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/values/modules/records/records.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/values/modules/records/records.bal
@@ -72,3 +72,7 @@ public function getReadonlyRecordNegative(string recordName) returns record{} = 
 public function getRecordWithRestFieldsNegative() returns record{} = @java:Method {
     'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
 } external;
+
+public function getRecordWithRestFieldsNegative2() returns record{} = @java:Method {
+    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
+} external;


### PR DESCRIPTION
## Purpose
> This PR will add a validation for runtime APIs to validate the assignability of Java types to Ballerina types.

Fixes #34587

## Approach

## Samples

## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
