### PR TITLE
[`master`] Fix quoted identifier semantics issue in field symbols

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/FieldMap.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/FieldMap.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.compiler.api.impl;
+
+import java.util.LinkedHashMap;
+
+import static io.ballerina.compiler.api.impl.util.SymbolUtils.unescapeUnicode;
+
+/**
+ * This is a map used for storing the field symbols of record, object and class symbols. The key is a String and this
+ * map will store the field names(keys) in unescaped format. e.g., 'int will be stored as int. However, when querying
+ * for keys, this follows the semantics of the language. i.e., both 'int and int will return the same field symbol if
+ * such a symbol is present.
+ *
+ * This map is only meant to be used as a container for fields and as such, is intended to be used wrapped in an
+ * unmodifiable map. Therefore, only the put() method is overridden since that's the only modifying operation required
+ * for building the fields map (at least so far).
+ *
+ * @param <K> The key. Supposed to be String
+ * @param <V> The field symbol type
+ */
+public class FieldMap<K, V> extends LinkedHashMap<K, V> {
+
+    @Override
+    public V get(Object key) {
+        validateKeyType(key);
+        return super.get(unescapeUnicode((String) key));
+    }
+
+    @Override
+    public V getOrDefault(Object key, V defaultValue) {
+        validateKeyType(key);
+        return super.getOrDefault(unescapeUnicode((String) key), defaultValue);
+    }
+
+    @Override
+    public V put(K key, V value) {
+        validateKeyType(key);
+        return super.put((K) unescapeUnicode((String) key), value);
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        validateKeyType(key);
+        return super.containsKey(unescapeUnicode((String) key));
+    }
+
+    private void validateKeyType(Object key) {
+        if (!(key instanceof String)) {
+            throw new IllegalArgumentException(
+                    "Expected a String arg, but found: " + key.getClass().getCanonicalName());
+        }
+    }
+}

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/AbstractTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/AbstractTypeSymbol.java
@@ -23,7 +23,6 @@ import io.ballerina.compiler.api.symbols.ParameterSymbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
-import io.ballerina.identifier.Utils;
 import io.ballerina.tools.diagnostics.Location;
 import org.wso2.ballerinalang.compiler.semantics.analyzer.Types;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BArrayType;
@@ -33,6 +32,8 @@ import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+
+import static io.ballerina.compiler.api.impl.util.SymbolUtils.unescapeUnicode;
 
 /**
  * Represents a Ballerina Type Descriptor.
@@ -119,7 +120,7 @@ public abstract class AbstractTypeSymbol implements TypeSymbol {
         if (name.equals(symName)) {
             return true;
         }
-        return unescapedUnicode(name).equals(unescapedUnicode(symName));
+        return unescapeUnicode(name).equals(unescapeUnicode(symName));
     }
 
     @Override
@@ -190,12 +191,5 @@ public abstract class AbstractTypeSymbol implements TypeSymbol {
         }
 
         return ((BallerinaClassSymbol) typeSymbol).getBType();
-    }
-
-    private String unescapedUnicode(String value) {
-        if (value.startsWith("'")) {
-            return Utils.unescapeUnicodeCodepoints(value.substring(1));
-        }
-        return Utils.unescapeUnicodeCodepoints(value);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaClassSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaClassSymbol.java
@@ -17,6 +17,7 @@
  */
 package io.ballerina.compiler.api.impl.symbols;
 
+import io.ballerina.compiler.api.impl.FieldMap;
 import io.ballerina.compiler.api.impl.SymbolFactory;
 import io.ballerina.compiler.api.symbols.AnnotationSymbol;
 import io.ballerina.compiler.api.symbols.ClassFieldSymbol;
@@ -82,11 +83,11 @@ public class BallerinaClassSymbol extends BallerinaSymbol implements ClassSymbol
             return classFields;
         }
 
