### PR TITLE
Fix invalid type cast code action suggestion

### DIFF
--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/TypeCastTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/TypeCastTest.java
@@ -79,6 +79,7 @@ public class TypeCastTest extends AbstractCodeActionTest {
                 {"typeCastNegative2.json", "typeCast.bal"},
                 {"typeCastNegative3.json", "typeCast.bal"},
                 {"typeCastNegative4.json", "typeCast.bal"},
+                {"typeCastNegative5.json", "typeCast.bal"},
         };
     }
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/type-cast/config/typeCastNegative5.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/type-cast/config/typeCastNegative5.json
@@ -1,0 +1,9 @@
+{
+  "line": 136,
+  "character": 13,
+  "expected": [
+    {
+      "title": "Add type cast to assignment"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/type-cast/source/typeCast.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/type-cast/source/typeCast.bal
@@ -130,3 +130,9 @@ function testFuture() {
     future<string> a1 = a0;
 }
 
+type MyUnion any|error;
+
+public function testUnionOfError() {
+    MyUnion var1 = 3;
+    int e = var1;
+}


### PR DESCRIPTION
## Purpose
$subject

Fixes #35804

## Approach
Consider the raw type when there is a type reference.
```java
        if ("BCE2068".equals(diagnostic.diagnosticInfo().code())) {
            optionalActualTypeSymbol = positionDetails.diagnosticProperty(CodeActionUtil
                    .getDiagPropertyFilterFunction(DiagBasedPositionDetails
                            .DIAG_PROP_INCOMPATIBLE_TYPES_FOUND_SYMBOL_INDEX));
        } else {
            optionalActualTypeSymbol = positionDetails.diagnosticProperty(
                    DiagBasedPositionDetails.DIAG_PROP_INCOMPATIBLE_TYPES_FOUND_SYMBOL_INDEX);
        }

        Optional<TypeSymbol> optionalExpectedTypeSymbol = positionDetails.diagnosticProperty(
                DiagBasedPositionDetails.DIAG_PROP_INCOMPATIBLE_TYPES_EXPECTED_SYMBOL_INDEX);
        if (optionalExpectedTypeSymbol.isEmpty() || optionalActualTypeSymbol.isEmpty()) {
            return Collections.emptyList();
        }

        TypeSymbol actualTypeSymbol = CommonUtil.getRawType(optionalActualTypeSymbol.get()
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
