### PR TITLE
Improve change return type code action to add optional error for check expression

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/FixReturnTypeCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/FixReturnTypeCodeAction.java
@@ -101,17 +101,15 @@ public class FixReturnTypeCodeAction extends AbstractCodeActionProvider {
 
         List<TextEdit> importEdits = new ArrayList<>();
         List<String> types = new ArrayList<>();
-        boolean returnsClause = funcDef.get().functionSignature().returnTypeDesc().isPresent();
+        boolean returnTypeDescPresent = funcDef.get().functionSignature().returnTypeDesc().isPresent();
 
         if (checkExprDiagnostic) {
             // Add error return type for check expression
-            String error = "error";
-            String optionalError = "error?";
-            if (returnsClause) {
+            if (returnTypeDescPresent) {
                 types.add(funcDef.get().functionSignature().returnTypeDesc().get().type().toString().trim().concat("|")
-                        .concat(error));
+                        .concat("error"));
             } else {
-                types.add(optionalError);
+                types.add("error?");
             }
         } else {
             // Get all possible return types including ambiguous scenarios
@@ -121,7 +119,7 @@ public class FixReturnTypeCodeAction extends AbstractCodeActionProvider {
         // Where to insert the edit: Depends on if a return statement already available or not
         Position start;
         Position end;
-        if (returnsClause) {
+        if (returnTypeDescPresent) {
             // eg. function test() returns () {...}
             ReturnTypeDescriptorNode returnTypeDesc = funcDef.get().functionSignature().returnTypeDesc().get();
             LinePosition retStart = returnTypeDesc.type().lineRange().startLine();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/FixReturnTypeCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/FixReturnTypeCodeAction.java
@@ -105,11 +105,12 @@ public class FixReturnTypeCodeAction extends AbstractCodeActionProvider {
 
         if (checkExprDiagnostic) {
             // Add optional error for check expression
+            String optionalError = "error?";
             if (returnsClause) {
-                types.add(funcDef.get().functionSignature().returnTypeDesc().get().type().toString().trim() 
-                        + "|error?");
+                types.add(funcDef.get().functionSignature().returnTypeDesc().get().type().toString().trim().concat("|")
+                        .concat(optionalError));
             } else {
-                types.add("error?");
+                types.add(optionalError);
             }
         } else {
             // Get all possible return types including ambiguous scenarios

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/FixReturnTypeCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/FixReturnTypeCodeAction.java
@@ -104,11 +104,12 @@ public class FixReturnTypeCodeAction extends AbstractCodeActionProvider {
         boolean returnsClause = funcDef.get().functionSignature().returnTypeDesc().isPresent();
 
         if (checkExprDiagnostic) {
-            // Add optional error for check expression
+            // Add error return type for check expression
+            String error = "error";
             String optionalError = "error?";
             if (returnsClause) {
                 types.add(funcDef.get().functionSignature().returnTypeDesc().get().type().toString().trim().concat("|")
-                        .concat(optionalError));
+                        .concat(error));
             } else {
                 types.add(optionalError);
             }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/FixReturnTypeCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/FixReturnTypeCodeAction.java
@@ -52,7 +52,7 @@ import java.util.Set;
 public class FixReturnTypeCodeAction extends AbstractCodeActionProvider {
 
     public static final String NAME = "Fix Return Type";
-    public static final Set<String> DIAGNOSTIC_CODES = Set.of("BCE2066", "BCE2068");
+    public static final Set<String> DIAGNOSTIC_CODES = Set.of("BCE2066", "BCE2068", "BCE3032");
 
     @Override
     public boolean validate(Diagnostic diagnostic, DiagBasedPositionDetails positionDetails,
@@ -64,7 +64,8 @@ public class FixReturnTypeCodeAction extends AbstractCodeActionProvider {
         //Suggest the code action only if the immediate parent of the matched node is a return statement 
         // and the return statement corresponds to the enclosing function's signature. 
         NonTerminalNode parentNode = positionDetails.matchedNode().parent();
-        if (parentNode != null && parentNode.kind() != SyntaxKind.RETURN_STATEMENT) {
+        if (parentNode != null && parentNode.kind() != SyntaxKind.RETURN_STATEMENT && 
+                positionDetails.matchedNode().kind() != SyntaxKind.CHECK_EXPRESSION) {
             return false;
         }
 
@@ -79,16 +80,17 @@ public class FixReturnTypeCodeAction extends AbstractCodeActionProvider {
                                                     DiagBasedPositionDetails positionDetails,
                                                     CodeActionContext context) {
         
-        Optional<TypeSymbol> foundType;
+        Optional<TypeSymbol> foundType = Optional.empty();
         if ("BCE2068".equals(diagnostic.diagnosticInfo().code())) {
             foundType = positionDetails.diagnosticProperty(CodeActionUtil
                     .getDiagPropertyFilterFunction(DiagBasedPositionDetails
                             .DIAG_PROP_INCOMPATIBLE_TYPES_FOUND_SYMBOL_INDEX));
-        } else {
+        } else if ("BCE2066".equals(diagnostic.diagnosticInfo().code())) {
             foundType = positionDetails.diagnosticProperty(
                     DiagBasedPositionDetails.DIAG_PROP_INCOMPATIBLE_TYPES_FOUND_SYMBOL_INDEX);
         }
-        if (foundType.isEmpty()) {
+        boolean checkExprDiagnostic = "BCE3032".equals(diagnostic.diagnosticInfo().code());
+        if (foundType.isEmpty() && !checkExprDiagnostic) {
             return Collections.emptyList();
         }
 
@@ -97,28 +99,41 @@ public class FixReturnTypeCodeAction extends AbstractCodeActionProvider {
             return Collections.emptyList();
         }
 
+        List<TextEdit> importEdits = new ArrayList<>();
+        List<String> types = new ArrayList<>();
+        boolean returnsClause = funcDef.get().functionSignature().returnTypeDesc().isPresent();
+
+        if (checkExprDiagnostic) {
+            // Add optional error for check expression
+            if (returnsClause) {
+                types.add(funcDef.get().functionSignature().returnTypeDesc().get().type().toString().trim() 
+                        + "|error?");
+            } else {
+                types.add("error?");
+            }
+        } else {
+            // Get all possible return types including ambiguous scenarios
+            types = CodeActionUtil.getPossibleTypes(foundType.get(), importEdits, context);
+        }
+
         // Where to insert the edit: Depends on if a return statement already available or not
         Position start;
         Position end;
-        if (funcDef.get().functionSignature().returnTypeDesc().isEmpty()) {
-            // eg. function test() {...}
-            Position funcBodyStart = PositionUtil.toPosition(funcDef.get().functionSignature().lineRange().endLine());
-            start = funcBodyStart;
-            end = funcBodyStart;
-        } else {
+        if (returnsClause) {
             // eg. function test() returns () {...}
             ReturnTypeDescriptorNode returnTypeDesc = funcDef.get().functionSignature().returnTypeDesc().get();
             LinePosition retStart = returnTypeDesc.type().lineRange().startLine();
             LinePosition retEnd = returnTypeDesc.type().lineRange().endLine();
             start = new Position(retStart.line(), retStart.offset());
             end = new Position(retEnd.line(), retEnd.offset());
+        } else {
+            // eg. function test() {...}
+            Position funcBodyStart = PositionUtil.toPosition(funcDef.get().functionSignature().lineRange().endLine());
+            start = funcBodyStart;
+            end = funcBodyStart;
         }
 
         List<CodeAction> codeActions = new ArrayList<>();
-        List<TextEdit> importEdits = new ArrayList<>();
-        // Get all possible return types including ambiguous scenarios
-        List<String> types = CodeActionUtil.getPossibleTypes(foundType.get(), importEdits, context);
-
         types.forEach(type -> {
             List<TextEdit> edits = new ArrayList<>();
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/FixReturnTypeTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/FixReturnTypeTest.java
@@ -54,8 +54,8 @@ public class FixReturnTypeTest extends AbstractCodeActionTest {
                 {"fixReturnTypeWithClass2.json", "fixReturnTypeInClass.bal"},
                 {"fixReturnTypeWithClass3.json", "fixReturnTypeInClass.bal"},
                 {"fixReturnTypeWithService1.json", "fixReturnTypeInService.bal"},
-                {"fixReturnTypeWithCheckExpr1.json","fixReturnTypeWithCheckExpr1.bal"},
-                {"fixReturnTypeWithCheckExpr2.json","fixReturnTypeWithCheckExpr2.bal"}
+                {"fixReturnTypeWithCheckExpr1.json", "fixReturnTypeWithCheckExpr1.bal"},
+                {"fixReturnTypeWithCheckExpr2.json", "fixReturnTypeWithCheckExpr2.bal"}
         };
     }
 }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/FixReturnTypeTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/FixReturnTypeTest.java
@@ -55,7 +55,9 @@ public class FixReturnTypeTest extends AbstractCodeActionTest {
                 {"fixReturnTypeWithClass3.json", "fixReturnTypeInClass.bal"},
                 {"fixReturnTypeWithService1.json", "fixReturnTypeInService.bal"},
                 {"fixReturnTypeWithCheckExpr1.json", "fixReturnTypeWithCheckExpr1.bal"},
-                {"fixReturnTypeWithCheckExpr2.json", "fixReturnTypeWithCheckExpr2.bal"}
+                {"fixReturnTypeWithCheckExpr2.json", "fixReturnTypeWithCheckExpr2.bal"},
+                {"fixReturnTypeWithCheckExpr3.json", "fixReturnTypeWithCheckExpr3.bal"},
+                {"fixReturnTypeWithCheckExpr4.json", "fixReturnTypeWithCheckExpr4.bal"}
         };
     }
 }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/FixReturnTypeTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/FixReturnTypeTest.java
@@ -54,6 +54,8 @@ public class FixReturnTypeTest extends AbstractCodeActionTest {
                 {"fixReturnTypeWithClass2.json", "fixReturnTypeInClass.bal"},
                 {"fixReturnTypeWithClass3.json", "fixReturnTypeInClass.bal"},
                 {"fixReturnTypeWithService1.json", "fixReturnTypeInService.bal"},
+                {"fixReturnTypeWithCheckExpr1.json","fixReturnTypeWithCheckExpr1.bal"},
+                {"fixReturnTypeWithCheckExpr2.json","fixReturnTypeWithCheckExpr2.bal"}
         };
     }
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/config/fixReturnTypeWithCheckExpr1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/config/fixReturnTypeWithCheckExpr1.json
@@ -1,0 +1,24 @@
+{
+    "line": 1,
+    "character": 20,
+    "expected": [
+        {
+            "title": "Change return type to 'error?'",
+            "edits": [
+                {
+                    "range": {
+                        "start": {
+                            "line": 0,
+                            "character": 22
+                        },
+                        "end": {
+                            "line": 0,
+                            "character": 22
+                        }
+                    },
+                    "newText": " returns error?"
+                }
+            ]
+        }
+    ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/config/fixReturnTypeWithCheckExpr2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/config/fixReturnTypeWithCheckExpr2.json
@@ -3,20 +3,20 @@
     "character": 20,
     "expected": [
         {
-            "title": "Change return type to 'int|error?'",
+            "title": "Change return type to 'error?'",
             "edits": [
                 {
                     "range": {
                         "start": {
                             "line": 0,
-                            "character": 31
+                            "character": 22
                         },
                         "end": {
                             "line": 0,
-                            "character": 34
+                            "character": 22
                         }
                     },
-                    "newText": "int|error?"
+                    "newText": " returns error?"
                 }
             ]
         }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/config/fixReturnTypeWithCheckExpr2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/config/fixReturnTypeWithCheckExpr2.json
@@ -1,0 +1,24 @@
+{
+    "line": 1,
+    "character": 20,
+    "expected": [
+        {
+            "title": "Change return type to 'int|error?'",
+            "edits": [
+                {
+                    "range": {
+                        "start": {
+                            "line": 0,
+                            "character": 31
+                        },
+                        "end": {
+                            "line": 0,
+                            "character": 34
+                        }
+                    },
+                    "newText": "int|error?"
+                }
+            ]
+        }
+    ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/config/fixReturnTypeWithCheckExpr3.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/config/fixReturnTypeWithCheckExpr3.json
@@ -1,0 +1,24 @@
+{
+    "line": 1,
+    "character": 20,
+    "expected": [
+        {
+            "title": "Change return type to 'int|error'",
+            "edits": [
+                {
+                    "range": {
+                        "start": {
+                            "line": 0,
+                            "character": 31
+                        },
+                        "end": {
+                            "line": 0,
+                            "character": 34
+                        }
+                    },
+                    "newText": "int|error"
+                }
+            ]
+        }
+    ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/config/fixReturnTypeWithCheckExpr4.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/config/fixReturnTypeWithCheckExpr4.json
@@ -1,0 +1,24 @@
+{
+    "line": 1,
+    "character": 20,
+    "expected": [
+        {
+            "title": "Change return type to 'int?|error'",
+            "edits": [
+                {
+                    "range": {
+                        "start": {
+                            "line": 0,
+                            "character": 31
+                        },
+                        "end": {
+                            "line": 0,
+                            "character": 35
+                        }
+                    },
+                    "newText": "int?|error"
+                }
+            ]
+        }
+    ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/source/fixReturnTypeWithCheckExpr1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/source/fixReturnTypeWithCheckExpr1.bal
@@ -1,0 +1,7 @@
+public function name() {
+      var myvar = check findNum();
+}
+
+function findNum() returns int|error { 
+    return 0;
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/source/fixReturnTypeWithCheckExpr2.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/source/fixReturnTypeWithCheckExpr2.bal
@@ -1,0 +1,8 @@
+public function name() returns int {
+      var myvar = check findNum();
+      return 0;
+}
+
+function findNum() returns int|error { 
+    return 0;
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/source/fixReturnTypeWithCheckExpr2.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/source/fixReturnTypeWithCheckExpr2.bal
@@ -1,6 +1,6 @@
-public function name() returns int {
-      var myvar = check findNum();
-      return 0;
+public function name() {
+    var myvar = check findNum();
+    return;
 }
 
 function findNum() returns int|error { 

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/source/fixReturnTypeWithCheckExpr3.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/source/fixReturnTypeWithCheckExpr3.bal
@@ -1,0 +1,8 @@
+public function name() returns int {
+    var myvar = check findNum();
+    return 0;
+}
+
+function findNum() returns int|error { 
+    return 0;
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/source/fixReturnTypeWithCheckExpr4.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/source/fixReturnTypeWithCheckExpr4.bal
@@ -1,0 +1,8 @@
+public function name() returns int? {
+    var myvar = check findNum();
+    return 0;
+}
+
+function findNum() returns int|error { 
+    return 0;
+}


### PR DESCRIPTION
## Purpose
This PR improves the change return type code action to add `error` for check expression.

Fixes #34036

## Approach
When the diagnostic is `BCE3032`, finds the closest function and add `error` as a return type if the returns clause exists and `error?` otherwise.

## Samples
1.
https://user-images.githubusercontent.com/27485094/170259493-2f8a5905-6ba4-4353-92cf-0459d02c075b.mov

2.
https://user-images.githubusercontent.com/27485094/170259505-85632337-3d07-4b66-82bf-17b34f055178.mov

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