-        Map<String, ClassFieldSymbol> fields = new LinkedHashMap<>();
+        FieldMap<String, ClassFieldSymbol> fields = new FieldMap<>();
         BObjectType type = (BObjectType) this.getBType();
 
         for (BField field : type.fields.values()) {
-            fields.put(field.name.value, new BallerinaClassFieldSymbol(this.context, field));
+            fields.put(field.symbol.getOriginalName().value, new BallerinaClassFieldSymbol(this.context, field));
         }
 
         this.classFields = Collections.unmodifiableMap(fields);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaClassSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaClassSymbol.java
@@ -17,8 +17,8 @@
  */
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.impl.FieldMap;
 import io.ballerina.compiler.api.impl.SymbolFactory;
+import io.ballerina.compiler.api.impl.util.FieldMap;
 import io.ballerina.compiler.api.symbols.AnnotationSymbol;
 import io.ballerina.compiler.api.symbols.ClassFieldSymbol;
 import io.ballerina.compiler.api.symbols.ClassSymbol;
@@ -42,7 +42,6 @@ import org.wso2.ballerinalang.util.Flags;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectFieldSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectFieldSymbol.java
@@ -53,7 +53,6 @@ public class BallerinaObjectFieldSymbol extends BallerinaSymbol implements Objec
     private List<AnnotationSymbol> annots;
     private String signature;
     private boolean deprecated;
