### PR TITLE
Revert "Allow additive-expr with operands of a union type containing builtin subtypes of string and xml"

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -2154,7 +2154,8 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
                 boolean match = true;
                 for (int i = 0; i < typeList.size(); i++) {
                     BType t = Types.getReferredType(typeList.get(i));
-                    if ((t.getKind() == TypeKind.UNION) && (opType.paramTypes.get(i).getKind() == TypeKind.UNION)) {
+                    if ((t.getKind() == TypeKind.UNION) &&
+                            (opType.paramTypes.get(i).getKind() == TypeKind.UNION)) {
                         if (!this.types.isSameType(t, opType.paramTypes.get(i))) {
                             match = false;
                         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -3954,9 +3954,6 @@ public class Types {
         switch (type.tag) {
             case TypeTags.XML:
             case TypeTags.XML_TEXT:
-            case TypeTags.XML_ELEMENT:
-            case TypeTags.XML_PI:
-            case TypeTags.XML_COMMENT:
                 return true;
             case TypeTags.UNION:
                 BUnionType unionType = (BUnionType) type;
@@ -3972,14 +3969,14 @@ public class Types {
                                 return false;
                             }
                         }
-                        if (!validStringOrXmlTypeExists(memType)) {
+                        if (!checkValidStringOrXmlTypesInUnion(memType, firstTypeInUnion.tag)) {
                             return false;
                         }
                     }
                 } else {
                     for (BType memType : memberTypes) {
                        memType = getReferredType(memType);
-                        if (!validStringOrXmlTypeExists(memType)) {
+                        if (!checkValidStringOrXmlTypesInUnion(memType, firstTypeInUnion.tag)) {
                             return false;
                         }
                     }
@@ -4000,6 +3997,18 @@ public class Types {
             default:
                 return false;
         }
+    }
+
+    private boolean checkValidStringOrXmlTypesInUnion(BType memType, int firstTypeTag) {
+        if (memType.tag != firstTypeTag && !checkTypesBelongToStringOrXml(memType.tag, firstTypeTag)) {
+            return false;
+        }
+        return validStringOrXmlTypeExists(memType);
+    }
+
+    private boolean checkTypesBelongToStringOrXml(int firstTypeTag, int secondTypeTag) {
+        return (TypeTags.isStringTypeTag(firstTypeTag) && TypeTags.isStringTypeTag(secondTypeTag)) ||
+                (TypeTags.isXMLTypeTag(firstTypeTag) && TypeTags.isXMLTypeTag(secondTypeTag));
     }
 
     public boolean checkTypeContainString(BType type) {
@@ -5945,9 +5954,6 @@ public class Types {
             case TypeTags.FLOAT:
             case TypeTags.XML:
             case TypeTags.XML_TEXT:
-            case TypeTags.XML_ELEMENT:
-            case TypeTags.XML_PI:
-            case TypeTags.XML_COMMENT:
                 return type;
             case TypeTags.INT:
             case TypeTags.BYTE:

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
@@ -709,6 +709,21 @@ public class SymbolTable {
                 defineBinaryOperator(OperatorKind.MOD, lhs, rhs, intOptional);
             }
         }
+
+        for (BType lhs : intTypes) {
+            for (BUnionType rhs : nilableIntTypes) {
+                defineBinaryOperator(OperatorKind.ADD, lhs, rhs, intOptional);
+                defineBinaryOperator(OperatorKind.ADD, rhs, lhs, intOptional);
+                defineBinaryOperator(OperatorKind.SUB, lhs, rhs, intOptional);
+                defineBinaryOperator(OperatorKind.SUB, rhs, lhs, intOptional);
+                defineBinaryOperator(OperatorKind.DIV, lhs, rhs, intOptional);
+                defineBinaryOperator(OperatorKind.DIV, rhs, lhs, intOptional);
+                defineBinaryOperator(OperatorKind.MUL, lhs, rhs, intOptional);
+                defineBinaryOperator(OperatorKind.MUL, rhs, lhs, intOptional);
+                defineBinaryOperator(OperatorKind.MOD, lhs, rhs, intOptional);
+                defineBinaryOperator(OperatorKind.MOD, rhs, lhs, intOptional);
+            }
+        }
     }
 
     private void defineIntegerBitwiseAndOperations() {

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/onfail_clause_ctx_config2c.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/onfail_clause_ctx_config2c.json
@@ -254,6 +254,102 @@
       "filterText": "var",
       "insertText": "var ",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "test/project2",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "project2",
+      "insertText": "project2",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import test/project2;\n"
+        }
+      ]
+    },
+    {
+      "label": "test/project1",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "project1",
+      "insertText": "project1",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import test/project1;\n"
+        }
+      ]
+    },
+    {
+      "label": "test/local_project2",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "local_project2",
+      "insertText": "local_project2",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import test/local_project2;\n"
+        }
+      ]
+    },
+    {
+      "label": "test/local_project1",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "local_project1",
+      "insertText": "local_project1",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import test/local_project1;\n"
+        }
+      ]
     }
   ]
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/AddOperationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/AddOperationTest.java
@@ -156,15 +156,13 @@ public class AddOperationTest {
                 "testAdditionWithTypes",
                 "testAddSingleton",
                 "testStringCharAddition",
-                "testStringXmlSubtypesAddition",
-                "testStringSubtypesAddition",
-                "testXmlSubtypesAddition"
+                "testStringXmlSubtypesAddition"
         };
     }
 
     @Test(description = "Test binary statement with errors")
     public void testSubtractStmtNegativeCases() {
-        Assert.assertEquals(resultNegative.getErrorCount(), 17);
+        Assert.assertEquals(resultNegative.getErrorCount(), 15);
         BAssertUtil.validateError(resultNegative, 0, "operator '+' not defined for 'json' and 'json'", 8, 10);
         BAssertUtil.validateError(resultNegative, 1, "operator '+' not defined for 'int' and 'string'", 14, 9);
         BAssertUtil.validateError(resultNegative, 2, "operator '+' not defined for 'C' and 'string'", 28, 14);
@@ -180,7 +178,5 @@ public class AddOperationTest {
         BAssertUtil.validateError(resultNegative, 12, "operator '+' not defined for 'int' and 'float'", 60, 18);
         BAssertUtil.validateError(resultNegative, 13, "operator '+' not defined for 'C' and 'float'", 64, 14);
         BAssertUtil.validateError(resultNegative, 14, "operator '+' not defined for 'C' and 'float'", 65, 14);
-        BAssertUtil.validateError(resultNegative, 15, "incompatible types: expected 'string', found 'xml'", 72, 16);
-        BAssertUtil.validateError(resultNegative, 16, "incompatible types: expected 'FO', found 'string'", 73, 12);
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/add-operation-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/add-operation-negative.bal
@@ -63,18 +63,4 @@ function testImplicitConversion() {
     float e = 12.25;
     var y1 = d + e;
     any y2 = d + e;
-
-    I i = "i";
-    O o = "o";
-    xml x = xml `<foo>foo</foo><?foo?>text1<!--comment-->`;
-    string y = "abc";
-
-    string _ = x + y;
-    FO _ = i + o;
 }
-
-type FO "fo";
-
-type I "i";
-
-type O "o";

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/add-operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/add-operation.bal
@@ -368,15 +368,6 @@ function testStringXmlSubtypesAddition() {
     string:Char c = "d";
     xml x1 = xml `efg`;
     xml:Text x2 = xml `text`;
-    string:Char|Strings b = "d";
-    Strings|Baz e = "bar";
-    Bar d = "B";
-    xml l = x2 + b;
-    xml m = x2 + e;
-    xml n = x2 + d;
-    xml o = x1 + b;
-    xml p = x1 + e;
-    xml q = x1 + d;
 
     assertEquality(s + x2, xml `abctext`);
     assertEquality(x2 + s, xml `textabc`);
@@ -384,80 +375,6 @@ function testStringXmlSubtypesAddition() {
     assertEquality(x1 + c, xml `efgd`);
     assertEquality(c + x2, xml `dtext`);
     assertEquality(x2 + c, xml `textd`);
-    assertEquality(l, xml `textd`);
-    assertEquality(m, xml `textbar`);
-    assertEquality(n, xml `textB`);
-    assertEquality(o, xml `efgd`);
-    assertEquality(p, xml `efgbar`);
-    assertEquality(q, xml `efgB`);
-}
-
-type Baz "B"|"bar";
-type Bar Baz|string;
-
-function testStringSubtypesAddition() {
-    string a = "abc";
-    string:Char|Strings b = "d";
-    Strings|Baz c = "bar";
-    Bar d = "B";
-    string:Char e = "e";
-    string f = a + c;
-    string g = a + b;
-    string h = d + e;
-    string i = a + b + a;
-    string j = c + b;
-    string k = a + e;
-    string l = b + e;
-    string m = c + e;
-    string n = b + e + b;
-
-    assertEquality(f, "abcbar");
-    assertEquality(g, "abcd");
-    assertEquality(i, "abcdabc");
-    assertEquality(j, "bard");
-    assertEquality(k, "abce");
-    assertEquality(l, "de");
-    assertEquality(m, "bare");
-    assertEquality(h, "Be");
-    assertEquality(n, "ded");
-}
-
-type Foo xml<'xml:Text>|xml<'xml:Comment> ;
-type Foo2 xml<'xml:Element|'xml:ProcessingInstruction>;
-type Foo3 Foo|Foo2;
-
-function testXmlSubtypesAddition() {
-    xml a = xml `<foo>foo</foo><?foo?>text1<!--comment-->`;
-    xml<'xml:Element>|Foo b = xml `<foo>Anne</foo><fuu>Peter</fuu>`;
-    Foo2 c = xml `<?foo?><?faa?>`;
-    Foo3 d = xml `text1 text2`;
-    xml<'xml:Comment> e = xml `<!--comment1--><!--comment2-->`;
-    xml<'xml:Text|'xml:Comment> f = xml `<!--comment-->`;
-    xml<'xml:Text>|xml<'xml:Comment> g = xml `<!--comment-->`;
-    xml<'xml:Element|'xml:ProcessingInstruction> h = xml `<root> text1<foo>100</foo><foo>200</foo></root><?foo?>`;
-    xml<'xml:Element>|'xml:Text i = xml `<root> text1<foo>100</foo><foo>200</foo></root> text1`;
-    xml j = a + b;
-    xml k = a + c;
-    xml l = a + d;
-    xml m = c + g;
-    xml n = c + h;
-    xml o = d + f;
-    xml p = g + h;
-    
-    xml result1 = xml `<foo>foo</foo><?foo ?>text1<!--comment--><foo>Anne</foo><fuu>Peter</fuu>`;
-    xml result2 = xml `<foo>foo</foo><?foo ?>text1<!--comment--><?foo ?><?faa ?>`;
-    xml result3 = xml `<foo>foo</foo><?foo ?>text1<!--comment-->text1 text2`;
-    xml result4 = xml `<?foo ?><?faa ?><!--comment-->`;
-    xml result5 = xml `<?foo ?><?faa ?><root> text1<foo>100</foo><foo>200</foo></root><?foo ?>`;
-    xml result6 = xml `text1 text2<!--comment-->`;
-    xml result7 = xml `<!--comment--><root> text1<foo>100</foo><foo>200</foo></root><?foo ?>`;
-    assertEquality(j, result1);
-    assertEquality(k, result2);
-    assertEquality(l, result3);
-    assertEquality(m, result4);
-    assertEquality(n, result5);
-    assertEquality(o, result6);
-    assertEquality(p, result7);
 }
 
 function assertEquality(any actual, any expected) {


### PR DESCRIPTION
Reverts ballerina-platform/ballerina-lang#34817

Since it was to the 2201.0.x branch.