### PR TITLE
[Debugger] Add runtime breakpoint verification support

### DIFF
--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/BreakpointProcessor.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/BreakpointProcessor.java
@@ -187,11 +187,11 @@ public class BreakpointProcessor {
      * Activates user-configured source breakpoints in the program VM, via Java Debug Interface(JDI).
      *
      * @param referenceType represent the type of an object in the remote VM
-     * @param shouldVerify  if true, notifies the debugger frontend with the user breakpoint verification information
+     * @param shouldNotify  if true, notifies the debugger frontend with the user breakpoint verification information
      */
-    void activateUserBreakPoints(ReferenceType referenceType, boolean shouldVerify) {
+    void activateUserBreakPoints(ReferenceType referenceType, boolean shouldNotify) {
         try {
-            // Avoids setting break points if the server is running in 'no-debug' mode.
+            // avoids setting break points if the server is running in 'no-debug' mode.
             ClientConfigHolder configHolder = context.getAdapter().getClientConfigHolder();
             if (configHolder instanceof ClientLaunchConfigHolder
                     && ((ClientLaunchConfigHolder) configHolder).isNoDebugMode()) {
@@ -210,9 +210,12 @@ public class BreakpointProcessor {
                     BreakpointRequest bpReq = context.getEventManager().createBreakpointRequest(loc);
                     bpReq.enable();
 
-                    if (shouldVerify && !breakpoint.isVerified()) {
+                    // verifies the breakpoint reachability and notifies the client if required.
+                    if (!breakpoint.isVerified()) {
                         breakpoint.setVerified(true);
-                        notifyBreakPointChangesToClient(breakpoint);
+                        if (shouldNotify) {
+                            notifyBreakPointChangesToClient(breakpoint);
+                        }
                     }
                 }
             }

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/BreakpointProcessor.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/BreakpointProcessor.java
@@ -51,7 +51,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.stream.Collectors;
 
 import static org.ballerinalang.debugadapter.utils.PackageUtils.getQualifiedClassName;
 
@@ -74,21 +73,19 @@ public class BreakpointProcessor {
         this.jdiEventProcessor = jdiEventProcessor;
     }
 
-    public List<BalBreakpoint> getAllUserBreakpoints() {
-        return userBreakpoints.values().stream()
-                .flatMap(breakpointMap -> breakpointMap.values().stream())
-                .collect(Collectors.toList());
+    public Map<String, LinkedHashMap<Integer, BalBreakpoint>> getUserBreakpoints() {
+        return Map.copyOf(userBreakpoints);
     }
 
     /**
      * Updates the user breakpoints map with a list of breakpoints against its source.
      *
-     * @param sourcePath  source file path which contains the given breakpoint.
-     * @param breakpoints the map of breakpoints against the line numbers.
+     * @param qualifiedClassName full-qualified classname generated for the corresponding Ballerina source file,
+     *                           which contains the given breakpoints
+     * @param breakpoints        the map of breakpoints against the line numbers
      */
-    public void addSourceBreakpoints(String sourcePath, LinkedHashMap<Integer, BalBreakpoint> breakpoints) {
-        Optional<String> qualifiedClassName = getQualifiedClassName(context, sourcePath);
-        qualifiedClassName.ifPresent(s -> userBreakpoints.put(s, breakpoints));
+    public void addSourceBreakpoints(String qualifiedClassName, LinkedHashMap<Integer, BalBreakpoint> breakpoints) {
+        userBreakpoints.put(qualifiedClassName, breakpoints);
     }
 
     /**

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/BreakpointProcessor.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/BreakpointProcessor.java
@@ -209,8 +209,9 @@ public class BreakpointProcessor {
                     Location loc = locations.get(0);
                     BreakpointRequest bpReq = context.getEventManager().createBreakpointRequest(loc);
                     bpReq.enable();
-                    breakpoint.setVerified(true);
-                    if (shouldVerify) {
+
+                    if (shouldVerify && !breakpoint.isVerified()) {
+                        breakpoint.setVerified(true);
                         notifyBreakPointChangesToClient(breakpoint);
                     }
                 }

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JBallerinaDebugServer.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JBallerinaDebugServer.java
@@ -80,8 +80,6 @@ import org.eclipse.lsp4j.debug.ScopesResponse;
 import org.eclipse.lsp4j.debug.SetBreakpointsArguments;
 import org.eclipse.lsp4j.debug.SetBreakpointsResponse;
 import org.eclipse.lsp4j.debug.SetExceptionBreakpointsArguments;
-import org.eclipse.lsp4j.debug.SetFunctionBreakpointsArguments;
-import org.eclipse.lsp4j.debug.SetFunctionBreakpointsResponse;
 import org.eclipse.lsp4j.debug.Source;
 import org.eclipse.lsp4j.debug.SourceArguments;
 import org.eclipse.lsp4j.debug.SourceBreakpoint;
@@ -196,7 +194,9 @@ public class JBallerinaDebugServer implements IDebugProtocolServer {
         capabilities.setSupportsStepBack(false);
         capabilities.setSupportsTerminateThreadsRequest(false);
         capabilities.setSupportsFunctionBreakpoints(false);
-        capabilities.setSupportsFunctionBreakpoints(false);
+        capabilities.setSupportsExceptionOptions(false);
+        capabilities.setSupportsExceptionFilterOptions(false);
+        capabilities.setSupportsExceptionInfoRequest(false);
 
         context.setClient(client);
         eventProcessor = new JDIEventProcessor(context);
@@ -539,12 +539,6 @@ public class JBallerinaDebugServer implements IDebugProtocolServer {
             }
             return completionsResponse;
         });
-    }
-
-    @Override
-    public CompletableFuture<SetFunctionBreakpointsResponse> setFunctionBreakpoints(
-            SetFunctionBreakpointsArguments args) {
-        return CompletableFuture.completedFuture(null);
     }
 
     private BalBreakpoint toBreakpoint(SourceBreakpoint sourceBreakpoint, Source source) {

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JDIEventProcessor.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JDIEventProcessor.java
@@ -126,8 +126,8 @@ public class JDIEventProcessor {
         }
     }
 
-    void enableBreakpoints(String debugSourcePath, LinkedHashMap<Integer, BalBreakpoint> breakpoints) {
-        breakpointProcessor.addSourceBreakpoints(debugSourcePath, breakpoints);
+    void enableBreakpoints(String qualifiedClassName, LinkedHashMap<Integer, BalBreakpoint> breakpoints) {
+        breakpointProcessor.addSourceBreakpoints(qualifiedClassName, breakpoints);
 
         if (context.getDebuggeeVM() != null) {
             // Setting breakpoints to a already running debug session.

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JDIEventProcessor.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JDIEventProcessor.java
@@ -39,15 +39,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import static org.ballerinalang.debugadapter.BreakpointProcessor.DynamicBreakpointMode;
 import static org.ballerinalang.debugadapter.JBallerinaDebugServer.isBalStackFrame;
 import static org.ballerinalang.debugadapter.utils.PackageUtils.BAL_FILE_EXT;
-import static org.ballerinalang.debugadapter.utils.PackageUtils.getQualifiedClassName;
 
 /**
  * JDI Event processor implementation.
@@ -128,9 +126,8 @@ public class JDIEventProcessor {
         }
     }
 
-    void setBreakpoints(String debugSourcePath, Map<Integer, BalBreakpoint> breakpoints) {
-        Optional<String> qualifiedClassName = getQualifiedClassName(context, debugSourcePath);
-        qualifiedClassName.ifPresent(qClassName -> breakpointProcessor.userBreakpoints().put(qClassName, breakpoints));
+    void enableBreakpoints(String debugSourcePath, LinkedHashMap<Integer, BalBreakpoint> breakpoints) {
+        breakpointProcessor.addSourceBreakpoints(debugSourcePath, breakpoints);
 
         if (context.getDebuggeeVM() != null) {
             // Setting breakpoints to a already running debug session.

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JDIEventProcessor.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JDIEventProcessor.java
@@ -102,7 +102,7 @@ public class JDIEventProcessor {
         if (event instanceof ClassPrepareEvent) {
             if (context.getLastInstruction() != DebugInstruction.STEP_OVER) {
                 ClassPrepareEvent evt = (ClassPrepareEvent) event;
-                breakpointProcessor.activateUserBreakPoints(evt.referenceType());
+                breakpointProcessor.activateUserBreakPoints(evt.referenceType(), true);
             }
             eventSet.resume();
         } else if (event instanceof BreakpointEvent) {
@@ -132,7 +132,8 @@ public class JDIEventProcessor {
         if (context.getDebuggeeVM() != null) {
             // Setting breakpoints to a already running debug session.
             context.getEventManager().deleteAllBreakpoints();
-            context.getDebuggeeVM().allClasses().forEach(breakpointProcessor::activateUserBreakPoints);
+            context.getDebuggeeVM().allClasses().forEach(referenceType ->
+                    breakpointProcessor.activateUserBreakPoints(referenceType, false));
         }
     }
 

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/breakpoint/BalBreakpoint.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/breakpoint/BalBreakpoint.java
@@ -78,6 +78,10 @@ public class BalBreakpoint {
         }
     }
 
+    public boolean isVerified() {
+        return isVerified;
+    }
+
     public void setVerified(boolean isVerified) {
         this.isVerified = isVerified;
     }

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/breakpoint/BalBreakpoint.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/breakpoint/BalBreakpoint.java
@@ -22,6 +22,7 @@ import org.eclipse.lsp4j.debug.Breakpoint;
 import org.eclipse.lsp4j.debug.Source;
 
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
 
 import static org.ballerinalang.debugadapter.breakpoint.LogMessage.INTERPOLATION_REGEX;
@@ -33,13 +34,17 @@ import static org.ballerinalang.debugadapter.breakpoint.LogMessage.INTERPOLATION
  */
 public class BalBreakpoint {
 
+    private final int id;
     private final Source source;
     private final int line;
     private String condition;
     private LogMessage logMessage;
     private boolean isVerified;
 
+    private static final AtomicInteger nextID = new AtomicInteger(0);
+
     public BalBreakpoint(Source source, int line) {
+        this.id = nextID.getAndIncrement();
         this.source = source;
         this.line = line;
         this.isVerified = false;
@@ -79,6 +84,7 @@ public class BalBreakpoint {
 
     public Breakpoint getAsDAPBreakpoint() {
         Breakpoint breakpoint = new Breakpoint();
+        breakpoint.setId(id);
         breakpoint.setLine(line);
         breakpoint.setSource(source);
         breakpoint.setVerified(isVerified);

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/breakpoint/BalBreakpoint.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/breakpoint/BalBreakpoint.java
@@ -37,10 +37,12 @@ public class BalBreakpoint {
     private final int line;
     private String condition;
     private LogMessage logMessage;
+    private boolean isVerified;
 
     public BalBreakpoint(Source source, int line) {
         this.source = source;
         this.line = line;
+        this.isVerified = false;
     }
 
     public Integer getLine() {
@@ -71,11 +73,15 @@ public class BalBreakpoint {
         }
     }
 
+    public void setVerified(boolean isVerified) {
+        this.isVerified = isVerified;
+    }
+
     public Breakpoint getAsDAPBreakpoint() {
         Breakpoint breakpoint = new Breakpoint();
         breakpoint.setLine(line);
         breakpoint.setSource(source);
-        breakpoint.setVerified(true);
+        breakpoint.setVerified(isVerified);
         return breakpoint;
     }
 

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/utils/PackageUtils.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/utils/PackageUtils.java
@@ -241,11 +241,10 @@ public class PackageUtils {
     /**
      * Returns full-qualified class name for a given JDI class reference instance.
      *
-     * @param context       Debug context
      * @param referenceType JDI class reference instance
      * @return full-qualified class name
      */
-    public static String getQualifiedClassName(ExecutionContext context, ReferenceType referenceType) {
+    public static String getQualifiedClassName(ReferenceType referenceType) {
         try {
             List<String> paths = referenceType.sourcePaths(null);
             List<String> names = referenceType.sourceNames(null);

--- a/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/BallerinaTestDebugPoint.java
+++ b/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/BallerinaTestDebugPoint.java
@@ -40,28 +40,42 @@ public class BallerinaTestDebugPoint {
     private final int line;
     private final String condition;
     private final String logMessage;
+    private final boolean verified;
 
     public BallerinaTestDebugPoint(Path filePath, int line) {
-        this(filePath, line, null, null);
+        this(filePath, line, null, null, false);
+    }
+
+    public BallerinaTestDebugPoint(Path filePath, int line, boolean verified) {
+        this(filePath, line, null, null, verified);
     }
 
     public BallerinaTestDebugPoint(URI filePathUri, int line) {
-        this(filePathUri, line, null, null);
+        this(filePathUri, line, null, null, false);
     }
 
     public BallerinaTestDebugPoint(Path filePath, int line, String condition, String logMessage) {
-        this(filePath.toAbsolutePath().toUri(), line, condition, logMessage);
+        this(filePath.toAbsolutePath().toUri(), line, condition, logMessage, false);
     }
 
-    public BallerinaTestDebugPoint(URI filePathUri, int line, String condition, String logMessage) {
+    public BallerinaTestDebugPoint(Path filePath, int line, String condition, String logMessage, boolean verified) {
+        this(filePath.toAbsolutePath().toUri(), line, condition, logMessage, verified);
+    }
+
+    public BallerinaTestDebugPoint(URI filePathUri, int line, String condition, String logMessage, boolean verified) {
         this.filePathUri = filePathUri;
         this.line = line;
         this.condition = condition;
         this.logMessage = logMessage;
+        this.verified = verified;
     }
 
     public URI getSourceURI() {
         return filePathUri;
+    }
+
+    public boolean isVerified() {
+        return verified;
     }
 
     public Source getSource() throws BallerinaTestException {

--- a/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/BallerinaTestDebugPoint.java
+++ b/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/BallerinaTestDebugPoint.java
@@ -78,6 +78,10 @@ public class BallerinaTestDebugPoint {
         return verified;
     }
 
+    public int getLine() {
+        return line;
+    }
+
     public Source getSource() throws BallerinaTestException {
         Source source = new Source();
         if (filePathUri.getScheme().equals(URI_SCHEME_FILE)) {

--- a/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/BreakpointEventListener.java
+++ b/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/BreakpointEventListener.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.debugger.test.utils;
+
+import org.ballerinalang.debugger.test.utils.client.DAPClientConnector;
+import org.eclipse.lsp4j.debug.Breakpoint;
+import org.eclipse.lsp4j.debug.BreakpointEventArguments;
+import org.eclipse.lsp4j.debug.BreakpointEventArgumentsReason;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TimerTask;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+/**
+ * Timer Task implementation to capture breakpoint events.
+ */
+public class BreakpointEventListener extends TimerTask {
+
+    private final DAPClientConnector connector;
+    private final List<BallerinaTestDebugPoint> modifiedBreakpoints;
+    private boolean breakpointEventFound;
+
+    public BreakpointEventListener(DAPClientConnector connector) {
+        this.connector = connector;
+        this.breakpointEventFound = false;
+        this.modifiedBreakpoints = new ArrayList<>();
+    }
+
+    public boolean isBreakpointEventFound() {
+        return breakpointEventFound;
+    }
+
+    public List<BallerinaTestDebugPoint> getModifiedBreakpoints() {
+        return modifiedBreakpoints;
+    }
+
+    @Override
+    public void run() {
+        ConcurrentLinkedQueue<BreakpointEventArguments> events = connector.getServerEventHolder().getBreakpointEvents();
+        while (!events.isEmpty() && connector.isConnected()) {
+            breakpointEventFound = true;
+            events.forEach(event -> {
+                if (event != null && event.getReason().equals(BreakpointEventArgumentsReason.CHANGED)) {
+                    Breakpoint breakpoint = event.getBreakpoint();
+                    modifiedBreakpoints.add(new BallerinaTestDebugPoint(Path.of(breakpoint.getSource().getPath()),
+                            breakpoint.getLine()));
+                }
+            });
+            events.clear();
+            this.cancel();
+        }
+
+        // If the debuggee program execution is already finished, cancels the timer task immediately.
+        if (!connector.getServerEventHolder().getTerminatedEvents().isEmpty() ||
+                !connector.getServerEventHolder().getExitedEvents().isEmpty()) {
+            this.cancel();
+        }
+    }
+}

--- a/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/BreakpointEventListener.java
+++ b/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/BreakpointEventListener.java
@@ -61,7 +61,7 @@ public class BreakpointEventListener extends TimerTask {
                 if (event != null && event.getReason().equals(BreakpointEventArgumentsReason.CHANGED)) {
                     Breakpoint breakpoint = event.getBreakpoint();
                     modifiedBreakpoints.add(new BallerinaTestDebugPoint(Path.of(breakpoint.getSource().getPath()),
-                            breakpoint.getLine()));
+                            breakpoint.getLine(), breakpoint.isVerified()));
                 }
             });
             events.clear();

--- a/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/DebugServerEventHolder.java
+++ b/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/DebugServerEventHolder.java
@@ -1,5 +1,6 @@
 package org.ballerinalang.debugger.test.utils;
 
+import org.eclipse.lsp4j.debug.BreakpointEventArguments;
 import org.eclipse.lsp4j.debug.ExitedEventArguments;
 import org.eclipse.lsp4j.debug.OutputEventArguments;
 import org.eclipse.lsp4j.debug.StoppedEventArguments;
@@ -16,6 +17,7 @@ public class DebugServerEventHolder {
     private final ConcurrentLinkedQueue<TerminatedEventArguments> terminatedEvents = new ConcurrentLinkedQueue<>();
     private final ConcurrentLinkedQueue<ExitedEventArguments> exitedEvents = new ConcurrentLinkedQueue<>();
     private final ConcurrentLinkedQueue<OutputEventArguments> outputEvents = new ConcurrentLinkedQueue<>();
+    private final ConcurrentLinkedQueue<BreakpointEventArguments> breakpointEvents = new ConcurrentLinkedQueue<>();
 
     public ConcurrentLinkedQueue<StoppedEventArguments> getStoppedEvents() {
         return stoppedEvents;
@@ -47,5 +49,20 @@ public class DebugServerEventHolder {
 
     public void addOutputEvent(OutputEventArguments event) {
         this.outputEvents.add(event);
+    }
+
+    public ConcurrentLinkedQueue<BreakpointEventArguments> getBreakpointEvents() {
+        return breakpointEvents;
+    }
+
+    public void addBreakpointEvent(BreakpointEventArguments event) {
+        this.breakpointEvents.add(event);
+    }
+
+    void reset() {
+        stoppedEvents.clear();
+        breakpointEvents.clear();
+        outputEvents.clear();
+        // Todo: need to clear termination and exited events?
     }
 }

--- a/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/DebugTestRunner.java
+++ b/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/DebugTestRunner.java
@@ -303,8 +303,6 @@ public class DebugTestRunner {
      * @throws BallerinaTestException if an error occurs when resuming program.
      */
     public void resumeProgram(StoppedEventArguments context, DebugResumeKind kind) throws BallerinaTestException {
-        // clears all the client notification events before resuming the program.
-        debugClientConnector.getServerEventHolder().reset();
         if (kind == DebugResumeKind.NEXT_BREAKPOINT) {
             ContinueArguments continueArgs = new ContinueArguments();
             continueArgs.setThreadId(context.getThreadId());
@@ -433,7 +431,7 @@ public class DebugTestRunner {
         timer.cancel();
 
         if (!breakpointEventListener.isBreakpointEventFound()) {
-            throw new BallerinaTestException("Timeout expired waiting for the debugger output");
+            throw new BallerinaTestException("Timeout expired waiting for the breakpoint events");
         }
         return breakpointEventListener.getModifiedBreakpoints();
     }

--- a/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/DebugTestRunner.java
+++ b/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/DebugTestRunner.java
@@ -67,8 +67,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Timer;
 
-import javax.swing.text.html.Option;
-
 import static org.ballerinalang.debugger.test.utils.DebugUtils.findFreePort;
 
 /**
@@ -91,7 +89,6 @@ public class DebugTestRunner {
     private AssertionMode assertionMode;
     private SoftAssert softAsserter;
 
-    private static final int MAX_RETRY_COUNT = 3;
     private static final int SCHEDULER_INTERVAL_MS = 1000;
     private static final Logger LOGGER = LoggerFactory.getLogger(DebugTestRunner.class);
 

--- a/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/client/DAPRequestManager.java
+++ b/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/client/DAPRequestManager.java
@@ -313,7 +313,7 @@ public class DAPRequestManager {
     }
 
     public void breakpoint(BreakpointEventArguments args) {
-        // Todo
+        clientConnector.getServerEventHolder().addBreakpointEvent(args);
     }
 
     public void module(ModuleEventArguments args) {

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/BreakpointVerificationTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/BreakpointVerificationTest.java
@@ -24,7 +24,6 @@ import org.ballerinalang.debugger.test.utils.BallerinaTestDebugPoint;
 import org.ballerinalang.debugger.test.utils.DebugTestRunner;
 import org.ballerinalang.debugger.test.utils.DebugUtils;
 import org.ballerinalang.test.context.BallerinaTestException;
-import org.eclipse.lsp4j.debug.Breakpoint;
 import org.eclipse.lsp4j.debug.SetBreakpointsResponse;
 import org.eclipse.lsp4j.debug.StoppedEventArguments;
 import org.testng.Assert;

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/BreakpointVerificationTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/BreakpointVerificationTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2022 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.debugger.test.adapter;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.ballerinalang.debugger.test.BaseTestCase;
+import org.ballerinalang.debugger.test.utils.BallerinaTestDebugPoint;
+import org.ballerinalang.debugger.test.utils.DebugTestRunner;
+import org.ballerinalang.debugger.test.utils.DebugUtils;
+import org.ballerinalang.test.context.BallerinaTestException;
+import org.eclipse.lsp4j.debug.StoppedEventArguments;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Test implementation for debug breakpoint verification scenarios.
+ */
+public class BreakpointVerificationTest extends BaseTestCase {
+
+    DebugTestRunner debugTestRunner;
+    private static final int SRC_LINE_COUNT = 115; // last line number of the debug source.
+
+    private static final int ENUM_DCLN_START = 17;
+    private static final int CLASS_DEFN_START = ENUM_DCLN_START + 6;
+    private static final int TYPE_DEFN_START = CLASS_DEFN_START + 16;
+    private static final int IF_STATEMENT_START = TYPE_DEFN_START + 20;
+    private static final int WHILE_LOOP_START = IF_STATEMENT_START + 9;
+    private static final int FOREACH_LOOP_START = WHILE_LOOP_START + 10;
+    private static final int MATCH_STMT_START = FOREACH_LOOP_START + 10;
+    private static final int DOCUMENTATION_START = MATCH_STMT_START + 8;
+    private static final int WORKER_DCLN_START = DOCUMENTATION_START + 10;
+
+    @BeforeClass
+    public void setup() {
+        String testProjectName = "breakpoint-verification-tests";
+        String testModuleFileName = "main.bal";
+        debugTestRunner = new DebugTestRunner(testProjectName, testModuleFileName, true);
+    }
+
+    @Test(description = "Test to assert runtime verification on breakpoints which were added before starting a " +
+            "debug session")
+    public void testInitialBreakpointVerification() throws BallerinaTestException {
+        // Adds breakpoints for all the lines in the source.
+        for (int line = 1; line <= SRC_LINE_COUNT; line++) {
+            debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, line));
+        }
+
+        debugTestRunner.initDebugSession(DebugUtils.DebuggeeExecutionKind.RUN);
+        Pair<BallerinaTestDebugPoint, StoppedEventArguments> debugHitInfo = debugTestRunner.waitForDebugHit(25000);
+        debugTestRunner.resumeProgram(debugHitInfo.getRight(), DebugTestRunner.DebugResumeKind.NEXT_BREAKPOINT);
+        debugHitInfo = debugTestRunner.waitForDebugHit(10000);
+        debugTestRunner.resumeProgram(debugHitInfo.getRight(), DebugTestRunner.DebugResumeKind.NEXT_BREAKPOINT);
+        debugHitInfo = debugTestRunner.waitForDebugHit(10000);
+        debugTestRunner.resumeProgram(debugHitInfo.getRight(), DebugTestRunner.DebugResumeKind.NEXT_BREAKPOINT);
+        debugHitInfo = debugTestRunner.waitForDebugHit(10000);
+
+        List<BallerinaTestDebugPoint> changedBreakpoints = debugTestRunner.waitForModifiedBreakpoints(2000);
+        assertBreakpointChanges(changedBreakpoints);
+    }
+
+    @Test(description = "Test to assert runtime verification on breakpoints which are getting added on-the-fly " +
+            "during a debug session")
+    public void testOnTheFlyBreakpointVerification() throws BallerinaTestException {
+
+    }
+
+    private void assertBreakpointChanges(List<BallerinaTestDebugPoint> breakpoints) {
+        // if statement
+        assertVerifiedBreakpoints(breakpoints, IF_STATEMENT_START, 7, true, true, true, true, false, true, false);
+        // while statement
+        assertVerifiedBreakpoints(breakpoints, WHILE_LOOP_START, 8, true, true, true, true, false, true, true, false);
+        // foreach statement
+        assertVerifiedBreakpoints(breakpoints, MATCH_STMT_START, 5, true, true, true, false, false);
+        // documentation statement
+        assertVerifiedBreakpoints(breakpoints, DOCUMENTATION_START, 4, false, false, false, false);
+
+        // enum declaration
+        assertVerifiedBreakpoints(breakpoints, ENUM_DCLN_START, 5, false, false, false, false, false);
+        // class definition
+        assertVerifiedBreakpoints(breakpoints, CLASS_DEFN_START, 15, false, false, false, true, true, true, false,
+                false, true, true, false, false, true, true, false);
+        // type definition
+        assertVerifiedBreakpoints(breakpoints, TYPE_DEFN_START, 5, false, false, false, false, true);
+        // worker declarations
+        assertVerifiedBreakpoints(breakpoints, WORKER_DCLN_START, 9, true, true, false, false, true, true, false, false,
+                true);
+    }
+
+    private void assertVerifiedBreakpoints(List<BallerinaTestDebugPoint> breakpoints, int startLine, int length,
+                                           boolean... expectedResults) {
+        Assert.assertEquals(length, expectedResults.length, "Number of expected breakpoints should be equal to" +
+                " the number of source lines");
+
+        for (int line = startLine; line < startLine + length; line++) {
+            int finalLine = line;
+            Optional<BallerinaTestDebugPoint> breakpointMatch = breakpoints.stream()
+                    .filter(debugPoint -> debugPoint.getLine() == finalLine)
+                    .findAny();
+
+            Assert.assertEquals(breakpointMatch.isPresent() && breakpointMatch.get().isVerified(),
+                    expectedResults[line - startLine], "Mismatching breakpoint verification status at line: " + line);
+        }
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void cleanUp() {
+        debugTestRunner.terminateDebugSession();
+    }
+}

--- a/tests/jballerina-debugger-integration-test/src/test/resources/project-based-tests/breakpoint-verification-tests/Ballerina.toml
+++ b/tests/jballerina-debugger-integration-test/src/test/resources/project-based-tests/breakpoint-verification-tests/Ballerina.toml
@@ -1,0 +1,5 @@
+[package]
+org = "debug_test_resources"
+name = "bp_verification_tests"
+version = "0.1.0"
+

--- a/tests/jballerina-debugger-integration-test/src/test/resources/project-based-tests/breakpoint-verification-tests/main.bal
+++ b/tests/jballerina-debugger-integration-test/src/test/resources/project-based-tests/breakpoint-verification-tests/main.bal
@@ -1,0 +1,115 @@
+// Copyright (c) 2022 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+enum Language {
+    ENG = "English",
+    TL = "Tamil",
+    SI = "Sinhala"
+}
+
+public class Counter {
+    private int n;
+
+    public function init(int n = 0) {
+        self.n = n;
+    }
+
+    public function get() returns int {
+        return self.n;
+    }
+
+    public function inc() {
+        self.n += 1;
+    }
+}
+
+type Headers record {
+    string 'from;
+    string to;
+    string subject?;
+};
+
+Headers h = {
+    'from: "John",
+    to: "Jill"
+};
+
+public function main() {
+    Counter ct = new();
+    Counter ct2 = new();
+    int v01_intVar = 10;
+    int v02_intVar = 1;
+    int v03_intVar = 5;
+    int z = 0;
+
+    // if statement
+    if (v02_intVar < 0 && v03_intVar == 5) {
+        z = 4;
+    } else if (v02_intVar > 0 && v03_intVar == 5) {
+        z = 5;
+    } else {
+        z = 6;
+    }
+
+    // while loop
+    int v04_intVar = 0;
+    while (true) {
+        if (v04_intVar >= 1) {
+            break;
+        }
+        v04_intVar = v04_intVar + 1;
+        z += 1;
+    }
+
+    // foreach loop
+    string[] v05_fruits = ["apple", "orange"];
+    foreach string v in v05_fruits {
+        string fruit = v;
+        z += 1;
+    }
+
+    // match statement
+    int[1] v06_intArray = [7];
+    int v07_intVar;
+    foreach var counter in v06_intArray {
+        match counter {
+            7 => {
+                v07_intVar = 7;
+            }
+        }
+    }
+}
+
+# Adds two integers.
+# + x - an integer
+# + y - another integer
+# + return - the sum of `x` and `y`
+public function add(int x, int y) returns int {
+    return x + y;
+}
+
+function altFetch(string urlA, string urlB) returns int|error {
+
+    worker A returns int|error {
+        return add(1, 2);
+    }
+
+    worker B returns int|error {
+        return add(3, 4);
+    }
+
+    return wait A | B;
+}

--- a/tests/jballerina-debugger-integration-test/src/test/resources/testng.xml
+++ b/tests/jballerina-debugger-integration-test/src/test/resources/testng.xml
@@ -63,6 +63,7 @@ under the License.
             <class name="org.ballerinalang.debugger.test.adapter.run.DebugEngageTest"/>
             <class name="org.ballerinalang.debugger.test.adapter.DebugOutputTest"/>
             <class name="org.ballerinalang.debugger.test.adapter.RecursiveDebugTest"/>
+            <class name="org.ballerinalang.debugger.test.adapter.BreakpointVerificationTest"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
## Purpose
Currently the debugger users can configure breakpoints on any line of their source code. But in order to a breakpoint to be valid, it should be set on an executable line of code. 

With this new support, the debugger will verify all valid breakpoints in the current debug source, using the line number table information from the Ballerina runtime. Therefore the breakpoints that are set on Ballerina line comments, documentation , blank lines, declarations, and other non-executable lines of code will be marked as `unverified` by the Ballerina debug server.

Fixes #34438.

## Samples
![ezgif com-gif-maker (5)](https://user-images.githubusercontent.com/29032600/156994109-3f74f3c1-ac5c-4045-a693-cbeb028dad6b.gif)


## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [x] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [x] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