-    private String escapedName;
 
     public BallerinaObjectFieldSymbol(CompilerContext context, BField bField, SymbolKind kind) {
         super(bField.symbol.getOriginalName().value, kind, bField.symbol, context);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectFieldSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectFieldSymbol.java
@@ -56,7 +56,7 @@ public class BallerinaObjectFieldSymbol extends BallerinaSymbol implements Objec
     private String escapedName;
 
     public BallerinaObjectFieldSymbol(CompilerContext context, BField bField, SymbolKind kind) {
-        super(bField.name.value, kind, bField.symbol, context);
+        super(bField.symbol.getOriginalName().value, kind, bField.symbol, context);
         this.bField = bField;
         this.docAttachment = new BallerinaDocumentation(bField.symbol.markdownDocumentation);
         this.deprecated = Symbols.isFlagOn(bField.symbol.flags, Flags.DEPRECATED);
@@ -64,15 +64,6 @@ public class BallerinaObjectFieldSymbol extends BallerinaSymbol implements Objec
 
     public BallerinaObjectFieldSymbol(CompilerContext context, BField bField) {
         this(context, bField, OBJECT_FIELD);
-    }
-
-    @Override
-    public Optional<String> getName() {
-        if (this.escapedName != null) {
-            return Optional.of(this.escapedName);
-        }
-        this.escapedName = escapeReservedKeyword(this.bField.getName().getValue());
-        return Optional.ofNullable(this.escapedName);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectTypeSymbol.java
@@ -17,6 +17,7 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.impl.FieldMap;
 import io.ballerina.compiler.api.impl.SymbolFactory;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
 import io.ballerina.compiler.api.symbols.MethodSymbol;
@@ -88,11 +89,11 @@ public class BallerinaObjectTypeSymbol extends AbstractTypeSymbol implements Obj
             return this.objectFields;
         }
 
-        Map<String, ObjectFieldSymbol> fields = new LinkedHashMap<>();
+        FieldMap<String, ObjectFieldSymbol> fields = new FieldMap<>();
         BObjectType type = (BObjectType) this.getBType();
 
         for (BField field : type.fields.values()) {
-            fields.put(field.name.value, new BallerinaObjectFieldSymbol(this.context, field));
+            fields.put(field.symbol.getOriginalName().value, new BallerinaObjectFieldSymbol(this.context, field));
         }
 
         this.objectFields = Collections.unmodifiableMap(fields);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectTypeSymbol.java
@@ -17,8 +17,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
-import io.ballerina.compiler.api.impl.FieldMap;
 import io.ballerina.compiler.api.impl.SymbolFactory;
+import io.ballerina.compiler.api.impl.util.FieldMap;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
 import io.ballerina.compiler.api.symbols.MethodSymbol;
 import io.ballerina.compiler.api.symbols.ObjectFieldSymbol;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaRecordFieldSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaRecordFieldSymbol.java
@@ -55,19 +55,10 @@ public class BallerinaRecordFieldSymbol extends BallerinaSymbol implements Recor
     private String escapedName;
 
     public BallerinaRecordFieldSymbol(CompilerContext context, BField bField) {
-        super(bField.name.value, SymbolKind.RECORD_FIELD, bField.symbol, context);
+        super(bField.symbol.getOriginalName().value, SymbolKind.RECORD_FIELD, bField.symbol, context);
         this.bField = bField;
         this.docAttachment = new BallerinaDocumentation(bField.symbol.markdownDocumentation);
         this.deprecated = Symbols.isFlagOn(bField.symbol.flags, Flags.DEPRECATED);
-    }
-
-    @Override
-    public Optional<String> getName() {
-        if (this.escapedName != null) {
-            return Optional.of(this.escapedName);
-        }
-        this.escapedName = escapeReservedKeyword(this.bField.getName().getValue());
-        return Optional.ofNullable(this.escapedName);
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaRecordFieldSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaRecordFieldSymbol.java
@@ -52,7 +52,6 @@ public class BallerinaRecordFieldSymbol extends BallerinaSymbol implements Recor
     private List<Qualifier> qualifiers;
     private String signature;
     private boolean deprecated;
-    private String escapedName;
 
     public BallerinaRecordFieldSymbol(CompilerContext context, BField bField) {
         super(bField.symbol.getOriginalName().value, SymbolKind.RECORD_FIELD, bField.symbol, context);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaRecordTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaRecordTypeSymbol.java
@@ -17,7 +17,7 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
-import io.ballerina.compiler.api.impl.FieldMap;
+import io.ballerina.compiler.api.impl.util.FieldMap;
 import io.ballerina.compiler.api.symbols.RecordFieldSymbol;
 import io.ballerina.compiler.api.symbols.RecordTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaRecordTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaRecordTypeSymbol.java
@@ -17,6 +17,7 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.impl.FieldMap;
 import io.ballerina.compiler.api.symbols.RecordFieldSymbol;
 import io.ballerina.compiler.api.symbols.RecordTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
@@ -29,7 +30,6 @@ import org.wso2.ballerinalang.compiler.util.TypeTags;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -56,11 +56,11 @@ public class BallerinaRecordTypeSymbol extends AbstractTypeSymbol implements Rec
             return this.fieldSymbols;
         }
 
-        Map<String, RecordFieldSymbol> fields = new LinkedHashMap<>();
+        FieldMap<String, RecordFieldSymbol> fields = new FieldMap<>();
         BRecordType type = (BRecordType) this.getBType();
 
         for (BField field : type.fields.values()) {
-            fields.put(field.name.value, new BallerinaRecordFieldSymbol(this.context, field));
+            fields.put(field.symbol.getOriginalName().value, new BallerinaRecordFieldSymbol(this.context, field));
         }
 
         this.fieldSymbols = Collections.unmodifiableMap(fields);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaServiceDeclarationSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaServiceDeclarationSymbol.java
@@ -48,6 +48,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.StringJoiner;
 
+import static io.ballerina.compiler.api.impl.util.SymbolUtils.unescapeUnicode;
 import static io.ballerina.compiler.api.symbols.SymbolKind.SERVICE_DECLARATION;
 
 /**
@@ -247,6 +248,6 @@ public class BallerinaServiceDeclarationSymbol extends BallerinaSymbol implement
         if (name.equals(symbolName)) {
             return true;
         }
-        return unescapedUnicode(name).equals(unescapedUnicode(symbolName));
+        return unescapeUnicode(name).equals(unescapeUnicode(symbolName));
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSymbol.java
@@ -17,13 +17,11 @@
  */
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.impl.BallerinaKeywordsProvider;
 import io.ballerina.compiler.api.impl.SymbolFactory;
 import io.ballerina.compiler.api.symbols.Documentation;
 import io.ballerina.compiler.api.symbols.ModuleSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
-import io.ballerina.identifier.Utils;
 import io.ballerina.tools.diagnostics.Location;
 import io.ballerina.tools.text.LineRange;
 import io.ballerina.tools.text.TextRange;
@@ -34,6 +32,8 @@ import org.wso2.ballerinalang.compiler.util.CompilerContext;
 
 import java.util.Objects;
 import java.util.Optional;
+
+import static io.ballerina.compiler.api.impl.util.SymbolUtils.unescapeUnicode;
 
 /**
  * Represents the implementation of a Compiled Ballerina Symbol.
@@ -128,7 +128,7 @@ public class BallerinaSymbol implements Symbol {
         if (name.equals(symName)) {
             return true;
         }
-        return unescapedUnicode(name).equals(unescapedUnicode(symName));
+        return unescapeUnicode(name).equals(unescapeUnicode(symName));
     }
 
     @Override
@@ -177,25 +177,6 @@ public class BallerinaSymbol implements Symbol {
         }
 
         return loc1.get().lineRange().equals(loc2.get().lineRange());
-    }
-
-    protected String unescapedUnicode(String value) {
-        if (value.startsWith("'")) {
-            return Utils.unescapeUnicodeCodepoints(value.substring(1));
-        }
-        return Utils.unescapeUnicodeCodepoints(value);
-    }
-
-    public boolean isReservedKeyword(String value) {
-        return BallerinaKeywordsProvider.BALLERINA_KEYWORDS.contains(value);
-    }
-
-    public String escapeReservedKeyword(String value) {
-        if (BallerinaKeywordsProvider.BALLERINA_KEYWORDS.contains(value)) {
-            return "'" + value;
-        }
-
-        return value;
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/util/FieldMap.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/util/FieldMap.java
@@ -37,6 +37,8 @@ import static io.ballerina.compiler.api.impl.util.SymbolUtils.unescapeUnicode;
  */
 public class FieldMap<K, V> extends LinkedHashMap<K, V> {
 
+    private static final long serialVersionUID = 609051204130116L;
+
     @Override
     public V get(Object key) {
         validateKeyType(key);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/util/FieldMap.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/util/FieldMap.java
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-package io.ballerina.compiler.api.impl;
+package io.ballerina.compiler.api.impl.util;
 
 import java.util.LinkedHashMap;
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/util/SymbolUtils.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/util/SymbolUtils.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.compiler.api.impl.util;
+
+import io.ballerina.identifier.Utils;
+
+public class SymbolUtils {
+
+    public static String unescapeUnicode(String value) {
+        if (value.startsWith("'")) {
+            return Utils.unescapeUnicodeCodepoints(value.substring(1));
+        }
+        return Utils.unescapeUnicodeCodepoints(value);
+    }
+}

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/util/SymbolUtils.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/util/SymbolUtils.java
@@ -20,6 +20,9 @@ package io.ballerina.compiler.api.impl.util;
 
 import io.ballerina.identifier.Utils;
 
+/**
+ * Common util methods related to symbols.
+ */
 public class SymbolUtils {
 
     public static String unescapeUnicode(String value) {

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/field_symbols_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/field_symbols_test.bal
@@ -51,3 +51,18 @@ function booleanSubtypeUnion(anydata d1, anydata d2) returns BooleanSubtype {
     BooleanSubtype v2 = <BooleanSubtype>d2;
     return v1.value == v2.value ? v1 : true;
 }
+
+type Foo record {|
+    int 'f1;
+    string '\'f2;
+    int 'sm\u{1F600}iley1;
+    string sm\u{1F600}iley2;
+|}
+
+type Bar object {
+    int 'order;
+}
+
+class Baz {
+    string 'int;
+}


### PR DESCRIPTION
## Purpose
This PR fixes an issue in how the fields map returned in record, object and class symbols handled quoted identifiers. With this PR, the returned map will take the quoted identifier semantics into account when a user looks up fields in the map.

e.g., consider a record fields map of type `Map<String, RecordFieldSymbol>` called `fields` and a Ballerina record type like the following `record {| int 'order; |}`
```java
fields.containsKey("'order") == fields.containsKey("order"); // will evaluate to true always
fields.get("'order"); // will not return null
fields.get("order"); // will not return null
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
