### PR TITLE
Disallow accessing isolated variables outside lock statements in field default values of local record typedescs

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
@@ -759,7 +759,10 @@ public enum DiagnosticErrorCode implements DiagnosticCode {
     SERVICE_DOES_NOT_IMPLEMENT_REQUIRED_CONSTRUCTS("BCE4022", "service.decl.does.not.implement.required.constructs"),
     INVALID_ASSIGNMENT_TO_NARROWED_VAR_IN_QUERY_ACTION("BCE4023", "invalid.assignment.to.narrowed.var.in.query.action"),
     COMPOUND_ASSIGNMENT_NOT_ALLOWED_WITH_NULLABLE_OPERANDS("BCE4024",
-            "compound.assignment.not.allowed.with.nullable.operands")
+            "compound.assignment.not.allowed.with.nullable.operands"),
+
+    INVALID_ISOLATED_VARIABLE_ACCESS_OUTSIDE_LOCK_IN_RECORD_DEFAULT(
+            "BCE4025", "invalid.isolated.variable.access.outside.lock.in.record.default")
     ;
 
     private String diagnosticId;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/IsolationAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/IsolationAnalyzer.java
@@ -1291,7 +1291,14 @@ public class IsolationAnalyzer extends BLangNodeVisitor {
         }
 
         if (isolatedModuleVariableReference) {
-            if (!inLockStatement) {
+            if (inLockStatement) {
+                return;
+            }
+
+            if (recordFieldDefaultValue) {
+                dlog.error(varRefExpr.pos,
+                           DiagnosticErrorCode.INVALID_ISOLATED_VARIABLE_ACCESS_OUTSIDE_LOCK_IN_RECORD_DEFAULT);
+            } else {
                 dlog.error(varRefExpr.pos, DiagnosticErrorCode.INVALID_ISOLATED_VARIABLE_ACCESS_OUTSIDE_LOCK);
             }
             return;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/IsolationAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/IsolationAnalyzer.java
@@ -1820,9 +1820,12 @@ public class IsolationAnalyzer extends BLangNodeVisitor {
     public void visit(BLangRecordTypeNode recordTypeNode) {
         SymbolEnv typeEnv = SymbolEnv.createTypeEnv(recordTypeNode, recordTypeNode.symbol.scope, env);
 
+        boolean prevInLockStatement = this.inLockStatement;
+        this.inLockStatement = false;
         for (BLangSimpleVariable field : recordTypeNode.fields) {
             analyzeNode(field, typeEnv);
         }
+        this.inLockStatement = prevInLockStatement;
 
         for (BLangSimpleVariable referencedField : recordTypeNode.includedFields) {
             analyzeNode(referencedField, typeEnv);

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1881,3 +1881,6 @@ error.constant.cyclic.reference=\
 
 error.unsupported.multilevel.closures=\
     closure variable ''{0}'' : closures not yet supported for object constructors which are fields
+
+error.invalid.isolated.variable.access.outside.lock.in.record.default=\
+  invalid access of an isolated variable outside a lock statement in the default value of a record field

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/isolation/IsolationAnalysisTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/isolation/IsolationAnalysisTest.java
@@ -265,6 +265,8 @@ public class IsolationAnalysisTest {
         validateError(result, i++, INVALID_ISOLATED_VAR_ACCESS_OUTSIDE_LOCK_IN_RECORD_FIELD_DEFAULT, 68, 23);
         validateError(result, i++, INVALID_ISOLATED_VAR_ACCESS_OUTSIDE_LOCK_IN_RECORD_FIELD_DEFAULT, 81, 25);
         validateError(result, i++, INVALID_ISOLATED_VAR_ACCESS_OUTSIDE_LOCK_IN_RECORD_FIELD_DEFAULT, 95, 25);
+        validateError(result, i++, INVALID_ISOLATED_VAR_ACCESS_OUTSIDE_LOCK_IN_RECORD_FIELD_DEFAULT, 108, 27);
+        validateError(result, i++, INVALID_ISOLATED_VAR_ACCESS_OUTSIDE_LOCK_IN_RECORD_FIELD_DEFAULT, 111, 23);
         Assert.assertEquals(result.getErrorCount(), i);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/isolation/IsolationAnalysisTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/isolation/IsolationAnalysisTest.java
@@ -50,6 +50,8 @@ public class IsolationAnalysisTest {
             "invalid invocation of a non-isolated function in the default value of a record field";
     private static final String INVALID_NON_ISOLATED_INIT_EXPRESSION_IN_RECORD_FIELD_DEFAULT =
             "invalid non-isolated initialization expression in the default value of a record field";
+    private static final String INVALID_ISOLATED_VAR_ACCESS_OUTSIDE_LOCK_IN_RECORD_FIELD_DEFAULT =
+            "invalid access of an isolated variable outside a lock statement in the default value of a record field";
 
     private static final String INVALID_MUTABLE_STORAGE_ACCESS_IN_OBJECT_FIELD_DEFAULT =
             "invalid access of mutable storage in the initializer of an object field";
@@ -259,8 +261,11 @@ public class IsolationAnalysisTest {
         validateError(result, i++, INVALID_NON_ISOLATED_FUNCTION_CALL_IN_RECORD_FIELD_DEFAULT, 33, 20);
         validateError(result, i++, INVALID_MUTABLE_STORAGE_ACCESS_IN_RECORD_FIELD_DEFAULT, 33, 24);
         validateError(result, i++, INVALID_MUTABLE_STORAGE_ACCESS_IN_OBJECT_FIELD_DEFAULT, 39, 25);
+        validateError(result, i++, INVALID_ISOLATED_VAR_ACCESS_OUTSIDE_LOCK_IN_RECORD_FIELD_DEFAULT, 67, 23);
+        validateError(result, i++, INVALID_ISOLATED_VAR_ACCESS_OUTSIDE_LOCK_IN_RECORD_FIELD_DEFAULT, 68, 23);
+        validateError(result, i++, INVALID_ISOLATED_VAR_ACCESS_OUTSIDE_LOCK_IN_RECORD_FIELD_DEFAULT, 81, 25);
+        validateError(result, i++, INVALID_ISOLATED_VAR_ACCESS_OUTSIDE_LOCK_IN_RECORD_FIELD_DEFAULT, 95, 25);
         Assert.assertEquals(result.getErrorCount(), i);
-
     }
 
     @Test

--- a/tests/jballerina-unit-test/src/test/resources/test-src/isolation-analysis/isolated_record_field_default_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/isolation-analysis/isolated_record_field_default_negative.bal
@@ -100,3 +100,15 @@ function f3() returns typedesc<record { int[] arr; }> {
         return typeof r;
     }
 }
+
+function f4() {
+    lock {
+        record {
+            record {
+                int[] i = z; // error
+                int j = 3; // OK
+            } r = {};
+            int[] k = z; // error
+        } _ = {};
+    }
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/isolation-analysis/isolated_record_field_default_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/isolation-analysis/isolated_record_field_default_negative.bal
@@ -58,3 +58,45 @@ class Bar {
         self.i = 1;
     }
 }
+
+isolated int[] z = [1];
+
+function f1() {
+    lock {
+        record {
+            int[] a = z; // error
+            int[] b = z.clone(); // error
+            function c = function () {
+                lock {
+                    _ = z; // OK
+                }
+            };
+        } _ = {};
+    }
+}
+
+function f2() returns typedesc<record { int[] arr; }> {
+    lock {
+        record {
+            int[] arr = z; // error
+        } r = {};
+
+        int[] _ = z; // OK
+
+        return typeof r;
+    }
+}
+
+function f3() returns typedesc<record { int[] arr; }> {
+    lock {
+        int[] _ = z; // OK
+
+        record {
+            int[] arr = z; // error
+        } r = {};
+
+        int[] _ = z; // OK
+
+        return typeof r;
+    }
+}


### PR DESCRIPTION
## Purpose
$title. The analysis did not happen correctly for certain local anonymous record types.

```ballerina
isolated int[] v = [1];

function fn() {
    lock {
        record {
            int[] a = v; // now an error
            int[] b = v.clone(); // now an error
        } _ = {};
    }
}
```

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/35431

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
