### PR TITLE
[Debugger] Improve dynamic breakpoint handling and add support for recent codegen changes

### DIFF
--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/BreakpointProcessor.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/BreakpointProcessor.java
@@ -349,15 +349,15 @@ public class BreakpointProcessor {
      */
     enum DynamicBreakpointMode {
         /**
-         * Configures dynamic breakpoints only for the current method (active stack frame)
+         * Configures dynamic breakpoints only for the current method (active stack frame).
          */
         CURRENT,
         /**
-         * Configures dynamic breakpoints only for the caller method (parent stack frame)
+         * Configures dynamic breakpoints only for the caller method (parent stack frame).
          */
         CALLER,
         /**
-         * Configures dynamic breakpoints only for both the current and caller methods.
+         * Configures dynamic breakpoints for both the current and caller methods.
          */
         BOTH
     }

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/BreakpointProcessor.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/BreakpointProcessor.java
@@ -1,0 +1,364 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ballerinalang.debugadapter;
+
+import com.sun.jdi.AbsentInformationException;
+import com.sun.jdi.Location;
+import com.sun.jdi.ReferenceType;
+import com.sun.jdi.ThreadReference;
+import com.sun.jdi.event.BreakpointEvent;
+import com.sun.jdi.request.BreakpointRequest;
+import com.sun.jdi.request.EventRequest;
+import com.sun.jdi.request.StepRequest;
+import org.ballerinalang.debugadapter.breakpoint.BalBreakpoint;
+import org.ballerinalang.debugadapter.breakpoint.LogMessage;
+import org.ballerinalang.debugadapter.breakpoint.TemplateLogMessage;
+import org.ballerinalang.debugadapter.config.ClientConfigHolder;
+import org.ballerinalang.debugadapter.config.ClientLaunchConfigHolder;
+import org.ballerinalang.debugadapter.evaluation.BExpressionValue;
+import org.ballerinalang.debugadapter.evaluation.DebugExpressionEvaluator;
+import org.ballerinalang.debugadapter.evaluation.EvaluationException;
+import org.ballerinalang.debugadapter.evaluation.EvaluationExceptionKind;
+import org.ballerinalang.debugadapter.jdi.JdiProxyException;
+import org.ballerinalang.debugadapter.jdi.StackFrameProxyImpl;
+import org.ballerinalang.debugadapter.jdi.ThreadReferenceProxyImpl;
+import org.ballerinalang.debugadapter.variable.BVariableType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.ballerinalang.debugadapter.utils.PackageUtils.getQualifiedClassName;
+
+/**
+ * Implementation of Ballerina breakpoint processor. The existing implementation is capable of switching in-between
+ * user breakpoints and dynamic breakpoints based on the debug instruction.
+ *
+ * @since 2201.0.1
+ */
+public class BreakpointProcessor {
+
+    private final ExecutionContext context;
+    private final JDIEventProcessor jdiEventProcessor;
+    private final Map<String, Map<Integer, BalBreakpoint>> userBreakpoints = new HashMap<>();
+    private static final Logger LOGGER = LoggerFactory.getLogger(BreakpointProcessor.class);
+
+    public BreakpointProcessor(ExecutionContext context, JDIEventProcessor jdiEventProcessor) {
+        this.context = context;
+        this.jdiEventProcessor = jdiEventProcessor;
+    }
+
+    public Map<String, Map<Integer, BalBreakpoint>> userBreakpoints() {
+        return userBreakpoints;
+    }
+
+    /**
+     * Process the JDI notification of a breakpoint in the target VM. The breakpoint event is generated before the
+     * code at its location is executed.
+     *
+     * @param bpEvent JDI breakpoint event
+     */
+    void processBreakpointEvent(BreakpointEvent bpEvent) {
+        ReferenceType bpReference = bpEvent.location().declaringType();
+        String qualifiedClassName = getQualifiedClassName(context, bpReference);
+        Map<Integer, BalBreakpoint> fileBreakpoints = userBreakpoints.get(qualifiedClassName);
+        int lineNumber = bpEvent.location().lineNumber();
+
+        // since Ballerina code generation provides a line number of '}' in the function for the injected bytecodes, we
+        // need to internally step out if we are at the last line of a function, in order to ignore having debug hits
+        // on the last line.
+        if (requireStepOut(bpEvent)) {
+            configureDynamicBreakPoints((int) bpEvent.thread().uniqueID(), DynamicBreakpointMode.CALLER);
+            context.getDebuggeeVM().resume();
+        } else if (context.getLastInstruction() != null && context.getLastInstruction() != DebugInstruction.CONTINUE) {
+            jdiEventProcessor.notifyStopEvent(bpEvent);
+        } else if (fileBreakpoints == null || !fileBreakpoints.containsKey(lineNumber)) {
+            jdiEventProcessor.notifyStopEvent(bpEvent);
+        } else {
+            BalBreakpoint balBreakpoint = fileBreakpoints.get(lineNumber);
+            processAdvanceBreakpoints(bpEvent, balBreakpoint, lineNumber);
+        }
+    }
+
+    /**
+     * Examines whether the breakpoint belongs to an non-conventional breakpoint type (logpoint or conditional
+     * breakpoint) and process accordingly.
+     */
+    private void processAdvanceBreakpoints(BreakpointEvent event, BalBreakpoint breakpoint, int lineNumber) {
+        String condition = breakpoint.getCondition().isPresent() && !breakpoint.getCondition().get().isBlank() ?
+                breakpoint.getCondition().get() : "";
+        Optional<LogMessage> logMessage = breakpoint.getLogMessage();
+        if (logMessage.isEmpty() && condition.isEmpty()) {
+            jdiEventProcessor.notifyStopEvent(event);
+            return;
+        }
+
+        // If there's a non-empty user defined log message and no breakpoint condition, resumes the remote VM
+        // after showing the log on the debug console.
+        if (logMessage.isPresent() && condition.isEmpty()) {
+            printLogMessage(event, logMessage.get(), lineNumber);
+            context.getDebuggeeVM().resume();
+            return;
+        }
+
+        CompletableFuture<Boolean> resultFuture = evaluateBreakpointCondition(condition, event.thread(), lineNumber);
+        try {
+            Boolean result = resultFuture.get(5000, TimeUnit.MILLISECONDS);
+            if (result) {
+                if (logMessage.isPresent()) {
+                    printLogMessage(event, logMessage.get(), lineNumber);
+                    context.getDebuggeeVM().resume();
+                } else {
+                    jdiEventProcessor.notifyStopEvent(event);
+                }
+            } else {
+                context.getDebuggeeVM().resume();
+            }
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            context.getOutputLogger().sendErrorOutput(String.format("Warning: Skipping conditional breakpoint at " +
+                    "line: %d, due to timeout while evaluating the condition:'%s'.", lineNumber, condition));
+            if (logMessage.isPresent()) {
+                printLogMessage(event, logMessage.get(), lineNumber);
+                context.getDebuggeeVM().resume();
+            } else {
+                jdiEventProcessor.notifyStopEvent(event);
+            }
+        }
+    }
+
+    void restoreUserBreakpoints(DebugInstruction instruction) {
+        if (context.getDebuggeeVM() == null) {
+            return;
+        }
+
+        context.getEventManager().deleteAllBreakpoints();
+        if (instruction == DebugInstruction.CONTINUE || instruction == DebugInstruction.STEP_OVER) {
+            context.getDebuggeeVM().allClasses().forEach(this::configureUserBreakPoints);
+        }
+    }
+
+    void configureUserBreakPoints(ReferenceType referenceType) {
+        try {
+            // Avoids setting break points if the server is running in 'no-debug' mode.
+            ClientConfigHolder configHolder = context.getAdapter().getClientConfigHolder();
+            if (configHolder instanceof ClientLaunchConfigHolder
+                    && ((ClientLaunchConfigHolder) configHolder).isNoDebugMode()) {
+                return;
+            }
+
+            String qualifiedClassName = getQualifiedClassName(context, referenceType);
+            if (!userBreakpoints.containsKey(qualifiedClassName)) {
+                return;
+            }
+            Map<Integer, BalBreakpoint> breakpoints = this.userBreakpoints.get(qualifiedClassName);
+            for (BalBreakpoint bp : breakpoints.values()) {
+                List<Location> locations = referenceType.locationsOfLine(bp.getLine());
+                if (!locations.isEmpty()) {
+                    Location loc = locations.get(0);
+                    BreakpointRequest bpReq = context.getEventManager().createBreakpointRequest(loc);
+                    bpReq.enable();
+                }
+            }
+        } catch (AbsentInformationException ignored) {
+            // classes with no line number information can be ignored.
+        } catch (Exception e) {
+            LOGGER.error(e.getMessage(), e);
+        }
+    }
+
+    void configureDynamicBreakPoints(int threadId, DynamicBreakpointMode mode) {
+        ThreadReferenceProxyImpl threadReference = context.getAdapter().getAllThreads().get(threadId);
+        try {
+            List<StackFrameProxyImpl> jStackFrames = threadReference.frames();
+            List<BallerinaStackFrame> validFrames = jdiEventProcessor.filterValidBallerinaFrames(jStackFrames);
+
+            if (mode == DynamicBreakpointMode.CURRENT && !validFrames.isEmpty()) {
+                configureBreakpointsForMethod(validFrames.get(0));
+            }
+            // If the current function is invoked within another ballerina function, we need to explicitly set another
+            // temporary breakpoint on the location of its invocation. This is supposed to handle the situations where
+            // the user wants to step over on an exit point of the current function.
+            if (mode == DynamicBreakpointMode.CALLER && validFrames.size() > 1) {
+                configureBreakpointsForMethod(validFrames.get(1));
+            }
+        } catch (JdiProxyException e) {
+            LOGGER.error(e.getMessage());
+            int stepType = ((StepRequest) jdiEventProcessor.getStepRequests().get(0)).depth();
+            jdiEventProcessor.sendStepRequest(threadId, stepType);
+        }
+    }
+
+    /**
+     * Configures temporary(dynamic) breakpoints for all the lines within the method, which encloses the given stack
+     * frame location. This strategy is used when processing STEP_OVER requests.
+     */
+    private void configureBreakpointsForMethod(BallerinaStackFrame balStackFrame) {
+        try {
+            Location currentLocation = balStackFrame.getJStackFrame().location();
+            ReferenceType referenceType = currentLocation.declaringType();
+            List<Location> allLocations = currentLocation.method().allLineLocations();
+            Optional<Location> firstLocation = allLocations.stream()
+                    .filter(location -> location.lineNumber() > 0)
+                    .min(Comparator.comparingInt(Location::lineNumber));
+            Optional<Location> lastLocation = allLocations.stream().max(Comparator.comparingInt(Location::lineNumber));
+            if (firstLocation.isEmpty() || lastLocation.isEmpty()) {
+                return;
+            }
+
+            int nextStepPoint = firstLocation.get().lineNumber();
+            do {
+                List<Location> locations = referenceType.locationsOfLine(nextStepPoint);
+                if (!locations.isEmpty() && (locations.get(0).lineNumber() >= firstLocation.get().lineNumber())) {
+                    // Checks whether there are any user breakpoint configured for the same location, before adding the
+                    // dynamic breakpoint.
+                    boolean bpAlreadyExist = context.getEventManager().breakpointRequests().stream()
+                            .anyMatch(breakpointRequest -> breakpointRequest.location().equals(locations.get(0)));
+                    if (!bpAlreadyExist) {
+                        BreakpointRequest bpReq = context.getEventManager().createBreakpointRequest(locations.get(0));
+                        bpReq.enable();
+                    }
+                }
+                nextStepPoint++;
+            } while (nextStepPoint <= lastLocation.get().lineNumber());
+        } catch (AbsentInformationException | JdiProxyException e) {
+            LOGGER.error(e.getMessage());
+        }
+    }
+
+    /**
+     * Evaluates the given breakpoint condition (expression) using the ballerina debugger expression evaluation engine.
+     *
+     * @param expression      breakpoint expression
+     * @param threadReference suspended thread reference, which should be used to get the top stack frame
+     * @return result of the given breakpoint condition (logical expression).
+     */
+    private CompletableFuture<Boolean> evaluateBreakpointCondition(String expression, ThreadReference threadReference,
+                                                                   int lineNumber) {
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                BExpressionValue evaluatorResult = evaluateExpressionSafely(expression, threadReference);
+                String condition = evaluatorResult.getStringValue();
+                if (evaluatorResult.getType() != BVariableType.BOOLEAN) {
+                    String errorMessage = String.format(EvaluationExceptionKind.TYPE_MISMATCH.getReason(),
+                            BVariableType.BOOLEAN.getString(), evaluatorResult.getType().getString(), expression);
+                    context.getOutputLogger().sendErrorOutput(String.format("Warning: Skipping conditional " +
+                            "breakpoint at line: %d, due to: %s%s", lineNumber, System.lineSeparator(), errorMessage));
+                }
+                return condition.equalsIgnoreCase(Boolean.TRUE.toString());
+            } catch (EvaluationException e) {
+                context.getOutputLogger().sendErrorOutput(String.format("Warning: Skipping conditional breakpoint " +
+                        "at line: %d, due to: %s%s", lineNumber, System.lineSeparator(), e.getMessage()));
+                return false;
+            } catch (Exception e) {
+                context.getOutputLogger().sendErrorOutput(String.format("Warning: Skipping conditional breakpoint " +
+                        "at line: %d, due to an internal error", lineNumber));
+                return false;
+            }
+        });
+    }
+
+    void printLogMessage(BreakpointEvent event, LogMessage logMessage, int lineNumber) {
+        try {
+            if (logMessage instanceof TemplateLogMessage) {
+                TemplateLogMessage template = (TemplateLogMessage) logMessage;
+                List<String> expressions = template.getExpressions();
+                List<String> evaluationResults = new ArrayList<>();
+                for (String expression : expressions) {
+                    evaluationResults.add(evaluateExpressionSafely(expression, event.thread()).getStringValue());
+                }
+                template.resolveInterpolations(evaluationResults);
+                context.getOutputLogger().sendProgramOutput(template.getMessage());
+            } else {
+                context.getOutputLogger().sendProgramOutput(logMessage.getMessage());
+            }
+        } catch (Exception e) {
+            context.getOutputLogger().sendErrorOutput(String.format("Warning: Skipping logpoint at line: %d, " +
+                    "due to: %s%s", lineNumber, System.lineSeparator(), e.getMessage()));
+        }
+    }
+
+    private BExpressionValue evaluateExpressionSafely(String expression, ThreadReference threadReference)
+            throws EvaluationException, JdiProxyException {
+        // When evaluating breakpoint conditions, we might need to invoke methods in the remote JVM and it can
+        // cause deadlocks if 'invokeMethod' is called from the client's event handler thread. In that case, the
+        // thread will be waiting for the invokeMethod to complete and won't read the EventSet that comes in for
+        // the new event. If this new EventSet is in 'SUSPEND_ALL' mode, then a deadlock will occur because no one
+        // will resume the EventSet. Therefore to avoid this, we are disabling possible event requests before doing
+        // the condition evaluation.
+        context.getEventManager().classPrepareRequests().forEach(EventRequest::disable);
+        context.getEventManager().breakpointRequests().forEach(BreakpointRequest::disable);
+
+        ThreadReferenceProxyImpl thread = context.getAdapter().getAllThreads().get((int) threadReference.uniqueID());
+        List<BallerinaStackFrame> validFrames = jdiEventProcessor.filterValidBallerinaFrames(thread.frames());
+        if (validFrames.isEmpty()) {
+            throw new IllegalStateException("Failed to use stack frames for evaluation");
+        }
+
+        SuspendedContext ctx = new SuspendedContext(context, thread, validFrames.get(0).getJStackFrame());
+        EvaluationContext evaluationContext = new EvaluationContext(ctx);
+        DebugExpressionEvaluator evaluator = new DebugExpressionEvaluator(evaluationContext);
+        evaluator.setExpression(expression);
+        BExpressionValue evaluationResult = evaluator.evaluate();
+
+        // As we are disabling all the breakpoint requests before evaluating the user's conditional
+        // expression, need to re-enable all the breakpoints before continuing the remote VM execution.
+        restoreUserBreakpoints(context.getLastInstruction());
+        return evaluationResult;
+    }
+
+    private boolean requireStepOut(BreakpointEvent event) {
+        try {
+            if (context.getLastInstruction() != DebugInstruction.STEP_OVER
+                    && context.getLastInstruction() != DebugInstruction.STEP_OUT) {
+                return false;
+            }
+            Location currentLocation = event.location();
+            List<Location> allLocations = currentLocation.method().allLineLocations();
+            Optional<Location> lastLocation = allLocations.stream().max(Comparator.comparingInt(Location::lineNumber));
+            return lastLocation.isPresent() && currentLocation.lineNumber() == lastLocation.get().lineNumber();
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /**
+     * Dynamic Breakpoint Options.
+     */
+    enum DynamicBreakpointMode {
+        /**
+         * Configures dynamic breakpoints only for the current method (active stack frame)
+         */
+        CURRENT,
+        /**
+         * Configures dynamic breakpoints only for the caller method (parent stack frame)
+         */
+        CALLER,
+        /**
+         * Configures dynamic breakpoints only for both the current and caller methods.
+         */
+        BOTH
+    }
+}

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JBallerinaDebugServer.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JBallerinaDebugServer.java
@@ -1013,7 +1013,7 @@ public class JBallerinaDebugServer implements IDebugProtocolServer {
      */
     private void prepareFor(DebugInstruction instruction) {
         clearState();
-        eventProcessor.restoreBreakpoints(instruction);
+        eventProcessor.getBreakpointProcessor().restoreUserBreakpoints(instruction);
         context.setLastInstruction(instruction);
     }
 

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JDIEventProcessor.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JDIEventProcessor.java
@@ -44,6 +44,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
+import static org.ballerinalang.debugadapter.BreakpointProcessor.DynamicBreakpointMode;
 import static org.ballerinalang.debugadapter.JBallerinaDebugServer.isBalStackFrame;
 import static org.ballerinalang.debugadapter.utils.PackageUtils.BAL_FILE_EXT;
 import static org.ballerinalang.debugadapter.utils.PackageUtils.getQualifiedClassName;
@@ -140,7 +141,7 @@ public class JDIEventProcessor {
 
     void sendStepRequest(int threadId, int stepType) {
         if (stepType == StepRequest.STEP_OVER) {
-            breakpointProcessor.configureDynamicBreakPoints(threadId, BreakpointProcessor.DynamicBreakpointMode.CURRENT);
+            breakpointProcessor.configureDynamicBreakPoints(threadId, DynamicBreakpointMode.CURRENT);
         } else if (stepType == StepRequest.STEP_INTO || stepType == StepRequest.STEP_OUT) {
             createStepRequest(threadId, stepType);
         }

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JDIEventProcessor.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JDIEventProcessor.java
@@ -18,8 +18,6 @@ package org.ballerinalang.debugadapter;
 
 import com.sun.jdi.AbsentInformationException;
 import com.sun.jdi.Location;
-import com.sun.jdi.ReferenceType;
-import com.sun.jdi.ThreadReference;
 import com.sun.jdi.VMDisconnectedException;
 import com.sun.jdi.event.BreakpointEvent;
 import com.sun.jdi.event.ClassPrepareEvent;
@@ -29,22 +27,11 @@ import com.sun.jdi.event.EventSet;
 import com.sun.jdi.event.StepEvent;
 import com.sun.jdi.event.VMDeathEvent;
 import com.sun.jdi.event.VMDisconnectEvent;
-import com.sun.jdi.request.BreakpointRequest;
 import com.sun.jdi.request.EventRequest;
 import com.sun.jdi.request.StepRequest;
 import org.ballerinalang.debugadapter.breakpoint.BalBreakpoint;
-import org.ballerinalang.debugadapter.breakpoint.LogMessage;
-import org.ballerinalang.debugadapter.breakpoint.TemplateLogMessage;
-import org.ballerinalang.debugadapter.config.ClientConfigHolder;
-import org.ballerinalang.debugadapter.config.ClientLaunchConfigHolder;
-import org.ballerinalang.debugadapter.evaluation.BExpressionValue;
-import org.ballerinalang.debugadapter.evaluation.DebugExpressionEvaluator;
-import org.ballerinalang.debugadapter.evaluation.EvaluationException;
-import org.ballerinalang.debugadapter.evaluation.EvaluationExceptionKind;
-import org.ballerinalang.debugadapter.jdi.JdiProxyException;
 import org.ballerinalang.debugadapter.jdi.StackFrameProxyImpl;
 import org.ballerinalang.debugadapter.jdi.ThreadReferenceProxyImpl;
-import org.ballerinalang.debugadapter.variable.BVariableType;
 import org.eclipse.lsp4j.debug.ContinuedEventArguments;
 import org.eclipse.lsp4j.debug.StoppedEventArguments;
 import org.eclipse.lsp4j.debug.StoppedEventArgumentsReason;
@@ -52,15 +39,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import static org.ballerinalang.debugadapter.JBallerinaDebugServer.isBalStackFrame;
 import static org.ballerinalang.debugadapter.utils.PackageUtils.BAL_FILE_EXT;
@@ -72,14 +54,22 @@ import static org.ballerinalang.debugadapter.utils.PackageUtils.getQualifiedClas
 public class JDIEventProcessor {
 
     private final ExecutionContext context;
+    private final BreakpointProcessor breakpointProcessor;
     private boolean isRemoteVmAttached = false;
-    private final Map<String, Map<Integer, BalBreakpoint>> breakpoints = new HashMap<>();
-    private final List<EventRequest> stepEventRequests = new ArrayList<>();
-    private static final Logger LOGGER = LoggerFactory.getLogger(JBallerinaDebugServer.class);
-    private static final String CONDITION_TRUE = "true";
+    private final List<EventRequest> stepRequests = new ArrayList<>();
+    private static final Logger LOGGER = LoggerFactory.getLogger(JDIEventProcessor.class);
 
     JDIEventProcessor(ExecutionContext context) {
         this.context = context;
+        breakpointProcessor = new BreakpointProcessor(context, this);
+    }
+
+    BreakpointProcessor getBreakpointProcessor() {
+        return breakpointProcessor;
+    }
+
+    List<EventRequest> getStepRequests() {
+        return stepRequests;
     }
 
     /**
@@ -113,25 +103,12 @@ public class JDIEventProcessor {
         if (event instanceof ClassPrepareEvent) {
             if (context.getLastInstruction() != DebugInstruction.STEP_OVER) {
                 ClassPrepareEvent evt = (ClassPrepareEvent) event;
-                configureUserBreakPoints(evt.referenceType());
+                breakpointProcessor.configureUserBreakPoints(evt.referenceType());
             }
             eventSet.resume();
         } else if (event instanceof BreakpointEvent) {
             BreakpointEvent bpEvent = (BreakpointEvent) event;
-            ReferenceType bpReference = bpEvent.location().declaringType();
-            String qualifiedClassName = getQualifiedClassName(context, bpReference);
-            Map<Integer, BalBreakpoint> fileBreakpoints = this.breakpoints.get(qualifiedClassName);
-            int lineNumber = bpEvent.location().lineNumber();
-
-            if (context.getLastInstruction() != null && context.getLastInstruction() != DebugInstruction.CONTINUE) {
-                notifyStopEvent(event);
-                return;
-            } else if (fileBreakpoints == null || !fileBreakpoints.containsKey(lineNumber)) {
-                notifyStopEvent(event);
-                return;
-            }
-            BalBreakpoint balBreakpoint = fileBreakpoints.get(lineNumber);
-            processBreakpointEvent(bpEvent, balBreakpoint, lineNumber);
+            breakpointProcessor.processBreakpointEvent(bpEvent);
         } else if (event instanceof StepEvent) {
             StepEvent stepEvent = (StepEvent) event;
             int threadId = (int) stepEvent.thread().uniqueID();
@@ -150,66 +127,20 @@ public class JDIEventProcessor {
         }
     }
 
-    /**
-     * Examines the breakpoint event to see if the related breakpoint has any user configured breakpoint condition
-     * and/or log message attached with it, and process accordingly.
-     */
-    private void processBreakpointEvent(BreakpointEvent event, BalBreakpoint breakpoint, int lineNumber) {
-        String condition = breakpoint.getCondition().isPresent() && !breakpoint.getCondition().get().isBlank() ?
-                breakpoint.getCondition().get() : "";
-        Optional<LogMessage> logMessage = breakpoint.getLogMessage();
-        if (logMessage.isEmpty() && condition.isEmpty()) {
-            notifyStopEvent(event);
-            return;
-        }
-
-        // If there's a non-empty user defined log message and no breakpoint condition, resumes the remote VM
-        // after showing the log on the debug console.
-        if (logMessage.isPresent() && condition.isEmpty()) {
-            printLogMessage(event, logMessage.get(), lineNumber);
-            context.getDebuggeeVM().resume();
-            return;
-        }
-
-        CompletableFuture<Boolean> resultFuture = evaluateBreakpointCondition(condition, event.thread(), lineNumber);
-        try {
-            Boolean result = resultFuture.get(5000, TimeUnit.MILLISECONDS);
-            if (result) {
-                if (logMessage.isPresent()) {
-                    printLogMessage(event, logMessage.get(), lineNumber);
-                    context.getDebuggeeVM().resume();
-                } else {
-                    notifyStopEvent(event);
-                }
-            } else {
-                context.getDebuggeeVM().resume();
-            }
-        } catch (InterruptedException | ExecutionException | TimeoutException e) {
-            context.getOutputLogger().sendErrorOutput(String.format("Warning: Skipping conditional breakpoint at " +
-                    "line: %d, due to timeout while evaluating the condition:'%s'.", lineNumber, condition));
-            if (logMessage.isPresent()) {
-                printLogMessage(event, logMessage.get(), lineNumber);
-                context.getDebuggeeVM().resume();
-            } else {
-                notifyStopEvent(event);
-            }
-        }
-    }
-
     void setBreakpoints(String debugSourcePath, Map<Integer, BalBreakpoint> breakpoints) {
         Optional<String> qualifiedClassName = getQualifiedClassName(context, debugSourcePath);
-        qualifiedClassName.ifPresent(qClassName -> this.breakpoints.put(qClassName, breakpoints));
+        qualifiedClassName.ifPresent(qClassName -> breakpointProcessor.userBreakpoints().put(qClassName, breakpoints));
 
         if (context.getDebuggeeVM() != null) {
             // Setting breakpoints to a already running debug session.
             context.getEventManager().deleteAllBreakpoints();
-            context.getDebuggeeVM().allClasses().forEach(this::configureUserBreakPoints);
+            context.getDebuggeeVM().allClasses().forEach(breakpointProcessor::configureUserBreakPoints);
         }
     }
 
     void sendStepRequest(int threadId, int stepType) {
         if (stepType == StepRequest.STEP_OVER) {
-            configureDynamicBreakPoints(threadId);
+            breakpointProcessor.configureDynamicBreakPoints(threadId, BreakpointProcessor.DynamicBreakpointMode.CURRENT);
         } else if (stepType == StepRequest.STEP_INTO || stepType == StepRequest.STEP_OUT) {
             createStepRequest(threadId, stepType);
         }
@@ -220,107 +151,8 @@ public class JDIEventProcessor {
         context.getClient().continued(continuedEventArguments);
     }
 
-    void restoreBreakpoints(DebugInstruction instruction) {
-        if (context.getDebuggeeVM() == null) {
-            return;
-        }
-
-        context.getEventManager().deleteAllBreakpoints();
-        if (instruction == DebugInstruction.CONTINUE || instruction == DebugInstruction.STEP_OVER) {
-            context.getDebuggeeVM().allClasses().forEach(this::configureUserBreakPoints);
-        }
-    }
-
-    private void configureUserBreakPoints(ReferenceType referenceType) {
-        try {
-            // Avoids setting break points if the server is running in 'no-debug' mode.
-            ClientConfigHolder configHolder = context.getAdapter().getClientConfigHolder();
-            if (configHolder instanceof ClientLaunchConfigHolder
-                    && ((ClientLaunchConfigHolder) configHolder).isNoDebugMode()) {
-                return;
-            }
-
-            String qualifiedClassName = getQualifiedClassName(context, referenceType);
-            if (!breakpoints.containsKey(qualifiedClassName)) {
-                return;
-            }
-            Map<Integer, BalBreakpoint> breakpoints = this.breakpoints.get(qualifiedClassName);
-            for (BalBreakpoint bp : breakpoints.values()) {
-                List<Location> locations = referenceType.locationsOfLine(bp.getLine());
-                if (!locations.isEmpty()) {
-                    Location loc = locations.get(0);
-                    BreakpointRequest bpReq = context.getEventManager().createBreakpointRequest(loc);
-                    bpReq.enable();
-                }
-            }
-        } catch (AbsentInformationException ignored) {
-            // classes with no line number information can be ignored.
-        } catch (Exception e) {
-            LOGGER.error(e.getMessage(), e);
-        }
-    }
-
-    private void configureDynamicBreakPoints(int threadId) {
-        ThreadReferenceProxyImpl threadReference = context.getAdapter().getAllThreads().get(threadId);
-        try {
-            List<StackFrameProxyImpl> jStackFrames = threadReference.frames();
-            List<BallerinaStackFrame> validFrames = filterValidBallerinaFrames(jStackFrames);
-
-            if (!validFrames.isEmpty()) {
-                configureBreakpointsForMethod(validFrames.get(0));
-            }
-            // If the current function is invoked within another ballerina function, we need to explicitly set another
-            // temporary breakpoint on the location of its invocation. This is supposed to handle the situations where
-            // the user wants to step over on an exit point of the current function.
-            if (validFrames.size() > 1) {
-                configureBreakpointsForMethod(validFrames.get(1));
-            }
-        } catch (JdiProxyException e) {
-            LOGGER.error(e.getMessage());
-            int stepType = ((StepRequest) this.stepEventRequests.get(0)).depth();
-            sendStepRequest(threadId, stepType);
-        }
-    }
-
-    /**
-     * Configures temporary(dynamic) breakpoints for all the lines within the method, which encloses the given stack
-     * frame location. This strategy is used when processing STEP_OVER requests.
-     */
-    private void configureBreakpointsForMethod(BallerinaStackFrame balStackFrame) {
-        try {
-            Location currentLocation = balStackFrame.getJStackFrame().location();
-            ReferenceType referenceType = currentLocation.declaringType();
-            List<Location> allLocations = currentLocation.method().allLineLocations();
-            Optional<Location> firstLocation = allLocations.stream()
-                    .filter(location -> location.lineNumber() > 0)
-                    .min(Comparator.comparingInt(Location::lineNumber));
-            Optional<Location> lastLocation = allLocations.stream().max(Comparator.comparingInt(Location::lineNumber));
-            if (firstLocation.isEmpty()) {
-                return;
-            }
-
-            int nextStepPoint = firstLocation.get().lineNumber();
-            do {
-                List<Location> locations = referenceType.locationsOfLine(nextStepPoint);
-                if (!locations.isEmpty() && (locations.get(0).lineNumber() > firstLocation.get().lineNumber())) {
-                    // Checks whether there are any user breakpoint configured for the same location, before adding the
-                    // dynamic breakpoint.
-                    boolean bpAlreadyExist = context.getEventManager().breakpointRequests().stream()
-                            .anyMatch(breakpointRequest -> breakpointRequest.location().equals(locations.get(0)));
-                    if (!bpAlreadyExist) {
-                        BreakpointRequest bpReq = context.getEventManager().createBreakpointRequest(locations.get(0));
-                        bpReq.enable();
-                    }
-                }
-                nextStepPoint++;
-            } while (nextStepPoint <= lastLocation.get().lineNumber());
-        } catch (AbsentInformationException | JdiProxyException e) {
-            LOGGER.error(e.getMessage());
-        }
-    }
-
     private void createStepRequest(int threadId, int stepType) {
-        context.getEventManager().deleteEventRequests(stepEventRequests);
+        context.getEventManager().deleteEventRequests(stepRequests);
         ThreadReferenceProxyImpl proxy = context.getAdapter().getAllThreads().get(threadId);
         if (proxy == null || proxy.getThreadReference() == null) {
             return;
@@ -335,91 +167,9 @@ public class JDIEventProcessor {
         request.addClassExclusionFilter("org.*");
         request.addClassExclusionFilter("java.*");
         request.addClassExclusionFilter("$lambda$main$");
-        stepEventRequests.add(request);
         request.addCountFilter(1);
-        stepEventRequests.add(request);
+        stepRequests.add(request);
         request.enable();
-    }
-
-    /**
-     * Evaluates the given breakpoint condition (expression) using the ballerina debugger expression evaluation engine.
-     *
-     * @param expression      breakpoint expression
-     * @param threadReference suspended thread reference, which should be used to get the top stack frame
-     * @return result of the given breakpoint condition (logical expression).
-     */
-    private CompletableFuture<Boolean> evaluateBreakpointCondition(String expression, ThreadReference threadReference,
-                                                                   int lineNumber) {
-        return CompletableFuture.supplyAsync(() -> {
-            try {
-                BExpressionValue evaluatorResult = evaluateExpressionSafely(expression, threadReference);
-                String condition = evaluatorResult.getStringValue();
-                if (evaluatorResult.getType() != BVariableType.BOOLEAN) {
-                    String errorMessage = String.format(EvaluationExceptionKind.TYPE_MISMATCH.getReason(),
-                            BVariableType.BOOLEAN.getString(), evaluatorResult.getType().getString(), expression);
-                    context.getOutputLogger().sendErrorOutput(String.format("Warning: Skipping conditional " +
-                            "breakpoint at line: %d, due to: %s%s", lineNumber, System.lineSeparator(), errorMessage));
-                }
-                return condition.equalsIgnoreCase(CONDITION_TRUE);
-            } catch (EvaluationException e) {
-                context.getOutputLogger().sendErrorOutput(String.format("Warning: Skipping conditional breakpoint " +
-                        "at line: %d, due to: %s%s", lineNumber, System.lineSeparator(), e.getMessage()));
-                return false;
-            } catch (Exception e) {
-                context.getOutputLogger().sendErrorOutput(String.format("Warning: Skipping conditional breakpoint " +
-                        "at line: %d, due to an internal error", lineNumber));
-                return false;
-            }
-        });
-    }
-
-    private void printLogMessage(BreakpointEvent event, LogMessage logMessage, int lineNumber) {
-        try {
-            if (logMessage instanceof TemplateLogMessage) {
-                TemplateLogMessage template = (TemplateLogMessage) logMessage;
-                List<String> expressions = template.getExpressions();
-                List<String> evaluationResults = new ArrayList<>();
-                for (String expression : expressions) {
-                    evaluationResults.add(evaluateExpressionSafely(expression, event.thread()).getStringValue());
-                }
-                template.resolveInterpolations(evaluationResults);
-                context.getOutputLogger().sendProgramOutput(template.getMessage());
-            } else {
-                context.getOutputLogger().sendProgramOutput(logMessage.getMessage());
-            }
-        } catch (Exception e) {
-            context.getOutputLogger().sendErrorOutput(String.format("Warning: Skipping logpoint at line: %d, " +
-                    "due to: %s%s", lineNumber, System.lineSeparator(), e.getMessage()));
-        }
-    }
-
-    private BExpressionValue evaluateExpressionSafely(String expression, ThreadReference threadReference)
-            throws EvaluationException, JdiProxyException {
-        // When evaluating breakpoint conditions, we might need to invoke methods in the remote JVM and it can
-        // cause deadlocks if 'invokeMethod' is called from the client's event handler thread. In that case, the
-        // thread will be waiting for the invokeMethod to complete and won't read the EventSet that comes in for
-        // the new event. If this new EventSet is in 'SUSPEND_ALL' mode, then a deadlock will occur because no one
-        // will resume the EventSet. Therefore to avoid this, we are disabling possible event requests before doing
-        // the condition evaluation.
-        context.getEventManager().classPrepareRequests().forEach(EventRequest::disable);
-        context.getEventManager().breakpointRequests().forEach(BreakpointRequest::disable);
-
-        ThreadReferenceProxyImpl thread = context.getAdapter().getAllThreads().get((int) threadReference.uniqueID());
-        List<BallerinaStackFrame> validFrames = filterValidBallerinaFrames(thread.frames());
-        if (validFrames.isEmpty()) {
-            throw new IllegalStateException("Failed to use stack frames for evaluation");
-        }
-
-        SuspendedContext ctx = new SuspendedContext(context, thread, validFrames.get(0).getJStackFrame());
-        EvaluationContext evaluationContext = new EvaluationContext(ctx);
-        DebugExpressionEvaluator evaluator = new DebugExpressionEvaluator(evaluationContext);
-        evaluator.setExpression(expression);
-        BExpressionValue evaluationResult = evaluator.evaluate();
-
-        // As we are disabling all the breakpoint requests before evaluating the user's conditional
-        // expression, need to re-enable all the breakpoints before continuing the remote VM execution.
-        restoreBreakpoints(context.getLastInstruction());
-        return evaluationResult;
     }
 
     /**
@@ -427,7 +177,7 @@ public class JDIEventProcessor {
      *
      * @param jStackFrames java stack trace.
      */
-    private List<BallerinaStackFrame> filterValidBallerinaFrames(List<StackFrameProxyImpl> jStackFrames) {
+    List<BallerinaStackFrame> filterValidBallerinaFrames(List<StackFrameProxyImpl> jStackFrames) {
         List<BallerinaStackFrame> validFrames = new ArrayList<>();
         for (StackFrameProxyImpl stackFrameProxy : jStackFrames) {
             try {
@@ -467,7 +217,7 @@ public class JDIEventProcessor {
     /**
      * Notifies DAP client that the remote VM is stopped due to a breakpoint hit / step event.
      */
-    private void notifyStopEvent(Event event) {
+    void notifyStopEvent(Event event) {
         if (event instanceof BreakpointEvent) {
             notifyStopEvent(StoppedEventArgumentsReason.BREAKPOINT, ((BreakpointEvent) event).thread().uniqueID());
         } else if (event instanceof StepEvent) {
@@ -483,7 +233,7 @@ public class JDIEventProcessor {
      * @param threadId relevant thread ID
      */
     void notifyStopEvent(String reason, long threadId) {
-        context.getEventManager().deleteEventRequests(stepEventRequests);
+        context.getEventManager().deleteEventRequests(stepRequests);
         StoppedEventArguments stoppedEventArguments = new StoppedEventArguments();
         stoppedEventArguments.setReason(reason);
         stoppedEventArguments.setThreadId((int) threadId);

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/DebugInstructionTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/DebugInstructionTest.java
@@ -45,7 +45,7 @@ public class DebugInstructionTest extends BaseTestCase {
     }
 
     // Need to be enabled after fixing #35084
-    @Test(description = "Tests the behaviour when stepping over on a return statement", enabled = false)
+    @Test(description = "Tests the behaviour when stepping over on a return statement")
     public void stepOverOnReturnStatementTest() throws BallerinaTestException {
         String testProjectName = "debug-instruction-tests-1";
         String testModuleFileName = "main.bal";
@@ -62,7 +62,7 @@ public class DebugInstructionTest extends BaseTestCase {
     }
 
     // Need to be enabled after fixing #35084
-    @Test(description = "Tests whether the debugger honors the breakpoints in-between step overs", enabled = false)
+    @Test(description = "Tests whether the debugger honors the breakpoints in-between step overs")
     public void breakpointInBetweenStepOverTest() throws BallerinaTestException {
         String testProjectName = "debug-instruction-tests-1";
         String testModuleFileName = "main.bal";
@@ -84,7 +84,7 @@ public class DebugInstructionTest extends BaseTestCase {
     }
 
     // Need to be enabled after fixing #35084
-    @Test(description = "Object related debug instruction test", enabled = false)
+    @Test(description = "Object related debug instruction test")
     public void objectDebugInstructionTest() throws BallerinaTestException {
         String testProjectName = "debug-instruction-tests-1";
         String testModuleFileName = "main.bal";
@@ -108,10 +108,6 @@ public class DebugInstructionTest extends BaseTestCase {
         Assert.assertEquals(debugHitInfo.getLeft(), new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 21));
 
         // Tests STEP_OVER behaviour inside object init() method.
-        debugTestRunner.resumeProgram(debugHitInfo.getRight(), DebugTestRunner.DebugResumeKind.STEP_OVER);
-        debugHitInfo = debugTestRunner.waitForDebugHit(10000);
-        Assert.assertEquals(debugHitInfo.getLeft(), new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 22));
-
         debugTestRunner.resumeProgram(debugHitInfo.getRight(), DebugTestRunner.DebugResumeKind.STEP_OVER);
         debugHitInfo = debugTestRunner.waitForDebugHit(10000);
         Assert.assertEquals(debugHitInfo.getLeft(), new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 34));


### PR DESCRIPTION
## Purpose
This PR 
- Fixes debugger breakpoint logic to support recent codegen changes added in https://github.com/ballerina-platform/ballerina-lang/pull/35104 (which assigns the last line number (`)`} of the function for the injected bytecodes)
- refactors the dynamic breakpoint handling logic to improve debugging support in recursive contexts.
- fixes https://github.com/ballerina-platform/ballerina-lang/issues/35084
- partially fixes https://github.com/ballerina-platform/ballerina-lang/issues/34847

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
