### PR TITLE
Fix array and map inherent types when the contextually-expected type for the constructor is `any`

### DIFF
--- a/ballerina-shell/modules/shell-core/src/test/resources/testcases/evaluator/query.expr.json
+++ b/ballerina-shell/modules/shell-core/src/test/resources/testcases/evaluator/query.expr.json
@@ -19,7 +19,7 @@
   {
     "description": "Query stream evaluation - get value.",
     "code": "reportListStream",
-    "expr": "stream <stream<map>>"
+    "expr": "stream <stream<map<(any|error)>>>"
   },
   {
     "description": "String from query evaluation.",

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -1674,8 +1674,8 @@ public class TypeChecker extends BLangNodeVisitor {
                         ImmutableTypeCloner.getEffectiveImmutableType(null, types, symTable.arrayAnydataType,
                                                                       env, symTable, anonymousModelHelper, names);
             case TypeTags.ANY:
-                return !Symbols.isFlagOn(type.flags, Flags.READONLY) ? symTable.arrayType :
-                        ImmutableTypeCloner.getEffectiveImmutableType(null, types, symTable.arrayType, env,
+                return !Symbols.isFlagOn(type.flags, Flags.READONLY) ? symTable.arrayAllType :
+                        ImmutableTypeCloner.getEffectiveImmutableType(null, types, symTable.arrayAllType, env,
                                                                       symTable, anonymousModelHelper, names);
             case TypeTags.INTERSECTION:
                 return ((BIntersectionType) type).effectiveType;
@@ -2124,8 +2124,8 @@ public class TypeChecker extends BLangNodeVisitor {
                         ImmutableTypeCloner.getEffectiveImmutableType(null, types, symTable.mapAnydataType,
                                                                       env, symTable, anonymousModelHelper, names);
             case TypeTags.ANY:
-                return !Symbols.isFlagOn(type.flags, Flags.READONLY) ? symTable.mapType :
-                        ImmutableTypeCloner.getEffectiveImmutableType(null, types, symTable.mapType, env,
+                return !Symbols.isFlagOn(type.flags, Flags.READONLY) ? symTable.mapAllType :
+                        ImmutableTypeCloner.getEffectiveImmutableType(null, types, symTable.mapAllType, env,
                                                                       symTable, anonymousModelHelper, names);
             case TypeTags.INTERSECTION:
                 return ((BIntersectionType) type).effectiveType;

--- a/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_bound_type_as_cet.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_bound_type_as_cet.bal
@@ -138,11 +138,11 @@ function testBroadTypeAsCET() {
     assertTrue(arr[0] is string);
     assertValueEquality("foo", <string> arr[0]);
 
-    assertTrue(arr[1] is any[]);
+    assertTrue(arr[1] is (any|error)[]);
 
-    any[] anyArr = <any[]> arr[1];
+    (any|error)[] anyArr = <(any|error)[]> arr[1];
 
-    any val = anyArr[0];
+    any|error val = anyArr[0];
     assertTrue(val is int && val == 1);
 
     val = anyArr[1];
@@ -151,9 +151,9 @@ function testBroadTypeAsCET() {
     val = anyArr[2];
     assertTrue(val is float && val == 2.0);
 
-    assertTrue(arr[2] is map<any>);
+    assertTrue(arr[2] is map<any|error>);
 
-    map<any> anyMap = <map<any>> arr[2];
+    map<any|error> anyMap = <map<any|error>> arr[2];
 
     val = anyMap["a"];
     assertTrue(val is string && val == "abc");

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/evaluation/ExpressionEvaluationNegativeTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/evaluation/ExpressionEvaluationNegativeTest.java
@@ -436,9 +436,11 @@ public abstract class ExpressionEvaluationNegativeTest extends ExpressionEvaluat
                 , "Failed to evaluate." + System.lineSeparator() +
                         "Reason: compilation error(s) found while creating executables for evaluation: " +
                         System.lineSeparator() +
-                        "field name 'id' used in key specifier is not found in table constraint type 'map'" +
+                        "field name 'id' used in key specifier is not found in table constraint type" +
+                                                      " 'map<(any|error)>'" +
                         System.lineSeparator() +
-                        "field name 'name' used in key specifier is not found in table constraint type 'map'");
+                        "field name 'name' used in key specifier is not found in table constraint type" +
+                                                      " 'map<(any|error)>'");
 
         // on conflict clauses usages with non-table returns
         debugTestRunner.assertEvaluationError(context, "from var customer in conflictedCustomerList" +

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/evaluation/ExpressionEvaluationTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/evaluation/ExpressionEvaluationTest.java
@@ -805,7 +805,7 @@ public abstract class ExpressionEvaluationTest extends ExpressionEvaluationBaseT
                         "                degree: degreeName," +
                         "                graduationYear: graduationYear" +
                         "    };",
-                "stream<map>", "stream");
+                "stream<map<(any|error)>>", "stream");
 
         // Query join expression evaluation
         debugTestRunner.assertExpression(context, "from var student in gradStudentList" +

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/listconstructor/ListConstructorExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/listconstructor/ListConstructorExprTest.java
@@ -82,6 +82,7 @@ public class ListConstructorExprTest {
         BAssertUtil.validateError(resultNegative, i++, "incompatible types: 'int' cannot be cast to 'string'", 97, 23);
         BAssertUtil.validateError(resultNegative, i++, "unknown type 'Foo'", 98, 14);
         BAssertUtil.validateError(resultNegative, i++, "incompatible types: 'int' cannot be cast to 'string'", 98, 23);
+        BAssertUtil.validateError(resultNegative, i++, "ambiguous type '(any|any[])'", 102, 19);
         Assert.assertEquals(resultNegative.getErrorCount(), i);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/mappingconstructor/MappingConstructorExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/mappingconstructor/MappingConstructorExprTest.java
@@ -70,7 +70,7 @@ public class MappingConstructorExprTest {
     public void diagnosticsTest() {
         CompileResult result = BCompileUtil.compile(
                 "test-src/expressions/mappingconstructor/mapping_constructor_negative.bal");
-        Assert.assertEquals(result.getErrorCount(), 13);
+        Assert.assertEquals(result.getErrorCount(), 14);
         validateError(result, 0, "incompatible mapping constructor expression for type '(string|Person)'", 33, 23);
         validateError(result, 1, "ambiguous type '(PersonTwo|PersonThree)'", 37, 31);
         validateError(result, 2,
@@ -86,6 +86,7 @@ public class MappingConstructorExprTest {
         validateError(result, 10, "incompatible types: 'string' cannot be cast to 'boolean'", 59, 17);
         validateError(result, 11, "unknown type 'Foo'", 60, 5);
         validateError(result, 12, "incompatible types: 'int' cannot be cast to 'boolean'", 60, 30);
+        validateError(result, 13, "ambiguous type '(any|map)'", 64, 22);
     }
 
     @Test

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/types/test_union_type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/types/test_union_type.bal
@@ -51,21 +51,21 @@ function testUnionRuntimeToString() {
     assertTrue(b is error);
     error err = <error> b;
     assertEquals("{ballerina}TypeCastError", err.message());
-    assertEquals("incompatible types: 'any[]' cannot be cast to 'testorg/foo:1:IntOrString'",
+    assertEquals("incompatible types: '(any|error)[]' cannot be cast to 'testorg/foo:1:IntOrString'",
                  <string> checkpanic err.detail()["message"]);
 
     foo:FooBar|error c = trap <foo:FooBar> a;
     assertTrue(c is error);
     err = <error> c;
     assertEquals("{ballerina}TypeCastError", err.message());
-    assertEquals("incompatible types: 'any[]' cannot be cast to 'testorg/foo:1:FooBar'",
+    assertEquals("incompatible types: '(any|error)[]' cannot be cast to 'testorg/foo:1:FooBar'",
                  <string> checkpanic err.detail()["message"]);
 
     foo:BazQux|error d = trap <foo:BazQux> a;
     assertTrue(d is error);
     err = <error> d;
     assertEquals("{ballerina}TypeCastError", err.message());
-    assertEquals("incompatible types: 'any[]' cannot be cast to 'testorg/foo:1:BazQux'",
+    assertEquals("incompatible types: '(any|error)[]' cannot be cast to 'testorg/foo:1:BazQux'",
                  <string> checkpanic err.detail()["message"]);
 }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/listconstructor/list_constructor.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/listconstructor/list_constructor.bal
@@ -51,16 +51,16 @@ function testListConstructorAutoFillExpr() {
     }
 }
 
-const TYPEDESC_ARRAY_ANY = "typedesc any[]";
+const TYPEDESC_ARRAY_ALL = "typedesc (any|error)[]";
 
 function testListConstructorWithAnyACET() {
     any a = [1, 2];
     typedesc<any> ta = typeof a;
-    assertEquality(TYPEDESC_ARRAY_ANY, ta.toString());
+    assertEquality(TYPEDESC_ARRAY_ALL, ta.toString());
 
-    any|any[] b = [];
+    any|((any|error)[]) b = [];
     ta = typeof b;
-    assertEquality(TYPEDESC_ARRAY_ANY, ta.toString());
+    assertEquality(TYPEDESC_ARRAY_ALL, ta.toString());
 }
 
 const TYPEDESC_ARRAY_ANYDATA = "typedesc anydata[]";

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/listconstructor/list_constructor_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/listconstructor/list_constructor_negative.bal
@@ -97,3 +97,7 @@ function testListConstrWithIssuesInCET() {
     Foo f = ["hello", <string> 1]; // Unknown type.
     string[]|Foo g = [<string> 1, "hello"]; // Unknown type in union.
 }
+
+function testAmbiguousTypeWithAny() {
+    any|any[] _ = [1, 2];
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/mapping_constructor.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/mapping_constructor.bal
@@ -16,26 +16,26 @@
 
 const ASSERTION_ERROR_REASON = "AssertionError";
 
-const TYPEDESC_MAP_ANY = "typedesc map";
+const TYPEDESC_MAP_ALL = "typedesc map<(any|error)>";
 
 function testMappingConstuctorWithAnyACET() {
     any a = {a: 1, b: 2};
     typedesc<any> ta = typeof a;
     string typedescString = ta.toString();
 
-    if typedescString != TYPEDESC_MAP_ANY {
-        panic getFailureError(TYPEDESC_MAP_ANY, typedescString);
+    if typedescString != TYPEDESC_MAP_ALL {
+        panic getFailureError(TYPEDESC_MAP_ALL, typedescString);
     }
 
-    any|map<any> b = {a: "hello", b: 1};
+    any|map<any|error> b = {a: "hello", b: 1};
     ta = typeof b;
     typedescString = ta.toString();
 
-    if typedescString == TYPEDESC_MAP_ANY {
+    if typedescString == TYPEDESC_MAP_ALL {
         return;
     }
 
-    panic getFailureError(TYPEDESC_MAP_ANY, typedescString);
+    panic getFailureError(TYPEDESC_MAP_ALL, typedescString);
 }
 
 const TYPEDESC_MAP_ANYDATA = "typedesc map<anydata>";

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/mapping_constructor_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/mapping_constructor_negative.bal
@@ -59,3 +59,7 @@ function testMappingConstrWithIssuesInCET() {
     Foo f = {a: <boolean> "hello", b: 1}; // Unknown type.
     Foo|map<boolean> g = {a: <boolean> 1, c: true}; // Unknown type in union.
 }
+
+function testAmbiguousTypeWithAny() {
+    any|map<any> _ = {a: 1};
+}


### PR DESCRIPTION
## Purpose
$title.

The types were previously `any[]` and `map<any>`. This PR updates them to be `(any|error)[]` and `map<any|error>` in-line with the spec.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/33377

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
