### PR TITLE
Implement `getModule()` for builtin subtype symbols

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/AbstractIntSubTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/AbstractIntSubTypeSymbol.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.ballerina.compiler.api.impl.symbols;
+
+import io.ballerina.compiler.api.impl.SymbolFactory;
+import io.ballerina.compiler.api.symbols.ModuleSymbol;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BIntSubType;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
+
+import java.util.Optional;
+
+/**
+ * A base class for the int subtypes.
+ *
+ * @since 2201.1.0
+ */
+public abstract class AbstractIntSubTypeSymbol extends AbstractTypeSymbol {
+
+    private ModuleSymbol module;
+
+    public AbstractIntSubTypeSymbol(CompilerContext context, TypeDescKind typeKind, BIntSubType type) {
+        super(context, typeKind, type);
+    }
+
+    @Override
+    public Optional<ModuleSymbol> getModule() {
+        if (this.module != null) {
+            return Optional.of(this.module);
+        }
+
+        SymbolTable symTable = SymbolTable.getInstance(this.context);
+        SymbolFactory symFactory = SymbolFactory.getInstance(this.context);
+        this.module = (ModuleSymbol) symFactory.getBCompiledSymbol(symTable.langIntModuleSymbol,
+                                                                   symTable.langIntModuleSymbol
+                                                                           .getOriginalName().value);
+        return Optional.of(this.module);
+    }
+}

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/AbstractXMLSubTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/AbstractXMLSubTypeSymbol.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.ballerina.compiler.api.impl.symbols;
+
+import io.ballerina.compiler.api.impl.SymbolFactory;
+import io.ballerina.compiler.api.symbols.ModuleSymbol;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BXMLSubType;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
+
+import java.util.Optional;
+
+/**
+ * A base class for the xml subtypes.
+ *
+ * @since 2201.1.0
+ */
+public abstract class AbstractXMLSubTypeSymbol extends AbstractTypeSymbol {
+
+    private ModuleSymbol module;
+
+    public AbstractXMLSubTypeSymbol(CompilerContext context, TypeDescKind typeKind, BXMLSubType type) {
+        super(context, typeKind, type);
+    }
+
+    @Override
+    public Optional<ModuleSymbol> getModule() {
+        if (this.module != null) {
+            return Optional.of(this.module);
+        }
+
+        SymbolTable symTable = SymbolTable.getInstance(this.context);
+        SymbolFactory symFactory = SymbolFactory.getInstance(this.context);
+        this.module = (ModuleSymbol) symFactory.getBCompiledSymbol(symTable.langXmlModuleSymbol,
+                                                                   symTable.langXmlModuleSymbol
+                                                                           .getOriginalName().value);
+        return Optional.of(this.module);
+    }
+}

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntSigned16TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntSigned16TypeSymbol.java
@@ -32,7 +32,7 @@ import java.util.Optional;
  *
  * @since 2.0.0
  */
