### PR TITLE
Fix short-circuiting on operand evaluation in nil-lifted operations

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -6966,10 +6966,13 @@ public class Desugar extends BLangNodeVisitor {
          * int? z = x + y;
          * Above is desugared to
          * int? $result$;
-         * if (x is () or y is ()) {
+         * // Evaluate both operands to avoid short-circuiting.
+         * int? $lhsExprVar$ = x;
+         * int? $rhsExprVar$ = y;
+         * if (lhsVar is () or rhsVar is ()) {
          *    $result$ = ();
          * } else {
-         *    $result$ = x + y;
+         *    $result$ = $lhsExprVar$ + $rhsExprVar$;
          * }
          * int z = $result$;
          */
@@ -7010,12 +7013,20 @@ public class Desugar extends BLangNodeVisitor {
         BLangSimpleVarRef tempVarRef = ASTBuilderUtil.createVariableRef(binaryExpr.pos, tempVarDef.var.symbol);
         blockStmt.addStatement(tempVarDef);
 
-        BLangTypeTestExpr typeTestExprOne = createTypeCheckExpr(binaryExpr.pos, binaryExpr.lhsExpr,
-                getNillTypeNode());
+        BLangSimpleVariableDef lhsVarDef = createVarDef("$lhsExprVar$", binaryExpr.lhsExpr.getBType(),
+                binaryExpr.lhsExpr, binaryExpr.pos);
+        BLangSimpleVarRef lhsVarRef = ASTBuilderUtil.createVariableRef(binaryExpr.pos, lhsVarDef.var.symbol);
+        blockStmt.addStatement(lhsVarDef);
+
+        BLangSimpleVariableDef rhsVarDef = createVarDef("$rhsExprVar$", binaryExpr.rhsExpr.getBType(),
+                binaryExpr.rhsExpr, binaryExpr.pos);
+        BLangSimpleVarRef rhsVarRef = ASTBuilderUtil.createVariableRef(binaryExpr.pos, rhsVarDef.var.symbol);
+        blockStmt.addStatement(rhsVarDef);
+
+        BLangTypeTestExpr typeTestExprOne = createTypeCheckExpr(binaryExpr.pos, lhsVarRef, getNillTypeNode());
         typeTestExprOne.setBType(symTable.booleanType);
 
-        BLangTypeTestExpr typeTestExprTwo = createTypeCheckExpr(binaryExpr.pos,
-                binaryExpr.rhsExpr, getNillTypeNode());
+        BLangTypeTestExpr typeTestExprTwo = createTypeCheckExpr(binaryExpr.pos, rhsVarRef, getNillTypeNode());
         typeTestExprTwo.setBType(symTable.booleanType);
 
         BLangBinaryExpr ifBlockCondition = ASTBuilderUtil.createBinaryExpr(binaryExpr.pos, typeTestExprOne,
@@ -7030,10 +7041,10 @@ public class Desugar extends BLangNodeVisitor {
         BLangAssignment bLangAssignmentElse = ASTBuilderUtil.createAssignmentStmt(binaryExpr.pos, elseBody);
         bLangAssignmentElse.varRef = tempVarRef;
 
-        BLangBinaryExpr newBinaryExpr = ASTBuilderUtil.createBinaryExpr(binaryExpr.pos, binaryExpr.lhsExpr,
-                binaryExpr.rhsExpr, nonNilType, binaryExpr.opKind, binaryExpr.opSymbol);
-        newBinaryExpr.lhsExpr = createTypeCastExpr(newBinaryExpr.lhsExpr, lhsType);
-        newBinaryExpr.rhsExpr = createTypeCastExpr(newBinaryExpr.rhsExpr, rhsType);
+        BLangBinaryExpr newBinaryExpr = ASTBuilderUtil.createBinaryExpr(binaryExpr.pos, lhsVarRef, rhsVarRef,
+                nonNilType, binaryExpr.opKind, binaryExpr.opSymbol);
+        newBinaryExpr.lhsExpr = createTypeCastExpr(lhsVarRef, lhsType);
+        newBinaryExpr.rhsExpr = createTypeCastExpr(rhsVarRef, rhsType);
         bLangAssignmentElse.expr = newBinaryExpr;
 
         BLangIf ifStatement = ASTBuilderUtil.createIfStmt(binaryExpr.pos, blockStmt);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/AddOperationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/AddOperationTest.java
@@ -162,6 +162,19 @@ public class AddOperationTest {
         };
     }
 
+    @Test(dataProvider = "dataToTestShortCircuitingInAddition")
+    public void testShortCircuitingInAddition(String functionName) {
+        BRunUtil.invoke(result, functionName);
+    }
+
+    @DataProvider
+    public Object[] dataToTestShortCircuitingInAddition() {
+        return new Object[]{
+                "testNoShortCircuitingInAdditionWithNullable",
+                "testNoShortCircuitingInAdditionWithNonNullable"
+        };
+    }
+
     @Test(description = "Test binary statement with errors")
     public void testSubtractStmtNegativeCases() {
         Assert.assertEquals(resultNegative.getErrorCount(), 17);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/BinaryBitwiseOperationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/BinaryBitwiseOperationTest.java
@@ -69,6 +69,23 @@ public class BinaryBitwiseOperationTest {
         BRunUtil.invoke(result, "testBinaryBitwiseXOROperationForUserDefinedTypes");
     }
 
+    @Test(dataProvider = "dataToTestShortCircuitingInBinaryBitwiseOp")
+    public void testShortCircuitingInBinaryBitwiseOp(String functionName) {
+        BRunUtil.invoke(result, functionName);
+    }
+
+    @DataProvider
+    public Object[] dataToTestShortCircuitingInBinaryBitwiseOp() {
+        return new Object[]{
+                "testNoShortCircuitingInBitwiseAndWithNullable",
+                "testNoShortCircuitingInBitwiseAndWithNonNullable",
+                "testNoShortCircuitingInBitwiseOrWithNullable",
+                "testNoShortCircuitingInBitwiseOrWithNonNullable",
+                "testNoShortCircuitingInBitwiseXorWithNullable",
+                "testNoShortCircuitingInBitwiseXorWithNonNullable"
+        };
+    }
+
     @Test(description = "Test binary bitwise operations negative scenarios")
     public void testBinaryBitwiseOperationsNegativeScenarios() {
         Assert.assertEquals(negativeResult.getErrorCount(), 21);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/BitwiseShiftOperationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/BitwiseShiftOperationTest.java
@@ -22,6 +22,7 @@ import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 /**
@@ -57,6 +58,23 @@ public class BitwiseShiftOperationTest {
     @Test(description = "Test bitwise operations for nullable values")
     public void testBitWiseOperationsForNullable() {
         BRunUtil.invoke(result, "testBitwiseUnsignedRightShiftOp");
+    }
+
+    @Test(dataProvider = "dataToTestShortCircuitingInBitwiseShiftOp")
+    public void testShortCircuitingInBitwiseShiftOp(String functionName) {
+        BRunUtil.invoke(result, functionName);
+    }
+
+    @DataProvider
+    public Object[] dataToTestShortCircuitingInBitwiseShiftOp() {
+        return new Object[]{
+                "testNoShortCircuitingInBitwiseLeftShiftWithNullable",
+                "testNoShortCircuitingInBitwiseLeftShiftWithNonNullable",
+                "testNoShortCircuitingInBitwiseSignedRightShiftWithNullable",
+                "testNoShortCircuitingInBitwiseSignedRightShiftWithNonNullable",
+                "testNoShortCircuitingInBitwiseUnsignedRightShiftWithNullable",
+                "testNoShortCircuitingInBitwiseUnsignedRightShiftWithNonNullable"
+        };
     }
 
     @Test(description = "Test bitwise shift operation negative scenarios")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/DivisionOperationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/DivisionOperationTest.java
@@ -168,4 +168,17 @@ public class DivisionOperationTest {
                 "testResultTypeOfDivisionDecimalIntForNilableOperandsByInfering",
         };
     }
+
+    @Test(dataProvider = "dataToTestShortCircuitingInDivision")
+    public void testShortCircuitingInDivision(String functionName) {
+        BRunUtil.invoke(result, functionName);
+    }
+
+    @DataProvider
+    public Object[] dataToTestShortCircuitingInDivision() {
+        return new Object[]{
+                "testNoShortCircuitingInDivisionWithNullable",
+                "testNoShortCircuitingInDivisionWithNonNullable"
+        };
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/ModOperationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/ModOperationTest.java
@@ -159,4 +159,17 @@ public class ModOperationTest {
                 "testResultTypeOfModDecimalIntForNilableOperandsByInfering",
         };
     }
+
+    @Test(dataProvider = "dataToTestShortCircuitingInMod")
+    public void testShortCircuitingInMod(String functionName) {
+        BRunUtil.invoke(result, functionName);
+    }
+
+    @DataProvider
+    public Object[] dataToTestShortCircuitingInMod() {
+        return new Object[]{
+                "testNoShortCircuitingInModWithNullable",
+                "testNoShortCircuitingInModWithNonNullable"
+        };
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/MultiplyOperationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/MultiplyOperationTest.java
@@ -144,4 +144,17 @@ public class MultiplyOperationTest {
                 "testResultTypeOfMultiplyDecimalIntForNilableOperandsByInfering",
         };
     }
+
+    @Test(dataProvider = "dataToTestShortCircuitingInMultiplication")
+    public void testShortCircuitingInMultiplication(String functionName) {
+        BRunUtil.invoke(result, functionName);
+    }
+
+    @DataProvider
+    public Object[] dataToTestShortCircuitingInMultiplication() {
+        return new Object[]{
+                "testNoShortCircuitingInMultiplicationWithNullable",
+                "testNoShortCircuitingInMultiplicationWithNonNullable"
+        };
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/SubtractOperationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/SubtractOperationTest.java
@@ -101,6 +101,19 @@ public class SubtractOperationTest {
         BRunUtil.invoke(result, "testContextuallyExpectedTypeOfNumericLiteralInSubtract");
     }
 
+    @Test(dataProvider = "dataToTestShortCircuitingInSubtraction")
+    public void testShortCircuitingInSubtraction(String functionName) {
+        BRunUtil.invoke(result, functionName);
+    }
+
+    @DataProvider
+    public Object[] dataToTestShortCircuitingInSubtraction() {
+        return new Object[]{
+                "testNoShortCircuitingInSubtractionWithNullable",
+                "testNoShortCircuitingInSubtractionWithNonNullable"
+        };
+    }
+
     @Test(description = "Test subtract statement with errors")
     public void testSubtractStmtNegativeCases() {
         Assert.assertEquals(resultNegative.getErrorCount(), 12);

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/add-operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/add-operation.bal
@@ -460,6 +460,75 @@ function testXmlSubtypesAddition() {
     assertEquality(p, result7);
 }
 
+int intVal = 10;
+
+function testNoShortCircuitingInAdditionWithNullable() {
+    int? result = foo() + bar();
+    assertEquality(result, ());
+    assertEquality(intVal, 18);
+
+    result = foo() + 12;
+    assertEquality(result, ());
+    assertEquality(intVal, 20);
+
+    result = 12 + bar();
+    assertEquality(result, ());
+    assertEquality(intVal, 26);
+
+    int? x = 12;
+    result = foo() + x;
+    assertEquality(result, ());
+    assertEquality(intVal, 28);
+
+    result = x + bar();
+    assertEquality(result, ());
+    assertEquality(intVal, 34);
+
+    result = x + bam();
+    assertEquality(result, 17);
+    assertEquality(intVal, 44);
+
+    result = bam() + x;
+    assertEquality(result, 17);
+    assertEquality(intVal, 54);
+
+    result = foo() + bam();
+    assertEquality(result, ());
+    assertEquality(intVal, 66);
+
+    result = bam() + bar();
+    assertEquality(result, ());
+    assertEquality(intVal, 82);
+}
+
+function testNoShortCircuitingInAdditionWithNonNullable() {
+    intVal = 10;
+    int x = 10;
+
+    int result = x + bam();
+    assertEquality(result, 15);
+    assertEquality(intVal, 20);
+
+    result = bam() + 12;
+    assertEquality(result, 17);
+    assertEquality(intVal, 30);
+}
+
+function foo() returns int? {
+    intVal += 2;
+    return ();
+}
+
+function bar() returns int? {
+    intVal += 6;
+    return ();
+}
+
+function bam() returns int {
+    intVal += 10;
+    return 5;
+}
+
 function assertEquality(any actual, any expected) {
     if actual is anydata && expected is anydata && actual == expected {
         return;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/binary_bitwise_operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/binary_bitwise_operation.bal
@@ -398,6 +398,183 @@ function testBinaryBitwiseXOROperationForUserDefinedTypes() {
     assertEqual(f ^ g, -1);
 }
 
+int intVal = 10;
+
+function testNoShortCircuitingInBitwiseAndWithNullable() {
+    int? result = foo() & bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 18);
+
+    result = foo() & 12;
+    assertEqual(result, ());
+    assertEqual(intVal, 20);
+
+    result = 12 & bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 26);
+
+    int? x = 12;
+    result = foo() & x;
+    assertEqual(result, ());
+    assertEqual(intVal, 28);
+
+    result = x & bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 34);
+
+    result = x & bam();
+    assertEqual(result, 4);
+    assertEqual(intVal, 44);
+
+    result = bam() & x;
+    assertEqual(result, 4);
+    assertEqual(intVal, 54);
+
+    result = foo() & bam();
+    assertEqual(result, ());
+    assertEqual(intVal, 66);
+
+    result = bam() & bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 82);
+}
+
+function testNoShortCircuitingInBitwiseAndWithNonNullable() {
+    intVal = 10;
+    int x = 10;
+
+    int result = x & bam();
+    assertEqual(result, 0);
+    assertEqual(intVal, 20);
+
+    result = bam() & 12;
+    assertEqual(result, 4);
+    assertEqual(intVal, 30);
+}
+
+function testNoShortCircuitingInBitwiseOrWithNullable() {
+    intVal = 10;
+
+    int? result = foo() | bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 18);
+
+    result = foo() | 12;
+    assertEqual(result, ());
+    assertEqual(intVal, 20);
+
+    result = 12 | bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 26);
+
+    int? x = 12;
+    result = foo() | x;
+    assertEqual(result, ());
+    assertEqual(intVal, 28);
+
+    result = x | bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 34);
+
+    result = x | bam();
+    assertEqual(result, 13);
+    assertEqual(intVal, 44);
+
+    result = bam() | x;
+    assertEqual(result, 13);
+    assertEqual(intVal, 54);
+
+    result = foo() | bam();
+    assertEqual(result, ());
+    assertEqual(intVal, 66);
+
+    result = bam() | bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 82);
+}
+
+function testNoShortCircuitingInBitwiseOrWithNonNullable() {
+    intVal = 10;
+    int x = 10;
+
+    int result = x | bam();
+    assertEqual(result, 15);
+    assertEqual(intVal, 20);
+
+    result = bam() | 12;
+    assertEqual(result, 13);
+    assertEqual(intVal, 30);
+}
+
+function testNoShortCircuitingInBitwiseXorWithNullable() {
+    intVal = 10;
+
+    int? result = foo() ^ bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 18);
+
+    result = foo() ^ 12;
+    assertEqual(result, ());
+    assertEqual(intVal, 20);
+
+    result = 12 ^ bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 26);
+
+    int? x = 12;
+    result = foo() ^ x;
+    assertEqual(result, ());
+    assertEqual(intVal, 28);
+
+    result = x ^ bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 34);
+
+    result = x ^ bam();
+    assertEqual(result, 9);
+    assertEqual(intVal, 44);
+
+    result = bam() ^ x;
+    assertEqual(result, 9);
+    assertEqual(intVal, 54);
+
+    result = foo() ^ bam();
+    assertEqual(result, ());
+    assertEqual(intVal, 66);
+
+    result = bam() ^ bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 82);
+}
+
+function testNoShortCircuitingInBitwiseXorWithNonNullable() {
+    intVal = 10;
+    int x = 10;
+
+    int result = x ^ bam();
+    assertEqual(result, 15);
+    assertEqual(intVal, 20);
+
+    result = bam() ^ 12;
+    assertEqual(result, 9);
+    assertEqual(intVal, 30);
+}
+
+function foo() returns int? {
+    intVal += 2;
+    return ();
+}
+
+function bar() returns int? {
+    intVal += 6;
+    return ();
+}
+
+function bam() returns int {
+    intVal += 10;
+    return 5;
+}
+
 function assertEqual(anydata actual, anydata expected) {
     if actual == expected {
         return;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/bitwise_shift_operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/bitwise_shift_operation.bal
@@ -207,6 +207,183 @@ function testBitWiseOperationsForNullable() {
     assertEqual(11 << b, 1408);
 }
 
+int intVal = 10;
+
+function testNoShortCircuitingInBitwiseLeftShiftWithNullable() {
+    int? result = foo() << bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 18);
+
+    result = foo() << 12;
+    assertEqual(result, ());
+    assertEqual(intVal, 20);
+
+    result = 12 << bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 26);
+
+    int? x = 12;
+    result = foo() << x;
+    assertEqual(result, ());
+    assertEqual(intVal, 28);
+
+    result = x << bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 34);
+
+    result = x << bam();
+    assertEqual(result, 384);
+    assertEqual(intVal, 44);
+
+    result = bam() << x;
+    assertEqual(result, 20480);
+    assertEqual(intVal, 54);
+
+    result = foo() << bam();
+    assertEqual(result, ());
+    assertEqual(intVal, 66);
+
+    result = bam() << bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 82);
+}
+
+function testNoShortCircuitingInBitwiseLeftShiftWithNonNullable() {
+    intVal = 10;
+    int x = 10;
+
+    int result = x << bam();
+    assertEqual(result, 320);
+    assertEqual(intVal, 20);
+
+    result = bam() << 12;
+    assertEqual(result, 20480);
+    assertEqual(intVal, 30);
+}
+
+function testNoShortCircuitingInBitwiseSignedRightShiftWithNullable() {
+    intVal = 10;
+
+    int? result = foo() >> bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 18);
+
+    result = foo() >> 12;
+    assertEqual(result, ());
+    assertEqual(intVal, 20);
+
+    result = 12 >> bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 26);
+
+    int? x = 12;
+    result = foo() >> x;
+    assertEqual(result, ());
+    assertEqual(intVal, 28);
+
+    result = x >> bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 34);
+
+    result = x >> bam();
+    assertEqual(result, 0);
+    assertEqual(intVal, 44);
+
+    result = bam() >> x;
+    assertEqual(result, 0);
+    assertEqual(intVal, 54);
+
+    result = foo() >> bam();
+    assertEqual(result, ());
+    assertEqual(intVal, 66);
+
+    result = bam() >> bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 82);
+}
+
+function testNoShortCircuitingInBitwiseSignedRightShiftWithNonNullable() {
+    intVal = 10;
+    int x = 10;
+
+    int result = x >> bam();
+    assertEqual(result, 0);
+    assertEqual(intVal, 20);
+
+    result = bam() >> 12;
+    assertEqual(result, 0);
+    assertEqual(intVal, 30);
+}
+
+function testNoShortCircuitingInBitwiseUnsignedRightShiftWithNullable() {
+    intVal = 10;
+
+    int? result = foo() >>> bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 18);
+
+    result = foo() >>> 12;
+    assertEqual(result, ());
+    assertEqual(intVal, 20);
+
+    result = 12 >>> bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 26);
+
+    int? x = 12;
+    result = foo() >>> x;
+    assertEqual(result, ());
+    assertEqual(intVal, 28);
+
+    result = x >>> bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 34);
+
+    result = x >>> bam();
+    assertEqual(result, 0);
+    assertEqual(intVal, 44);
+
+    result = bam() >>> x;
+    assertEqual(result, 0);
+    assertEqual(intVal, 54);
+
+    result = foo() >>> bam();
+    assertEqual(result, ());
+    assertEqual(intVal, 66);
+
+    result = bam() >>> bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 82);
+}
+
+function testNoShortCircuitingInBitwiseUnsignedRightShiftWithNonNullable() {
+    intVal = 10;
+    int x = 10;
+
+    int result = x >>> bam();
+    assertEqual(result, 0);
+    assertEqual(intVal, 20);
+
+    result = bam() >>> 12;
+    assertEqual(result, 0);
+    assertEqual(intVal, 30);
+}
+
+function foo() returns int? {
+    intVal += 2;
+    return ();
+}
+
+function bar() returns int? {
+    intVal += 6;
+    return ();
+}
+
+function bam() returns int {
+    intVal += 10;
+    return 5;
+}
+
 function assertEqual(any actual, any expected) {
     if actual is anydata && expected is anydata && actual == expected {
         return;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/division-operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/division-operation.bal
@@ -775,6 +775,75 @@ function testResultTypeOfDivisionDecimalIntForNilableOperandsByInfering() {
     assertEqual(var7, 4.1d);
 }
 
+int intVal = 10;
+
+function testNoShortCircuitingInDivisionWithNullable() {
+    int? result = foo() / bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 18);
+
+    result = foo() / 12;
+    assertEqual(result, ());
+    assertEqual(intVal, 20);
+
+    result = 12 / bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 26);
+
+    int? x = 20;
+    result = foo() / x;
+    assertEqual(result, ());
+    assertEqual(intVal, 28);
+
+    result = x / bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 34);
+
+    result = x / bam();
+    assertEqual(result, 4);
+    assertEqual(intVal, 44);
+
+    result = bam() / x;
+    assertEqual(result, 0);
+    assertEqual(intVal, 54);
+
+    result = foo() / bam();
+    assertEqual(result, ());
+    assertEqual(intVal, 66);
+
+    result = bam() / bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 82);
+}
+
+function testNoShortCircuitingInDivisionWithNonNullable() {
+    intVal = 10;
+    int x = 10;
+
+    int result = x / bam();
+    assertEqual(result, 2);
+    assertEqual(intVal, 20);
+
+    result = bam() / 2;
+    assertEqual(result, 2);
+    assertEqual(intVal, 30);
+}
+
+function foo() returns int? {
+    intVal += 2;
+    return ();
+}
+
+function bar() returns int? {
+    intVal += 6;
+    return ();
+}
+
+function bam() returns int {
+    intVal += 10;
+    return 5;
+}
+
 function assertEqual(any actual, any expected) {
     if actual is anydata && expected is anydata && actual == expected {
         return;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/mod-operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/mod-operation.bal
@@ -620,6 +620,75 @@ function testResultTypeOfModDecimalIntForNilableOperandsByInfering() {
     assertEqual(var7, 0.5d);
 }
 
+int intVal = 10;
+
+function testNoShortCircuitingInModWithNullable() {
+    int? result = foo() % bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 18);
+
+    result = foo() % 12;
+    assertEqual(result, ());
+    assertEqual(intVal, 20);
+
+    result = 12 % bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 26);
+
+    int? x = 12;
+    result = foo() % x;
+    assertEqual(result, ());
+    assertEqual(intVal, 28);
+
+    result = x % bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 34);
+
+    result = x % bam();
+    assertEqual(result, 2);
+    assertEqual(intVal, 44);
+
+    result = bam() % x;
+    assertEqual(result, 5);
+    assertEqual(intVal, 54);
+
+    result = foo() % bam();
+    assertEqual(result, ());
+    assertEqual(intVal, 66);
+
+    result = bam() % bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 82);
+}
+
+function testNoShortCircuitingInModWithNonNullable() {
+    intVal = 10;
+    int x = 10;
+
+    int result = x % bam();
+    assertEqual(result, 0);
+    assertEqual(intVal, 20);
+
+    result = bam() % 12;
+    assertEqual(result, 5);
+    assertEqual(intVal, 30);
+}
+
+function foo() returns int? {
+    intVal += 2;
+    return ();
+}
+
+function bar() returns int? {
+    intVal += 6;
+    return ();
+}
+
+function bam() returns int {
+    intVal += 10;
+    return 5;
+}
+
 function assertEqual(any actual, any expected) {
     if actual is anydata && expected is anydata && actual == expected {
         return;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/multiply-operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/multiply-operation.bal
@@ -957,6 +957,75 @@ function testResultTypeOfMultiplyDecimalIntForNilableOperandsByInfering() {
     assertEqual(var6, 61.50d);
 }
 
+int intVal = 10;
+
+function testNoShortCircuitingInMultiplicationWithNullable() {
+    int? result = foo() * bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 18);
+
+    result = foo() * 12;
+    assertEqual(result, ());
+    assertEqual(intVal, 20);
+
+    result = 12 * bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 26);
+
+    int? x = 12;
+    result = foo() * x;
+    assertEqual(result, ());
+    assertEqual(intVal, 28);
+
+    result = x * bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 34);
+
+    result = x * bam();
+    assertEqual(result, 60);
+    assertEqual(intVal, 44);
+
+    result = bam() * x;
+    assertEqual(result, 60);
+    assertEqual(intVal, 54);
+
+    result = foo() * bam();
+    assertEqual(result, ());
+    assertEqual(intVal, 66);
+
+    result = bam() * bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 82);
+}
+
+function testNoShortCircuitingInMultiplicationWithNonNullable() {
+    intVal = 10;
+    int x = 10;
+
+    int result = x * bam();
+    assertEqual(result, 50);
+    assertEqual(intVal, 20);
+
+    result = bam() * 12;
+    assertEqual(result, 60);
+    assertEqual(intVal, 30);
+}
+
+function foo() returns int? {
+    intVal += 2;
+    return ();
+}
+
+function bar() returns int? {
+    intVal += 6;
+    return ();
+}
+
+function bam() returns int {
+    intVal += 10;
+    return 5;
+}
+
 function assertEqual(any actual, any expected) {
     if actual is anydata && expected is anydata && actual == expected {
         return;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/subtract-operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/subtract-operation.bal
@@ -284,6 +284,75 @@ function testContextuallyExpectedTypeOfNumericLiteralInSubtract() {
     assertEqual(a6, 15.0d);
 }
 
+int intVal = 10;
+
+function testNoShortCircuitingInSubtractionWithNullable() {
+    int? result = foo() - bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 18);
+
+    result = foo() - 12;
+    assertEqual(result, ());
+    assertEqual(intVal, 20);
+
+    result = 12 - bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 26);
+
+    int? x = 12;
+    result = foo() - x;
+    assertEqual(result, ());
+    assertEqual(intVal, 28);
+
+    result = x - bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 34);
+
+    result = x - bam();
+    assertEqual(result, 7);
+    assertEqual(intVal, 44);
+
+    result = bam() - x;
+    assertEqual(result, -7);
+    assertEqual(intVal, 54);
+
+    result = foo() - bam();
+    assertEqual(result, ());
+    assertEqual(intVal, 66);
+
+    result = bam() - bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 82);
+}
+
+function testNoShortCircuitingInSubtractionWithNonNullable() {
+    intVal = 10;
+    int x = 10;
+
+    int result = x - bam();
+    assertEqual(result, 5);
+    assertEqual(intVal, 20);
+
+    result = bam() - 12;
+    assertEqual(result, -7);
+    assertEqual(intVal, 30);
+}
+
+function foo() returns int? {
+    intVal += 2;
+    return ();
+}
+
+function bar() returns int? {
+    intVal += 6;
+    return ();
+}
+
+function bam() returns int {
+    intVal += 10;
+    return 5;
+}
+
 function assertEqual(any actual, any expected) {
     if actual is anydata && expected is anydata && actual == expected {
         return;


### PR DESCRIPTION
## Purpose
$title

Fixes #34441

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
