### PR TITLE
Fix conversion of numeric singletons

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -42,7 +42,6 @@ import io.ballerina.runtime.internal.types.BField;
 import io.ballerina.runtime.internal.types.BFiniteType;
 import io.ballerina.runtime.internal.types.BFunctionType;
 import io.ballerina.runtime.internal.types.BFutureType;
-import io.ballerina.runtime.internal.types.BIntegerType;
 import io.ballerina.runtime.internal.types.BIntersectionType;
 import io.ballerina.runtime.internal.types.BJsonType;
 import io.ballerina.runtime.internal.types.BMapType;

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeConverter.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeConverter.java
@@ -337,7 +337,7 @@ public class TypeConverter {
                     if (inputValue == valueSpaceItem) {
                         return Set.of(inputValueType);
                     }
-                    if (TypeChecker.isFiniteTypeValue(inputValue, inputValueType, valueSpaceItem)) {
+                    if (TypeChecker.isFiniteTypeValue(inputValue, inputValueType, valueSpaceItem, true)) {
                         convertibleTypes.add(TypeChecker.getType(valueSpaceItem));
                     }
                 }

--- a/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
@@ -1247,6 +1247,9 @@ function testCloneWithTypeImmutableStructuredTypes() {
     assert(person4.id, 14);
 }
 
+type IntOne 1;
+type FloatOne 1.0;
+type DecimalOne 1d;
 type IntOneOrTwo 1|2;
 type IntTwoOrThree 2|3;
 type IntThreeOrFour 3|4;
@@ -1255,6 +1258,7 @@ type FloatTwoOrThree 2.0|3.0;
 type FloatThreeOrFour 3.0|4.0;
 type IntOneOrFloatTwo 1|2.0;
 type IntTwoOrFloatTwo 2|2.0;
+type DecimalOneOrTwo 1d|2d;
 
 function testCloneWithTypeWithFiniteType() {
     int x = 2;
@@ -1279,6 +1283,34 @@ function testCloneWithTypeWithFiniteType() {
     assert(g is error, false);
     IntTwoOrFloatTwo h = checkpanic g;
     assert(h, 2.0);
+
+    int z = 1;
+    float w = 1.0;
+    decimal v = 1d;
+
+    DecimalOne|error i = z.cloneWithType();
+    assert(checkpanic i, 1.0d);
+    DecimalOneOrTwo|error j = z.cloneWithType();
+    assert(checkpanic j, 1.0d);
+    DecimalOne|error k = w.cloneWithType();
+    assert(checkpanic k, 1.0d);
+    DecimalOneOrTwo|error l = w.cloneWithType();
+    assert(checkpanic l, 1.0d);
+
+    IntOne|error m = v.cloneWithType();
+    assert(checkpanic m, 1);
+    FloatOne|error n = v.cloneWithType();
+    assert(checkpanic n, 1.0);
+    IntOneOrTwo|error p = v.cloneWithType();
+    assert(checkpanic p, 1);
+
+    DecimalOneOrTwo decimalOneOrTwo = 2d;
+    IntTwoOrFloatTwo|error q = decimalOneOrTwo.cloneWithType();
+    assert(q is error, true);
+    error err = <error> q;
+    assert(err.message(), "{ballerina/lang.value}ConversionError");
+    assert(<string> checkpanic err.detail()["message"],
+            "'decimal' value cannot be converted to 'IntTwoOrFloatTwo': ambiguous target type");
 }
 
 function testCloneWithTypeWithUnionOfFiniteType() {
@@ -1299,6 +1331,9 @@ function testCloneWithTypeWithUnionOfFiniteType() {
     assert(e is error, false);
     IntOneOrFloatTwo|IntTwoOrThree f = checkpanic e;
     assert(f, 2);
+
+    (DecimalOneOrTwo|FloatThreeOrFour)|error g = y.cloneWithType();
+    assert(checkpanic g, 2d);
 }
 
 function testCloneWithTypeWithFiniteArrayTypeFromIntArray() {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/TypeTestExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/TypeTestExprTest.java
@@ -747,7 +747,8 @@ public class TypeTestExprTest {
                 "testRecordIntersectionWithFunctionFields",
                 "testBuiltInSubTypeTypeTestAgainstFiniteType",
                 "testIntSubtypes",
-                "testRecordsWithOptionalFields"
+                "testRecordsWithOptionalFields",
+                "testTypeTestExprWithSingletons"
         };
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/type-test-expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/type-test-expr.bal
@@ -902,6 +902,39 @@ function testFiniteTypeAsBroaderType_1() returns boolean {
     return a is string;
 }
 
+type IntOne 1;
+type FloatOne 1.0;
+type FloatNaN float:NaN;
+type DecimalOne 1d;
+
+function testTypeTestExprWithSingletons() {
+    IntOne intOne = 1;
+    FloatOne floatOne = 1.0;
+    DecimalOne decimalOne = 1d;
+
+    any a = intOne;
+    test:assertFalse(a is FloatOne);
+    test:assertFalse(a is DecimalOne);
+    test:assertFalse(a is 1f);
+    test:assertFalse(a is float);
+    test:assertTrue(a is FloatOne|IntOne);
+
+    any b = floatOne;
+    test:assertFalse(b is IntOne);
+    test:assertFalse(b is 1);
+    test:assertFalse(b is int);
+
+    FloatNaN floatNaN = float:NaN;
+    any c = floatNaN;
+    test:assertTrue(c is FloatNaN);
+    test:assertTrue(c is float:NaN);
+
+    any d = decimalOne;
+    test:assertFalse(d is IntOne);
+    test:assertFalse(d is FloatOne);
+    test:assertFalse(d is 1);
+}
+
 type FRUIT_OR_COUNT "apple"|2|"grape"|10;
 
 function testFiniteTypeAsBroaderType_2() returns [boolean, boolean] {


### PR DESCRIPTION
## Purpose
> This PR fixes some incorrect results with cloneWithType() for the conversion of decimal singletons.

Fixes #35168 

## Samples
```ballerina
type DecimalOne 1.0d;
type DecimalOneOrTwo 1.0d|2d;

public function main() {
    int x = 1;

    DecimalOne|error z2 = x.cloneWithType();
    io:println(z2); // 1.0

    DecimalOneOrTwo|error z3 = x.cloneWithType();
    io:println(z3); // 1.0

}
```
## Remarks
> 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
