### PR TITLE
Add document this code action to annotation declarations

### DIFF
--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/codeaction/CodeActionNodeType.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/codeaction/CodeActionNodeType.java
@@ -33,6 +33,7 @@ public enum CodeActionNodeType {
     CLASS,
     RECORD,
     IMPORTS,
+    ANNOTATION,
     NONE;
 
     /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionNodeAnalyzer.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionNodeAnalyzer.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.langserver.codeaction;
 
+import io.ballerina.compiler.syntax.tree.AnnotationDeclarationNode;
 import io.ballerina.compiler.syntax.tree.ClassDefinitionNode;
 import io.ballerina.compiler.syntax.tree.ConstantDeclarationNode;
 import io.ballerina.compiler.syntax.tree.EnumDeclarationNode;
@@ -65,6 +66,23 @@ public class CodeActionNodeAnalyzer extends NodeVisitor {
             }
         }
 
+        this.visitNode(node);
+    }
+
+    @Override
+    public void visit(AnnotationDeclarationNode node) {
+        int startOffset = node.visibilityQualifier().map(token -> token.textRange().startOffset())
+                .orElseGet(() -> node.constKeyword().map(token -> token.textRange().startOffset())
+                        .orElseGet(() -> node.annotationKeyword().textRange().startOffset()));
+        int annotationNameEnd = node.annotationTag().textRange().endOffset();
+        int endOffset = node.semicolonToken().textRange().endOffset();
+        if (isWithinRange(startOffset, endOffset)) {
+            positionDetailsBuilder.setEnclosingDocumentableNode(node);
+            if (isWithinRange(startOffset, annotationNameEnd)) {
+                positionDetailsBuilder.setDocumentableNode(node);
+                return;
+            }
+        }
         this.visitNode(node);
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/docs/AddAllDocumentationCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/docs/AddAllDocumentationCodeAction.java
@@ -50,6 +50,7 @@ public class AddAllDocumentationCodeAction extends AbstractCodeActionProvider {
                 CodeActionNodeType.RESOURCE,
                 CodeActionNodeType.RECORD,
                 CodeActionNodeType.OBJECT_FUNCTION,
+                CodeActionNodeType.ANNOTATION,
                 CodeActionNodeType.CLASS_FUNCTION));
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/docs/AddDocumentationCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/docs/AddDocumentationCodeAction.java
@@ -55,6 +55,7 @@ public class AddDocumentationCodeAction extends AbstractCodeActionProvider {
                 CodeActionNodeType.RECORD,
                 CodeActionNodeType.OBJECT_FUNCTION,
                 CodeActionNodeType.CLASS_FUNCTION,
+                CodeActionNodeType.ANNOTATION,
                 CodeActionNodeType.MODULE_VARIABLE));
     }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/AddDocumentationTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/AddDocumentationTest.java
@@ -55,6 +55,7 @@ public class AddDocumentationTest extends AbstractCodeActionTest {
                 {"singleDocGeneration7.json", "singleDocGeneration.bal"},
                 {"singleDocGeneration8.json", "singleDocGeneration.bal"},
                 {"singleDocGeneration9.json", "singleDocGeneration.bal"},
+                {"singleDocGeneration10.json", "singleDocGeneration.bal"},
                 // Already documented nodes
                 {"documentAlreadyDocumentedConfig1.json", "alreadyDocumentedSource.bal"},
         };

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/command/AddDocumentationCommandExecTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/command/AddDocumentationCommandExecTest.java
@@ -61,6 +61,7 @@ public class AddDocumentationCommandExecTest extends AbstractCommandExecutionTes
                 {"addSingleObjectDocumentation.json", "commonDocumentation.bal"},
                 {"addSingleModuleVarDocumentation1.json", "commonDocumentation.bal"},
                 {"addSingleModuleVarDocumentation2.json", "commonDocumentation.bal"},
