### PR TITLE
Fix a bug in `is-expr` with readonly arrays

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -2511,9 +2511,8 @@ public class TypeChecker {
             }
         }
 
-        int targetTypeSize = targetType.getSize();
         int sourceSize = source.size();
-        if ((targetTypeSize != -1) && (sourceSize != targetTypeSize)) {
+        if ((targetType.getState() != ArrayState.OPEN) && (sourceSize != targetType.getSize())) {
             return false;
         }
         for (int i = 0; i < sourceSize; i++) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -2511,7 +2511,12 @@ public class TypeChecker {
             }
         }
 
-        for (int i = 0; i < source.size(); i++) {
+        int targetTypeSize = targetType.getSize();
+        int sourceSize = source.size();
+        if ((targetTypeSize != -1) && (sourceSize != targetTypeSize)) {
+            return false;
+        }
+        for (int i = 0; i < sourceSize; i++) {
             if (!checkIsLikeType(null, source.get(i), targetTypeElementType, unresolvedValues,
                     allowNumericConversion, null)) {
                 return false;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/TypeTestExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/TypeTestExprTest.java
@@ -747,7 +747,8 @@ public class TypeTestExprTest {
                 "testRecordIntersectionWithFunctionFields",
                 "testBuiltInSubTypeTypeTestAgainstFiniteType",
                 "testIntSubtypes",
-                "testRecordsWithOptionalFields"
+                "testRecordsWithOptionalFields",
+                "testReadOnlyArrays"
         };
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/types/type_reference_type_bala_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/types/type_reference_type_bala_test.bal
@@ -54,9 +54,9 @@ function testFn() {
     a1 = [1, 2].cloneReadOnly();
     assertEquality(true, a1 is int[2]);
     a1 = [1, 2, 3].cloneReadOnly();
-//  assertEquality(false, a1 is tr:IntArray); // Uncomment after fixing ballerina-lang/issues/#34879
+    assertEquality(false, a1 is tr:IntArray);
     a1 = [1].cloneReadOnly();
-    assertEquality(true, a1 is tr:IntArray);
+    assertEquality(false, a1 is tr:IntArray);
 
     a1 = [1.2, true].cloneReadOnly();
     assertEquality(true, a1 is tr:FloatBooleanTuple);

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/type-test-expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/type-test-expr.bal
@@ -711,6 +711,21 @@ public function testEmptyArrayType() {
     test:assertEquals(c is int[], true);
 }
 
+function testReadOnlyArrays() {
+    anydata & readonly arr1 = [2, 2, 3];
+    test:assertTrue(arr1 is int[3]);
+    test:assertTrue(arr1 is int[]);
+    test:assertFalse(arr1 is int[2]);
+    test:assertFalse(arr1 is boolean[3]);
+
+    anydata arr2 = ["a", "b", "c"];
+    anydata & readonly arr3 = arr2.cloneReadOnly();
+    test:assertTrue(arr3 is string[3]);
+    test:assertTrue(arr3 is string[]);
+    test:assertFalse(arr3 is string[2]);
+    test:assertTrue(arr3 is anydata[3]);
+}
+
 // ========================== Tuples ==========================
 
 function testSimpleTuples() returns [boolean, boolean, boolean, boolean, boolean] {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/typereftype/type_reference.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/typereftype/type_reference.bal
@@ -104,9 +104,9 @@ function testTypeRef() {
     a1 = [1, 2];
     assertEqual(a1.cloneReadOnly() is IntArray, true);
     a1 = [1, 2, 3];
-//  assertEqual(a1.cloneReadOnly() is IntArray, false); // Need to fix ballerina-lang/#34879
+    assertEqual(a1.cloneReadOnly() is IntArray, false);
     a1 = [1];
-//  assertEqual(a1.cloneReadOnly() is int[2], false); // Need to fix ballerina-lang/#34879
+    assertEqual(a1.cloneReadOnly() is int[2], false);
 
     FloatBooleanTuple c5 = [1.2, true];
     assertEqual(c5, [1.2, true]);


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues.

$title
Fixes https://github.com/ballerina-platform/ballerina-lang/issues/34879

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
