### PR TITLE
Add missing create function code action in several contexts

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/visitors/FunctionCallExpressionTypeFinder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/visitors/FunctionCallExpressionTypeFinder.java
@@ -49,8 +49,10 @@ import io.ballerina.compiler.syntax.tree.ModuleVariableDeclarationNode;
 import io.ballerina.compiler.syntax.tree.NamedArgumentNode;
 import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.compiler.syntax.tree.NodeVisitor;
+import io.ballerina.compiler.syntax.tree.ObjectFieldNode;
 import io.ballerina.compiler.syntax.tree.ParenthesizedArgList;
 import io.ballerina.compiler.syntax.tree.PositionalArgumentNode;
+import io.ballerina.compiler.syntax.tree.RecordFieldWithDefaultValueNode;
 import io.ballerina.compiler.syntax.tree.RemoteMethodCallActionNode;
 import io.ballerina.compiler.syntax.tree.ReturnStatementNode;
 import io.ballerina.compiler.syntax.tree.SeparatedNodeList;
@@ -86,6 +88,20 @@ public class FunctionCallExpressionTypeFinder extends NodeVisitor {
 
     public void findTypeOf(FunctionCallExpressionNode functionCallExpressionNode) {
         functionCallExpressionNode.accept(this);
+    }
+
+    @Override
+    public void visit(ObjectFieldNode objectFieldNode) {
+        Symbol symbol = semanticModel.symbol(objectFieldNode).orElse(null);
+        TypeSymbol typeDescriptor = SymbolUtil.getTypeDescriptor(symbol).orElse(null);
+        checkAndSetTypeResult(typeDescriptor);
+    }
+
+    @Override
+    public void visit(RecordFieldWithDefaultValueNode recordFieldWithDefaultValueNode) {
+        Symbol symbol = semanticModel.symbol(recordFieldWithDefaultValueNode).orElse(null);
+        TypeSymbol typeDescriptor = SymbolUtil.getTypeDescriptor(symbol).orElse(null);
+        checkAndSetTypeResult(typeDescriptor);
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/visitors/IsolatedBlockResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/visitors/IsolatedBlockResolver.java
@@ -22,6 +22,7 @@ import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
 import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.compiler.syntax.tree.NodeList;
 import io.ballerina.compiler.syntax.tree.NodeTransformer;
+import io.ballerina.compiler.syntax.tree.ObjectFieldNode;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.compiler.syntax.tree.Token;
 
@@ -33,9 +34,14 @@ import java.util.Optional;
  * @since 2.0.0
  */
 public class IsolatedBlockResolver extends NodeTransformer<Boolean> {
-    
+
     public Boolean findIsolatedBlock(FunctionCallExpressionNode functionCallExpressionNode) {
         return functionCallExpressionNode.apply(this);
+    }
+
+    @Override
+    public Boolean transform(ObjectFieldNode objectFieldNode) {
+        return true;
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/CreateFunctionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/CreateFunctionTest.java
@@ -56,7 +56,7 @@ public class CreateFunctionTest extends AbstractCodeActionTest {
                 {"undefinedFunctionCodeActionInLet2.json", "createUndefinedFunctionInLet.bal"},
                 {"createFunctionCodeActionWithStrands.json", "createFunctionCodeActionWithStrands.bal"},
                 {"createFunctionInErrorConstructor.json", "createFunctionInErrorConstructor.bal"},
-                {"undefinedFunctionCodeActionInObjectField1.json","createUndefinedFunctionInObjectField.bal"},
+                {"undefinedFunctionCodeActionInObjectField1.json", "createUndefinedFunctionInObjectField.bal"},
                 {"undefinedFunctionCodeActionInRecordField1.json", "createUndefinedFunctionInRecordField.bal"}
         };
     }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/CreateFunctionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/CreateFunctionTest.java
@@ -56,6 +56,8 @@ public class CreateFunctionTest extends AbstractCodeActionTest {
                 {"undefinedFunctionCodeActionInLet2.json", "createUndefinedFunctionInLet.bal"},
                 {"createFunctionCodeActionWithStrands.json", "createFunctionCodeActionWithStrands.bal"},
                 {"createFunctionInErrorConstructor.json", "createFunctionInErrorConstructor.bal"},
+                {"undefinedFunctionCodeActionInObjectField1.json","createUndefinedFunctionInObjectField.bal"},
+                {"undefinedFunctionCodeActionInRecordField1.json", "createUndefinedFunctionInRecordField.bal"}
         };
     }
 }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/command/CreateFunctionCommandExecTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/command/CreateFunctionCommandExecTest.java
@@ -77,6 +77,8 @@ public class CreateFunctionCommandExecTest extends AbstractCommandExecutionTest 
 
                 {"createUndefinedFunctionInRecord.json", "createUndefinedFunctionInRecord.bal"},
                 {"createUndefinedFunctionInRecord2.json", "createUndefinedFunctionInRecord.bal"},
+                {"createUndefinedFunctionInRecordField1.json", "createUndefinedFunctionInRecordField.bal"},
+                {"createUndefinedFunctionInObjectField1.json", "createUndefinedFunctionInObjectField.bal"},
 
                 {"projectCreateUndefinedFunction1.json", "testproject/main.bal"},
                 {"projectCreateUndefinedFunction2.json", "testproject/main.bal"},

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/undefinedFunctionCodeActionInObjectField1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/undefinedFunctionCodeActionInObjectField1.json
@@ -1,0 +1,28 @@
+{
+  "line": 1,
+  "character": 14,
+  "expected": [
+    {
+      "title": "Create function 'fn(...)'",
+      "command": {
+        "title": "Create function 'fn(...)'",
+        "command": "CREATE_FUNC",
+        "arguments": [
+          {
+            "key": "node.range",
+            "value": {
+              "start": {
+                "line": 1,
+                "character": 13
+              },
+              "end": {
+                "line": 1,
+                "character": 17
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/undefinedFunctionCodeActionInRecordField1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/undefinedFunctionCodeActionInRecordField1.json
@@ -1,0 +1,28 @@
+{
+  "line": 2,
+  "character": 15,
+  "expected": [
+    {
+      "title": "Create function 'fn(...)'",
+      "command": {
+        "title": "Create function 'fn(...)'",
+        "command": "CREATE_FUNC",
+        "arguments": [
+          {
+            "key": "node.range",
+            "value": {
+              "start": {
+                "line":2,
+                "character": 13
+              },
+              "end": {
+                "line": 2,
+                "character": 17
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/source/createUndefinedFunctionInObjectField.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/source/createUndefinedFunctionInObjectField.bal
@@ -1,0 +1,3 @@
+class TestClass {
+    int id = fn();
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/source/createUndefinedFunctionInRecordField.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/source/createUndefinedFunctionInRecordField.bal
@@ -1,0 +1,4 @@
+type TestRecord record {|
+    string name;
+    int id = fn();
+|};

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunctionInObjectField1.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunctionInObjectField1.json
@@ -1,0 +1,40 @@
+{
+  "arguments": {
+    "node.range": {
+      "start": {
+        "line": 1,
+        "character": 13
+      },
+      "end": {
+        "line": 1,
+        "character": 17
+      }
+    }
+  },
+  "expected": {
+    "result": {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "range": {
+                  "start": {
+                    "line": 2,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 2,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nisolated function fn() returns int {\n    return 0;\n}\n"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "jsonrpc": "2.0"
+  }
+}

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunctionInRecordField1.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunctionInRecordField1.json
@@ -1,0 +1,40 @@
+{
+  "arguments": {
+    "node.range": {
+      "start": {
+        "line": 2,
+        "character": 13
+      },
+      "end": {
+        "line": 2,
+        "character": 17
+      }
+    }
+  },
+  "expected": {
+    "result": {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "range": {
+                  "start": {
+                    "line": 3,
+                    "character": 3
+                  },
+                  "end": {
+                    "line": 3,
+                    "character": 3
+                  }
+                },
+                "newText": "\n\nfunction fn() returns int {\n    return 0;\n}\n"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "jsonrpc": "2.0"
+  }
+}

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/source/createUndefinedFunctionInObjectField.bal
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/source/createUndefinedFunctionInObjectField.bal
@@ -1,0 +1,3 @@
+class TestClass {
+    int id = fn();
+}

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/source/createUndefinedFunctionInRecordField.bal
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/source/createUndefinedFunctionInRecordField.bal
@@ -1,0 +1,4 @@
+type TestRecord record {|
+    string name;
+    int id = fn();
+|};


### PR DESCRIPTION
## Purpose
Improving the ReturnTypeFinder to visit ObjectFieldNode and RecordFieldWithDefaultValue nodes and find the possible return type of the created function. 

Fixes #35347

## Samples
![Peek 2022-03-28 14-18](https://user-images.githubusercontent.com/35211477/160361654-c57ef39a-9b8e-40ce-bb26-16928fc61e96.gif)

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [x] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
