### PR TITLE
Introduce symbol visitor and transformer APIs

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/SymbolTransformer.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/SymbolTransformer.java
@@ -81,8 +81,11 @@ import io.ballerina.compiler.api.symbols.XMLProcessingInstructionTypeSymbol;
 import io.ballerina.compiler.api.symbols.XMLTextTypeSymbol;
 import io.ballerina.compiler.api.symbols.XMLTypeSymbol;
 
+
 /**
  * A transformer for visiting a symbol and mapping the symbol to some other representation.
+ *
+ * @param <R> The type to which the symbol will be mapped
  */
 public abstract class SymbolTransformer<R> {
 
@@ -92,7 +95,8 @@ public abstract class SymbolTransformer<R> {
      * include any common pre-processing and post-processing tasks to be done during the course of transforming the
      * symbol.
      *
-     * @param symbol symbol to be traversed
+     * @param symbol Symbol to be traversed
+     * @return The transformed instance for the symbol
      */
     public abstract R transformSymbol(Symbol symbol);
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/SymbolTransformer.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/SymbolTransformer.java
@@ -1,0 +1,346 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.compiler.api;
+
+import io.ballerina.compiler.api.symbols.AnnotationSymbol;
+import io.ballerina.compiler.api.symbols.AnyTypeSymbol;
+import io.ballerina.compiler.api.symbols.AnydataTypeSymbol;
+import io.ballerina.compiler.api.symbols.ArrayTypeSymbol;
+import io.ballerina.compiler.api.symbols.BooleanTypeSymbol;
+import io.ballerina.compiler.api.symbols.ByteTypeSymbol;
+import io.ballerina.compiler.api.symbols.ClassFieldSymbol;
+import io.ballerina.compiler.api.symbols.ClassSymbol;
+import io.ballerina.compiler.api.symbols.CompilationErrorTypeSymbol;
+import io.ballerina.compiler.api.symbols.ConstantSymbol;
+import io.ballerina.compiler.api.symbols.DecimalTypeSymbol;
+import io.ballerina.compiler.api.symbols.EnumSymbol;
+import io.ballerina.compiler.api.symbols.ErrorTypeSymbol;
+import io.ballerina.compiler.api.symbols.FloatTypeSymbol;
+import io.ballerina.compiler.api.symbols.FunctionSymbol;
+import io.ballerina.compiler.api.symbols.FunctionTypeSymbol;
+import io.ballerina.compiler.api.symbols.FutureTypeSymbol;
+import io.ballerina.compiler.api.symbols.HandleTypeSymbol;
+import io.ballerina.compiler.api.symbols.IntSigned16TypeSymbol;
+import io.ballerina.compiler.api.symbols.IntSigned32TypeSymbol;
+import io.ballerina.compiler.api.symbols.IntSigned8TypeSymbol;
+import io.ballerina.compiler.api.symbols.IntTypeSymbol;
+import io.ballerina.compiler.api.symbols.IntUnsigned16TypeSymbol;
+import io.ballerina.compiler.api.symbols.IntUnsigned32TypeSymbol;
+import io.ballerina.compiler.api.symbols.IntUnsigned8TypeSymbol;
+import io.ballerina.compiler.api.symbols.IntersectionTypeSymbol;
+import io.ballerina.compiler.api.symbols.JSONTypeSymbol;
+import io.ballerina.compiler.api.symbols.MapTypeSymbol;
+import io.ballerina.compiler.api.symbols.MethodSymbol;
+import io.ballerina.compiler.api.symbols.ModuleSymbol;
+import io.ballerina.compiler.api.symbols.NeverTypeSymbol;
+import io.ballerina.compiler.api.symbols.NilTypeSymbol;
+import io.ballerina.compiler.api.symbols.NoneTypeSymbol;
+import io.ballerina.compiler.api.symbols.ObjectFieldSymbol;
+import io.ballerina.compiler.api.symbols.ObjectTypeSymbol;
+import io.ballerina.compiler.api.symbols.ParameterSymbol;
+import io.ballerina.compiler.api.symbols.PathParameterSymbol;
+import io.ballerina.compiler.api.symbols.ReadonlyTypeSymbol;
+import io.ballerina.compiler.api.symbols.RecordFieldSymbol;
+import io.ballerina.compiler.api.symbols.RecordTypeSymbol;
+import io.ballerina.compiler.api.symbols.ResourceMethodSymbol;
+import io.ballerina.compiler.api.symbols.ServiceDeclarationSymbol;
+import io.ballerina.compiler.api.symbols.SingletonTypeSymbol;
+import io.ballerina.compiler.api.symbols.StreamTypeSymbol;
+import io.ballerina.compiler.api.symbols.StringCharTypeSymbol;
+import io.ballerina.compiler.api.symbols.StringTypeSymbol;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.TableTypeSymbol;
+import io.ballerina.compiler.api.symbols.TupleTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeDefinitionSymbol;
+import io.ballerina.compiler.api.symbols.TypeDescTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
+import io.ballerina.compiler.api.symbols.VariableSymbol;
+import io.ballerina.compiler.api.symbols.WorkerSymbol;
+import io.ballerina.compiler.api.symbols.XMLCommentTypeSymbol;
+import io.ballerina.compiler.api.symbols.XMLElementTypeSymbol;
+import io.ballerina.compiler.api.symbols.XMLProcessingInstructionTypeSymbol;
+import io.ballerina.compiler.api.symbols.XMLTextTypeSymbol;
+import io.ballerina.compiler.api.symbols.XMLTypeSymbol;
+
+/**
+ * A transformer for recursively visiting a symbol and mapping the symbol to some other representation.
+ */
+public abstract class SymbolTransformer<R> {
+
+    /**
+     * An end user using a visitor should always be calling this method to transform a symbol instead of calling the
+     * individual transform() methods. One implementing a transformer should implement this method and can use this to
+     * include any common pre-processing and post-processing tasks to be done during the course of transforming the
+     * symbol.
+     *
+     * @param symbol symbol to be traversed
+     */
+    public abstract R transformSymbol(Symbol symbol);
+
+    // Symbols
+    public R transform(AnnotationSymbol annotation) {
+        return transformSymbol(annotation);
+    }
+
+    public R transform(ClassSymbol clazz) {
+        return transformSymbol(clazz);
+    }
+
+    public R transform(ConstantSymbol constant) {
+        return transformSymbol(constant);
+    }
+
+    public R transform(EnumSymbol enumSymbol) {
+        return transformSymbol(enumSymbol);
+    }
+
+    public R transform(FunctionSymbol function) {
+        return transformSymbol(function);
+    }
+
+    public R transform(ModuleSymbol module) {
+        return transformSymbol(module);
+    }
+
+    public R transform(ServiceDeclarationSymbol service) {
+        return transformSymbol(service);
+    }
+
+    public R transform(TypeDefinitionSymbol typeDef) {
+        return transformSymbol(typeDef);
+    }
+
+    public R transform(VariableSymbol var) {
+        return transformSymbol(var);
+    }
+
+    public R transform(WorkerSymbol worker) {
+        return transformSymbol(worker);
+    }
+
+    // Util symbols (i.e., used within above symbols or type symbols)
+
+    public R transform(ClassFieldSymbol classField) {
+        return transformSymbol(classField);
+    }
+
+    public R transform(MethodSymbol method) {
+        return transformSymbol(method);
+    }
+
+    public R transform(ObjectFieldSymbol objectField) {
+        return transformSymbol(objectField);
+    }
+
+    public R transform(ParameterSymbol param) {
+        return transformSymbol(param);
+    }
+
+    public R transform(PathParameterSymbol pathParam) {
+        return transformSymbol(pathParam);
+    }
+
+    public R transform(RecordFieldSymbol recordField) {
+        return transformSymbol(recordField);
+    }
+
+    public R transform(ResourceMethodSymbol resourceMethod) {
+        return transformSymbol(resourceMethod);
+    }
+
+    // Types
+
+    public R transform(AnyTypeSymbol anyType) {
+        return transformSymbol(anyType);
+    }
+
+    public R transform(AnydataTypeSymbol anydataType) {
+        return transformSymbol(anydataType);
+    }
+
+    public R transform(ArrayTypeSymbol arrayType) {
+        return transformSymbol(arrayType);
+    }
+
+    public R transform(BooleanTypeSymbol booleanType) {
+        return transformSymbol(booleanType);
+    }
+
+    public R transform(ByteTypeSymbol byteType) {
+        return transformSymbol(byteType);
+    }
+
+    public R transform(CompilationErrorTypeSymbol compileErrorType) {
+        return transformSymbol(compileErrorType);
+    }
+
+    public R transform(DecimalTypeSymbol decimalType) {
+        return transformSymbol(decimalType);
+    }
+
+    public R transform(ErrorTypeSymbol errorType) {
+        return transformSymbol(errorType);
+    }
+
+    public R transform(FloatTypeSymbol floatType) {
+        return transformSymbol(floatType);
+    }
+
+    public R transform(FunctionTypeSymbol functionType) {
+        return transformSymbol(functionType);
+    }
+
+    public R transform(FutureTypeSymbol futureType) {
+        return transformSymbol(futureType);
+    }
+
+    public R transform(HandleTypeSymbol handleType) {
+        return transformSymbol(handleType);
+    }
+
+    public R transform(IntTypeSymbol intType) {
+        return transformSymbol(intType);
+    }
+
+    public R transform(IntSigned8TypeSymbol signedInt8Type) {
+        return transformSymbol(signedInt8Type);
+    }
+
+    public R transform(IntSigned16TypeSymbol signedInt16Type) {
+        return transformSymbol(signedInt16Type);
+    }
+
+    public R transform(IntSigned32TypeSymbol signedInt32Type) {
+        return transformSymbol(signedInt32Type);
+    }
+
+    public R transform(IntUnsigned8TypeSymbol unsignedInt8Type) {
+        return transformSymbol(unsignedInt8Type);
+    }
+
+    public R transform(IntUnsigned16TypeSymbol unsignedInt16Type) {
+        return transformSymbol(unsignedInt16Type);
+    }
+
+    public R transform(IntUnsigned32TypeSymbol unsignedInt32Type) {
+        return transformSymbol(unsignedInt32Type);
+    }
+
+    public R transform(IntersectionTypeSymbol intersectionType) {
+        return transformSymbol(intersectionType);
+    }
+
+    public R transform(JSONTypeSymbol jsonType) {
+        return transformSymbol(jsonType);
+    }
+
+    public R transform(MapTypeSymbol mapType) {
+        return transformSymbol(mapType);
+    }
+
+    public R transform(NeverTypeSymbol neverType) {
+        return transformSymbol(neverType);
+    }
+
+    public R transform(NilTypeSymbol nilType) {
+        return transformSymbol(nilType);
+    }
+
+    public R transform(NoneTypeSymbol noneType) {
+        return transformSymbol(noneType);
+    }
+
+    public R transform(ObjectTypeSymbol objectType) {
+        return transformSymbol(objectType);
+    }
+
+    public R transform(ReadonlyTypeSymbol readonlyType) {
+        return transformSymbol(readonlyType);
+    }
+
+    public R transform(RecordTypeSymbol recordType) {
+        return transformSymbol(recordType);
+    }
+
+    public R transform(SingletonTypeSymbol singletonType) {
+        return transformSymbol(singletonType);
+    }
+
+    public R transform(StreamTypeSymbol streamType) {
+        return transformSymbol(streamType);
+    }
+
+    public R transform(StringTypeSymbol stringType) {
+        return transformSymbol(stringType);
+    }
+
+    public R transform(StringCharTypeSymbol charType) {
+        return transformSymbol(charType);
+    }
+
+    public R transform(TableTypeSymbol tableType) {
+        return transformSymbol(tableType);
+    }
+
+    public R transform(TupleTypeSymbol tupleType) {
+        return transformSymbol(tupleType);
+    }
+
+    public R transform(TypeDescTypeSymbol typedescType) {
+        return transformSymbol(typedescType);
+    }
+
+    public R transform(TypeReferenceTypeSymbol typeRefType) {
+        return transformSymbol(typeRefType);
+    }
+
+    public R transform(UnionTypeSymbol unionType) {
+        return transformSymbol(unionType);
+    }
+
+    public R transform(XMLTypeSymbol xmlType) {
+        return transformSymbol(xmlType);
+    }
+
+    public R transform(XMLCommentTypeSymbol xmlCommentType) {
+        return transformSymbol(xmlCommentType);
+    }
+
+    public R transform(XMLElementTypeSymbol xmlElementType) {
+        return transformSymbol(xmlElementType);
+    }
+
+    public R transform(XMLProcessingInstructionTypeSymbol xmlPIType) {
+        return transformSymbol(xmlPIType);
+    }
+
+    public R transform(XMLTextTypeSymbol xmlTextType) {
+        return transformSymbol(xmlTextType);
+    }
+
+    public R transform(Symbol symbol) {
+        throw new UnsupportedOperationException();
+    }
+
+    public R transform(TypeSymbol symbol) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/SymbolTransformer.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/SymbolTransformer.java
@@ -76,12 +76,13 @@ import io.ballerina.compiler.api.symbols.VariableSymbol;
 import io.ballerina.compiler.api.symbols.WorkerSymbol;
 import io.ballerina.compiler.api.symbols.XMLCommentTypeSymbol;
 import io.ballerina.compiler.api.symbols.XMLElementTypeSymbol;
+import io.ballerina.compiler.api.symbols.XMLNamespaceSymbol;
 import io.ballerina.compiler.api.symbols.XMLProcessingInstructionTypeSymbol;
 import io.ballerina.compiler.api.symbols.XMLTextTypeSymbol;
 import io.ballerina.compiler.api.symbols.XMLTypeSymbol;
 
 /**
- * A transformer for recursively visiting a symbol and mapping the symbol to some other representation.
+ * A transformer for visiting a symbol and mapping the symbol to some other representation.
  */
 public abstract class SymbolTransformer<R> {
 
@@ -134,6 +135,10 @@ public abstract class SymbolTransformer<R> {
 
     public R transform(WorkerSymbol worker) {
         return transformSymbol(worker);
+    }
+
+    public R transform(XMLNamespaceSymbol xmlns) {
+        return transformSymbol(xmlns);
     }
 
     // Util symbols (i.e., used within above symbols or type symbols)

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/SymbolVisitor.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/SymbolVisitor.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.compiler.api;
+
+import io.ballerina.compiler.api.symbols.AnnotationSymbol;
+import io.ballerina.compiler.api.symbols.AnyTypeSymbol;
+import io.ballerina.compiler.api.symbols.AnydataTypeSymbol;
+import io.ballerina.compiler.api.symbols.ArrayTypeSymbol;
+import io.ballerina.compiler.api.symbols.BooleanTypeSymbol;
+import io.ballerina.compiler.api.symbols.ByteTypeSymbol;
+import io.ballerina.compiler.api.symbols.ClassFieldSymbol;
+import io.ballerina.compiler.api.symbols.ClassSymbol;
+import io.ballerina.compiler.api.symbols.CompilationErrorTypeSymbol;
+import io.ballerina.compiler.api.symbols.ConstantSymbol;
+import io.ballerina.compiler.api.symbols.DecimalTypeSymbol;
+import io.ballerina.compiler.api.symbols.EnumSymbol;
+import io.ballerina.compiler.api.symbols.ErrorTypeSymbol;
+import io.ballerina.compiler.api.symbols.FloatTypeSymbol;
+import io.ballerina.compiler.api.symbols.FunctionSymbol;
+import io.ballerina.compiler.api.symbols.FunctionTypeSymbol;
+import io.ballerina.compiler.api.symbols.FutureTypeSymbol;
+import io.ballerina.compiler.api.symbols.HandleTypeSymbol;
+import io.ballerina.compiler.api.symbols.IntSigned16TypeSymbol;
+import io.ballerina.compiler.api.symbols.IntSigned32TypeSymbol;
+import io.ballerina.compiler.api.symbols.IntSigned8TypeSymbol;
+import io.ballerina.compiler.api.symbols.IntTypeSymbol;
+import io.ballerina.compiler.api.symbols.IntUnsigned16TypeSymbol;
+import io.ballerina.compiler.api.symbols.IntUnsigned32TypeSymbol;
+import io.ballerina.compiler.api.symbols.IntUnsigned8TypeSymbol;
+import io.ballerina.compiler.api.symbols.IntersectionTypeSymbol;
+import io.ballerina.compiler.api.symbols.JSONTypeSymbol;
+import io.ballerina.compiler.api.symbols.MapTypeSymbol;
+import io.ballerina.compiler.api.symbols.MethodSymbol;
+import io.ballerina.compiler.api.symbols.ModuleSymbol;
+import io.ballerina.compiler.api.symbols.NeverTypeSymbol;
+import io.ballerina.compiler.api.symbols.NilTypeSymbol;
+import io.ballerina.compiler.api.symbols.NoneTypeSymbol;
+import io.ballerina.compiler.api.symbols.ObjectFieldSymbol;
+import io.ballerina.compiler.api.symbols.ObjectTypeSymbol;
+import io.ballerina.compiler.api.symbols.ParameterSymbol;
+import io.ballerina.compiler.api.symbols.PathParameterSymbol;
+import io.ballerina.compiler.api.symbols.ReadonlyTypeSymbol;
+import io.ballerina.compiler.api.symbols.RecordFieldSymbol;
+import io.ballerina.compiler.api.symbols.RecordTypeSymbol;
+import io.ballerina.compiler.api.symbols.ResourceMethodSymbol;
+import io.ballerina.compiler.api.symbols.ServiceDeclarationSymbol;
+import io.ballerina.compiler.api.symbols.SingletonTypeSymbol;
+import io.ballerina.compiler.api.symbols.StreamTypeSymbol;
+import io.ballerina.compiler.api.symbols.StringCharTypeSymbol;
+import io.ballerina.compiler.api.symbols.StringTypeSymbol;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.TableTypeSymbol;
+import io.ballerina.compiler.api.symbols.TupleTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeDefinitionSymbol;
+import io.ballerina.compiler.api.symbols.TypeDescTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
+import io.ballerina.compiler.api.symbols.VariableSymbol;
+import io.ballerina.compiler.api.symbols.WorkerSymbol;
+import io.ballerina.compiler.api.symbols.XMLCommentTypeSymbol;
+import io.ballerina.compiler.api.symbols.XMLElementTypeSymbol;
+import io.ballerina.compiler.api.symbols.XMLProcessingInstructionTypeSymbol;
+import io.ballerina.compiler.api.symbols.XMLTextTypeSymbol;
+import io.ballerina.compiler.api.symbols.XMLTypeSymbol;
+
+/**
+ * A visitor for recursively visiting a symbol.
+ */
+public abstract class SymbolVisitor {
+
+    /**
+     * An end user using a visitor should always be calling this method to visit a symbol instead of calling the
+     * individual visit() methods. One implementing a visitor should implement this method and can use this to include
+     * any common pre-processing and post-processing tasks to be done during the course of visiting the symbol.
+     *
+     * @param symbol symbol to be traversed
+     */
+    public abstract void visitSymbol(Symbol symbol);
+
+    // Symbols
+    public void visit(AnnotationSymbol annotation) {
+    }
+
+    public void visit(ClassSymbol clazz) {
+    }
+
+    public void visit(ConstantSymbol constant) {
+    }
+
+    public void visit(EnumSymbol enumSymbol) {
+    }
+
+    public void visit(FunctionSymbol function) {
+    }
+
+    public void visit(ModuleSymbol module) {
+    }
+
+    public void visit(ServiceDeclarationSymbol service) {
+    }
+
+    public void visit(TypeDefinitionSymbol typeDef) {
+    }
+
+    public void visit(VariableSymbol var) {
+    }
+
+    public void visit(WorkerSymbol worker) {
+    }
+
+    // Util symbols (i.e., used within above symbols or type symbols)
+
+    public void visit(ClassFieldSymbol classField) {
+    }
+
+    public void visit(MethodSymbol method) {
+    }
+
+    public void visit(ObjectFieldSymbol objectField) {
+    }
+
+    public void visit(ParameterSymbol param) {
+    }
+
+    public void visit(PathParameterSymbol pathParam) {
+    }
+
+    public void visit(RecordFieldSymbol recordField) {
+    }
+
+    public void visit(ResourceMethodSymbol resourceMethod) {
+    }
+
+    // Types
+
+    public void visit(AnyTypeSymbol anyType) {
+    }
+
+    public void visit(AnydataTypeSymbol anydataType) {
+    }
+
+    public void visit(ArrayTypeSymbol arrayType) {
+    }
+
+    public void visit(BooleanTypeSymbol booleanType) {
+    }
+
+    public void visit(ByteTypeSymbol byteType) {
+    }
+
+    public void visit(CompilationErrorTypeSymbol compileErrorType) {
+    }
+
+    public void visit(DecimalTypeSymbol decimalType) {
+    }
+
+    public void visit(ErrorTypeSymbol errorType) {
+    }
+
+    public void visit(FloatTypeSymbol floatType) {
+    }
+
+    public void visit(FunctionTypeSymbol functionType) {
+    }
+
+    public void visit(FutureTypeSymbol futureType) {
+    }
+
+    public void visit(HandleTypeSymbol handleType) {
+    }
+
+    public void visit(IntTypeSymbol intType) {
+    }
+
+    public void visit(IntSigned8TypeSymbol signedInt8Type) {
+    }
+
+    public void visit(IntSigned16TypeSymbol signedInt16Type) {
+    }
+
+    public void visit(IntSigned32TypeSymbol signedInt32Type) {
+    }
+
+    public void visit(IntUnsigned8TypeSymbol unsignedInt8Type) {
+    }
+
+    public void visit(IntUnsigned16TypeSymbol unsignedInt16Type) {
+    }
+
+    public void visit(IntUnsigned32TypeSymbol unsignedInt32Type) {
+    }
+
+    public void visit(IntersectionTypeSymbol intersectionType) {
+    }
+
+    public void visit(JSONTypeSymbol jsonType) {
+    }
+
+    public void visit(MapTypeSymbol mapType) {
+    }
+
+    public void visit(NeverTypeSymbol neverType) {
+    }
+
+    public void visit(NilTypeSymbol nilType) {
+    }
+
+    public void visit(NoneTypeSymbol noneType) {
+    }
+
+    public void visit(ObjectTypeSymbol objectType) {
+    }
+
+    public void visit(ReadonlyTypeSymbol readonlyType) {
+    }
+
+    public void visit(RecordTypeSymbol recordType) {
+    }
+
+    public void visit(SingletonTypeSymbol singletonType) {
+    }
+
+    public void visit(StreamTypeSymbol streamType) {
+    }
+
+    public void visit(StringTypeSymbol stringType) {
+    }
+
+    public void visit(StringCharTypeSymbol charType) {
+    }
+
+    public void visit(TableTypeSymbol tableType) {
+    }
+
+    public void visit(TupleTypeSymbol tupleType) {
+    }
+
+    public void visit(TypeDescTypeSymbol typedescType) {
+    }
+
+    public void visit(TypeReferenceTypeSymbol typeRefType) {
+    }
+
+    public void visit(UnionTypeSymbol unionType) {
+    }
+
+    public void visit(XMLTypeSymbol xmlType) {
+    }
+
+    public void visit(XMLCommentTypeSymbol xmlCommentType) {
+    }
+
+    public void visit(XMLElementTypeSymbol xmlElementType) {
+    }
+
+    public void visit(XMLProcessingInstructionTypeSymbol xmlPIType) {
+    }
+
+    public void visit(XMLTextTypeSymbol xmlTextType) {
+    }
+
+    public void visit(Symbol symbol) {
+        throw new UnsupportedOperationException();
+    }
+
+    public void visit(TypeSymbol symbol) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/SymbolVisitor.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/SymbolVisitor.java
@@ -76,6 +76,7 @@ import io.ballerina.compiler.api.symbols.VariableSymbol;
 import io.ballerina.compiler.api.symbols.WorkerSymbol;
 import io.ballerina.compiler.api.symbols.XMLCommentTypeSymbol;
 import io.ballerina.compiler.api.symbols.XMLElementTypeSymbol;
+import io.ballerina.compiler.api.symbols.XMLNamespaceSymbol;
 import io.ballerina.compiler.api.symbols.XMLProcessingInstructionTypeSymbol;
 import io.ballerina.compiler.api.symbols.XMLTextTypeSymbol;
 import io.ballerina.compiler.api.symbols.XMLTypeSymbol;
@@ -123,6 +124,9 @@ public abstract class SymbolVisitor {
     }
 
     public void visit(WorkerSymbol worker) {
+    }
+
+    public void visit(XMLNamespaceSymbol xmlns) {
     }
 
     // Util symbols (i.e., used within above symbols or type symbols)

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaAnnotationSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaAnnotationSymbol.java
@@ -17,6 +17,8 @@
  */
 package io.ballerina.compiler.api.impl.symbols;
 
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.AnnotationAttachPoint;
 import io.ballerina.compiler.api.symbols.AnnotationSymbol;
 import io.ballerina.compiler.api.symbols.Documentation;
@@ -104,6 +106,16 @@ public class BallerinaAnnotationSymbol extends BallerinaSymbol implements Annota
     @Override
     public boolean deprecated() {
         return this.deprecated;
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaAnyTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaAnyTypeSymbol.java
@@ -18,6 +18,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.AnyTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BAnyType;
@@ -37,5 +39,15 @@ public class BallerinaAnyTypeSymbol extends AbstractTypeSymbol implements AnyTyp
     @Override
     public String signature() {
         return "any";
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaAnydataTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaAnydataTypeSymbol.java
@@ -18,6 +18,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.AnydataTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BAnydataType;
@@ -37,5 +39,15 @@ public class BallerinaAnydataTypeSymbol extends AbstractTypeSymbol implements An
     @Override
     public String signature() {
         return "anydata";
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaArrayTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaArrayTypeSymbol.java
@@ -17,6 +17,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.ArrayTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
@@ -64,5 +66,15 @@ public class BallerinaArrayTypeSymbol extends AbstractTypeSymbol implements Arra
     @Override
     public Optional<Integer> size() {
         return Optional.ofNullable(size);
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaBooleanTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaBooleanTypeSymbol.java
@@ -18,6 +18,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.BooleanTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
@@ -37,5 +39,15 @@ public class BallerinaBooleanTypeSymbol extends AbstractTypeSymbol implements Bo
     @Override
     public String signature() {
         return "boolean";
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaByteTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaByteTypeSymbol.java
@@ -18,6 +18,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.ByteTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
@@ -37,5 +39,15 @@ public class BallerinaByteTypeSymbol extends AbstractTypeSymbol implements ByteT
     @Override
     public String signature() {
         return "byte";
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaClassFieldSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaClassFieldSymbol.java
@@ -17,6 +17,8 @@
  */
 package io.ballerina.compiler.api.impl.symbols;
 
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.ClassFieldSymbol;
 import io.ballerina.compiler.api.symbols.Qualifier;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
@@ -70,5 +72,15 @@ public class BallerinaClassFieldSymbol extends BallerinaObjectFieldSymbol implem
 
         this.qualifiers = Collections.unmodifiableList(quals);
         return this.qualifiers;
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaClassSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaClassSymbol.java
@@ -17,6 +17,8 @@
  */
 package io.ballerina.compiler.api.impl.symbols;
 
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.impl.SymbolFactory;
 import io.ballerina.compiler.api.impl.util.FieldMap;
 import io.ballerina.compiler.api.symbols.AnnotationSymbol;
@@ -163,6 +165,16 @@ public class BallerinaClassSymbol extends BallerinaSymbol implements ClassSymbol
     @Override
     public List<Qualifier> qualifiers() {
         return this.qualifiers;
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 
     BType getBType() {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaCompilationErrorTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaCompilationErrorTypeSymbol.java
@@ -18,6 +18,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.CompilationErrorTypeSymbol;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
@@ -49,5 +51,15 @@ public class BallerinaCompilationErrorTypeSymbol extends AbstractTypeSymbol impl
     @Override
     public List<FunctionSymbol> langLibMethods() {
         return langLibMethods;
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaConstantSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaConstantSymbol.java
@@ -17,6 +17,8 @@
  */
 package io.ballerina.compiler.api.impl.symbols;
 
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.AnnotationSymbol;
 import io.ballerina.compiler.api.symbols.ConstantSymbol;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
@@ -108,6 +110,16 @@ public class BallerinaConstantSymbol extends BallerinaVariableSymbol implements 
     @Override
     public boolean subtypeOf(TypeSymbol targetType) {
         return this.typeDescriptor().subtypeOf(targetType);
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 
     private String stringValueOf(BLangConstantValue value) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaDecimalTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaDecimalTypeSymbol.java
@@ -18,6 +18,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.DecimalTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
@@ -37,5 +39,15 @@ public class BallerinaDecimalTypeSymbol extends AbstractTypeSymbol implements De
     @Override
     public String signature() {
         return "decimal";
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaEnumSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaEnumSymbol.java
@@ -18,6 +18,8 @@
 
 package io.ballerina.compiler.api.impl.symbols;
 
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.AnnotationSymbol;
 import io.ballerina.compiler.api.symbols.ConstantSymbol;
 import io.ballerina.compiler.api.symbols.EnumSymbol;
@@ -62,6 +64,16 @@ public class BallerinaEnumSymbol extends BallerinaTypeDefinitionSymbol implement
     @Override
     public SymbolKind kind() {
         return SymbolKind.ENUM;
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaErrorTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaErrorTypeSymbol.java
@@ -17,6 +17,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.impl.SymbolFactory;
 import io.ballerina.compiler.api.symbols.ErrorTypeSymbol;
 import io.ballerina.compiler.api.symbols.ModuleSymbol;
@@ -111,6 +113,16 @@ public class BallerinaErrorTypeSymbol extends AbstractTypeSymbol implements Erro
         }
 
         return this.signature;
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 
     private boolean isDefaultDetailTypeDesc() {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFloatTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFloatTypeSymbol.java
@@ -18,6 +18,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.FloatTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
@@ -37,5 +39,15 @@ public class BallerinaFloatTypeSymbol extends AbstractTypeSymbol implements Floa
     @Override
     public String signature() {
         return "float";
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFunctionSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFunctionSymbol.java
@@ -17,6 +17,8 @@
  */
 package io.ballerina.compiler.api.impl.symbols;
 
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.AnnotationSymbol;
 import io.ballerina.compiler.api.symbols.Documentation;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
@@ -92,6 +94,16 @@ public class BallerinaFunctionSymbol extends BallerinaSymbol implements Function
     @Override
     public Optional<Documentation> documentation() {
         return Optional.ofNullable(this.docAttachment);
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFunctionTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFunctionTypeSymbol.java
@@ -17,6 +17,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.impl.SymbolFactory;
 import io.ballerina.compiler.api.symbols.Annotatable;
 import io.ballerina.compiler.api.symbols.AnnotationSymbol;
@@ -189,6 +191,16 @@ public class BallerinaFunctionTypeSymbol extends AbstractTypeSymbol implements F
         this.returnTypeDescriptor().ifPresent(typeDescriptor -> signature.append(" returns ")
                 .append(typeDescriptor.signature()));
         return signature.toString();
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 
     private static class AnnotatableReturnType implements Annotatable {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFutureTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFutureTypeSymbol.java
@@ -17,6 +17,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.FutureTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
@@ -57,5 +59,15 @@ public class BallerinaFutureTypeSymbol extends AbstractTypeSymbol implements Fut
             memberSignature = "()";
         }
         return "future<" + memberSignature + ">";
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaHandleTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaHandleTypeSymbol.java
@@ -18,6 +18,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.HandleTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BHandleType;
@@ -37,5 +39,15 @@ public class BallerinaHandleTypeSymbol extends AbstractTypeSymbol implements Han
     @Override
     public String signature() {
         return "handle";
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntSigned16TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntSigned16TypeSymbol.java
@@ -18,6 +18,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.IntSigned16TypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BIntSubType;
@@ -45,5 +47,15 @@ public class BallerinaIntSigned16TypeSymbol extends AbstractTypeSymbol implement
     @Override
     public String signature() {
         return "int:" + Names.STRING_SIGNED16;
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntSigned32TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntSigned32TypeSymbol.java
@@ -18,6 +18,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.IntSigned32TypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BIntSubType;
@@ -45,5 +47,15 @@ public class BallerinaIntSigned32TypeSymbol extends AbstractTypeSymbol implement
     @Override
     public String signature() {
         return "int:" + Names.STRING_SIGNED32;
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntSigned8TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntSigned8TypeSymbol.java
@@ -18,6 +18,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.IntSigned8TypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BIntSubType;
@@ -45,5 +47,15 @@ public class BallerinaIntSigned8TypeSymbol extends AbstractTypeSymbol implements
     @Override
     public String signature() {
         return "int:" + Names.STRING_SIGNED8;
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntTypeSymbol.java
@@ -18,6 +18,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.IntTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
@@ -37,5 +39,15 @@ public class BallerinaIntTypeSymbol extends AbstractTypeSymbol implements IntTyp
     @Override
     public String signature() {
         return "int";
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntUnsigned16TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntUnsigned16TypeSymbol.java
@@ -18,6 +18,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.IntUnsigned16TypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BIntSubType;
@@ -45,5 +47,15 @@ public class BallerinaIntUnsigned16TypeSymbol extends AbstractTypeSymbol impleme
     @Override
     public String signature() {
         return "int:" + Names.STRING_UNSIGNED16;
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntUnsigned32TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntUnsigned32TypeSymbol.java
@@ -18,6 +18,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.IntUnsigned32TypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BIntSubType;
@@ -45,5 +47,15 @@ public class BallerinaIntUnsigned32TypeSymbol extends AbstractTypeSymbol impleme
     @Override
     public String signature() {
         return "int:" + Names.STRING_UNSIGNED32;
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntUnsigned8TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntUnsigned8TypeSymbol.java
@@ -18,6 +18,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.IntUnsigned8TypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BIntSubType;
@@ -45,5 +47,15 @@ public class BallerinaIntUnsigned8TypeSymbol extends AbstractTypeSymbol implemen
     @Override
     public String signature() {
         return "int:" + Names.STRING_UNSIGNED8;
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntersectionTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntersectionTypeSymbol.java
@@ -17,6 +17,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.impl.LangLibrary;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
 import io.ballerina.compiler.api.symbols.IntersectionTypeSymbol;
@@ -101,5 +103,15 @@ public class BallerinaIntersectionTypeSymbol extends AbstractTypeSymbol implemen
         memberTypes.forEach(typeDescriptor -> joiner.add(typeDescriptor.signature()));
         this.signature = joiner.toString();
         return this.signature;
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaJSONTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaJSONTypeSymbol.java
@@ -18,6 +18,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.JSONTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BJSONType;
@@ -37,5 +39,15 @@ public class BallerinaJSONTypeSymbol extends AbstractTypeSymbol implements JSONT
     @Override
     public String signature() {
         return "json";
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaMapTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaMapTypeSymbol.java
@@ -17,6 +17,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.MapTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
@@ -67,5 +69,15 @@ public class BallerinaMapTypeSymbol extends AbstractTypeSymbol implements MapTyp
         }
 
         return this.signature;
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaMethodSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaMethodSymbol.java
@@ -17,6 +17,8 @@
  */
 package io.ballerina.compiler.api.impl.symbols;
 
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.AnnotationSymbol;
 import io.ballerina.compiler.api.symbols.Documentation;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
@@ -133,5 +135,15 @@ public class BallerinaMethodSymbol extends BallerinaSymbol implements MethodSymb
         }
         this.signature = signature.toString();
         return this.signature;
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaModule.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaModule.java
@@ -18,6 +18,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.impl.BallerinaModuleID;
 import io.ballerina.compiler.api.impl.SymbolFactory;
 import io.ballerina.compiler.api.symbols.ClassSymbol;
@@ -243,6 +245,16 @@ public class BallerinaModule extends BallerinaSymbol implements ModuleSymbol {
         }
 
         return this.allSymbols;
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaNeverTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaNeverTypeSymbol.java
@@ -18,6 +18,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.NeverTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BNeverType;
@@ -37,5 +39,15 @@ public class BallerinaNeverTypeSymbol extends AbstractTypeSymbol implements Neve
     @Override
     public String signature() {
         return "never";
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaNilTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaNilTypeSymbol.java
@@ -17,6 +17,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.NilTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BNilType;
@@ -36,5 +38,15 @@ public class BallerinaNilTypeSymbol extends AbstractTypeSymbol implements NilTyp
     @Override
     public String signature() {
         return "()";
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaNoneTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaNoneTypeSymbol.java
@@ -18,6 +18,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.NoneTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BNoType;
@@ -35,5 +37,15 @@ public class BallerinaNoneTypeSymbol extends AbstractTypeSymbol implements NoneT
     @Override
     public String signature() {
         return "";
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectFieldSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectFieldSymbol.java
@@ -17,6 +17,8 @@
  */
 package io.ballerina.compiler.api.impl.symbols;
 
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.impl.SymbolFactory;
 import io.ballerina.compiler.api.symbols.AnnotationSymbol;
 import io.ballerina.compiler.api.symbols.Documentation;
@@ -130,5 +132,15 @@ public class BallerinaObjectFieldSymbol extends BallerinaSymbol implements Objec
 
         this.signature = joiner.add(this.typeDescriptor().signature()).add(this.getName().get()).toString();
         return this.signature;
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectTypeSymbol.java
@@ -17,6 +17,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.impl.SymbolFactory;
 import io.ballerina.compiler.api.impl.util.FieldMap;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
@@ -180,6 +182,16 @@ public class BallerinaObjectTypeSymbol extends AbstractTypeSymbol implements Obj
         }
 
         return signature.append(methodJoiner).append("}").toString();
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaParameterSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaParameterSymbol.java
@@ -16,6 +16,8 @@
  */
 package io.ballerina.compiler.api.impl.symbols;
 
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.AnnotationSymbol;
 import io.ballerina.compiler.api.symbols.ParameterKind;
 import io.ballerina.compiler.api.symbols.ParameterSymbol;
@@ -108,5 +110,15 @@ public class BallerinaParameterSymbol extends BallerinaSymbol implements Paramet
     @Override
     public ParameterKind paramKind() {
         return this.paramKind;
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaPathParameterSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaPathParameterSymbol.java
@@ -18,6 +18,8 @@
 
 package io.ballerina.compiler.api.impl.symbols;
 
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.impl.SymbolFactory;
 import io.ballerina.compiler.api.symbols.AnnotationSymbol;
 import io.ballerina.compiler.api.symbols.ArrayTypeSymbol;
@@ -100,5 +102,15 @@ public class BallerinaPathParameterSymbol extends BallerinaSymbol implements Pat
 
         this.signature = "[" + typeSignature + " " + this.getName().get() + "]";
         return this.signature;
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaReadonlyTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaReadonlyTypeSymbol.java
@@ -18,6 +18,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.ReadonlyTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BReadonlyType;
@@ -37,5 +39,15 @@ public class BallerinaReadonlyTypeSymbol extends AbstractTypeSymbol implements R
     @Override
     public String signature() {
         return "readonly";
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaRecordFieldSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaRecordFieldSymbol.java
@@ -17,6 +17,8 @@
  */
 package io.ballerina.compiler.api.impl.symbols;
 
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.impl.SymbolFactory;
 import io.ballerina.compiler.api.symbols.AnnotationSymbol;
 import io.ballerina.compiler.api.symbols.Documentation;
@@ -157,5 +159,15 @@ public class BallerinaRecordFieldSymbol extends BallerinaSymbol implements Recor
         }
 
         return this.signature;
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaRecordTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaRecordTypeSymbol.java
@@ -17,6 +17,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.impl.util.FieldMap;
 import io.ballerina.compiler.api.symbols.RecordFieldSymbol;
 import io.ballerina.compiler.api.symbols.RecordTypeSymbol;
@@ -117,5 +119,15 @@ public class BallerinaRecordTypeSymbol extends AbstractTypeSymbol implements Rec
         });
 
         return "record " + joiner.toString();
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaResourceMethodSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaResourceMethodSymbol.java
@@ -18,6 +18,8 @@
 
 package io.ballerina.compiler.api.impl.symbols;
 
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.impl.symbols.resourcepath.BallerinaDotResourcePath;
 import io.ballerina.compiler.api.impl.symbols.resourcepath.BallerinaPathRestParam;
 import io.ballerina.compiler.api.impl.symbols.resourcepath.BallerinaPathSegmentList;
@@ -122,6 +124,16 @@ public class BallerinaResourceMethodSymbol extends BallerinaMethodSymbol impleme
 
         this.signature = signature.toString();
         return this.signature;
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 
     private BResourceFunction getBResourceFunction(List<BAttachedFunction> methods, BInvokableSymbol internalSymbol) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaServiceDeclarationSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaServiceDeclarationSymbol.java
@@ -18,6 +18,8 @@
 
 package io.ballerina.compiler.api.impl.symbols;
 
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.impl.SymbolFactory;
 import io.ballerina.compiler.api.symbols.AnnotationSymbol;
 import io.ballerina.compiler.api.symbols.ClassFieldSymbol;
@@ -174,6 +176,16 @@ public class BallerinaServiceDeclarationSymbol extends BallerinaSymbol implement
     @Override
     public List<Qualifier> qualifiers() {
         return this.qualifiers;
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSingletonTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSingletonTypeSymbol.java
@@ -17,6 +17,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.impl.LangLibrary;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
 import io.ballerina.compiler.api.symbols.SingletonTypeSymbol;
@@ -69,5 +71,15 @@ public class BallerinaSingletonTypeSymbol extends AbstractTypeSymbol implements 
     @Override
     public String signature() {
         return this.typeName;
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaStreamTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaStreamTypeSymbol.java
@@ -17,6 +17,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.StreamTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
@@ -72,5 +74,15 @@ public class BallerinaStreamTypeSymbol extends AbstractTypeSymbol implements Str
             this.signature = sigBuilder.toString();
         }
         return this.signature;
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaStringCharTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaStringCharTypeSymbol.java
@@ -18,6 +18,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.StringCharTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BStringSubType;
@@ -45,5 +47,15 @@ public class BallerinaStringCharTypeSymbol extends AbstractTypeSymbol implements
     @Override
     public String signature() {
         return "string:" + Names.STRING_CHAR;
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaStringTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaStringTypeSymbol.java
@@ -18,6 +18,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.StringTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
@@ -37,5 +39,15 @@ public class BallerinaStringTypeSymbol extends AbstractTypeSymbol implements Str
     @Override
     public String signature() {
         return "string";
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSymbol.java
@@ -17,6 +17,8 @@
  */
 package io.ballerina.compiler.api.impl.symbols;
 
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.impl.SymbolFactory;
 import io.ballerina.compiler.api.symbols.Documentation;
 import io.ballerina.compiler.api.symbols.ModuleSymbol;
@@ -129,6 +131,16 @@ public class BallerinaSymbol implements Symbol {
             return true;
         }
         return unescapeUnicode(name).equals(unescapeUnicode(symName));
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTableTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTableTypeSymbol.java
@@ -18,6 +18,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.TableTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
@@ -107,5 +109,15 @@ public class BallerinaTableTypeSymbol extends AbstractTypeSymbol implements Tabl
         }
 
         return this.signature;
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTupleTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTupleTypeSymbol.java
@@ -17,6 +17,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.TupleTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
@@ -93,5 +95,15 @@ public class BallerinaTupleTypeSymbol extends AbstractTypeSymbol implements Tupl
             joiner.add(restTypeDescriptor().get().signature() + "...");
         }
         return "[" + joiner.toString() + "]";
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeDefinitionSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeDefinitionSymbol.java
@@ -17,6 +17,8 @@
  */
 package io.ballerina.compiler.api.impl.symbols;
 
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.AnnotationSymbol;
 import io.ballerina.compiler.api.symbols.Documentation;
 import io.ballerina.compiler.api.symbols.Qualifier;
@@ -91,6 +93,16 @@ public class BallerinaTypeDefinitionSymbol extends BallerinaSymbol implements Ty
     @Override
     public Optional<Documentation> documentation() {
         return Optional.ofNullable(this.docAttachment);
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeDescTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeDescTypeSymbol.java
@@ -17,6 +17,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeDescTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
@@ -54,5 +56,15 @@ public class BallerinaTypeDescTypeSymbol extends AbstractTypeSymbol implements T
             return this.typeKind().getName() + "<" + this.typeParameter().get().signature() + ">";
         }
         return this.typeKind().name();
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeReferenceTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeReferenceTypeSymbol.java
@@ -17,6 +17,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.impl.SymbolFactory;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
 import io.ballerina.compiler.api.symbols.ModuleSymbol;
@@ -167,6 +169,16 @@ public class BallerinaTypeReferenceTypeSymbol extends AbstractTypeSymbol impleme
         }
 
         return this.signature;
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 
     private boolean isAnonOrg(ModuleID moduleID) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeSymbol.java
@@ -17,6 +17,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
@@ -40,5 +42,15 @@ public class BallerinaTypeSymbol extends AbstractTypeSymbol {
     @Override
     public String signature() {
         return this.typeName;
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaUnionTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaUnionTypeSymbol.java
@@ -17,6 +17,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
@@ -143,6 +145,16 @@ public class BallerinaUnionTypeSymbol extends AbstractTypeSymbol implements Unio
         }
 
         return this.signature;
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 
     private String getSignatureForUnion(BType type) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaVariableSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaVariableSymbol.java
@@ -17,6 +17,8 @@
  */
 package io.ballerina.compiler.api.impl.symbols;
 
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.AnnotationSymbol;
 import io.ballerina.compiler.api.symbols.DiagnosticState;
 import io.ballerina.compiler.api.symbols.Documentation;
@@ -97,6 +99,16 @@ public class BallerinaVariableSymbol extends BallerinaSymbol implements Variable
     @Override
     public Optional<Documentation> documentation() {
         return Optional.ofNullable(this.docAttachment);
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaWorkerSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaWorkerSymbol.java
@@ -17,6 +17,8 @@
  */
 package io.ballerina.compiler.api.impl.symbols;
 
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.AnnotationSymbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
@@ -57,6 +59,16 @@ public class BallerinaWorkerSymbol extends BallerinaSymbol implements WorkerSymb
     @Override
     public List<AnnotationSymbol> annotations() {
         return this.annots;
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLCommentTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLCommentTypeSymbol.java
@@ -18,6 +18,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.XMLCommentTypeSymbol;
@@ -51,5 +53,15 @@ public class BallerinaXMLCommentTypeSymbol extends AbstractTypeSymbol implements
     @Override
     public String signature() {
         return "xml:" + Names.STRING_XML_COMMENT;
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLElementTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLElementTypeSymbol.java
@@ -18,6 +18,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.XMLElementTypeSymbol;
@@ -51,5 +53,15 @@ public class BallerinaXMLElementTypeSymbol extends AbstractTypeSymbol implements
     @Override
     public String signature() {
         return "xml:" + Names.STRING_XML_ELEMENT;
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLNSSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLNSSymbol.java
@@ -17,6 +17,8 @@
  */
 package io.ballerina.compiler.api.impl.symbols;
 
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.XMLNamespaceSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
@@ -40,6 +42,16 @@ public class BallerinaXMLNSSymbol extends BallerinaSymbol implements XMLNamespac
     @Override
     public String namespaceUri() {
         return this.namespaceUri;
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLProcessingInstructionTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLProcessingInstructionTypeSymbol.java
@@ -18,6 +18,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.XMLProcessingInstructionTypeSymbol;
@@ -53,5 +55,15 @@ public class BallerinaXMLProcessingInstructionTypeSymbol extends AbstractTypeSym
     @Override
     public String signature() {
         return "xml:" + Names.STRING_XML_PI;
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLTextTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLTextTypeSymbol.java
@@ -18,6 +18,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.XMLTextTypeSymbol;
@@ -51,5 +53,15 @@ public class BallerinaXMLTextTypeSymbol extends AbstractTypeSymbol implements XM
     @Override
     public String signature() {
         return "xml:" + Names.STRING_XML_TEXT;
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLTypeSymbol.java
@@ -18,6 +18,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.XMLTypeSymbol;
@@ -82,5 +84,15 @@ public class BallerinaXMLTypeSymbol extends AbstractTypeSymbol implements XMLTyp
         }
 
         return this.signature;
+    }
+
+    @Override
+    public void accept(SymbolVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(SymbolTransformer<T> transformer) {
+        return transformer.transform(this);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/Symbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/Symbol.java
@@ -17,6 +17,8 @@
  */
 package io.ballerina.compiler.api.symbols;
 
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
 import io.ballerina.tools.diagnostics.Location;
 
 import java.util.Optional;
@@ -74,4 +76,8 @@ public interface Symbol {
      * @return true if the name is similar to the symbol's name and false otherwise
      */
     boolean nameEquals(String name);
+
+    void accept(SymbolVisitor visitor);
+
+    <T> T apply(SymbolTransformer<T> transformer);
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/VisitorAPITest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/VisitorAPITest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.semantic.api.test;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.SymbolTransformer;
+import io.ballerina.compiler.api.SymbolVisitor;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.SymbolKind;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.api.symbols.VariableSymbol;
+import io.ballerina.projects.Document;
+import io.ballerina.projects.Project;
+import io.ballerina.tools.text.LinePosition;
+import org.ballerinalang.test.BCompileUtil;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDefaultModulesSemanticModel;
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDocumentForSingleSource;
+
+/**
+ * Test cases for ensuring that the visitor and transformer covers all the symbols.
+ */
+public class VisitorAPITest {
+
+    private final SymbolVisitor visitor = new SymbolVisitor() {
+        @Override
+        public void visitSymbol(Symbol symbol) {
+            symbol.accept(this);
+        }
+    };
+
+    private final SymbolTransformer<Integer> transformer = new SymbolTransformer<>() {
+        private final Set<Symbol> visited = new HashSet<>();
+
+        @Override
+        public Integer transformSymbol(Symbol symbol) {
+            if (visited.contains(symbol)) {
+                return symbol.hashCode();
+            }
+            visited.add(symbol);
+            return symbol.apply(this);
+        }
+    };
+
+    private SemanticModel model;
+    private Document srcFile;
+
+    @BeforeClass
+    public void setup() {
+        Project project = BCompileUtil.loadProject("test-src/symbol_visitor_test.bal");
+        model = getDefaultModulesSemanticModel(project);
+        srcFile = getDocumentForSingleSource(project);
+    }
+
+    @Test(dataProvider = "SymbolPos")
+    public void testSymbolVisitor(int line, int col) {
+        Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, col));
+        Assert.assertTrue(symbol.isPresent());
+        visitor.visitSymbol(symbol.get());
+    }
+
+    @Test(dataProvider = "TypeSymbolPos")
+    public void testTypeSymbolVisitor(int line, int col) {
+        Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, col));
+        Assert.assertTrue(symbol.isPresent());
+        Assert.assertEquals(symbol.get().kind(), SymbolKind.VARIABLE);
+        visitor.visitSymbol(((VariableSymbol) symbol.get()).typeDescriptor());
+    }
+
+    @Test(dataProvider = "SymbolPos")
+    public void testSymbolTransformer(int line, int col) {
+        Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, col));
+        Assert.assertTrue(symbol.isPresent());
+        Assert.assertEquals((int) transformer.transformSymbol(symbol.get()), symbol.get().hashCode());
+    }
+
+    @Test(dataProvider = "TypeSymbolPos")
+    public void testTypeSymbolTransformer(int line, int col) {
+        Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, col));
+        Assert.assertTrue(symbol.isPresent());
+        Assert.assertEquals(symbol.get().kind(), SymbolKind.VARIABLE);
+
+        TypeSymbol type = ((VariableSymbol) symbol.get()).typeDescriptor();
+        Assert.assertEquals((int) transformer.transformSymbol(type), type.hashCode());
+    }
+
+    @DataProvider(name = "SymbolPos")
+    public Object[][] getSymbolPos() {
+        return new Object[][]{
+                {16, 22},
+                {18, 11},
+                {20, 6},
+                {22, 5},
+                {26, 5},
+                {28, 6},
+                {29, 11},
+                {31, 13},
+                {34, 31},
+                {36, 9},
+                {36, 21},
+                {61, 15},
+                {62, 17},
+                {65, 20},
+                {83, 11},
+                {87, 0},
+                {89, 22},
+                {89, 37},
+        };
+    }
+
+    @DataProvider(name = "TypeSymbolPos")
+    public Object[][] getTypeSymbolPos() {
+        return new Object[][]{
+                {37, 12},
+                {38, 8},
+                {39, 10},
+                {40, 12},
+                {41, 9},
+                {42, 12},
+                {43, 10},
+                {44, 10},
+                {45, 13},
+                {46, 11},
+                {47, 11},
+                {48, 21},
+                {49, 16},
+                {50, 17},
+                {51, 17},
+                {52, 8},
+                {53, 18},
+                {54, 19},
+                {55, 19},
+                {56, 9},
+                {57, 16},
+                {58, 10},
+                {59, 7},
+                {63, 6},
+                {64, 13},
+                {65, 28},
+                {66, 7},
+                {67, 16},
+                {68, 16},
+                {69, 11},
+                {70, 32},
+                {71, 18},
+                {72, 18},
+                {73, 8},
+                {74, 15},
+                {75, 16},
+                {76, 16},
+                {77, 30},
+                {78, 13},
+                {79, 8},
+        };
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol_visitor_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol_visitor_test.bal
@@ -1,0 +1,108 @@
+// Copyright (c) 2022 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/lang.value;
+
+annotation annot;
+
+const PI = 3.14;
+
+enum Colour {
+    RED, GREEN, BLUE
+}
+
+type Foo int;
+
+class PersonClass {
+    string name;
+
+    function getName() returns string => self.name;
+}
+
+xmlns "http://ballerina.io" as b7a;
+
+function test(string p) {
+    anydata ad;
+    any a;
+    int[] arr;
+    boolean b;
+    byte byt;
+    decimal d;
+    error e;
+    float f;
+    function fn;
+    future fu;
+    handle h;
+    int[] & readonly intArr;
+    int:Signed8 si8;
+    int:Signed16 si16;
+    int:Signed32 si32;
+    int i;
+    int:Unsigned8 usi8;
+    int:Unsigned16 usi16;
+    int:Unsigned32 usi32;
+    json j;
+    map<string> m;
+    never n;
+    () nil;
+    object {
+        string name;
+        function getName() returns string;
+    } o;
+    readonly r;
+    record {|string name;|} rec;
+    10 s;
+    stream<int> st;
+    string:Char c;
+    string s;
+    table<record{string name;}> t;
+    [string, int] tup;
+    typedesc<int> td;
+    Foo foo;
+    int|string u;
+    xml:Comment xc;
+    xml:Element xe;
+    xml:ProcessingInstruction xpi;
+    xml:Text xt;
+    xml x;
+}
+
+function workers() {
+    worker w {
+    }
+}
+
+service HelloWorld "GreetingService" on new Listener() {
+
+    resource function get greet/[int x]/hello/[float y]/[string... rest] () returns json => { output: self.greeting };
+}
+
+public class Listener {
+    public function start() returns error? {
+    }
+
+    public function gracefulStop() returns error? {
+    }
+
+    public function immediateStop() returns error? {
+    }
+
+    public function detach(service object {} s) returns error? {
+    }
+
+    public function attach(service object {} s, string[]? name = ()) returns error? {
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
+++ b/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
@@ -39,6 +39,7 @@
             <class name="io.ballerina.semantic.api.test.TestSourcesTest" />
             <class name="io.ballerina.semantic.api.test.TypeAssignabilityTest" />
             <class name="io.ballerina.semantic.api.test.TypedescriptorTest" />
+            <class name="io.ballerina.semantic.api.test.VisitorAPITest" />
             <class name="io.ballerina.semantic.api.test.WorkspaceSymbolLookupTest" />
 
             <class name="io.ballerina.semantic.api.test.allreferences.AnnotationRefsTest" />


### PR DESCRIPTION
## Purpose
This PR introduces a visitor and a transformer to the Semantic API to be used with symbols. This will allow the users of the API to organize the analysis logic more methodically.

Fixes #30027

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
