### PR TITLE
Add `toTable` util into InlineTableValueNode

### DIFF
--- a/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/ast/TomlInlineTableValueNode.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/ast/TomlInlineTableValueNode.java
@@ -50,7 +50,7 @@ public class TomlInlineTableValueNode extends TomlValueNode {
      * Get a single element of the array based on the Index.
      *
      * @param index index of the element
-     * @param <T> Type of the element
+     * @param <T>   Type of the element
      * @return Element object
      */
     public <T extends TopLevelNode> T get(int index) {
@@ -106,7 +106,7 @@ public class TomlInlineTableValueNode extends TomlValueNode {
         }
         return list;
     }
-    
+
     public TomlTableNode toTable() {
         Map<String, TopLevelNode> table = new HashMap<>();
         for (TopLevelNode node : elements) {
@@ -115,14 +115,14 @@ public class TomlInlineTableValueNode extends TomlValueNode {
         return new TomlTableNode((InlineTableNode) this.externalTreeNode(), generateKey(), false,
                 this.location(), table);
     }
-    
+
     private TomlKeyNode generateKey() {
-        String inlineValueKey = "__inline_value";
+        String tableKey = "__inline_value";
         IdentifierLiteralNode key =
-                NodeFactory.createIdentifierLiteralNode(NodeFactory.createIdentifierToken(inlineValueKey));
-        TomlKeyEntryNode root = new TomlKeyEntryNode(key, new TomlUnquotedKeyNode(key, inlineValueKey, this.location()));
+                NodeFactory.createIdentifierLiteralNode(NodeFactory.createIdentifierToken(tableKey));
+        TomlKeyEntryNode root = new TomlKeyEntryNode(key, new TomlUnquotedKeyNode(key, tableKey, this.location()));
         List<TomlKeyEntryNode> tomlKeyEntryNodes = Collections.singletonList(root);
-        return  new TomlKeyNode(NodeFactory.createKeyNode(NodeFactory.createSeparatedNodeList(key)),
+        return new TomlKeyNode(NodeFactory.createKeyNode(NodeFactory.createSeparatedNodeList(key)),
                 tomlKeyEntryNodes, this.location());
     }
 }

--- a/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/ast/TomlInlineTableValueNode.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/ast/TomlInlineTableValueNode.java
@@ -20,11 +20,16 @@ package io.ballerina.toml.semantic.ast;
 
 import io.ballerina.toml.semantic.TomlType;
 import io.ballerina.toml.semantic.diagnostics.TomlNodeLocation;
+import io.ballerina.toml.syntax.tree.IdentifierLiteralNode;
 import io.ballerina.toml.syntax.tree.InlineTableNode;
+import io.ballerina.toml.syntax.tree.NodeFactory;
 import io.ballerina.tools.diagnostics.Diagnostic;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -100,5 +105,24 @@ public class TomlInlineTableValueNode extends TomlValueNode {
             list.add(element.toNativeObject());
         }
         return list;
+    }
+    
+    public TomlTableNode toTable() {
+        Map<String, TopLevelNode> table = new HashMap<>();
+        for (TopLevelNode node : elements) {
+            table.put(node.key().name(), node);
+        }
+        return new TomlTableNode((InlineTableNode) this.externalTreeNode(), generateKey(), false,
+                this.location(), table);
+    }
+    
+    private TomlKeyNode generateKey() {
+        String inlineValueKey = "__inline_value";
+        IdentifierLiteralNode key =
+                NodeFactory.createIdentifierLiteralNode(NodeFactory.createIdentifierToken(inlineValueKey));
+        TomlKeyEntryNode root = new TomlKeyEntryNode(key, new TomlUnquotedKeyNode(key, inlineValueKey, this.location()));
+        List<TomlKeyEntryNode> tomlKeyEntryNodes = Collections.singletonList(root);
+        return  new TomlKeyNode(NodeFactory.createKeyNode(NodeFactory.createSeparatedNodeList(key)),
+                tomlKeyEntryNodes, this.location());
     }
 }

--- a/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/ast/TomlTableNode.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/ast/TomlTableNode.java
@@ -22,6 +22,7 @@ import io.ballerina.toml.semantic.TomlType;
 import io.ballerina.toml.semantic.diagnostics.TomlNodeLocation;
 import io.ballerina.toml.syntax.tree.DocumentMemberDeclarationNode;
 import io.ballerina.toml.syntax.tree.DocumentNode;
+import io.ballerina.toml.syntax.tree.InlineTableNode;
 import io.ballerina.toml.syntax.tree.KeyValueNode;
 import io.ballerina.toml.syntax.tree.Node;
 import io.ballerina.toml.syntax.tree.SyntaxKind;
@@ -79,6 +80,13 @@ public class TomlTableNode extends TopLevelNode {
     public TomlTableNode(KeyValueNode keyValueNode, TomlKeyNode key, boolean generated, TomlNodeLocation location,
                          Map<String, TopLevelNode> entries) {
         super(keyValueNode, key, TomlType.TABLE, location);
+        this.entries = entries;
+        this.generated = generated;
+    }
+
+    public TomlTableNode(InlineTableNode tableNode, TomlKeyNode key, boolean generated, TomlNodeLocation location,
+                         Map<String, TopLevelNode> entries) {
+        super(tableNode, key, TomlType.INLINE_TABLE, location);
         this.entries = entries;
         this.generated = generated;
     }

--- a/misc/toml-parser/src/test/java/toml/parser/test/api/core/KeyValueTest.java
+++ b/misc/toml-parser/src/test/java/toml/parser/test/api/core/KeyValueTest.java
@@ -412,25 +412,25 @@ public class KeyValueTest {
         Assert.assertEquals(arrVal2.getValue(), "how are youu");
 
         TomlArrayValueNode arrSample = (TomlArrayValueNode) read.get("arrSample").get();
-        Assert.assertEquals(((TomlStringValueNode)arrSample.get(2)).getValue(), "hello");
+        Assert.assertEquals(((TomlStringValueNode) arrSample.get(2)).getValue(), "hello");
 
         TomlInlineTableValueNode inlineTable1 = arrSample.get(0);
         TomlKeyValueNode inlineTable1Val1 = (TomlKeyValueNode) inlineTable1.elements().get(0);
-        Assert.assertEquals(inlineTable1Val1.key().name(),"first");
-        Assert.assertEquals(((TomlStringValueNode)inlineTable1Val1.value()).getValue(),"yagami");
+        Assert.assertEquals(inlineTable1Val1.key().name(), "first");
+        Assert.assertEquals(((TomlStringValueNode) inlineTable1Val1.value()).getValue(), "yagami");
 
         TomlInlineTableValueNode inlineTable2 = arrSample.get(1);
         TomlKeyValueNode inlineTable2Val1 = (TomlKeyValueNode) inlineTable2.elements().get(0);
-        Assert.assertEquals(inlineTable2Val1.key().name(),"first");
-        Assert.assertEquals(((TomlStringValueNode)inlineTable2Val1.value()).getValue(),"Anjana");
+        Assert.assertEquals(inlineTable2Val1.key().name(), "first");
+        Assert.assertEquals(((TomlStringValueNode) inlineTable2Val1.value()).getValue(), "Anjana");
 
         TomlTableNode convertedTable = inlineTable2.toTable();
         Map<String, TopLevelNode> entries = convertedTable.entries();
-        
+
         TomlValueNode firstVal = ((TomlKeyValueNode) entries.get("first")).value();
-        Assert.assertEquals(((TomlStringValueNode)firstVal).getValue(), "Anjana");
+        Assert.assertEquals(((TomlStringValueNode) firstVal).getValue(), "Anjana");
 
         TomlValueNode lsatVal = ((TomlKeyValueNode) entries.get("last")).value();
-        Assert.assertEquals(((TomlStringValueNode)lsatVal).getValue(), "Supun");
+        Assert.assertEquals(((TomlStringValueNode) lsatVal).getValue(), "Supun");
     }
 }

--- a/misc/toml-parser/src/test/java/toml/parser/test/api/core/KeyValueTest.java
+++ b/misc/toml-parser/src/test/java/toml/parser/test/api/core/KeyValueTest.java
@@ -28,6 +28,7 @@ import io.ballerina.toml.semantic.ast.TomlLongValueNode;
 import io.ballerina.toml.semantic.ast.TomlStringValueNode;
 import io.ballerina.toml.semantic.ast.TomlTableNode;
 import io.ballerina.toml.semantic.ast.TomlValueNode;
+import io.ballerina.toml.semantic.ast.TopLevelNode;
 import io.ballerina.tools.text.LineRange;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -36,6 +37,7 @@ import toml.parser.test.ParserTestUtils;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -408,5 +410,27 @@ public class KeyValueTest {
         TomlStringValueNode arrVal2 =
                 (TomlStringValueNode) (read.getTables("tableArr").get(1).get("name.nested.greeting").get());
         Assert.assertEquals(arrVal2.getValue(), "how are youu");
+
+        TomlArrayValueNode arrSample = (TomlArrayValueNode) read.get("arrSample").get();
+        Assert.assertEquals(((TomlStringValueNode)arrSample.get(2)).getValue(), "hello");
+
+        TomlInlineTableValueNode inlineTable1 = arrSample.get(0);
+        TomlKeyValueNode inlineTable1Val1 = (TomlKeyValueNode) inlineTable1.elements().get(0);
+        Assert.assertEquals(inlineTable1Val1.key().name(),"first");
+        Assert.assertEquals(((TomlStringValueNode)inlineTable1Val1.value()).getValue(),"yagami");
+
+        TomlInlineTableValueNode inlineTable2 = arrSample.get(1);
+        TomlKeyValueNode inlineTable2Val1 = (TomlKeyValueNode) inlineTable2.elements().get(0);
+        Assert.assertEquals(inlineTable2Val1.key().name(),"first");
+        Assert.assertEquals(((TomlStringValueNode)inlineTable2Val1.value()).getValue(),"Anjana");
+
+        TomlTableNode convertedTable = inlineTable2.toTable();
+        Map<String, TopLevelNode> entries = convertedTable.entries();
+        
+        TomlValueNode firstVal = ((TomlKeyValueNode) entries.get("first")).value();
+        Assert.assertEquals(((TomlStringValueNode)firstVal).getValue(), "Anjana");
+
+        TomlValueNode lsatVal = ((TomlKeyValueNode) entries.get("last")).value();
+        Assert.assertEquals(((TomlStringValueNode)lsatVal).getValue(), "Supun");
     }
 }

