### PR TITLE
Allow `int, floating point` multiplication with singleton types

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -1947,7 +1947,8 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
                 compatibleType2 = types.findCompatibleType(rhsType);
             }
 
-            if (types.isBasicNumericType(compatibleType1) && compatibleType1 != compatibleType2) {
+            if (types.isBasicNumericType(compatibleType1) && compatibleType1 != compatibleType2 && 
+                    !isIntFloatingPointMultiplication(opKind, compatibleType1, compatibleType2)) {
                 return symTable.notFoundSymbol;
             }
             if (compatibleType1.tag < compatibleType2.tag) {
@@ -1964,6 +1965,24 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
             return createBinaryOperator(opKind, lhsType, rhsType, compatibleType1);
         }
         return symTable.notFoundSymbol;
+    }
+    
+    private boolean isIntFloatingPointMultiplication(OperatorKind opKind, BType lhsCompatibleType, 
+                                                     BType rhsCompatibleType) {
+        switch (opKind) {
+            case MUL:
+                return lhsCompatibleType.tag == TypeTags.INT && isFloatingPointType(rhsCompatibleType) ||
+                        rhsCompatibleType.tag == TypeTags.INT && isFloatingPointType(lhsCompatibleType);
+            case DIV:
+            case MOD:
+                return isFloatingPointType(lhsCompatibleType) && rhsCompatibleType.tag == TypeTags.INT;
+            default:
+                return false;
+        }
+    }
+    
+    private boolean isFloatingPointType(BType type) {
+        return type.tag == TypeTags.DECIMAL || type.tag == TypeTags.FLOAT;
     }
 
     public BSymbol getUnaryOpsForTypeSets(OperatorKind opKind, BType type) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -1951,18 +1951,19 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
                     !isIntFloatingPointMultiplication(opKind, compatibleType1, compatibleType2)) {
                 return symTable.notFoundSymbol;
             }
+
+            BType returnType;
             if (compatibleType1.tag < compatibleType2.tag) {
-                return createBinaryOperator(opKind, lhsType, rhsType, compatibleType2);
+                returnType = compatibleType2;
+            } else {
+                returnType = compatibleType1;
             }
-            if (lhsType.isNullable()) {
-                compatibleType1 = BUnionType.create(null, compatibleType1, symTable.nilType);
-                return createBinaryOperator(opKind, lhsType, rhsType, compatibleType1);
+
+            if (lhsType.isNullable() || rhsType.isNullable()) {
+                returnType = BUnionType.create(null, returnType, symTable.nilType);
             }
-            if (rhsType.isNullable()) {
-                compatibleType2 = BUnionType.create(null, compatibleType2, symTable.nilType);
-                return createBinaryOperator(opKind, lhsType, rhsType, compatibleType2);
-            }
-            return createBinaryOperator(opKind, lhsType, rhsType, compatibleType1);
+
+            return createBinaryOperator(opKind, lhsType, rhsType, returnType);
         }
         return symTable.notFoundSymbol;
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -1947,18 +1947,12 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
                 compatibleType2 = types.findCompatibleType(rhsType);
             }
 
