### PR TITLE
Remove moduleID param from type symbol constructors

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaAnyTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaAnyTypeSymbol.java
@@ -17,7 +17,6 @@
 
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SymbolTransformer;
 import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.AnyTypeSymbol;
@@ -32,7 +31,7 @@ import org.wso2.ballerinalang.compiler.util.CompilerContext;
  */
 public class BallerinaAnyTypeSymbol extends AbstractTypeSymbol implements AnyTypeSymbol {
 
-    public BallerinaAnyTypeSymbol(CompilerContext context, ModuleID moduleID, BAnyType anyType) {
+    public BallerinaAnyTypeSymbol(CompilerContext context, BAnyType anyType) {
         super(context, TypeDescKind.ANY, anyType);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaAnydataTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaAnydataTypeSymbol.java
@@ -17,7 +17,6 @@
 
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SymbolTransformer;
 import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.AnydataTypeSymbol;
@@ -32,7 +31,7 @@ import org.wso2.ballerinalang.compiler.util.CompilerContext;
  */
 public class BallerinaAnydataTypeSymbol extends AbstractTypeSymbol implements AnydataTypeSymbol {
 
-    public BallerinaAnydataTypeSymbol(CompilerContext context, ModuleID moduleID, BAnydataType anydataType) {
+    public BallerinaAnydataTypeSymbol(CompilerContext context, BAnydataType anydataType) {
         super(context, TypeDescKind.ANYDATA, anydataType);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaArrayTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaArrayTypeSymbol.java
@@ -16,7 +16,6 @@
  */
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SymbolTransformer;
 import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.ArrayTypeSymbol;
@@ -37,7 +36,7 @@ public class BallerinaArrayTypeSymbol extends AbstractTypeSymbol implements Arra
     private Integer size;
     private TypeSymbol memberTypeDesc;
 
-    public BallerinaArrayTypeSymbol(CompilerContext context, ModuleID moduleID, BArrayType arrayType) {
+    public BallerinaArrayTypeSymbol(CompilerContext context, BArrayType arrayType) {
         super(context, TypeDescKind.ARRAY, arrayType);
         if (arrayType.getSize() >= 0) {
             size = arrayType.getSize();

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaBooleanTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaBooleanTypeSymbol.java
@@ -17,7 +17,6 @@
 
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SymbolTransformer;
 import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.BooleanTypeSymbol;
@@ -32,7 +31,7 @@ import org.wso2.ballerinalang.compiler.util.CompilerContext;
  */
 public class BallerinaBooleanTypeSymbol extends AbstractTypeSymbol implements BooleanTypeSymbol {
 
-    public BallerinaBooleanTypeSymbol(CompilerContext context, ModuleID moduleID, BType booleanType) {
+    public BallerinaBooleanTypeSymbol(CompilerContext context, BType booleanType) {
         super(context, TypeDescKind.BOOLEAN, booleanType);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaByteTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaByteTypeSymbol.java
@@ -17,7 +17,6 @@
 
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SymbolTransformer;
 import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.ByteTypeSymbol;
@@ -32,7 +31,7 @@ import org.wso2.ballerinalang.compiler.util.CompilerContext;
  */
 public class BallerinaByteTypeSymbol extends AbstractTypeSymbol implements ByteTypeSymbol {
 
-    public BallerinaByteTypeSymbol(CompilerContext context, ModuleID moduleID, BType byteType) {
+    public BallerinaByteTypeSymbol(CompilerContext context, BType byteType) {
         super(context, TypeDescKind.BYTE, byteType);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaCompilationErrorTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaCompilationErrorTypeSymbol.java
@@ -17,7 +17,6 @@
 
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SymbolTransformer;
 import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.CompilationErrorTypeSymbol;
@@ -39,7 +38,7 @@ public class BallerinaCompilationErrorTypeSymbol extends AbstractTypeSymbol impl
 
     private static final List<FunctionSymbol> langLibMethods = Collections.unmodifiableList(new ArrayList<>());
 
-    public BallerinaCompilationErrorTypeSymbol(CompilerContext context, ModuleID moduleID, BType error) {
+    public BallerinaCompilationErrorTypeSymbol(CompilerContext context, BType error) {
         super(context, TypeDescKind.COMPILATION_ERROR, error);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaDecimalTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaDecimalTypeSymbol.java
@@ -17,7 +17,6 @@
 
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SymbolTransformer;
 import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.DecimalTypeSymbol;
@@ -32,7 +31,7 @@ import org.wso2.ballerinalang.compiler.util.CompilerContext;
  */
 public class BallerinaDecimalTypeSymbol extends AbstractTypeSymbol implements DecimalTypeSymbol {
 
-    public BallerinaDecimalTypeSymbol(CompilerContext context, ModuleID moduleID, BType decimalType) {
+    public BallerinaDecimalTypeSymbol(CompilerContext context, BType decimalType) {
         super(context, TypeDescKind.DECIMAL, decimalType);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaErrorTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaErrorTypeSymbol.java
@@ -45,7 +45,7 @@ public class BallerinaErrorTypeSymbol extends AbstractTypeSymbol implements Erro
     private ModuleSymbol module;
     private boolean moduleEvaluated;
 
-    public BallerinaErrorTypeSymbol(CompilerContext context, ModuleID moduleID, BErrorType errorType) {
+    public BallerinaErrorTypeSymbol(CompilerContext context, BErrorType errorType) {
         super(context, TypeDescKind.ERROR, errorType);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFloatTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFloatTypeSymbol.java
@@ -17,7 +17,6 @@
 
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SymbolTransformer;
 import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.FloatTypeSymbol;
@@ -32,7 +31,7 @@ import org.wso2.ballerinalang.compiler.util.CompilerContext;
  */
 public class BallerinaFloatTypeSymbol extends AbstractTypeSymbol implements FloatTypeSymbol {
 
-    public BallerinaFloatTypeSymbol(CompilerContext context, ModuleID moduleID, BType floatType) {
+    public BallerinaFloatTypeSymbol(CompilerContext context, BType floatType) {
         super(context, TypeDescKind.FLOAT, floatType);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFunctionTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFunctionTypeSymbol.java
@@ -16,7 +16,6 @@
  */
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SymbolTransformer;
 import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.impl.SymbolFactory;
@@ -64,8 +63,7 @@ public class BallerinaFunctionTypeSymbol extends AbstractTypeSymbol implements F
     private final BInvokableTypeSymbol typeSymbol;
     private String signature;
 
-    public BallerinaFunctionTypeSymbol(CompilerContext context, ModuleID moduleID,
-                                       BInvokableTypeSymbol invokableSymbol, BType type) {
+    public BallerinaFunctionTypeSymbol(CompilerContext context, BInvokableTypeSymbol invokableSymbol, BType type) {
         super(context, TypeDescKind.FUNCTION, type);
         this.typeSymbol = invokableSymbol;
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFutureTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFutureTypeSymbol.java
@@ -16,7 +16,6 @@
  */
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SymbolTransformer;
 import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.FutureTypeSymbol;
@@ -36,7 +35,7 @@ public class BallerinaFutureTypeSymbol extends AbstractTypeSymbol implements Fut
 
     private TypeSymbol memberTypeDesc;
 
-    public BallerinaFutureTypeSymbol(CompilerContext context, ModuleID moduleID, BFutureType futureType) {
+    public BallerinaFutureTypeSymbol(CompilerContext context, BFutureType futureType) {
         super(context, TypeDescKind.FUTURE, futureType);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaHandleTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaHandleTypeSymbol.java
@@ -17,7 +17,6 @@
 
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SymbolTransformer;
 import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.HandleTypeSymbol;
@@ -32,7 +31,7 @@ import org.wso2.ballerinalang.compiler.util.CompilerContext;
  */
 public class BallerinaHandleTypeSymbol extends AbstractTypeSymbol implements HandleTypeSymbol {
 
-    public BallerinaHandleTypeSymbol(CompilerContext context, ModuleID moduleID, BHandleType handleType) {
+    public BallerinaHandleTypeSymbol(CompilerContext context, BHandleType handleType) {
         super(context, TypeDescKind.HANDLE, handleType);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntSigned16TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntSigned16TypeSymbol.java
@@ -17,7 +17,6 @@
 
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SymbolTransformer;
 import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.IntSigned16TypeSymbol;
@@ -35,7 +34,7 @@ import java.util.Optional;
  */
 public class BallerinaIntSigned16TypeSymbol extends AbstractTypeSymbol implements IntSigned16TypeSymbol {
 
-    public BallerinaIntSigned16TypeSymbol(CompilerContext context, ModuleID moduleID, BIntSubType signed16Type) {
+    public BallerinaIntSigned16TypeSymbol(CompilerContext context, BIntSubType signed16Type) {
         super(context, TypeDescKind.INT_SIGNED16, signed16Type);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntSigned32TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntSigned32TypeSymbol.java
@@ -17,7 +17,6 @@
 
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SymbolTransformer;
 import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.IntSigned32TypeSymbol;
@@ -35,7 +34,7 @@ import java.util.Optional;
  */
 public class BallerinaIntSigned32TypeSymbol extends AbstractTypeSymbol implements IntSigned32TypeSymbol {
 
-    public BallerinaIntSigned32TypeSymbol(CompilerContext context, ModuleID moduleID, BIntSubType signed32Type) {
+    public BallerinaIntSigned32TypeSymbol(CompilerContext context, BIntSubType signed32Type) {
         super(context, TypeDescKind.INT_SIGNED32, signed32Type);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntSigned8TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntSigned8TypeSymbol.java
@@ -17,7 +17,6 @@
 
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SymbolTransformer;
 import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.IntSigned8TypeSymbol;
@@ -35,7 +34,7 @@ import java.util.Optional;
  */
 public class BallerinaIntSigned8TypeSymbol extends AbstractTypeSymbol implements IntSigned8TypeSymbol {
 
-    public BallerinaIntSigned8TypeSymbol(CompilerContext context, ModuleID moduleID, BIntSubType signed8Type) {
+    public BallerinaIntSigned8TypeSymbol(CompilerContext context, BIntSubType signed8Type) {
         super(context, TypeDescKind.INT_SIGNED8, signed8Type);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntTypeSymbol.java
@@ -17,7 +17,6 @@
 
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SymbolTransformer;
 import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.IntTypeSymbol;
@@ -32,7 +31,7 @@ import org.wso2.ballerinalang.compiler.util.CompilerContext;
  */
 public class BallerinaIntTypeSymbol extends AbstractTypeSymbol implements IntTypeSymbol {
 
-    public BallerinaIntTypeSymbol(CompilerContext context, ModuleID moduleID, BType intType) {
+    public BallerinaIntTypeSymbol(CompilerContext context, BType intType) {
         super(context, TypeDescKind.INT, intType);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntUnsigned16TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntUnsigned16TypeSymbol.java
@@ -17,7 +17,6 @@
 
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SymbolTransformer;
 import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.IntUnsigned16TypeSymbol;
@@ -35,7 +34,7 @@ import java.util.Optional;
  */
 public class BallerinaIntUnsigned16TypeSymbol extends AbstractTypeSymbol implements IntUnsigned16TypeSymbol {
 
-    public BallerinaIntUnsigned16TypeSymbol(CompilerContext context, ModuleID moduleID, BIntSubType unsigned16Type) {
+    public BallerinaIntUnsigned16TypeSymbol(CompilerContext context, BIntSubType unsigned16Type) {
         super(context, TypeDescKind.INT_UNSIGNED16, unsigned16Type);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntUnsigned32TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntUnsigned32TypeSymbol.java
@@ -17,7 +17,6 @@
 
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SymbolTransformer;
 import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.IntUnsigned32TypeSymbol;
@@ -35,7 +34,7 @@ import java.util.Optional;
  */
 public class BallerinaIntUnsigned32TypeSymbol extends AbstractTypeSymbol implements IntUnsigned32TypeSymbol {
 
-    public BallerinaIntUnsigned32TypeSymbol(CompilerContext context, ModuleID moduleID, BIntSubType unsigned32Type) {
+    public BallerinaIntUnsigned32TypeSymbol(CompilerContext context, BIntSubType unsigned32Type) {
         super(context, TypeDescKind.INT_UNSIGNED32, unsigned32Type);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntUnsigned8TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntUnsigned8TypeSymbol.java
@@ -17,7 +17,6 @@
 
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SymbolTransformer;
 import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.IntUnsigned8TypeSymbol;
@@ -35,7 +34,7 @@ import java.util.Optional;
  */
 public class BallerinaIntUnsigned8TypeSymbol extends AbstractTypeSymbol implements IntUnsigned8TypeSymbol {
 
-    public BallerinaIntUnsigned8TypeSymbol(CompilerContext context, ModuleID moduleID, BIntSubType unsigned8Type) {
+    public BallerinaIntUnsigned8TypeSymbol(CompilerContext context, BIntSubType unsigned8Type) {
         super(context, TypeDescKind.INT_UNSIGNED8, unsigned8Type);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntersectionTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntersectionTypeSymbol.java
@@ -16,7 +16,6 @@
  */
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SymbolTransformer;
 import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.impl.LangLibrary;
@@ -44,8 +43,7 @@ public class BallerinaIntersectionTypeSymbol extends AbstractTypeSymbol implemen
     private TypeSymbol effectiveType;
     private String signature;
 
-    public BallerinaIntersectionTypeSymbol(CompilerContext context, ModuleID moduleID,
-                                           BIntersectionType intersectionType) {
+    public BallerinaIntersectionTypeSymbol(CompilerContext context, BIntersectionType intersectionType) {
         super(context, TypeDescKind.INTERSECTION, intersectionType);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaJSONTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaJSONTypeSymbol.java
@@ -17,7 +17,6 @@
 
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SymbolTransformer;
 import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.JSONTypeSymbol;
@@ -32,7 +31,7 @@ import org.wso2.ballerinalang.compiler.util.CompilerContext;
  */
 public class BallerinaJSONTypeSymbol extends AbstractTypeSymbol implements JSONTypeSymbol {
 
-    public BallerinaJSONTypeSymbol(CompilerContext context, ModuleID moduleID, BJSONType jsonType) {
+    public BallerinaJSONTypeSymbol(CompilerContext context, BJSONType jsonType) {
         super(context, TypeDescKind.JSON, jsonType);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaMapTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaMapTypeSymbol.java
@@ -16,7 +16,6 @@
  */
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SymbolTransformer;
 import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.MapTypeSymbol;
@@ -37,7 +36,7 @@ public class BallerinaMapTypeSymbol extends AbstractTypeSymbol implements MapTyp
     private TypeSymbol memberTypeDesc;
     private String signature;
 
-    public BallerinaMapTypeSymbol(CompilerContext context, ModuleID moduleID, BMapType mapType) {
+    public BallerinaMapTypeSymbol(CompilerContext context, BMapType mapType) {
         super(context, TypeDescKind.MAP, mapType);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaNeverTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaNeverTypeSymbol.java
@@ -17,7 +17,6 @@
 
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SymbolTransformer;
 import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.NeverTypeSymbol;
@@ -32,7 +31,7 @@ import org.wso2.ballerinalang.compiler.util.CompilerContext;
  */
 public class BallerinaNeverTypeSymbol extends AbstractTypeSymbol implements NeverTypeSymbol {
 
-    public BallerinaNeverTypeSymbol(CompilerContext context, ModuleID moduleID, BNeverType neverType) {
+    public BallerinaNeverTypeSymbol(CompilerContext context, BNeverType neverType) {
         super(context, TypeDescKind.NEVER, neverType);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaNilTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaNilTypeSymbol.java
@@ -16,7 +16,6 @@
  */
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SymbolTransformer;
 import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.NilTypeSymbol;
@@ -31,7 +30,7 @@ import org.wso2.ballerinalang.compiler.util.CompilerContext;
  */
 public class BallerinaNilTypeSymbol extends AbstractTypeSymbol implements NilTypeSymbol {
 
-    public BallerinaNilTypeSymbol(CompilerContext context, ModuleID moduleID, BNilType nilType) {
+    public BallerinaNilTypeSymbol(CompilerContext context, BNilType nilType) {
         super(context, TypeDescKind.NIL, nilType);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaNoneTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaNoneTypeSymbol.java
@@ -17,7 +17,6 @@
 
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SymbolTransformer;
 import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.NoneTypeSymbol;
@@ -30,7 +29,7 @@ import org.wso2.ballerinalang.compiler.util.CompilerContext;
  */
 public class BallerinaNoneTypeSymbol extends AbstractTypeSymbol implements NoneTypeSymbol {
 
-    public BallerinaNoneTypeSymbol(CompilerContext context, ModuleID moduleID, BNoType bNoType) {
+    public BallerinaNoneTypeSymbol(CompilerContext context, BNoType bNoType) {
         super(context, TypeDescKind.NONE, bNoType);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectTypeSymbol.java
@@ -16,7 +16,6 @@
  */
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SymbolTransformer;
 import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.impl.SymbolFactory;
@@ -61,7 +60,7 @@ public class BallerinaObjectTypeSymbol extends AbstractTypeSymbol implements Obj
     private Map<String, MethodSymbol> methods;
     private List<TypeSymbol> typeInclusions;
 
-    public BallerinaObjectTypeSymbol(CompilerContext context, ModuleID moduleID, BObjectType objectType) {
+    public BallerinaObjectTypeSymbol(CompilerContext context, BObjectType objectType) {
         super(context, TypeDescKind.OBJECT, objectType);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaReadonlyTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaReadonlyTypeSymbol.java
@@ -17,7 +17,6 @@
 
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SymbolTransformer;
 import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.ReadonlyTypeSymbol;
@@ -32,7 +31,7 @@ import org.wso2.ballerinalang.compiler.util.CompilerContext;
  */
 public class BallerinaReadonlyTypeSymbol extends AbstractTypeSymbol implements ReadonlyTypeSymbol {
 
-    public BallerinaReadonlyTypeSymbol(CompilerContext context, ModuleID moduleID, BReadonlyType readonlyType) {
+    public BallerinaReadonlyTypeSymbol(CompilerContext context, BReadonlyType readonlyType) {
         super(context, TypeDescKind.READONLY, readonlyType);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaRecordTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaRecordTypeSymbol.java
@@ -16,7 +16,6 @@
  */
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SymbolTransformer;
 import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.impl.util.FieldMap;
@@ -48,7 +47,7 @@ public class BallerinaRecordTypeSymbol extends AbstractTypeSymbol implements Rec
     private TypeSymbol restTypeDesc;
     private List<TypeSymbol> typeInclusions;
 
-    public BallerinaRecordTypeSymbol(CompilerContext context, ModuleID moduleID, BRecordType recordType) {
+    public BallerinaRecordTypeSymbol(CompilerContext context, BRecordType recordType) {
         super(context, TypeDescKind.RECORD, recordType);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSingletonTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSingletonTypeSymbol.java
@@ -16,7 +16,6 @@
  */
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SymbolTransformer;
 import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.impl.LangLibrary;
@@ -40,8 +39,7 @@ public class BallerinaSingletonTypeSymbol extends AbstractTypeSymbol implements 
 
     private final String typeName;
 
-    public BallerinaSingletonTypeSymbol(CompilerContext context, ModuleID moduleID, BLangLiteral shape,
-                                        BType bType) {
+    public BallerinaSingletonTypeSymbol(CompilerContext context, BLangLiteral shape, BType bType) {
         super(context, TypeDescKind.SINGLETON, bType);
 
         // Special case handling for `()` since in BLangLiteral, `null` is used to represent nil.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaStreamTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaStreamTypeSymbol.java
@@ -16,7 +16,6 @@
  */
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SymbolTransformer;
 import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.StreamTypeSymbol;
@@ -37,7 +36,7 @@ public class BallerinaStreamTypeSymbol extends AbstractTypeSymbol implements Str
     private TypeSymbol completionValueTypeParameter;
     private String signature;
 
-    public BallerinaStreamTypeSymbol(CompilerContext context, ModuleID moduleID, BStreamType streamType) {
+    public BallerinaStreamTypeSymbol(CompilerContext context, BStreamType streamType) {
         super(context, TypeDescKind.STREAM, streamType);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaStringCharTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaStringCharTypeSymbol.java
@@ -17,7 +17,6 @@
 
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SymbolTransformer;
 import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.StringCharTypeSymbol;
@@ -35,7 +34,7 @@ import java.util.Optional;
  */
 public class BallerinaStringCharTypeSymbol extends AbstractTypeSymbol implements StringCharTypeSymbol {
 
-    public BallerinaStringCharTypeSymbol(CompilerContext context, ModuleID moduleID, BStringSubType charType) {
+    public BallerinaStringCharTypeSymbol(CompilerContext context, BStringSubType charType) {
         super(context, TypeDescKind.STRING_CHAR, charType);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaStringTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaStringTypeSymbol.java
@@ -17,7 +17,6 @@
 
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SymbolTransformer;
 import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.StringTypeSymbol;
@@ -32,7 +31,7 @@ import org.wso2.ballerinalang.compiler.util.CompilerContext;
  */
 public class BallerinaStringTypeSymbol extends AbstractTypeSymbol implements StringTypeSymbol {
 
-    public BallerinaStringTypeSymbol(CompilerContext context, ModuleID moduleID, BType stringType) {
+    public BallerinaStringTypeSymbol(CompilerContext context, BType stringType) {
         super(context, TypeDescKind.STRING, stringType);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTableTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTableTypeSymbol.java
@@ -17,7 +17,6 @@
 
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SymbolTransformer;
 import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.TableTypeSymbol;
@@ -44,7 +43,7 @@ public class BallerinaTableTypeSymbol extends AbstractTypeSymbol implements Tabl
     private List<String> keySpecifiers;
     private String signature;
 
-    public BallerinaTableTypeSymbol(CompilerContext context, ModuleID moduleID, BTableType tableType) {
+    public BallerinaTableTypeSymbol(CompilerContext context, BTableType tableType) {
         super(context, TypeDescKind.TABLE, tableType);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTupleTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTupleTypeSymbol.java
@@ -16,7 +16,6 @@
  */
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SymbolTransformer;
 import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.TupleTypeSymbol;
@@ -42,7 +41,7 @@ public class BallerinaTupleTypeSymbol extends AbstractTypeSymbol implements Tupl
     private List<TypeSymbol> memberTypes;
     private TypeSymbol restTypeDesc;
 
-    public BallerinaTupleTypeSymbol(CompilerContext context, ModuleID moduleID, BTupleType tupleType) {
+    public BallerinaTupleTypeSymbol(CompilerContext context, BTupleType tupleType) {
         super(context, TypeDescKind.TUPLE, tupleType);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeDescTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeDescTypeSymbol.java
@@ -16,7 +16,6 @@
  */
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SymbolTransformer;
 import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
@@ -36,7 +35,7 @@ public class BallerinaTypeDescTypeSymbol extends AbstractTypeSymbol implements T
 
     private TypeSymbol typeParameter;
 
-    public BallerinaTypeDescTypeSymbol(CompilerContext context, ModuleID moduleID, BTypedescType typedescType) {
+    public BallerinaTypeDescTypeSymbol(CompilerContext context, BTypedescType typedescType) {
         super(context, TypeDescKind.TYPEDESC, typedescType);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeReferenceTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeReferenceTypeSymbol.java
@@ -59,8 +59,8 @@ public class BallerinaTypeReferenceTypeSymbol extends AbstractTypeSymbol impleme
     public BType referredType;
 
 
-    public BallerinaTypeReferenceTypeSymbol(CompilerContext context, ModuleID moduleID, BType bType,
-                                            BSymbol tSymbol, boolean fromIntersectionType) {
+    public BallerinaTypeReferenceTypeSymbol(CompilerContext context, BType bType, BSymbol tSymbol,
+                                            boolean fromIntersectionType) {
         super(context, TypeDescKind.TYPE_REFERENCE, bType);
         referredType = getReferredType(bType);
         this.definitionName = tSymbol.getOriginalName().getValue();

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeSymbol.java
@@ -16,7 +16,6 @@
  */
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SymbolTransformer;
 import io.ballerina.compiler.api.SymbolVisitor;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
@@ -32,7 +31,7 @@ public class BallerinaTypeSymbol extends AbstractTypeSymbol {
 
     private final String typeName;
 
-    public BallerinaTypeSymbol(CompilerContext context, ModuleID moduleID, BType bType) {
+    public BallerinaTypeSymbol(CompilerContext context, BType bType) {
         super(context, TypesFactory.getTypeDescKind(bType.getKind()), bType);
         // In an unlikely event if the `BNoType` get exposed, this would ensure that the user would know that this is
         // not a typical condition.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaUnionTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaUnionTypeSymbol.java
@@ -59,11 +59,11 @@ public class BallerinaUnionTypeSymbol extends AbstractTypeSymbol implements Unio
     private List<TypeSymbol> originalMemberTypes;
     private String signature;
 
-    public BallerinaUnionTypeSymbol(CompilerContext context, ModuleID moduleID, BUnionType unionType) {
+    public BallerinaUnionTypeSymbol(CompilerContext context, BUnionType unionType) {
         super(context, TypeDescKind.UNION, unionType);
     }
 
-    public BallerinaUnionTypeSymbol(CompilerContext context, ModuleID moduleID, BFiniteType finiteType) {
+    public BallerinaUnionTypeSymbol(CompilerContext context, BFiniteType finiteType) {
         super(context, TypeDescKind.UNION, finiteType);
     }
 
@@ -85,7 +85,7 @@ public class BallerinaUnionTypeSymbol extends AbstractTypeSymbol implements Unio
                     for (BLangExpression value : finiteType.getValueSpace()) {
                         ModuleID moduleID = getModule().isPresent() ? getModule().get().id() : null;
                         BFiniteType bFiniteType = new BFiniteType(value.getBType().tsymbol, Set.of(value));
-                        members.add(new BallerinaSingletonTypeSymbol(this.context, moduleID, (BLangLiteral) value,
+                        members.add(new BallerinaSingletonTypeSymbol(this.context, (BLangLiteral) value,
                                                                      bFiniteType));
                     }
                 }
@@ -93,7 +93,7 @@ public class BallerinaUnionTypeSymbol extends AbstractTypeSymbol implements Unio
                 for (BLangExpression value : ((BFiniteType) this.getBType()).getValueSpace()) {
                     ModuleID moduleID = getModule().isPresent() ? getModule().get().id() : null;
                     BFiniteType bFiniteType = new BFiniteType(value.getBType().tsymbol, Set.of(value));
-                    members.add(new BallerinaSingletonTypeSymbol(this.context, moduleID, (BLangLiteral) value,
+                    members.add(new BallerinaSingletonTypeSymbol(this.context, (BLangLiteral) value,
                                                                  bFiniteType));
                 }
             }
@@ -118,7 +118,7 @@ public class BallerinaUnionTypeSymbol extends AbstractTypeSymbol implements Unio
             } else {
                 for (BLangExpression value : ((BFiniteType) this.getBType()).getValueSpace()) {
                     ModuleID moduleID = getModule().isPresent() ? getModule().get().id() : null;
-                    members.add(new BallerinaSingletonTypeSymbol(this.context, moduleID, (BLangLiteral) value,
+                    members.add(new BallerinaSingletonTypeSymbol(this.context, (BLangLiteral) value,
                                                                  value.getBType()));
                 }
             }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLCommentTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLCommentTypeSymbol.java
@@ -17,7 +17,6 @@
 
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SymbolTransformer;
 import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
@@ -36,7 +35,7 @@ import java.util.Optional;
  */
 public class BallerinaXMLCommentTypeSymbol extends AbstractTypeSymbol implements XMLCommentTypeSymbol {
 
-    public BallerinaXMLCommentTypeSymbol(CompilerContext context, ModuleID moduleID, BXMLSubType commentType) {
+    public BallerinaXMLCommentTypeSymbol(CompilerContext context, BXMLSubType commentType) {
         super(context, TypeDescKind.XML_COMMENT, commentType);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLElementTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLElementTypeSymbol.java
@@ -17,7 +17,6 @@
 
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SymbolTransformer;
 import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
@@ -36,7 +35,7 @@ import java.util.Optional;
  */
 public class BallerinaXMLElementTypeSymbol extends AbstractTypeSymbol implements XMLElementTypeSymbol {
 
-    public BallerinaXMLElementTypeSymbol(CompilerContext context, ModuleID moduleID, BXMLSubType elementType) {
+    public BallerinaXMLElementTypeSymbol(CompilerContext context, BXMLSubType elementType) {
         super(context, TypeDescKind.XML_ELEMENT, elementType);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLProcessingInstructionTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLProcessingInstructionTypeSymbol.java
@@ -17,7 +17,6 @@
 
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SymbolTransformer;
 import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
@@ -37,8 +36,7 @@ import java.util.Optional;
 public class BallerinaXMLProcessingInstructionTypeSymbol extends AbstractTypeSymbol implements
                                                                                     XMLProcessingInstructionTypeSymbol {
 
-    public BallerinaXMLProcessingInstructionTypeSymbol(CompilerContext context, ModuleID moduleID,
-                                                       BXMLSubType piType) {
+    public BallerinaXMLProcessingInstructionTypeSymbol(CompilerContext context, BXMLSubType piType) {
         super(context, TypeDescKind.XML_PROCESSING_INSTRUCTION, piType);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLTextTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLTextTypeSymbol.java
@@ -17,7 +17,6 @@
 
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SymbolTransformer;
 import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
@@ -36,7 +35,7 @@ import java.util.Optional;
  */
 public class BallerinaXMLTextTypeSymbol extends AbstractTypeSymbol implements XMLTextTypeSymbol {
 
-    public BallerinaXMLTextTypeSymbol(CompilerContext context, ModuleID moduleID, BXMLSubType textType) {
+    public BallerinaXMLTextTypeSymbol(CompilerContext context, BXMLSubType textType) {
         super(context, TypeDescKind.XML_TEXT, textType);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLTypeSymbol.java
@@ -17,7 +17,6 @@
 
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SymbolTransformer;
 import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
@@ -40,7 +39,7 @@ public class BallerinaXMLTypeSymbol extends AbstractTypeSymbol implements XMLTyp
     private String typeName;
     private String signature;
 
-    public BallerinaXMLTypeSymbol(CompilerContext context, ModuleID moduleID, BXMLType xmlType) {
+    public BallerinaXMLTypeSymbol(CompilerContext context, BXMLType xmlType) {
         super(context, TypeDescKind.XML, xmlType);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/TypesFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/TypesFactory.java
@@ -25,7 +25,6 @@ import io.ballerina.compiler.api.symbols.XMLTypeSymbol;
 import org.ballerinalang.model.symbols.SymbolKind;
 import org.ballerinalang.model.types.IntersectableReferenceType;
 import org.ballerinalang.model.types.TypeKind;
-import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BClassSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
@@ -112,14 +111,12 @@ public class TypesFactory {
 
     private final CompilerContext context;
     private final SymbolFactory symbolFactory;
-    private final SymbolTable symbolTable;
 
     private TypesFactory(CompilerContext context) {
         context.put(TYPES_FACTORY_KEY, this);
 
         this.context = context;
         this.symbolFactory = SymbolFactory.getInstance(context);
-        this.symbolTable = SymbolTable.getInstance(context);
     }
 
     public static TypesFactory getInstance(CompilerContext context) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/TypesFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/TypesFactory.java
@@ -16,8 +16,6 @@
  */
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
-import io.ballerina.compiler.api.impl.BallerinaModuleID;
 import io.ballerina.compiler.api.impl.SymbolFactory;
 import io.ballerina.compiler.api.symbols.IntTypeSymbol;
 import io.ballerina.compiler.api.symbols.ObjectTypeSymbol;
@@ -169,143 +167,135 @@ public class TypesFactory {
             }
         }
 
-        ModuleID moduleID = tSymbol == null ? null : new BallerinaModuleID(tSymbol.pkgID);
-
         if (isTypeReference(bType, tSymbol, rawTypeOnly)) {
-            return new BallerinaTypeReferenceTypeSymbol(this.context, moduleID, bType, tSymbol,
-                    typeRefFromIntersectType);
+            return new BallerinaTypeReferenceTypeSymbol(this.context, bType, tSymbol, typeRefFromIntersectType);
         }
         BTypeSymbol typeSymbol = tSymbol instanceof BTypeDefinitionSymbol ? tSymbol.type.tsymbol
                 : (BTypeSymbol) tSymbol;
-        return createTypeDescriptor(bType, typeSymbol, moduleID);
+        return createTypeDescriptor(bType, typeSymbol);
     }
 
-    private TypeSymbol createTypeDescriptor(BType bType, BTypeSymbol tSymbol, ModuleID moduleID) {
+    private TypeSymbol createTypeDescriptor(BType bType, BTypeSymbol tSymbol) {
         switch (bType.getKind()) {
             case BOOLEAN:
-                return new BallerinaBooleanTypeSymbol(this.context, moduleID, bType);
+                return new BallerinaBooleanTypeSymbol(this.context, bType);
             case BYTE:
-                return new BallerinaByteTypeSymbol(this.context, moduleID, bType);
+                return new BallerinaByteTypeSymbol(this.context, bType);
             case INT:
                 if (bType instanceof BIntSubType) {
                     return createIntSubType((BIntSubType) bType);
                 }
-                return new BallerinaIntTypeSymbol(this.context, moduleID, bType);
+                return new BallerinaIntTypeSymbol(this.context, bType);
             case FLOAT:
-                return new BallerinaFloatTypeSymbol(this.context, moduleID, bType);
+                return new BallerinaFloatTypeSymbol(this.context, bType);
             case DECIMAL:
-                return new BallerinaDecimalTypeSymbol(this.context, moduleID, bType);
+                return new BallerinaDecimalTypeSymbol(this.context, bType);
             case STRING:
                 if (bType instanceof BStringSubType) {
-                    moduleID = new BallerinaModuleID(symbolTable.langStringModuleSymbol.pkgID);
-                    return new BallerinaStringCharTypeSymbol(this.context, moduleID, (BStringSubType) bType);
+                    return new BallerinaStringCharTypeSymbol(this.context, (BStringSubType) bType);
                 }
-                return new BallerinaStringTypeSymbol(this.context, moduleID, bType);
+                return new BallerinaStringTypeSymbol(this.context, bType);
             case ANY:
-                return new BallerinaAnyTypeSymbol(this.context, moduleID, (BAnyType) bType);
+                return new BallerinaAnyTypeSymbol(this.context, (BAnyType) bType);
             case ANYDATA:
-                return new BallerinaAnydataTypeSymbol(this.context, moduleID, (BAnydataType) bType);
+                return new BallerinaAnydataTypeSymbol(this.context, (BAnydataType) bType);
             case HANDLE:
-                return new BallerinaHandleTypeSymbol(this.context, moduleID, (BHandleType) bType);
+                return new BallerinaHandleTypeSymbol(this.context, (BHandleType) bType);
             case JSON:
-                return new BallerinaJSONTypeSymbol(this.context, moduleID, (BJSONType) bType);
+                return new BallerinaJSONTypeSymbol(this.context, (BJSONType) bType);
             case READONLY:
-                return new BallerinaReadonlyTypeSymbol(this.context, moduleID, (BReadonlyType) bType);
+                return new BallerinaReadonlyTypeSymbol(this.context, (BReadonlyType) bType);
             case TABLE:
-                return new BallerinaTableTypeSymbol(this.context, moduleID, (BTableType) bType);
+                return new BallerinaTableTypeSymbol(this.context, (BTableType) bType);
             case XML:
                 if (bType instanceof BXMLSubType) {
                     return createXMLSubType((BXMLSubType) bType);
                 }
-                return new BallerinaXMLTypeSymbol(this.context, moduleID, (BXMLType) bType);
+                return new BallerinaXMLTypeSymbol(this.context, (BXMLType) bType);
             case OBJECT:
-                ObjectTypeSymbol objType = new BallerinaObjectTypeSymbol(this.context, moduleID, (BObjectType) bType);
+                ObjectTypeSymbol objType = new BallerinaObjectTypeSymbol(this.context, (BObjectType) bType);
                 if (Symbols.isFlagOn(tSymbol.flags, Flags.CLASS)) {
                     return symbolFactory.createClassSymbol((BClassSymbol) tSymbol, tSymbol.name.value, objType);
                 }
                 return objType;
             case RECORD:
-                return new BallerinaRecordTypeSymbol(this.context, moduleID, (BRecordType) bType);
+                return new BallerinaRecordTypeSymbol(this.context, (BRecordType) bType);
             case ERROR:
-                return new BallerinaErrorTypeSymbol(this.context, moduleID, (BErrorType) bType);
+                return new BallerinaErrorTypeSymbol(this.context, (BErrorType) bType);
             case UNION:
-                return new BallerinaUnionTypeSymbol(this.context, moduleID, (BUnionType) bType);
+                return new BallerinaUnionTypeSymbol(this.context, (BUnionType) bType);
             case FUTURE:
-                return new BallerinaFutureTypeSymbol(this.context, moduleID, (BFutureType) bType);
+                return new BallerinaFutureTypeSymbol(this.context, (BFutureType) bType);
             case MAP:
-                return new BallerinaMapTypeSymbol(this.context, moduleID, (BMapType) bType);
+                return new BallerinaMapTypeSymbol(this.context, (BMapType) bType);
             case STREAM:
-                return new BallerinaStreamTypeSymbol(this.context, moduleID, (BStreamType) bType);
+                return new BallerinaStreamTypeSymbol(this.context, (BStreamType) bType);
             case ARRAY:
-                return new BallerinaArrayTypeSymbol(this.context, moduleID, (BArrayType) bType);
+                return new BallerinaArrayTypeSymbol(this.context, (BArrayType) bType);
             case TUPLE:
-                return new BallerinaTupleTypeSymbol(this.context, moduleID, (BTupleType) bType);
+                return new BallerinaTupleTypeSymbol(this.context, (BTupleType) bType);
             case TYPEDESC:
-                return new BallerinaTypeDescTypeSymbol(this.context, moduleID, (BTypedescType) bType);
+                return new BallerinaTypeDescTypeSymbol(this.context, (BTypedescType) bType);
             case NIL:
-                return new BallerinaNilTypeSymbol(this.context, moduleID, (BNilType) bType);
+                return new BallerinaNilTypeSymbol(this.context, (BNilType) bType);
             case FINITE:
                 BFiniteType finiteType = (BFiniteType) bType;
                 Set<BLangExpression> valueSpace = finiteType.getValueSpace();
 
                 if (valueSpace.size() == 1) {
                     BLangExpression shape = valueSpace.iterator().next();
-                    return new BallerinaSingletonTypeSymbol(this.context, moduleID, (BLangLiteral) shape, bType);
+                    return new BallerinaSingletonTypeSymbol(this.context, (BLangLiteral) shape, bType);
                 }
 
-                return new BallerinaUnionTypeSymbol(this.context, moduleID, finiteType);
+                return new BallerinaUnionTypeSymbol(this.context, finiteType);
             case FUNCTION:
-                return new BallerinaFunctionTypeSymbol(this.context, moduleID, (BInvokableTypeSymbol) tSymbol, bType);
+                return new BallerinaFunctionTypeSymbol(this.context, (BInvokableTypeSymbol) tSymbol, bType);
             case NEVER:
-                return new BallerinaNeverTypeSymbol(this.context, moduleID, (BNeverType) bType);
+                return new BallerinaNeverTypeSymbol(this.context, (BNeverType) bType);
             case NONE:
-                return new BallerinaNoneTypeSymbol(this.context, moduleID, (BNoType) bType);
+                return new BallerinaNoneTypeSymbol(this.context, (BNoType) bType);
             case INTERSECTION:
-                return new BallerinaIntersectionTypeSymbol(this.context, moduleID, (BIntersectionType) bType);
+                return new BallerinaIntersectionTypeSymbol(this.context, (BIntersectionType) bType);
             case TYPEREFDESC:
-                return new BallerinaTypeReferenceTypeSymbol(this.context, moduleID, bType, tSymbol, false);
+                return new BallerinaTypeReferenceTypeSymbol(this.context, bType, tSymbol, false);
             default:
                 if (bType.tag == SEMANTIC_ERROR) {
-                    return new BallerinaCompilationErrorTypeSymbol(this.context, moduleID, bType);
+                    return new BallerinaCompilationErrorTypeSymbol(this.context, bType);
                 }
 
-                return new BallerinaTypeSymbol(this.context, moduleID, bType);
+                return new BallerinaTypeSymbol(this.context, bType);
         }
     }
 
     private IntTypeSymbol createIntSubType(BIntSubType internalType) {
-        ModuleID moduleID = new BallerinaModuleID(symbolTable.langIntModuleSymbol.pkgID);
-
         switch (internalType.tag) {
             case UNSIGNED8_INT:
-                return new BallerinaIntUnsigned8TypeSymbol(this.context, moduleID, internalType);
+                return new BallerinaIntUnsigned8TypeSymbol(this.context, internalType);
             case SIGNED8_INT:
-                return new BallerinaIntSigned8TypeSymbol(this.context, moduleID, internalType);
+                return new BallerinaIntSigned8TypeSymbol(this.context, internalType);
             case UNSIGNED16_INT:
-                return new BallerinaIntUnsigned16TypeSymbol(this.context, moduleID, internalType);
+                return new BallerinaIntUnsigned16TypeSymbol(this.context, internalType);
             case SIGNED16_INT:
-                return new BallerinaIntSigned16TypeSymbol(this.context, moduleID, internalType);
+                return new BallerinaIntSigned16TypeSymbol(this.context, internalType);
             case UNSIGNED32_INT:
-                return new BallerinaIntUnsigned32TypeSymbol(this.context, moduleID, internalType);
+                return new BallerinaIntUnsigned32TypeSymbol(this.context, internalType);
             case SIGNED32_INT:
-                return new BallerinaIntSigned32TypeSymbol(this.context, moduleID, internalType);
+                return new BallerinaIntSigned32TypeSymbol(this.context, internalType);
         }
 
         throw new IllegalStateException("Invalid integer subtype type tag: " + internalType.tag);
     }
 
     private XMLTypeSymbol createXMLSubType(BXMLSubType internalType) {
-        ModuleID moduleID = new BallerinaModuleID(symbolTable.langXmlModuleSymbol.pkgID);
-
         switch (internalType.tag) {
             case XML_ELEMENT:
-                return new BallerinaXMLElementTypeSymbol(this.context, moduleID, internalType);
+                return new BallerinaXMLElementTypeSymbol(this.context, internalType);
             case XML_PI:
-                return new BallerinaXMLProcessingInstructionTypeSymbol(this.context, moduleID, internalType);
+                return new BallerinaXMLProcessingInstructionTypeSymbol(this.context, internalType);
             case XML_COMMENT:
-                return new BallerinaXMLCommentTypeSymbol(this.context, moduleID, internalType);
+                return new BallerinaXMLCommentTypeSymbol(this.context, internalType);
             case XML_TEXT:
-                return new BallerinaXMLTextTypeSymbol(this.context, moduleID, internalType);
+                return new BallerinaXMLTextTypeSymbol(this.context, internalType);
         }
 
         throw new IllegalStateException("Invalid XML subtype type tag: " + internalType.tag);


### PR DESCRIPTION
## Purpose
Removes the unused moduleID param from type symbol constructors.

## Remarks
Partial refactoring needed for addressing #34174

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
