### PR TITLE
Fix throwing ambiguity error for convertible numeric unions

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/TypeTags.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/TypeTags.java
@@ -123,4 +123,15 @@ public class TypeTags {
         }
         return false;
     }
+
+    public static boolean isUnionTypeTag(int tag) {
+        switch (tag) {
+            case UNION_TAG:
+            case ANYDATA_TAG:
+            case JSON_TAG:
+                return true;
+            default:
+                return false;
+        }
+    }
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/TypeTags.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/TypeTags.java
@@ -129,6 +129,7 @@ public class TypeTags {
             case UNION_TAG:
             case ANYDATA_TAG:
             case JSON_TAG:
+            case ANY_TAG:
                 return true;
             default:
                 return false;

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/JsonUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/JsonUtils.java
@@ -54,6 +54,7 @@ import io.ballerina.runtime.internal.values.RefValue;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -352,7 +353,7 @@ public class JsonUtils {
                         return jsonNodeToInt(jsonValue);
                     } else {
                         matchingTypes.addAll(TypeConverter.getConvertibleTypes(jsonValue, memType, null,
-                                true, new ArrayList<>(), new ArrayList<>(), false, new ArrayList<>(), targetType));
+                                true, new ArrayList<>(), new ArrayList<>(), false, new HashSet<>(), targetType));
                     }
                 }
                 if (((matchingTypes.size() > 1) && !matchingTypes.contains(inputValueType) &&

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/JsonUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/JsonUtils.java
@@ -352,7 +352,7 @@ public class JsonUtils {
                         return jsonNodeToInt(jsonValue);
                     } else {
                         matchingTypes.addAll(TypeConverter.getConvertibleTypes(jsonValue, memType, null,
-                                true, new ArrayList<>(), new ArrayList<>(), false));
+                                true, new ArrayList<>(), new ArrayList<>(), false, new ArrayList<>(), targetType));
                     }
                 }
                 if (((matchingTypes.size() > 1) && !matchingTypes.contains(inputValueType) &&

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeConverter.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeConverter.java
@@ -263,8 +263,7 @@ public class TypeConverter {
                                                 List<TypeValuePair> unresolvedValues, List<String> errors,
                                                 boolean allowAmbiguity, Set<Type> numericTypeSet, Type parentType) {
         Set<Type> convertibleTypes = new LinkedHashSet<>();
-//        TODO: Add tests for ambiguity
-//        TODO: Check whether this can happen for other union types - record, map etc.
+
         Type inputValueType;
         int targetTypeTag = targetType.getTag();
 

--- a/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/CloneWithType.java
+++ b/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/CloneWithType.java
@@ -110,7 +110,7 @@ public class CloneWithType {
         List<String> errors = new ArrayList<>();
         Set<Type> convertibleTypes;
         convertibleTypes = TypeConverter.getConvertibleTypes(value, targetType, null, false,
-                new ArrayList<>(), errors, allowAmbiguity);
+                new ArrayList<>(), errors, allowAmbiguity, new ArrayList<>(), targetType);
 
         Type sourceType = TypeChecker.getType(value);
         if (convertibleTypes.isEmpty()) {

--- a/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/CloneWithType.java
+++ b/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/CloneWithType.java
@@ -51,6 +51,7 @@ import io.ballerina.runtime.internal.util.exceptions.RuntimeErrors;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -110,7 +111,7 @@ public class CloneWithType {
         List<String> errors = new ArrayList<>();
         Set<Type> convertibleTypes;
         convertibleTypes = TypeConverter.getConvertibleTypes(value, targetType, null, false,
-                new ArrayList<>(), errors, allowAmbiguity, new ArrayList<>(), targetType);
+                new ArrayList<>(), errors, allowAmbiguity, new HashSet<>(), targetType);
 
         Type sourceType = TypeChecker.getType(value);
         if (convertibleTypes.isEmpty()) {

--- a/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/FromJsonWithType.java
+++ b/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/FromJsonWithType.java
@@ -48,6 +48,7 @@ import io.ballerina.runtime.internal.util.exceptions.RuntimeErrors;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -98,7 +99,7 @@ public class FromJsonWithType {
 
         List<String> errors = new ArrayList<>();
         List<Type> convertibleTypes = TypeConverter.getConvertibleTypesFromJson(value, targetType,
-                null, new ArrayList<>(), errors, new ArrayList<>());
+                null, new ArrayList<>(), errors, new HashSet<>());
         if (convertibleTypes.isEmpty()) {
             throw CloneUtils.createConversionError(value, targetType, errors);
         }

--- a/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/FromJsonWithType.java
+++ b/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/FromJsonWithType.java
@@ -98,7 +98,7 @@ public class FromJsonWithType {
 
         List<String> errors = new ArrayList<>();
         List<Type> convertibleTypes = TypeConverter.getConvertibleTypesFromJson(value, targetType,
-                null, new ArrayList<>(), errors);
+                null, new ArrayList<>(), errors, new ArrayList<>());
         if (convertibleTypes.isEmpty()) {
             throw CloneUtils.createConversionError(value, targetType, errors);
         }

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibValueTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibValueTest.java
@@ -354,7 +354,8 @@ public class LangLibValueTest {
                 "testCloneWithTypeWithUnionOfFiniteTypeArraysFromIntArray",
                 "testCloneWithTypeWithUnionTypeArrayFromIntArray",
                 "testCloneWithTypeWithFiniteTypeArrayFromIntArrayNegative", "testConvertJsonToNestedRecordsWithErrors",
-                "testCloneWithTypeNestedStructuredTypesNegative", "testCloneWithTypeJsonToRecordRestField"
+                "testCloneWithTypeNestedStructuredTypesNegative", "testCloneWithTypeJsonToRecordRestField",
+                "testCloneWithTypeWithAmbiguousNumericUnion"
         };
     }
 

--- a/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
@@ -1807,6 +1807,8 @@ type Movie record {
 
 type Union int|decimal|string|Union[]|map<Union>;
 
+type Finite 2|2d;
+
 function testCloneWithTypeWithAmbiguousNumericUnion() {
     // json
     json val = 23.0d;
@@ -2013,11 +2015,29 @@ function testCloneWithTypeWithAmbiguousNumericUnion() {
         assertTrue(mov.year is int[]);
     }
 
+    // With Finite types
+    jsonArr = [2];
+    string[]|Finite[] arrayFiniteVal = checkpanic jsonArr.cloneWithType();
+    assertFalse(arrayFiniteVal[0] is decimal);
+    assertTrue(arrayFiniteVal[0] is int);
+
+    jsonArr = [2.0d];
+    string[]|Finite[] arrayFiniteVal1 = checkpanic jsonArr.cloneWithType();
+    assertTrue(arrayFiniteVal1[0] is decimal);
+    assertFalse(arrayFiniteVal1[0] is int);
+
+    jsonArr = [2.0];
+    string[]|Finite[]|error arrayFiniteVal2 = jsonArr.cloneWithType();
+    assertTrue(arrayFiniteVal2 is error);
+    error err = <error>arrayFiniteVal2;
+    assertEquality("{ballerina/lang.value}ConversionError", err.message());
+    assertEquality("'json[]' value cannot be converted to '(string[]|Finite[])': \n\t	array element '[0]' should be of type 'string', found '2.0'\n\t	value '2.0' cannot be converted to 'Finite': ambiguous target type", <string>checkpanic err.detail()["message"]);
+
     // Negative cases
     json jVal = [23.0d, 24];
     int[]|[decimal, float]|error result1 = jVal.cloneWithType();
     assertTrue(result1 is error);
-    error err = <error>result1;
+    err = <error>result1;
     assertEquality("{ballerina/lang.value}ConversionError", err.message());
     assertEquality("'json[]' value cannot be converted to '(int[]|[decimal,float])': \n\t	value '[23.0,24]' cannot be converted to '(int[]|[decimal,float])': ambiguous target type", <string>checkpanic err.detail()["message"]);
 

--- a/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
@@ -1764,6 +1764,242 @@ function testCloneWithTypeJsonToRecordRestField() {
     assert(rec, {"arrVal":[{}],"mapVal":{}});
 }
 
+type Movie record {
+    string title;
+    int[]|decimal[] year;
+};
+
+type Union int|decimal|string|Union[]|map<Union>;
+
+function testCloneWithTypeWithAmbiguousNumericUnion() {
+    // json
+    json val = 23.0d;
+    int|decimal unionVal = checkpanic val.cloneWithType();
+    assertTrue(unionVal is decimal);
+    assert(unionVal, 23.0d);
+
+    json[] jsonArr = [23d];
+    string[]|int[]|decimal[] arrayUnionVal = checkpanic  jsonArr.cloneWithType();
+    assert(arrayUnionVal, [23d]);
+    assertTrue(arrayUnionVal is decimal[]);
+
+    json[] jsonArr1 = [23.0d, 24];
+    int[]|[decimal, int] arrTupleUnionVal = checkpanic  jsonArr1.cloneWithType();
+    assert(arrTupleUnionVal, [23.0d, 24]);
+    assertTrue(arrTupleUnionVal is [decimal, int]);
+
+    json jsonMap = {
+        title: "Inception",
+        year: [2010.0d, 2011.0d]
+    };
+
+    Movie recordVal = checkpanic  jsonMap.cloneWithType(Movie);
+    assertTrue(recordVal.year is decimal[]);
+
+    json jsonMap1 = {a: [1d, 2.03d], b: [2d, 3d, 4d]};
+    map<int[]|decimal[]> mapVal = checkpanic  jsonMap1.cloneWithType();
+    assertTrue(mapVal["b"] is decimal[]);
+
+    json moviesJson = [
+        {
+            title: "Inception",
+            year: [2010.0d, 2011.0d]
+        },
+        {
+            title: "Alice in wonderland",
+            year: [2010.0d, 2016.0d]
+        },
+        {
+            title: "Coco",
+            year: [2017.0d, 2018.0d]
+        }
+    ];
+
+    table<map<json>> tableJson = table [
+            {
+                title: "Inception",
+                year: [2010, 2011]
+            },
+            {
+                title: "Alice in wonderland",
+                year: [2010, 2016]
+            },
+            {
+                title: "Coco",
+                year: [2017, 2018]
+            }
+        ];
+
+    Movie[] movieArr = checkpanic moviesJson.cloneWithType();
+    assertTrue(movieArr[0].year is decimal[]);
+    assertTrue(movieArr[1].year is decimal[]);
+    assertTrue(movieArr[2].year is decimal[]);
+
+    table<Movie> movieTab = checkpanic tableJson.cloneWithType();
+    foreach Movie mov in movieTab {
+        assertTrue(mov.year is int[]);
+    }
+
+    // anydata
+
+    anydata val1 = 23.0d;
+    int|decimal unionVal1 = checkpanic val1.cloneWithType();
+    assertTrue(unionVal1 is decimal);
+    assert(unionVal1, 23.0d);
+
+    anydata[] anydataArr = [23d];
+    string[]|int[]|decimal[] arrayUnionVal1 = checkpanic anydataArr.cloneWithType();
+    assert(arrayUnionVal1, [23d]);
+    assertTrue(arrayUnionVal1 is decimal[]);
+
+    anydata[] anydataArr1 = [23.0d, 24];
+    int[]|[decimal, int] arrTupleUnionVal1 = checkpanic anydataArr1.cloneWithType();
+    assert(arrTupleUnionVal1, [23.0d, 24]);
+    assertTrue(arrTupleUnionVal1 is [decimal, int]);
+
+    anydata anydataMap = {
+        title: "Inception",
+        year: [2010.0d, 2011.0d]
+    };
+
+    Movie recordVal1 = checkpanic anydataMap.cloneWithType(Movie);
+    assertTrue(recordVal1.year is decimal[]);
+
+    anydata anydataMap1 = {a: [1d, 2.03d], b: [2d, 3d, 4d]};
+    map<int[]|decimal[]> mapVal1 = checkpanic anydataMap1.cloneWithType();
+    assertTrue(mapVal1["b"] is decimal[]);
+
+    anydata moviesAnydata = [
+        {
+            title: "Inception",
+            year: [2010.0d, 2011.0d]
+        },
+        {
+            title: "Alice in wonderland",
+            year: [2010.0d, 2016.0d]
+        },
+        {
+            title: "Coco",
+            year: [2017.0d, 2018.0d]
+        }
+    ];
+
+    table<map<anydata>> tableAnydata = table [
+            {
+                title: "Inception",
+                year: [2010, 2011]
+            },
+            {
+                title: "Alice in wonderland",
+                year: [2010, 2016]
+            },
+            {
+                title: "Coco",
+                year: [2017, 2018]
+            }
+        ];
+
+    Movie[] movieArr1 = checkpanic moviesAnydata.cloneWithType();
+    assertTrue(movieArr1[0].year is decimal[]);
+    assertTrue(movieArr1[1].year is decimal[]);
+    assertTrue(movieArr1[2].year is decimal[]);
+
+    table<Movie> movieTab1 = checkpanic tableAnydata.cloneWithType();
+    foreach Movie mov in movieTab1 {
+        assertTrue(mov.year is int[]);
+    }
+
+    // union
+    Union val2 = 23.0d;
+    int|decimal unionVal2 = checkpanic val2.cloneWithType();
+    assertTrue(unionVal2 is decimal);
+    assert(unionVal2, 23.0d);
+
+    Union[] unionArr = [23d];
+    string[]|int[]|decimal[] arrayUnionVal2 = checkpanic unionArr.cloneWithType();
+    assert(arrayUnionVal2, [23d]);
+    assertTrue(arrayUnionVal2 is decimal[]);
+
+    Union[] UnionArr2 = [23.0d, 24];
+    int[]|[decimal, int] arrTupleUnionVal2 = checkpanic UnionArr2.cloneWithType();
+    assert(arrTupleUnionVal2, [23.0d, 24]);
+    assertTrue(arrTupleUnionVal2 is [decimal, int]);
+
+    Union unionMap = {
+        title: "Inception",
+        year: [2010.0d, 2011.0d]
+    };
+
+    Movie recordVal2 = checkpanic unionMap.cloneWithType(Movie);
+    assertTrue(recordVal2.year is decimal[]);
+
+    Union unionMap1 = {a: [1d, 2.03d], b: [2d, 3d, 4d]};
+    map<int[]|decimal[]> mapVal2 = checkpanic unionMap1.cloneWithType();
+    assertTrue(mapVal2["b"] is decimal[]);
+
+    Union moviesUnion = [
+        {
+            title: "Inception",
+            year: [2010.0d, 2011.0d]
+        },
+        {
+            title: "Alice in wonderland",
+            year: [2010.0d, 2016.0d]
+        },
+        {
+            title: "Coco",
+            year: [2017.0d, 2018.0d]
+        }
+    ];
+
+    table<map<Union>> tableUnion = table [
+            {
+                title: "Inception",
+                year: [2010, 2011]
+            },
+            {
+                title: "Alice in wonderland",
+                year: [2010, 2016]
+            },
+            {
+                title: "Coco",
+                year: [2017, 2018]
+            }
+        ];
+
+    Movie[] movieArr2 = checkpanic moviesUnion.cloneWithType();
+    assertTrue(movieArr2[0].year is decimal[]);
+    assertTrue(movieArr2[1].year is decimal[]);
+    assertTrue(movieArr2[2].year is decimal[]);
+
+    table<Movie> movieTab2 = checkpanic tableUnion.cloneWithType();
+    foreach Movie mov in movieTab2 {
+        assertTrue(mov.year is int[]);
+    }
+
+    // Negative cases
+    json jVal = [23.0d, 24];
+    int[]|[decimal, float]|error result1 = jVal.cloneWithType();
+    assertTrue(result1 is error);
+    error err = <error>result1;
+    assertEquality("{ballerina/lang.value}ConversionError", err.message());
+    assertEquality("'json[]' value cannot be converted to '(int[]|[decimal,float])': \n\t	value '[23.0,24]' cannot be converted to '(int[]|[decimal,float])': ambiguous target type", <string>checkpanic err.detail()["message"]);
+
+    jVal = [23.0, 24];
+    int[]|decimal[]|float[]|error result2 = jVal.cloneWithType();
+    assertTrue(result2 is error);
+    err = <error>result2;
+    assertEquality("{ballerina/lang.value}ConversionError", err.message());
+    assertEquality("'json[]' value cannot be converted to '(int[]|decimal[]|float[])': \n\t	value '[23.0,24]' cannot be converted to '(int[]|decimal[]|float[])': ambiguous target type", <string>checkpanic err.detail()["message"]);
+
+    jVal = {a: [1d, 2.03], b: [2, 3d, 4]};
+    map<int[]|decimal[]>|error result3 = jVal.cloneWithType(); 
+    assertTrue(result3 is error);
+    err = <error>result3;
+    assertEquality("{ballerina/lang.value}ConversionError", err.message());
+    assertEquality("'map<json>' value cannot be converted to 'map<(int[]|decimal[])>': \n\t	value '[1,2.03]' cannot be converted to '(int[]|decimal[])': ambiguous target type\n\t	value '[2,3,4]' cannot be converted to '(int[]|decimal[])': ambiguous target type", <string>checkpanic err.detail()["message"]);
+}
+
 /////////////////////////// Tests for `toJson()` ///////////////////////////
 
 type Student2 record {


### PR DESCRIPTION
## Purpose
$subject

Fixes #35855 

## Approach
The issue happens when the type of a numeric array value is a union array/tuple and it needed to be converted into another union. If the target union type contains the exact type of the numeric array it should provide that same typed value even if there are other numeric types in the union members. 
This PR fixes it by keeping track of the union members that do not need numeric conversion through a `Set` and validating it for ambiguity. 


## Samples
```ballerina
public function main() returns error? {
    json[] jsonArr = [23.1d];
    string[]|int[]|decimal[] arrayUnionVal = check  jsonArr.cloneWithType(); // result should be decimal[]

    jsonArr = [23.0d, 24];
    int[]|[decimal, int] arrTupleUnionVal = check jsonArr.cloneWithType(); // result should be [decimal, int] 

    jsonArr = [23.0, 24];
    int[]|decimal[]|float[]|error result2 = jsonArr.cloneWithType(); // should throw ambiguity error
}

```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
