### PR TITLE
Removing an unused ANTLR dependency from the distribution

### DIFF
--- a/distribution/zip/jballerina-tools/build.gradle
+++ b/distribution/zip/jballerina-tools/build.gradle
@@ -78,7 +78,6 @@ dependencies {
     dist "org.apache.commons:commons-compress:${project.apacheCommonsCompressVersion}"
     dist "me.tongfei:progressbar:${project.tongfeiProgressbarVersion}"
     dist "org.jline:jline:${project.jlineVersion}"
-    dist "org.wso2.orbit.org.antlr:antlr4-runtime:${project.wso2OrbitAntlr4Version}"
     dist "org.apache.commons:commons-text:${project.apacheCommonsTextVersion}"
     dist "com.github.spullara.mustache.java:compiler:${project.spullaraMustacheCompilerVersion}"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -155,5 +155,4 @@ wso2TransportHttpVersion=6.3.11
 wso2TransportLocalFileSystemVersion=6.0.55
 wso2StaxonCoreVersion=1.2.0.wso2v2
 wso2CommonsPoolVersion=1.5.6.wso2v1
-wso2OrbitAntlr4Version=4.5.1.wso2v1
 zafarkhajaJsemverVersion=0.9.0


### PR DESCRIPTION
## Purpose
This ANTLR dependency was added to the `bre/lib` through https://github.com/ballerina-platform/ballerina-lang/pull/27116, since it was required as a transitive dependency by the `com.github.jknack:handlebars` library used by the `bindgen` tool (which was previously removed in https://github.com/ballerina-platform/ballerina-lang/pull/25821). 

However, the bindgen implementation no longer required this library, hence removing this dependency.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/33811

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
