### PR TITLE
Fix hashcode method for cyclic types

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BTupleType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BTupleType.java
@@ -252,6 +252,9 @@ public class BTupleType extends BType implements TupleType {
 
     @Override
     public int hashCode() {
+        if (isCyclic) {
+            return super.hashCode();
+        }
         return Objects.hash(super.hashCode(), tupleTypes);
     }
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BTupleType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BTupleType.java
@@ -251,14 +251,6 @@ public class BTupleType extends BType implements TupleType {
     }
 
     @Override
-    public int hashCode() {
-        if (isCyclic) {
-            return super.hashCode();
-        }
-        return Objects.hash(super.hashCode(), tupleTypes);
-    }
-
-    @Override
     public boolean isAnydata() {
         return TypeFlags.isFlagOn(this.typeFlags, TypeFlags.ANYDATA);
     }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BUnionType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BUnionType.java
@@ -32,7 +32,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.StringJoiner;
@@ -372,14 +371,6 @@ public class BUnionType extends BType implements UnionType, SelectivelyImmutable
             }
         }
         return this.readonly == that.readonly;
-    }
-
-    @Override
-    public int hashCode() {
-        if (isCyclic) {
-            return super.hashCode();
-        }
-        return Objects.hash(super.hashCode(), memberTypes);
     }
 
     @Override

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BUnionType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BUnionType.java
@@ -376,7 +376,9 @@ public class BUnionType extends BType implements UnionType, SelectivelyImmutable
 
     @Override
     public int hashCode() {
-
+        if (isCyclic) {
+            return super.hashCode();
+        }
         return Objects.hash(super.hashCode(), memberTypes);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/typedefs/CyclicTypeDefinitionsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/typedefs/CyclicTypeDefinitionsTest.java
@@ -64,6 +64,7 @@ public class CyclicTypeDefinitionsTest {
                 {"testCastingToImmutableCyclicTuple"},
                 {"recursiveTupleArrayCloneTest"},
                 {"testRecursiveTupleWithRestType"},
+                {"testUnionWithCyclicTuplesHashCode"}
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/typedefs/tuple-type-definitions-cyclic.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/typedefs/tuple-type-definitions-cyclic.bal
@@ -305,6 +305,28 @@ function testRecursiveTupleWithRestType() {
    assertTrue(c[2] is RestTypeTuple);
 }
 
+public type Type string|Union|Tuple;
+
+public type Union ["|", Type...];
+
+public type Tuple ["tuple", Type, Type...]; 
+
+type SubtypeRelation record {|
+    Type subtype;
+    Type superType;
+|};
+
+function testUnionWithCyclicTuplesHashCode() {
+    Tuple tup1 = ["tuple", "never", "int"];
+    Tuple tup2 = ["tuple", "never", ["|", "int", "string"]];
+
+    Type subtype = ["|", "int", tup1];
+    Type superType = ["|", ["|", "int", "float"], tup2];
+    SubtypeRelation p = {subtype: subtype, superType: superType};
+    assert(p.toJsonString(), "{\"subtype\":[\"|\", \"int\", [\"tuple\", \"never\", \"int\"]], " +
+    "\"superType\":[\"|\", [\"|\", \"int\", \"float\"], [\"tuple\", \"never\", [\"|\", \"int\", \"string\"]]]}"); 
+}
+
 function assertTrue(anydata actual) {
     assert(true, actual);
 }


### PR DESCRIPTION
## Purpose
$subject
Fixes #35762 

## Approach
The error happens when the generated methods of a record value call the `hashcode()` implementation of union & tuple types which are cyclic. 
This is because we didn't consider whether the type is cyclic when we retrieve the hash code of them. 
This PR fixes this by providing the hashcode of the superclass (`BType`). 

## Samples
```ballerina
public type Type string|Union|Tuple;

public type Union ["|", Type...];

public type Tuple ["tuple", Type, Type...]; // rest + members

type SubtypeRelation record {|
    Type subtype;
    Type superType;
|};

public function main() {
    Tuple tup1 = ["tuple", "never", "int"];
    Tuple tup2 = ["tuple", "never", ["|", "int", "string"]];

    Type subtype = ["|", "int", tup1];
    Type superType = ["|", ["|", "int", "float"], tup2];
    SubtypeRelation p = {subtype: subtype, superType: superType};
    io:println(p.toJsonString());  // Stack overflow error thrown
}
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
