### PR TITLE
Fix `anydata` casting with any value

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -2349,6 +2349,9 @@ public class TypeChecker {
             case TypeTags.MAP_TAG:
                 return isLikeType(((MapValueImpl) sourceValue).values().toArray(), TYPE_ANYDATA,
                                   unresolvedValues, allowNumericConversion);
+            case TypeTags.TABLE_TAG:
+                return isLikeType(((TableValueImpl) sourceValue).values().toArray(), TYPE_ANYDATA,
+                        unresolvedValues, allowNumericConversion);
             case TypeTags.ARRAY_TAG:
                 ArrayValue arr = (ArrayValue) sourceValue;
                 BArrayType arrayType = (BArrayType) arr.getType();

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BTableType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BTableType.java
@@ -133,6 +133,11 @@ public class BTableType extends BType implements TableType {
     }
 
     @Override
+    public boolean isAnydata() {
+        return this.constraint.isAnydata();
+    }
+
+    @Override
     public boolean isReadOnly() {
         return this.readonly;
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/CodeGenerator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/CodeGenerator.java
@@ -21,6 +21,7 @@ import org.wso2.ballerinalang.compiler.CompiledJarFile;
 import org.wso2.ballerinalang.compiler.PackageCache;
 import org.wso2.ballerinalang.compiler.bir.codegen.optimizer.LargeMethodOptimizer;
 import org.wso2.ballerinalang.compiler.diagnostic.BLangDiagnosticLog;
+import org.wso2.ballerinalang.compiler.semantics.analyzer.Types;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BPackageSymbol;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
@@ -44,6 +45,7 @@ public class CodeGenerator {
     private PackageCache packageCache;
     private BLangDiagnosticLog dlog;
     private CompilerContext compilerContext;
+    private Types types;
     private LargeMethodOptimizer largeMethodOptimizer;
 
     private CodeGenerator(CompilerContext compilerContext) {
@@ -52,6 +54,7 @@ public class CodeGenerator {
         this.symbolTable = SymbolTable.getInstance(compilerContext);
         this.packageCache = PackageCache.getInstance(compilerContext);
         this.dlog = BLangDiagnosticLog.getInstance(compilerContext);
+        this.types = Types.getInstance(compilerContext);
         this.compilerContext = compilerContext;
     }
 
@@ -84,7 +87,7 @@ public class CodeGenerator {
         JvmObservabilityGen jvmObservabilityGen = new JvmObservabilityGen(packageCache, symbolTable);
         jvmObservabilityGen.instrumentPackage(packageSymbol.bir);
         dlog.setCurrentPackageId(packageSymbol.pkgID);
-        final JvmPackageGen jvmPackageGen = new JvmPackageGen(symbolTable, packageCache, dlog, compilerContext);
+        final JvmPackageGen jvmPackageGen = new JvmPackageGen(symbolTable, packageCache, dlog, types);
 
         populateExternalMap(jvmPackageGen);
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCastGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCastGen.java
@@ -32,7 +32,6 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BIntersectionType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BMapType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BUnionType;
-import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.util.Flags;
 
@@ -140,10 +139,10 @@ public class JvmCastGen {
     private final JvmTypeGen jvmTypeGen;
     private final Types types;
 
-    public JvmCastGen(SymbolTable symbolTable, JvmTypeGen jvmTypeGen, CompilerContext compilerContext) {
+    public JvmCastGen(SymbolTable symbolTable, JvmTypeGen jvmTypeGen, Types types) {
         this.symbolTable = symbolTable;
         this.jvmTypeGen = jvmTypeGen;
-        this.types = Types.getInstance(compilerContext);
+        this.types = types;
     }
 
     void generatePlatformCheckCast(MethodVisitor mv, BIRVarToJVMIndexMap indexMap, BType sourceType,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
@@ -39,6 +39,7 @@ import org.wso2.ballerinalang.compiler.bir.model.BIRNonTerminator.NewTable;
 import org.wso2.ballerinalang.compiler.bir.model.BIROperand;
 import org.wso2.ballerinalang.compiler.bir.model.InstructionKind;
 import org.wso2.ballerinalang.compiler.bir.model.VarKind;
+import org.wso2.ballerinalang.compiler.semantics.analyzer.Types;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.SchedulerPolicy;
@@ -46,7 +47,6 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BArrayType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BIntersectionType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BObjectType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
-import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.util.Flags;
 
@@ -247,8 +247,7 @@ public class JvmInstructionGen {
 
     public JvmInstructionGen(MethodVisitor mv, BIRVarToJVMIndexMap indexMap, PackageID currentPackage,
                              JvmPackageGen jvmPackageGen, JvmTypeGen jvmTypeGen, JvmCastGen jvmCastGen,
-                             JvmConstantsGen jvmConstantsGen, AsyncDataCollector asyncDataCollector,
-                             CompilerContext compilerContext) {
+                             JvmConstantsGen jvmConstantsGen, AsyncDataCollector asyncDataCollector, Types types) {
         this.mv = mv;
         this.indexMap = indexMap;
         this.currentPackage = currentPackage;
@@ -259,7 +258,7 @@ public class JvmInstructionGen {
         this.asyncDataCollector = asyncDataCollector;
         this.jvmCastGen = jvmCastGen;
         this.jvmConstantsGen = jvmConstantsGen;
-        typeTestGen = new JvmTypeTestGen(this, compilerContext, mv, jvmTypeGen);
+        typeTestGen = new JvmTypeTestGen(this, types, mv, jvmTypeGen);
     }
 
     static void addJUnboxInsn(MethodVisitor mv, JType jType) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmPackageGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmPackageGen.java
@@ -56,6 +56,7 @@ import org.wso2.ballerinalang.compiler.bir.model.VarKind;
 import org.wso2.ballerinalang.compiler.bir.model.VarScope;
 import org.wso2.ballerinalang.compiler.diagnostic.BLangDiagnosticLog;
 import org.wso2.ballerinalang.compiler.semantics.analyzer.TypeHashVisitor;
+import org.wso2.ballerinalang.compiler.semantics.analyzer.Types;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BObjectTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BPackageSymbol;
@@ -64,7 +65,6 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BInvokableType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BNilType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
-import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.Names;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
@@ -142,10 +142,9 @@ public class JvmPackageGen {
     private final Map<String, String> globalVarClassMap;
     private final Set<PackageID> dependentModules;
     private final BLangDiagnosticLog dlog;
-    private final CompilerContext compilerContext;
+    private final Types types;
 
-    JvmPackageGen(SymbolTable symbolTable, PackageCache packageCache, BLangDiagnosticLog dlog,
-                  CompilerContext compilerContext) {
+    JvmPackageGen(SymbolTable symbolTable, PackageCache packageCache, BLangDiagnosticLog dlog, Types types) {
         birFunctionMap = new HashMap<>();
         globalVarClassMap = new HashMap<>();
         externClassMap = new HashMap<>();
@@ -153,8 +152,8 @@ public class JvmPackageGen {
         this.symbolTable = symbolTable;
         this.packageCache = packageCache;
         this.dlog = dlog;
-        this.compilerContext = compilerContext;
-        methodGen = new MethodGen(this, compilerContext);
+        this.types = types;
+        methodGen = new MethodGen(this, types);
         initMethodGen = new InitMethodGen(symbolTable);
         configMethodGen = new ConfigMethodGen();
         frameClassGen = new FrameClassGen();
@@ -401,7 +400,7 @@ public class JvmPackageGen {
             AsyncDataCollector asyncDataCollector = new AsyncDataCollector(moduleClass);
             boolean isInitClass = Objects.equals(moduleClass, moduleInitClass);
             JvmTypeGen jvmTypeGen = new JvmTypeGen(jvmConstantsGen, module.packageID, typeHashVisitor);
-            JvmCastGen jvmCastGen = new JvmCastGen(symbolTable, jvmTypeGen, compilerContext);
+            JvmCastGen jvmCastGen = new JvmCastGen(symbolTable, jvmTypeGen, types);
             LambdaGen lambdaGen = new LambdaGen(this, jvmCastGen);
             if (isInitClass) {
                 cw.visit(V1_8, ACC_PUBLIC + ACC_SUPER, moduleClass, null, VALUE_CREATOR, null);
@@ -783,8 +782,7 @@ public class JvmPackageGen {
         // enrich current package with package initializers
         initMethodGen.enrichPkgWithInitializers(jvmClassMapping, moduleInitClass, module, flattenedModuleImports);
         TypeHashVisitor typeHashVisitor = new TypeHashVisitor();
-        JvmConstantsGen jvmConstantsGen = new JvmConstantsGen(module, moduleInitClass, compilerContext,
-                typeHashVisitor);
+        JvmConstantsGen jvmConstantsGen = new JvmConstantsGen(module, moduleInitClass, types, typeHashVisitor);
         JvmMethodsSplitter jvmMethodsSplitter = new JvmMethodsSplitter(this, jvmConstantsGen, module, moduleInitClass
                 , typeHashVisitor);
         configMethodGen.generateConfigMapper(flattenedModuleImports, module, moduleInitClass, jvmConstantsGen,
@@ -797,7 +795,7 @@ public class JvmPackageGen {
         rewriteRecordInits(module.typeDefs);
 
         // generate object/record value classes
-        JvmValueGen valueGen = new JvmValueGen(module, this, methodGen, typeHashVisitor, compilerContext);
+        JvmValueGen valueGen = new JvmValueGen(module, this, methodGen, typeHashVisitor, types);
         valueGen.generateValueClasses(jarEntries, jvmConstantsGen);
 
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmPackageGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmPackageGen.java
@@ -401,7 +401,7 @@ public class JvmPackageGen {
             AsyncDataCollector asyncDataCollector = new AsyncDataCollector(moduleClass);
             boolean isInitClass = Objects.equals(moduleClass, moduleInitClass);
             JvmTypeGen jvmTypeGen = new JvmTypeGen(jvmConstantsGen, module.packageID, typeHashVisitor);
-            JvmCastGen jvmCastGen = new JvmCastGen(symbolTable, jvmTypeGen);
+            JvmCastGen jvmCastGen = new JvmCastGen(symbolTable, jvmTypeGen, compilerContext);
             LambdaGen lambdaGen = new LambdaGen(this, jvmCastGen);
             if (isInitClass) {
                 cw.visit(V1_8, ACC_PUBLIC + ACC_SUPER, moduleClass, null, VALUE_CREATOR, null);
@@ -797,7 +797,7 @@ public class JvmPackageGen {
         rewriteRecordInits(module.typeDefs);
 
         // generate object/record value classes
-        JvmValueGen valueGen = new JvmValueGen(module, this, methodGen, typeHashVisitor);
+        JvmValueGen valueGen = new JvmValueGen(module, this, methodGen, typeHashVisitor, compilerContext);
         valueGen.generateValueClasses(jarEntries, jvmConstantsGen);
 
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTypeTestGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTypeTestGen.java
@@ -24,7 +24,6 @@ import org.wso2.ballerinalang.compiler.bir.model.BIRNonTerminator;
 import org.wso2.ballerinalang.compiler.semantics.analyzer.Types;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BUnionType;
-import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 
 import static org.objectweb.asm.Opcodes.GOTO;
@@ -50,10 +49,9 @@ public class JvmTypeTestGen {
     private final MethodVisitor mv;
     private final JvmTypeGen jvmTypeGen;
 
-    public JvmTypeTestGen(JvmInstructionGen jvmInstructionGen, CompilerContext compilerContext, MethodVisitor mv,
-                          JvmTypeGen jvmTypeGen) {
+    public JvmTypeTestGen(JvmInstructionGen jvmInstructionGen, Types types, MethodVisitor mv, JvmTypeGen jvmTypeGen) {
         this.jvmInstructionGen = jvmInstructionGen;
-        types = Types.getInstance(compilerContext);
+        this.types = types;
         this.mv = mv;
         this.jvmTypeGen = jvmTypeGen;
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmValueGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmValueGen.java
@@ -40,6 +40,7 @@ import org.wso2.ballerinalang.compiler.bir.model.BIRInstruction;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRFunction;
 import org.wso2.ballerinalang.compiler.semantics.analyzer.TypeHashVisitor;
+import org.wso2.ballerinalang.compiler.semantics.analyzer.Types;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BAttachedFunction;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BRecordTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
@@ -47,7 +48,6 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BField;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BObjectType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BRecordType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
-import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Names;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.util.Flags;
@@ -138,10 +138,10 @@ public class JvmValueGen {
     private final JvmObjectGen jvmObjectGen;
     private final JvmRecordGen jvmRecordGen;
     private final TypeHashVisitor typeHashVisitor;
-    private final CompilerContext compilerContext;
+    private final Types types;
 
     JvmValueGen(BIRNode.BIRPackage module, JvmPackageGen jvmPackageGen, MethodGen methodGen,
-                TypeHashVisitor typeHashVisitor, CompilerContext compilerContext) {
+                TypeHashVisitor typeHashVisitor, Types types) {
         this.module = module;
         this.jvmPackageGen = jvmPackageGen;
         this.methodGen = methodGen;
@@ -149,7 +149,7 @@ public class JvmValueGen {
         this.jvmRecordGen = new JvmRecordGen(jvmPackageGen.symbolTable);
         this.jvmObjectGen = new JvmObjectGen();
         this.typeHashVisitor = typeHashVisitor;
-        this.compilerContext = compilerContext;
+        this.types = types;
     }
 
     static void injectDefaultParamInitsToAttachedFuncs(BIRNode.BIRPackage module, InitMethodGen initMethodGen,
@@ -360,7 +360,7 @@ public class JvmValueGen {
             cw.visitSource(className, null);
         }
         JvmTypeGen jvmTypeGen = new JvmTypeGen(jvmConstantsGen, module.packageID, typeHashVisitor);
-        JvmCastGen jvmCastGen = new JvmCastGen(jvmPackageGen.symbolTable, jvmTypeGen, compilerContext);
+        JvmCastGen jvmCastGen = new JvmCastGen(jvmPackageGen.symbolTable, jvmTypeGen, types);
         LambdaGen lambdaGen = new LambdaGen(jvmPackageGen, jvmCastGen);
         cw.visit(V1_8, ACC_PUBLIC + ACC_SUPER, className,
                 RECORD_VALUE_CLASS,
@@ -568,7 +568,7 @@ public class JvmValueGen {
         cw.visitSource(typeDef.pos.lineRange().filePath(), null);
 
         JvmTypeGen jvmTypeGen = new JvmTypeGen(jvmConstantsGen, module.packageID, typeHashVisitor);
-        JvmCastGen jvmCastGen = new JvmCastGen(jvmPackageGen.symbolTable, jvmTypeGen, compilerContext);
+        JvmCastGen jvmCastGen = new JvmCastGen(jvmPackageGen.symbolTable, jvmTypeGen, types);
         LambdaGen lambdaGen = new LambdaGen(jvmPackageGen, jvmCastGen);
         cw.visit(V1_8, ACC_PUBLIC + ACC_SUPER, className, null, ABSTRACT_OBJECT_VALUE, new String[]{B_OBJECT});
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmValueGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmValueGen.java
@@ -47,6 +47,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BField;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BObjectType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BRecordType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Names;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.util.Flags;
@@ -137,10 +138,10 @@ public class JvmValueGen {
     private final JvmObjectGen jvmObjectGen;
     private final JvmRecordGen jvmRecordGen;
     private final TypeHashVisitor typeHashVisitor;
-
+    private final CompilerContext compilerContext;
 
     JvmValueGen(BIRNode.BIRPackage module, JvmPackageGen jvmPackageGen, MethodGen methodGen,
-                TypeHashVisitor typeHashVisitor) {
+                TypeHashVisitor typeHashVisitor, CompilerContext compilerContext) {
         this.module = module;
         this.jvmPackageGen = jvmPackageGen;
         this.methodGen = methodGen;
@@ -148,6 +149,7 @@ public class JvmValueGen {
         this.jvmRecordGen = new JvmRecordGen(jvmPackageGen.symbolTable);
         this.jvmObjectGen = new JvmObjectGen();
         this.typeHashVisitor = typeHashVisitor;
+        this.compilerContext = compilerContext;
     }
 
     static void injectDefaultParamInitsToAttachedFuncs(BIRNode.BIRPackage module, InitMethodGen initMethodGen,
@@ -358,7 +360,7 @@ public class JvmValueGen {
             cw.visitSource(className, null);
         }
         JvmTypeGen jvmTypeGen = new JvmTypeGen(jvmConstantsGen, module.packageID, typeHashVisitor);
-        JvmCastGen jvmCastGen = new JvmCastGen(jvmPackageGen.symbolTable, jvmTypeGen);
+        JvmCastGen jvmCastGen = new JvmCastGen(jvmPackageGen.symbolTable, jvmTypeGen, compilerContext);
         LambdaGen lambdaGen = new LambdaGen(jvmPackageGen, jvmCastGen);
         cw.visit(V1_8, ACC_PUBLIC + ACC_SUPER, className,
                 RECORD_VALUE_CLASS,
@@ -566,7 +568,7 @@ public class JvmValueGen {
         cw.visitSource(typeDef.pos.lineRange().filePath(), null);
 
         JvmTypeGen jvmTypeGen = new JvmTypeGen(jvmConstantsGen, module.packageID, typeHashVisitor);
-        JvmCastGen jvmCastGen = new JvmCastGen(jvmPackageGen.symbolTable, jvmTypeGen);
+        JvmCastGen jvmCastGen = new JvmCastGen(jvmPackageGen.symbolTable, jvmTypeGen, compilerContext);
         LambdaGen lambdaGen = new LambdaGen(jvmPackageGen, jvmCastGen);
         cw.visit(V1_8, ACC_PUBLIC + ACC_SUPER, className, null, ABSTRACT_OBJECT_VALUE, new String[]{B_OBJECT});
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/ExternalMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/ExternalMethodGen.java
@@ -37,10 +37,10 @@ import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRVariableDcl;
 import org.wso2.ballerinalang.compiler.bir.model.BIROperand;
 import org.wso2.ballerinalang.compiler.bir.model.BIRTerminator;
 import org.wso2.ballerinalang.compiler.bir.model.InstructionKind;
+import org.wso2.ballerinalang.compiler.semantics.analyzer.Types;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BInvokableType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
-import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 
 import java.util.ArrayList;
@@ -70,11 +70,11 @@ public class ExternalMethodGen {
                                                   JvmTypeGen jvmTypeGen, JvmCastGen jvmCastGen,
                                                  JvmConstantsGen jvmConstantsGen,
                                                   String moduleClassName, AsyncDataCollector lambdaGenMetadata,
-                                                  CompilerContext compilerContext) {
+                                                  Types types) {
         if (birFunc instanceof JFieldBIRFunction) {
             genJFieldForInteropField((JFieldBIRFunction) birFunc, cw, birModule.packageID,
                                      jvmPackageGen, jvmTypeGen, jvmCastGen, jvmConstantsGen,
-                                     moduleClassName, lambdaGenMetadata, compilerContext);
+                                     moduleClassName, lambdaGenMetadata, types);
         } else {
             methodGen.genJMethodForBFunc(birFunc, cw, birModule, jvmTypeGen, jvmCastGen, jvmConstantsGen,
                                          moduleClassName, attachedType, lambdaGenMetadata);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropMethodGen.java
@@ -43,11 +43,11 @@ import org.wso2.ballerinalang.compiler.bir.model.BIROperand;
 import org.wso2.ballerinalang.compiler.bir.model.BIRTerminator;
 import org.wso2.ballerinalang.compiler.bir.model.BirScope;
 import org.wso2.ballerinalang.compiler.bir.model.VarKind;
+import org.wso2.ballerinalang.compiler.semantics.analyzer.Types;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BArrayType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
-import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.util.Flags;
@@ -127,7 +127,7 @@ public class InteropMethodGen {
     static void genJFieldForInteropField(JFieldBIRFunction birFunc, ClassWriter classWriter, PackageID birModule,
                                          JvmPackageGen jvmPackageGen, JvmTypeGen jvmTypeGen, JvmCastGen jvmCastGen,
                                          JvmConstantsGen jvmConstantsGen, String moduleClassName,
-                                         AsyncDataCollector asyncDataCollector, CompilerContext compilerContext) {
+                                         AsyncDataCollector asyncDataCollector, Types types) {
 
         BIRVarToJVMIndexMap indexMap = new BIRVarToJVMIndexMap();
         indexMap.addIfNotExists("$_strand_$", jvmPackageGen.symbolTable.stringType);
@@ -143,8 +143,7 @@ public class InteropMethodGen {
         int access = birFunc.receiver != null ? ACC_PUBLIC : ACC_PUBLIC + ACC_STATIC;
         MethodVisitor mv = classWriter.visitMethod(access, birFunc.name.value, desc, null, null);
         JvmInstructionGen instGen = new JvmInstructionGen(mv, indexMap, birModule, jvmPackageGen, jvmTypeGen,
-                                                          jvmCastGen, jvmConstantsGen, asyncDataCollector,
-                                                          compilerContext);
+                                                          jvmCastGen, jvmConstantsGen, asyncDataCollector, types);
         JvmErrorGen errorGen = new JvmErrorGen(mv, indexMap, instGen);
         LabelGenerator labelGen = new LabelGenerator();
         JvmTerminatorGen termGen = new JvmTerminatorGen(mv, indexMap, labelGen, errorGen, birModule, instGen,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/MethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/MethodGen.java
@@ -50,11 +50,11 @@ import org.wso2.ballerinalang.compiler.bir.model.BIRTerminator.Return;
 import org.wso2.ballerinalang.compiler.bir.model.BirScope;
 import org.wso2.ballerinalang.compiler.bir.model.InstructionKind;
 import org.wso2.ballerinalang.compiler.bir.model.VarKind;
+import org.wso2.ballerinalang.compiler.semantics.analyzer.Types;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BTypeReferenceType;
-import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.util.Flags;
 
@@ -144,12 +144,12 @@ public class MethodGen {
     private static final String RESUME_INDEX = "resumeIndex";
     private final JvmPackageGen jvmPackageGen;
     private final SymbolTable symbolTable;
-    private final CompilerContext compilerContext;
+    private final Types types;
 
-    public MethodGen(JvmPackageGen jvmPackageGen, CompilerContext compilerContext) {
+    public MethodGen(JvmPackageGen jvmPackageGen, Types types) {
         this.jvmPackageGen = jvmPackageGen;
         this.symbolTable = jvmPackageGen.symbolTable;
-        this.compilerContext = compilerContext;
+        this.types = types;
     }
 
     public void generateMethod(BIRFunction birFunc, ClassWriter cw, BIRPackage birModule, BType attachedType,
@@ -158,7 +158,7 @@ public class MethodGen {
         if (JvmCodeGenUtil.isExternFunc(birFunc)) {
             ExternalMethodGen.genJMethodForBExternalFunc(birFunc, cw, birModule, attachedType, this, jvmPackageGen,
                                                          jvmTypeGen, jvmCastGen, jvmConstantsGen, moduleClassName,
-                                                         asyncDataCollector, compilerContext);
+                                                         asyncDataCollector, types);
         } else {
             genJMethodForBFunc(birFunc, cw, birModule, jvmTypeGen, jvmCastGen, jvmConstantsGen, moduleClassName,
                                attachedType, asyncDataCollector);
@@ -224,8 +224,7 @@ public class MethodGen {
         addCasesForBasicBlocks(func, funcName, labelGen, labels, states);
 
         JvmInstructionGen instGen = new JvmInstructionGen(mv, indexMap, module.packageID, jvmPackageGen, jvmTypeGen,
-                                                          jvmCastGen, jvmConstantsGen, asyncDataCollector,
-                                                          compilerContext);
+                                                          jvmCastGen, jvmConstantsGen, asyncDataCollector, types);
         JvmErrorGen errorGen = new JvmErrorGen(mv, indexMap, instGen);
         JvmTerminatorGen termGen = new JvmTerminatorGen(mv, indexMap, labelGen, errorGen, module.packageID, instGen,
                                                         jvmPackageGen, jvmTypeGen, jvmCastGen, asyncDataCollector);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/JvmConstantsGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/JvmConstantsGen.java
@@ -33,7 +33,6 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BArrayType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BTupleType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BUnionType;
-import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 
 import java.util.Map;
@@ -59,7 +58,7 @@ public class JvmConstantsGen {
 
     public final BTypeHashComparator bTypeHashComparator;
 
-    public JvmConstantsGen(BIRNode.BIRPackage module, String moduleInitClass, CompilerContext compilerContext,
+    public JvmConstantsGen(BIRNode.BIRPackage module, String moduleInitClass, Types types,
                            TypeHashVisitor typeHashVisitor) {
         this.bTypeHashComparator = new BTypeHashComparator(typeHashVisitor);
         this.stringConstantsGen = new JvmBStringConstantsGen(module.packageID);
@@ -67,8 +66,7 @@ public class JvmConstantsGen {
         this.jvmBallerinaConstantsGen = new JvmBallerinaConstantsGen(module, moduleInitClass, this);
         this.unionTypeConstantsGen = new JvmUnionTypeConstantsGen(module.packageID, bTypeHashComparator);
         this.tupleTypeConstantsGen = new JvmTupleTypeConstantsGen(module.packageID, bTypeHashComparator);
-        this.arrayTypeConstantsGen = new JvmArrayTypeConstantsGen(module.packageID,
-                bTypeHashComparator, Types.getInstance(compilerContext));
+        this.arrayTypeConstantsGen = new JvmArrayTypeConstantsGen(module.packageID, bTypeHashComparator, types);
     }
 
     public String getBStringConstantVar(String value) {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/anydata/AnydataTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/anydata/AnydataTest.java
@@ -112,26 +112,6 @@ public class AnydataTest {
         assertEquals(returns.toString(), "{\"name\":\"apple\",\"color\":\"red\",\"price\":40}");
     }
 
-    @Test(description = "Test table assignment")
-    public void testTableAssignment() {
-        BRunUtil.invoke(result, "testTableAssignment");
-    }
-
-    @Test(description = "Test map assignment")
-    public void testMapAssignment() {
-        BRunUtil.invoke(result, "testMapAssignment");
-    }
-
-    @Test(description = "Test for maps constrained by anydata")
-    public void testConstrainedMaps() {
-        BRunUtil.invoke(result, "testConstrainedMaps");
-    }
-
-    @Test(description = "Test array assignment")
-    public void testArrayAssignment() {
-        BRunUtil.invoke(result, "testArrayAssignment");
-    }
-
     @Test(description = "Test union assignment")
     public void testUnionAssignment() {
         BArray returns = (BArray) BRunUtil.invoke(result, "testUnionAssignment");
@@ -140,16 +120,6 @@ public class AnydataTest {
         assertEquals(returns.get(2), 23.45);
         assertTrue((Boolean) returns.get(3));
         assertEquals(returns.get(4), 255);
-    }
-
-    @Test(description = "Test union assignment for more complex types")
-    public void testUnionAssignment2() {
-        BRunUtil.invoke(result, "testUnionAssignment2");
-    }
-
-    @Test(description = "Test tuple assignment")
-    public void testTupleAssignment() {
-        BRunUtil.invoke(result, "testTupleAssignment");
     }
 
     @Test(description = "Test nil assignment")
@@ -214,11 +184,6 @@ public class AnydataTest {
         assertEquals(returns.get(0).toString(), "{\"a\":15}");
     }
 
-    @Test(description = "Test anydata to table conversion")
-    public void testAnydataToTable() {
-        BRunUtil.invoke(result, "testAnydataToTable");
-    }
-
     @Test(description = "Test anydata to union conversion")
     public void testAnydataToUnion() {
         BArray returns = (BArray) BRunUtil.invoke(result, "testAnydataToUnion");
@@ -232,11 +197,6 @@ public class AnydataTest {
         assertEquals(returns.get(2).toString(), "hello world!");
         assertTrue((Boolean) returns.get(3));
         assertEquals(returns.get(4), 255);
-    }
-
-    @Test(description = "Test anydata to union conversion for complex types")
-    public void testAnydataToUnion2() {
-        BRunUtil.invoke(result, "testAnydataToUnion2");
     }
 
     @Test(description = "Test anydata to tuple conversion")
@@ -255,11 +215,6 @@ public class AnydataTest {
                 "[json,xml<(lang.xml:Element|lang.xml:Comment|lang.xml:ProcessingInstruction|lang.xml:Text)>]");
         assertEquals(returns.toString(), "[{\"name\":\"apple\",\"color\":\"red\",\"price\":40},`<book>The Lost " +
                 "World</book>`]");
-    }
-
-    @Test(description = "Test anydata to tuple conversion")
-    public void testAnydataToTuple3() {
-        BRunUtil.invoke(result, "testAnydataToTuple3");
     }
 
     @Test(description = "Test anydata to nil conversion")
@@ -296,24 +251,30 @@ public class AnydataTest {
         assertEquals(rets.getRefValue(7).toString(), "{\"ca\":15}");
     }
 
-    @Test
-    public void testRuntimeIsAnydata() {
-        BRunUtil.invoke(result, "testRuntimeIsAnydata");
-    }
-
-    @Test(dataProvider = "subtypeOfBasicTypesIsAnydata")
-    public void testSubtypeOfBasicTypesIsAnydata(String function) {
+    @Test(dataProvider = "getAnydataFuntion")
+    public void testAnydata(String function) {
         BRunUtil.invoke(result, function);
     }
 
-    @DataProvider(name = "subtypeOfBasicTypesIsAnydata")
-    public Object[][] subtypeOfBasicTypesIsAnydata() {
-        return new Object[][]{
-                {"testMapOfCharIsAnydata"},
-                {"testCharArrayIsAnydata"},
-                {"testMapOfIntSubtypeIsAnydata"},
-                {"testArrayOfIntSubtypeIsAnydata"},
-                {"testMapOfNeverTypeIsAnydata"}
+    @DataProvider(name = "getAnydataFuntion")
+    public Object[] getAnydataFuntion() {
+        return new String[]{
+                "testMapOfCharIsAnydata",
+                "testCharArrayIsAnydata",
+                "testMapOfIntSubtypeIsAnydata",
+                "testArrayOfIntSubtypeIsAnydata",
+                "testMapOfNeverTypeIsAnydata",
+                "testRuntimeIsAnydata",
+                "testAnydataToTuple3",
+                "testAnydataToUnion2",
+                "testAnydataToTable",
+                "testTupleAssignment",
+                "testUnionAssignment2",
+                "testTableAssignment",
+                "testMapAssignment",
+                "testConstrainedMaps",
+                "testArrayAssignment",
+                "testAnytoAnydataTypeCast"
         };
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/anydata/anydata_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/anydata/anydata_test.bal
@@ -27,7 +27,7 @@ type Employee record {|
     string name;
     float salary;
 |};
-    
+
 type Person record {|
     string name = "";
     int age = 0;
@@ -76,16 +76,17 @@ function testRecordAssignment() returns [anydata, anydata] {
 }
 
 function testCyclicRecordAssignment() returns (anydata) {
-    Person p = {name:"Child",
-                age:25,
-                parent:{name:"Parent", age:50},
-                address:{"city":"Colombo", "country":"SriLanka"},
-                info:{status:"single"},
-                marks:[67, 38, 91]
+    Person p = {
+        name: "Child",
+        age: 25,
+        parent: {name: "Parent", age: 50},
+        address: {"city": "Colombo", "country": "SriLanka"},
+        info: {status: "single"},
+        marks: [67, 38, 91]
     };
     anydata adp = p;
-    any p2 =  <Person> adp;
-    if(p2 is anydata){
+    any p2 = <Person>adp;
+    if (p2 is anydata) {
         return p2;
     } else {
         return ();
@@ -109,9 +110,9 @@ function testJSONAssignment() returns anydata {
 
 function testTableAssignment() {
     table<Employee> t = table key(id) [
-          { id: 1, name: "Mary", salary: 300.5 },
-          { id: 2, name: "John", salary: 200.5 },
-          { id: 3, name: "Jim", salary: 330.5 }
+            {id: 1, name: "Mary", salary: 300.5},
+            {id: 2, name: "John", salary: 200.5},
+            {id: 3, name: "Jim", salary: 330.5}
         ];
 
     anydata adt = t;
@@ -168,7 +169,7 @@ function testMapAssignment() {
     ad = mnil;
 }
 
-function testConstrainedMaps(){
+function testConstrainedMaps() {
     byte b = 10;
     Foo foo = {a: 15};
     json j = {name: "apple", color: "red", price: 40};
@@ -191,10 +192,10 @@ function testConstrainedMaps(){
     adm["nil"] = ();
 
     table<Employee> t = table key(id) [
-        { id: 1, name: "Mary", salary: 300.5 },
-        { id: 2, name: "John", salary: 200.5 },
-        { id: 3, name: "Jim", salary: 330.5 }
-    ];
+            {id: 1, name: "Mary", salary: 300.5},
+            {id: 2, name: "John", salary: 200.5},
+            {id: 3, name: "Jim", salary: 330.5}
+        ];
     adm["table"] = t;
 
     assertEquality(1234, adm["int"]);
@@ -234,16 +235,16 @@ function testArrayAssignment() {
     xml[] ax = [xml `<book>The Lost World</book>`];
     ad = ax;
 
-    Foo[] ar = [{a:10}, {a:20}];
+    Foo[] ar = [{a: 10}, {a: 20}];
     ad = ar;
 
-    ClosedFoo[] acr = [{ca:10}, {ca:20}];
+    ClosedFoo[] acr = [{ca: 10}, {ca: 20}];
     ad = acr;
 
     table<Employee> t = table key(id) [
-            { id: 1, name: "Mary", salary: 300.5 },
-            { id: 2, name: "John", salary: 200.5 },
-            { id: 3, name: "Jim", salary: 330.5 }
+            {id: 1, name: "Mary", salary: 300.5},
+            {id: 2, name: "John", salary: 200.5},
+            {id: 3, name: "Jim", salary: 330.5}
         ];
     table<Employee>[] at = [t];
     ad = at;
@@ -263,7 +264,7 @@ function testArrayAssignment() {
 }
 
 function testAnydataArray() returns anydata[] {
-    Foo foo = {a:15};
+    Foo foo = {a: 15};
     json j = {name: "apple", color: "red", price: 40};
     xml x = xml `<book>The Lost World</book>`;
     byte b = 10;
@@ -272,6 +273,7 @@ function testAnydataArray() returns anydata[] {
 }
 
 type ValueType int|float|string|boolean|byte|decimal;
+
 type DataType ValueType|table<map<any>>|json|xml|ClosedFoo|Foo|map<anydata>|anydata[]|();
 
 function testUnionAssignment() returns anydata[] {
@@ -302,7 +304,7 @@ function testUnionAssignment() returns anydata[] {
     return rets;
 }
 
-function testUnionAssignment2(){
+function testUnionAssignment2() {
     anydata[] rets = [];
     int i = 0;
 
@@ -311,9 +313,9 @@ function testUnionAssignment2(){
     i += 1;
 
     table<Employee> t = table key(id) [
-            { id: 1, name: "Mary", salary: 300.5 },
-            { id: 2, name: "John", salary: 200.5 },
-            { id: 3, name: "Jim", salary: 330.5 }
+            {id: 1, name: "Mary", salary: 300.5},
+            {id: 2, name: "John", salary: 200.5},
+            {id: 3, name: "Jim", salary: 330.5}
         ];
     dt = t;
     rets[i] = dt;
@@ -328,12 +330,12 @@ function testUnionAssignment2(){
     rets[i] = dt;
     i += 1;
 
-    Foo foo = {a:15};
+    Foo foo = {a: 15};
     dt = foo;
     rets[i] = dt;
     i += 1;
 
-    ClosedFoo cfoo = {ca:15};
+    ClosedFoo cfoo = {ca: 15};
     dt = cfoo;
     rets[i] = dt;
     i += 1;
@@ -360,7 +362,7 @@ function testUnionAssignment2(){
     assertEquality(m, rets[6]);
 }
 
-function testTupleAssignment(){
+function testTupleAssignment() {
     anydata[] rets = [];
     int i = 0;
 
@@ -369,7 +371,7 @@ function testTupleAssignment(){
     rets[i] = vt;
     i += 1;
 
-    json j = { name: "apple", color: "red", price: 40 };
+    json j = {name: "apple", color: "red", price: 40};
     xml x = xml `<book>The Lost World</book>`;
     [json, xml] jxt = [j, x];
     rets[i] = jxt;
@@ -452,7 +454,7 @@ function testAnydataToValueTypes() returns [int, float, boolean, string] {
 }
 
 function testAnydataToJson() returns json {
-    json j = { name: "apple", color: "red", price: 40 };
+    json j = {name: "apple", color: "red", price: 40};
     anydata adJ = j;
     json convertedJ = null;
     if (adJ is json) {
@@ -597,11 +599,11 @@ function testAnydataToMap() {
     }
 }
 
-function testAnydataToTable(){
-    table<Employee> t = table key(id)[
-                    { id: 1, name: "Mary", salary: 300.5 },
-                    { id: 2, name: "John", salary: 200.5 },
-                    { id: 3, name: "Jim", salary: 330.5 }
+function testAnydataToTable() {
+    table<Employee> t = table key(id) [
+            {id: 1, name: "Mary", salary: 300.5},
+            {id: 2, name: "John", salary: 200.5},
+            {id: 3, name: "Jim", salary: 330.5}
         ];
 
     anydata ad = t;
@@ -650,12 +652,12 @@ function testAnydataToUnion() returns ValueType?[] {
     return vt;
 }
 
-function testAnydataToUnion2(){
+function testAnydataToUnion2() {
     anydata ad;
     DataType[] dt = [];
     int i = 0;
 
-    json j = { name: "apple", color: "red", price: 40 };
+    json j = {name: "apple", color: "red", price: 40};
     ad = j;
     dt[i] = ad;
     i += 1;
@@ -666,10 +668,10 @@ function testAnydataToUnion2(){
     i += 1;
 
     table<Employee> t = table key(id) [
-        { id: 1, name: "Mary", salary: 300.5 },
-        { id: 2, name: "John", salary: 200.5 },
-        { id: 3, name: "Jim", salary: 330.5 }
-    ];
+            {id: 1, name: "Mary", salary: 300.5},
+            {id: 2, name: "John", salary: 200.5},
+            {id: 3, name: "Jim", salary: 330.5}
+        ];
 
     ad = t;
     dt[i] = ad;
@@ -722,7 +724,7 @@ function testAnydataToTuple() returns [int, float, boolean, string, byte]? {
 function testAnydataToTuple2() returns [json, xml]? {
     anydata ad;
 
-    json j = { name: "apple", color: "red", price: 40 };
+    json j = {name: "apple", color: "red", price: 40};
     xml x = xml `<book>The Lost World</book>`;
     [json, xml] jxt = [j, x];
     ad = jxt;
@@ -737,7 +739,7 @@ function testAnydataToTuple2() returns [json, xml]? {
 function testAnydataToTuple3() {
     anydata ad;
 
-    json j = { name: "apple", color: "red", price: 40 };
+    json j = {name: "apple", color: "red", price: 40};
     xml x = xml `<book>The Lost World</book>`;
     DataType[] dt = [j, x];
     [DataType[], string] ct = [dt, "hello world!"];
@@ -830,7 +832,7 @@ function testTypeCheckingOnAny() returns anydata {
         i += 1;
     }
 
-    json j = { name: "apple", color: "red", price: 40 };
+    json j = {name: "apple", color: "red", price: 40};
     a = j;
     if (a is anydata) {
         ad[i] = a;
@@ -861,15 +863,15 @@ function testTypeCheckingOnAny() returns anydata {
 }
 
 function testRuntimeIsAnydata() {
-    any a = <(anydata|error)[]> [1, error("error!")];
-    any b = <(anydata|error)[]> [1];
-    any c = <[int, error]> [1, error("error!")];
-    any d = <[int, error...]> [1, error("error!")];
-    any e = <map<anydata|error>> {a: 1, b: error("error!")};
-    any f = <map<anydata|error>> {a: 1, b: "hello"};
-    any g = <record {anydata a; error e;}> {a: 1, e: error("error!")};
-    any h = <record {|anydata a; error...;|}> {a: 1};
-    any i = <record {anydata a; error e?;}> {a: 1};
+    any a = <(anydata|error)[]>[1, error("error!")];
+    any b = <(anydata|error)[]>[1];
+    any c = <[int, error]>[1, error("error!")];
+    any d = <[int, error...]>[1, error("error!")];
+    any e = <map<anydata|error>>{a: 1, b: error("error!")};
+    any f = <map<anydata|error>>{a: 1, b: "hello"};
+    any g = <record {anydata a; error e;}>{a: 1, e: error("error!")};
+    any h = <record {|anydata a;error...; |}>{a: 1};
+    any i = <record {anydata a; error e?;}>{a: 1};
 
     assertFalse(a is anydata);
     assertFalse(b is anydata);
@@ -881,14 +883,14 @@ function testRuntimeIsAnydata() {
     assertFalse(h is anydata);
     assertFalse(i is anydata);
 
-    any a2 = <(anydata|error)[] & readonly> [1, 2];
-    any b2 = <anydata[]> [1];
-    any c2 = <[int]> [1];
-    any d2 = <[int, error...] & readonly> [1];
-    any e2 = <map<anydata|error> & readonly> {a: 1};
-    any f2 = <map<anydata>> {a: 1, b: "hello"};
-    any g2 = <record {anydata a; error e?;} & readonly> {a: 1};
-    any h2 = <record {|anydata a; error...;|} & readonly> {a: 1};
+    any a2 = <(anydata|error)[] & readonly>[1, 2];
+    any b2 = <anydata[]>[1];
+    any c2 = <[int]>[1];
+    any d2 = <[int, error...] & readonly>[1];
+    any e2 = <map<anydata|error> & readonly>{a: 1};
+    any f2 = <map<anydata>>{a: 1, b: "hello"};
+    any g2 = <record {anydata a; error e?;} & readonly>{a: 1};
+    any h2 = <record {|anydata a;error...; |} & readonly>{a: 1};
 
     assertTrue(a2 is anydata);
     assertTrue(b2 is anydata);
@@ -928,6 +930,77 @@ function testMapOfNeverTypeIsAnydata() {
     map<never> x5 = {};
     any a5 = x5;
     assertTrue(a5 is anydata);
+}
+
+function testAnytoAnydataTypeCast() returns error? {
+    // negative cases
+    any anyVal = {a: 23};
+    anydata|error result = trap <anydata>anyVal;
+
+    assertTrue(result is error);
+    error err = <error>result;
+    assertEquality("{ballerina}TypeCastError", err.message());
+    assertEquality("incompatible types: 'map' cannot be cast to 'anydata'",
+    <string>checkpanic err.detail()["message"]);
+
+    any[] arr = [1, "2", 3.4];
+    result = trap <anydata>arr;
+    assertTrue(result is error);
+    err = <error>result;
+    assertEquality("{ballerina}TypeCastError", err.message());
+    assertEquality("incompatible types: 'any[]' cannot be cast to 'anydata'",
+    <string>checkpanic err.detail()["message"]);
+
+    map<any> anyMap = {"a": 2, "b": 3};
+    result = trap <anydata>anyMap;
+    assertTrue(result is error);
+    err = <error>result;
+    assertEquality("{ballerina}TypeCastError", err.message());
+    assertEquality("incompatible types: 'map' cannot be cast to 'anydata'",
+    <string>checkpanic err.detail()["message"]);
+
+    table<map<any>> tab = table [
+            {id: 12, name: "abc"},
+            {id: 34, name: "def"}
+        ];
+    result = trap <anydata>tab;
+    assertTrue(result is error);
+    err = <error>result;
+    assertEquality("{ballerina}TypeCastError", err.message());
+    assertEquality("incompatible types: 'table<map>' cannot be cast to 'anydata'",
+    <string>checkpanic err.detail()["message"]);
+
+    // positive cases
+    any & readonly anyValRO = {a: 23};
+    anyVal = anyValRO;
+    result = trap <anydata>anyVal;
+    assertTrue(result is anydata);
+    anydata anyDataVal = check result;
+    assertEquality("{\"a\":23}", anyDataVal.toString());
+
+    any[] & readonly arrRO = [1, "2", 3.4];
+    arr = arrRO;
+    result = trap <anydata>arr;
+    assertTrue(result is anydata);
+    anyDataVal = check result;
+    assertEquality("[1,\"2\",3.4]", anyDataVal.toString());
+
+    map<any> & readonly mapAnyRO = {a: 23};
+    anyMap = mapAnyRO;
+    result = trap <anydata>anyMap;
+    assertTrue(result is anydata);
+    anyDataVal = check result;
+    assertEquality("{\"a\":23}", anyDataVal.toString());
+
+    table<map<any>> & readonly tabRO = table [
+            {id: 12, name: "abc"},
+            {id: 34, name: "def"}
+        ];
+    tab = tabRO;
+    result = trap <anydata>tab;
+    assertTrue(result is anydata);
+    anyDataVal = check result;
+    assertEquality("[{\"id\":12,\"name\":\"abc\"},{\"id\":34,\"name\":\"def\"}]", anyDataVal.toString());
 }
 
 function assertTrue(any|error actual) {


### PR DESCRIPTION
## Purpose
$subject

Fixes #35517

## Approach
When casting an `any` value to `anydata`, we need to verify the casting at runtime, as it can contain a non-anydata value. This check is currently done only for `any` values and not validated for some types like `any[]`, `map<any>` and `table<map<any>>`.This PR modifies this to add a runtime check.  

## Samples
```ballerina
 any[] arr = [1, "2", 3.4];
 anydata result = <anydata>arr; // should panic
 
 any[] & readonly arr1= [1, "2", 3.4];
 arr = arr1;
 anydata result = <anydata>arr; // should pass
```

## Remarks
As the `TypeChecker` contains a bug when checking table values, this PR fixes it as well.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