-            if (types.isBasicNumericType(compatibleType1) && compatibleType1 != compatibleType2 && 
+            if (compatibleType1 != compatibleType2 && types.isBasicNumericType(compatibleType1) && 
                     !isIntFloatingPointMultiplication(opKind, compatibleType1, compatibleType2)) {
                 return symTable.notFoundSymbol;
             }
 
-            BType returnType;
-            if (compatibleType1.tag < compatibleType2.tag) {
-                returnType = compatibleType2;
-            } else {
-                returnType = compatibleType1;
-            }
-
+            BType returnType = compatibleType1.tag < compatibleType2.tag ? compatibleType2 : compatibleType1;
             if (lhsType.isNullable() || rhsType.isNullable()) {
                 returnType = BUnionType.create(null, returnType, symTable.nilType);
             }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/MultiplyOperationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/MultiplyOperationTest.java
@@ -91,7 +91,7 @@ public class MultiplyOperationTest {
 
     @Test(description = "Test binary statement with errors")
     public void testMultiplyStmtNegativeCases() {
-        Assert.assertEquals(resultNegative.getErrorCount(), 9);
+        Assert.assertEquals(resultNegative.getErrorCount(), 7);
         int i = 0;
         BAssertUtil.validateError(resultNegative, i++, "operator '*' not defined for 'json' and 'json'", 8, 10);
         BAssertUtil.validateError(resultNegative, i++, "operator '*' not defined for 'float' and 'string'", 14, 9);
@@ -101,8 +101,6 @@ public class MultiplyOperationTest {
                 "'(string|string:Char)'", 30, 17);
         BAssertUtil.validateError(resultNegative, i++, "operator '*' not defined for 'float' and 'decimal'", 37, 14);
         BAssertUtil.validateError(resultNegative, i++, "operator '*' not defined for 'float' and 'decimal'", 38, 14);
-        BAssertUtil.validateError(resultNegative, i++, "operator '*' not defined for 'C' and 'float'", 45, 14);
-        BAssertUtil.validateError(resultNegative, i++, "operator '*' not defined for 'C' and 'float'", 46, 14);
     }
 
     @Test(description = "Test multiplication of nullable values")
@@ -142,19 +140,6 @@ public class MultiplyOperationTest {
                 "testMultiplyDecimalIntSubTypeWithNullableOperands",
                 "testResultTypeOfMultiplyDecimalIntByInfering",
                 "testResultTypeOfMultiplyDecimalIntForNilableOperandsByInfering",
-        };
-    }
-
-    @Test(dataProvider = "dataToTestShortCircuitingInMultiplication")
-    public void testShortCircuitingInMultiplication(String functionName) {
-        BRunUtil.invoke(result, functionName);
-    }
-
-    @DataProvider
-    public Object[] dataToTestShortCircuitingInMultiplication() {
-        return new Object[]{
-                "testNoShortCircuitingInMultiplicationWithNullable",
-                "testNoShortCircuitingInMultiplicationWithNonNullable"
         };
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/MultiplyOperationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/MultiplyOperationTest.java
@@ -142,4 +142,17 @@ public class MultiplyOperationTest {
                 "testResultTypeOfMultiplyDecimalIntForNilableOperandsByInfering",
         };
     }
+
+    @Test(dataProvider = "dataToTestShortCircuitingInMultiplication")
+    public void testShortCircuitingInMultiplication(String functionName) {
+        BRunUtil.invoke(result, functionName);
+    }
+
+    @DataProvider
+    public Object[] dataToTestShortCircuitingInMultiplication() {
+        return new Object[]{
+                "testNoShortCircuitingInMultiplicationWithNullable",
+                "testNoShortCircuitingInMultiplicationWithNonNullable"
+        };
+    }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/division-operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/division-operation.bal
@@ -829,6 +829,75 @@ function testResultTypeOfDivisionDecimalIntForNilableOperandsByInfering() {
     assertEqual(var7, 4.1d);
 }
 
+int intVal = 10;
+
+function testNoShortCircuitingInDivisionWithNullable() {
+    int? result = foo() / bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 18);
+
+    result = foo() / 12;
+    assertEqual(result, ());
+    assertEqual(intVal, 20);
+
+    result = 12 / bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 26);
+
+    int? x = 20;
+    result = foo() / x;
+    assertEqual(result, ());
+    assertEqual(intVal, 28);
+
+    result = x / bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 34);
+
+    result = x / bam();
+    assertEqual(result, 4);
+    assertEqual(intVal, 44);
+
+    result = bam() / x;
+    assertEqual(result, 0);
+    assertEqual(intVal, 54);
+
+    result = foo() / bam();
+    assertEqual(result, ());
+    assertEqual(intVal, 66);
+
+    result = bam() / bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 82);
+}
+
+function testNoShortCircuitingInDivisionWithNonNullable() {
+    intVal = 10;
+    int x = 10;
+
+    int result = x / bam();
+    assertEqual(result, 2);
+    assertEqual(intVal, 20);
+
+    result = bam() / 2;
+    assertEqual(result, 2);
+    assertEqual(intVal, 30);
+}
+
+function foo() returns int? {
+    intVal += 2;
+    return ();
+}
+
+function bar() returns int? {
+    intVal += 6;
+    return ();
+}
+
+function bam() returns int {
+    intVal += 10;
+    return 5;
+}
+
 function assertEqual(any actual, any expected) {
     if actual is anydata && expected is anydata && actual == expected {
         return;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/division-operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/division-operation.bal
@@ -312,6 +312,8 @@ function testDivisionFloatInt() {
     int f = int:MIN_VALUE;
     MyInt g = 2;
     MyFloat h = 4.5;
+    2 i = 2;
+    4.5 j = 4.5;
 
     float var4 = b / a;
     assertEqual(var4, float:Infinity);
@@ -321,6 +323,8 @@ function testDivisionFloatInt() {
     assertEqual(var6, 0.0);
     float var61 = h / a;
     assertEqual(var61, 2.25);
+    float var62 = j / a;
+    assertEqual(var62, 2.25);
 
     float var7 = b / a1;
     assertEqual(var7, float:Infinity);
@@ -330,6 +334,8 @@ function testDivisionFloatInt() {
     assertEqual(var9, float:NaN);
     float var91 = h / a1;
     assertEqual(var91, float:Infinity);
+    float var92 = j / a1;
+    assertEqual(var92, float:Infinity);
 
     float var10 = b / constInt;
     assertEqual(var10, float:Infinity);
@@ -339,6 +345,8 @@ function testDivisionFloatInt() {
     assertEqual(var12, 0.0);
     float var121 = h / constInt;
     assertEqual(var121, 0.9);
+    float var122 = j / constInt;
+    assertEqual(var122, 0.9);
 
     float var13 = constFloat / constInt;
     assertEqual(var13, 4.1);
@@ -347,16 +355,25 @@ function testDivisionFloatInt() {
     assertEqual(var15, 10.25);
     float var16 = constFloat / d;
     assertEqual(var16, float:Infinity);
-    
+    float var161 = constFloat / i;
+    assertEqual(var161, 10.25);
+
     float var17 = c / e;
     assertEqual(var17, 4.87890977618477E-20);
     float var18 = c / f;
     assertEqual(var18, -4.87890977618477E-20);
     float var19 = c / g;
     assertEqual(var19, 0.225);
+    float var191 = c / i;
+    assertEqual(var191, 0.225);
 
     float var20 = h / g;
     assertEqual(var20, 2.25);
+    float var201 = h / i;
+    assertEqual(var201, 2.25);
+
+    float var21 = j / i;
+    assertEqual(var21, 2.25);
 }
 
 function testDivisionFloatIntSubTypes() {
@@ -393,6 +410,8 @@ function testDivisionFloatIntWithNullableOperands() {
     float? d = -10.5;
     int? e = ();
     float? f = ();
+    2? g = 2;
+    5.5 h = 5.5;
 
     float? var2 = d / a;
     assertEqual(var2, -5.25);
@@ -423,6 +442,15 @@ function testDivisionFloatIntWithNullableOperands() {
 
     float? var14 = constFloat / e;
     assertEqual(var14, ());
+
+    float? var15 = c / g;
+    assertEqual(var15, 0.225);
+
+    float? var16 = h / a;
+    assertEqual(var16, 2.75);
+
+    float? var17 = h / g;
+    assertEqual(var17, 2.75);
 }
 
 function testDivisionFloatIntSubTypeWithNullableOperands() {
@@ -569,6 +597,8 @@ function testDivisionDecimalInt() {
     int f = int:MIN_VALUE;
     MyInt g = 2;
     MyDecimal h = 4.5;
+    2 i = 2;
+    4.5d j = 4.5d;
 
     decimal var5 = c / a;
     assertEqual(var5, 0.225d);
@@ -576,6 +606,8 @@ function testDivisionDecimalInt() {
     assertEqual(var6, 0.0d);
     decimal var61 = h / a;
     assertEqual(var61, 2.25d);
+    decimal var62 = j / a;
+    assertEqual(var62, 2.25d);
 
     decimal var11 = c / constInt;
     assertEqual(var11, 0.09d);
@@ -583,22 +615,33 @@ function testDivisionDecimalInt() {
     assertEqual(var12, 0d);
     decimal var121 = h / constInt;
     assertEqual(var121, 0.9d);
+    decimal var122 = j / constInt;
+    assertEqual(var122, 0.9d);
 
     decimal var13 = constDecimal / constInt;
     assertEqual(var13, 4.1d);
 
     decimal var15 = constDecimal / a;
     assertEqual(var15, 10.25d);
-    
+    decimal var16 = constDecimal / i;
+    assertEqual(var16, 10.25d);
+
     decimal var17 = c / e;
     assertEqual(var17, 4.878909776184769953562510061784767E-20d);
     decimal var18 = c / f;
     assertEqual(var18, -4.878909776184769953033537603914738E-20d);
     decimal var19 = c / g;
     assertEqual(var19, 0.225d);
+    decimal var191 = c / i;
+    assertEqual(var191, 0.225d);
 
     decimal var20 = h / g;
     assertEqual(var20, 2.25d);
+    decimal var201 = h / i;
+    assertEqual(var201, 2.25d);
+
+    decimal var21 = j / i;
+    assertEqual(var21, 2.25d);
 }
 
 function testDivisionDecimalIntSubTypes() {
@@ -635,6 +678,8 @@ function testDivisionDecimalIntWithNullableOperands() {
     decimal? d = -10.5;
     int? e = ();
     decimal? f = ();
+    2? g = 2;
+    5.5d h = 5.5d;
 
     decimal? var2 = d / a;
     assertEqual(var2, -5.25d);
@@ -665,6 +710,15 @@ function testDivisionDecimalIntWithNullableOperands() {
 
     decimal? var14 = constDecimal / e;
     assertEqual(var14, ());
+
+    decimal? var15 = c / g;
+    assertEqual(var15, 0.225d);
+
+    decimal? var16 = h / a;
+    assertEqual(var16, 2.75d);
+
+    decimal? var17 = h / g;
+    assertEqual(var17, 2.75d);
 }
 
 function testDivisionDecimalIntSubTypeWithNullableOperands() {
@@ -773,75 +827,6 @@ function testResultTypeOfDivisionDecimalIntForNilableOperandsByInfering() {
     var i = constDecimal / constInt;
     decimal? var7 = i;
     assertEqual(var7, 4.1d);
-}
-
-int intVal = 10;
-
-function testNoShortCircuitingInDivisionWithNullable() {
-    int? result = foo() / bar();
-    assertEqual(result, ());
-    assertEqual(intVal, 18);
-
-    result = foo() / 12;
-    assertEqual(result, ());
-    assertEqual(intVal, 20);
-
-    result = 12 / bar();
-    assertEqual(result, ());
-    assertEqual(intVal, 26);
-
-    int? x = 20;
-    result = foo() / x;
-    assertEqual(result, ());
-    assertEqual(intVal, 28);
-
-    result = x / bar();
-    assertEqual(result, ());
-    assertEqual(intVal, 34);
-
-    result = x / bam();
-    assertEqual(result, 4);
-    assertEqual(intVal, 44);
-
-    result = bam() / x;
-    assertEqual(result, 0);
-    assertEqual(intVal, 54);
-
-    result = foo() / bam();
-    assertEqual(result, ());
-    assertEqual(intVal, 66);
-
-    result = bam() / bar();
-    assertEqual(result, ());
-    assertEqual(intVal, 82);
-}
-
-function testNoShortCircuitingInDivisionWithNonNullable() {
-    intVal = 10;
-    int x = 10;
-
-    int result = x / bam();
-    assertEqual(result, 2);
-    assertEqual(intVal, 20);
-
-    result = bam() / 2;
-    assertEqual(result, 2);
-    assertEqual(intVal, 30);
-}
-
-function foo() returns int? {
-    intVal += 2;
-    return ();
-}
-
-function bar() returns int? {
-    intVal += 6;
-    return ();
-}
-
-function bam() returns int {
-    intVal += 10;
-    return 5;
 }
 
 function assertEqual(any actual, any expected) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/division-operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/division-operation.bal
@@ -302,6 +302,10 @@ type MyInt int;
 
 type MyFloat float;
 
+type TWO 2;
+
+type FOUR_POINT_FIVE 4.5;
+
 function testDivisionFloatInt() {
     int a = 2;
     int a1 = 0;
@@ -314,6 +318,10 @@ function testDivisionFloatInt() {
     MyFloat h = 4.5;
     2 i = 2;
     4.5 j = 4.5;
+    constInt k = 5;
+    constFloat m = 20.5;
+    TWO n = 2;
+    FOUR_POINT_FIVE p = 4.5;
 
     float var4 = b / a;
     assertEqual(var4, float:Infinity);
@@ -325,6 +333,10 @@ function testDivisionFloatInt() {
     assertEqual(var61, 2.25);
     float var62 = j / a;
     assertEqual(var62, 2.25);
+    float var63 = m / a;
+    assertEqual(var63, 10.25);
+    float var64 = p / a;
+    assertEqual(var64, 2.25);
 
     float var7 = b / a1;
     assertEqual(var7, float:Infinity);
@@ -336,6 +348,10 @@ function testDivisionFloatInt() {
     assertEqual(var91, float:Infinity);
     float var92 = j / a1;
     assertEqual(var92, float:Infinity);
+    float var93 = m / a1;
+    assertEqual(var93, float:Infinity);
+    float var94 = p / a1;
+    assertEqual(var94, float:Infinity);
 
     float var10 = b / constInt;
     assertEqual(var10, float:Infinity);
@@ -347,6 +363,10 @@ function testDivisionFloatInt() {
     assertEqual(var121, 0.9);
     float var122 = j / constInt;
     assertEqual(var122, 0.9);
+    float var123 = m / constInt;
+    assertEqual(var123, 4.1);
+    float var124 = p / constInt;
+    assertEqual(var124, 0.9);
 
     float var13 = constFloat / constInt;
     assertEqual(var13, 4.1);
@@ -366,14 +386,32 @@ function testDivisionFloatInt() {
     assertEqual(var19, 0.225);
     float var191 = c / i;
     assertEqual(var191, 0.225);
+    float var192 = c / k;
+    assertEqual(var192, 0.09);
+    float var193 = c / n;
+    assertEqual(var193, 0.225);
 
     float var20 = h / g;
     assertEqual(var20, 2.25);
     float var201 = h / i;
     assertEqual(var201, 2.25);
+    float var202 = h / k;
+    assertEqual(var202, 0.9);
+    float var203 = h / n;
+    assertEqual(var203, 2.25);
 
     float var21 = j / i;
     assertEqual(var21, 2.25);
+
+    float var22 = m / k;
+    assertEqual(var22, 4.1);
+    float var23 = p / k;
+    assertEqual(var23, 0.9);
+
+    float var24 = m / n;
+    assertEqual(var24, 10.25);
+    float var25 = p / n;
+    assertEqual(var25, 2.25);
 }
 
 function testDivisionFloatIntSubTypes() {
@@ -589,6 +627,8 @@ const decimal constDecimal = 20.5;
 
 type MyDecimal decimal;
 
+type FOUR_POINT_FIVE_DECIMAL 4.5d;
+
 function testDivisionDecimalInt() {
     int a = 2;
     decimal c = 4.5e-1;
@@ -599,6 +639,10 @@ function testDivisionDecimalInt() {
     MyDecimal h = 4.5;
     2 i = 2;
     4.5d j = 4.5d;
+    constInt k = 5;
+    constDecimal m = 20.5;
+    TWO n = 2;
+    FOUR_POINT_FIVE_DECIMAL p = 4.5;
 
     decimal var5 = c / a;
     assertEqual(var5, 0.225d);
@@ -608,6 +652,10 @@ function testDivisionDecimalInt() {
     assertEqual(var61, 2.25d);
     decimal var62 = j / a;
     assertEqual(var62, 2.25d);
+    decimal var63 = m / a;
+    assertEqual(var63, 10.25d);
+    decimal var64 = p / a;
+    assertEqual(var64, 2.25d);
 
     decimal var11 = c / constInt;
     assertEqual(var11, 0.09d);
@@ -617,6 +665,10 @@ function testDivisionDecimalInt() {
     assertEqual(var121, 0.9d);
     decimal var122 = j / constInt;
     assertEqual(var122, 0.9d);
+    decimal var123 = m / constInt;
+    assertEqual(var123, 4.1d);
+    decimal var124 = p / constInt;
+    assertEqual(var124, 0.9d);
 
     decimal var13 = constDecimal / constInt;
     assertEqual(var13, 4.1d);
@@ -634,14 +686,32 @@ function testDivisionDecimalInt() {
     assertEqual(var19, 0.225d);
     decimal var191 = c / i;
     assertEqual(var191, 0.225d);
+    decimal var192 = c / k;
+    assertEqual(var192, 0.09d);
+    decimal var193 = c / n;
+    assertEqual(var193, 0.225d);
 
     decimal var20 = h / g;
     assertEqual(var20, 2.25d);
     decimal var201 = h / i;
     assertEqual(var201, 2.25d);
+    decimal var202 = h / k;
+    assertEqual(var202, 0.9d);
+    decimal var203 = h / n;
+    assertEqual(var203, 2.25d);
 
     decimal var21 = j / i;
     assertEqual(var21, 2.25d);
+
+    decimal var22 = m / k;
+    assertEqual(var22, 4.1d);
+    decimal var23 = p / k;
+    assertEqual(var23, 0.9d);
+
+    decimal var24 = m / n;
+    assertEqual(var24, 10.25d);
+    decimal var25 = p / n;
+    assertEqual(var25, 2.25d);
 }
 
 function testDivisionDecimalIntSubTypes() {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/mod-operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/mod-operation.bal
@@ -674,6 +674,75 @@ function testResultTypeOfModDecimalIntForNilableOperandsByInfering() {
     assertEqual(var7, 0.5d);
 }
 
+int intVal = 10;
+
+function testNoShortCircuitingInModWithNullable() {
+    int? result = foo() % bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 18);
+
+    result = foo() % 12;
+    assertEqual(result, ());
+    assertEqual(intVal, 20);
+
+    result = 12 % bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 26);
+
+    int? x = 12;
+    result = foo() % x;
+    assertEqual(result, ());
+    assertEqual(intVal, 28);
+
+    result = x % bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 34);
+
+    result = x % bam();
+    assertEqual(result, 2);
+    assertEqual(intVal, 44);
+
+    result = bam() % x;
+    assertEqual(result, 5);
+    assertEqual(intVal, 54);
+
+    result = foo() % bam();
+    assertEqual(result, ());
+    assertEqual(intVal, 66);
+
+    result = bam() % bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 82);
+}
+
+function testNoShortCircuitingInModWithNonNullable() {
+    intVal = 10;
+    int x = 10;
+
+    int result = x % bam();
+    assertEqual(result, 0);
+    assertEqual(intVal, 20);
+
+    result = bam() % 12;
+    assertEqual(result, 5);
+    assertEqual(intVal, 30);
+}
+
+function foo() returns int? {
+    intVal += 2;
+    return ();
+}
+
+function bar() returns int? {
+    intVal += 6;
+    return ();
+}
+
+function bam() returns int {
+    intVal += 10;
+    return 5;
+}
+
 function assertEqual(any actual, any expected) {
     if actual is anydata && expected is anydata && actual == expected {
         return;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/mod-operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/mod-operation.bal
@@ -180,6 +180,8 @@ function testModFloatInt() {
     int f = int:MIN_VALUE;
     MyInt g = 2;
     MyFloat h = 4.5;
+    2 i = 2;
+    4.5 j = 4.5;
 
     float var4 = b % a;
     assertEqual(var4, float:NaN);
@@ -189,6 +191,8 @@ function testModFloatInt() {
     assertEqual(var6, 0.0);
     float var61 = h % a;
     assertEqual(var61, 0.5);
+    float var62 = j % a;
+    assertEqual(var62, 0.5);
 
     float var7 = b % a1;
     assertEqual(var7, float:NaN);
@@ -198,6 +202,8 @@ function testModFloatInt() {
     assertEqual(var9, float:NaN);
     float var91 = h % a1;
     assertEqual(var91, float:NaN);
+    float var92 = j % a1;
+    assertEqual(var92, float:NaN);
 
     float var10 = b % constInt;
     assertEqual(var10, float:NaN);
@@ -207,6 +213,8 @@ function testModFloatInt() {
     assertEqual(var12, 0.0);
     float var121 = h % constInt;
     assertEqual(var121, 4.5);
+    float var122 = j % constInt;
+    assertEqual(var122, 4.5);
 
     float var13 = constFloat % constInt;
     assertEqual(var13, 0.5);
@@ -215,16 +223,25 @@ function testModFloatInt() {
     assertEqual(var15, 0.5);
     float var16 = constFloat % d;
     assertEqual(var16, float:NaN);
-    
+    float var161 = constFloat % i;
+    assertEqual(var161, 0.5);
+
     float var17 = c % e;
     assertEqual(var17, 0.45);
     float var18 = c % f;
     assertEqual(var18, 0.45);
     float var19 = c % g;
     assertEqual(var19, 0.45);
+    float var191 = c % i;
+    assertEqual(var191, 0.45);
 
     float var20 = h % g;
     assertEqual(var20, 0.5);
+    float var201 = h % i;
+    assertEqual(var201, 0.5);
+
+    float var21 = j % i;
+    assertEqual(var21, 0.5);
 }
 
 function testModFloatIntSubTypes() {
@@ -261,6 +278,8 @@ function testModFloatIntWithNullableOperands() {
     float? d = -10.5;
     int? e = ();
     float? f = ();
+    2? g = 2;
+    5.5 h = 5.5;
 
     float? var2 = d % a;
     assertEqual(var2, -0.5);
@@ -291,6 +310,15 @@ function testModFloatIntWithNullableOperands() {
 
     float? var14 = constFloat % e;
     assertEqual(var14, ());
+
+    float? var15 = c % g;
+    assertEqual(var15, 0.45);
+
+    float? var16 = h % a;
+    assertEqual(var16, 1.5);
+
+    float? var17 = h % g;
+    assertEqual(var17, 1.5);
 }
 
 function testModFloatIntSubTypeWithNullableOperands() {
@@ -413,6 +441,8 @@ function testModDecimalInt() {
     int f = int:MIN_VALUE;
     MyInt g = 2;
     MyDecimal h = 4.5;
+    2 i = 2;
+    4.5d j = 4.5d;
 
     decimal var5 = c % a;
     assertEqual(var5, 0.45d);
@@ -420,6 +450,8 @@ function testModDecimalInt() {
     assertEqual(var6, 0d);
     decimal var61 = h % a;
     assertEqual(var61, 0.5d);
+    decimal var62 = j % a;
+    assertEqual(var62, 0.5d);
 
     decimal var11 = c % constInt;
     assertEqual(var11, 0.45d);
@@ -427,23 +459,34 @@ function testModDecimalInt() {
     assertEqual(var12, 0d);
     decimal var121 = h % constInt;
     assertEqual(var121, 4.5d);
+    decimal var122 = j % constInt;
+    assertEqual(var122, 4.5d);
 
     decimal var13 = constDecimal % constInt;
     assertEqual(var13, 0.5d);
 
     decimal var15 = constDecimal % a;
     assertEqual(var15, 0.5d);
-    
+    decimal var16 = constDecimal % i;
+    assertEqual(var16, 0.5d);
+
     decimal var17 = c % e;
     assertEqual(var17, 0.45d);
     decimal var18 = c % f;
     assertEqual(var18, 0.45d);
-    
+
     decimal var19 = c % g;
     assertEqual(var19, 0.45d);
+    decimal var191 = c % i;
+    assertEqual(var191, 0.45d);
 
     decimal var20 = h % g;
     assertEqual(var20, 0.5d);
+    decimal var201 = h % i;
+    assertEqual(var201, 0.5d);
+
+    decimal var21 = j % i;
+    assertEqual(var21, 0.5d);
 }
 
 function testModDecimalIntSubTypes() {
@@ -480,6 +523,8 @@ function testModDecimalIntWithNullableOperands() {
     decimal? d = -10.5;
     int? e = ();
     decimal? f = ();
+    2? g = 2;
+    5.5d h = 5.5d;
 
     decimal? var2 = d % a;
     assertEqual(var2, -0.5d);
@@ -510,6 +555,15 @@ function testModDecimalIntWithNullableOperands() {
 
     decimal? var14 = constDecimal % e;
     assertEqual(var14, ());
+
+    decimal? var15 = c % g;
+    assertEqual(var15, 0.45d);
+
+    decimal? var16 = h % a;
+    assertEqual(var16, 1.5d);
+
+    decimal? var17 = h % g;
+    assertEqual(var17, 1.5d);
 }
 
 function testModDecimalIntSubTypeWithNullableOperands() {
@@ -618,75 +672,6 @@ function testResultTypeOfModDecimalIntForNilableOperandsByInfering() {
     var i = constDecimal % constInt;
     decimal? var7 = i;
     assertEqual(var7, 0.5d);
-}
-
-int intVal = 10;
-
-function testNoShortCircuitingInModWithNullable() {
-    int? result = foo() % bar();
-    assertEqual(result, ());
-    assertEqual(intVal, 18);
-
-    result = foo() % 12;
-    assertEqual(result, ());
-    assertEqual(intVal, 20);
-
-    result = 12 % bar();
-    assertEqual(result, ());
-    assertEqual(intVal, 26);
-
-    int? x = 12;
-    result = foo() % x;
-    assertEqual(result, ());
-    assertEqual(intVal, 28);
-
-    result = x % bar();
-    assertEqual(result, ());
-    assertEqual(intVal, 34);
-
-    result = x % bam();
-    assertEqual(result, 2);
-    assertEqual(intVal, 44);
-
-    result = bam() % x;
-    assertEqual(result, 5);
-    assertEqual(intVal, 54);
-
-    result = foo() % bam();
-    assertEqual(result, ());
-    assertEqual(intVal, 66);
-
-    result = bam() % bar();
-    assertEqual(result, ());
-    assertEqual(intVal, 82);
-}
-
-function testNoShortCircuitingInModWithNonNullable() {
-    intVal = 10;
-    int x = 10;
-
-    int result = x % bam();
-    assertEqual(result, 0);
-    assertEqual(intVal, 20);
-
-    result = bam() % 12;
-    assertEqual(result, 5);
-    assertEqual(intVal, 30);
-}
-
-function foo() returns int? {
-    intVal += 2;
-    return ();
-}
-
-function bar() returns int? {
-    intVal += 6;
-    return ();
-}
-
-function bam() returns int {
-    intVal += 10;
-    return 5;
 }
 
 function assertEqual(any actual, any expected) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/mod-operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/mod-operation.bal
@@ -170,6 +170,10 @@ type MyInt int;
 
 type MyFloat float;
 
+type TWO 2;
+
+type FOUR_POINT_FIVE 4.5;
+
 function testModFloatInt() {
     int a = 2;
     int a1 = 0;
@@ -182,6 +186,10 @@ function testModFloatInt() {
     MyFloat h = 4.5;
     2 i = 2;
     4.5 j = 4.5;
+    constInt k = 5;
+    constFloat m = 20.5;
+    TWO n = 2;
+    FOUR_POINT_FIVE p = 4.5;
 
     float var4 = b % a;
     assertEqual(var4, float:NaN);
@@ -193,6 +201,10 @@ function testModFloatInt() {
     assertEqual(var61, 0.5);
     float var62 = j % a;
     assertEqual(var62, 0.5);
+    float var63 = m % a;
+    assertEqual(var63, 0.5);
+    float var64 = p % a;
+    assertEqual(var64, 0.5);
 
     float var7 = b % a1;
     assertEqual(var7, float:NaN);
@@ -204,6 +216,10 @@ function testModFloatInt() {
     assertEqual(var91, float:NaN);
     float var92 = j % a1;
     assertEqual(var92, float:NaN);
+    float var93 = m % a1;
+    assertEqual(var93, float:NaN);
+    float var94 = p % a1;
+    assertEqual(var94, float:NaN);
 
     float var10 = b % constInt;
     assertEqual(var10, float:NaN);
@@ -215,6 +231,10 @@ function testModFloatInt() {
     assertEqual(var121, 4.5);
     float var122 = j % constInt;
     assertEqual(var122, 4.5);
+    float var123 = m % constInt;
+    assertEqual(var123, 0.5);
+    float var124 = p % constInt;
+    assertEqual(var124, 4.5);
 
     float var13 = constFloat % constInt;
     assertEqual(var13, 0.5);
@@ -234,14 +254,32 @@ function testModFloatInt() {
     assertEqual(var19, 0.45);
     float var191 = c % i;
     assertEqual(var191, 0.45);
+    float var192 = c % k;
+    assertEqual(var192, 0.45);
+    float var193 = c % n;
+    assertEqual(var193, 0.45);
 
     float var20 = h % g;
     assertEqual(var20, 0.5);
     float var201 = h % i;
     assertEqual(var201, 0.5);
+    float var202 = h % k;
+    assertEqual(var202, 4.5);
+    float var203 = h % n;
+    assertEqual(var203, 0.5);
 
     float var21 = j % i;
     assertEqual(var21, 0.5);
+
+    float var22 = m % k;
+    assertEqual(var22, 0.5);
+    float var23 = p % k;
+    assertEqual(var23, 4.5);
+
+    float var24 = m % n;
+    assertEqual(var24, 0.5);
+    float var25 = p % n;
+    assertEqual(var25, 0.5);
 }
 
 function testModFloatIntSubTypes() {
@@ -433,6 +471,8 @@ const decimal constDecimal = 20.5;
 
 type MyDecimal decimal;
 
+type FOUR_POINT_FIVE_DECIMAL 4.5d;
+
 function testModDecimalInt() {
     int a = 2;
     decimal c = 4.5e-1;
@@ -443,6 +483,10 @@ function testModDecimalInt() {
     MyDecimal h = 4.5;
     2 i = 2;
     4.5d j = 4.5d;
+    constInt k = 5;
+    constDecimal m = 20.5;
+    TWO n = 2;
+    FOUR_POINT_FIVE_DECIMAL p = 4.5;
 
     decimal var5 = c % a;
     assertEqual(var5, 0.45d);
@@ -452,6 +496,10 @@ function testModDecimalInt() {
     assertEqual(var61, 0.5d);
     decimal var62 = j % a;
     assertEqual(var62, 0.5d);
+    decimal var63 = m % a;
+    assertEqual(var63, 0.5d);
+    decimal var64 = p % a;
+    assertEqual(var64, 0.5d);
 
     decimal var11 = c % constInt;
     assertEqual(var11, 0.45d);
@@ -461,6 +509,10 @@ function testModDecimalInt() {
     assertEqual(var121, 4.5d);
     decimal var122 = j % constInt;
     assertEqual(var122, 4.5d);
+    decimal var123 = m % constInt;
+    assertEqual(var123, 0.5d);
+    decimal var124 = p % constInt;
+    assertEqual(var124, 4.5d);
 
     decimal var13 = constDecimal % constInt;
     assertEqual(var13, 0.5d);
@@ -474,19 +526,36 @@ function testModDecimalInt() {
     assertEqual(var17, 0.45d);
     decimal var18 = c % f;
     assertEqual(var18, 0.45d);
-
     decimal var19 = c % g;
     assertEqual(var19, 0.45d);
     decimal var191 = c % i;
     assertEqual(var191, 0.45d);
+    decimal var192 = c % k;
+    assertEqual(var192, 0.45d);
+    decimal var193 = c % n;
+    assertEqual(var193, 0.45d);
 
     decimal var20 = h % g;
     assertEqual(var20, 0.5d);
     decimal var201 = h % i;
     assertEqual(var201, 0.5d);
+    decimal var202 = h % k;
+    assertEqual(var202, 4.5d);
+    decimal var203 = h % n;
+    assertEqual(var203, 0.5d);
 
     decimal var21 = j % i;
     assertEqual(var21, 0.5d);
+
+    decimal var22 = m % k;
+    assertEqual(var22, 0.5d);
+    decimal var23 = p % k;
+    assertEqual(var23, 4.5d);
+
+    decimal var24 = m % n;
+    assertEqual(var24, 0.5d);
+    decimal var25 = p % n;
+    assertEqual(var25, 0.5d);
 }
 
 function testModDecimalIntSubTypes() {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/multiply-operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/multiply-operation.bal
@@ -301,6 +301,8 @@ function testMultiplyFloatInt() {
     int f = int:MIN_VALUE;
     MyInt g = 2;
     MyFloat h = 4.5;
+    2 i = 2;
+    4.5 j = 4.5;
 
     float var1 = a * b;
     assertEqual(var1, 9.0);
@@ -310,6 +312,8 @@ function testMultiplyFloatInt() {
     assertEqual(var3, -21.0);
     float var31 = a * h;
     assertEqual(var31, 9.0);
+    float var32 = a * j;
+    assertEqual(var32, 9.0);
 
     float var4 = b * a;
     assertEqual(var4, 9.0);
@@ -319,6 +323,8 @@ function testMultiplyFloatInt() {
     assertEqual(var6, -21.0);
     float var61 = h * a;
     assertEqual(var61, 9.0);
+    float var62 = j * a;
+    assertEqual(var62, 9.0);
 
     float var7 = constInt * b;
     assertEqual(var7, 22.5);
@@ -328,6 +334,8 @@ function testMultiplyFloatInt() {
     assertEqual(var9, -52.5);
     float var91 = constInt * h;
     assertEqual(var91, 22.5);
+    float var92 = constInt * j;
+    assertEqual(var92, 22.5);
 
     float var10 = b * constInt;
     assertEqual(var10, 22.5);
@@ -337,6 +345,8 @@ function testMultiplyFloatInt() {
     assertEqual(var12, -52.5);
     float var121 = h * constInt;
     assertEqual(var121, 22.5);
+    float var122 = j * constInt;
+    assertEqual(var122, 22.5);
 
     float var13 = constFloat * constInt;
     assertEqual(var13, 102.5);
@@ -357,6 +367,19 @@ function testMultiplyFloatInt() {
 
     float var20 = g * h;
     assertEqual(var20, 9.0);
+
+    float var21 = i * b;
+    assertEqual(var21, 9.0);
+    float var22 = b * i;
+    assertEqual(var22, 9.0);
+    float var23 = h * i;
+    assertEqual(var23, 9.0);
+    float var24 = i * h;
+    assertEqual(var24, 9.0);
+    float var25 = i * constFloat;
+    assertEqual(var25, 41.0);
+    float var26 = constFloat * i;
+    assertEqual(var26, 41.0);
 }
 
 function testMultiplyFloatIntSubTypes() {
@@ -404,33 +427,50 @@ function testMultiplyFloatIntSubTypes() {
 function testMultiplyFloatIntWithNullableOperands() {
     int a = 2;
     int? b = 4;
-    float c = 4.5e-1;
-    float? d = -10.5;
+    5? c = 5;
+    float d = 4.5e-1;
+    float? e = -10.5;
+    2.5? f = 2.5;
 
-    float? var1 = a * d;
+    float? var1 = a * e;
     assertEqual(var1, -21.0);
-    float? var2 = d * a;
+    float? var2 = e * a;
     assertEqual(var2, -21.0);
 
-    float? var3 = b * c;
+    float? var3 = b * d;
     assertEqual(var3, 1.8);
-    float? var4 = c * b;
+    float? var4 = d * b;
     assertEqual(var4, 1.8);
 
-    float? var5 = b * d;
+    float? var5 = b * e;
     assertEqual(var5, -42.0);
-    float? var6 = d * b;
+    float? var6 = e * b;
     assertEqual(var6, -42.0);
 
-    float? var7 = constInt * d;
+    float? var7 = constInt * e;
     assertEqual(var7, -52.5);
-    float? var8 = d * constInt;
+    float? var8 = e * constInt;
     assertEqual(var8, -52.5);
 
     float? var9 = constFloat * b;
     assertEqual(var9, 82.0);
     float? var10 = b * constFloat;
     assertEqual(var10, 82.0);
+
+    float? var11 = a * f;
+    assertEqual(var11, 5.0);
+    float? var12 = f * a;
+    assertEqual(var12, 5.0);
+
+    float? var13 = c * d;
+    assertEqual(var13, 2.25);
+    float? var14 = d * c;
+    assertEqual(var14, 2.25);
+
+    float? var15 = c * f;
+    assertEqual(var15, 12.5);
+    float? var16 = f * c;
+    assertEqual(var16, 12.5);
 }
 
 function testMultiplyFloatIntSubTypeWithNullableOperands() {
@@ -648,6 +688,8 @@ function testMultiplyDecimalInt() {
     int f = int:MIN_VALUE;
     MyInt g = 2;
     MyDecimal h = 4.5;
+    2 i = 2;
+    4.5d j = 4.5d;
 
     decimal var1 = a * b;
     assertEqual(var1, 9.00d);
@@ -657,6 +699,8 @@ function testMultiplyDecimalInt() {
     assertEqual(var3, -21.00d);
     decimal var31 = a * h;
     assertEqual(var31, 9.00d);
+    decimal var32 = a * j;
+    assertEqual(var32, 9.00d);
 
     decimal var4 = b * a;
     assertEqual(var4, 9.00d);
@@ -666,6 +710,8 @@ function testMultiplyDecimalInt() {
     assertEqual(var6, -21.00d);
     decimal var61 = h * a;
     assertEqual(var61, 9.00d);
+    decimal var62 = j * a;
+    assertEqual(var62, 9.00d);
 
     decimal var7 = constInt * b;
     assertEqual(var7, 22.50d);
@@ -675,6 +721,8 @@ function testMultiplyDecimalInt() {
     assertEqual(var9, -52.50d);
     decimal var91 = constInt * h;
     assertEqual(var91, 22.50d);
+    decimal var92 = constInt * j;
+    assertEqual(var92, 22.50d);
 
     decimal var10 = b * constInt;
     assertEqual(var10, 22.50d);
@@ -684,6 +732,8 @@ function testMultiplyDecimalInt() {
     assertEqual(var12, -52.50d);
     decimal var121 = h * constInt;
     assertEqual(var121, 22.50d);
+    decimal var122 = j * constInt;
+    assertEqual(var122, 22.50d);
 
     decimal var13 = constDecimal * constInt;
     assertEqual(var13, 102.50d);
@@ -694,7 +744,7 @@ function testMultiplyDecimalInt() {
     assertEqual(var15, 41.00d);
     decimal var16 = a * constDecimal;
     assertEqual(var16, 41.00d);
-    
+
     decimal var17 = b * e;
     assertEqual(var17, 41505174165846491131.50d);
     decimal var18 = b * f;
@@ -704,6 +754,19 @@ function testMultiplyDecimalInt() {
 
     decimal var20 = g * h;
     assertEqual(var20, 9.00d);
+
+    decimal var21 = i * b;
+    assertEqual(var21, 9.00d);
+    decimal var22 = b * i;
+    assertEqual(var22, 9.00d);
+    decimal var23 = h * i;
+    assertEqual(var23, 9.00d);
+    decimal var24 = i * h;
+    assertEqual(var24, 9.00d);
+    decimal var25 = i * constDecimal;
+    assertEqual(var25, 41.00d);
+    decimal var26 = constDecimal * i;
+    assertEqual(var26, 41.00d);
 }
 
 function testMultiplyDecimalIntSubTypes() {
@@ -751,33 +814,50 @@ function testMultiplyDecimalIntSubTypes() {
 function testMultiplyDecimalIntWithNullableOperands() {
     int a = 2;
     int? b = 4;
-    decimal c = 4.5e-1;
-    decimal? d = -10.5;
+    5? c = 5;
+    decimal d = 4.5e-1;
+    decimal? e = -10.5;
+    2.5d? f = 2.5d;
 
-    decimal? var1 = a * d;
+    decimal? var1 = a * e;
     assertEqual(var1, -21.00d);
-    decimal? var2 = d * a;
+    decimal? var2 = e * a;
     assertEqual(var2, -21.00d);
 
-    decimal? var3 = b * c;
+    decimal? var3 = b * d;
     assertEqual(var3, 1.80d);
-    decimal? var4 = c * b;
+    decimal? var4 = d * b;
     assertEqual(var4, 1.80d);
 
-    decimal? var5 = b * d;
+    decimal? var5 = b * e;
     assertEqual(var5, -42.00d);
-    decimal? var6 = d * b;
+    decimal? var6 = e * b;
     assertEqual(var6, -42.00d);
 
-    decimal? var7 = constInt * d;
+    decimal? var7 = constInt * e;
     assertEqual(var7, -52.50d);
-    decimal? var8 = d * constInt;
+    decimal? var8 = e * constInt;
     assertEqual(var8, -52.50d);
 
     decimal? var9 = constDecimal * b;
     assertEqual(var9, 82.00d);
     decimal? var10 = b * constDecimal;
     assertEqual(var10, 82.00d);
+
+    decimal? var11 = a * f;
+    assertEqual(var11, 5.00d);
+    decimal? var12 = f * a;
+    assertEqual(var12, 5.00d);
+
+    decimal? var13 = c * d;
+    assertEqual(var13, 2.250d);
+    decimal? var14 = d * c;
+    assertEqual(var14, 2.250d);
+
+    decimal? var15 = c * f;
+    assertEqual(var15, 12.50d);
+    decimal? var16 = f * c;
+    assertEqual(var16, 12.50d);
 }
 
 function testMultiplyDecimalIntSubTypeWithNullableOperands() {
@@ -955,75 +1035,6 @@ function testResultTypeOfMultiplyDecimalIntForNilableOperandsByInfering() {
     var h = b * constDecimal;
     decimal? var6 = h;
     assertEqual(var6, 61.50d);
-}
-
-int intVal = 10;
-
-function testNoShortCircuitingInMultiplicationWithNullable() {
-    int? result = foo() * bar();
-    assertEqual(result, ());
-    assertEqual(intVal, 18);
-
-    result = foo() * 12;
-    assertEqual(result, ());
-    assertEqual(intVal, 20);
-
-    result = 12 * bar();
-    assertEqual(result, ());
-    assertEqual(intVal, 26);
-
-    int? x = 12;
-    result = foo() * x;
-    assertEqual(result, ());
-    assertEqual(intVal, 28);
-
-    result = x * bar();
-    assertEqual(result, ());
-    assertEqual(intVal, 34);
-
-    result = x * bam();
-    assertEqual(result, 60);
-    assertEqual(intVal, 44);
-
-    result = bam() * x;
-    assertEqual(result, 60);
-    assertEqual(intVal, 54);
-
-    result = foo() * bam();
-    assertEqual(result, ());
-    assertEqual(intVal, 66);
-
-    result = bam() * bar();
-    assertEqual(result, ());
-    assertEqual(intVal, 82);
-}
-
-function testNoShortCircuitingInMultiplicationWithNonNullable() {
-    intVal = 10;
-    int x = 10;
-
-    int result = x * bam();
-    assertEqual(result, 50);
-    assertEqual(intVal, 20);
-
-    result = bam() * 12;
-    assertEqual(result, 60);
-    assertEqual(intVal, 30);
-}
-
-function foo() returns int? {
-    intVal += 2;
-    return ();
-}
-
-function bar() returns int? {
-    intVal += 6;
-    return ();
-}
-
-function bam() returns int {
-    intVal += 10;
-    return 5;
 }
 
 function assertEqual(any actual, any expected) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/multiply-operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/multiply-operation.bal
@@ -292,6 +292,10 @@ type MyInt int;
 
 type MyFloat float;
 
+type TWO 2;
+
+type FOUR_POINT_FIVE 4.5;
+
 function testMultiplyFloatInt() {
     int a = 2;
     float b = 4.5;
@@ -303,6 +307,10 @@ function testMultiplyFloatInt() {
     MyFloat h = 4.5;
     2 i = 2;
     4.5 j = 4.5;
+    constInt k = 5;
+    constFloat m = 20.5;
+    TWO n = 2;
+    FOUR_POINT_FIVE p = 4.5;
 
     float var1 = a * b;
     assertEqual(var1, 9.0);
@@ -314,6 +322,10 @@ function testMultiplyFloatInt() {
     assertEqual(var31, 9.0);
     float var32 = a * j;
     assertEqual(var32, 9.0);
+    float var33 = a * m;
+    assertEqual(var33, 41.0);
+    float var34 = a * p;
+    assertEqual(var34, 9.0);
 
     float var4 = b * a;
     assertEqual(var4, 9.0);
@@ -325,6 +337,10 @@ function testMultiplyFloatInt() {
     assertEqual(var61, 9.0);
     float var62 = j * a;
     assertEqual(var62, 9.0);
+    float var63 = m * a;
+    assertEqual(var63, 41.0);
+    float var64 = p * a;
+    assertEqual(var64, 9.0);
 
     float var7 = constInt * b;
     assertEqual(var7, 22.5);
@@ -336,6 +352,10 @@ function testMultiplyFloatInt() {
     assertEqual(var91, 22.5);
     float var92 = constInt * j;
     assertEqual(var92, 22.5);
+    float var93 = constInt * m;
+    assertEqual(var93, 102.5);
+    float var94 = constInt * p;
+    assertEqual(var94, 22.5);
 
     float var10 = b * constInt;
     assertEqual(var10, 22.5);
@@ -347,6 +367,10 @@ function testMultiplyFloatInt() {
     assertEqual(var121, 22.5);
     float var122 = j * constInt;
     assertEqual(var122, 22.5);
+    float var123 = m * constInt;
+    assertEqual(var123, 102.5);
+    float var124 = p * constInt;
+    assertEqual(var124, 22.5);
 
     float var13 = constFloat * constInt;
     assertEqual(var13, 102.5);
@@ -380,6 +404,32 @@ function testMultiplyFloatInt() {
     assertEqual(var25, 41.0);
     float var26 = constFloat * i;
     assertEqual(var26, 41.0);
+
+    float var27 = k * b;
+    assertEqual(var27, 22.5);
+    float var28 = b * k;
+    assertEqual(var28, 22.5);
+    float var29 = h * k;
+    assertEqual(var29, 22.5);
+    float var30 = k * h;
+    assertEqual(var30, 22.5);
+    float var311 = k * constFloat;
+    assertEqual(var311, 102.5);
+    float var312 = constFloat * k;
+    assertEqual(var312, 102.5);
+
+    float var313 = n * b;
+    assertEqual(var313, 9.0);
+    float var314 = b * n;
+    assertEqual(var314, 9.0);
+    float var315 = h * n;
+    assertEqual(var315, 9.0);
+    float var316 = n * h;
+    assertEqual(var316, 9.0);
+    float var317 = n * constFloat;
+    assertEqual(var317, 41.0);
+    float var318 = constFloat * n;
+    assertEqual(var318, 41.0);
 }
 
 function testMultiplyFloatIntSubTypes() {
@@ -679,6 +729,8 @@ const decimal constDecimal = 20.5;
 
 type MyDecimal decimal;
 
+type FOUR_POINT_FIVE_DECIMAL 4.5d;
+
 function testMultiplyDecimalInt() {
     int a = 2;
     decimal b = 4.5;
@@ -690,6 +742,10 @@ function testMultiplyDecimalInt() {
     MyDecimal h = 4.5;
     2 i = 2;
     4.5d j = 4.5d;
+    constInt k = 5;
+    constDecimal m = 20.5;
+    TWO n = 2;
+    FOUR_POINT_FIVE_DECIMAL p = 4.5d;
 
     decimal var1 = a * b;
     assertEqual(var1, 9.00d);
@@ -701,6 +757,10 @@ function testMultiplyDecimalInt() {
     assertEqual(var31, 9.00d);
     decimal var32 = a * j;
     assertEqual(var32, 9.00d);
+    decimal var33 = a * m;
+    assertEqual(var33, 41.00d);
+    decimal var34 = a * p;
+    assertEqual(var34, 9.00d);
 
     decimal var4 = b * a;
     assertEqual(var4, 9.00d);
@@ -712,6 +772,10 @@ function testMultiplyDecimalInt() {
     assertEqual(var61, 9.00d);
     decimal var62 = j * a;
     assertEqual(var62, 9.00d);
+    decimal var63 = m * a;
+    assertEqual(var63, 41.00d);
+    decimal var64 = p * a;
+    assertEqual(var64, 9.00d);
 
     decimal var7 = constInt * b;
     assertEqual(var7, 22.50d);
@@ -723,6 +787,10 @@ function testMultiplyDecimalInt() {
     assertEqual(var91, 22.50d);
     decimal var92 = constInt * j;
     assertEqual(var92, 22.50d);
+    decimal var93 = constInt * m;
+    assertEqual(var93, 102.50d);
+    decimal var94 = constInt * p;
+    assertEqual(var94, 22.50d);
 
     decimal var10 = b * constInt;
     assertEqual(var10, 22.50d);
@@ -734,6 +802,10 @@ function testMultiplyDecimalInt() {
     assertEqual(var121, 22.50d);
     decimal var122 = j * constInt;
     assertEqual(var122, 22.50d);
+    decimal var123 = m * constInt;
+    assertEqual(var123, 102.50d);
+    decimal var124 = p * constInt;
+    assertEqual(var124, 22.50d);
 
     decimal var13 = constDecimal * constInt;
     assertEqual(var13, 102.50d);
@@ -767,6 +839,32 @@ function testMultiplyDecimalInt() {
     assertEqual(var25, 41.00d);
     decimal var26 = constDecimal * i;
     assertEqual(var26, 41.00d);
+
+    decimal var27 = k * b;
+    assertEqual(var27, 22.50d);
+    decimal var28 = b * k;
+    assertEqual(var28, 22.50d);
+    decimal var29 = h * k;
+    assertEqual(var29, 22.50d);
+    decimal var30 = k * h;
+    assertEqual(var30, 22.50d);
+    decimal var311 = k * constDecimal;
+    assertEqual(var311, 102.50d);
+    decimal var312 = constDecimal * k;
+    assertEqual(var312, 102.50d);
+
+    decimal var313 = n * b;
+    assertEqual(var313, 9.00d);
+    decimal var314 = b * n;
+    assertEqual(var314, 9.00d);
+    decimal var315 = h * n;
+    assertEqual(var315, 9.00d);
+    decimal var316 = n * h;
+    assertEqual(var316, 9.00d);
+    decimal var317 = n * constDecimal;
+    assertEqual(var317, 41.00d);
+    decimal var318 = constDecimal * n;
+    assertEqual(var318, 41.00d);
 }
 
 function testMultiplyDecimalIntSubTypes() {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/multiply-operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/multiply-operation.bal
@@ -1037,6 +1037,75 @@ function testResultTypeOfMultiplyDecimalIntForNilableOperandsByInfering() {
     assertEqual(var6, 61.50d);
 }
 
+int intVal = 10;
+
+function testNoShortCircuitingInMultiplicationWithNullable() {
+    int? result = foo() * bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 18);
+
+    result = foo() * 12;
+    assertEqual(result, ());
+    assertEqual(intVal, 20);
+
+    result = 12 * bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 26);
+
+    int? x = 12;
+    result = foo() * x;
+    assertEqual(result, ());
+    assertEqual(intVal, 28);
+
+    result = x * bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 34);
+
+    result = x * bam();
+    assertEqual(result, 60);
+    assertEqual(intVal, 44);
+
+    result = bam() * x;
+    assertEqual(result, 60);
+    assertEqual(intVal, 54);
+
+    result = foo() * bam();
+    assertEqual(result, ());
+    assertEqual(intVal, 66);
+
+    result = bam() * bar();
+    assertEqual(result, ());
+    assertEqual(intVal, 82);
+}
+
+function testNoShortCircuitingInMultiplicationWithNonNullable() {
+    intVal = 10;
+    int x = 10;
+
+    int result = x * bam();
+    assertEqual(result, 50);
+    assertEqual(intVal, 20);
+
+    result = bam() * 12;
+    assertEqual(result, 60);
+    assertEqual(intVal, 30);
+}
+
+function foo() returns int? {
+    intVal += 2;
+    return ();
+}
+
+function bar() returns int? {
+    intVal += 6;
+    return ();
+}
+
+function bam() returns int {
+    intVal += 10;
+    return 5;
+}
+
 function assertEqual(any actual, any expected) {
     if actual is anydata && expected is anydata && actual == expected {
         return;


### PR DESCRIPTION
## Purpose
$title

Fixes #36074

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
