### PR TITLE
Deprecate the connect method in Extended Language Server Service

### DIFF
--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/service/spi/ExtendedLanguageServerService.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/service/spi/ExtendedLanguageServerService.java
@@ -73,7 +73,9 @@ public interface ExtendedLanguageServerService extends JsonRpcMethodProvider {
      * Callback when client connected.
      *
      * @param client {@link ExtendedLanguageClient}
+     * @deprecated use {@link #init(LanguageServer, WorkspaceManager)}} instead.
      */
+    @Deprecated(forRemoval = true)
     default void connect(ExtendedLanguageClient client) {
     }
 

--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/service/spi/ExtendedLanguageServerService.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/service/spi/ExtendedLanguageServerService.java
@@ -73,7 +73,7 @@ public interface ExtendedLanguageServerService extends JsonRpcMethodProvider {
      * Callback when client connected.
      *
      * @param client {@link ExtendedLanguageClient}
-     * @deprecated use {@link #init(LanguageServer, WorkspaceManager)}} instead.
+     * @deprecated use {@link LanguageServerContext} to obtain the {@link ExtendedLanguageClient} instead.
      */
     @Deprecated(forRemoval = true)
     default void connect(ExtendedLanguageClient client) {


### PR DESCRIPTION
## Purpose
$subject to avoid incorrect further usage of connect method. The users of the interface should use the` init()` method instead. 

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
