### PR TITLE
Fix readonly check for in-built union type 

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BAnydataType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BAnydataType.java
@@ -50,7 +50,7 @@ public class BAnydataType extends BUnionType implements AnydataType {
     }
 
     public BAnydataType(BUnionType unionType, String typeName, boolean readonly) {
-        super(unionType, typeName);
+        super(unionType, typeName, readonly);
         if (!readonly) {
             BAnydataType immutableAnydataType = new BAnydataType(unionType, TypeConstants.READONLY_ANYDATA_TNAME, true);
             this.immutableType = new BIntersectionType(pkg, new Type[]{this, PredefinedTypes.TYPE_READONLY},

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BJsonType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BJsonType.java
@@ -62,7 +62,7 @@ public class BJsonType extends BUnionType implements JsonType {
     }
 
     public BJsonType(BUnionType unionType, String typeName, boolean readonly) {
-        super(unionType, typeName);
+        super(unionType, typeName, readonly);
         if (!readonly) {
             BJsonType immutableJsonType = new BJsonType(unionType, TypeConstants.READONLY_JSON_TNAME, true);
             this.immutableType = new BIntersectionType(pkg, new Type[]{this, PredefinedTypes.TYPE_READONLY},

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BUnionType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BUnionType.java
@@ -136,13 +136,13 @@ public class BUnionType extends BType implements UnionType, SelectivelyImmutable
      * @param unionType flags associated with the type
      * @param typeName typename associated with the type
      */
-    protected BUnionType(BUnionType unionType, String typeName) {
+    protected BUnionType(BUnionType unionType, String typeName, boolean readonly) {
         super(typeName, unionType.pkg, unionType.valueClass);
-        this.readonly = unionType.readonly;
         this.typeFlags = unionType.typeFlags;
         this.memberTypes = new ArrayList<>(unionType.memberTypes.size());
         this.originalMemberTypes = new ArrayList<>(unionType.memberTypes.size());
         this.mergeUnionType(unionType);
+        this.readonly = readonly;
     }
 
     public BUnionType(Type[] memberTypes, Type[] originalMemberTypes, String name, Module pkg, int typeFlags,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/emit/TypeEmitter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/emit/TypeEmitter.java
@@ -31,6 +31,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BIntersectionType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BInvokableType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BMapType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BObjectType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BParameterizedType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BRecordType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BStreamType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BTableType;
@@ -147,9 +148,19 @@ class TypeEmitter {
                 return emitBStreamType((BStreamType) bType, tabs);
             case TypeTags.TYPEREFDESC:
                 return emitTypeRefDesc((BTypeReferenceType) bType, tabs);
+            case TypeTags.PARAMETERIZED_TYPE:
+                return emitParameterizedType((BParameterizedType) bType, tabs);
             default:
                 throw new IllegalStateException("Invalid type");
         }
+    }
+
+    private static String emitParameterizedType(BParameterizedType type, int tabs) {
+        String str = "parameterized ";
+        str += "<";
+        str += emitTypeRef(type.paramValueType, 0);
+        str += ">";
+        return str;
     }
 
     private static String emitTableType(BTableType bType, int tabs) {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/readonly/SelectivelyImmutableTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/readonly/SelectivelyImmutableTypeTest.java
@@ -77,7 +77,8 @@ public class SelectivelyImmutableTypeTest {
                 {"testReadOnlyIntersectionWithNeverExplicitlyInType"},
                 {"testReadOnlyIntersectionWithRecordThatHasAnOptionalNeverReadOnlyField"},
                 {"testReadOnlyIntersectionWithRecordThatHasANeverReadOnlyRestField"},
-                {"testTypeDefinitionForReadOnlyIntersectionWithBuiltinType"}
+                {"testTypeDefinitionForReadOnlyIntersectionWithBuiltinType"},
+                {"testIsReadonlyWithInBuiltUnionType"}
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/readonly/test_selectively_immutable_type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/readonly/test_selectively_immutable_type.bal
@@ -1137,6 +1137,18 @@ function testTypeDefinitionForReadOnlyIntersectionWithBuiltinType() {
                    <string> checkpanic d.detail()["message"]);
 }
 
+function testIsReadonlyWithInBuiltUnionType() returns error? {
+    json j = {a: 1};
+    string s = j.toJsonString();
+    json & readonly x = check s.fromJsonStringWithType();
+    assertTrue(x is readonly);
+
+    anydata k = {b: 2};
+    string t = k.toJsonString();
+    anydata & readonly y = check t.fromJsonStringWithType();
+    assertTrue(y is readonly);
+}
+
 const ASSERTION_ERROR_REASON = "AssertionError";
 
 function assertTrue(any|error actual) {


### PR DESCRIPTION
## Purpose
$subject
Fixes #35813 

## Approach
The readonly parameter gets ignored when we create the json type constant. This causes wrong behavior in the runtime type checker when we create values from the type constant. this PR fixes this. 

## Remarks
Duplicate PR of https://github.com/ballerina-platform/ballerina-lang/pull/35849

## Samples
```ballerina
import ballerina/io;

public function main() returns error? {
    json j = {a: 1};
    string s = j.toJsonString();
    json & readonly x = check s.fromJsonStringWithType();
    io:println(x is readonly); // should be true
}
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