+                {"addSingleAnnotationDocumentation.json", "commonDocumentation.bal"},
                 {"serviceDocumentationWithAnnotations.json", "serviceDocumentationWithAnnotations.bal"},
                 {"addResourceFunctionDocumentation.json", "addResourceFunctionDocumentation.bal"},
                 {"add_single_documentation_with_deprecated1.json", "add_single_documentation_with_deprecated1.bal"},

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/command/AddDocumentationCommandExecTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/command/AddDocumentationCommandExecTest.java
@@ -73,6 +73,7 @@ public class AddDocumentationCommandExecTest extends AbstractCommandExecutionTes
                 {"document_already_documented_config4.json", "document_already_documented1.bal"},
                 {"document_already_documented_config5.json", "document_already_documented1.bal"},
                 {"document_already_documented_config6.json", "document_already_documented1.bal"},
+                {"document_already_documented_config7.json", "document_already_documented1.bal"},
         };
     }
 

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/add-documentation/config/singleDocGeneration10.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/add-documentation/config/singleDocGeneration10.json
@@ -1,0 +1,36 @@
+{
+  "line": 10,
+  "character": 8,
+  "expected": [
+    {
+      "title": "Document this",
+      "command": {
+        "title": "Document this",
+        "command": "ADD_DOC",
+        "arguments": [
+          {
+            "key": "node.range",
+            "value": {
+              "start": {
+                "line": 10,
+                "character": 0
+              },
+              "end": {
+                "line": 10,
+                "character": 54
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "title": "Document all",
+      "command": {
+        "title": "Document all",
+        "command": "ADD_ALL_DOC",
+        "arguments": []
+      }
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/command/add-documentation/config/addSingleAnnotationDocumentation.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/add-documentation/config/addSingleAnnotationDocumentation.json
@@ -1,0 +1,40 @@
+{
+  "arguments": {
+    "node.range": {
+      "start": {
+        "line": 37,
+        "character": 4
+      },
+      "end": {
+        "line": 37,
+        "character": 4
+      }
+    }
+  },
+  "expected": {
+    "result": {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "range": {
+                  "start": {
+                    "line": 37,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 37,
+                    "character": 0
+                  }
+                },
+                "newText": "# Description\n"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "jsonrpc": "2.0"
+  }
+}

--- a/language-server/modules/langserver-core/src/test/resources/command/add-documentation/config/document_already_documented_config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/add-documentation/config/document_already_documented_config7.json
@@ -1,0 +1,40 @@
+{
+  "arguments": {
+    "node.range": {
+      "start": {
+        "line": 46,
+        "character": 4
+      },
+      "end": {
+        "line": 46,
+        "character": 4
+      }
+    }
+  },
+  "expected": {
+    "result": {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "range": {
+                  "start": {
+                    "line": 45,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 45,
+                    "character": 0
+                  }
+                },
+                "newText":  "# Description\n"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "jsonrpc": "2.0"
+  }
+}

--- a/language-server/modules/langserver-core/src/test/resources/command/add-documentation/source/commonDocumentation.bal
+++ b/language-server/modules/langserver-core/src/test/resources/command/add-documentation/source/commonDocumentation.bal
@@ -36,4 +36,3 @@ final int testModuleVar2 = 10;
 final int testModuleVar1 = 10;
 
 annotation varAnnotation;
-

--- a/language-server/modules/langserver-core/src/test/resources/command/add-documentation/source/document_already_documented1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/command/add-documentation/source/document_already_documented1.bal
@@ -42,3 +42,12 @@ service / on new http:Listener(8080) {
         return "Hello, " + name;
     }
 }
+
+@MyAnnot
+annotation varAnnotation;
+
+# Description
+public const annotation Data MyAnnot;
+
+# Description
+public type Data record {};


### PR DESCRIPTION
## Purpose
> $Title

Fixes #34423

## Approach
> Adds `Document this` and `Doccument all` code actions for annotation declarations.

## Samples
https://user-images.githubusercontent.com/46120162/166621556-c978cf7c-7f62-4fa0-9c0b-c597ce320d08.mp4

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
