### PR TITLE
Allow additive-expr with operands of a union type containing builtin subtypes of string and xml

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -403,8 +403,7 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
     public BSymbol resolveBinaryOperator(OperatorKind opKind,
                                          BType lhsType,
                                          BType rhsType) {
-        boolean isAdditiveExpr = opKind.equals(OperatorKind.ADD) || opKind.equals(OperatorKind.SUB);
-        return resolveOperator(isAdditiveExpr, names.fromString(opKind.value()), Lists.of(lhsType, rhsType));
+        return resolveOperator(names.fromString(opKind.value()), Lists.of(lhsType, rhsType));
     }
 
     private BSymbol createEqualityOperator(OperatorKind opKind, BType lhsType, BType rhsType) {
@@ -416,12 +415,12 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
 
     public BSymbol resolveUnaryOperator(OperatorKind opKind,
                                         BType type) {
-        return resolveOperator(false, names.fromString(opKind.value()), Lists.of(type));
+        return resolveOperator(names.fromString(opKind.value()), Lists.of(type));
     }
 
-    public BSymbol resolveOperator(boolean isAdditiveExpr, Name name, List<BType> types) {
+    public BSymbol resolveOperator(Name name, List<BType> types) {
         ScopeEntry entry = symTable.rootScope.lookup(name);
-        return resolveOperator(isAdditiveExpr, entry, types);
+        return resolveOperator(entry, types);
     }
 
     private BSymbol createBinaryComparisonOperator(OperatorKind opKind, BType lhsType, BType rhsType) {
@@ -2147,7 +2146,7 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
 
     // private methods
 
-    private BSymbol resolveOperator(boolean isAdditiveExpr, ScopeEntry entry, List<BType> typeList) {
+    private BSymbol resolveOperator(ScopeEntry entry, List<BType> typeList) {
         BSymbol foundSymbol = symTable.notFoundSymbol;
         while (entry != NOT_FOUND_ENTRY) {
             BInvokableType opType = (BInvokableType) entry.symbol.type;
@@ -2155,12 +2154,7 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
                 boolean match = true;
                 for (int i = 0; i < typeList.size(); i++) {
                     BType t = Types.getReferredType(typeList.get(i));
-                    if (isAdditiveExpr) {
-                        if (t.getKind() == TypeKind.NIL || !types.isAssignable(t, opType.paramTypes.get(i))) {
-                            match = false;
-                        }
-                    } else if ((t.getKind() == TypeKind.UNION) &&
-                            (opType.paramTypes.get(i).getKind() == TypeKind.UNION)) {
+                    if ((t.getKind() == TypeKind.UNION) && (opType.paramTypes.get(i).getKind() == TypeKind.UNION)) {
                         if (!this.types.isSameType(t, opType.paramTypes.get(i))) {
                             match = false;
                         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -403,7 +403,7 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
     public BSymbol resolveBinaryOperator(OperatorKind opKind,
                                          BType lhsType,
                                          BType rhsType) {
-        boolean isAdditiveExpr = (opKind.equals(OperatorKind.ADD) || opKind.equals(OperatorKind.SUB));
+        boolean isAdditiveExpr = opKind.equals(OperatorKind.ADD) || opKind.equals(OperatorKind.SUB);
         return resolveOperator(isAdditiveExpr, names.fromString(opKind.value()), Lists.of(lhsType, rhsType));
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -403,7 +403,8 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
     public BSymbol resolveBinaryOperator(OperatorKind opKind,
                                          BType lhsType,
                                          BType rhsType) {
-        return resolveOperator(names.fromString(opKind.value()), Lists.of(lhsType, rhsType));
+        boolean isAdditiveExpr = (opKind.equals(OperatorKind.ADD) || opKind.equals(OperatorKind.SUB));
+        return resolveOperator(isAdditiveExpr, names.fromString(opKind.value()), Lists.of(lhsType, rhsType));
     }
 
     private BSymbol createEqualityOperator(OperatorKind opKind, BType lhsType, BType rhsType) {
@@ -415,12 +416,12 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
 
     public BSymbol resolveUnaryOperator(OperatorKind opKind,
                                         BType type) {
-        return resolveOperator(names.fromString(opKind.value()), Lists.of(type));
+        return resolveOperator(false, names.fromString(opKind.value()), Lists.of(type));
     }
 
-    public BSymbol resolveOperator(Name name, List<BType> types) {
+    public BSymbol resolveOperator(boolean isAdditiveExpr, Name name, List<BType> types) {
         ScopeEntry entry = symTable.rootScope.lookup(name);
-        return resolveOperator(entry, types);
+        return resolveOperator(isAdditiveExpr, entry, types);
     }
 
     private BSymbol createBinaryComparisonOperator(OperatorKind opKind, BType lhsType, BType rhsType) {
@@ -2146,7 +2147,7 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
 
     // private methods
 
-    private BSymbol resolveOperator(ScopeEntry entry, List<BType> typeList) {
+    private BSymbol resolveOperator(boolean isAdditiveExpr, ScopeEntry entry, List<BType> typeList) {
         BSymbol foundSymbol = symTable.notFoundSymbol;
         while (entry != NOT_FOUND_ENTRY) {
             BInvokableType opType = (BInvokableType) entry.symbol.type;
@@ -2154,7 +2155,11 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
                 boolean match = true;
                 for (int i = 0; i < typeList.size(); i++) {
                     BType t = Types.getReferredType(typeList.get(i));
-                    if ((t.getKind() == TypeKind.UNION) &&
+                    if (isAdditiveExpr) {
+                        if (t.getKind() == TypeKind.NIL || !types.isAssignable(t, opType.paramTypes.get(i))) {
+                            match = false;
+                        }
+                    } else if ((t.getKind() == TypeKind.UNION) &&
                             (opType.paramTypes.get(i).getKind() == TypeKind.UNION)) {
                         if (!this.types.isSameType(t, opType.paramTypes.get(i))) {
                             match = false;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -3959,6 +3959,9 @@ public class Types {
         switch (type.tag) {
             case TypeTags.XML:
             case TypeTags.XML_TEXT:
+            case TypeTags.XML_ELEMENT:
+            case TypeTags.XML_PI:
+            case TypeTags.XML_COMMENT:
                 return true;
             case TypeTags.UNION:
                 BUnionType unionType = (BUnionType) type;
@@ -3974,14 +3977,14 @@ public class Types {
                                 return false;
                             }
                         }
-                        if (!checkValidStringOrXmlTypesInUnion(memType, firstTypeInUnion.tag)) {
+                        if (!validStringOrXmlTypeExists(memType)) {
                             return false;
                         }
                     }
                 } else {
                     for (BType memType : memberTypes) {
                        memType = getReferredType(memType);
-                        if (!checkValidStringOrXmlTypesInUnion(memType, firstTypeInUnion.tag)) {
+                        if (!validStringOrXmlTypeExists(memType)) {
                             return false;
                         }
                     }
@@ -4002,18 +4005,6 @@ public class Types {
             default:
                 return false;
         }
-    }
-
-    private boolean checkValidStringOrXmlTypesInUnion(BType memType, int firstTypeTag) {
-        if (memType.tag != firstTypeTag && !checkTypesBelongToStringOrXml(memType.tag, firstTypeTag)) {
-            return false;
-        }
-        return validStringOrXmlTypeExists(memType);
-    }
-
-    private boolean checkTypesBelongToStringOrXml(int firstTypeTag, int secondTypeTag) {
-        return (TypeTags.isStringTypeTag(firstTypeTag) && TypeTags.isStringTypeTag(secondTypeTag)) ||
-                (TypeTags.isXMLTypeTag(firstTypeTag) && TypeTags.isXMLTypeTag(secondTypeTag));
     }
 
     public boolean checkTypeContainString(BType type) {
@@ -5959,6 +5950,9 @@ public class Types {
             case TypeTags.FLOAT:
             case TypeTags.XML:
             case TypeTags.XML_TEXT:
+            case TypeTags.XML_ELEMENT:
+            case TypeTags.XML_PI:
+            case TypeTags.XML_COMMENT:
                 return type;
             case TypeTags.INT:
             case TypeTags.BYTE:

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
@@ -475,7 +475,7 @@ public class SymbolTable {
         defineIntFloatingPointArithmeticOperations();
 
         defineNilableIntFloatingPointArithmeticOperations();
-        
+
         // Binary bitwise operators for nullable integer types
         defineNilableIntegerBitwiseAndOperations();
         defineNilableIntegerBitwiseOrAndXorOperations(OperatorKind.BITWISE_OR);
@@ -731,7 +731,7 @@ public class SymbolTable {
         for (int i = 0; i < intTypes.length; i++) {
             nilableIntTypes[i] = getNilableBType(intTypes[i]);
         }
-        
+
         for (BType intType : intTypes) {
             defineBinaryOperator(OperatorKind.MUL, nullableDecimal, intType, nullableDecimal);
             defineBinaryOperator(OperatorKind.MUL, intType, nullableDecimal, nullableDecimal);
@@ -752,7 +752,7 @@ public class SymbolTable {
             defineBinaryOperator(OperatorKind.MUL, nilableIntType, decimalType, nullableDecimal);
             defineBinaryOperator(OperatorKind.MUL, nilableIntType, nullableDecimal, nullableDecimal);
             defineBinaryOperator(OperatorKind.MUL, nullableDecimal, nilableIntType, nullableDecimal);
-            
+
             defineBinaryOperator(OperatorKind.DIV, floatType, nilableIntType, nullableFloat);
             defineBinaryOperator(OperatorKind.DIV, nullableFloat, nilableIntType, nullableFloat);
             defineBinaryOperator(OperatorKind.DIV, decimalType, nilableIntType, nullableDecimal);
@@ -764,7 +764,7 @@ public class SymbolTable {
             defineBinaryOperator(OperatorKind.MOD, nullableDecimal, nilableIntType, nullableDecimal);
         }
     }
-    
+
     private void defineNilableIntegerArithmeticOperations() {
         BType[] intTypes = {intType, byteType, signed32IntType, signed16IntType, signed8IntType, unsigned32IntType,
                 unsigned16IntType,
@@ -785,21 +785,6 @@ public class SymbolTable {
                 defineBinaryOperator(OperatorKind.DIV, lhs, rhs, intOptional);
                 defineBinaryOperator(OperatorKind.MUL, lhs, rhs, intOptional);
                 defineBinaryOperator(OperatorKind.MOD, lhs, rhs, intOptional);
-            }
-        }
-
-        for (BType lhs : intTypes) {
-            for (BUnionType rhs : nilableIntTypes) {
-                defineBinaryOperator(OperatorKind.ADD, lhs, rhs, intOptional);
-                defineBinaryOperator(OperatorKind.ADD, rhs, lhs, intOptional);
-                defineBinaryOperator(OperatorKind.SUB, lhs, rhs, intOptional);
-                defineBinaryOperator(OperatorKind.SUB, rhs, lhs, intOptional);
-                defineBinaryOperator(OperatorKind.DIV, lhs, rhs, intOptional);
-                defineBinaryOperator(OperatorKind.DIV, rhs, lhs, intOptional);
-                defineBinaryOperator(OperatorKind.MUL, lhs, rhs, intOptional);
-                defineBinaryOperator(OperatorKind.MUL, rhs, lhs, intOptional);
-                defineBinaryOperator(OperatorKind.MOD, lhs, rhs, intOptional);
-                defineBinaryOperator(OperatorKind.MOD, rhs, lhs, intOptional);
             }
         }
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/AddOperationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/AddOperationTest.java
@@ -181,6 +181,6 @@ public class AddOperationTest {
         BAssertUtil.validateError(resultNegative, 13, "operator '+' not defined for 'C' and 'float'", 64, 14);
         BAssertUtil.validateError(resultNegative, 14, "operator '+' not defined for 'C' and 'float'", 65, 14);
         BAssertUtil.validateError(resultNegative, 15, "incompatible types: expected 'string', found 'xml'", 72, 16);
-        BAssertUtil.validateError(resultNegative, 16, "incompatible types: expected 'FO', found 'string'", 73, 13);
+        BAssertUtil.validateError(resultNegative, 16, "incompatible types: expected 'FO', found 'string'", 73, 12);
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/AddOperationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/AddOperationTest.java
@@ -164,7 +164,7 @@ public class AddOperationTest {
 
     @Test(description = "Test binary statement with errors")
     public void testSubtractStmtNegativeCases() {
-        Assert.assertEquals(resultNegative.getErrorCount(), 15);
+        Assert.assertEquals(resultNegative.getErrorCount(), 17);
         BAssertUtil.validateError(resultNegative, 0, "operator '+' not defined for 'json' and 'json'", 8, 10);
         BAssertUtil.validateError(resultNegative, 1, "operator '+' not defined for 'int' and 'string'", 14, 9);
         BAssertUtil.validateError(resultNegative, 2, "operator '+' not defined for 'C' and 'string'", 28, 14);
@@ -180,5 +180,7 @@ public class AddOperationTest {
         BAssertUtil.validateError(resultNegative, 12, "operator '+' not defined for 'int' and 'float'", 60, 18);
         BAssertUtil.validateError(resultNegative, 13, "operator '+' not defined for 'C' and 'float'", 64, 14);
         BAssertUtil.validateError(resultNegative, 14, "operator '+' not defined for 'C' and 'float'", 65, 14);
+        BAssertUtil.validateError(resultNegative, 15, "incompatible types: expected 'string', found 'xml'", 72, 16);
+        BAssertUtil.validateError(resultNegative, 16, "incompatible types: expected 'FO', found 'string'", 73, 13);
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/AddOperationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/AddOperationTest.java
@@ -156,7 +156,9 @@ public class AddOperationTest {
                 "testAdditionWithTypes",
                 "testAddSingleton",
                 "testStringCharAddition",
-                "testStringXmlSubtypesAddition"
+                "testStringXmlSubtypesAddition",
+                "testStringSubtypesAddition",
+                "testXmlSubtypesAddition"
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/add-operation-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/add-operation-negative.bal
@@ -63,4 +63,18 @@ function testImplicitConversion() {
     float e = 12.25;
     var y1 = d + e;
     any y2 = d + e;
+
+    I i = "i";
+    O o = "o";
+    xml x = xml `<foo>foo</foo><?foo?>text1<!--comment-->`;
+    string y = "abc";
+
+    string z = x + y;
+    FO xx = i + o;
 }
+
+type FO "fo";
+
+type I "i";
+
+type O "o";

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/add-operation-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/add-operation-negative.bal
@@ -69,8 +69,8 @@ function testImplicitConversion() {
     xml x = xml `<foo>foo</foo><?foo?>text1<!--comment-->`;
     string y = "abc";
 
-    string z = x + y;
-    FO xx = i + o;
+    string _ = x + y;
+    FO _ = i + o;
 }
 
 type FO "fo";

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/add-operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/add-operation.bal
@@ -368,6 +368,9 @@ function testStringXmlSubtypesAddition() {
     string:Char c = "d";
     xml x1 = xml `efg`;
     xml:Text x2 = xml `text`;
+    string:Char|Strings b = "d";
+    Strings|Chars e = "bar";
+    bar d = "B";
 
     assertEquality(s + x2, xml `abctext`);
     assertEquality(x2 + s, xml `textabc`);
@@ -375,6 +378,12 @@ function testStringXmlSubtypesAddition() {
     assertEquality(x1 + c, xml `efgd`);
     assertEquality(c + x2, xml `dtext`);
     assertEquality(x2 + c, xml `textd`);
+    assertEquality(x2 + b, xml `textd`);
+    assertEquality(x2 + e, xml `textbar`);
+    assertEquality(x2 + d, xml `textB`);
+    assertEquality(x1 + b, xml `efgd`);
+    assertEquality(x1 + e, xml `efgbar`);
+    assertEquality(x1 + d, xml `efgB`);
 }
 
 type Chars "B"|"bar";
@@ -396,6 +405,7 @@ function testStringSubtypesAddition() {
     assertEquality(d + e, "Be");
     assertEquality(b + e + b, "ded");
 }
+
 type foo xml<'xml:Text>|xml<'xml:Comment> ;
 type foo2 xml<'xml:Element|'xml:ProcessingInstruction>;
 type foo3 foo|foo2;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/add-operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/add-operation.bal
@@ -369,8 +369,8 @@ function testStringXmlSubtypesAddition() {
     xml x1 = xml `efg`;
     xml:Text x2 = xml `text`;
     string:Char|Strings b = "d";
-    Strings|Chars e = "bar";
-    bar d = "B";
+    Strings|Baz e = "bar";
+    Bar d = "B";
 
     assertEquality(s + x2, xml `abctext`);
     assertEquality(x2 + s, xml `textabc`);
@@ -386,14 +386,14 @@ function testStringXmlSubtypesAddition() {
     assertEquality(x1 + d, xml `efgB`);
 }
 
-type Chars "B"|"bar";
-type bar Chars|string;
+type Baz "B"|"bar";
+type Bar Baz|string;
 
 function testStringSubtypesAddition() {
     string a = "abc";
     string:Char|Strings b = "d";
-    Strings|Chars c = "bar";
-    bar d = "B";
+    Strings|Baz c = "bar";
+    Bar d = "B";
     string:Char e = "e";
     assertEquality(a + c, "abcbar");
     assertEquality(a + b, "abcd");
@@ -406,15 +406,15 @@ function testStringSubtypesAddition() {
     assertEquality(b + e + b, "ded");
 }
 
-type foo xml<'xml:Text>|xml<'xml:Comment> ;
-type foo2 xml<'xml:Element|'xml:ProcessingInstruction>;
-type foo3 foo|foo2;
+type Foo xml<'xml:Text>|xml<'xml:Comment> ;
+type Foo2 xml<'xml:Element|'xml:ProcessingInstruction>;
+type Foo3 Foo|Foo2;
 
 function testXmlSubtypesAddition() {
     xml a = xml `<foo>foo</foo><?foo?>text1<!--comment-->`;
-    xml<'xml:Element>|foo b = xml `<foo>Anne</foo><fuu>Peter</fuu>`;
-    foo2 c = xml `<?foo?><?faa?>`;
-    foo3 d = xml `text1 text2`;
+    xml<'xml:Element>|Foo b = xml `<foo>Anne</foo><fuu>Peter</fuu>`;
+    Foo2 c = xml `<?foo?><?faa?>`;
+    Foo3 d = xml `text1 text2`;
     xml<'xml:Comment> e = xml `<!--comment1--><!--comment2-->`;
     xml<'xml:Text|'xml:Comment> f = xml `<!--comment-->`;
     xml<'xml:Text>|xml<'xml:Comment> g = xml `<!--comment-->`;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/add-operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/add-operation.bal
@@ -377,6 +377,56 @@ function testStringXmlSubtypesAddition() {
     assertEquality(x2 + c, xml `textd`);
 }
 
+type Chars "B"|"bar";
+type bar Chars|string;
+
+function testStringSubtypesAddition() {
+    string a = "abc";
+    string:Char|Strings b = "d";
+    Strings|Chars c = "bar";
+    bar d = "B";
+    string:Char e = "e";
+    assertEquality(a + c, "abcbar");
+    assertEquality(a + b, "abcd");
+    assertEquality(a + b + a, "abcdabc");
+    assertEquality(c + b, "bard");
+    assertEquality(a + e, "abce");
+    assertEquality(b + e, "de");
+    assertEquality(c + e, "bare");
+    assertEquality(d + e, "Be");
+    assertEquality(b + e + b, "ded");
+}
+type foo xml<'xml:Text>|xml<'xml:Comment> ;
+type foo2 xml<'xml:Element|'xml:ProcessingInstruction>;
+type foo3 foo|foo2;
+
+function testXmlSubtypesAddition() {
+    xml a = xml `<foo>foo</foo><?foo?>text1<!--comment-->`;
+    xml<'xml:Element>|foo b = xml `<foo>Anne</foo><fuu>Peter</fuu>`;
+    foo2 c = xml `<?foo?><?faa?>`;
+    foo3 d = xml `text1 text2`;
+    xml<'xml:Comment> e = xml `<!--comment1--><!--comment2-->`;
+    xml<'xml:Text|'xml:Comment> f = xml `<!--comment-->`;
+    xml<'xml:Text>|xml<'xml:Comment> g = xml `<!--comment-->`;
+    xml<'xml:Element|'xml:ProcessingInstruction> h = xml `<root> text1<foo>100</foo><foo>200</foo></root><?foo?>`;
+    xml<'xml:Element>|'xml:Text i = xml `<root> text1<foo>100</foo><foo>200</foo></root> text1`;
+
+    xml result1 = xml `<foo>foo</foo><?foo ?>text1<!--comment--><foo>Anne</foo><fuu>Peter</fuu>`;
+    xml result2 = xml `<foo>foo</foo><?foo ?>text1<!--comment--><?foo ?><?faa ?>`;
+    xml result3 = xml `<foo>foo</foo><?foo ?>text1<!--comment-->text1 text2`;
+    xml result4 = xml `<?foo ?><?faa ?><!--comment-->`;
+    xml result5 = xml `<?foo ?><?faa ?><root> text1<foo>100</foo><foo>200</foo></root><?foo ?>`;
+    xml result6 = xml `text1 text2<!--comment-->`;
+    xml result7 = xml `<!--comment--><root> text1<foo>100</foo><foo>200</foo></root><?foo ?>`;
+    assertEquality(a + b, result1);
+    assertEquality(a + c, result2);
+    assertEquality(a + d, result3);
+    assertEquality(c + g, result4);
+    assertEquality(c + h, result5);
+    assertEquality(d + f, result6);
+    assertEquality(g + h, result7);
+}
+
 function assertEquality(any actual, any expected) {
     if actual is anydata && expected is anydata && actual == expected {
         return;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/add-operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/add-operation.bal
@@ -395,14 +395,17 @@ function testStringSubtypesAddition() {
     Strings|Baz c = "bar";
     Bar d = "B";
     string:Char e = "e";
-    assertEquality(a + c, "abcbar");
-    assertEquality(a + b, "abcd");
+    string f = a + c;
+    string g = a + b;
+    string h = d + e;
+    assertEquality(f, "abcbar");
+    assertEquality(g, "abcd");
     assertEquality(a + b + a, "abcdabc");
     assertEquality(c + b, "bard");
     assertEquality(a + e, "abce");
     assertEquality(b + e, "de");
     assertEquality(c + e, "bare");
-    assertEquality(d + e, "Be");
+    assertEquality(h, "Be");
     assertEquality(b + e + b, "ded");
 }
 
@@ -420,7 +423,14 @@ function testXmlSubtypesAddition() {
     xml<'xml:Text>|xml<'xml:Comment> g = xml `<!--comment-->`;
     xml<'xml:Element|'xml:ProcessingInstruction> h = xml `<root> text1<foo>100</foo><foo>200</foo></root><?foo?>`;
     xml<'xml:Element>|'xml:Text i = xml `<root> text1<foo>100</foo><foo>200</foo></root> text1`;
-
+    xml j = a + b;
+    xml k = a + c;
+    xml l = a + d;
+    xml m = c + g;
+    xml n = c + h;
+    xml o = d + f;
+    xml p = g + h;
+    
     xml result1 = xml `<foo>foo</foo><?foo ?>text1<!--comment--><foo>Anne</foo><fuu>Peter</fuu>`;
     xml result2 = xml `<foo>foo</foo><?foo ?>text1<!--comment--><?foo ?><?faa ?>`;
     xml result3 = xml `<foo>foo</foo><?foo ?>text1<!--comment-->text1 text2`;
@@ -428,13 +438,13 @@ function testXmlSubtypesAddition() {
     xml result5 = xml `<?foo ?><?faa ?><root> text1<foo>100</foo><foo>200</foo></root><?foo ?>`;
     xml result6 = xml `text1 text2<!--comment-->`;
     xml result7 = xml `<!--comment--><root> text1<foo>100</foo><foo>200</foo></root><?foo ?>`;
-    assertEquality(a + b, result1);
-    assertEquality(a + c, result2);
-    assertEquality(a + d, result3);
-    assertEquality(c + g, result4);
-    assertEquality(c + h, result5);
-    assertEquality(d + f, result6);
-    assertEquality(g + h, result7);
+    assertEquality(j, result1);
+    assertEquality(k, result2);
+    assertEquality(l, result3);
+    assertEquality(m, result4);
+    assertEquality(n, result5);
+    assertEquality(o, result6);
+    assertEquality(p, result7);
 }
 
 function assertEquality(any actual, any expected) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/add-operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/add-operation.bal
@@ -371,6 +371,12 @@ function testStringXmlSubtypesAddition() {
     string:Char|Strings b = "d";
     Strings|Baz e = "bar";
     Bar d = "B";
+    xml l = x2 + b;
+    xml m = x2 + e;
+    xml n = x2 + d;
+    xml o = x1 + b;
+    xml p = x1 + e;
+    xml q = x1 + d;
 
     assertEquality(s + x2, xml `abctext`);
     assertEquality(x2 + s, xml `textabc`);
@@ -378,12 +384,12 @@ function testStringXmlSubtypesAddition() {
     assertEquality(x1 + c, xml `efgd`);
     assertEquality(c + x2, xml `dtext`);
     assertEquality(x2 + c, xml `textd`);
-    assertEquality(x2 + b, xml `textd`);
-    assertEquality(x2 + e, xml `textbar`);
-    assertEquality(x2 + d, xml `textB`);
-    assertEquality(x1 + b, xml `efgd`);
-    assertEquality(x1 + e, xml `efgbar`);
-    assertEquality(x1 + d, xml `efgB`);
+    assertEquality(l, xml `textd`);
+    assertEquality(m, xml `textbar`);
+    assertEquality(n, xml `textB`);
+    assertEquality(o, xml `efgd`);
+    assertEquality(p, xml `efgbar`);
+    assertEquality(q, xml `efgB`);
 }
 
 type Baz "B"|"bar";
@@ -398,15 +404,22 @@ function testStringSubtypesAddition() {
     string f = a + c;
     string g = a + b;
     string h = d + e;
+    string i = a + b + a;
+    string j = c + b;
+    string k = a + e;
+    string l = b + e;
+    string m = c + e;
+    string n = b + e + b;
+
     assertEquality(f, "abcbar");
     assertEquality(g, "abcd");
-    assertEquality(a + b + a, "abcdabc");
-    assertEquality(c + b, "bard");
-    assertEquality(a + e, "abce");
-    assertEquality(b + e, "de");
-    assertEquality(c + e, "bare");
+    assertEquality(i, "abcdabc");
+    assertEquality(j, "bard");
+    assertEquality(k, "abce");
+    assertEquality(l, "de");
+    assertEquality(m, "bare");
     assertEquality(h, "Be");
-    assertEquality(b + e + b, "ded");
+    assertEquality(n, "ded");
 }
 
 type Foo xml<'xml:Text>|xml<'xml:Comment> ;


### PR DESCRIPTION
## Purpose
> $title.

Fixes #33059

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