-public class BallerinaIntSigned16TypeSymbol extends AbstractTypeSymbol implements IntSigned16TypeSymbol {
+public class BallerinaIntSigned16TypeSymbol extends AbstractIntSubTypeSymbol implements IntSigned16TypeSymbol {
 
     public BallerinaIntSigned16TypeSymbol(CompilerContext context, BIntSubType signed16Type) {
         super(context, TypeDescKind.INT_SIGNED16, signed16Type);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntSigned32TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntSigned32TypeSymbol.java
@@ -32,7 +32,7 @@ import java.util.Optional;
  *
  * @since 2.0.0
  */
-public class BallerinaIntSigned32TypeSymbol extends AbstractTypeSymbol implements IntSigned32TypeSymbol {
+public class BallerinaIntSigned32TypeSymbol extends AbstractIntSubTypeSymbol implements IntSigned32TypeSymbol {
 
     public BallerinaIntSigned32TypeSymbol(CompilerContext context, BIntSubType signed32Type) {
         super(context, TypeDescKind.INT_SIGNED32, signed32Type);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntSigned8TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntSigned8TypeSymbol.java
@@ -32,7 +32,7 @@ import java.util.Optional;
  *
  * @since 2.0.0
  */
-public class BallerinaIntSigned8TypeSymbol extends AbstractTypeSymbol implements IntSigned8TypeSymbol {
+public class BallerinaIntSigned8TypeSymbol extends AbstractIntSubTypeSymbol implements IntSigned8TypeSymbol {
 
     public BallerinaIntSigned8TypeSymbol(CompilerContext context, BIntSubType signed8Type) {
         super(context, TypeDescKind.INT_SIGNED8, signed8Type);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntUnsigned16TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntUnsigned16TypeSymbol.java
@@ -32,7 +32,7 @@ import java.util.Optional;
  *
  * @since 2.0.0
  */
-public class BallerinaIntUnsigned16TypeSymbol extends AbstractTypeSymbol implements IntUnsigned16TypeSymbol {
+public class BallerinaIntUnsigned16TypeSymbol extends AbstractIntSubTypeSymbol implements IntUnsigned16TypeSymbol {
 
     public BallerinaIntUnsigned16TypeSymbol(CompilerContext context, BIntSubType unsigned16Type) {
         super(context, TypeDescKind.INT_UNSIGNED16, unsigned16Type);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntUnsigned32TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntUnsigned32TypeSymbol.java
@@ -32,7 +32,7 @@ import java.util.Optional;
  *
  * @since 2.0.0
  */
-public class BallerinaIntUnsigned32TypeSymbol extends AbstractTypeSymbol implements IntUnsigned32TypeSymbol {
+public class BallerinaIntUnsigned32TypeSymbol extends AbstractIntSubTypeSymbol implements IntUnsigned32TypeSymbol {
 
     public BallerinaIntUnsigned32TypeSymbol(CompilerContext context, BIntSubType unsigned32Type) {
         super(context, TypeDescKind.INT_UNSIGNED32, unsigned32Type);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntUnsigned8TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntUnsigned8TypeSymbol.java
@@ -32,7 +32,7 @@ import java.util.Optional;
  *
  * @since 2.0.0
  */
-public class BallerinaIntUnsigned8TypeSymbol extends AbstractTypeSymbol implements IntUnsigned8TypeSymbol {
+public class BallerinaIntUnsigned8TypeSymbol extends AbstractIntSubTypeSymbol implements IntUnsigned8TypeSymbol {
 
     public BallerinaIntUnsigned8TypeSymbol(CompilerContext context, BIntSubType unsigned8Type) {
         super(context, TypeDescKind.INT_UNSIGNED8, unsigned8Type);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaStringCharTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaStringCharTypeSymbol.java
@@ -19,8 +19,11 @@ package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.SymbolTransformer;
 import io.ballerina.compiler.api.SymbolVisitor;
+import io.ballerina.compiler.api.impl.SymbolFactory;
+import io.ballerina.compiler.api.symbols.ModuleSymbol;
 import io.ballerina.compiler.api.symbols.StringCharTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
+import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BStringSubType;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Names;
@@ -34,6 +37,8 @@ import java.util.Optional;
  */
 public class BallerinaStringCharTypeSymbol extends AbstractTypeSymbol implements StringCharTypeSymbol {
 
+    private ModuleSymbol module;
+
     public BallerinaStringCharTypeSymbol(CompilerContext context, BStringSubType charType) {
         super(context, TypeDescKind.STRING_CHAR, charType);
     }
@@ -46,6 +51,20 @@ public class BallerinaStringCharTypeSymbol extends AbstractTypeSymbol implements
     @Override
     public String signature() {
         return "string:" + Names.STRING_CHAR;
+    }
+
+    @Override
+    public Optional<ModuleSymbol> getModule() {
+        if (this.module != null) {
+            return Optional.of(this.module);
+        }
+
+        SymbolTable symTable = SymbolTable.getInstance(this.context);
+        SymbolFactory symFactory = SymbolFactory.getInstance(this.context);
+        this.module = (ModuleSymbol) symFactory.getBCompiledSymbol(symTable.langStringModuleSymbol,
+                                                                   symTable.langStringModuleSymbol
+                                                                           .getOriginalName().value);
+        return Optional.of(this.module);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLCommentTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLCommentTypeSymbol.java
@@ -33,7 +33,7 @@ import java.util.Optional;
  *
  * @since 2.0.0
  */
-public class BallerinaXMLCommentTypeSymbol extends AbstractTypeSymbol implements XMLCommentTypeSymbol {
+public class BallerinaXMLCommentTypeSymbol extends AbstractXMLSubTypeSymbol implements XMLCommentTypeSymbol {
 
     public BallerinaXMLCommentTypeSymbol(CompilerContext context, BXMLSubType commentType) {
         super(context, TypeDescKind.XML_COMMENT, commentType);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLElementTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLElementTypeSymbol.java
@@ -33,7 +33,7 @@ import java.util.Optional;
  *
  * @since 2.0.0
  */
-public class BallerinaXMLElementTypeSymbol extends AbstractTypeSymbol implements XMLElementTypeSymbol {
+public class BallerinaXMLElementTypeSymbol extends AbstractXMLSubTypeSymbol implements XMLElementTypeSymbol {
 
     public BallerinaXMLElementTypeSymbol(CompilerContext context, BXMLSubType elementType) {
         super(context, TypeDescKind.XML_ELEMENT, elementType);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLProcessingInstructionTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLProcessingInstructionTypeSymbol.java
@@ -33,7 +33,7 @@ import java.util.Optional;
  *
  * @since 2.0.0
  */
-public class BallerinaXMLProcessingInstructionTypeSymbol extends AbstractTypeSymbol implements
+public class BallerinaXMLProcessingInstructionTypeSymbol extends AbstractXMLSubTypeSymbol implements
                                                                                     XMLProcessingInstructionTypeSymbol {
 
     public BallerinaXMLProcessingInstructionTypeSymbol(CompilerContext context, BXMLSubType piType) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLTextTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLTextTypeSymbol.java
@@ -33,7 +33,7 @@ import java.util.Optional;
  *
  * @since 2.0.0
  */
-public class BallerinaXMLTextTypeSymbol extends AbstractTypeSymbol implements XMLTextTypeSymbol {
+public class BallerinaXMLTextTypeSymbol extends AbstractXMLSubTypeSymbol implements XMLTextTypeSymbol {
 
     public BallerinaXMLTextTypeSymbol(CompilerContext context, BXMLSubType textType) {
         super(context, TypeDescKind.XML_TEXT, textType);

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/ModuleSymbolTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/ModuleSymbolTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.semantic.api.test.symbols;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.ModuleSymbol;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.SymbolKind;
+import io.ballerina.projects.Document;
+import io.ballerina.projects.Project;
+import io.ballerina.tools.text.LinePosition;
+import org.ballerinalang.test.BCompileUtil;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDefaultModulesSemanticModel;
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDocumentForSingleSource;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Test cases for module symbols.
+ */
+public class ModuleSymbolTest {
+
+    private SemanticModel model;
+    private Document srcFile;
+
+    @BeforeClass
+    public void setup() {
+        Project project = BCompileUtil.loadProject("test-src/symbols/module_symbol_test.bal");
+        model = getDefaultModulesSemanticModel(project);
+        srcFile = getDocumentForSingleSource(project);
+    }
+
+    @Test(dataProvider = "TypePosProvider")
+    public void testBuiltinSubtypeModule(int line, int col, String expName) {
+        Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, col));
+
+        assertTrue(symbol.isPresent());
+        assertTrue(symbol.get().getModule().isPresent());
+
+        ModuleSymbol module = symbol.get().getModule().get();
+
+        assertEquals(module.kind(), SymbolKind.MODULE);
+        assertEquals(module.getName().get(), expName);
+        assertEquals(module.id().moduleName(), expName);
+        assertEquals(module.id().orgName(), "ballerina");
+        assertEquals(module.id().version(), "0.0.0");
+    }
+
+    @DataProvider(name = "TypePosProvider")
+    public Object[][] getTypePos() {
+        return new Object[][]{
+                {17, 8, "lang.int"},
+                {18, 8, "lang.int"},
+                {19, 8, "lang.int"},
+                {20, 8, "lang.int"},
+                {21, 8, "lang.int"},
+                {22, 8, "lang.int"},
+                {23, 11, "lang.string"},
+                {24, 8, "lang.xml"},
+                {25, 8, "lang.xml"},
+                {26, 8, "lang.xml"},
+                {27, 8, "lang.xml"},
+        };
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbols/module_symbol_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbols/module_symbol_test.bal
@@ -1,0 +1,29 @@
+// Copyright (c) 2022 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+function testBuiltinSubtypes() {
+    int:Signed8 is8;
+    int:Signed16 is16;
+    int:Signed32 is32;
+    int:Unsigned8 ius8;
+    int:Unsigned16 ius16;
+    int:Unsigned32 ius32;
+    string:Char ch;
+    xml:Comment comment;
+    xml:Element elem;
+    xml:ProcessingInstruction pi;
+    xml:Text txt;
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
+++ b/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
@@ -136,6 +136,7 @@
             <class name="io.ballerina.semantic.api.test.symbols.ErrorTypeSymbolTest" />
             <class name="io.ballerina.semantic.api.test.symbols.FunctionTypeSymbolTest" />
             <class name="io.ballerina.semantic.api.test.symbols.ImportDeclSymbolTest" />
+            <class name="io.ballerina.semantic.api.test.symbols.ModuleSymbolTest" />
             <class name="io.ballerina.semantic.api.test.symbols.ObjectTypeSymbolTest" />
             <class name="io.ballerina.semantic.api.test.symbols.ParameterSymbolTest" />
             <class name="io.ballerina.semantic.api.test.symbols.RecordTypeSymbolTest" />


### PR DESCRIPTION
## Purpose
Previously, `getModule()` used to return empty for the builtin subtypes. With this PR, the builtin subtype symbols will return the respective lang lib module's symbols. 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
