### PR TITLE
Fix member access with int and string built-in sub-type key expressions

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -7858,8 +7858,7 @@ public class TypeChecker extends BLangNodeVisitor {
             actualType = checkMappingIndexBasedAccess(indexBasedAccessExpr, varRefType);
 
             if (actualType == symTable.semanticError) {
-                if (Types.getReferredType(indexExpr.getBType()).tag == TypeTags.STRING
-                        && isConstExpr(indexExpr)) {
+                if (isConstExpr(indexExpr)) {
                     String fieldName = getConstFieldName(indexExpr);
                     dlog.error(indexBasedAccessExpr.pos, DiagnosticErrorCode.UNDEFINED_STRUCTURE_FIELD,
                             fieldName, indexBasedAccessExpr.expr.getBType());
@@ -7884,7 +7883,7 @@ public class TypeChecker extends BLangNodeVisitor {
             indexBasedAccessExpr.originalType = actualType;
 
             if (actualType == symTable.semanticError) {
-                if (indexExpr.getBType().tag == TypeTags.INT && isConstExpr(indexExpr)) {
+                if (isConstExpr(indexExpr)) {
                     dlog.error(indexBasedAccessExpr.indexExpr.pos,
                             DiagnosticErrorCode.LIST_INDEX_OUT_OF_RANGE, getConstIndex(indexExpr));
                     return actualType;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -8251,6 +8251,7 @@ public class TypeChecker extends BLangNodeVisitor {
         BLangExpression indexExpr = accessExpr.indexExpr;
         switch (currentType.tag) {
             case TypeTags.STRING:
+            case TypeTags.CHAR_STRING:
                 if (isConstExpr(indexExpr)) {
                     String fieldName = Utils.escapeSpecialCharacters(getConstFieldName(indexExpr));
                     actualType = checkRecordRequiredFieldAccess(accessExpr, names.fromString(fieldName), record);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/access/MemberAccessTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/access/MemberAccessTest.java
@@ -123,6 +123,9 @@ public class MemberAccessTest {
         validateError(negativeResult, i++, "invalid operation: type '((Grault|int[]) & readonly)?' does " +
                 "not support member access", 222, 14);
         validateError(negativeResult, i++, "incompatible types: expected 'string', found 'int?'", 225, 17);
+        validateError(negativeResult, i++, "incompatible types: expected 'byte', found 'int'", 231, 14);
+        validateError(negativeResult, i++, "incompatible types: expected 'int:Signed32', found 'int'", 234, 22);
+        validateError(negativeResult, i++, "incompatible types: expected 'int', found 'int?'", 244, 13);
         Assert.assertEquals(negativeResult.getErrorCount(), i);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/access/MemberAccessTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/access/MemberAccessTest.java
@@ -241,6 +241,19 @@ public class MemberAccessTest {
         };
     }
 
+    @Test(dataProvider = "recordMemberAccessTestFunctions")
+    public void testRecordMemberAccess2(String function) {
+        BRunUtil.invoke(result, function);
+    }
+
+    @DataProvider
+    public Object[][] recordMemberAccessTestFunctions() {
+        return new Object[][] {
+                { "testValidRecordMemberAccessWithStringCharKeyExpr" },
+                { "testUnspecifiedFieldRecordMemberAccessWithStringCharKeyExpr" }
+        };
+    }
+
     @Test(dataProvider = "mapMemberAccessFunctions")
     public void testMapMemberAccess(String function) {
         Object returns = BRunUtil.invoke(result, function);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/access/MemberAccessTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/access/MemberAccessTest.java
@@ -146,7 +146,22 @@ public class MemberAccessTest {
             { "testTupleMemberAccessByLiteralPositive" },
             { "testTupleMemberAccessByConstPositive" },
             { "testTupleMemberAccessByVariablePositive" },
-            { "testTupleMemberAccessByFiniteTypeVariablePositive" },
+            { "testTupleMemberAccessByFiniteTypeVariablePositive" }
+        };
+    }
+
+    @Test(dataProvider = "listMemberAccessTestFunctions")
+    public void testListMemberAccess2(String function) {
+        BRunUtil.invoke(result, function);
+    }
+
+    @DataProvider
+    public Object[][] listMemberAccessTestFunctions() {
+        return new Object[][] {
+                { "testValidArrayMemberAccessWithBuiltInIntSubTypeKeyExpr" },
+                { "testOutOfRangeArrayMemberAccessWithBuiltInIntSubTypeKeyExpr" },
+                { "testValidTupleMemberAccessWithBuiltInIntSubTypeKeyExpr" },
+                { "testOutOfRangeTupleMemberAccessWithBuiltInIntSubTypeKeyExpr" }
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/SealedArrayTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/SealedArrayTest.java
@@ -44,8 +44,8 @@ public class SealedArrayTest {
         compileResult = BCompileUtil.compile("test-src/statements/arrays/sealed_array.bal");
         resultNegative = BCompileUtil.compile("test-src/statements/arrays/sealed_array_negative.bal");
         listExprNegative = BCompileUtil.compile("test-src/statements/arrays/sealed_array_listexpr_negative.bal");
-        semanticsNegative = BCompileUtil.compile("test-src/statements/arrays/sealed_array_semantics_negative" +
-                                                         ".bal");
+        semanticsNegative = BCompileUtil.compile(
+                "test-src/statements/arrays/sealed_array_semantics_negative.bal");
     }
 
     @Test
@@ -248,7 +248,6 @@ public class SealedArrayTest {
 
     @Test
     public void testSemanticsNegativeSealedArrays() {
-        Assert.assertEquals(semanticsNegative.getErrorCount(), 22);
         int i = 0;
         BAssertUtil.validateError(semanticsNegative, i++, "list index out of range: index: '5'", 19, 30);
         BAssertUtil.validateError(semanticsNegative, i++, "list index out of range: index: '5'", 25, 33);
@@ -285,8 +284,13 @@ public class SealedArrayTest {
                         "'FiniteFour'", 108, 20);
         BAssertUtil.validateError(semanticsNegative, i++, "invalid list member access expression: value space " +
                 "'FiniteFive' out of range", 109, 23);
-        BAssertUtil.validateError(semanticsNegative, i, "incompatible types: expected 'int[*]', found " +
+        BAssertUtil.validateError(semanticsNegative, i++, "incompatible types: expected 'int[*]', found " +
                         "'int[]'", 114, 22);
+        BAssertUtil.validateError(semanticsNegative, i++, "list index out of range: index: '3'", 123, 15);
+        BAssertUtil.validateError(semanticsNegative, i++, "list index out of range: index: '3'", 124, 15);
+        BAssertUtil.validateError(semanticsNegative, i++, "list index out of range: index: '3'", 125, 7);
+        BAssertUtil.validateError(semanticsNegative, i++, "list index out of range: index: '3'", 126, 7);
+        Assert.assertEquals(semanticsNegative.getErrorCount(), i);
     }
 
     @Test(description = "Test accessing invalid index of sealed array",

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/assign/LValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/assign/LValueTest.java
@@ -228,6 +228,11 @@ public class LValueTest {
         BRunUtil.invoke(result, "testTupleMemberAccessLvExprWithBuiltInIntSubTypeKeyExpr");
     }
 
+    @Test
+    public void testRecordMemberAccessLvExprWithStringCharKeyExpr() {
+        BRunUtil.invoke(result, "testRecordMemberAccessLvExprWithStringCharKeyExpr");
+    }
+
     @AfterClass
     public void tearDown() {
         result = null;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/assign/LValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/assign/LValueTest.java
@@ -73,7 +73,6 @@ public class LValueTest {
 
     @Test
     public void testSemanticsNegativeCases() {
-        Assert.assertEquals(semanticsNegativeResult.getErrorCount(), 9);
         int i = 0;
         validateError(semanticsNegativeResult, i++, "incompatible types: expected 'int', found 'string'", 18, 13);
         validateError(semanticsNegativeResult, i++, "undefined field 'y' in object 'A'", 27, 7);
@@ -86,8 +85,16 @@ public class LValueTest {
         validateError(semanticsNegativeResult, i++, "undefined field 'y' in record 'E'", 75, 5);
         validateError(semanticsNegativeResult, i++, "invalid operation: type 'map<int>?' does not support member " +
                 "access for assignment", 78, 5);
-        validateError(semanticsNegativeResult, i, "invalid operation: type 'E?' does not support field access",
+        validateError(semanticsNegativeResult, i++, "invalid operation: type 'E?' does not support field access",
                 79, 5);
+        validateError(semanticsNegativeResult, i++, "incompatible types: expected 'int', found 'string'", 85, 12);
+        validateError(semanticsNegativeResult, i++, "incompatible types: expected 'int', found 'boolean'", 88, 12);
+        // https://github.com/ballerina-platform/ballerina-lang/issues/35442
+        // validateError(semanticsNegativeResult, i++, "incompatible types: expected 'int:Signed8', found 'int'",
+        //              98, 12);
+        validateError(semanticsNegativeResult, i++, "incompatible types: expected 'int:Signed8?', found 'int'",
+                      98, 12);
+        Assert.assertEquals(semanticsNegativeResult.getErrorCount(), i);
     }
 
     @Test

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/assign/LValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/assign/LValueTest.java
@@ -218,6 +218,16 @@ public class LValueTest {
         BRunUtil.invoke(result, "testFillingReadOnRecordNegativeMemberAccessLvExpr");
     }
 
+    @Test
+    public void testArrayMemberAccessLvExprWithBuiltInIntSubTypeKeyExpr() {
+        BRunUtil.invoke(result, "testArrayMemberAccessLvExprWithBuiltInIntSubTypeKeyExpr");
+    }
+
+    @Test
+    public void testTupleMemberAccessLvExprWithBuiltInIntSubTypeKeyExpr() {
+        BRunUtil.invoke(result, "testTupleMemberAccessLvExprWithBuiltInIntSubTypeKeyExpr");
+    }
+
     @AfterClass
     public void tearDown() {
         result = null;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/access/member_access.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/access/member_access.bal
@@ -1136,6 +1136,48 @@ function assertIndexTooLargeError(error? res, string index) {
     assertEquality(string `index number too large: ${index}`, err.detail()["message"]);
 }
 
+function testValidRecordMemberAccessWithStringCharKeyExpr() {
+    record {|
+        int a = 1;
+        int b;
+        int cd;
+    |} r = {b: 2, cd: 3};
+
+    string:Char a = "a";
+    string:Char b = "b";
+
+    int? v = r[a];
+    assertEquality(1, v);
+
+    v = r[b];
+    assertEquality(2, v);
+
+    record {
+        int a = 10;
+        int b;
+        int cd;
+    } s = {b: 20, cd: 30};
+
+    anydata w = s[a];
+    assertEquality(10, w);
+
+    w = s[b];
+    assertEquality(20, w);
+}
+
+function testUnspecifiedFieldRecordMemberAccessWithStringCharKeyExpr() {
+    record {|
+        int a = 1;
+        int b;
+        int cd;
+    |} r = {b: 2, cd: 3};
+
+    string:Char c = "c";
+
+    int? v = r[c];
+    assertTrue(v is ());
+}
+
 const ASSERTION_ERROR_REASON = "AssertionError";
 
 function assertTrue(any|error actual) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/access/member_access.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/access/member_access.bal
@@ -892,6 +892,250 @@ public function testMemberAccessInInferTypeCtxWithTypeRef() {
     assertEquality(33, s);
 }
 
+function testValidArrayMemberAccessWithBuiltInIntSubTypeKeyExpr() {
+    int[] a = [10, 20];
+
+    byte b = 0;
+    int:Unsigned8 c = 0;
+    int:Unsigned16 d = 0;
+    int:Unsigned32 e = 0;
+    int:Signed8 f = 0;
+    int:Signed16 g = 0;
+    int:Signed32 h = 0;
+
+    int v = a[b];
+    assertEquality(10, v);
+    v = a[c];
+    assertEquality(10, v);
+    v = a[d];
+    assertEquality(10, v);
+    v = a[e];
+    assertEquality(10, v);
+    v = a[f];
+    assertEquality(10, v);
+    v = a[g];
+    assertEquality(10, v);
+    v = a[h];
+    assertEquality(10, v);
+
+    b = 1;
+    c = 1;
+    d = 1;
+    e = 1;
+    f = 1;
+    g = 1;
+    h = 1;
+
+    assertEquality(20, a[b]);
+    assertEquality(20, a[c]);
+    assertEquality(20, a[d]);
+    assertEquality(20, a[e]);
+    assertEquality(20, a[f]);
+    assertEquality(20, a[g]);
+    assertEquality(20, a[h]);
+}
+
+function testOutOfRangeArrayMemberAccessWithBuiltInIntSubTypeKeyExpr() {
+    int[] a = [10, 20];
+
+    byte b = 255;
+    int:Unsigned8 c = 255;
+    int:Unsigned16 d = 65535;
+    int:Unsigned32 e = 4294967295;
+    int:Signed8 f = 127;
+    int:Signed16 g = 32767;
+    int:Signed32 h = 2147483647;
+
+    function () fn = function () {
+        int _ = a[b];
+    };
+    assertArrayOutOfRangeError(trap fn(), 255, 2);
+
+    fn = function () {
+        int _ = a[c];
+    };
+    assertArrayOutOfRangeError(trap fn(), 255, 2);
+
+    fn = function () {
+        int _ = a[d];
+    };
+    assertArrayOutOfRangeError(trap fn(), "65,535", 2);
+
+    fn = function () {
+        int _ = a[e];
+    };
+    assertIndexTooLargeError(trap fn(), "4,294,967,295");
+
+    fn = function () {
+        int _ = a[f];
+    };
+    assertArrayOutOfRangeError(trap fn(), 127, 2);
+
+    fn = function () {
+        int _ = a[g];
+    };
+    assertArrayOutOfRangeError(trap fn(), "32,767", 2);
+
+    fn = function () {
+        int _ = a[h];
+    };
+    assertArrayOutOfRangeError(trap fn(), "2,147,483,647", 2);
+
+    f = -128;
+    g = -32768;
+    h = -2147483648;
+
+    fn = function () {
+        int _ = a[f];
+    };
+    assertArrayOutOfRangeError(trap fn(), -128, 2);
+
+    fn = function () {
+        int _ = a[g];
+    };
+    assertArrayOutOfRangeError(trap fn(), "-32,768", 2);
+
+    fn = function () {
+        int _ = a[h];
+    };
+    assertArrayOutOfRangeError(trap fn(), "-2,147,483,648", 2);
+}
+
+function testValidTupleMemberAccessWithBuiltInIntSubTypeKeyExpr() {
+    [int, int...] a = [10, 20];
+
+    byte b = 0;
+    int:Unsigned8 c = 0;
+    int:Unsigned16 d = 0;
+    int:Unsigned32 e = 0;
+    int:Signed8 f = 0;
+    int:Signed16 g = 0;
+    int:Signed32 h = 0;
+
+    int v = a[b];
+    assertEquality(10, v);
+    v = a[c];
+    assertEquality(10, v);
+    v = a[d];
+    assertEquality(10, v);
+    v = a[e];
+    assertEquality(10, v);
+    v = a[f];
+    assertEquality(10, v);
+    v = a[g];
+    assertEquality(10, v);
+    v = a[h];
+    assertEquality(10, v);
+
+    b = 1;
+    c = 1;
+    d = 1;
+    e = 1;
+    f = 1;
+    g = 1;
+    h = 1;
+
+    assertEquality(20, a[b]);
+    assertEquality(20, a[c]);
+    assertEquality(20, a[d]);
+    assertEquality(20, a[e]);
+    assertEquality(20, a[f]);
+    assertEquality(20, a[g]);
+    assertEquality(20, a[h]);
+}
+
+function testOutOfRangeTupleMemberAccessWithBuiltInIntSubTypeKeyExpr() {
+    [int, int...] a = [10, 20];
+
+    byte b = 255;
+    int:Unsigned8 c = 255;
+    int:Unsigned16 d = 65535;
+    int:Unsigned32 e = 4294967295;
+    int:Signed8 f = 127;
+    int:Signed16 g = 32767;
+    int:Signed32 h = 2147483647;
+
+    function () fn = function () {
+        int _ = a[b];
+    };
+    assertTupleOutOfRangeError(trap fn(), 255, 2);
+
+    fn = function () {
+        int _ = a[c];
+    };
+    assertTupleOutOfRangeError(trap fn(), 255, 2);
+
+    fn = function () {
+        int _ = a[d];
+    };
+    assertTupleOutOfRangeError(trap fn(), "65,535", 2);
+
+    fn = function () {
+        int _ = a[e];
+    };
+    assertIndexTooLargeError(trap fn(), "4,294,967,295");
+
+    fn = function () {
+        int _ = a[f];
+    };
+    assertTupleOutOfRangeError(trap fn(), 127, 2);
+
+    fn = function () {
+        int _ = a[g];
+    };
+    assertTupleOutOfRangeError(trap fn(), "32,767", 2);
+
+    fn = function () {
+        int _ = a[h];
+    };
+    assertTupleOutOfRangeError(trap fn(), "2,147,483,647", 2);
+
+    f = -128;
+    g = -32768;
+    h = -2147483648;
+
+    fn = function () {
+        int _ = a[f];
+    };
+    assertTupleOutOfRangeError(trap fn(), -128, 2);
+
+    fn = function () {
+        int _ = a[g];
+    };
+    assertTupleOutOfRangeError(trap fn(), "-32,768", 2);
+
+    fn = function () {
+        int _ = a[h];
+    };
+    assertTupleOutOfRangeError(trap fn(), "-2,147,483,648", 2);
+}
+
+function assertArrayOutOfRangeError(error? res, int|string index, int size) {
+    assertOutOfRangeError(res, "array", index, size);
+}
+
+function assertTupleOutOfRangeError(error? res, int|string index, int size) {
+    assertOutOfRangeError(res, "tuple", index, size);
+}
+
+function assertOutOfRangeError(error? res, "array"|"tuple" listKind, int|string index, int size) {
+    assertTrue(res is error);
+
+    error err = <error> res;
+
+    assertEquality("{ballerina/lang.array}IndexOutOfRange", err.message());
+    assertEquality(string `${listKind} index out of range: index: ${index}, size: ${size}`, err.detail()["message"]);
+}
+
+function assertIndexTooLargeError(error? res, string index) {
+    assertTrue(res is error);
+
+    error err = <error> res;
+
+    assertEquality("{ballerina/lang.array}IndexOutOfRange", err.message());
+    assertEquality(string `index number too large: ${index}`, err.detail()["message"]);
+}
+
 const ASSERTION_ERROR_REASON = "AssertionError";
 
 function assertTrue(any|error actual) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/access/member_access_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/access/member_access_negative.bal
@@ -224,3 +224,22 @@ public function testNestedMemberAccessOnIntersectionTypesNegative() {
     Corge & readonly q2 = {i: 1, baz: {a: "hello", i: 2}};
     string v2 = q2["baz"]["i"];
 }
+
+function testListMemberAccessWithIntBuiltInSubTypeKeyExprNegative() {
+    int[] a = [];
+    byte b = 0;
+    byte _ = a[b]; // error: incompatible types: expected 'byte', found 'int'
+
+    int:Signed32 c = 0;
+    int:Signed32 _ = a[c]; // error: incompatible types: expected 'int:Signed32', found 'int'
+}
+
+function testRecordMemberAccessWithStringCharKeyExprNegative() {
+    record {|
+        int a;
+        int b;
+        int cd;
+    |} r = {a: 1, b: 2, cd: 3};
+    string:Char a = "a";
+    int _ = r[a]; // error: incompatible types: expected 'int', found 'int?'
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/sealed_array_semantics_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/sealed_array_semantics_negative.bal
@@ -113,3 +113,15 @@ function openToSealArrrayAssignment() {
     int[] intArr1 = [];
     int[*] intArr2 = intArr1.clone();
 }
+
+const I1 = 0x3;
+const I2 = 3;
+
+function testInvalidArrayAccessByConst() {
+    int[2] a = [];
+
+    int _ = a[I1]; // list index out of range: index: '3'
+    int _ = a[I2]; // list index out of range: index: '3'
+    a[I1] = 3; // list index out of range: index: '3'
+    a[I2] = 4; // list index out of range: index: '3'
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/assign/lvalue-semantics-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/assign/lvalue-semantics-negative.bal
@@ -78,3 +78,22 @@ function testInvalidRecordFieldAccessLvExpr() {
     f.m["two"] = 2;
     f.e.x = "ddd";
 }
+
+function testListMemberAccessLvExprWithIntBuiltInSubTypeKeyExprNegative() {
+    int[] a = [];
+    byte b = 0;
+    a[b] = ""; // error: incompatible types: expected 'int', found 'string'
+
+    int:Signed32 c = 0;
+    a[c] = true; // error: incompatible types: expected 'int', found 'boolean'
+}
+
+function testRecordMemberAccessLvExprWithStringCharKeyExprNegative() {
+    record {|
+        int:Signed8 a;
+        int:Signed8 b;
+        int:Signed8 cd;
+    |} r = {a: 1, b: 2, cd: 3};
+    string:Char a = "a";
+    r[a] = 200; // error: incompatible types: expected 'int:Signed8', found 'int'
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/assign/lvalue.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/assign/lvalue.bal
@@ -472,6 +472,30 @@ function testTupleMemberAccessLvExprWithBuiltInIntSubTypeKeyExpr() {
     //                <string> checkpanic err.detail()["message"]);
 }
 
+function testRecordMemberAccessLvExprWithStringCharKeyExpr() {
+    record {|
+        int a;
+        int b;
+    |} r = {a: 1, b: 2};
+
+    string:Char a = "a";
+    r[a] = 101;
+    assertEquality(101, r.a);
+
+    function () fn = function () {
+        string:Char c = "c";
+        r[c] = 20;
+    };
+
+    error? res = trap fn();
+    assertTrue(res is error);
+
+    error err = <error> res;
+    assertEquality("{ballerina/lang.map}KeyNotFound", err.message());
+    assertEquality("invalid field access: field 'c' not found in record type 'record {| int a; int b; |}'",
+                   <string> checkpanic err.detail()["message"]);
+}
+
 function assertTrue(anydata actual) {
     assertEquality(true, actual);
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/assign/lvalue.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/assign/lvalue.bal
@@ -398,3 +398,88 @@ function testFillingReadOnRecordNegativeMemberAccessLvExpr() {
     M m = {};
     m["l"]["i"] = 1;
 }
+
+function testArrayMemberAccessLvExprWithBuiltInIntSubTypeKeyExpr() {
+    int[] a = [];
+    byte b = 0;
+    int:Signed32 c = 355;
+
+    a[b] = 10;
+
+    b = 255;
+    a[b] = 30;
+
+    a[c] = 20;
+
+    assertEquality(356, a.length());
+    assertEquality(10, a[0]);
+    assertEquality(0, a[100]);
+    assertEquality(0, a[254]);
+    assertEquality(30, a[255]);
+    assertEquality(30, a[b]);
+    assertEquality(0, a[256]);
+    assertEquality(20, a[355]);
+
+    function () fn = function () {
+        record {| int i; |}[] d = [];
+        int:Unsigned16 e = 45;
+        d[e] = {i: 1};
+    };
+
+    error? res = trap fn();
+    assertTrue(res is error);
+
+    error err = <error> res;
+    assertEquality("{ballerina/lang.array}IllegalListInsertion", err.message());
+    assertEquality("array of length 0 cannot be expanded into array of length 46 without filler values",
+                   <string> checkpanic err.detail()["message"]);
+}
+
+function testTupleMemberAccessLvExprWithBuiltInIntSubTypeKeyExpr() {
+    [int, int...] a = [-1];
+    byte b = 0;
+    int:Signed32 c = 355;
+
+    a[b] = 10;
+
+    b = 255;
+    a[b] = 30;
+
+    a[c] = 20;
+
+    assertEquality(356, a.length());
+    assertEquality(10, a[0]);
+    assertEquality(0, a[100]);
+    assertEquality(0, a[254]);
+    assertEquality(30, a[255]);
+    assertEquality(30, a[b]);
+    assertEquality(0, a[256]);
+    assertEquality(20, a[355]);
+
+    // https://github.com/ballerina-platform/ballerina-lang/issues/35441
+    // function () fn = function () {
+    //     [record {| int i; |}...] d = [];
+    //     int:Unsigned16 e = 45;
+    //     d[e] = {i: 1};
+    // };
+
+    // error? res = trap fn();
+    // assertTrue(res is error);
+
+    // error err = <error> res;
+    // assertEquality("{ballerina/lang.array}IllegalListInsertion", err.message());
+    // assertEquality("tuple of length 0 cannot be expanded into tuple of length 46 without filler values",
+    //                <string> checkpanic err.detail()["message"]);
+}
+
+function assertTrue(anydata actual) {
+    assertEquality(true, actual);
+}
+
+function assertEquality(anydata expected, anydata actual) {
+    if expected == actual {
+        return;
+    }
+
+    panic error("expected '" + expected.toString() + "', found '" + actual.toString() + "'");
+}


### PR DESCRIPTION
## Purpose
$title.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/33346
Fixes https://github.com/ballerina-platform/ballerina-lang/issues/35439

## Remarks
https://github.com/ballerina-platform/ballerina-lang/issues/35442
https://github.com/ballerina-platform/ballerina-lang/issues/35441
https://github.com/ballerina-platform/ballerina-lang/issues/35440

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
