### PR TITLE
Allow int varref with other numeric operands in a multiplicative expression

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
@@ -762,7 +762,8 @@ public enum DiagnosticErrorCode implements DiagnosticCode {
             "compound.assignment.not.allowed.with.nullable.operands"),
 
     INVALID_ISOLATED_VARIABLE_ACCESS_OUTSIDE_LOCK_IN_RECORD_DEFAULT(
-            "BCE4025", "invalid.isolated.variable.access.outside.lock.in.record.default")
+            "BCE4025", "invalid.isolated.variable.access.outside.lock.in.record.default"),
+    BINARY_OP_INCOMPATIBLE_TYPES_INT_FLOAT_DIVISION("BCE4026", "binary.op.incompatible.types.int.float.division")
     ;
 
     private String diagnosticId;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -4417,8 +4417,19 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                     }
 
                     if (opSymbol == symTable.notFoundSymbol) {
-                        dlog.error(binaryExpr.pos, DiagnosticErrorCode.BINARY_OP_INCOMPATIBLE_TYPES, binaryExpr.opKind,
-                                lhsType, rhsType);
+                        String lhsParam = lhsType.toString();
+                        String rhsParam = rhsType.toString();
+
+                        DiagnosticErrorCode errorCode = DiagnosticErrorCode.BINARY_OP_INCOMPATIBLE_TYPES;
+                        
+                        if ((binaryExpr.opKind == OperatorKind.DIV || binaryExpr.opKind == OperatorKind.MOD) &&
+                                lhsType.tag == TypeTags.INT && 
+                                (rhsType.tag == TypeTags.DECIMAL || rhsType.tag == TypeTags.FLOAT)) {
+                            errorCode = DiagnosticErrorCode.BINARY_OP_INCOMPATIBLE_TYPES_INT_FLOAT_DIVISION;
+                        }
+                        
+                        dlog.error(binaryExpr.pos, errorCode, binaryExpr.opKind,
+                                lhsParam, rhsParam);
                     } else {
                         binaryExpr.opSymbol = (BOperatorSymbol) opSymbol;
                         actualType = opSymbol.type.getReturnType();

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -4344,8 +4344,6 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
             return;
         }
 
-        checkDecimalCompatibilityForBinaryArithmeticOverLiteralValues(binaryExpr, data);
-
         SymbolEnv rhsExprEnv;
         BType lhsType;
         BType referredExpType = Types.getReferredType(binaryExpr.expectedType);
@@ -4514,25 +4512,6 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
             constituent = type;
         }
         return constituent;
