### PR TITLE
Modify treegen to allow "createdYear" in new node license header

### DIFF
--- a/compiler/ballerina-treegen/src/main/java/io/ballerinalang/compiler/internal/treegen/model/json/SyntaxNode.java
+++ b/compiler/ballerina-treegen/src/main/java/io/ballerinalang/compiler/internal/treegen/model/json/SyntaxNode.java
@@ -32,19 +32,22 @@ public class SyntaxNode {
     private String base;
     private String type;
     private boolean isAbstract;
+    private String createdYear;
 
     public SyntaxNode(String name,
                       List<SyntaxNodeAttribute> attributes,
                       String kind,
                       String base,
                       String type,
-                      boolean isAbstract) {
+                      boolean isAbstract,
+                      String createdYear) {
         this.name = name;
         this.attributes = attributes;
         this.kind = kind;
         this.base = base;
         this.type = type;
         this.isAbstract = isAbstract;
+        this.createdYear = createdYear;
     }
 
     public SyntaxNode() {
@@ -73,5 +76,9 @@ public class SyntaxNode {
 
     public boolean isAbstract() {
         return isAbstract;
+    }
+
+    public String getCreatedYear() {
+        return createdYear;
     }
 }

--- a/compiler/ballerina-treegen/src/main/java/io/ballerinalang/compiler/internal/treegen/model/template/TreeNodeClass.java
+++ b/compiler/ballerina-treegen/src/main/java/io/ballerinalang/compiler/internal/treegen/model/template/TreeNodeClass.java
@@ -36,6 +36,7 @@ public class TreeNodeClass {
     private final List<ImportClass> imports;
     private final List<Field> fields;
     private final String syntaxKind;
+    private final String createdYear;
 
     private final String externalClassName;
     private final String internalClassName;
@@ -48,13 +49,15 @@ public class TreeNodeClass {
                          boolean isAbstract,
                          String superClassName,
                          List<Field> fields,
-                         String syntaxKind) {
+                         String syntaxKind,
+                         String createdYear) {
         this.packageName = packageName;
         this.isAbstract = isAbstract;
         this.superClassName = superClassName;
         this.imports = new ArrayList<>();
         this.fields = fields;
         this.syntaxKind = syntaxKind;
+        this.createdYear = createdYear == null ? "2020" : createdYear;
 
         this.externalClassName = className;
         this.internalClassName = INTERNAL_NODE_CLASS_NAME_PREFIX + className;
@@ -85,6 +88,10 @@ public class TreeNodeClass {
 
     public String syntaxKind() {
         return syntaxKind;
+    }
+
+    public String createdYear() {
+        return createdYear;
     }
 
     public String externalClassName() {

--- a/compiler/ballerina-treegen/src/main/java/io/ballerinalang/compiler/internal/treegen/targets/Target.java
+++ b/compiler/ballerina-treegen/src/main/java/io/ballerinalang/compiler/internal/treegen/targets/Target.java
@@ -64,7 +64,7 @@ public abstract class Target {
                                                    List<String> importClassNameList) {
         TreeNodeClass nodeClass = new TreeNodeClass(packageName,
                 syntaxNode.getName(), syntaxNode.isAbstract(), syntaxNode.getBase(),
-                getFields(syntaxNode), syntaxNode.getKind());
+                getFields(syntaxNode), syntaxNode.getKind(), syntaxNode.getCreatedYear());
 
         // TODO Can we pass this as part of the constructor
         nodeClass.addImports(importClassNameList);

--- a/compiler/ballerina-treegen/src/main/resources/external_node_template.mustache
+++ b/compiler/ballerina-treegen/src/main/resources/external_node_template.mustache
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) {{createdYear}}, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except

--- a/compiler/ballerina-treegen/src/main/resources/internal_node_template.mustache
+++ b/compiler/ballerina-treegen/src/main/resources/internal_node_template.mustache
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) {{createdYear}}, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except


### PR DESCRIPTION
## Purpose
$subject.

Fixes #31047 

## Approach
- Add `createdYear` property to `syntax_tree_descriptor.json`. In absence of specification, it is defaulted to "2020". 
- `{{createdYear}}` variable was only introduced to `internal_node_template.mustache` & `external_node_template.mustache`
as other template license headers are not impacted on new node creation.

## Samples
To test, add the following to [syntax_tree_descriptor.json](https://github.com/ballerina-platform/ballerina-lang/blob/master/compiler/ballerina-treegen/src/main/resources/syntax_tree_descriptor.json) and run `./gradlew treegen`.
```json
        {
            "name": "SpreadMemberNode",
            "base": "Node",
            "kind": "SPREAD_MEMBER",
            "createdYear": "2022",
            "attributes": [
                {
                    "name": "ellipsis",
                    "type": "Token"
                },
                {
                    "name": "expression",
                    "type": "ExpressionNode"
                }
            ]
        }
```
To test the default behavior you can remove the `"createdYear": "2022"` property.

## Remarks
N/A

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples