### PR TITLE
Allow skipping tests with certain labels in spec conformance test runner

### DIFF
--- a/tests/ballerina-spec-conformance-tests/src/test/java/org/ballerinalang/test/TestRunner.java
+++ b/tests/ballerina-spec-conformance-tests/src/test/java/org/ballerinalang/test/TestRunner.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -55,15 +56,16 @@ public class TestRunner {
     private final Path path = TEST_DIR.resolve("src").resolve("test").resolve("resources")
                                      .resolve("ballerina-spec-tests").resolve("conformance");
     private static final Set<String> predefinedLabels = TestRunnerUtils.readLabels(TEST_DIR.toString()).keySet();
+    private static final HashSet<String> skippedTestLabels = new HashSet<>(Arrays.asList("transactional-expr"));
 
     @Test(dataProvider = "spec-conformance-tests-file-provider")
     public void test(String kind, String path, List<String> outputValues, List<Integer> lineNumbers, String fileName,
-                     int absLineNum, boolean isSkippedTest, String diagnostics, ITestContext context,
-                     boolean isKnownIssue, String labels, HashSet<String> skippedTestLabels) {
+                     int absLineNum, String diagnostics, ITestContext context, boolean isKnownIssue,
+                     String[] testCaseLabels) {
         setDetailsOfTest(context, kind, fileName, absLineNum, diagnostics);
-        handleTestSkip(isSkippedTest);
         validateTestFormat(diagnostics);
-        validateLabels(labels, predefinedLabels, absLineNum, skippedTestLabels);
+        validateLabels(testCaseLabels, predefinedLabels, absLineNum);
+        handleTestSkip(testCaseLabels, skippedTestLabels);
         validateTestOutput(path, kind, outputValues, isKnownIssue, lineNumbers, fileName, absLineNum, context);
     }
 

--- a/tests/ballerina-spec-conformance-tests/src/test/java/org/ballerinalang/test/TestRunner.java
+++ b/tests/ballerina-spec-conformance-tests/src/test/java/org/ballerinalang/test/TestRunner.java
@@ -59,11 +59,11 @@ public class TestRunner {
     @Test(dataProvider = "spec-conformance-tests-file-provider")
     public void test(String kind, String path, List<String> outputValues, List<Integer> lineNumbers, String fileName,
                      int absLineNum, boolean isSkippedTest, String diagnostics, ITestContext context,
-                     boolean isKnownIssue, String labels) {
+                     boolean isKnownIssue, String labels, List<String> skippedTestLabels) {
         setDetailsOfTest(context, kind, fileName, absLineNum, diagnostics);
         handleTestSkip(isSkippedTest);
         validateTestFormat(diagnostics);
-        validateLabels(labels, predefinedLabels, absLineNum);
+        validateLabels(labels, predefinedLabels, absLineNum, skippedTestLabels);
         validateTestOutput(path, kind, outputValues, isKnownIssue, lineNumbers, fileName, absLineNum, context);
     }
 

--- a/tests/ballerina-spec-conformance-tests/src/test/java/org/ballerinalang/test/TestRunner.java
+++ b/tests/ballerina-spec-conformance-tests/src/test/java/org/ballerinalang/test/TestRunner.java
@@ -78,8 +78,8 @@ public class TestRunner {
         generateReport();
     }
 
-    private static HashSet<String> getSkippedTestLabels() {
-        HashSet<String> hashSet = new HashSet<>();
+    private static Set<String> getSkippedTestLabels() {
+        Set<String> hashSet = new HashSet<>();
         hashSet.add("transactional-expr"); // issue #35939
         // New entries go here.
         return hashSet;

--- a/tests/ballerina-spec-conformance-tests/src/test/java/org/ballerinalang/test/TestRunner.java
+++ b/tests/ballerina-spec-conformance-tests/src/test/java/org/ballerinalang/test/TestRunner.java
@@ -28,7 +28,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -56,7 +55,7 @@ public class TestRunner {
     private final Path path = TEST_DIR.resolve("src").resolve("test").resolve("resources")
                                      .resolve("ballerina-spec-tests").resolve("conformance");
     private static final Set<String> predefinedLabels = TestRunnerUtils.readLabels(TEST_DIR.toString()).keySet();
-    private static final HashSet<String> skippedTestLabels = new HashSet<>(Arrays.asList("transactional-expr"));
+    private static final HashSet<String> skippedTestLabels = getSkippedTestLabels();
 
     @Test(dataProvider = "spec-conformance-tests-file-provider")
     public void test(String kind, String path, List<String> outputValues, List<Integer> lineNumbers, String fileName,
@@ -77,6 +76,13 @@ public class TestRunner {
     @AfterClass
     public void generateReports(ITestContext context) throws IOException {
         generateReport();
+    }
+
+    private static HashSet<String> getSkippedTestLabels() {
+        HashSet<String> hashSet = new HashSet<>();
+        hashSet.add("transactional-expr"); // issue #35939
+        // New entries go here.
+        return hashSet;
     }
 
     private HashSet<String> runSelectedTests(HashMap<String, HashSet<String>> definedLabels) {
@@ -104,8 +110,7 @@ public class TestRunner {
                     .map(path -> new Object[]{path.toFile().getName(), path.toString()})
                     .forEach(object -> {
                         try {
-                            TestRunnerUtils.readTestFile((String) object[0], (String) object[1], testCases,
-                                    predefinedLabels);
+                            TestRunnerUtils.readTestFile((String) object[0], (String) object[1], testCases);
                         } catch (IOException e) {
                             Assert.fail("failed to read spec conformance test: \"" + object[0] + "\"", e);
                         }

--- a/tests/ballerina-spec-conformance-tests/src/test/java/org/ballerinalang/test/TestRunner.java
+++ b/tests/ballerina-spec-conformance-tests/src/test/java/org/ballerinalang/test/TestRunner.java
@@ -55,7 +55,7 @@ public class TestRunner {
     private final Path path = TEST_DIR.resolve("src").resolve("test").resolve("resources")
                                      .resolve("ballerina-spec-tests").resolve("conformance");
     private static final Set<String> predefinedLabels = TestRunnerUtils.readLabels(TEST_DIR.toString()).keySet();
-    private static final HashSet<String> skippedTestLabels = getSkippedTestLabels();
+    private static final Set<String> skippedTestLabels = getSkippedTestLabels();
 
     @Test(dataProvider = "spec-conformance-tests-file-provider")
     public void test(String kind, String path, List<String> outputValues, List<Integer> lineNumbers, String fileName,
@@ -79,10 +79,10 @@ public class TestRunner {
     }
 
     private static Set<String> getSkippedTestLabels() {
-        Set<String> hashSet = new HashSet<>();
-        hashSet.add("transactional-expr"); // issue #35939
+        Set<String> skippedTestLabels = new HashSet<>();
+        skippedTestLabels.add("transactional-expr"); // issue #35939
         // New entries go here.
-        return hashSet;
+        return skippedTestLabels;
     }
 
     private HashSet<String> runSelectedTests(HashMap<String, HashSet<String>> definedLabels) {

--- a/tests/ballerina-spec-conformance-tests/src/test/java/org/ballerinalang/test/TestRunner.java
+++ b/tests/ballerina-spec-conformance-tests/src/test/java/org/ballerinalang/test/TestRunner.java
@@ -59,7 +59,7 @@ public class TestRunner {
     @Test(dataProvider = "spec-conformance-tests-file-provider")
     public void test(String kind, String path, List<String> outputValues, List<Integer> lineNumbers, String fileName,
                      int absLineNum, boolean isSkippedTest, String diagnostics, ITestContext context,
-                     boolean isKnownIssue, String labels, List<String> skippedTestLabels) {
+                     boolean isKnownIssue, String labels, HashSet<String> skippedTestLabels) {
         setDetailsOfTest(context, kind, fileName, absLineNum, diagnostics);
         handleTestSkip(isSkippedTest);
         validateTestFormat(diagnostics);

--- a/tests/ballerina-spec-conformance-tests/src/test/java/org/ballerinalang/test/TestRunnerUtils.java
+++ b/tests/ballerina-spec-conformance-tests/src/test/java/org/ballerinalang/test/TestRunnerUtils.java
@@ -85,8 +85,7 @@ public class TestRunnerUtils {
     private static int absLineNum;
     public static String diagnostics = null;
 
-    public static void readTestFile(String fileName, String path, List<Object[]> testCases, Set<String> labels)
-                                                                                                    throws IOException {
+    public static void readTestFile(String fileName, String path, List<Object[]> testCases) throws IOException {
         String subPath = path.split("/conformance/")[1];
         subPath = subPath.substring(0, subPath.lastIndexOf("/") + 1);
 
@@ -96,11 +95,11 @@ public class TestRunnerUtils {
         if (!tempFile.isDirectory() && !new File(tempDir).mkdirs()) {
             reportDiagnostics("Failed to create directory!");
         }
-        readTestFile(testFile, tempDir, fileName, testCases, labels);
+        readTestFile(testFile, tempDir, fileName, testCases);
     }
 
-    private static void readTestFile(File testFile, String tempDir, String fileName, List<Object[]>  testCases,
-                                     Set<String> selectedLabels) throws IOException {
+    private static void readTestFile(File testFile, String tempDir, String fileName, List<Object[]>  testCases)
+            throws IOException {
         BufferedReader buffReader = new BufferedReader(new FileReader(testFile));
         //line number relative to .balt file
         absLineNum = 1;

--- a/tests/ballerina-spec-conformance-tests/src/test/java/org/ballerinalang/test/TestRunnerUtils.java
+++ b/tests/ballerina-spec-conformance-tests/src/test/java/org/ballerinalang/test/TestRunnerUtils.java
@@ -122,6 +122,7 @@ public class TestRunnerUtils {
             testCase[6] = isSkippedTestCase;
             testCase[8] = headersOfTestCase.containsKey(FAIL_ISSUE);
             testCase[9] = headersOfTestCase.get(LABELS);
+            testCase[10] = Arrays.asList("transactional-expr");
 
             line = writeToBalFile(testCases, testCase, kindOfTestCase, tempDir, tempFileName, buffReader);
         }
@@ -198,13 +199,18 @@ public class TestRunnerUtils {
         }
     }
 
-    public static void validateLabels(String labels, Set<String> predefinedLabels, int absLineNum) {
+    public static void validateLabels(String labels, Set<String> predefinedLabels, int absLineNum,
+                                      List<String> skippedTestLabels) {
         HashSet<String> labelsList = new HashSet<>();
         StringJoiner duplicateLabels = new StringJoiner(", ");
         StringJoiner unknownLabels = new StringJoiner(", ");
+        boolean isSkippedTest = false;
 
         for (String label : labels.split(",")) {
             String trimmedLabel = label.trim();
+            if (skippedTestLabels.contains(trimmedLabel)) {
+                isSkippedTest = true;
+            }
             if (labelsList.contains(trimmedLabel)) {
                 duplicateLabels.add(trimmedLabel);
                 continue;
@@ -226,6 +232,8 @@ public class TestRunnerUtils {
         if (!diagnosticMsg.isEmpty()) {
             Assert.fail("Errors in labels at line number: " + (absLineNum - 1) + "\n" + diagnosticMsg);
         }
+
+        handleTestSkip(isSkippedTest);
     }
 
     private static Map<String, String> readHeaders(String line, BufferedReader buffReader) throws IOException {

--- a/tests/ballerina-spec-conformance-tests/src/test/java/org/ballerinalang/test/TestRunnerUtils.java
+++ b/tests/ballerina-spec-conformance-tests/src/test/java/org/ballerinalang/test/TestRunnerUtils.java
@@ -311,7 +311,7 @@ public class TestRunnerUtils {
         }
     }
 
-    public static void handleTestSkip(String[] testCaseLabels, HashSet<String> skippedTestLabels) {
+    public static void handleTestSkip(String[] testCaseLabels, Set<String> skippedTestLabels) {
         for (String label : testCaseLabels) {
             if (skippedTestLabels.contains(label)) {
                 throw new SkipException("Skip");

--- a/tests/ballerina-spec-conformance-tests/src/test/java/org/ballerinalang/test/TestRunnerUtils.java
+++ b/tests/ballerina-spec-conformance-tests/src/test/java/org/ballerinalang/test/TestRunnerUtils.java
@@ -122,7 +122,7 @@ public class TestRunnerUtils {
             testCase[6] = isSkippedTestCase;
             testCase[8] = headersOfTestCase.containsKey(FAIL_ISSUE);
             testCase[9] = headersOfTestCase.get(LABELS);
-            testCase[10] = Arrays.asList("transactional-expr");
+            testCase[10] = new HashSet<>(Arrays.asList("transactional-expr"));
 
             line = writeToBalFile(testCases, testCase, kindOfTestCase, tempDir, tempFileName, buffReader);
         }
@@ -200,7 +200,7 @@ public class TestRunnerUtils {
     }
 
     public static void validateLabels(String labels, Set<String> predefinedLabels, int absLineNum,
-                                      List<String> skippedTestLabels) {
+                                      HashSet<String> skippedTestLabels) {
         HashSet<String> labelsList = new HashSet<>();
         StringJoiner duplicateLabels = new StringJoiner(", ");
         StringJoiner unknownLabels = new StringJoiner(", ");


### PR DESCRIPTION
## Purpose
$title

This allows skipping tests with `transactional-expr` label until #35939 is resolved.

## Approach


## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