-    }
-
-    private void checkDecimalCompatibilityForBinaryArithmeticOverLiteralValues(BLangBinaryExpr binaryExpr,
-                                                                               AnalyzerData data) {
-        if (data.expType.tag != TypeTags.DECIMAL) {
-            return;
-        }
-
-        switch (binaryExpr.opKind) {
-            case ADD:
-            case SUB:
-            case MUL:
-            case DIV:
-                checkExpr(binaryExpr.lhsExpr, data.expType, data);
-                checkExpr(binaryExpr.rhsExpr, data.expType, data);
-                break;
-            default:
-                break;
-        }
     }
 
     public void visit(BLangElvisExpr elvisExpr, AnalyzerData data) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -4417,9 +4417,6 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                     }
 
                     if (opSymbol == symTable.notFoundSymbol) {
-                        String lhsParam = lhsType.toString();
-                        String rhsParam = rhsType.toString();
-
                         DiagnosticErrorCode errorCode = DiagnosticErrorCode.BINARY_OP_INCOMPATIBLE_TYPES;
                         
                         if ((binaryExpr.opKind == OperatorKind.DIV || binaryExpr.opKind == OperatorKind.MOD) &&
@@ -4428,8 +4425,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                             errorCode = DiagnosticErrorCode.BINARY_OP_INCOMPATIBLE_TYPES_INT_FLOAT_DIVISION;
                         }
                         
-                        dlog.error(binaryExpr.pos, errorCode, binaryExpr.opKind,
-                                lhsParam, rhsParam);
+                        dlog.error(binaryExpr.pos, errorCode, binaryExpr.opKind, lhsType, rhsType);
                     } else {
                         binaryExpr.opSymbol = (BOperatorSymbol) opSymbol;
                         actualType = opSymbol.type.getReturnType();

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
@@ -694,15 +694,16 @@ public class SymbolTable {
     private void defineIntFloatingPointArithmeticOperations() {
         BType[] intTypes = {intType, byteType, signed32IntType, signed16IntType, signed8IntType, unsigned32IntType,
                 unsigned16IntType, unsigned8IntType};
-        OperatorKind[] opKinds = {OperatorKind.DIV, OperatorKind.MUL, OperatorKind.MOD};
-        
+
         for (BType intType : intTypes) {
-            for (OperatorKind opKind : opKinds) {
-                defineBinaryOperator(opKind, decimalType, intType, decimalType);
-                defineBinaryOperator(opKind, intType, decimalType, decimalType);
-                defineBinaryOperator(opKind, floatType, intType, floatType);
-                defineBinaryOperator(opKind, intType, floatType, floatType); 
-            }
+            defineBinaryOperator(OperatorKind.MUL, decimalType, intType, decimalType);
+            defineBinaryOperator(OperatorKind.MUL, intType, decimalType, decimalType);
+            defineBinaryOperator(OperatorKind.MUL, floatType, intType, floatType);
+            defineBinaryOperator(OperatorKind.MUL, intType, floatType, floatType);
+            defineBinaryOperator(OperatorKind.DIV, decimalType, intType, decimalType);
+            defineBinaryOperator(OperatorKind.DIV, floatType, intType, floatType);
+            defineBinaryOperator(OperatorKind.MOD, decimalType, intType, decimalType);
+            defineBinaryOperator(OperatorKind.MOD, floatType, intType, floatType);
         }
     }
 
@@ -719,27 +720,37 @@ public class SymbolTable {
         for (int i = 0; i < intTypes.length; i++) {
             nilableIntTypes[i] = getNilableBType(intTypes[i]);
         }
-
-        OperatorKind[] opKinds = {OperatorKind.MUL, OperatorKind.DIV, OperatorKind.MOD};
         
-        for (OperatorKind opKind : opKinds) {
-            for (BType intType : intTypes) {
-                defineBinaryOperator(opKind, decimalOptional, intType, decimalOptional);
-                defineBinaryOperator(opKind, intType, decimalOptional, decimalOptional);
-                defineBinaryOperator(opKind, floatOptional, intType, floatOptional);
-                defineBinaryOperator(opKind, intType, floatOptional, floatOptional);
-            }
+        for (BType intType : intTypes) {
+            defineBinaryOperator(OperatorKind.MUL, decimalOptional, intType, decimalOptional);
+            defineBinaryOperator(OperatorKind.MUL, intType, decimalOptional, decimalOptional);
+            defineBinaryOperator(OperatorKind.MUL, floatOptional, intType, floatOptional);
+            defineBinaryOperator(OperatorKind.MUL, intType, floatOptional, floatOptional);
+            defineBinaryOperator(OperatorKind.DIV, decimalOptional, intType, decimalOptional);
+            defineBinaryOperator(OperatorKind.DIV, floatOptional, intType, floatOptional);
+            defineBinaryOperator(OperatorKind.MOD, decimalOptional, intType, decimalOptional);
+            defineBinaryOperator(OperatorKind.MOD, floatOptional, intType, floatOptional);
+        }
 
-            for (BUnionType nilableIntType : nilableIntTypes) {
-                    defineBinaryOperator(opKind, floatType, nilableIntType, floatOptional);
-                    defineBinaryOperator(opKind, nilableIntType, floatType, floatOptional);
-                    defineBinaryOperator(opKind, nilableIntType, floatOptional, floatOptional);
-                    defineBinaryOperator(opKind, floatOptional, nilableIntType, floatOptional);
-                    defineBinaryOperator(opKind, decimalType, nilableIntType, decimalOptional);
-                    defineBinaryOperator(opKind, nilableIntType, decimalType, decimalOptional);
-                    defineBinaryOperator(opKind, nilableIntType, decimalOptional, decimalOptional);
-                    defineBinaryOperator(opKind, decimalOptional, nilableIntType, decimalOptional);
-            }
+        for (BUnionType nilableIntType : nilableIntTypes) {
+            defineBinaryOperator(OperatorKind.MUL, floatType, nilableIntType, floatOptional);
+            defineBinaryOperator(OperatorKind.MUL, nilableIntType, floatType, floatOptional);
+            defineBinaryOperator(OperatorKind.MUL, nilableIntType, floatOptional, floatOptional);
+            defineBinaryOperator(OperatorKind.MUL, floatOptional, nilableIntType, floatOptional);
+            defineBinaryOperator(OperatorKind.MUL, decimalType, nilableIntType, decimalOptional);
+            defineBinaryOperator(OperatorKind.MUL, nilableIntType, decimalType, decimalOptional);
+            defineBinaryOperator(OperatorKind.MUL, nilableIntType, decimalOptional, decimalOptional);
+            defineBinaryOperator(OperatorKind.MUL, decimalOptional, nilableIntType, decimalOptional);
+            
+            defineBinaryOperator(OperatorKind.DIV, floatType, nilableIntType, floatOptional);
+            defineBinaryOperator(OperatorKind.DIV, floatOptional, nilableIntType, floatOptional);
+            defineBinaryOperator(OperatorKind.DIV, decimalType, nilableIntType, decimalOptional);
+            defineBinaryOperator(OperatorKind.DIV, decimalOptional, nilableIntType, decimalOptional);
+
+            defineBinaryOperator(OperatorKind.MOD, floatType, nilableIntType, floatOptional);
+            defineBinaryOperator(OperatorKind.MOD, floatOptional, nilableIntType, floatOptional);
+            defineBinaryOperator(OperatorKind.MOD, decimalType, nilableIntType, decimalOptional);
+            defineBinaryOperator(OperatorKind.MOD, decimalOptional, nilableIntType, decimalOptional);
         }
     }
     

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
@@ -461,6 +461,10 @@ public class SymbolTable {
         // Binary arithmetic operators for nullable integer types
         defineNilableIntegerArithmeticOperations();
 
+        defineIntFloatingPointArithmeticOperations();
+
+        defineNilableIntFloatingPointArithmeticOperations();
+        
         // Binary bitwise operators for nullable integer types
         defineNilableIntegerBitwiseAndOperations();
         defineNilableIntegerBitwiseOrAndXorOperations(OperatorKind.BITWISE_OR);
@@ -687,6 +691,58 @@ public class SymbolTable {
         }
     }
 
+    private void defineIntFloatingPointArithmeticOperations() {
+        BType[] intTypes = {intType, byteType, signed32IntType, signed16IntType, signed8IntType, unsigned32IntType,
+                unsigned16IntType, unsigned8IntType};
+        OperatorKind[] opKinds = {OperatorKind.DIV, OperatorKind.MUL, OperatorKind.MOD};
+        
+        for (BType intType : intTypes) {
+            for (OperatorKind opKind : opKinds) {
+                defineBinaryOperator(opKind, decimalType, intType, decimalType);
+                defineBinaryOperator(opKind, intType, decimalType, decimalType);
+                defineBinaryOperator(opKind, floatType, intType, floatType);
+                defineBinaryOperator(opKind, intType, floatType, floatType); 
+            }
+        }
+    }
+
+    private void defineNilableIntFloatingPointArithmeticOperations() {
+        BType[] intTypes = {intType, byteType, signed32IntType, signed16IntType, signed8IntType, unsigned32IntType,
+                unsigned16IntType, unsigned8IntType};
+        BType floatOptional = getNilableBType(floatType);
+        ((BUnionType) floatOptional).setNullable(true);
+        BType decimalOptional = getNilableBType(decimalType);
+        ((BUnionType) decimalOptional).setNullable(true);
+
+        BUnionType[] nilableIntTypes = new BUnionType[8];
+
+        for (int i = 0; i < intTypes.length; i++) {
+            nilableIntTypes[i] = getNilableBType(intTypes[i]);
+        }
+
+        OperatorKind[] opKinds = {OperatorKind.MUL, OperatorKind.DIV, OperatorKind.MOD};
+        
+        for (OperatorKind opKind : opKinds) {
+            for (BType intType : intTypes) {
+                defineBinaryOperator(opKind, decimalOptional, intType, decimalOptional);
+                defineBinaryOperator(opKind, intType, decimalOptional, decimalOptional);
+                defineBinaryOperator(opKind, floatOptional, intType, floatOptional);
+                defineBinaryOperator(opKind, intType, floatOptional, floatOptional);
+            }
+
+            for (BUnionType nilableIntType : nilableIntTypes) {
+                    defineBinaryOperator(opKind, floatType, nilableIntType, floatOptional);
+                    defineBinaryOperator(opKind, nilableIntType, floatType, floatOptional);
+                    defineBinaryOperator(opKind, nilableIntType, floatOptional, floatOptional);
+                    defineBinaryOperator(opKind, floatOptional, nilableIntType, floatOptional);
+                    defineBinaryOperator(opKind, decimalType, nilableIntType, decimalOptional);
+                    defineBinaryOperator(opKind, nilableIntType, decimalType, decimalOptional);
+                    defineBinaryOperator(opKind, nilableIntType, decimalOptional, decimalOptional);
+                    defineBinaryOperator(opKind, decimalOptional, nilableIntType, decimalOptional);
+            }
+        }
+    }
+    
     private void defineNilableIntegerArithmeticOperations() {
         BType[] intTypes = {intType, byteType, signed32IntType, signed16IntType, signed8IntType, unsigned32IntType,
                 unsigned16IntType,
@@ -1004,7 +1060,7 @@ public class SymbolTable {
         OperatorKind[] binaryOperators = {OperatorKind.ADD, OperatorKind.SUB, OperatorKind.MUL,
                 OperatorKind.DIV, OperatorKind.MOD};
 
-        for (OperatorKind operator: binaryOperators) {
+        for (OperatorKind operator : binaryOperators) {
             defineBinaryOperator(operator, floatType, floatOptional, floatOptional);
             defineBinaryOperator(operator, floatOptional, floatType, floatOptional);
             defineBinaryOperator(operator, floatOptional, floatOptional, floatOptional);
@@ -1015,7 +1071,7 @@ public class SymbolTable {
 
         OperatorKind[] unaryOperators = {OperatorKind.ADD, OperatorKind.SUB, OperatorKind.BITWISE_COMPLEMENT};
 
-        for (OperatorKind operator: unaryOperators) {
+        for (OperatorKind operator : unaryOperators) {
             defineUnaryOperator(operator, floatOptional, floatOptional);
             defineUnaryOperator(operator, decimalOptional, decimalOptional);
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
@@ -637,7 +637,9 @@ public class SymbolTable {
     }
 
     private BUnionType getNilableBType(BType type) {
-        return BUnionType.create(null, type, nilType);
+        BUnionType nilableType = BUnionType.create(null, type, nilType);
+        nilableType.setNullable(true);
+        return nilableType;
     }
 
     private void defineNilableIntegerUnaryOperations() {
@@ -710,10 +712,8 @@ public class SymbolTable {
     private void defineNilableIntFloatingPointArithmeticOperations() {
         BType[] intTypes = {intType, byteType, signed32IntType, signed16IntType, signed8IntType, unsigned32IntType,
                 unsigned16IntType, unsigned8IntType};
-        BType floatOptional = getNilableBType(floatType);
-        ((BUnionType) floatOptional).setNullable(true);
-        BType decimalOptional = getNilableBType(decimalType);
-        ((BUnionType) decimalOptional).setNullable(true);
+        BUnionType nullableFloat = getNilableBType(floatType);
+        BUnionType nullableDecimal = getNilableBType(decimalType);
 
         BUnionType[] nilableIntTypes = new BUnionType[8];
 
@@ -722,35 +722,35 @@ public class SymbolTable {
         }
         
         for (BType intType : intTypes) {
-            defineBinaryOperator(OperatorKind.MUL, decimalOptional, intType, decimalOptional);
-            defineBinaryOperator(OperatorKind.MUL, intType, decimalOptional, decimalOptional);
-            defineBinaryOperator(OperatorKind.MUL, floatOptional, intType, floatOptional);
-            defineBinaryOperator(OperatorKind.MUL, intType, floatOptional, floatOptional);
-            defineBinaryOperator(OperatorKind.DIV, decimalOptional, intType, decimalOptional);
-            defineBinaryOperator(OperatorKind.DIV, floatOptional, intType, floatOptional);
-            defineBinaryOperator(OperatorKind.MOD, decimalOptional, intType, decimalOptional);
-            defineBinaryOperator(OperatorKind.MOD, floatOptional, intType, floatOptional);
+            defineBinaryOperator(OperatorKind.MUL, nullableDecimal, intType, nullableDecimal);
+            defineBinaryOperator(OperatorKind.MUL, intType, nullableDecimal, nullableDecimal);
+            defineBinaryOperator(OperatorKind.MUL, nullableFloat, intType, nullableFloat);
+            defineBinaryOperator(OperatorKind.MUL, intType, nullableFloat, nullableFloat);
+            defineBinaryOperator(OperatorKind.DIV, nullableDecimal, intType, nullableDecimal);
+            defineBinaryOperator(OperatorKind.DIV, nullableFloat, intType, nullableFloat);
+            defineBinaryOperator(OperatorKind.MOD, nullableDecimal, intType, nullableDecimal);
+            defineBinaryOperator(OperatorKind.MOD, nullableFloat, intType, nullableFloat);
         }
 
         for (BUnionType nilableIntType : nilableIntTypes) {
-            defineBinaryOperator(OperatorKind.MUL, floatType, nilableIntType, floatOptional);
-            defineBinaryOperator(OperatorKind.MUL, nilableIntType, floatType, floatOptional);
-            defineBinaryOperator(OperatorKind.MUL, nilableIntType, floatOptional, floatOptional);
-            defineBinaryOperator(OperatorKind.MUL, floatOptional, nilableIntType, floatOptional);
-            defineBinaryOperator(OperatorKind.MUL, decimalType, nilableIntType, decimalOptional);
-            defineBinaryOperator(OperatorKind.MUL, nilableIntType, decimalType, decimalOptional);
-            defineBinaryOperator(OperatorKind.MUL, nilableIntType, decimalOptional, decimalOptional);
-            defineBinaryOperator(OperatorKind.MUL, decimalOptional, nilableIntType, decimalOptional);
+            defineBinaryOperator(OperatorKind.MUL, floatType, nilableIntType, nullableFloat);
+            defineBinaryOperator(OperatorKind.MUL, nilableIntType, floatType, nullableFloat);
+            defineBinaryOperator(OperatorKind.MUL, nilableIntType, nullableFloat, nullableFloat);
+            defineBinaryOperator(OperatorKind.MUL, nullableFloat, nilableIntType, nullableFloat);
+            defineBinaryOperator(OperatorKind.MUL, decimalType, nilableIntType, nullableDecimal);
+            defineBinaryOperator(OperatorKind.MUL, nilableIntType, decimalType, nullableDecimal);
+            defineBinaryOperator(OperatorKind.MUL, nilableIntType, nullableDecimal, nullableDecimal);
+            defineBinaryOperator(OperatorKind.MUL, nullableDecimal, nilableIntType, nullableDecimal);
             
-            defineBinaryOperator(OperatorKind.DIV, floatType, nilableIntType, floatOptional);
-            defineBinaryOperator(OperatorKind.DIV, floatOptional, nilableIntType, floatOptional);
-            defineBinaryOperator(OperatorKind.DIV, decimalType, nilableIntType, decimalOptional);
-            defineBinaryOperator(OperatorKind.DIV, decimalOptional, nilableIntType, decimalOptional);
+            defineBinaryOperator(OperatorKind.DIV, floatType, nilableIntType, nullableFloat);
+            defineBinaryOperator(OperatorKind.DIV, nullableFloat, nilableIntType, nullableFloat);
+            defineBinaryOperator(OperatorKind.DIV, decimalType, nilableIntType, nullableDecimal);
+            defineBinaryOperator(OperatorKind.DIV, nullableDecimal, nilableIntType, nullableDecimal);
 
-            defineBinaryOperator(OperatorKind.MOD, floatType, nilableIntType, floatOptional);
-            defineBinaryOperator(OperatorKind.MOD, floatOptional, nilableIntType, floatOptional);
-            defineBinaryOperator(OperatorKind.MOD, decimalType, nilableIntType, decimalOptional);
-            defineBinaryOperator(OperatorKind.MOD, decimalOptional, nilableIntType, decimalOptional);
+            defineBinaryOperator(OperatorKind.MOD, floatType, nilableIntType, nullableFloat);
+            defineBinaryOperator(OperatorKind.MOD, nullableFloat, nilableIntType, nullableFloat);
+            defineBinaryOperator(OperatorKind.MOD, decimalType, nilableIntType, nullableDecimal);
+            defineBinaryOperator(OperatorKind.MOD, nullableDecimal, nilableIntType, nullableDecimal);
         }
     }
     
@@ -1064,9 +1064,7 @@ public class SymbolTable {
 
     private void defineNilableFloatingPointOperations() {
         BType floatOptional = getNilableBType(floatType);
-        ((BUnionType) floatOptional).setNullable(true);
         BType decimalOptional = getNilableBType(decimalType);
-        ((BUnionType) decimalOptional).setNullable(true);
 
         OperatorKind[] binaryOperators = {OperatorKind.ADD, OperatorKind.SUB, OperatorKind.MUL,
                 OperatorKind.DIV, OperatorKind.MOD};

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -384,6 +384,9 @@ error.unary.op.incompatible.types=\
 error.binary.op.incompatible.types=\
   operator ''{0}'' not defined for ''{1}'' and ''{2}''
 
+error.binary.op.incompatible.types.int.float.division=\
+  operator ''{0}'' not defined for ''{1}''(dividend) and ''{2}''(divisor)
+
 error.self.reference.var=\
   self referenced variable ''{0}''
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/DivisionOperationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/DivisionOperationTest.java
@@ -96,8 +96,10 @@ public class DivisionOperationTest {
                 "'(string|string:Char)'", 30, 17);
         BAssertUtil.validateError(resultNegative, i++, "operator '/' not defined for 'float' and 'decimal'", 37, 14);
         BAssertUtil.validateError(resultNegative, i++, "operator '/' not defined for 'float' and 'decimal'", 38, 14);
-        BAssertUtil.validateError(resultNegative, i++, "operator '/' not defined for 'int'(dividend) and 'float'(divisor)", 39, 18);
-        BAssertUtil.validateError(resultNegative, i++, "operator '/' not defined for 'int'(dividend) and 'decimal'(divisor)", 40, 18);
+        BAssertUtil.validateError(resultNegative, i++, 
+                "operator '/' not defined for 'int'(dividend) and 'float'(divisor)", 39, 18);
+        BAssertUtil.validateError(resultNegative, i++, 
+                "operator '/' not defined for 'int'(dividend) and 'decimal'(divisor)", 40, 18);
         BAssertUtil.validateError(resultNegative, i++, "operator '/' not defined for 'C' and 'float'", 44, 14);
         BAssertUtil.validateError(resultNegative, i, "operator '/' not defined for 'C' and 'float'", 45, 14);
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/DivisionOperationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/DivisionOperationTest.java
@@ -86,20 +86,20 @@ public class DivisionOperationTest {
 
     @Test(description = "Test divide statement with errors")
     public void testDivideStmtNegativeCases() {
-        Assert.assertEquals(resultNegative.getErrorCount(), 12);
-        BAssertUtil.validateError(resultNegative, 0, "operator '/' not defined for 'json' and 'json'", 8, 10);
-        BAssertUtil.validateError(resultNegative, 1, "operator '/' not defined for 'string' and 'float'", 14, 11);
-        BAssertUtil.validateError(resultNegative, 2, "operator '/' not defined for 'C' and 'string'", 28, 14);
-        BAssertUtil.validateError(resultNegative, 3, "operator '/' not defined for 'C' and '(float|int)'", 29, 14);
-        BAssertUtil.validateError(resultNegative, 4, "operator '/' not defined for 'string' and " +
+        Assert.assertEquals(resultNegative.getErrorCount(), 11);
+        int i = 0;
+        BAssertUtil.validateError(resultNegative, i++, "operator '/' not defined for 'json' and 'json'", 8, 10);
+        BAssertUtil.validateError(resultNegative, i++, "operator '/' not defined for 'string' and 'float'", 14, 11);
+        BAssertUtil.validateError(resultNegative, i++, "operator '/' not defined for 'C' and 'string'", 28, 14);
+        BAssertUtil.validateError(resultNegative, i++, "operator '/' not defined for 'C' and '(float|int)'", 29, 14);
+        BAssertUtil.validateError(resultNegative, i++, "operator '/' not defined for 'string' and " +
                 "'(string|string:Char)'", 30, 17);
-        BAssertUtil.validateError(resultNegative, 5, "operator '/' not defined for 'float' and 'decimal'", 37, 14);
-        BAssertUtil.validateError(resultNegative, 6, "operator '/' not defined for 'float' and 'decimal'", 38, 14);
-        BAssertUtil.validateError(resultNegative, 7, "operator '/' not defined for 'float' and 'int'", 39, 14);
-        BAssertUtil.validateError(resultNegative, 8, "operator '/' not defined for 'decimal' and 'int'", 40, 14);
-        BAssertUtil.validateError(resultNegative, 9, "operator '/' not defined for 'int' and 'float'", 41, 18);
-        BAssertUtil.validateError(resultNegative, 10, "operator '/' not defined for 'C' and 'float'", 45, 14);
-        BAssertUtil.validateError(resultNegative, 11, "operator '/' not defined for 'C' and 'float'", 46, 14);
+        BAssertUtil.validateError(resultNegative, i++, "operator '/' not defined for 'float' and 'decimal'", 37, 14);
+        BAssertUtil.validateError(resultNegative, i++, "operator '/' not defined for 'float' and 'decimal'", 38, 14);
+        BAssertUtil.validateError(resultNegative, i++, "operator '/' not defined for 'int'(dividend) and 'float'(divisor)", 39, 18);
+        BAssertUtil.validateError(resultNegative, i++, "operator '/' not defined for 'int'(dividend) and 'decimal'(divisor)", 40, 18);
+        BAssertUtil.validateError(resultNegative, i++, "operator '/' not defined for 'C' and 'float'", 44, 14);
+        BAssertUtil.validateError(resultNegative, i, "operator '/' not defined for 'C' and 'float'", 45, 14);
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class,
@@ -130,5 +130,40 @@ public class DivisionOperationTest {
     @Test(description = "Test division of nullable values")
     public void testDivisionNullable() {
         BRunUtil.invoke(result, "testDivisionNullable");
+    }
+
+    @Test(dataProvider = "dataToTestDivisionFloatInt", description = "Test division float with int")
+    public void testDivisionFloatInt(String functionName) {
+        BRunUtil.invoke(result, functionName);
+    }
+
+    @DataProvider
+    public Object[] dataToTestDivisionFloatInt() {
+        return new Object[]{
+                "testDivisionFloatInt",
+                "testDivisionFloatIntSubTypes",
+                "testDivisionFloatIntWithNullableOperands",
+                "testDivisionFloatIntSubTypeWithNullableOperands",
+                "testResultTypeOfDivisionFloatIntByInfering",
+                "testResultTypeOfDivisionFloatIntForNilableOperandsByInfering",
+                "testDivisionFloatIntToInfinityAndNaN"
+        };
+    }
+
+    @Test(dataProvider = "dataToTestDivisionDecimalInt", description = "Test division decimal with int")
+    public void testDivisionDecimalInt(String functionName) {
+        BRunUtil.invoke(result, functionName);
+    }
+
+    @DataProvider
+    public Object[] dataToTestDivisionDecimalInt() {
+        return new Object[]{
+                "testDivisionDecimalInt",
+                "testDivisionDecimalIntSubTypes",
+                "testDivisionDecimalIntWithNullableOperands",
+                "testDivisionDecimalIntSubTypeWithNullableOperands",
+                "testResultTypeOfDivisionDecimalIntByInfering",
+                "testResultTypeOfDivisionDecimalIntForNilableOperandsByInfering",
+        };
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/ModOperationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/ModOperationTest.java
@@ -112,8 +112,10 @@ public class ModOperationTest {
                 "'(string|string:Char)'", 30, 17);
         BAssertUtil.validateError(resultNegative, i++, "operator '%' not defined for 'float' and 'decimal'", 37, 14);
         BAssertUtil.validateError(resultNegative, i++, "operator '%' not defined for 'float' and 'decimal'", 38, 14);
-        BAssertUtil.validateError(resultNegative, i++, "operator '%' not defined for 'int'(dividend) and 'float'(divisor)", 39, 18);
-        BAssertUtil.validateError(resultNegative, i++, "operator '%' not defined for 'int'(dividend) and 'decimal'(divisor)", 40, 18);
+        BAssertUtil.validateError(resultNegative, i++, 
+                "operator '%' not defined for 'int'(dividend) and 'float'(divisor)", 39, 18);
+        BAssertUtil.validateError(resultNegative, i++, 
+                "operator '%' not defined for 'int'(dividend) and 'decimal'(divisor)", 40, 18);
         BAssertUtil.validateError(resultNegative, i++, "operator '%' not defined for 'C' and 'float'", 44, 14);
         BAssertUtil.validateError(resultNegative, i, "operator '%' not defined for 'C' and 'float'", 45, 14);
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/ModOperationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/ModOperationTest.java
@@ -104,22 +104,57 @@ public class ModOperationTest {
 
     @Test(description = "Test mod operation negative scenarios")
     public void testModStmtNegativeCases() {
-        Assert.assertEquals(resultNegative.getErrorCount(), 10);
-        BAssertUtil.validateError(resultNegative, 0, "operator '%' not defined for 'C' and 'string'", 28, 14);
-        BAssertUtil.validateError(resultNegative, 1, "operator '%' not defined for 'C' and '(float|int)'", 29, 14);
-        BAssertUtil.validateError(resultNegative, 2, "operator '%' not defined for 'string' and " +
+        Assert.assertEquals(resultNegative.getErrorCount(), 9);
+        int i = 0;
+        BAssertUtil.validateError(resultNegative, i++, "operator '%' not defined for 'C' and 'string'", 28, 14);
+        BAssertUtil.validateError(resultNegative, i++, "operator '%' not defined for 'C' and '(float|int)'", 29, 14);
+        BAssertUtil.validateError(resultNegative, i++, "operator '%' not defined for 'string' and " +
                 "'(string|string:Char)'", 30, 17);
-        BAssertUtil.validateError(resultNegative, 3, "operator '%' not defined for 'float' and 'decimal'", 37, 14);
-        BAssertUtil.validateError(resultNegative, 4, "operator '%' not defined for 'float' and 'decimal'", 38, 14);
-        BAssertUtil.validateError(resultNegative, 5, "operator '%' not defined for 'float' and 'int'", 39, 14);
-        BAssertUtil.validateError(resultNegative, 6, "operator '%' not defined for 'decimal' and 'int'", 40, 14);
-        BAssertUtil.validateError(resultNegative, 7, "operator '%' not defined for 'int' and 'float'", 41, 18);
-        BAssertUtil.validateError(resultNegative, 8, "operator '%' not defined for 'C' and 'float'", 45, 14);
-        BAssertUtil.validateError(resultNegative, 9, "operator '%' not defined for 'C' and 'float'", 46, 14);
+        BAssertUtil.validateError(resultNegative, i++, "operator '%' not defined for 'float' and 'decimal'", 37, 14);
+        BAssertUtil.validateError(resultNegative, i++, "operator '%' not defined for 'float' and 'decimal'", 38, 14);
+        BAssertUtil.validateError(resultNegative, i++, "operator '%' not defined for 'int'(dividend) and 'float'(divisor)", 39, 18);
+        BAssertUtil.validateError(resultNegative, i++, "operator '%' not defined for 'int'(dividend) and 'decimal'(divisor)", 40, 18);
+        BAssertUtil.validateError(resultNegative, i++, "operator '%' not defined for 'C' and 'float'", 44, 14);
+        BAssertUtil.validateError(resultNegative, i, "operator '%' not defined for 'C' and 'float'", 45, 14);
     }
 
     @Test(description = "Test mod of nullable values")
     public void testModNullable() {
         BRunUtil.invoke(result, "testModNullable");
+    }
+
+
+    @Test(dataProvider = "dataToTestModFloatInt", description = "Test float modulo by int")
+    public void testModFloatInt(String functionName) {
+        BRunUtil.invoke(result, functionName);
+    }
+
+    @DataProvider
+    public Object[] dataToTestModFloatInt() {
+        return new Object[]{
+                "testModFloatInt",
+                "testModFloatIntSubTypes",
+                "testModFloatIntWithNullableOperands",
+                "testModFloatIntSubTypeWithNullableOperands",
+                "testResultTypeOfModFloatIntByInfering",
+                "testResultTypeOfModFloatIntForNilableOperandsByInfering",
+        };
+    }
+
+    @Test(dataProvider = "dataToTestModDecimalInt", description = "Test decimal modulo by int")
+    public void testModDecimalInt(String functionName) {
+        BRunUtil.invoke(result, functionName);
+    }
+
+    @DataProvider
+    public Object[] dataToTestModDecimalInt() {
+        return new Object[]{
+                "testModDecimalInt",
+                "testModDecimalIntSubTypes",
+                "testModDecimalIntWithNullableOperands",
+                "testModDecimalIntSubTypeWithNullableOperands",
+                "testResultTypeOfModDecimalIntByInfering",
+                "testResultTypeOfModDecimalIntForNilableOperandsByInfering",
+        };
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/MultiplyOperationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/MultiplyOperationTest.java
@@ -91,24 +91,57 @@ public class MultiplyOperationTest {
 
     @Test(description = "Test binary statement with errors")
     public void testMultiplyStmtNegativeCases() {
-        Assert.assertEquals(resultNegative.getErrorCount(), 12);
-        BAssertUtil.validateError(resultNegative, 0, "operator '*' not defined for 'json' and 'json'", 8, 10);
-        BAssertUtil.validateError(resultNegative, 1, "operator '*' not defined for 'float' and 'string'", 14, 9);
-        BAssertUtil.validateError(resultNegative, 2, "operator '*' not defined for 'C' and 'string'", 28, 14);
-        BAssertUtil.validateError(resultNegative, 3, "operator '*' not defined for 'C' and '(float|int)'", 29, 14);
-        BAssertUtil.validateError(resultNegative, 4, "operator '*' not defined for 'string' and " +
+        Assert.assertEquals(resultNegative.getErrorCount(), 9);
+        int i = 0;
+        BAssertUtil.validateError(resultNegative, i++, "operator '*' not defined for 'json' and 'json'", 8, 10);
+        BAssertUtil.validateError(resultNegative, i++, "operator '*' not defined for 'float' and 'string'", 14, 9);
+        BAssertUtil.validateError(resultNegative, i++, "operator '*' not defined for 'C' and 'string'", 28, 14);
+        BAssertUtil.validateError(resultNegative, i++, "operator '*' not defined for 'C' and '(float|int)'", 29, 14);
+        BAssertUtil.validateError(resultNegative, i++, "operator '*' not defined for 'string' and " +
                 "'(string|string:Char)'", 30, 17);
-        BAssertUtil.validateError(resultNegative, 5, "operator '*' not defined for 'float' and 'decimal'", 37, 14);
-        BAssertUtil.validateError(resultNegative, 6, "operator '*' not defined for 'float' and 'decimal'", 38, 14);
-        BAssertUtil.validateError(resultNegative, 7, "operator '*' not defined for 'float' and 'int'", 39, 14);
-        BAssertUtil.validateError(resultNegative, 8, "operator '*' not defined for 'decimal' and 'int'", 40, 14);
-        BAssertUtil.validateError(resultNegative, 9, "operator '*' not defined for 'int' and 'float'", 41, 18);
-        BAssertUtil.validateError(resultNegative, 10, "operator '*' not defined for 'C' and 'float'", 45, 14);
-        BAssertUtil.validateError(resultNegative, 11, "operator '*' not defined for 'C' and 'float'", 46, 14);
+        BAssertUtil.validateError(resultNegative, i++, "operator '*' not defined for 'float' and 'decimal'", 37, 14);
+        BAssertUtil.validateError(resultNegative, i++, "operator '*' not defined for 'float' and 'decimal'", 38, 14);
+        BAssertUtil.validateError(resultNegative, i++, "operator '*' not defined for 'C' and 'float'", 45, 14);
+        BAssertUtil.validateError(resultNegative, i++, "operator '*' not defined for 'C' and 'float'", 46, 14);
     }
 
     @Test(description = "Test multiplication of nullable values")
     public void testMultiplyNullable() {
         BRunUtil.invoke(result, "testMultiplyNullable");
+    }
+
+    @Test(dataProvider = "dataToTestMultiplyFloatInt", description = "Test multiplication float with int")
+    public void testMultiplyFloatInt(String functionName) {
+        BRunUtil.invoke(result, functionName);
+    }
+
+    @DataProvider
+    public Object[] dataToTestMultiplyFloatInt() {
+        return new Object[]{
+                "testMultiplyFloatInt",
+                "testMultiplyFloatIntSubTypes",
+                "testMultiplyFloatIntWithNullableOperands",
+                "testMultiplyFloatIntSubTypeWithNullableOperands",
+                "testResultTypeOfMultiplyFloatIntByInfering",
+                "testResultTypeOfMultiplyFloatIntForNilableOperandsByInfering",
+                "testMultiplyFloatIntToInfinityAndNaN"
+        };
+    }
+
+    @Test(dataProvider = "dataToTestMultiplyDecimalInt", description = "Test multiplication decimal with int")
+    public void testMultiplyDecimalInt(String functionName) {
+        BRunUtil.invoke(result, functionName);
+    }
+
+    @DataProvider
+    public Object[] dataToTestMultiplyDecimalInt() {
+        return new Object[]{
+                "testMultiplyDecimalInt",
+                "testMultiplyDecimalIntSubTypes",
+                "testMultiplyDecimalIntWithNullableOperands",
+                "testMultiplyDecimalIntSubTypeWithNullableOperands",
+                "testResultTypeOfMultiplyDecimalIntByInfering",
+                "testResultTypeOfMultiplyDecimalIntForNilableOperandsByInfering",
+        };
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/decimaltype/BDecimalValueNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/decimaltype/BDecimalValueNegativeTest.java
@@ -66,12 +66,12 @@ public class BDecimalValueNegativeTest {
         BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 27, 22);
         BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 27, 31);
         BAssertUtil.validateError(negative, i++, "incompatible types: expected '(int|decimal)', found 'float'", 28, 23);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 34, 23);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 35, 23);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 36, 24);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 37, 23);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 38, 17);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 39, 17);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 41, 37);
+        BAssertUtil.validateError(negative, i++, "operator '/' not defined for 'decimal' and 'float'", 34, 17);
+        BAssertUtil.validateError(negative, i++, "operator '+' not defined for 'decimal' and 'float'", 35, 17);
+        BAssertUtil.validateError(negative, i++, "operator '+' not defined for 'decimal' and 'float'", 36, 17);
+        BAssertUtil.validateError(negative, i++, "operator '*' not defined for 'decimal' and 'float'", 37, 17);
+        BAssertUtil.validateError(negative, i++, "operator '+' not defined for 'float' and 'decimal'", 38, 17);
+        BAssertUtil.validateError(negative, i++, "operator '-' not defined for 'float' and 'decimal'", 39, 17);
+        BAssertUtil.validateError(negative, i++, "operator '+' not defined for 'decimal' and 'float'", 41, 17);
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/division-operation-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/division-operation-negative.bal
@@ -36,9 +36,8 @@ function testImplicitConversion() {
     int c = 1;
     var x1 = a / b;
     any x2 = a / b;
-    var x3 = a / c;
-    any x4 = b / c;
     anydata x5 = c / a;
+    anydata x6 = c / b;
 
     C d = 10;
     float e = 12.25;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/division-operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/division-operation.bal
@@ -304,6 +304,8 @@ function testDivisionFloatInt() {
     float b = float:Infinity;
     float c = 4.5e-1;
     float d = 0;
+    int e = int:MAX_VALUE;
+    int f = int:MIN_VALUE;
 
     float var4 = b / a;
     assertEqual(var4, float:Infinity);
@@ -333,6 +335,11 @@ function testDivisionFloatInt() {
     assertEqual(var15, 10.25);
     float var16 = constFloat / d;
     assertEqual(var16, float:Infinity);
+    
+    float var17 = c / e;
+    assertEqual(var17, 4.87890977618477E-20);
+    float var18 = c / f;
+    assertEqual(var18, -4.87890977618477E-20);
 }
 
 function testDivisionFloatIntSubTypes() {
@@ -539,6 +546,8 @@ function testDivisionDecimalInt() {
     int a = 2;
     decimal c = 4.5e-1;
     decimal d = 0;
+    int e = int:MAX_VALUE;
+    int f = int:MIN_VALUE;
 
     decimal var5 = c / a;
     assertEqual(var5, 0.225d);
@@ -555,6 +564,11 @@ function testDivisionDecimalInt() {
 
     decimal var15 = constDecimal / a;
     assertEqual(var15, 10.25d);
+    
+    decimal var17 = c / e;
+    assertEqual(var17, 4.878909776184769953562510061784767E-20d);
+    decimal var18 = c / f;
+    assertEqual(var18, -4.878909776184769953033537603914738E-20d);
 }
 
 function testDivisionDecimalIntSubTypes() {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/division-operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/division-operation.bal
@@ -294,6 +294,443 @@ function testDivisionNullable() {
     assertEqual(a36 / a36, 1d);
 }
 
+const int constInt = 5;
+
+const float constFloat = 20.5;
+
+function testDivisionFloatInt() {
+    int a = 2;
+    int a1 = 0;
+    float b = float:Infinity;
+    float c = 4.5e-1;
+    float d = 0;
+
+    float var4 = b / a;
+    assertEqual(var4, float:Infinity);
+    float var5 = c / a;
+    assertEqual(var5, 0.225);
+    float var6 = d / a;
+    assertEqual(var6, 0.0);
+
+    float var7 = b / a1;
+    assertEqual(var7, float:Infinity);
+    float var8 = c / a1;
+    assertEqual(var8, float:Infinity);
+    float var9 = d / a1;
+    assertEqual(var9, float:NaN);
+
+    float var10 = b / constInt;
+    assertEqual(var10, float:Infinity);
+    float var11 = c / constInt;
+    assertEqual(var11, 0.09);
+    float var12 = d / constInt;
+    assertEqual(var12, 0.0);
+
+    float var13 = constFloat / constInt;
+    assertEqual(var13, 4.1);
+
+    float var15 = constFloat / a;
+    assertEqual(var15, 10.25);
+    float var16 = constFloat / d;
+    assertEqual(var16, float:Infinity);
+}
+
+function testDivisionFloatIntSubTypes() {
+    int:Signed8 a = -2;
+    int:Signed16 b = 2;
+    int:Signed32 c = -4;
+    int:Unsigned8 d = 4;
+    int:Unsigned16 e = 5;
+    int:Unsigned32 f = 10;
+    byte g = 25;
+
+    float h = 2.5;
+
+    float var8 = h / a;
+    assertEqual(var8, -1.25);
+    float var9 = h / b;
+    assertEqual(var9, 1.25);
+    float var10 = h / c;
+    assertEqual(var10, -0.625);
+    float var11 = h / d;
+    assertEqual(var11, 0.625);
+    float var12 = h / e;
+    assertEqual(var12, 0.5);
+    float var13 = h / f;
+    assertEqual(var13, 0.25);
+    float var14 = h / g;
+    assertEqual(var14, 0.1);
+}
+
+function testDivisionFloatIntWithNullableOperands() {
+    int a = 2;
+    int? b = 4;
+    float c = 4.5e-1;
+    float? d = -10.5;
+    int? e = ();
+    float? f = ();
+
+    float? var2 = d / a;
+    assertEqual(var2, -5.25);
+
+    float? var4 = c / b;
+    assertEqual(var4, 0.1125);
+
+    float? var6 = d / b;
+    assertEqual(var6, -2.625);
+
+    float? var8 = d / constInt;
+    assertEqual(var8, -2.1);
+
+    float? var9 = constFloat / b;
+    assertEqual(var9, 5.125);
+
+    float? var10 = c / e;
+    assertEqual(var10, ());
+
+    float? var11 = f / e;
+    assertEqual(var11, ());
+
+    float? var12 = f / a;
+    assertEqual(var12, ());
+
+    float? var13 = f / constInt;
+    assertEqual(var13, ());
+
+    float? var14 = constFloat / e;
+    assertEqual(var14, ());
+}
+
+function testDivisionFloatIntSubTypeWithNullableOperands() {
+    int:Signed8 a = -2;
+    int:Signed16 b = 2;
+    int:Signed32 c = -5;
+    int:Unsigned8 d = 10;
+    int:Unsigned16 e = 5;
+    int:Unsigned32 f = 10;
+    byte g = 4;
+
+    int:Signed8? h = -2;
+    int:Signed16? i = ();
+    int:Signed32? j = ();
+    int:Unsigned8? k = 4;
+    int:Unsigned16? m = 5;
+    int:Unsigned32? n = 10;
+    byte? p = ();
+
+    float q = 2.5;
+    float? r = 2.5;
+
+    float? var8 = r / a;
+    assertEqual(var8, -1.25);
+    float? var9 = r / b;
+    assertEqual(var9, 1.25);
+    float? var10 = r / c;
+    assertEqual(var10, -0.5);
+    float? var11 = r / d;
+    assertEqual(var11, 0.25);
+    float? var12 = r / e;
+    assertEqual(var12, 0.5);
+    float? var13 = r / f;
+    assertEqual(var13, 0.25);
+    float? var14 = r / g;
+    assertEqual(var14, 0.625);
+
+    float? var22 = q / h;
+    assertEqual(var22, -1.25);
+    float? var23 = q / i;
+    assertEqual(var23, ());
+    float? var24 = q / j;
+    assertEqual(var24, ());
+    float? var25 = q / k;
+    assertEqual(var25, 0.625);
+    float? var26 = q / m;
+    assertEqual(var26, 0.5);
+    float? var27 = q / n;
+    assertEqual(var27, 0.25);
+    float? var28 = q / p;
+    assertEqual(var28, ());
+
+    float? var36 = r / h;
+    assertEqual(var36, -1.25);
+    float? var37 = r / i;
+    assertEqual(var37, ());
+    float? var38 = r / j;
+    assertEqual(var38, ());
+    float? var39 = r / k;
+    assertEqual(var39, 0.625);
+    float? var40 = r / m;
+    assertEqual(var40, 0.5);
+    float? var41 = r / n;
+    assertEqual(var41, 0.25);
+    float? var42 = r / p;
+    assertEqual(var42, ());
+}
+
+function testResultTypeOfDivisionFloatIntByInfering() {
+    float a = 2.5;
+    int b = 5;
+
+    var c = a / b;
+    float var1 = c;
+    assertEqual(var1, 0.5);
+
+    var e = a / constInt;
+    float var3 = e;
+    assertEqual(var3, 0.5);
+
+    var g = constFloat / b;
+    float var5 = g;
+    assertEqual(var5, 4.1);
+
+    var i = constFloat / constInt;
+    float var7 = i;
+    assertEqual(var7, 4.1);
+}
+
+function testResultTypeOfDivisionFloatIntForNilableOperandsByInfering() {
+    float? a = 2.5;
+    int? b = 5;
+
+    var c = a / b;
+    float? var1 = c;
+    assertEqual(var1, 0.5);
+
+    var e = a / constInt;
+    float? var3 = e;
+    assertEqual(var3, 0.5);
+
+    var g = constFloat / b;
+    float? var5 = g;
+    assertEqual(var5, 4.1);
+
+    var i = constFloat / constInt;
+    float? var7 = i;
+    assertEqual(var7, 4.1);
+}
+
+function testDivisionFloatIntToInfinityAndNaN() {
+    float a = 8388608333e+298;
+    int b = 20;
+    float c = float:Infinity;
+    float d = float:NaN;
+    int e = 0;
+
+    float var4 = c / b;
+    assertEqual(var4, float:Infinity);
+
+    float var5 = d / b;
+    assertEqual(var5, float:NaN);
+
+    float var7 = a / e;
+    assertEqual(var7, float:Infinity);
+
+    float var8 = c / e;
+    assertEqual(var8, float:Infinity);
+
+    float var9 = d / e;
+    assertEqual(var9, float:NaN);
+
+}
+
+const decimal constDecimal = 20.5;
+
+function testDivisionDecimalInt() {
+    int a = 2;
+    decimal c = 4.5e-1;
+    decimal d = 0;
+
+    decimal var5 = c / a;
+    assertEqual(var5, 0.225d);
+    decimal var6 = d / a;
+    assertEqual(var6, 0.0d);
+
+    decimal var11 = c / constInt;
+    assertEqual(var11, 0.09d);
+    decimal var12 = d / constInt;
+    assertEqual(var12, 0d);
+
+    decimal var13 = constDecimal / constInt;
+    assertEqual(var13, 4.1d);
+
+    decimal var15 = constDecimal / a;
+    assertEqual(var15, 10.25d);
+}
+
+function testDivisionDecimalIntSubTypes() {
+    int:Signed8 a = -2;
+    int:Signed16 b = 2;
+    int:Signed32 c = -4;
+    int:Unsigned8 d = 4;
+    int:Unsigned16 e = 5;
+    int:Unsigned32 f = 10;
+    byte g = 25;
+
+    decimal h = 2.5;
+
+    decimal var8 = h / a;
+    assertEqual(var8, -1.25d);
+    decimal var9 = h / b;
+    assertEqual(var9, 1.25d);
+    decimal var10 = h / c;
+    assertEqual(var10, -0.625d);
+    decimal var11 = h / d;
+    assertEqual(var11, 0.625d);
+    decimal var12 = h / e;
+    assertEqual(var12, 0.5d);
+    decimal var13 = h / f;
+    assertEqual(var13, 0.25d);
+    decimal var14 = h / g;
+    assertEqual(var14, 0.1d);
+}
+
+function testDivisionDecimalIntWithNullableOperands() {
+    int a = 2;
+    int? b = 4;
+    decimal c = 4.5e-1;
+    decimal? d = -10.5;
+    int? e = ();
+    decimal? f = ();
+
+    decimal? var2 = d / a;
+    assertEqual(var2, -5.25d);
+
+    decimal? var4 = c / b;
+    assertEqual(var4, 0.1125d);
+
+    decimal? var6 = d / b;
+    assertEqual(var6, -2.625d);
+
+    decimal? var8 = d / constInt;
+    assertEqual(var8, -2.1d);
+
+    decimal? var9 = constDecimal / b;
+    assertEqual(var9, 5.125d);
+
+    decimal? var10 = c / e;
+    assertEqual(var10, ());
+
+    decimal? var11 = f / e;
+    assertEqual(var11, ());
+
+    decimal? var12 = f / a;
+    assertEqual(var12, ());
+
+    decimal? var13 = f / constInt;
+    assertEqual(var13, ());
+
+    decimal? var14 = constDecimal / e;
+    assertEqual(var14, ());
+}
+
+function testDivisionDecimalIntSubTypeWithNullableOperands() {
+    int:Signed8 a = -2;
+    int:Signed16 b = 2;
+    int:Signed32 c = -5;
+    int:Unsigned8 d = 10;
+    int:Unsigned16 e = 5;
+    int:Unsigned32 f = 10;
+    byte g = 4;
+
+    int:Signed8? h = -2;
+    int:Signed16? i = ();
+    int:Signed32? j = ();
+    int:Unsigned8? k = 4;
+    int:Unsigned16? m = 5;
+    int:Unsigned32? n = 10;
+    byte? p = ();
+
+    decimal q = 2.5;
+    decimal? r = 2.5;
+
+    decimal? var8 = r / a;
+    assertEqual(var8, -1.25d);
+    decimal? var9 = r / b;
+    assertEqual(var9, 1.25d);
+    decimal? var10 = r / c;
+    assertEqual(var10, -0.5d);
+    decimal? var11 = r / d;
+    assertEqual(var11, 0.25d);
+    decimal? var12 = r / e;
+    assertEqual(var12, 0.5d);
+    decimal? var13 = r / f;
+    assertEqual(var13, 0.25d);
+    decimal? var14 = r / g;
+    assertEqual(var14, 0.625d);
+
+    decimal? var22 = q / h;
+    assertEqual(var22, -1.25d);
+    decimal? var23 = q / i;
+    assertEqual(var23, ());
+    decimal? var24 = q / j;
+    assertEqual(var24, ());
+    decimal? var25 = q / k;
+    assertEqual(var25, 0.625d);
+    decimal? var26 = q / m;
+    assertEqual(var26, 0.5d);
+    decimal? var27 = q / n;
+    assertEqual(var27, 0.25d);
+    decimal? var28 = q / p;
+    assertEqual(var28, ());
+
+    decimal? var36 = r / h;
+    assertEqual(var36, -1.25d);
+    decimal? var37 = r / i;
+    assertEqual(var37, ());
+    decimal? var38 = r / j;
+    assertEqual(var38, ());
+    decimal? var39 = r / k;
+    assertEqual(var39, 0.625d);
+    decimal? var40 = r / m;
+    assertEqual(var40, 0.5d);
+    decimal? var41 = r / n;
+    assertEqual(var41, 0.25d);
+    decimal? var42 = r / p;
+    assertEqual(var42, ());
+}
+
+function testResultTypeOfDivisionDecimalIntByInfering() {
+    decimal a = 2.5;
+    int b = 5;
+
+    var c = a / b;
+    decimal var1 = c;
+    assertEqual(var1, 0.5d);
+
+    var e = a / constInt;
+    decimal var3 = e;
+    assertEqual(var3, 0.5d);
+
+    var g = constDecimal / b;
+    decimal var5 = g;
+    assertEqual(var5, 4.1d);
+
+    var i = constDecimal / constInt;
+    decimal var7 = i;
+    assertEqual(var7, 4.1d);
+}
+
+function testResultTypeOfDivisionDecimalIntForNilableOperandsByInfering() {
+    decimal? a = 2.5;
+    int? b = 5;
+
+    var c = a / b;
+    decimal? var1 = c;
+    assertEqual(var1, 0.5d);
+
+    var e = a / constInt;
+    decimal? var3 = e;
+    assertEqual(var3, 0.5d);
+
+    var g = constDecimal / b;
+    decimal? var5 = g;
+    assertEqual(var5, 4.1d);
+
+    var i = constDecimal / constInt;
+    decimal? var7 = i;
+    assertEqual(var7, 4.1d);
+}
+
 function assertEqual(any actual, any expected) {
     if actual is anydata && expected is anydata && actual == expected {
         return;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/mod-operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/mod-operation.bal
@@ -172,6 +172,8 @@ function testModFloatInt() {
     float b = float:Infinity;
     float c = 4.5e-1;
     float d = 0;
+    int e = int:MAX_VALUE;
+    int f = int:MIN_VALUE;
 
     float var4 = b % a;
     assertEqual(var4, float:NaN);
@@ -201,6 +203,11 @@ function testModFloatInt() {
     assertEqual(var15, 0.5);
     float var16 = constFloat % d;
     assertEqual(var16, float:NaN);
+    
+    float var17 = c % e;
+    assertEqual(var17, 0.45);
+    float var18 = c % f;
+    assertEqual(var18, 0.45);
 }
 
 function testModFloatIntSubTypes() {
@@ -383,6 +390,8 @@ function testModDecimalInt() {
     int a = 2;
     decimal c = 4.5e-1;
     decimal d = 0;
+    int e = int:MAX_VALUE;
+    int f = int:MIN_VALUE;
 
     decimal var5 = c % a;
     assertEqual(var5, 0.45d);
@@ -399,6 +408,11 @@ function testModDecimalInt() {
 
     decimal var15 = constDecimal % a;
     assertEqual(var15, 0.5d);
+    
+    decimal var17 = c % e;
+    assertEqual(var17, 0.45d);
+    decimal var18 = c % f;
+    assertEqual(var18, 0.45d);
 }
 
 function testModDecimalIntSubTypes() {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/mod-operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/mod-operation.bal
@@ -162,6 +162,419 @@ function testModNullable() {
     assertEqual(g % g, 0);
 }
 
+const int constInt = 5;
+
+const float constFloat = 20.5;
+
+function testModFloatInt() {
+    int a = 2;
+    int a1 = 0;
+    float b = float:Infinity;
+    float c = 4.5e-1;
+    float d = 0;
+
+    float var4 = b % a;
+    assertEqual(var4, float:NaN);
+    float var5 = c % a;
+    assertEqual(var5, 0.45);
+    float var6 = d % a;
+    assertEqual(var6, 0.0);
+
+    float var7 = b % a1;
+    assertEqual(var7, float:NaN);
+    float var8 = c % a1;
+    assertEqual(var8, float:NaN);
+    float var9 = d % a1;
+    assertEqual(var9, float:NaN);
+
+    float var10 = b % constInt;
+    assertEqual(var10, float:NaN);
+    float var11 = c % constInt;
+    assertEqual(var11, 0.45);
+    float var12 = d % constInt;
+    assertEqual(var12, 0.0);
+
+    float var13 = constFloat % constInt;
+    assertEqual(var13, 0.5);
+
+    float var15 = constFloat % a;
+    assertEqual(var15, 0.5);
+    float var16 = constFloat % d;
+    assertEqual(var16, float:NaN);
+}
+
+function testModFloatIntSubTypes() {
+    int:Signed8 a = -2;
+    int:Signed16 b = 2;
+    int:Signed32 c = -4;
+    int:Unsigned8 d = 4;
+    int:Unsigned16 e = 5;
+    int:Unsigned32 f = 10;
+    byte g = 25;
+
+    float h = 2.5;
+
+    float var8 = h % a;
+    assertEqual(var8, 0.5);
+    float var9 = h % b;
+    assertEqual(var9, 0.5);
+    float var10 = h % c;
+    assertEqual(var10, 2.5);
+    float var11 = h % d;
+    assertEqual(var11, 2.5);
+    float var12 = h % e;
+    assertEqual(var12, 2.5);
+    float var13 = h % f;
+    assertEqual(var13, 2.5);
+    float var14 = h % g;
+    assertEqual(var14, 2.5);
+}
+
+function testModFloatIntWithNullableOperands() {
+    int a = 2;
+    int? b = 4;
+    float c = 4.5e-1;
+    float? d = -10.5;
+    int? e = ();
+    float? f = ();
+
+    float? var2 = d % a;
+    assertEqual(var2, -0.5);
+
+    float? var4 = c % b;
+    assertEqual(var4, 0.45);
+
+    float? var6 = d % b;
+    assertEqual(var6, -2.5);
+
+    float? var8 = d % constInt;
+    assertEqual(var8, -0.5);
+
+    float? var9 = constFloat % b;
+    assertEqual(var9, 0.5);
+
+    float? var10 = c % e;
+    assertEqual(var10, ());
+
+    float? var11 = f % e;
+    assertEqual(var11, ());
+
+    float? var12 = f % a;
+    assertEqual(var12, ());
+
+    float? var13 = f % constInt;
+    assertEqual(var13, ());
+
+    float? var14 = constFloat % e;
+    assertEqual(var14, ());
+}
+
+function testModFloatIntSubTypeWithNullableOperands() {
+    int:Signed8 a = -2;
+    int:Signed16 b = 2;
+    int:Signed32 c = -5;
+    int:Unsigned8 d = 10;
+    int:Unsigned16 e = 5;
+    int:Unsigned32 f = 10;
+    byte g = 4;
+
+    int:Signed8? h = -2;
+    int:Signed16? i = ();
+    int:Signed32? j = ();
+    int:Unsigned8? k = 4;
+    int:Unsigned16? m = 5;
+    int:Unsigned32? n = 10;
+    byte? p = ();
+
+    float q = 2.5;
+    float? r = 2.5;
+
+    float? var8 = r % a;
+    assertEqual(var8, 0.5);
+    float? var9 = r % b;
+    assertEqual(var9, 0.5);
+    float? var10 = r % c;
+    assertEqual(var10, 2.5);
+    float? var11 = r % d;
+    assertEqual(var11, 2.5);
+    float? var12 = r % e;
+    assertEqual(var12, 2.5);
+    float? var13 = r % f;
+    assertEqual(var13, 2.5);
+    float? var14 = r % g;
+    assertEqual(var14, 2.5);
+
+    float? var22 = q % h;
+    assertEqual(var22, 0.5);
+    float? var23 = q % i;
+    assertEqual(var23, ());
+    float? var24 = q % j;
+    assertEqual(var24, ());
+    float? var25 = q % k;
+    assertEqual(var25, 2.5);
+    float? var26 = q % m;
+    assertEqual(var26, 2.5);
+    float? var27 = q % n;
+    assertEqual(var27, 2.5);
+    float? var28 = q % p;
+    assertEqual(var28, ());
+
+    float? var36 = r % h;
+    assertEqual(var36, 0.5);
+    float? var37 = r % i;
+    assertEqual(var37, ());
+    float? var38 = r % j;
+    assertEqual(var38, ());
+    float? var39 = r % k;
+    assertEqual(var39, 2.5);
+    float? var40 = r % m;
+    assertEqual(var40, 2.5);
+    float? var41 = r % n;
+    assertEqual(var41, 2.5);
+    float? var42 = r % p;
+    assertEqual(var42, ());
+}
+
+function testResultTypeOfModFloatIntByInfering() {
+    float a = 2.5;
+    int b = 5;
+
+    var c = a % b;
+    float var1 = c;
+    assertEqual(var1, 2.5);
+
+    var e = a % constInt;
+    float var3 = e;
+    assertEqual(var3, 2.5);
+
+    var g = constFloat % b;
+    float var5 = g;
+    assertEqual(var5, 0.5);
+
+    var i = constFloat % constInt;
+    float var7 = i;
+    assertEqual(var7, 0.5);
+}
+
+function testResultTypeOfModFloatIntForNilableOperandsByInfering() {
+    float? a = 2.5;
+    int? b = 5;
+
+    var c = a % b;
+    float? var1 = c;
+    assertEqual(var1, 2.5);
+
+    var e = a % constInt;
+    float? var3 = e;
+    assertEqual(var3, 2.5);
+
+    var g = constFloat % b;
+    float? var5 = g;
+    assertEqual(var5, 0.5);
+
+    var i = constFloat % constInt;
+    float? var7 = i;
+    assertEqual(var7, 0.5);
+}
+
+const decimal constDecimal = 20.5;
+
+function testModDecimalInt() {
+    int a = 2;
+    decimal c = 4.5e-1;
+    decimal d = 0;
+
+    decimal var5 = c % a;
+    assertEqual(var5, 0.45d);
+    decimal var6 = d % a;
+    assertEqual(var6, 0d);
+
+    decimal var11 = c % constInt;
+    assertEqual(var11, 0.45d);
+    decimal var12 = d % constInt;
+    assertEqual(var12, 0d);
+
+    decimal var13 = constDecimal % constInt;
+    assertEqual(var13, 0.5d);
+
+    decimal var15 = constDecimal % a;
+    assertEqual(var15, 0.5d);
+}
+
+function testModDecimalIntSubTypes() {
+    int:Signed8 a = -2;
+    int:Signed16 b = 2;
+    int:Signed32 c = -4;
+    int:Unsigned8 d = 4;
+    int:Unsigned16 e = 5;
+    int:Unsigned32 f = 10;
+    byte g = 25;
+
+    decimal h = 2.5;
+
+    decimal var8 = h % a;
+    assertEqual(var8, 0.5d);
+    decimal var9 = h % b;
+    assertEqual(var9, 0.5d);
+    decimal var10 = h % c;
+    assertEqual(var10, 2.5d);
+    decimal var11 = h % d;
+    assertEqual(var11, 2.5d);
+    decimal var12 = h % e;
+    assertEqual(var12, 2.5d);
+    decimal var13 = h % f;
+    assertEqual(var13, 2.5d);
+    decimal var14 = h % g;
+    assertEqual(var14, 2.5d);
+}
+
+function testModDecimalIntWithNullableOperands() {
+    int a = 2;
+    int? b = 4;
+    decimal c = 4.5e-1;
+    decimal? d = -10.5;
+    int? e = ();
+    decimal? f = ();
+
+    decimal? var2 = d % a;
+    assertEqual(var2, -0.5d);
+
+    decimal? var4 = c % b;
+    assertEqual(var4, 0.45d);
+
+    decimal? var6 = d % b;
+    assertEqual(var6, -2.5d);
+
+    decimal? var8 = d % constInt;
+    assertEqual(var8, -0.5d);
+
+    decimal? var9 = constDecimal % b;
+    assertEqual(var9, 0.5d);
+
+    decimal? var10 = c % e;
+    assertEqual(var10, ());
+
+    decimal? var11 = f % e;
+    assertEqual(var11, ());
+
+    decimal? var12 = f % a;
+    assertEqual(var12, ());
+
+    decimal? var13 = f % constInt;
+    assertEqual(var13, ());
+
+    decimal? var14 = constDecimal % e;
+    assertEqual(var14, ());
+}
+
+function testModDecimalIntSubTypeWithNullableOperands() {
+    int:Signed8 a = -2;
+    int:Signed16 b = 2;
+    int:Signed32 c = -5;
+    int:Unsigned8 d = 10;
+    int:Unsigned16 e = 5;
+    int:Unsigned32 f = 10;
+    byte g = 4;
+
+    int:Signed8? h = -2;
+    int:Signed16? i = ();
+    int:Signed32? j = ();
+    int:Unsigned8? k = 4;
+    int:Unsigned16? m = 5;
+    int:Unsigned32? n = 10;
+    byte? p = ();
+
+    decimal q = 2.5;
+    decimal? r = 2.5;
+
+    decimal? var8 = r % a;
+    assertEqual(var8, 0.5d);
+    decimal? var9 = r % b;
+    assertEqual(var9, 0.5d);
+    decimal? var10 = r % c;
+    assertEqual(var10, 2.5d);
+    decimal? var11 = r % d;
+    assertEqual(var11, 2.5d);
+    decimal? var12 = r % e;
+    assertEqual(var12, 2.5d);
+    decimal? var13 = r % f;
+    assertEqual(var13, 2.5d);
+    decimal? var14 = r % g;
+    assertEqual(var14, 2.5d);
+
+    decimal? var22 = q % h;
+    assertEqual(var22, 0.5d);
+    decimal? var23 = q % i;
+    assertEqual(var23, ());
+    decimal? var24 = q % j;
+    assertEqual(var24, ());
+    decimal? var25 = q % k;
+    assertEqual(var25, 2.5d);
+    decimal? var26 = q % m;
+    assertEqual(var26, 2.5d);
+    decimal? var27 = q % n;
+    assertEqual(var27, 2.5d);
+    decimal? var28 = q % p;
+    assertEqual(var28, ());
+
+    decimal? var36 = r % h;
+    assertEqual(var36, 0.5d);
+    decimal? var37 = r % i;
+    assertEqual(var37, ());
+    decimal? var38 = r % j;
+    assertEqual(var38, ());
+    decimal? var39 = r % k;
+    assertEqual(var39, 2.5d);
+    decimal? var40 = r % m;
+    assertEqual(var40, 2.5d);
+    decimal? var41 = r % n;
+    assertEqual(var41, 2.5d);
+    decimal? var42 = r % p;
+    assertEqual(var42, ());
+}
+
+function testResultTypeOfModDecimalIntByInfering() {
+    decimal a = 2.5;
+    int b = 5;
+
+    var c = a % b;
+    decimal var1 = c;
+    assertEqual(var1, 2.5d);
+
+    var e = a % constInt;
+    decimal var3 = e;
+    assertEqual(var3, 2.5d);
+
+    var g = constDecimal % b;
+    decimal var5 = g;
+    assertEqual(var5, 0.5d);
+
+    var i = constDecimal % constInt;
+    decimal var7 = i;
+    assertEqual(var7, 0.5d);
+}
+
+function testResultTypeOfModDecimalIntForNilableOperandsByInfering() {
+    decimal? a = 2.5;
+    int? b = 5;
+
+    var c = a % b;
+    decimal? var1 = c;
+    assertEqual(var1, 2.5d);
+
+    var e = a % constInt;
+    decimal? var3 = e;
+    assertEqual(var3, 2.5d);
+
+    var g = constDecimal % b;
+    decimal? var5 = g;
+    assertEqual(var5, 0.5d);
+
+    var i = constDecimal % constInt;
+    decimal? var7 = i;
+    assertEqual(var7, 0.5d);
+}
+
 function assertEqual(any actual, any expected) {
     if actual is anydata && expected is anydata && actual == expected {
         return;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/mod_operation_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/mod_operation_negative.bal
@@ -36,9 +36,8 @@ function testImplicitConversion() {
     int c = 1;
     var x1 = a % b;
     any x2 = a % b;
-    var x3 = a % c;
-    any x4 = b % c;
     anydata x5 = c % a;
+    anydata x6 = c % b;
 
     C d = 10;
     float e = 12.25;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/multiply-operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/multiply-operation.bal
@@ -293,6 +293,8 @@ function testMultiplyFloatInt() {
     float b = 4.5;
     float c = 4.5e-1;
     float d = -10.5;
+    int e = int:MAX_VALUE;
+    int f = int:MIN_VALUE;
 
     float var1 = a * b;
     assertEqual(var1, 9.0);
@@ -331,6 +333,11 @@ function testMultiplyFloatInt() {
     assertEqual(var15, 41.0);
     float var16 = a * constFloat;
     assertEqual(var16, 41.0);
+
+    float var17 = b * e;
+    assertEqual(var17, 4.150517416584649E19);
+    float var18 = b * f;
+    assertEqual(var18, -4.150517416584649E19);
 }
 
 function testMultiplyFloatIntSubTypes() {
@@ -616,6 +623,8 @@ function testMultiplyDecimalInt() {
     decimal b = 4.5;
     decimal c = 4.5e-1;
     decimal d = -10.5;
+    int e = int:MAX_VALUE;
+    int f = int:MIN_VALUE;
 
     decimal var1 = a * b;
     assertEqual(var1, 9.00d);
@@ -654,6 +663,11 @@ function testMultiplyDecimalInt() {
     assertEqual(var15, 41.00d);
     decimal var16 = a * constDecimal;
     assertEqual(var16, 41.00d);
+    
+    decimal var17 = b * e;
+    assertEqual(var17, 41505174165846491131.50d);
+    decimal var18 = b * f;
+    assertEqual(var18, -41505174165846491136.00d);
 }
 
 function testMultiplyDecimalIntSubTypes() {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/multiply-operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/multiply-operation.bal
@@ -284,6 +284,629 @@ function testMultiplyNullable() {
     assertEqual(a36 * a36, 9d);
 }
 
+const int constInt = 5;
+
+const float constFloat = 20.5;
+
+function testMultiplyFloatInt() {
+    int a = 2;
+    float b = 4.5;
+    float c = 4.5e-1;
+    float d = -10.5;
+
+    float var1 = a * b;
+    assertEqual(var1, 9.0);
+    float var2 = a * c;
+    assertEqual(var2, 0.9);
+    float var3 = a * d;
+    assertEqual(var3, -21.0);
+
+    float var4 = b * a;
+    assertEqual(var4, 9.0);
+    float var5 = c * a;
+    assertEqual(var5, 0.9);
+    float var6 = d * a;
+    assertEqual(var6, -21.0);
+
+    float var7 = constInt * b;
+    assertEqual(var7, 22.5);
+    float var8 = constInt * c;
+    assertEqual(var8, 2.25);
+    float var9 = constInt * d;
+    assertEqual(var9, -52.5);
+
+    float var10 = b * constInt;
+    assertEqual(var10, 22.5);
+    float var11 = c * constInt;
+    assertEqual(var11, 2.25);
+    float var12 = d * constInt;
+    assertEqual(var12, -52.5);
+
+    float var13 = constFloat * constInt;
+    assertEqual(var13, 102.5);
+    float var14 = constInt * constFloat;
+    assertEqual(var14, 102.5);
+
+    float var15 = constFloat * a;
+    assertEqual(var15, 41.0);
+    float var16 = a * constFloat;
+    assertEqual(var16, 41.0);
+}
+
+function testMultiplyFloatIntSubTypes() {
+    int:Signed8 a = -2;
+    int:Signed16 b = 2;
+    int:Signed32 c = -654;
+    int:Unsigned8 d = 3;
+    int:Unsigned16 e = 5;
+    int:Unsigned32 f = 10;
+    byte g = 43;
+
+    float h = 2.5;
+
+    float var1 = a * h;
+    assertEqual(var1, -5.0);
+    float var2 = b * h;
+    assertEqual(var2, 5.0);
+    float var3 = c * h;
+    assertEqual(var3, -1635.0);
+    float var4 = d * h;
+    assertEqual(var4, 7.5);
+    float var5 = e * h;
+    assertEqual(var5, 12.5);
+    float var6 = f * h;
+    assertEqual(var6, 25.0);
+    float var7 = g * h;
+    assertEqual(var7, 107.5);
+
+    float var8 = h * a;
+    assertEqual(var8, -5.0);
+    float var9 = h * b;
+    assertEqual(var9, 5.0);
+    float var10 = h * c;
+    assertEqual(var10, -1635.0);
+    float var11 = h * d;
+    assertEqual(var11, 7.5);
+    float var12 = h * e;
+    assertEqual(var12, 12.5);
+    float var13 = h * f;
+    assertEqual(var13, 25.0);
+    float var14 = h * g;
+    assertEqual(var14, 107.5);
+}
+
+function testMultiplyFloatIntWithNullableOperands() {
+    int a = 2;
+    int? b = 4;
+    float c = 4.5e-1;
+    float? d = -10.5;
+
+    float? var1 = a * d;
+    assertEqual(var1, -21.0);
+    float? var2 = d * a;
+    assertEqual(var2, -21.0);
+
+    float? var3 = b * c;
+    assertEqual(var3, 1.8);
+    float? var4 = c * b;
+    assertEqual(var4, 1.8);
+
+    float? var5 = b * d;
+    assertEqual(var5, -42.0);
+    float? var6 = d * b;
+    assertEqual(var6, -42.0);
+
+    float? var7 = constInt * d;
+    assertEqual(var7, -52.5);
+    float? var8 = d * constInt;
+    assertEqual(var8, -52.5);
+
+    float? var9 = constFloat * b;
+    assertEqual(var9, 82.0);
+    float? var10 = b * constFloat;
+    assertEqual(var10, 82.0);
+}
+
+function testMultiplyFloatIntSubTypeWithNullableOperands() {
+    int:Signed8 a = -2;
+    int:Signed16 b = 2;
+    int:Signed32 c = -654;
+    int:Unsigned8 d = 3;
+    int:Unsigned16 e = 5;
+    int:Unsigned32 f = 10;
+    byte g = 43;
+
+    int:Signed8? h = -2;
+    int:Signed16? i = 2;
+    int:Signed32? j = -654;
+    int:Unsigned8? k = 3;
+    int:Unsigned16? m = 5;
+    int:Unsigned32? n = 10;
+    byte? p = 43;
+
+    float q = 2.5;
+    float? r = 2.5;
+
+    float? var1 = a * r;
+    assertEqual(var1, -5.0);
+    float? var2 = b * r;
+    assertEqual(var2, 5.0);
+    float? var3 = c * r;
+    assertEqual(var3, -1635.0);
+    float? var4 = d * r;
+    assertEqual(var4, 7.5);
+    float? var5 = e * r;
+    assertEqual(var5, 12.5);
+    float? var6 = f * r;
+    assertEqual(var6, 25.0);
+    float? var7 = g * r;
+    assertEqual(var7, 107.5);
+
+    float? var8 = r * a;
+    assertEqual(var8, -5.0);
+    float? var9 = r * b;
+    assertEqual(var9, 5.0);
+    float? var10 = r * c;
+    assertEqual(var10, -1635.0);
+    float? var11 = r * d;
+    assertEqual(var11, 7.5);
+    float? var12 = r * e;
+    assertEqual(var12, 12.5);
+    float? var13 = r * f;
+    assertEqual(var13, 25.0);
+    float? var14 = r * g;
+    assertEqual(var14, 107.5);
+
+    float? var15 = h * q;
+    assertEqual(var15, -5.0);
+    float? var16 = i * q;
+    assertEqual(var16, 5.0);
+    float? var17 = j * q;
+    assertEqual(var17, -1635.0);
+    float? var18 = k * q;
+    assertEqual(var18, 7.5);
+    float? var19 = m * q;
+    assertEqual(var19, 12.5);
+    float? var20 = n * q;
+    assertEqual(var20, 25.0);
+    float? var21 = p * q;
+    assertEqual(var21, 107.5);
+
+    float? var22 = q * h;
+    assertEqual(var22, -5.0);
+    float? var23 = q * i;
+    assertEqual(var23, 5.0);
+    float? var24 = q * j;
+    assertEqual(var24, -1635.0);
+    float? var25 = q * k;
+    assertEqual(var25, 7.5);
+    float? var26 = q * m;
+    assertEqual(var26, 12.5);
+    float? var27 = q * n;
+    assertEqual(var27, 25.0);
+    float? var28 = q * p;
+    assertEqual(var28, 107.5);
+
+    float? var29 = h * r;
+    assertEqual(var29, -5.0);
+    float? var30 = i * r;
+    assertEqual(var30, 5.0);
+    float? var31 = j * r;
+    assertEqual(var31, -1635.0);
+    float? var32 = k * r;
+    assertEqual(var32, 7.5);
+    float? var33 = m * r;
+    assertEqual(var33, 12.5);
+    float? var34 = n * r;
+    assertEqual(var34, 25.0);
+    float? var35 = p * r;
+    assertEqual(var35, 107.5);
+
+    float? var36 = r * h;
+    assertEqual(var36, -5.0);
+    float? var37 = r * i;
+    assertEqual(var37, 5.0);
+    float? var38 = r * j;
+    assertEqual(var38, -1635.0);
+    float? var39 = r * k;
+    assertEqual(var39, 7.5);
+    float? var40 = r * m;
+    assertEqual(var40, 12.5);
+    float? var41 = r * n;
+    assertEqual(var41, 25.0);
+    float? var42 = r * p;
+    assertEqual(var42, 107.5);
+}
+
+function testResultTypeOfMultiplyFloatIntByInfering() {
+    float a = 2.5;
+    int b = 3;
+
+    var c = a * b;
+    float var1 = c;
+    assertEqual(var1, 7.5);
+
+    var d = b * a;
+    float var2 = d;
+    assertEqual(var2, 7.5);
+
+    var e = a * constInt;
+    float var3 = e;
+    assertEqual(var3, 12.5);
+
+    var f = constInt * a;
+    float var4 = f;
+    assertEqual(var4, 12.5);
+
+    var g = constFloat * b;
+    float var5 = g;
+    assertEqual(var5, 61.5);
+
+    var h = b * constFloat;
+    float var6 = h;
+    assertEqual(var6, 61.5);
+
+    var i = constFloat * constInt;
+    float var7 = i;
+    assertEqual(var7, 102.5);
+
+    var j = constInt * constFloat;
+    float var8 = j;
+    assertEqual(var8, 102.5);
+}
+
+function testResultTypeOfMultiplyFloatIntForNilableOperandsByInfering() {
+    float? a = 2.5;
+    int? b = 3;
+
+    var c = a * b;
+    float? var1 = c;
+    assertEqual(var1, 7.5);
+
+    var d = b * a;
+    float? var2 = d;
+    assertEqual(var2, 7.5);
+
+    var e = a * constInt;
+    float? var3 = e;
+    assertEqual(var3, 12.5);
+
+    var f = constInt * a;
+    float? var4 = f;
+    assertEqual(var4, 12.5);
+
+    var g = constFloat * b;
+    float? var5 = g;
+    assertEqual(var5, 61.5);
+
+    var h = b * constFloat;
+    float? var6 = h;
+    assertEqual(var6, 61.5);
+}
+
+function testMultiplyFloatIntToInfinityAndNaN() {
+    float a = 8388608333e+298;
+    int b = 20;
+    float c = float:Infinity;
+    float d = float:NaN;
+
+    float var1 = a * b;
+    assertEqual(var1, float:Infinity);
+
+    float var2 = b * a;
+    assertEqual(var2, float:Infinity);
+
+    float var3 = c * b;
+    assertEqual(var3, float:Infinity);
+
+    float var4 = b * c;
+    assertEqual(var4, float:Infinity);
+
+    float var5 = d * b;
+    assertEqual(var5, float:NaN);
+
+    float var6 = b * d;
+    assertEqual(var6, float:NaN);
+}
+
+const decimal constDecimal = 20.5;
+
+function testMultiplyDecimalInt() {
+    int a = 2;
+    decimal b = 4.5;
+    decimal c = 4.5e-1;
+    decimal d = -10.5;
+
+    decimal var1 = a * b;
+    assertEqual(var1, 9.00d);
+    decimal var2 = a * c;
+    assertEqual(var2, 0.900d);
+    decimal var3 = a * d;
+    assertEqual(var3, -21.00d);
+
+    decimal var4 = b * a;
+    assertEqual(var4, 9.00d);
+    decimal var5 = c * a;
+    assertEqual(var5, 0.900d);
+    decimal var6 = d * a;
+    assertEqual(var6, -21.00d);
+
+    decimal var7 = constInt * b;
+    assertEqual(var7, 22.50d);
+    decimal var8 = constInt * c;
+    assertEqual(var8, 2.250d);
+    decimal var9 = constInt * d;
+    assertEqual(var9, -52.50d);
+
+    decimal var10 = b * constInt;
+    assertEqual(var10, 22.50d);
+    decimal var11 = c * constInt;
+    assertEqual(var11, 2.250d);
+    decimal var12 = d * constInt;
+    assertEqual(var12, -52.50d);
+
+    decimal var13 = constDecimal * constInt;
+    assertEqual(var13, 102.50d);
+    decimal var14 = constInt * constDecimal;
+    assertEqual(var14, 102.50d);
+
+    decimal var15 = constDecimal * a;
+    assertEqual(var15, 41.00d);
+    decimal var16 = a * constDecimal;
+    assertEqual(var16, 41.00d);
+}
+
+function testMultiplyDecimalIntSubTypes() {
+    int:Signed8 a = -2;
+    int:Signed16 b = 2;
+    int:Signed32 c = -654;
+    int:Unsigned8 d = 3;
+    int:Unsigned16 e = 5;
+    int:Unsigned32 f = 10;
+    byte g = 43;
+
+    decimal h = 2.5;
+
+    decimal var1 = a * h;
+    assertEqual(var1, -5.00d);
+    decimal var2 = b * h;
+    assertEqual(var2, 5.00d);
+    decimal var3 = c * h;
+    assertEqual(var3, -1635.00d);
+    decimal var4 = d * h;
+    assertEqual(var4, 7.50d);
+    decimal var5 = e * h;
+    assertEqual(var5, 12.50d);
+    decimal var6 = f * h;
+    assertEqual(var6, 25.00d);
+    decimal var7 = g * h;
+    assertEqual(var7, 107.50d);
+
+    decimal var8 = h * a;
+    assertEqual(var8, -5.00d);
+    decimal var9 = h * b;
+    assertEqual(var9, 5.00d);
+    decimal var10 = h * c;
+    assertEqual(var10, -1635.00d);
+    decimal var11 = h * d;
+    assertEqual(var11, 7.50d);
+    decimal var12 = h * e;
+    assertEqual(var12, 12.50d);
+    decimal var13 = h * f;
+    assertEqual(var13, 25.00d);
+    decimal var14 = h * g;
+    assertEqual(var14, 107.50d);
+}
+
+function testMultiplyDecimalIntWithNullableOperands() {
+    int a = 2;
+    int? b = 4;
+    decimal c = 4.5e-1;
+    decimal? d = -10.5;
+
+    decimal? var1 = a * d;
+    assertEqual(var1, -21.00d);
+    decimal? var2 = d * a;
+    assertEqual(var2, -21.00d);
+
+    decimal? var3 = b * c;
+    assertEqual(var3, 1.80d);
+    decimal? var4 = c * b;
+    assertEqual(var4, 1.80d);
+
+    decimal? var5 = b * d;
+    assertEqual(var5, -42.00d);
+    decimal? var6 = d * b;
+    assertEqual(var6, -42.00d);
+
+    decimal? var7 = constInt * d;
+    assertEqual(var7, -52.50d);
+    decimal? var8 = d * constInt;
+    assertEqual(var8, -52.50d);
+
+    decimal? var9 = constDecimal * b;
+    assertEqual(var9, 82.00d);
+    decimal? var10 = b * constDecimal;
+    assertEqual(var10, 82.00d);
+}
+
+function testMultiplyDecimalIntSubTypeWithNullableOperands() {
+    int:Signed8 a = -2;
+    int:Signed16 b = 2;
+    int:Signed32 c = -654;
+    int:Unsigned8 d = 3;
+    int:Unsigned16 e = 5;
+    int:Unsigned32 f = 10;
+    byte g = 43;
+
+    int:Signed8? h = -2;
+    int:Signed16? i = 2;
+    int:Signed32? j = -654;
+    int:Unsigned8? k = 3;
+    int:Unsigned16? m = 5;
+    int:Unsigned32? n = 10;
+    byte? p = 43;
+
+    decimal q = 2.5;
+    decimal? r = 2.5;
+
+    decimal? var1 = a * r;
+    assertEqual(var1, -5.00d);
+    decimal? var2 = b * r;
+    assertEqual(var2, 5.00d);
+    decimal? var3 = c * r;
+    assertEqual(var3, -1635.00d);
+    decimal? var4 = d * r;
+    assertEqual(var4, 7.50d);
+    decimal? var5 = e * r;
+    assertEqual(var5, 12.50d);
+    decimal? var6 = f * r;
+    assertEqual(var6, 25.00d);
+    decimal? var7 = g * r;
+    assertEqual(var7, 107.50d);
+
+    decimal? var8 = r * a;
+    assertEqual(var8, -5.00d);
+    decimal? var9 = r * b;
+    assertEqual(var9, 5.00d);
+    decimal? var10 = r * c;
+    assertEqual(var10, -1635.00d);
+    decimal? var11 = r * d;
+    assertEqual(var11, 7.50d);
+    decimal? var12 = r * e;
+    assertEqual(var12, 12.50d);
+    decimal? var13 = r * f;
+    assertEqual(var13, 25.00d);
+    decimal? var14 = r * g;
+    assertEqual(var14, 107.50d);
+
+    decimal? var15 = h * q;
+    assertEqual(var15, -5.00d);
+    decimal? var16 = i * q;
+    assertEqual(var16, 5.00d);
+    decimal? var17 = j * q;
+    assertEqual(var17, -1635.00d);
+    decimal? var18 = k * q;
+    assertEqual(var18, 7.50d);
+    decimal? var19 = m * q;
+    assertEqual(var19, 12.50d);
+    decimal? var20 = n * q;
+    assertEqual(var20, 25.00d);
+    decimal? var21 = p * q;
+    assertEqual(var21, 107.50d);
+
+    decimal? var22 = q * h;
+    assertEqual(var22, -5.00d);
+    decimal? var23 = q * i;
+    assertEqual(var23, 5.00d);
+    decimal? var24 = q * j;
+    assertEqual(var24, -1635.00d);
+    decimal? var25 = q * k;
+    assertEqual(var25, 7.50d);
+    decimal? var26 = q * m;
+    assertEqual(var26, 12.50d);
+    decimal? var27 = q * n;
+    assertEqual(var27, 25.00d);
+    decimal? var28 = q * p;
+    assertEqual(var28, 107.50d);
+
+    decimal? var29 = h * r;
+    assertEqual(var29, -5.00d);
+    decimal? var30 = i * r;
+    assertEqual(var30, 5.00d);
+    decimal? var31 = j * r;
+    assertEqual(var31, -1635.00d);
+    decimal? var32 = k * r;
+    assertEqual(var32, 7.50d);
+    decimal? var33 = m * r;
+    assertEqual(var33, 12.50d);
+    decimal? var34 = n * r;
+    assertEqual(var34, 25.00d);
+    decimal? var35 = p * r;
+    assertEqual(var35, 107.50d);
+
+    decimal? var36 = r * h;
+    assertEqual(var36, -5.00d);
+    decimal? var37 = r * i;
+    assertEqual(var37, 5.00d);
+    decimal? var38 = r * j;
+    assertEqual(var38, -1635.00d);
+    decimal? var39 = r * k;
+    assertEqual(var39, 7.50d);
+    decimal? var40 = r * m;
+    assertEqual(var40, 12.50d);
+    decimal? var41 = r * n;
+    assertEqual(var41, 25.00d);
+    decimal? var42 = r * p;
+    assertEqual(var42, 107.50d);
+}
+
+function testResultTypeOfMultiplyDecimalIntByInfering() {
+    decimal a = 2.5;
+    int b = 3;
+
+    var c = a * b;
+    decimal var1 = c;
+    assertEqual(var1, 7.50d);
+
+    var d = b * a;
+    decimal var2 = d;
+    assertEqual(var2, 7.50d);
+
+    var e = a * constInt;
+    decimal var3 = e;
+    assertEqual(var3, 12.50d);
+
+    var f = constInt * a;
+    decimal var4 = f;
+    assertEqual(var4, 12.50d);
+
+    var g = constDecimal * b;
+    decimal var5 = g;
+    assertEqual(var5, 61.50d);
+
+    var h = b * constDecimal;
+    decimal var6 = h;
+    assertEqual(var6, 61.50d);
+
+    var i = constDecimal * constInt;
+    decimal var7 = i;
+    assertEqual(var7, 102.50d);
+
+    var j = constInt * constDecimal;
+    decimal var8 = j;
+    assertEqual(var8, 102.50d);
+}
+
+function testResultTypeOfMultiplyDecimalIntForNilableOperandsByInfering() {
+    decimal? a = 2.5;
+    int? b = 3;
+
+    var c = a * b;
+    decimal? var1 = c;
+    assertEqual(var1, 7.50d);
+
+    var d = b * a;
+    decimal? var2 = d;
+    assertEqual(var2, 7.50d);
+
+    var e = a * constInt;
+    decimal? var3 = e;
+    assertEqual(var3, 12.50d);
+
+    var f = constInt * a;
+    decimal? var4 = f;
+    assertEqual(var4, 12.50d);
+
+    var g = constDecimal * b;
+    decimal? var5 = g;
+    assertEqual(var5, 61.50d);
+
+    var h = b * constDecimal;
+    decimal? var6 = h;
+    assertEqual(var6, 61.50d);
+}
+
 function assertEqual(any actual, any expected) {
     if actual is anydata && expected is anydata && actual == expected {
         return;


### PR DESCRIPTION
## Purpose
$title

Fixes #35179
Fixes #32940

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
