### PR TITLE
Fix non-worker thread calling to `FromJsonWithType()`

### DIFF
--- a/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/FromJsonWithType.java
+++ b/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/FromJsonWithType.java
@@ -66,9 +66,8 @@ public class FromJsonWithType {
     private FromJsonWithType() {
     }
 
-    public static Object fromJsonWithType(Object v, BTypedesc t) {
-        Type describingType = t.getDescribingType();
-        return convert(v, describingType, t);
+    public static Object fromJsonWithType(Object value, BTypedesc t) {
+        return convert(value, t.getDescribingType(), t);
     }
 
     public static Object convert(Object value, Type targetType) {

--- a/tests/jballerina-unit-test/build.gradle
+++ b/tests/jballerina-unit-test/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation project(':ballerina-lang-test')
     implementation project(':ballerina-runtime')
     implementation project(':docerina')
+    implementation project(':ballerina-lang:value');
 
     implementation 'org.testng:testng'
     testCompile 'org.awaitility:awaitility'

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
@@ -47,7 +47,9 @@ import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BMapInitialValueEntry;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
+import io.ballerina.runtime.api.values.BTypedesc;
 import io.ballerina.runtime.internal.types.BFunctionType;
+import org.ballerinalang.langlib.value.FromJsonWithType;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -196,6 +198,10 @@ public class Values {
                 StringUtils.fromString("name"), StringUtils.fromString("studentName")),
                 ValueCreator.createKeyFieldEntry(StringUtils.fromString("id"), 123L)};
         return ValueCreator.createRecordValue(recordType, mapInitialValueEntries);
+    }
+
+    public static Object getRecordValueFromJson(Object jsonValue, BTypedesc type) {
+        return FromJsonWithType.convert(jsonValue, type.getDescribingType());
     }
 
     public static BObject getInvalidObject(BString objectName) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/values/modules/records/records.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/values/modules/records/records.bal
@@ -51,6 +51,11 @@ public function validateAPI() {
 
     Details recordVal2 = getRecordValueWithInitialValues();
     test:assertEquals(recordVal2, {"name": "studentName", "id": 123});
+
+    json jsonValue = {name: "Jane", id: 234};
+    anydata recordVal3 = getRecordValueFromJson(jsonValue, Details);
+    test:assertEquals(recordVal3, {"name": "Jane", "id": 234});
+    test:assertTrue(recordVal3 is Details);
 }
 
 function getRecordValue() returns anydata = @java:Method {
@@ -58,6 +63,10 @@ function getRecordValue() returns anydata = @java:Method {
 } external;
 
 function getRecordValueWithInitialValues() returns Details = @java:Method {
+    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
+} external;
+
+function getRecordValueFromJson(json value, typedesc<Details> recType) returns anydata = @java:Method {
     'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
 } external;
 


### PR DESCRIPTION
## Purpose
$subject

Fixes #35780

## Approach
The issue happens because the implementation calls the `fromJsonWithType()` before starting a scheduler thread while passing a typedesc.
This PR fixes it by checking whether the scheduler thread is started before calling the `typedesc.instantiate()`.

## Remarks
Since this will result in a call to value creator API to create a record value, it is not guaranteed that the record will initialize properly if it contains any default values in the type description. 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