--- a/misc/toml-parser/src/test/resources/syntax/key-value/inline-tables.json
+++ b/misc/toml-parser/src/test/resources/syntax/key-value/inline-tables.json
@@ -663,6 +663,396 @@
           ]
         },
         {
+          "kind": "KEY_VALUE",
+          "children": [
+            {
+              "kind": "KEY",
+              "children": [
+                {
+                  "kind": "LIST",
+                  "children": [
+                    {
+                      "kind": "IDENTIFIER_LITERAL",
+                      "children": [
+                        {
+                          "kind": "IDENTIFIER_LITERAL",
+                          "value": "arrSample",
+                          "leadingMinutiae": [
+                            {
+                              "kind": "END_OF_LINE_MINUTIAE",
+                              "value": "\n"
+                            }
+                          ],
+                          "trailingMinutiae": [
+                            {
+                              "kind": "WHITESPACE_MINUTIAE",
+                              "value": " "
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "EQUAL_TOKEN",
+              "trailingMinutiae": [
+                {
+                  "kind": "WHITESPACE_MINUTIAE",
+                  "value": " "
+                }
+              ]
+            },
+            {
+              "kind": "ARRAY",
+              "children": [
+                {
+                  "kind": "OPEN_BRACKET_TOKEN"
+                },
+                {
+                  "kind": "LIST",
+                  "children": [
+                    {
+                      "kind": "INLINE_TABLE",
+                      "children": [
+                        {
+                          "kind": "OPEN_BRACE_TOKEN",
+                          "trailingMinutiae": [
+                            {
+                              "kind": "WHITESPACE_MINUTIAE",
+                              "value": " "
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "LIST",
+                          "children": [
+                            {
+                              "kind": "KEY_VALUE",
+                              "children": [
+                                {
+                                  "kind": "KEY",
+                                  "children": [
+                                    {
+                                      "kind": "LIST",
+                                      "children": [
+                                        {
+                                          "kind": "IDENTIFIER_LITERAL",
+                                          "children": [
+                                            {
+                                              "kind": "IDENTIFIER_LITERAL",
+                                              "value": "first",
+                                              "trailingMinutiae": [
+                                                {
+                                                  "kind": "WHITESPACE_MINUTIAE",
+                                                  "value": " "
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "EQUAL_TOKEN",
+                                  "trailingMinutiae": [
+                                    {
+                                      "kind": "WHITESPACE_MINUTIAE",
+                                      "value": " "
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "STRING_LITERAL",
+                                  "children": [
+                                    {
+                                      "kind": "DOUBLE_QUOTE_TOKEN"
+                                    },
+                                    {
+                                      "kind": "IDENTIFIER_LITERAL",
+                                      "value": "yagami"
+                                    },
+                                    {
+                                      "kind": "DOUBLE_QUOTE_TOKEN"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "COMMA_TOKEN",
+                              "trailingMinutiae": [
+                                {
+                                  "kind": "WHITESPACE_MINUTIAE",
+                                  "value": " "
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "KEY_VALUE",
+                              "children": [
+                                {
+                                  "kind": "KEY",
+                                  "children": [
+                                    {
+                                      "kind": "LIST",
+                                      "children": [
+                                        {
+                                          "kind": "IDENTIFIER_LITERAL",
+                                          "children": [
+                                            {
+                                              "kind": "IDENTIFIER_LITERAL",
+                                              "value": "last",
+                                              "trailingMinutiae": [
+                                                {
+                                                  "kind": "WHITESPACE_MINUTIAE",
+                                                  "value": " "
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "EQUAL_TOKEN",
+                                  "trailingMinutiae": [
+                                    {
+                                      "kind": "WHITESPACE_MINUTIAE",
+                                      "value": " "
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "STRING_LITERAL",
+                                  "children": [
+                                    {
+                                      "kind": "DOUBLE_QUOTE_TOKEN"
+                                    },
+                                    {
+                                      "kind": "IDENTIFIER_LITERAL",
+                                      "value": "light"
+                                    },
+                                    {
+                                      "kind": "DOUBLE_QUOTE_TOKEN",
+                                      "trailingMinutiae": [
+                                        {
+                                          "kind": "WHITESPACE_MINUTIAE",
+                                          "value": " "
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "CLOSE_BRACE_TOKEN"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "COMMA_TOKEN",
+                      "trailingMinutiae": [
+                        {
+                          "kind": "WHITESPACE_MINUTIAE",
+                          "value": " "
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "INLINE_TABLE",
+                      "children": [
+                        {
+                          "kind": "OPEN_BRACE_TOKEN",
+                          "trailingMinutiae": [
+                            {
+                              "kind": "WHITESPACE_MINUTIAE",
+                              "value": " "
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "LIST",
+                          "children": [
+                            {
+                              "kind": "KEY_VALUE",
+                              "children": [
+                                {
+                                  "kind": "KEY",
+                                  "children": [
+                                    {
+                                      "kind": "LIST",
+                                      "children": [
+                                        {
+                                          "kind": "IDENTIFIER_LITERAL",
+                                          "children": [
+                                            {
+                                              "kind": "IDENTIFIER_LITERAL",
+                                              "value": "first",
+                                              "trailingMinutiae": [
+                                                {
+                                                  "kind": "WHITESPACE_MINUTIAE",
+                                                  "value": " "
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "EQUAL_TOKEN",
+                                  "trailingMinutiae": [
+                                    {
+                                      "kind": "WHITESPACE_MINUTIAE",
+                                      "value": " "
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "STRING_LITERAL",
+                                  "children": [
+                                    {
+                                      "kind": "DOUBLE_QUOTE_TOKEN"
+                                    },
+                                    {
+                                      "kind": "IDENTIFIER_LITERAL",
+                                      "value": "Anjana"
+                                    },
+                                    {
+                                      "kind": "DOUBLE_QUOTE_TOKEN"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "COMMA_TOKEN",
+                              "trailingMinutiae": [
+                                {
+                                  "kind": "WHITESPACE_MINUTIAE",
+                                  "value": " "
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "KEY_VALUE",
+                              "children": [
+                                {
+                                  "kind": "KEY",
+                                  "children": [
+                                    {
+                                      "kind": "LIST",
+                                      "children": [
+                                        {
+                                          "kind": "IDENTIFIER_LITERAL",
+                                          "children": [
+                                            {
+                                              "kind": "IDENTIFIER_LITERAL",
+                                              "value": "last",
+                                              "trailingMinutiae": [
+                                                {
+                                                  "kind": "WHITESPACE_MINUTIAE",
+                                                  "value": " "
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "EQUAL_TOKEN",
+                                  "trailingMinutiae": [
+                                    {
+                                      "kind": "WHITESPACE_MINUTIAE",
+                                      "value": " "
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "STRING_LITERAL",
+                                  "children": [
+                                    {
+                                      "kind": "DOUBLE_QUOTE_TOKEN"
+                                    },
+                                    {
+                                      "kind": "IDENTIFIER_LITERAL",
+                                      "value": "Supun"
+                                    },
+                                    {
+                                      "kind": "DOUBLE_QUOTE_TOKEN",
+                                      "trailingMinutiae": [
+                                        {
+                                          "kind": "WHITESPACE_MINUTIAE",
+                                          "value": " "
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "CLOSE_BRACE_TOKEN"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "COMMA_TOKEN",
+                      "trailingMinutiae": [
+                        {
+                          "kind": "WHITESPACE_MINUTIAE",
+                          "value": " "
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "STRING_LITERAL",
+                      "children": [
+                        {
+                          "kind": "DOUBLE_QUOTE_TOKEN"
+                        },
+                        {
+                          "kind": "IDENTIFIER_LITERAL",
+                          "value": "hello"
+                        },
+                        {
+                          "kind": "DOUBLE_QUOTE_TOKEN"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "CLOSE_BRACKET_TOKEN",
+                  "trailingMinutiae": [
+                    {
+                      "kind": "END_OF_LINE_MINUTIAE",
+                      "value": "\n"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
           "kind": "TABLE",
           "children": [
             {

--- a/misc/toml-parser/src/test/resources/syntax/key-value/inline-tables.toml
+++ b/misc/toml-parser/src/test/resources/syntax/key-value/inline-tables.toml
@@ -6,6 +6,8 @@ inline = { parent.child = "hello" }
 
 emptyInline = {}
 
+arrSample = [{ first = "yagami", last = "light" }, { first = "Anjana", last = "Supun" }, "hello"]
+
 [table]
 inlineTable = { nested = { greeting = "hello"}, another = "Another one" }
 


### PR DESCRIPTION
## Purpose
Add `toTable` util into InlineTableValueNode which returns a new TomlTableNode. 
Resolves #35304

We need to completely hide InlineTableValueNode from the ast in array values after we fix the hierarchy.  properly. Issue is tracked from #35378

Fixes #<Issue Number>

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
