### PR TITLE
Add json to record converter support to json null and empty arrays

### DIFF
--- a/misc/ls-extensions/modules/json-to-record-converter/src/main/java/io/ballerina/converters/JsonToRecordConverter.java
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/main/java/io/ballerina/converters/JsonToRecordConverter.java
@@ -304,7 +304,7 @@ public class JsonToRecordConverter {
                     String type;
                     Token typeName;
                     TypeDescriptorNode memberTypeDesc;
-                    if (arraySchema.getItems().getType().equals("object")) {
+                    if (arraySchema.getItems().getType() != null && arraySchema.getItems().getType().equals("object")) {
                         type = StringUtils.capitalize(name) + "Item";
                         typeName = AbstractNodeFactory.createIdentifierToken(type);
                         if (isRecordTypeDescriptor) {
@@ -454,7 +454,11 @@ public class JsonToRecordConverter {
             cleanedMap.replace("properties", properties);
         } else if (cleanedMap.get("type").equals("array")) {
             Map<String, Object> itemsSchema = (Map<String, Object>) cleanedMap.get("items");
-            cleanedMap.replace("items", cleanSchema(itemsSchema));
+            if (itemsSchema != null && itemsSchema.size() != 0) {
+                cleanedMap.replace("items", cleanSchema(itemsSchema));
+            } else {
+                cleanedMap.replace("items", itemsSchema);
+            }
         }
 
         return cleanedMap;

--- a/misc/ls-extensions/modules/json-to-record-converter/src/main/java/io/ballerina/converters/util/ConverterUtils.java
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/main/java/io/ballerina/converters/util/ConverterUtils.java
@@ -35,6 +35,12 @@ public class ConverterUtils {
      */
     public static String convertOpenAPITypeToBallerina(String type) {
         String convertedType;
+
+        //In the case where type is not specified return anydata by default
+        if (type == null || type.length() == 0) {
+            return "anydata";
+        }
+
         switch (type) {
             case Constants.INTEGER:
                 convertedType = "int";

--- a/misc/ls-extensions/modules/json-to-record-converter/src/main/java/io/ballerina/converters/util/SchemaGenerator.java
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/main/java/io/ballerina/converters/util/SchemaGenerator.java
@@ -43,7 +43,7 @@ public class SchemaGenerator {
     public static Map<String, Object> generate(JsonNode json) throws JsonToRecordConverterException {
         Map<String, Object> schema = new HashMap<>();
 
-        if (json.getNodeType() == JsonNodeType.NULL || json.getNodeType() == JsonNodeType.MISSING
+        if (json.getNodeType() == JsonNodeType.MISSING
                 || json.getNodeType() == JsonNodeType.POJO || json.getNodeType() == JsonNodeType.BINARY) {
             throw new JsonToRecordConverterException(ErrorMessages.unsupportedType());
         }
@@ -80,6 +80,11 @@ public class SchemaGenerator {
                 schema.put("items", generate(array.get(0)));
             }
 
+            return schema;
+        }
+
+        if (json.getNodeType() == JsonNodeType.NULL) {
+            schema.put("type", "anydata");
             return schema;
         }
 

--- a/misc/ls-extensions/modules/json-to-record-converter/src/test/java/io/ballerina/converters/JsonToRecordConverterTests.java
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/test/java/io/ballerina/converters/JsonToRecordConverterTests.java
@@ -98,6 +98,11 @@ public class JsonToRecordConverterTests {
     private final Path sample7TypeDescBal = RES_DIR.resolve("ballerina")
             .resolve("sample_7_type_desc.bal");
 
+    private final Path sample8Json = RES_DIR.resolve("json")
+            .resolve("sample_8.json");
+    private final Path sample8TypeDescBal = RES_DIR.resolve("ballerina")
+            .resolve("sample_8_type_desc.bal");
+
     private final Path crlfJson = RES_DIR.resolve("json")
             .resolve("crlf.json");
     private final Path crlfBal = RES_DIR.resolve("ballerina")
@@ -225,6 +230,15 @@ public class JsonToRecordConverterTests {
         String generatedCodeBlock = JsonToRecordConverter.convert(jsonFileContent, "",
                 true, false).getCodeBlock().replaceAll("\\s+", "");
         String expectedCodeBlock = Files.readString(sample7TypeDescBal).replaceAll("\\s+", "");
+        Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
+    }
+
+    @Test(description = "Test null and empty array field type extraction")
+    public void testNullAndEmptyArray() throws JsonToRecordConverterException, IOException, FormatterException {
+        String jsonFileContent = Files.readString(sample8Json);
+        String generatedCodeBlock = JsonToRecordConverter.convert(jsonFileContent, "",
+                true, false).getCodeBlock().replaceAll("\\s+", "");
+        String expectedCodeBlock = Files.readString(sample8TypeDescBal).replaceAll("\\s+", "");
         Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
     }
 }

--- a/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/sample_8_type_desc.bal
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/ballerina/sample_8_type_desc.bal
@@ -1,0 +1,9 @@
+type NewRecord record {
+    record {
+        anydata[] donations;
+        any subscription;
+    } contributions;
+    string school;
+    string name;
+    int age;
+};

--- a/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/json/sample_8.json
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/test/resources/json/sample_8.json
@@ -1,0 +1,9 @@
+{
+  "name": "John",
+  "school": "Everton High",
+  "age": 17,
+  "contributions": {
+    "donations": [],
+    "subscription": null
+  }
+}


### PR DESCRIPTION
## Purpose
Adds JSON to Record converter support for json null and empty json arrays

## Approach
Currently if null values are detected in a payload it responds with `JsonToRecordConverterException`. The fix applies `anydata` for json null values in payload and anydata[] for empty json array fields

## Samples
Converts `{"field1":null, "field2":[]}`

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
