### PR TITLE
Fix anydata casting with any value

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -2348,7 +2348,10 @@ public class TypeChecker {
             case TypeTags.JSON_TAG:
             case TypeTags.MAP_TAG:
                 return isLikeType(((MapValueImpl) sourceValue).values().toArray(), TYPE_ANYDATA,
-                                  unresolvedValues, allowNumericConversion);
+                        unresolvedValues, allowNumericConversion);
+            case TypeTags.TABLE_TAG:
+                return isLikeType(((TableValueImpl) sourceValue).values().toArray(), TYPE_ANYDATA,
+                        unresolvedValues, allowNumericConversion);
             case TypeTags.ARRAY_TAG:
                 ArrayValue arr = (ArrayValue) sourceValue;
                 BArrayType arrayType = (BArrayType) arr.getType();

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/CodeGenerator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/CodeGenerator.java
@@ -21,6 +21,7 @@ import org.wso2.ballerinalang.compiler.CompiledJarFile;
 import org.wso2.ballerinalang.compiler.PackageCache;
 import org.wso2.ballerinalang.compiler.bir.codegen.optimizer.LargeMethodOptimizer;
 import org.wso2.ballerinalang.compiler.diagnostic.BLangDiagnosticLog;
+import org.wso2.ballerinalang.compiler.semantics.analyzer.Types;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BPackageSymbol;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
@@ -43,7 +44,7 @@ public class CodeGenerator {
     private SymbolTable symbolTable;
     private PackageCache packageCache;
     private BLangDiagnosticLog dlog;
-    private CompilerContext compilerContext;
+    private Types types;
     private LargeMethodOptimizer largeMethodOptimizer;
 
     private CodeGenerator(CompilerContext compilerContext) {
@@ -52,7 +53,7 @@ public class CodeGenerator {
         this.symbolTable = SymbolTable.getInstance(compilerContext);
         this.packageCache = PackageCache.getInstance(compilerContext);
         this.dlog = BLangDiagnosticLog.getInstance(compilerContext);
-        this.compilerContext = compilerContext;
+        this.types = Types.getInstance(compilerContext);
     }
 
     public static CodeGenerator getInstance(CompilerContext context) {
@@ -84,7 +85,7 @@ public class CodeGenerator {
         JvmObservabilityGen jvmObservabilityGen = new JvmObservabilityGen(packageCache, symbolTable);
         jvmObservabilityGen.instrumentPackage(packageSymbol.bir);
         dlog.setCurrentPackageId(packageSymbol.pkgID);
-        final JvmPackageGen jvmPackageGen = new JvmPackageGen(symbolTable, packageCache, dlog, compilerContext);
+        final JvmPackageGen jvmPackageGen = new JvmPackageGen(symbolTable, packageCache, dlog, types);
 
         populateExternalMap(jvmPackageGen);
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
@@ -39,6 +39,7 @@ import org.wso2.ballerinalang.compiler.bir.model.BIRNonTerminator.NewTable;
 import org.wso2.ballerinalang.compiler.bir.model.BIROperand;
 import org.wso2.ballerinalang.compiler.bir.model.InstructionKind;
 import org.wso2.ballerinalang.compiler.bir.model.VarKind;
+import org.wso2.ballerinalang.compiler.semantics.analyzer.Types;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.SchedulerPolicy;
@@ -46,7 +47,6 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BArrayType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BIntersectionType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BObjectType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
-import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.util.Flags;
 
@@ -249,8 +249,7 @@ public class JvmInstructionGen {
 
     public JvmInstructionGen(MethodVisitor mv, BIRVarToJVMIndexMap indexMap, PackageID currentPackage,
                              JvmPackageGen jvmPackageGen, JvmTypeGen jvmTypeGen, JvmCastGen jvmCastGen,
-                             JvmConstantsGen jvmConstantsGen, AsyncDataCollector asyncDataCollector,
-                             CompilerContext compilerContext) {
+                             JvmConstantsGen jvmConstantsGen, AsyncDataCollector asyncDataCollector, Types types) {
         this.mv = mv;
         this.indexMap = indexMap;
         this.jvmPackageGen = jvmPackageGen;
@@ -260,7 +259,7 @@ public class JvmInstructionGen {
         this.asyncDataCollector = asyncDataCollector;
         this.jvmCastGen = jvmCastGen;
         this.jvmConstantsGen = jvmConstantsGen;
-        typeTestGen = new JvmTypeTestGen(this, compilerContext, mv, jvmTypeGen);
+        typeTestGen = new JvmTypeTestGen(this, types, mv, jvmTypeGen);
     }
 
     static void addJUnboxInsn(MethodVisitor mv, JType jType) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTypeTestGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTypeTestGen.java
@@ -24,7 +24,6 @@ import org.wso2.ballerinalang.compiler.bir.model.BIRNonTerminator;
 import org.wso2.ballerinalang.compiler.semantics.analyzer.Types;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BUnionType;
-import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 
 import static org.objectweb.asm.Opcodes.GOTO;
@@ -50,10 +49,9 @@ public class JvmTypeTestGen {
     private final MethodVisitor mv;
     private final JvmTypeGen jvmTypeGen;
 
-    public JvmTypeTestGen(JvmInstructionGen jvmInstructionGen, CompilerContext compilerContext, MethodVisitor mv,
-                          JvmTypeGen jvmTypeGen) {
+    public JvmTypeTestGen(JvmInstructionGen jvmInstructionGen, Types types, MethodVisitor mv, JvmTypeGen jvmTypeGen) {
         this.jvmInstructionGen = jvmInstructionGen;
-        types = Types.getInstance(compilerContext);
+        this.types = types;
         this.mv = mv;
         this.jvmTypeGen = jvmTypeGen;
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmValueGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmValueGen.java
@@ -40,6 +40,7 @@ import org.wso2.ballerinalang.compiler.bir.model.BIRInstruction;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRFunction;
 import org.wso2.ballerinalang.compiler.semantics.analyzer.TypeHashVisitor;
+import org.wso2.ballerinalang.compiler.semantics.analyzer.Types;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BAttachedFunction;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BRecordTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
@@ -137,10 +138,10 @@ public class JvmValueGen {
     private final JvmObjectGen jvmObjectGen;
     private final JvmRecordGen jvmRecordGen;
     private final TypeHashVisitor typeHashVisitor;
-
+    private final Types types;
 
     JvmValueGen(BIRNode.BIRPackage module, JvmPackageGen jvmPackageGen, MethodGen methodGen,
-                TypeHashVisitor typeHashVisitor) {
+                TypeHashVisitor typeHashVisitor, Types types) {
         this.module = module;
         this.jvmPackageGen = jvmPackageGen;
         this.methodGen = methodGen;
@@ -148,6 +149,7 @@ public class JvmValueGen {
         this.jvmRecordGen = new JvmRecordGen(jvmPackageGen.symbolTable);
         this.jvmObjectGen = new JvmObjectGen();
         this.typeHashVisitor = typeHashVisitor;
+        this.types = types;
     }
 
     static void injectDefaultParamInitsToAttachedFuncs(BIRNode.BIRPackage module, InitMethodGen initMethodGen,
@@ -358,7 +360,7 @@ public class JvmValueGen {
             cw.visitSource(className, null);
         }
         JvmTypeGen jvmTypeGen = new JvmTypeGen(jvmConstantsGen, module.packageID, typeHashVisitor);
-        JvmCastGen jvmCastGen = new JvmCastGen(jvmPackageGen.symbolTable, jvmTypeGen);
+        JvmCastGen jvmCastGen = new JvmCastGen(jvmPackageGen.symbolTable, jvmTypeGen, types);
         LambdaGen lambdaGen = new LambdaGen(jvmPackageGen, jvmCastGen);
         cw.visit(V1_8, ACC_PUBLIC + ACC_SUPER, className,
                 RECORD_VALUE_CLASS,
@@ -566,7 +568,7 @@ public class JvmValueGen {
         cw.visitSource(typeDef.pos.lineRange().filePath(), null);
 
         JvmTypeGen jvmTypeGen = new JvmTypeGen(jvmConstantsGen, module.packageID, typeHashVisitor);
-        JvmCastGen jvmCastGen = new JvmCastGen(jvmPackageGen.symbolTable, jvmTypeGen);
+        JvmCastGen jvmCastGen = new JvmCastGen(jvmPackageGen.symbolTable, jvmTypeGen, types);
         LambdaGen lambdaGen = new LambdaGen(jvmPackageGen, jvmCastGen);
         cw.visit(V1_8, ACC_PUBLIC + ACC_SUPER, className, null, ABSTRACT_OBJECT_VALUE, new String[]{B_OBJECT});
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/ExternalMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/ExternalMethodGen.java
@@ -37,10 +37,10 @@ import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRVariableDcl;
 import org.wso2.ballerinalang.compiler.bir.model.BIROperand;
 import org.wso2.ballerinalang.compiler.bir.model.BIRTerminator;
 import org.wso2.ballerinalang.compiler.bir.model.InstructionKind;
+import org.wso2.ballerinalang.compiler.semantics.analyzer.Types;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BInvokableType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
-import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 
 import java.util.ArrayList;
@@ -68,13 +68,13 @@ public class ExternalMethodGen {
     public static void genJMethodForBExternalFunc(BIRFunction birFunc, ClassWriter cw, BIRPackage birModule,
                                                   BType attachedType, MethodGen methodGen, JvmPackageGen jvmPackageGen,
                                                   JvmTypeGen jvmTypeGen, JvmCastGen jvmCastGen,
-                                                 JvmConstantsGen jvmConstantsGen,
+                                                  JvmConstantsGen jvmConstantsGen,
                                                   String moduleClassName, AsyncDataCollector lambdaGenMetadata,
-                                                  CompilerContext compilerContext) {
+                                                  Types types) {
         if (birFunc instanceof JFieldBIRFunction) {
             genJFieldForInteropField((JFieldBIRFunction) birFunc, cw, birModule.packageID,
                                      jvmPackageGen, jvmTypeGen, jvmCastGen, jvmConstantsGen,
-                                     moduleClassName, lambdaGenMetadata, compilerContext);
+                                     moduleClassName, lambdaGenMetadata, types);
         } else {
             methodGen.genJMethodForBFunc(birFunc, cw, birModule, jvmTypeGen, jvmCastGen, jvmConstantsGen,
                                          moduleClassName, attachedType, lambdaGenMetadata);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropMethodGen.java
@@ -43,11 +43,11 @@ import org.wso2.ballerinalang.compiler.bir.model.BIROperand;
 import org.wso2.ballerinalang.compiler.bir.model.BIRTerminator;
 import org.wso2.ballerinalang.compiler.bir.model.BirScope;
 import org.wso2.ballerinalang.compiler.bir.model.VarKind;
+import org.wso2.ballerinalang.compiler.semantics.analyzer.Types;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BArrayType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
-import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.util.Flags;
@@ -127,7 +127,7 @@ public class InteropMethodGen {
     static void genJFieldForInteropField(JFieldBIRFunction birFunc, ClassWriter classWriter, PackageID birModule,
                                          JvmPackageGen jvmPackageGen, JvmTypeGen jvmTypeGen, JvmCastGen jvmCastGen,
                                          JvmConstantsGen jvmConstantsGen, String moduleClassName,
-                                         AsyncDataCollector asyncDataCollector, CompilerContext compilerContext) {
+                                         AsyncDataCollector asyncDataCollector, Types types) {
 
         BIRVarToJVMIndexMap indexMap = new BIRVarToJVMIndexMap();
         indexMap.addIfNotExists("$_strand_$", jvmPackageGen.symbolTable.stringType);
@@ -143,8 +143,7 @@ public class InteropMethodGen {
         int access = birFunc.receiver != null ? ACC_PUBLIC : ACC_PUBLIC + ACC_STATIC;
         MethodVisitor mv = classWriter.visitMethod(access, birFunc.name.value, desc, null, null);
         JvmInstructionGen instGen = new JvmInstructionGen(mv, indexMap, birModule, jvmPackageGen, jvmTypeGen,
-                                                          jvmCastGen, jvmConstantsGen, asyncDataCollector,
-                                                          compilerContext);
+                                                          jvmCastGen, jvmConstantsGen, asyncDataCollector, types);
         JvmErrorGen errorGen = new JvmErrorGen(mv, indexMap, instGen);
         LabelGenerator labelGen = new LabelGenerator();
         JvmTerminatorGen termGen = new JvmTerminatorGen(mv, indexMap, labelGen, errorGen, birModule, instGen,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/MethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/MethodGen.java
@@ -50,11 +50,11 @@ import org.wso2.ballerinalang.compiler.bir.model.BIRTerminator.Return;
 import org.wso2.ballerinalang.compiler.bir.model.BirScope;
 import org.wso2.ballerinalang.compiler.bir.model.InstructionKind;
 import org.wso2.ballerinalang.compiler.bir.model.VarKind;
+import org.wso2.ballerinalang.compiler.semantics.analyzer.Types;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BTypeReferenceType;
-import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.util.Flags;
 
@@ -144,12 +144,12 @@ public class MethodGen {
     private static final String RESUME_INDEX = "resumeIndex";
     private final JvmPackageGen jvmPackageGen;
     private final SymbolTable symbolTable;
-    private final CompilerContext compilerContext;
+    private final Types types;
 
-    public MethodGen(JvmPackageGen jvmPackageGen, CompilerContext compilerContext) {
+    public MethodGen(JvmPackageGen jvmPackageGen, Types types) {
         this.jvmPackageGen = jvmPackageGen;
         this.symbolTable = jvmPackageGen.symbolTable;
-        this.compilerContext = compilerContext;
+        this.types = types;
     }
 
     public void generateMethod(BIRFunction birFunc, ClassWriter cw, BIRPackage birModule, BType attachedType,
@@ -158,7 +158,7 @@ public class MethodGen {
         if (JvmCodeGenUtil.isExternFunc(birFunc)) {
             ExternalMethodGen.genJMethodForBExternalFunc(birFunc, cw, birModule, attachedType, this, jvmPackageGen,
                                                          jvmTypeGen, jvmCastGen, jvmConstantsGen, moduleClassName,
-                                                         asyncDataCollector, compilerContext);
+                                                         asyncDataCollector, types);
         } else {
             genJMethodForBFunc(birFunc, cw, birModule, jvmTypeGen, jvmCastGen, jvmConstantsGen, moduleClassName,
                                attachedType, asyncDataCollector);
@@ -225,7 +225,7 @@ public class MethodGen {
 
         JvmInstructionGen instGen = new JvmInstructionGen(mv, indexMap, module.packageID, jvmPackageGen, jvmTypeGen,
                                                           jvmCastGen, jvmConstantsGen, asyncDataCollector,
-                                                          compilerContext);
+                                                          types);
         JvmErrorGen errorGen = new JvmErrorGen(mv, indexMap, instGen);
         JvmTerminatorGen termGen = new JvmTerminatorGen(mv, indexMap, labelGen, errorGen, module.packageID, instGen,
                                                         jvmPackageGen, jvmTypeGen, jvmCastGen, asyncDataCollector);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/JvmConstantsGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/JvmConstantsGen.java
@@ -33,7 +33,6 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BArrayType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BTupleType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BUnionType;
-import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 
 import java.util.Map;
@@ -59,7 +58,7 @@ public class JvmConstantsGen {
 
     public final BTypeHashComparator bTypeHashComparator;
 
-    public JvmConstantsGen(BIRNode.BIRPackage module, String moduleInitClass, CompilerContext compilerContext,
+    public JvmConstantsGen(BIRNode.BIRPackage module, String moduleInitClass, Types types,
                            TypeHashVisitor typeHashVisitor) {
         this.bTypeHashComparator = new BTypeHashComparator(typeHashVisitor);
         this.stringConstantsGen = new JvmBStringConstantsGen(module.packageID);
@@ -67,8 +66,7 @@ public class JvmConstantsGen {
         this.jvmBallerinaConstantsGen = new JvmBallerinaConstantsGen(module, moduleInitClass, this);
         this.unionTypeConstantsGen = new JvmUnionTypeConstantsGen(module.packageID, bTypeHashComparator);
         this.tupleTypeConstantsGen = new JvmTupleTypeConstantsGen(module.packageID, bTypeHashComparator);
-        this.arrayTypeConstantsGen = new JvmArrayTypeConstantsGen(module.packageID,
-                bTypeHashComparator, Types.getInstance(compilerContext));
+        this.arrayTypeConstantsGen = new JvmArrayTypeConstantsGen(module.packageID, bTypeHashComparator, types);
     }
 
     public String getBStringConstantVar(String value) {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/anydata/AnydataTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/anydata/AnydataTest.java
@@ -112,26 +112,6 @@ public class AnydataTest {
         assertEquals(returns.toString(), "{\"name\":\"apple\",\"color\":\"red\",\"price\":40}");
     }
 
-    @Test(description = "Test table assignment")
-    public void testTableAssignment() {
-        BRunUtil.invoke(result, "testTableAssignment");
-    }
-
-    @Test(description = "Test map assignment")
-    public void testMapAssignment() {
-        BRunUtil.invoke(result, "testMapAssignment");
-    }
-
-    @Test(description = "Test for maps constrained by anydata")
-    public void testConstrainedMaps() {
-        BRunUtil.invoke(result, "testConstrainedMaps");
-    }
-
-    @Test(description = "Test array assignment")
-    public void testArrayAssignment() {
-        BRunUtil.invoke(result, "testArrayAssignment");
-    }
-
     @Test(description = "Test union assignment")
     public void testUnionAssignment() {
         BArray returns = (BArray) BRunUtil.invoke(result, "testUnionAssignment");
@@ -140,16 +120,6 @@ public class AnydataTest {
         assertEquals(returns.get(2), 23.45);
         assertTrue((Boolean) returns.get(3));
         assertEquals(returns.get(4), 255);
-    }
-
-    @Test(description = "Test union assignment for more complex types")
-    public void testUnionAssignment2() {
-        BRunUtil.invoke(result, "testUnionAssignment2");
-    }
-
-    @Test(description = "Test tuple assignment")
-    public void testTupleAssignment() {
-        BRunUtil.invoke(result, "testTupleAssignment");
     }
 
     @Test(description = "Test nil assignment")
@@ -214,11 +184,6 @@ public class AnydataTest {
         assertEquals(returns.get(0).toString(), "{\"a\":15}");
     }
 
-    @Test(description = "Test anydata to table conversion")
-    public void testAnydataToTable() {
-        BRunUtil.invoke(result, "testAnydataToTable");
-    }
-
     @Test(description = "Test anydata to union conversion")
     public void testAnydataToUnion() {
         BArray returns = (BArray) BRunUtil.invoke(result, "testAnydataToUnion");
@@ -232,11 +197,6 @@ public class AnydataTest {
         assertEquals(returns.get(2).toString(), "hello world!");
         assertTrue((Boolean) returns.get(3));
         assertEquals(returns.get(4), 255);
-    }
-
-    @Test(description = "Test anydata to union conversion for complex types")
-    public void testAnydataToUnion2() {
-        BRunUtil.invoke(result, "testAnydataToUnion2");
     }
 
     @Test(description = "Test anydata to tuple conversion")
@@ -255,11 +215,6 @@ public class AnydataTest {
                 "[json,xml<(lang.xml:Element|lang.xml:Comment|lang.xml:ProcessingInstruction|lang.xml:Text)>]");
         assertEquals(returns.toString(), "[{\"name\":\"apple\",\"color\":\"red\",\"price\":40},`<book>The Lost " +
                 "World</book>`]");
-    }
-
-    @Test(description = "Test anydata to tuple conversion")
-    public void testAnydataToTuple3() {
-        BRunUtil.invoke(result, "testAnydataToTuple3");
     }
 
     @Test(description = "Test anydata to nil conversion")
@@ -296,24 +251,30 @@ public class AnydataTest {
         assertEquals(rets.getRefValue(7).toString(), "{\"ca\":15}");
     }
 
-    @Test
-    public void testRuntimeIsAnydata() {
-        BRunUtil.invoke(result, "testRuntimeIsAnydata");
-    }
-
-    @Test(dataProvider = "subtypeOfBasicTypesIsAnydata")
-    public void testSubtypeOfBasicTypesIsAnydata(String function) {
+    @Test(dataProvider = "getAnydataFuntion")
+    public void testAnydata(String function) {
         BRunUtil.invoke(result, function);
     }
 
-    @DataProvider(name = "subtypeOfBasicTypesIsAnydata")
-    public Object[][] subtypeOfBasicTypesIsAnydata() {
-        return new Object[][]{
-                {"testMapOfCharIsAnydata"},
-                {"testCharArrayIsAnydata"},
-                {"testMapOfIntSubtypeIsAnydata"},
-                {"testArrayOfIntSubtypeIsAnydata"},
-                {"testMapOfNeverTypeIsAnydata"}
+    @DataProvider(name = "getAnydataFuntion")
+    public Object[] getAnydataFuntion() {
+        return new String[]{
+                "testMapOfCharIsAnydata",
+                "testCharArrayIsAnydata",
+                "testMapOfIntSubtypeIsAnydata",
+                "testArrayOfIntSubtypeIsAnydata",
+                "testMapOfNeverTypeIsAnydata",
+                "testRuntimeIsAnydata",
+                "testAnydataToTuple3",
+                "testAnydataToUnion2",
+                "testAnydataToTable",
+                "testTupleAssignment",
+                "testUnionAssignment2",
+                "testTableAssignment",
+                "testMapAssignment",
+                "testConstrainedMaps",
+                "testArrayAssignment",
+                "testAnytoAnydataTypeCast"
         };
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/anydata/anydata_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/anydata/anydata_test.bal
@@ -934,6 +934,77 @@ function testMapOfNeverTypeIsAnydata() {
     assertTrue(a5 is anydata);
 }
 
+function testAnytoAnydataTypeCast() returns error? {
+    // negative cases
+    any anyVal = {a: 23};
+    anydata|error result = trap <anydata>anyVal;
+
+    assertTrue(result is error);
+    error err = <error>result;
+    assertEquality("{ballerina}TypeCastError", err.message());
+    assertEquality("incompatible types: 'map<(any|error)>' cannot be cast to 'anydata'",
+    <string>checkpanic err.detail()["message"]);
+
+    any[] arr = [1, "2", 3.4];
+    result = trap <anydata>arr;
+    assertTrue(result is error);
+    err = <error>result;
+    assertEquality("{ballerina}TypeCastError", err.message());
+    assertEquality("incompatible types: 'any[]' cannot be cast to 'anydata'",
+    <string>checkpanic err.detail()["message"]);
+
+    map<any> anyMap = {"a": 2, "b": 3};
+    result = trap <anydata>anyMap;
+    assertTrue(result is error);
+    err = <error>result;
+    assertEquality("{ballerina}TypeCastError", err.message());
+    assertEquality("incompatible types: 'map' cannot be cast to 'anydata'",
+    <string>checkpanic err.detail()["message"]);
+
+    table<map<any>> tab = table [
+            {id: 12, name: "abc"},
+            {id: 34, name: "def"}
+        ];
+    result = trap <anydata>tab;
+    assertTrue(result is error);
+    err = <error>result;
+    assertEquality("{ballerina}TypeCastError", err.message());
+    assertEquality("incompatible types: 'table<map>' cannot be cast to 'anydata'",
+    <string>checkpanic err.detail()["message"]);
+
+    // positive cases
+    any & readonly anyValRO = {a: 23};
+    anyVal = anyValRO;
+    result = trap <anydata>anyVal;
+    assertTrue(result is anydata);
+    anydata anyDataVal = check result;
+    assertEquality("{\"a\":23}", anyDataVal.toString());
+
+    any[] & readonly arrRO = [1, "2", 3.4];
+    arr = arrRO;
+    result = trap <anydata>arr;
+    assertTrue(result is anydata);
+    anyDataVal = check result;
+    assertEquality("[1,\"2\",3.4]", anyDataVal.toString());
+
+    map<any> & readonly mapAnyRO = {a: 23};
+    anyMap = mapAnyRO;
+    result = trap <anydata>anyMap;
+    assertTrue(result is anydata);
+    anyDataVal = check result;
+    assertEquality("{\"a\":23}", anyDataVal.toString());
+
+    table<map<any>> & readonly tabRO = table [
+            {id: 12, name: "abc"},
+            {id: 34, name: "def"}
+        ];
+    tab = tabRO;
+    result = trap <anydata>tab;
+    assertTrue(result is anydata);
+    anyDataVal = check result;
+    assertEquality("[{\"id\":12,\"name\":\"abc\"},{\"id\":34,\"name\":\"def\"}]", anyDataVal.toString());
+}
+
 function assertTrue(any|error actual) {
     assertEquality(true, actual);
 }


### PR DESCRIPTION
## Purpose
$subject

Fixes #35517

## Approach
When casting an `any` value to `anydata`, we need to verify the casting at runtime, as it can contain a non-anydata value. This check is currently done only for `any` values and not validated for some types like `any[]`, `map<any>` and `table<map<any>>`.This PR modifies this to add a runtime check.  

## Samples
```ballerina
 any[] arr = [1, "2", 3.4];
 anydata result = <anydata>arr; // should panic
 
 any[] & readonly arr1= [1, "2", 3.4];
 arr = arr1;
 anydata result = <anydata>arr; // should pass
```

## Remarks
As the `TypeChecker` contains a bug when checking table values, this PR fixes it as well.
Duplicate PR for https://github.com/ballerina-platform/ballerina-lang/pull/35799

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
