### PR TITLE
Fix the caching of complex types in separate config schema builder invocations

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/configschema/ConfigSchemaBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/configschema/ConfigSchemaBuilder.java
@@ -44,7 +44,7 @@ public class ConfigSchemaBuilder {
      * @param configDetails Map of configurable variables against module
      * @return config schema JSON content as String
      */
-    public static String getConfigSchemaContent(Map<ConfigModuleDetails, List<ConfigVariable>> configDetails) {
+    public String getConfigSchemaContent(Map<ConfigModuleDetails, List<ConfigVariable>> configDetails) {
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
         return gson.toJson(getRootNode(configDetails));
     }
@@ -55,7 +55,7 @@ public class ConfigSchemaBuilder {
      * @param configDetails Map of configurable variables against module
      * @return JsonObject with configurable details
      */
-    private static JsonObject getRootNode(Map<ConfigModuleDetails, List<ConfigVariable>> configDetails) {
+    private JsonObject getRootNode(Map<ConfigModuleDetails, List<ConfigVariable>> configDetails) {
         JsonObject rootNode = new JsonObject();
         // Create root node
         JsonObject root = new JsonObject();
@@ -144,10 +144,10 @@ public class ConfigSchemaBuilder {
      * @param node            JSONObject to set the configurable details
      * @return JSONObject with configurable details
      */
-    private static JsonObject setConfigVariables(List<ConfigVariable> configVariables,
+    private JsonObject setConfigVariables(List<ConfigVariable> configVariables,
                                                  JsonObject node) {
         for (ConfigVariable configVariable : configVariables) {
-            JsonObject typeNode = TypeConverter.getType(configVariable.type());
+            JsonObject typeNode = new TypeConverter().getType(configVariable.type());
             typeNode.addProperty("description", configVariable.description());
             node.add(configVariable.name(), typeNode);
         }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/configschema/TypeConverter.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/configschema/TypeConverter.java
@@ -55,20 +55,20 @@ public class TypeConverter {
     static final String ADDITIONAL_PROPERTIES = "additionalProperties";
     static final String TYPE = "type";
     // Stores already visited complex types against the type name
-    private static Map<String, VisitedType> visitedTypeMap = new HashMap<>();
+    private Map<String, VisitedType> visitedTypeMap = new HashMap<>();
 
-    public static VisitedType getVisitedType(String typeName) {
+    private VisitedType getVisitedType(String typeName) {
         if (visitedTypeMap.containsKey(typeName)) {
             return visitedTypeMap.get(typeName);
         }
         return null;
     }
 
-    public static void addVisitedTypeEntry(String typeName) {
+    public void addVisitedTypeEntry(String typeName) {
         visitedTypeMap.put(typeName, new VisitedType());
     }
 
-    public static void completeVisitedTypeEntry(String typeName, JsonObject typeNode) {
+    private void completeVisitedTypeEntry(String typeName, JsonObject typeNode) {
         VisitedType visitedType = visitedTypeMap.get(typeName);
         visitedType.setCompleted(true);
         visitedType.setTypeNode(typeNode);
@@ -80,7 +80,7 @@ public class TypeConverter {
      * @param type Ballerina type as BType
      * @return JsonObject with type details
      */
-    static JsonObject getType(BType type) {
+    JsonObject getType(BType type) {
         JsonObject typeNode = new JsonObject();
         if (TypeTags.isSimpleBasicType(type.tag)) {
             String typeVal = getSimpleType(type);
@@ -132,7 +132,7 @@ public class TypeConverter {
         return typeNode;
     }
 
-    private static void generateTableType(JsonObject typeNode, BTableType effectiveType) {
+    private void generateTableType(JsonObject typeNode, BTableType effectiveType) {
         typeNode.addProperty(TYPE, "array");
         typeNode.add("items", getType(effectiveType.getConstraint()));
     }
@@ -143,7 +143,7 @@ public class TypeConverter {
      * @param typeNode JsonObject representing type
      * @param effectiveType  BArrayType with array details
      */
-    private static void generateArrayType(JsonObject typeNode, BArrayType effectiveType) {
+    private void generateArrayType(JsonObject typeNode, BArrayType effectiveType) {
         typeNode.addProperty(TYPE, "array");
         typeNode.add("items", getType(effectiveType.getElementType()));
     }
@@ -154,7 +154,7 @@ public class TypeConverter {
      * @param effectiveType BRecordType with record details
      * @return JsonObject with record details
      */
-    private static JsonObject generateRecordType(BRecordType effectiveType) {
+    private JsonObject generateRecordType(BRecordType effectiveType) {
         JsonObject typeNode;
         LinkedHashMap<String, BField> fieldLinkedHashMap = effectiveType.getFields();
         JsonObject effectiveTypeNode = new JsonObject();
@@ -181,9 +181,9 @@ public class TypeConverter {
      * @param typeNode JsonObject representing type
      * @param effectiveType  BMapType with map details
      */
-    private static void generateMapType(JsonObject typeNode, BMapType effectiveType) {
+    private void generateMapType(JsonObject typeNode, BMapType effectiveType) {
         typeNode.addProperty(TYPE, "object");
-        typeNode.add("additionalProperties", getType(effectiveType.getConstraint()));
+        typeNode.add(ADDITIONAL_PROPERTIES, getType(effectiveType.getConstraint()));
     }
 
     /**
@@ -192,7 +192,7 @@ public class TypeConverter {
      * @param typeNode JsonObject representing type
      * @param effectiveType  BUnionType with union details
      */
-    private static void generateUnionType(JsonObject typeNode, BUnionType effectiveType) {
+    private void generateUnionType(JsonObject typeNode, BUnionType effectiveType) {
         LinkedHashSet<BType> members = effectiveType.getMemberTypes();
         JsonArray memberArray = new JsonArray();
         JsonArray enumArray = new JsonArray();
@@ -217,7 +217,7 @@ public class TypeConverter {
      * @param memberArray JSON array to hold non-enum union members
      * @param enumArray JSON array to hold enum union members
      */
-    private static void updateUnionMembers(LinkedHashSet<BType> members, JsonArray memberArray, JsonArray enumArray) {
+    private void updateUnionMembers(LinkedHashSet<BType> members, JsonArray memberArray, JsonArray enumArray) {
         for (BType member : members) {
             if (TypeTags.isSimpleBasicType(member.tag) ||
                     (TypeTags.INTERSECTION == member.tag && member instanceof BIntersectionType)) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/packages/BallerinaPackageService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/packages/BallerinaPackageService.java
@@ -125,7 +125,7 @@ public class BallerinaPackageService implements ExtendedLanguageServerService {
                     throw new UserErrorException("Project not found.");
                 }
                 Package currentPackage = project.get().currentPackage();
-                response.setConfigSchema(ConfigSchemaBuilder.getConfigSchemaContent(
+                response.setConfigSchema(new ConfigSchemaBuilder().getConfigSchemaContent(
                         ConfigReader.getConfigVariables(currentPackage)));
             } catch (Exception e) {
                 String msg = "Operation 'ballerinaPackage/configSchema' failed!";

--- a/misc/compiler-plugins/modules/configurable-schema-generator/src/main/java/org/ballerinalang/config/schema/generator/ConfigSchemaGenTask.java
+++ b/misc/compiler-plugins/modules/configurable-schema-generator/src/main/java/org/ballerinalang/config/schema/generator/ConfigSchemaGenTask.java
@@ -44,7 +44,7 @@ public class ConfigSchemaGenTask implements AnalysisTask<CompilationAnalysisCont
     @Override
     public void perform(CompilationAnalysisContext compilationAnalysisContext) {
         if (compilationAnalysisContext.currentPackage().compilationOptions().configSchemaGen()) {
-            String schema = ConfigSchemaBuilder.getConfigSchemaContent(ConfigReader.getConfigVariables(
+            String schema = new ConfigSchemaBuilder().getConfigSchemaContent(ConfigReader.getConfigVariables(
                     compilationAnalysisContext.currentPackage()));
             writeConfigJSONSchema(schema, compilationAnalysisContext.currentPackage().project());
         }

--- a/misc/compiler-plugins/modules/configurable-schema-generator/src/test/resources/DefaultModuleProjects/ComplexTypeConfigs2/expected-schema.json
+++ b/misc/compiler-plugins/modules/configurable-schema-generator/src/test/resources/DefaultModuleProjects/ComplexTypeConfigs2/expected-schema.json
@@ -70,8 +70,7 @@
                 "type": "object",
                 "additionalProperties": {
                   "type": "integer"
-                },
-                "description": ""
+                }
               },
               "description": ""
             },
@@ -134,8 +133,7 @@
                     "name",
                     "salary"
                   ]
-                },
-                "description": ""
+                }
               },
               "description": ""
             }

--- a/misc/compiler-plugins/modules/configurable-schema-generator/src/test/resources/DefaultModuleProjects/ComplexTypeConfigs3/expected-schema.json
+++ b/misc/compiler-plugins/modules/configurable-schema-generator/src/test/resources/DefaultModuleProjects/ComplexTypeConfigs3/expected-schema.json
@@ -359,7 +359,7 @@
                 "credentialBearer",
                 "clientConfig"
               ],
-              "description": "Set Up Gmail Connection"
+              "description": "Set Up Google Sheets Connection"
             },
             "spreadsheetId": {
               "type": "string",


### PR DESCRIPTION
## Purpose
In the current implementation, the config schema builder caches complex types even during separate invocations. This prevents the reflection of changes done to these complex types during separate config schema builder invocations.

Fixes https://github.com/wso2-enterprise/choreo/issues/11542

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
