### PR TITLE
[1.2.x] Fix `java.lang.NoClassDefFoundError` issue in openAPI validator

### DIFF
--- a/distribution/zip/jballerina-tools/build.gradle
+++ b/distribution/zip/jballerina-tools/build.gradle
@@ -69,10 +69,11 @@ configurations {
 
 dependencies {
     dist 'org.bytedeco:javacpp:1.4.2'
-    dist 'com.fasterxml.jackson.core:jackson-databind:2.12.4'
-    dist 'com.fasterxml.jackson.core:jackson-core:2.12.4'
-    dist 'com.fasterxml.jackson.core:jackson-annotations:2.12.4'
-    dist 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.9.8'
+    dist 'com.fasterxml.jackson.core:jackson-databind:2.13.1'
+    dist 'com.fasterxml.jackson.core:jackson-core:2.13.1'
+    dist 'com.fasterxml.jackson.core:jackson-annotations:2.13.1'
+    dist 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.1'
+    dist 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.1'
     // dist 'org.ow2.asm:asm:6.2.1'
     dist 'org.codehaus.woodstox:woodstox-core-asl:4.2.0'
     dist 'org.codehaus.woodstox:stax2-api:3.1.1'

--- a/gradle/javaProject.gradle
+++ b/gradle/javaProject.gradle
@@ -35,8 +35,8 @@ dependencies {
         implementation 'commons-logging:commons-logging:1.1.1'
         implementation 'com.atlassian.commonmark:commonmark:0.11.0'
         implementation 'com.atlassian.commonmark:commonmark-ext-gfm-tables:0.11.0'
-        implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.4'
-        implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.9.8'
+        implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.1'
+        implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.1'
         implementation 'com.h2database:h2:1.4.199'
         implementation 'org.hsqldb:hsqldb:2.2.7'
         implementation 'com.wix:wix-embedded-mysql:4.6.1'
@@ -119,9 +119,9 @@ dependencies {
         implementation 'io.opentracing:opentracing-api:0.33.0'
         implementation 'io.opentracing:opentracing-util:0.33.0'
         implementation 'io.opentracing:opentracing-mock:0.33.0'
-        implementation 'io.swagger.core.v3:swagger-models:1.5.18'
-        implementation 'io.swagger.parser.v3:swagger-parser:2.0.14'
-        implementation 'io.swagger.parser.v3:swagger-parser-v2-converter:2.0.14'
+        implementation "io.swagger.core.v3:swagger-models:2.1.11"
+        implementation "io.swagger.parser.v3:swagger-parser-v2-converter:2.0.28"
+        implementation "io.swagger.parser.v3:swagger-parser:2.0.28"
         implementation 'me.tongfei:progressbar:0.7.4'
         implementation 'org.jline:jline:3.11.0'
 

--- a/gradle/javaProject.gradle
+++ b/gradle/javaProject.gradle
@@ -119,9 +119,9 @@ dependencies {
         implementation 'io.opentracing:opentracing-api:0.33.0'
         implementation 'io.opentracing:opentracing-util:0.33.0'
         implementation 'io.opentracing:opentracing-mock:0.33.0'
-        implementation "io.swagger.core.v3:swagger-models:2.1.11"
-        implementation "io.swagger.parser.v3:swagger-parser-v2-converter:2.0.28"
-        implementation "io.swagger.parser.v3:swagger-parser:2.0.28"
+        implementation 'io.swagger.core.v3:swagger-models:2.1.11'
+        implementation 'io.swagger.parser.v3:swagger-parser-v2-converter:2.0.28'
+        implementation 'io.swagger.parser.v3:swagger-parser:2.0.28'
         implementation 'me.tongfei:progressbar:0.7.4'
         implementation 'org.jline:jline:3.11.0'
 


### PR DESCRIPTION
## Purpose
>
` java.lang.NoClassDefFoundError`  error was observed when building a project using Ballerina 1.2.25 release. The same code works in Ballerina 1.2.16. It happened due to a dependence version update.

Fixes [https://github.com/ballerina-platform/openapi-tools/issues/921](https://github.com/ballerina-platform/openapi-tools/issues/921)

## Approach
> Update the Jackson data format dependency and swagger dependencies to the latest versions. and add the necessary dependencies (jackson-datatype-jsr310) for the latest update versions.


 

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
