### PR TITLE
Fix xml subtypes not being suggested in xml type param

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/TypeParameterContextProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/TypeParameterContextProvider.java
@@ -189,8 +189,10 @@ public class TypeParameterContextProvider<T extends Node> extends AbstractComple
             if (symbol.kind() != SymbolKind.TYPE_DEFINITION) {
                 return false;
             }
-            Optional<? extends TypeSymbol> typeDescriptor = SymbolUtil.getTypeDescriptor(symbol);
-            return typeDescriptor.isPresent() && typeDescriptor.get().typeKind().isXMLType();
+            return SymbolUtil.getTypeDescriptor(symbol)
+                    .map(CommonUtil::getRawType)
+                    .filter(typeSymbol -> typeSymbol.typeKind().isXMLType())
+                    .isPresent();
         });
 
         if (QNameReferenceUtil.onQualifiedNameIdentifier(context, nodeAtCursor)) {

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/XMLTypeDescContextTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/XMLTypeDescContextTest.java
@@ -19,6 +19,7 @@ package org.ballerinalang.langserver.completion;
 
 import org.ballerinalang.langserver.commons.workspace.WorkspaceDocumentException;
 import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
 
 import java.io.IOException;
 
@@ -29,6 +30,7 @@ import java.io.IOException;
  */
 public class XMLTypeDescContextTest extends CompletionTest {
 
+    @Test(dataProvider = "completion-data-provider")
     @Override
     public void test(String config, String configPath) throws WorkspaceDocumentException, IOException {
         super.test(config, configPath);

--- a/language-server/modules/langserver-core/src/test/resources/completion/xml_typedesc_context/config/config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/xml_typedesc_context/config/config1.json
@@ -356,6 +356,14 @@
           "newText": "import test/local_project1;\n"
         }
       ]
+    },
+    {
+      "label": "NEW_XML_TYPE",
+      "kind": "TypeParameter",
+      "detail": "Element",
+      "sortText": "AN",
+      "insertText": "NEW_XML_TYPE",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/xml_typedesc_context/config/config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/xml_typedesc_context/config/config2.json
@@ -356,6 +356,14 @@
           "newText": "import test/local_project1;\n"
         }
       ]
+    },
+    {
+      "label": "NEW_XML_TYPE",
+      "kind": "TypeParameter",
+      "detail": "Element",
+      "sortText": "AN",
+      "insertText": "NEW_XML_TYPE",
+      "insertTextFormat": "Snippet"
     }
   ]
 }


### PR DESCRIPTION
## Purpose
$subject

Fixes #35874

## Approach
The original issue is a side effect of #31845

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
