### PR TITLE
Add support for simple union type configurable variables via CLI

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/configurable/providers/cli/CliProvider.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/configurable/providers/cli/CliProvider.java
@@ -223,12 +223,12 @@ public class CliProvider implements ConfigProvider {
 
     @Override
     public Optional<ConfigValue> getAsUnionAndMark(Module module, VariableKey key) {
+        CliArg cliArg = getCliArg(module, key);
         BUnionType unionType = (BUnionType) ((BIntersectionType) key.type).getEffectiveType();
         boolean isEnum = SymbolFlags.isFlagOn(unionType.getFlags(), SymbolFlags.ENUM);
         if (!isEnum && !containsSupportedMembers(unionType)) {
             throw new ConfigException(CONFIG_CLI_TYPE_NOT_SUPPORTED, key.variable, unionType);
         }
-        CliArg cliArg = getCliArg(module, key);
         if (cliArg.value == null) {
             return Optional.empty();
         }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/configurable/providers/cli/CliProvider.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/configurable/providers/cli/CliProvider.java
@@ -23,6 +23,7 @@ import io.ballerina.runtime.api.TypeTags;
 import io.ballerina.runtime.api.flags.SymbolFlags;
 import io.ballerina.runtime.api.types.IntersectionType;
 import io.ballerina.runtime.api.types.Type;
+import io.ballerina.runtime.api.types.UnionType;
 import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.api.values.BString;
@@ -42,6 +43,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 
 import static io.ballerina.identifier.Utils.decodeIdentifier;
 import static io.ballerina.runtime.internal.configurable.providers.cli.CliConstants.CLI_ARG_REGEX;
@@ -221,24 +223,95 @@ public class CliProvider implements ConfigProvider {
 
     @Override
     public Optional<ConfigValue> getAsUnionAndMark(Module module, VariableKey key) {
-        // Only `enum` type is supported
         BUnionType unionType = (BUnionType) ((BIntersectionType) key.type).getEffectiveType();
-        if (!SymbolFlags.isFlagOn(unionType.getFlags(), SymbolFlags.ENUM)) {
+        boolean isEnum = SymbolFlags.isFlagOn(unionType.getFlags(), SymbolFlags.ENUM);
+        if (!isEnum && !containsSupportedMembers(unionType)) {
             throw new ConfigException(CONFIG_CLI_TYPE_NOT_SUPPORTED, key.variable, unionType);
         }
         CliArg cliArg = getCliArg(module, key);
         if (cliArg.value == null) {
             return Optional.empty();
         }
+        if (isEnum) {
+            return getCliConfigValue(getFiniteValue(key, unionType, cliArg));
+        }
+        return getCliConfigValue(getUnionValue(key, unionType, cliArg));
+    }
+
+    private Object getUnionValue(VariableKey key, BUnionType unionType, CliArg cliArg) {
+        List<Object> matchingValues = getConvertibleMemberValues(cliArg.value, unionType);
+        if (matchingValues.size() == 1) {
+            return matchingValues.get(0);
+        }
+        String typeName = decodeIdentifier(unionType.toString());
+        if (matchingValues.isEmpty()) {
+            throw new ConfigException(CONFIG_INCOMPATIBLE_TYPE, cliArg, key.variable, typeName, cliArg.value);
+        }
+        throw new ConfigException(CONFIG_UNION_VALUE_AMBIGUOUS_TARGET, cliArg, key.variable, typeName);
+    }
+
+    private List<Object> getConvertibleMemberValues(String value, UnionType unionType) {
+        List<Object> matchingValues = new ArrayList<>();
+        for (Type type : unionType.getMemberTypes()) {
+            switch (type.getTag()) {
+                case TypeTags.BYTE_TAG:
+                    validateAndAddValue(matchingValues, TypeConverter::stringToByte, value);
+                    break;
+                case TypeTags.INT_TAG:
+                    validateAndAddValue(matchingValues, TypeConverter::stringToInt, value);
+                    break;
+                case TypeTags.BOOLEAN_TAG:
+                    validateAndAddValue(matchingValues, TypeConverter::stringToBoolean, value);
+                    break;
+                case TypeTags.FLOAT_TAG:
+                    validateAndAddValue(matchingValues, TypeConverter::stringToFloat, value);
+                    break;
+                case TypeTags.DECIMAL_TAG:
+                    validateAndAddValue(matchingValues, TypeConverter::stringToDecimal, value);
+                    break;
+                case TypeTags.STRING_TAG:
+                    validateAndAddValue(matchingValues, StringUtils::fromString, value);
+                    break;
+                default:
+                    validateAndAddValue(matchingValues, TypeConverter::stringToXml, value);
+            }
+        }
+        return matchingValues;
+    }
+
+    private void validateAndAddValue(List<Object> matchingValues, Function<String, Object> func, String value) {
+        Object unionValue;
+        try {
+            unionValue = func.apply(value);
+        } catch (NumberFormatException | BError e) {
+            return;
+        }
+        matchingValues.add(unionValue);
+    }
+
+    private BString getFiniteValue(VariableKey key, BUnionType unionType, CliArg cliArg) {
         BString stringVal = StringUtils.fromString(cliArg.value);
         List<Type> memberTypes = unionType.getMemberTypes();
         for (Type type : memberTypes) {
             if (((BFiniteType) type).valueSpace.contains(stringVal)) {
-                return getCliConfigValue(stringVal);
+                return stringVal;
             }
         }
         throw new ConfigException(CONFIG_INCOMPATIBLE_TYPE, cliArg, key.variable,
                 decodeIdentifier(unionType.toString()), cliArg.value);
+    }
+
+    private boolean containsSupportedMembers(BUnionType unionType) {
+        for (Type memberType : unionType.getMemberTypes()) {
+            if (!isCliSupported(memberType.getTag())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean isCliSupported(int tag) {
+        return tag <= TypeTags.BOOLEAN_TAG || TypeTags.isXMLTypeTag(tag);
     }
 
     @Override

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/configurable/providers/cli/CliProvider.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/configurable/providers/cli/CliProvider.java
@@ -239,7 +239,7 @@ public class CliProvider implements ConfigProvider {
     }
 
     private Object getUnionValue(VariableKey key, BUnionType unionType, CliArg cliArg) {
-        List<Object> matchingValues = getConvertibleMemberValues(cliArg.value, unionType);
+        List<Object> matchingValues = convertAndGetValuesFromString(cliArg.value, unionType);
         if (matchingValues.size() == 1) {
             return matchingValues.get(0);
         }
@@ -250,7 +250,7 @@ public class CliProvider implements ConfigProvider {
         throw new ConfigException(CONFIG_UNION_VALUE_AMBIGUOUS_TARGET, cliArg, key.variable, typeName);
     }
 
-    private List<Object> getConvertibleMemberValues(String value, UnionType unionType) {
+    private List<Object> convertAndGetValuesFromString(String value, UnionType unionType) {
         List<Object> matchingValues = new ArrayList<>();
         for (Type type : unionType.getMemberTypes()) {
             switch (type.getTag()) {
@@ -279,10 +279,10 @@ public class CliProvider implements ConfigProvider {
         return matchingValues;
     }
 
-    private void validateAndAddValue(List<Object> matchingValues, Function<String, Object> func, String value) {
+    private void validateAndAddValue(List<Object> matchingValues, Function<String, Object> convertFunc, String value) {
         Object unionValue;
         try {
-            unionValue = func.apply(value);
+            unionValue = convertFunc.apply(value);
         } catch (NumberFormatException | BError e) {
             return;
         }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/configurable/providers/cli/CliProvider.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/configurable/providers/cli/CliProvider.java
@@ -239,7 +239,7 @@ public class CliProvider implements ConfigProvider {
     }
 
     private Object getUnionValue(VariableKey key, BUnionType unionType, CliArg cliArg) {
-        List<Object> matchingValues = convertAndGetValuesFromString(cliArg.value, unionType);
+        List<Object> matchingValues = getConvertibleMemberValues(cliArg.value, unionType);
         if (matchingValues.size() == 1) {
             return matchingValues.get(0);
         }
@@ -250,36 +250,37 @@ public class CliProvider implements ConfigProvider {
         throw new ConfigException(CONFIG_UNION_VALUE_AMBIGUOUS_TARGET, cliArg, key.variable, typeName);
     }
 
-    private List<Object> convertAndGetValuesFromString(String value, UnionType unionType) {
+    private List<Object> getConvertibleMemberValues(String value, UnionType unionType) {
         List<Object> matchingValues = new ArrayList<>();
         for (Type type : unionType.getMemberTypes()) {
             switch (type.getTag()) {
                 case TypeTags.BYTE_TAG:
-                    validateAndAddValue(matchingValues, TypeConverter::stringToByte, value);
+                    convertAndGetValuesFromString(matchingValues, TypeConverter::stringToByte, value);
                     break;
                 case TypeTags.INT_TAG:
-                    validateAndAddValue(matchingValues, TypeConverter::stringToInt, value);
+                    convertAndGetValuesFromString(matchingValues, TypeConverter::stringToInt, value);
                     break;
                 case TypeTags.BOOLEAN_TAG:
-                    validateAndAddValue(matchingValues, TypeConverter::stringToBoolean, value);
+                    convertAndGetValuesFromString(matchingValues, TypeConverter::stringToBoolean, value);
                     break;
                 case TypeTags.FLOAT_TAG:
-                    validateAndAddValue(matchingValues, TypeConverter::stringToFloat, value);
+                    convertAndGetValuesFromString(matchingValues, TypeConverter::stringToFloat, value);
                     break;
                 case TypeTags.DECIMAL_TAG:
-                    validateAndAddValue(matchingValues, TypeConverter::stringToDecimal, value);
+                    convertAndGetValuesFromString(matchingValues, TypeConverter::stringToDecimal, value);
                     break;
                 case TypeTags.STRING_TAG:
-                    validateAndAddValue(matchingValues, StringUtils::fromString, value);
+                    convertAndGetValuesFromString(matchingValues, StringUtils::fromString, value);
                     break;
                 default:
-                    validateAndAddValue(matchingValues, TypeConverter::stringToXml, value);
+                    convertAndGetValuesFromString(matchingValues, TypeConverter::stringToXml, value);
             }
         }
         return matchingValues;
     }
 
-    private void validateAndAddValue(List<Object> matchingValues, Function<String, Object> convertFunc, String value) {
+    private void convertAndGetValuesFromString(List<Object> matchingValues, Function<String, Object> convertFunc,
+                                               String value) {
         Object unionValue;
         try {
             unionValue = convertFunc.apply(value);

--- a/bvm/ballerina-runtime/src/test/java/io/ballerina/runtime/test/config/negative/CliProviderNegativeTest.java
+++ b/bvm/ballerina-runtime/src/test/java/io/ballerina/runtime/test/config/negative/CliProviderNegativeTest.java
@@ -24,7 +24,9 @@ import io.ballerina.runtime.api.creators.TypeCreator;
 import io.ballerina.runtime.api.creators.ValueCreator;
 import io.ballerina.runtime.api.types.FiniteType;
 import io.ballerina.runtime.api.types.IntersectionType;
+import io.ballerina.runtime.api.types.MapType;
 import io.ballerina.runtime.api.types.Type;
+import io.ballerina.runtime.api.types.UnionType;
 import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.values.BDecimal;
 import io.ballerina.runtime.api.values.BString;
@@ -67,9 +69,8 @@ public class CliProviderNegativeTest {
                 new VariableKey(module, variableName, type, null, true),
         };
         configVarMap.put(module, keys);
-        ConfigResolver configResolver = new ConfigResolver(configVarMap,
-                                                           diagnosticLog,
-                                                           List.of(new CliProvider(ROOT_MODULE, args)));
+        ConfigResolver configResolver = new ConfigResolver(configVarMap, diagnosticLog,
+                List.of(new CliProvider(ROOT_MODULE, args)));
         configResolver.resolveConfigs();
         Assert.assertEquals(diagnosticLog.getErrorCount(), expectedErrorMessages.length);
         for (int i = 0; i < expectedErrorMessages.length; i++) {
@@ -111,7 +112,7 @@ public class CliProviderNegativeTest {
                 // Config array value which is not supported as cli arg
                 {new String[]{"-Cmyorg.mod.x=345"}, "myorg", "mod", "x",
                         new BIntersectionType(ROOT_MODULE, new Type[]{},
-                                              TypeCreator.createArrayType(PredefinedTypes.TYPE_INT), 0, true),
+                                TypeCreator.createArrayType(PredefinedTypes.TYPE_INT), 0, true),
                         "error: value for configurable variable 'x' with type 'int[]' is not supported as a command " +
                                 "line argument"},
                 // Config tuple value which is not supported as cli arg
@@ -122,14 +123,14 @@ public class CliProviderNegativeTest {
                 // Config record value which is not supported as cli arg
                 {new String[]{"-Cmyorg.mod.x=345"}, "myorg", "mod", "x",
                         new BIntersectionType(ROOT_MODULE, new Type[]{},
-                                              TypeCreator.createRecordType("customType", ROOT_MODULE, 0, false, 0), 0,
-                                              true),
+                                TypeCreator.createRecordType("customType", ROOT_MODULE, 0, false, 0), 0,
+                                true),
                         "error: value for configurable variable 'x' with type 'rootMod:customType' is not supported " +
                                 "as a command line argument"},
                 // Config table value which is not supported as cli arg
                 {new String[]{"-Cmyorg.mod.x=345"}, "myorg", "mod", "x",
                         new BIntersectionType(ROOT_MODULE, new Type[]{},
-                                              TypeCreator.createTableType(PredefinedTypes.TYPE_STRING, false), 0, true),
+                                TypeCreator.createTableType(PredefinedTypes.TYPE_STRING, false), 0, true),
                         "error: value for configurable variable 'x' with type 'table<string>' is not supported as a " +
                                 "command line argument"},
                 {new String[]{"-CxmlVar=<book"}, "rootOrg", "rootMod", "xmlVar",
@@ -151,18 +152,17 @@ public class CliProviderNegativeTest {
         Map<Module, VariableKey[]> configVarMap = new HashMap<>();
         VariableKey x = new VariableKey(module, "x", PredefinedTypes.TYPE_INT, true);
 
-        configVarMap.put(module, new VariableKey[] {x});
+        configVarMap.put(module, new VariableKey[]{x});
         String[] args = {"-Cmyorg.mod.x=123", "-Cmyorg.mod.y=apple", "-Cmyorg.mod.z=27.5"};
-        ConfigResolver configResolver = new ConfigResolver(configVarMap,
-                                                           diagnosticLog,
-                                                           List.of(new CliProvider(ROOT_MODULE, args)));
-        Map<VariableKey, ConfigValue> varKeyValueMap =  configResolver.resolveConfigs();
+        ConfigResolver configResolver = new ConfigResolver(configVarMap, diagnosticLog,
+                List.of(new CliProvider(ROOT_MODULE, args)));
+        Map<VariableKey, ConfigValue> varKeyValueMap = configResolver.resolveConfigs();
         Assert.assertEquals(diagnosticLog.getWarningCount(), 0);
         Assert.assertEquals(diagnosticLog.getErrorCount(), 2);
         Assert.assertEquals(diagnosticLog.getDiagnosticList().get(0).toString(),
-                            "error: [myorg.mod.z=27.5] unused command line argument");
+                "error: [myorg.mod.z=27.5] unused command line argument");
         Assert.assertEquals(diagnosticLog.getDiagnosticList().get(1).toString(),
-                            "error: [myorg.mod.y=apple] unused command line argument");
+                "error: [myorg.mod.y=apple] unused command line argument");
         Assert.assertEquals(varKeyValueMap.get(x).getValue(), 123L);
     }
 
@@ -179,9 +179,8 @@ public class CliProviderNegativeTest {
         };
         configVarMap.put(rootModule, keys);
         String[] args = {"-Ca.b.c=123", "-Ca.b.y=apple"};
-        ConfigResolver configResolver = new ConfigResolver(configVarMap,
-                                                           diagnosticLog,
-                                                           List.of(new CliProvider(rootModule, args)));
+        ConfigResolver configResolver = new ConfigResolver(configVarMap, diagnosticLog,
+                List.of(new CliProvider(rootModule, args)));
         Map<VariableKey, ConfigValue> varKeyValueMap = configResolver.resolveConfigs();
         Assert.assertEquals(diagnosticLog.getWarningCount(), 0);
         Assert.assertEquals(diagnosticLog.getErrorCount(), 1);
@@ -190,7 +189,6 @@ public class CliProviderNegativeTest {
                 "'[-CtestOrg.a.b.c=<value>]'");
         Assert.assertEquals(varKeyValueMap.get(validKey).getValue(), StringUtils.fromString("apple"));
     }
-
 
     @Test
     public void testAmbiguityWithRootModuleCliArgs() {
@@ -202,9 +200,8 @@ public class CliProviderNegativeTest {
         };
         configVarMap.put(ROOT_MODULE, keys);
         String[] args = {"-CrootMod.intVar=123", "-CintVar=321"};
-        ConfigResolver configResolver = new ConfigResolver(configVarMap,
-                                                           diagnosticLog,
-                                                           List.of(new CliProvider(ROOT_MODULE, args)));
+        ConfigResolver configResolver = new ConfigResolver(configVarMap, diagnosticLog,
+                List.of(new CliProvider(ROOT_MODULE, args)));
         configResolver.resolveConfigs();
         Assert.assertEquals(diagnosticLog.getWarningCount(), 0);
         Assert.assertEquals(diagnosticLog.getErrorCount(), 1);
@@ -240,6 +237,48 @@ public class CliProviderNegativeTest {
                         "expected to be of type 'Finite', but found '3.23'"},
                 {Set.of(strVal2, 3.23d, 1.34d), "error: [finiteVar=3.23] ambiguous target types " +
                         "found for configurable variable 'finiteVar' with type 'Finite'"},
+        };
+    }
+
+    @Test(dataProvider = "union-error-provider")
+    public void testInvalidUnionFiniteType(List<Type> members, String arg, String errorMsg) {
+        UnionType type = TypeCreator.createUnionType(members, true);
+        IntersectionType intersectionType = new BIntersectionType(ROOT_MODULE, new Type[]{type,
+                PredefinedTypes.TYPE_READONLY}, type, 1, true);
+        VariableKey finiteVar = new VariableKey(ROOT_MODULE, "unionVar", intersectionType, true);
+        Map<Module, VariableKey[]> configVarMap = Map.ofEntries(Map.entry(ROOT_MODULE, new VariableKey[]{finiteVar}));
+        RuntimeDiagnosticLog diagnosticLog = new RuntimeDiagnosticLog();
+        ConfigResolver configResolver = new ConfigResolver(configVarMap,
+                diagnosticLog, List.of(new CliProvider(ROOT_MODULE, arg)));
+        configResolver.resolveConfigs();
+        Assert.assertEquals(diagnosticLog.getWarningCount(), 0);
+        Assert.assertEquals(diagnosticLog.getErrorCount(), 1);
+        Assert.assertEquals(diagnosticLog.getDiagnosticList().get(0).toString(), "error: " + errorMsg);
+    }
+
+    @DataProvider(name = "union-error-provider")
+    public Object[] getUnionConfigData() {
+        MapType mapType = TypeCreator.createMapType(PredefinedTypes.TYPE_STRING, true);
+        return new Object[][]{
+                {List.of(PredefinedTypes.TYPE_INT, mapType), "-CunionVar=3", "value for configurable variable " +
+                        "'unionVar' with type '(int|map<string> & readonly)' is not supported as a command line " +
+                        "argument"},
+                {List.of(PredefinedTypes.TYPE_INT, PredefinedTypes.TYPE_FLOAT), "-CunionVar=test", "[unionVar=test] " +
+                        "configurable variable 'unionVar' is expected to be of type '(int|float)', but found 'test'"},
+                {List.of(PredefinedTypes.TYPE_INT, PredefinedTypes.TYPE_FLOAT), "-CunionVar=3", "[unionVar=3] " +
+                        "ambiguous target types found for configurable variable 'unionVar' with type '(int|float)'"},
+                {List.of(PredefinedTypes.TYPE_INT, PredefinedTypes.TYPE_BYTE), "-CunionVar=22", "[unionVar=22] " +
+                        "ambiguous target types found for configurable variable 'unionVar' with type '(int|byte)'"},
+                {List.of(PredefinedTypes.TYPE_INT, PredefinedTypes.TYPE_BOOLEAN), "-CunionVar=1", "[unionVar=1] " +
+                        "ambiguous target types found for configurable variable 'unionVar' with type '(int|boolean)'"},
+                {List.of(PredefinedTypes.TYPE_INT, PredefinedTypes.TYPE_STRING), "-CunionVar=12", "[unionVar=12] " +
+                        "ambiguous target types found for configurable variable 'unionVar' with type '(int|string)'"},
+                {List.of(PredefinedTypes.TYPE_STRING, PredefinedTypes.TYPE_XML), "-CunionVar=test", "[unionVar=test] " +
+                        "ambiguous target types found for configurable variable 'unionVar' with type '(string|xml<" +
+                        "(lang.xml:Element|lang.xml:Comment|lang.xml:ProcessingInstruction|lang.xml:Text)>)'"},
+                {List.of(PredefinedTypes.TYPE_FLOAT, PredefinedTypes.TYPE_DECIMAL), "-CunionVar=1.23", "[unionVar=1" +
+                        ".23] ambiguous target types found for configurable variable 'unionVar' with type '" +
+                        "(float|decimal)'"},
         };
     }
 }

--- a/bvm/ballerina-runtime/src/test/java/io/ballerina/runtime/test/config/negative/ConfigNegativeTest.java
+++ b/bvm/ballerina-runtime/src/test/java/io/ballerina/runtime/test/config/negative/ConfigNegativeTest.java
@@ -21,6 +21,7 @@ package io.ballerina.runtime.test.config.negative;
 import io.ballerina.runtime.api.Module;
 import io.ballerina.runtime.api.PredefinedTypes;
 import io.ballerina.runtime.api.creators.TypeCreator;
+import io.ballerina.runtime.api.types.MapType;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.internal.configurable.ConfigResolver;
 import io.ballerina.runtime.internal.configurable.VariableKey;
@@ -61,14 +62,14 @@ public class ConfigNegativeTest {
         ConfigResolver configResolver;
         if (tomlFilePath != null) {
             configResolver = new ConfigResolver(configVarMap,
-                                                diagnosticLog, List.of(
-                                                new CliProvider(ROOT_MODULE, args),
-                                                new TomlFileProvider(ROOT_MODULE,
-                                                        getConfigPathForNegativeCases(tomlFilePath), Set.of(MODULE))));
+                    diagnosticLog, List.of(
+                    new CliProvider(ROOT_MODULE, args),
+                    new TomlFileProvider(ROOT_MODULE,
+                            getConfigPathForNegativeCases(tomlFilePath), Set.of(MODULE))));
 
         } else {
             configResolver = new ConfigResolver(configVarMap,
-                                                diagnosticLog, List.of(new CliProvider(ROOT_MODULE, args)));
+                    diagnosticLog, List.of(new CliProvider(ROOT_MODULE, args)));
         }
         configResolver.resolveConfigs();
         Assert.assertEquals(diagnosticLog.getErrorCount(), errorCount);
@@ -80,15 +81,11 @@ public class ConfigNegativeTest {
 
     @DataProvider(name = "different-config-use-cases-data-provider")
     public Object[][] configErrorCases() {
+        MapType mapStringType = TypeCreator.createMapType(TYPE_STRING);
         Type incompatibleUnionType = new BIntersectionType(MODULE, new Type[]{},
-                                                           new BUnionType(Arrays.asList(PredefinedTypes.TYPE_INT,
-                                                                                        PredefinedTypes.TYPE_STRING)),
-                                                           0, true);
+                new BUnionType(Arrays.asList(PredefinedTypes.TYPE_INT, mapStringType)), 0, true);
         Type ambiguousUnionType = new BIntersectionType(MODULE, new Type[]{},
-                                                        new BUnionType(
-                                                                Arrays.asList(TypeCreator.createMapType(TYPE_ANYDATA),
-                                                                              TypeCreator.createMapType(TYPE_STRING))),
-                                                        0, true);
+                new BUnionType(Arrays.asList(TypeCreator.createMapType(TYPE_ANYDATA), mapStringType)), 0, true);
         return new Object[][]{
                 // Required but not given
                 {new String[]{}, null,
@@ -116,9 +113,9 @@ public class ConfigNegativeTest {
                 {new String[]{"-Corg.mod1.intVar=1"}, "MismatchedTypeValues.toml",
                         new VariableKey[]{new VariableKey(MODULE, "intVar", PredefinedTypes.TYPE_INT, null, true)}, 0
                         , 1, new String[]{
-                                "warning: [MismatchedTypeValues.toml:(3:10,3:18)] configurable variable 'intVar'" +
-                                        " is expected to be of type 'int', but found 'string'"
-                        }},
+                        "warning: [MismatchedTypeValues.toml:(3:10,3:18)] configurable variable 'intVar'" +
+                                " is expected to be of type 'int', but found 'string'"
+                }},
                 // valid toml value invalid cli
                 {new String[]{"-Corg.mod1.intVar=waruna"}, "MatchedTypeValues.toml",
                         new VariableKey[]{new VariableKey(MODULE, "intVar", PredefinedTypes.TYPE_INT, true)}, 2, 1,
@@ -130,11 +127,11 @@ public class ConfigNegativeTest {
                 {new String[]{"-Corg.mod1.intVar=waruna"}, "MismatchedTypeValues.toml",
                         new VariableKey[]{new VariableKey(MODULE, "intVar", PredefinedTypes.TYPE_INT, null, true)}, 2
                         , 0, new String[]{
-                                "error: [org.mod1.intVar=waruna] configurable variable 'intVar' is expected to be " +
-                                        "of type 'int', but found 'waruna'",
-                                "error: [MismatchedTypeValues.toml:(3:10,3:18)] configurable variable 'intVar'" +
-                                        " is expected to be of type 'int', but found 'string'"
-                        }},
+                        "error: [org.mod1.intVar=waruna] configurable variable 'intVar' is expected to be " +
+                                "of type 'int', but found 'waruna'",
+                        "error: [MismatchedTypeValues.toml:(3:10,3:18)] configurable variable 'intVar'" +
+                                " is expected to be of type 'int', but found 'string'"
+                }},
                 // invalid toml but valid cli
                 {new String[]{"-Corg.mod1.intVar=2"}, "Invalid.toml",
                         new VariableKey[]{new VariableKey(MODULE, "intVar", PredefinedTypes.TYPE_INT, true)}, 0, 1,
@@ -145,9 +142,9 @@ public class ConfigNegativeTest {
                 // supported toml type but not cli type and cli value given
                 {new String[]{"-Corg.mod1.intArr=3"}, "MatchedTypeValues.toml",
                         new VariableKey[]{new VariableKey(MODULE, "intArr",
-                                                          new BIntersectionType(MODULE, new BType[]{}, TypeCreator
-                                                                  .createArrayType(PredefinedTypes.TYPE_INT), 0, false),
-                                                          null, true)}, 2, 1,
+                                new BIntersectionType(MODULE, new BType[]{}, TypeCreator
+                                        .createArrayType(PredefinedTypes.TYPE_INT), 0, false),
+                                null, true)}, 2, 1,
                         new String[]{
                                 "warning: value for configurable variable 'intArr' with type '" +
                                         "int[]' is not supported as a command line argument",
@@ -156,9 +153,9 @@ public class ConfigNegativeTest {
                 // supported toml type but not cli type and cli value not given
                 {new String[]{""}, "MatchedTypeValues.toml",
                         new VariableKey[]{new VariableKey(MODULE, "intArr",
-                                                          new BIntersectionType(MODULE, new BType[]{}, TypeCreator
-                                                                  .createArrayType(PredefinedTypes.TYPE_INT), 0, false),
-                                                          null, true)}, 2, 0,
+                                new BIntersectionType(MODULE, new BType[]{}, TypeCreator
+                                        .createArrayType(PredefinedTypes.TYPE_INT), 0, false),
+                                null, true)}, 2, 0,
                         new String[]{
                                 "error: [MatchedTypeValues.toml:(3:1,3:14)] unused configuration value 'org.mod1" +
                                         ".intVar'"}},
@@ -169,22 +166,22 @@ public class ConfigNegativeTest {
                         "error: [org.mod1.myMap=4] unused command line argument"}},
                 // not supported cli union type
                 {new String[]{"-Corg.mod1.myUnion=5"}, null, new VariableKey[]{
-                        new VariableKey(MODULE, "myUnion", incompatibleUnionType, null, true)}, 2, 0,
-                        new String[]{"error: value for configurable variable 'myUnion' with type '(int|string)' is " +
-                                "not supported as a command line argument"}},
+                        new VariableKey(MODULE, "myUnion", incompatibleUnionType, null, true)}, 1, 0,
+                        new String[]{"error: value for configurable variable 'myUnion' with type '(int|map<string>)' " +
+                                "is not supported as a command line argument"}},
                 // not supported cli type
                 {new String[]{"-Corg.mod1.myMap=5"}, null,
                         new VariableKey[]{
                                 new VariableKey(MODULE, "myMap",
-                                                new BIntersectionType(MODULE, new BType[]{}, PredefinedTypes.TYPE_MAP
-                                                        , 0, true), null, true)}, 1
+                                        new BIntersectionType(MODULE, new BType[]{}, PredefinedTypes.TYPE_MAP
+                                                , 0, true), null, true)}, 1
                         , 0, new String[]{"error: value for configurable variable 'myMap' with type 'map' is not " +
-                "supported as a command line argument"}},
+                        "supported as a command line argument"}},
                 // not supported union type
                 {new String[]{""}, "InvalidUnionType.toml", new VariableKey[]{
                         new VariableKey(MODULE, "floatUnionVar", incompatibleUnionType, null, true)}, 3, 0,
                         new String[]{"error: [InvalidUnionType.toml:(2:1,2:19)] configurable variable 'floatUnionVar'" +
-                                " is expected to be of type '(int|string)', but found 'float'"}},
+                                " is expected to be of type '(int|map<string>)', but found 'float'"}},
                 {new String[]{""}, "InvalidUnionType.toml", new VariableKey[]{
                         new VariableKey(MODULE, "ambiguousUnionVar", ambiguousUnionType, null, true)}, 2, 0,
                         new String[]{"error: [InvalidUnionType.toml:(4:1,5:16)] ambiguous target types found for " +


### PR DESCRIPTION
## Purpose
$subject

Fixes #34034 

## Approach
Previously,  we only supported `enum` and union of singleton types through the CLI arguments for the union type. This PR adds implementation for supporting the union of the already supported simple types.

It also covers the validation for ambiguous values.

## Samples
```ballerina
configurable float|string val = 2.0; 
```
In the bal command,
```
bal run -- -Cval=test
```

## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
