### PR TITLE
Add documentation endpoint to lang-server

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSContextOperation.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSContextOperation.java
@@ -51,7 +51,8 @@ public enum LSContextOperation implements LSOperation {
     SOURCE_PRUNER("sourcePruner"),
     TEST_GEN("testGeneration"),
     CREATE_PROJECT("createProject"),
-    RELOAD_PROJECT("reloadProject");
+    RELOAD_PROJECT("reloadProject"),
+    SYMBOL_DOCUMENT("symbol/documentation");
 
     private final String name;
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/symbol/BallerinaSymbolClientCapabilities.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/symbol/BallerinaSymbolClientCapabilities.java
@@ -28,6 +28,16 @@ public class BallerinaSymbolClientCapabilities extends BallerinaClientCapability
 
     private boolean type;
 
+    private boolean getSymbol;
+
+    public boolean isGetSymbol() {
+        return getSymbol;
+    }
+
+    public void setGetSymbol(boolean getSymbol) {
+        this.getSymbol = getSymbol;
+    }
+
     public boolean isEndpoints() {
         return endpoints;
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/symbol/BallerinaSymbolServerCapabilities.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/symbol/BallerinaSymbolServerCapabilities.java
@@ -28,6 +28,16 @@ public class BallerinaSymbolServerCapabilities extends BallerinaServerCapability
 
     private boolean type;
 
+    private boolean getSymbol;
+
+    public boolean isGetSymbol() {
+        return getSymbol;
+    }
+
+    public void setGetSymbol(boolean getSymbol) {
+        this.getSymbol = getSymbol;
+    }
+
     public boolean isEndpoints() {
         return endpoints;
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/symbol/BallerinaSymbolService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/symbol/BallerinaSymbolService.java
@@ -179,8 +179,7 @@ public class BallerinaSymbolService implements ExtendedLanguageServerService {
                         List<ParameterSymbol> parameterSymbolList = functionSymbol.typeDescriptor().params().get();
 
                         parameterSymbolList.stream().filter((parameterSymbol) ->
-                                parameterSymbol.getName().isPresent() &&
-                                        documentation.get().parameterMap().containsKey(parameterSymbol.getName().get()))
+                                parameterSymbol.getName().isPresent())
                                 .forEach(parameterSymbol -> {
 
                                     symbolParams.add(new SymbolDocumentation.ParameterInfo(
@@ -192,8 +191,7 @@ public class BallerinaSymbolService implements ExtendedLanguageServerService {
                     }
 
                     Optional<ParameterSymbol> restParam = functionSymbol.typeDescriptor().restParam();
-                    if (restParam.isPresent() && restParam.get().getName().isPresent() &&
-                            documentation.get().parameterMap().containsKey(restParam.get().getName().get())) {
+                    if (restParam.isPresent() && restParam.get().getName().isPresent()) {
                         ParameterSymbol restParameter = restParam.get();
                         symbolParams.add(new SymbolDocumentation.ParameterInfo(
                                 restParameter.getName().get(),

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/symbol/BallerinaSymbolService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/symbol/BallerinaSymbolService.java
@@ -205,7 +205,8 @@ public class BallerinaSymbolService implements ExtendedLanguageServerService {
                     });
                 }
 
-                SymbolDocumentation symbolDoc = new SymbolDocumentation(documentation, symbolParams, deprecatedParams);
+                SymbolDocumentation symbolDoc = new SymbolDocumentation(documentation.get(), symbolParams,
+                        deprecatedParams);
 
                 symbolInfoResponse.setSymbolDocumentation(symbolDoc);
                 symbolInfoResponse.setSymbolKind(symbolAtCursor.get().kind());

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/symbol/BallerinaSymbolService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/symbol/BallerinaSymbolService.java
@@ -36,7 +36,6 @@ import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.commons.DocumentServiceContext;
 import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.commons.service.spi.ExtendedLanguageServerService;
-
 import org.ballerinalang.langserver.commons.workspace.WorkspaceManagerProxy;
 import org.ballerinalang.langserver.contexts.ContextBuilder;
 import org.eclipse.lsp4j.Position;
@@ -130,7 +129,7 @@ public class BallerinaSymbolService implements ExtendedLanguageServerService {
     }
 
     @JsonRequest
-    public CompletableFuture<SymbolInfoResponse> getSymbol(SymbolInfoRequest request){
+    public CompletableFuture<SymbolInfoResponse> getSymbol(SymbolInfoRequest request) {
         return CompletableFuture.supplyAsync(() -> {
             SymbolInfoResponse symbolInfoResponse = new SymbolInfoResponse();
             String fileUri = request.getDocumentIdentifier().getUri();
@@ -141,7 +140,8 @@ public class BallerinaSymbolService implements ExtendedLanguageServerService {
             }
 
             try {
-                Optional<SemanticModel> semanticModel = this.workspaceManagerProxy.get(fileUri).semanticModel(filePath.get());
+                Optional<SemanticModel> semanticModel = this.workspaceManagerProxy.get(fileUri).
+                        semanticModel(filePath.get());
                 if (semanticModel.isEmpty()) {
                     return symbolInfoResponse;
                 }
@@ -152,7 +152,8 @@ public class BallerinaSymbolService implements ExtendedLanguageServerService {
                         this.serverContext);
 
                 Optional<Document> srcFile = context.currentDocument();
-                LinePosition linePosition = LinePosition.from(request.getPosition().getLine(), request.getPosition().getCharacter());
+                LinePosition linePosition = LinePosition.from(request.getPosition().getLine(),
+                        request.getPosition().getCharacter());
                 Optional<? extends Symbol> symbolAtCursor = semanticModel.get().symbol(srcFile.get(), linePosition);
 
                 if (symbolAtCursor.isEmpty()) {
@@ -162,48 +163,49 @@ public class BallerinaSymbolService implements ExtendedLanguageServerService {
                 Optional<Documentation> documentation = symbolAtCursor.get() instanceof Documentable ?
                         ((Documentable) symbolAtCursor.get()).documentation() : Optional.empty();
 
-                if (documentation.isEmpty()){
+                if (documentation.isEmpty()) {
                     return symbolInfoResponse;
                 }
 
-                List<SymbolDocumentation.ParameterInfo> symbolParams = new ArrayList<>(documentation.get().parameterMap().size());
+                List<SymbolDocumentation.ParameterInfo> symbolParams = new ArrayList<>(documentation.get().
+                        parameterMap().size());
 
-                if (symbolAtCursor.get() instanceof FunctionSymbol){
+                if (symbolAtCursor.get() instanceof FunctionSymbol) {
                     FunctionSymbol functionSymbol = (FunctionSymbol) symbolAtCursor.get();
 
-                    if (functionSymbol.typeDescriptor().params().isPresent()){
+                    if (functionSymbol.typeDescriptor().params().isPresent()) {
                         List<ParameterSymbol> parameterSymbolList = functionSymbol.typeDescriptor().params().get();
                         parameterSymbolList.forEach(parameterSymbol -> {
                             symbolParams.add(new SymbolDocumentation.ParameterInfo(
                                     parameterSymbol.getName().get(),
                                     documentation.get().parameterMap().get(parameterSymbol.getName().get()),
                                     parameterSymbol.paramKind().name(),
-                                    CommonUtil.getModifiedTypeName(context,parameterSymbol.typeDescriptor())));
+                                    CommonUtil.getModifiedTypeName(context, parameterSymbol.typeDescriptor())));
                         });
                     }
 
                     Optional<ParameterSymbol> restParam = functionSymbol.typeDescriptor().restParam();
-                    if (restParam.isPresent()){
+                    if (restParam.isPresent()) {
                         ParameterSymbol restParameter = restParam.get();
                         symbolParams.add(new SymbolDocumentation.ParameterInfo(
                                 restParameter.getName().get(),
                                 documentation.get().parameterMap().get(restParameter.getName().get()),
                                 restParameter.paramKind().name(),
-                                CommonUtil.getModifiedTypeName(context,restParameter.typeDescriptor())
-                                ));
+                                CommonUtil.getModifiedTypeName(context, restParameter.typeDescriptor())
+                        ));
                     }
                 }
 
                 List<SymbolDocumentation.ParameterInfo> deprecatedParams = new ArrayList<>(
                         documentation.get().deprecatedParametersMap().size());
-                Map<String,String> deprecatedParamMap = documentation.get().deprecatedParametersMap();
-                if (!deprecatedParamMap.isEmpty()){
-                    deprecatedParamMap.forEach((param, desc)-> {
-                        deprecatedParams.add(new SymbolDocumentation.ParameterInfo(param,desc));
+                Map<String, String> deprecatedParamMap = documentation.get().deprecatedParametersMap();
+                if (!deprecatedParamMap.isEmpty()) {
+                    deprecatedParamMap.forEach((param, desc) -> {
+                        deprecatedParams.add(new SymbolDocumentation.ParameterInfo(param, desc));
                     });
                 }
 
-                SymbolDocumentation symbolDoc = new SymbolDocumentation(documentation,symbolParams,deprecatedParams);
+                SymbolDocumentation symbolDoc = new SymbolDocumentation(documentation, symbolParams, deprecatedParams);
 
                 symbolInfoResponse.setSymbolDocumentation(symbolDoc);
                 symbolInfoResponse.setSymbolKind(symbolAtCursor.get().kind());

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/symbol/BallerinaSymbolServiceServerCapabilitySetter.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/symbol/BallerinaSymbolServiceServerCapabilitySetter.java
@@ -34,6 +34,7 @@ public class BallerinaSymbolServiceServerCapabilitySetter extends
         BallerinaSymbolServerCapabilities capabilities = new BallerinaSymbolServerCapabilities();
         capabilities.setEndpoints(true);
         capabilities.setType(true);
+        capabilities.setGetSymbol(true);
         return Optional.of(capabilities);
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/symbol/SymbolContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/symbol/SymbolContext.java
@@ -23,7 +23,8 @@ import org.ballerinalang.langserver.commons.LSOperation;
  * @since 2.0.0
  */
 public enum SymbolContext implements LSOperation {
-    SC_TYPE_API("ballerinaSymbol/type");
+    SC_TYPE_API("ballerinaSymbol/type"),
+    SC_GET_SYMBOL_API("ballerinaSymbol/getSymbol");
     private final String name;
 
     SymbolContext(String name) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/symbol/SymbolDocumentation.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/symbol/SymbolDocumentation.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.langserver.extensions.ballerina.symbol;
+
+import io.ballerina.compiler.api.symbols.Documentation;
+
+import java.util.List;
+import java.util.Optional;
+/**
+ * Represents the documentation structure of getSymbol endpoint of BallerinaSymbolService
+ */
+public class SymbolDocumentation {
+    public String description;
+    public List<ParameterInfo> parameters;
+    public String returnValueDescription;
+    public String deprecatedDocumentation;
+    public List<ParameterInfo> deprecatedParams;
+
+
+    public SymbolDocumentation(Optional<Documentation> documentation, List<ParameterInfo> parameters, List<ParameterInfo> deprecatedParams) {
+        this.description = documentation.get().description().isEmpty() ?
+                null : documentation.get().description().get();
+        this.parameters = parameters.isEmpty() ? null : parameters;
+        this.returnValueDescription = documentation.get().returnDescription().isEmpty() ?
+                null : documentation.get().returnDescription().get();
+        this.deprecatedDocumentation = documentation.get().deprecatedDescription().isEmpty() ?
+                null : documentation.get().deprecatedDescription().get();
+        this.deprecatedParams = deprecatedParams.isEmpty() ? null : deprecatedParams;
+    }
+
+
+    /**
+     * Represents a parameter information
+     */
+    public static class ParameterInfo {
+
+        public String name;
+        public String description;
+        public String kind;
+        public String type;
+
+        public ParameterInfo(String name, String description, String kind, String type) {
+            this.name = name;
+            this.description = description;
+            this.kind = kind;
+            this.type = type;
+        }
+
+        public ParameterInfo(String name, String description) {
+            this.name = name;
+            this.description = description;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getKind() {
+            return kind;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+    }
+}

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/symbol/SymbolDocumentation.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/symbol/SymbolDocumentation.java
@@ -19,8 +19,9 @@ import io.ballerina.compiler.api.symbols.Documentation;
 
 import java.util.List;
 import java.util.Optional;
+
 /**
- * Represents the documentation structure of getSymbol endpoint of BallerinaSymbolService
+ * Represents the documentation structure of getSymbol endpoint of BallerinaSymbolService.
  */
 public class SymbolDocumentation {
     public String description;
@@ -30,7 +31,8 @@ public class SymbolDocumentation {
     public List<ParameterInfo> deprecatedParams;
 
 
-    public SymbolDocumentation(Optional<Documentation> documentation, List<ParameterInfo> parameters, List<ParameterInfo> deprecatedParams) {
+    public SymbolDocumentation(Optional<Documentation> documentation, List<ParameterInfo> parameters,
+                               List<ParameterInfo> deprecatedParams) {
         this.description = documentation.get().description().isEmpty() ?
                 null : documentation.get().description().get();
         this.parameters = parameters.isEmpty() ? null : parameters;
@@ -43,7 +45,7 @@ public class SymbolDocumentation {
 
 
     /**
-     * Represents a parameter information
+     * Represents a parameter information.
      */
     public static class ParameterInfo {
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/symbol/SymbolDocumentation.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/symbol/SymbolDocumentation.java
@@ -21,6 +21,8 @@ import java.util.List;
 
 /**
  * Represents the documentation structure of getSymbol endpoint of BallerinaSymbolService.
+ *
+ *  @since 2201.1.0
  */
 public class SymbolDocumentation {
     private final String description;
@@ -63,6 +65,8 @@ public class SymbolDocumentation {
 
     /**
      * Represents a parameter information.
+     *
+     * @since 2201.1.0
      */
     public static class ParameterInfo {
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/symbol/SymbolDocumentation.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/symbol/SymbolDocumentation.java
@@ -24,11 +24,11 @@ import java.util.Optional;
  * Represents the documentation structure of getSymbol endpoint of BallerinaSymbolService.
  */
 public class SymbolDocumentation {
-    public String description;
-    public List<ParameterInfo> parameters;
-    public String returnValueDescription;
-    public String deprecatedDocumentation;
-    public List<ParameterInfo> deprecatedParams;
+    private final String description;
+    private final List<ParameterInfo> parameters;
+    private final String returnValueDescription;
+    private final String deprecatedDocumentation;
+    private final List<ParameterInfo> deprecatedParams;
 
 
     public SymbolDocumentation(Optional<Documentation> documentation, List<ParameterInfo> parameters,
@@ -43,6 +43,25 @@ public class SymbolDocumentation {
         this.deprecatedParams = deprecatedParams.isEmpty() ? null : deprecatedParams;
     }
 
+    public String getDescription() {
+        return description;
+    }
+
+    public List<ParameterInfo> getParameters() {
+        return parameters;
+    }
+
+    public String getReturnValueDescription() {
+        return returnValueDescription;
+    }
+
+    public String getDeprecatedDocumentation() {
+        return deprecatedDocumentation;
+    }
+
+    public List<ParameterInfo> getDeprecatedParams() {
+        return deprecatedParams;
+    }
 
     /**
      * Represents a parameter information.

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/symbol/SymbolDocumentation.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/symbol/SymbolDocumentation.java
@@ -18,7 +18,6 @@ package org.ballerinalang.langserver.extensions.ballerina.symbol;
 import io.ballerina.compiler.api.symbols.Documentation;
 
 import java.util.List;
-import java.util.Optional;
 
 /**
  * Represents the documentation structure of getSymbol endpoint of BallerinaSymbolService.
@@ -31,15 +30,14 @@ public class SymbolDocumentation {
     private final List<ParameterInfo> deprecatedParams;
 
 
-    public SymbolDocumentation(Optional<Documentation> documentation, List<ParameterInfo> parameters,
+    public SymbolDocumentation(Documentation documentation, List<ParameterInfo> parameters,
                                List<ParameterInfo> deprecatedParams) {
-        this.description = documentation.get().description().isEmpty() ?
-                null : documentation.get().description().get();
+        this.description = documentation.description().isEmpty() ? null : documentation.description().get();
         this.parameters = parameters.isEmpty() ? null : parameters;
-        this.returnValueDescription = documentation.get().returnDescription().isEmpty() ?
-                null : documentation.get().returnDescription().get();
-        this.deprecatedDocumentation = documentation.get().deprecatedDescription().isEmpty() ?
-                null : documentation.get().deprecatedDescription().get();
+        this.returnValueDescription = documentation.returnDescription().isEmpty() ?
+                null : documentation.returnDescription().get();
+        this.deprecatedDocumentation = documentation.deprecatedDescription().isEmpty() ?
+                null : documentation.deprecatedDescription().get();
         this.deprecatedParams = deprecatedParams.isEmpty() ? null : deprecatedParams;
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/symbol/SymbolInfoRequest.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/symbol/SymbolInfoRequest.java
@@ -19,6 +19,8 @@ import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 /**
  * Represents the request for getSymbol endpoint of BallerinaSymbolService.
+ *
+ * @since 2201.1.0
  */
 public class SymbolInfoRequest {
     private TextDocumentIdentifier textDocumentIdentifier;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/symbol/SymbolInfoRequest.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/symbol/SymbolInfoRequest.java
@@ -18,7 +18,7 @@ package org.ballerinalang.langserver.extensions.ballerina.symbol;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 /**
- * Represents the request for getSymbol endpoint of BallerinaSymbolService
+ * Represents the request for getSymbol endpoint of BallerinaSymbolService.
  */
 public class SymbolInfoRequest {
     private TextDocumentIdentifier textDocumentIdentifier;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/symbol/SymbolInfoRequest.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/symbol/SymbolInfoRequest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.langserver.extensions.ballerina.symbol;
+
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+/**
+ * Represents the request for getSymbol endpoint of BallerinaSymbolService
+ */
+public class SymbolInfoRequest {
+    private TextDocumentIdentifier textDocumentIdentifier;
+    private Position position;
+
+
+    public TextDocumentIdentifier getDocumentIdentifier() {
+        return textDocumentIdentifier;
+    }
+
+    public Position getPosition() {
+        return position;
+    }
+
+    public Position setPosition(Position position) {
+        return this.position = position;
+    }
+
+    public TextDocumentIdentifier setTextDocumentIdentifier(TextDocumentIdentifier textDocumentIdentifier) {
+        return this.textDocumentIdentifier = textDocumentIdentifier;
+    }
+}

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/symbol/SymbolInfoResponse.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/symbol/SymbolInfoResponse.java
@@ -18,6 +18,8 @@ package org.ballerinalang.langserver.extensions.ballerina.symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 /**
  * Represents the response for getSymbol endpoint of BallerinaSymbolService.
+ *
+ * @since 2201.1.0
  */
 public class SymbolInfoResponse {
     private SymbolKind symbolKind;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/symbol/SymbolInfoResponse.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/symbol/SymbolInfoResponse.java
@@ -17,7 +17,7 @@ package org.ballerinalang.langserver.extensions.ballerina.symbol;
 
 import io.ballerina.compiler.api.symbols.SymbolKind;
 /**
- * Represents the response for getSymbol endpoint of BallerinaSymbolService
+ * Represents the response for getSymbol endpoint of BallerinaSymbolService.
  */
 public class SymbolInfoResponse {
     private SymbolKind symbolKind;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/symbol/SymbolInfoResponse.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/symbol/SymbolInfoResponse.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.langserver.extensions.ballerina.symbol;
+
+import io.ballerina.compiler.api.symbols.SymbolKind;
+/**
+ * Represents the response for getSymbol endpoint of BallerinaSymbolService
+ */
+public class SymbolInfoResponse {
+    private SymbolKind symbolKind;
+    private SymbolDocumentation documentation;
+
+
+    public void setSymbolDocumentation(SymbolDocumentation documentation) {
+        this.documentation = documentation;
+    }
+
+    public void setSymbolKind(SymbolKind kind) {
+        this.symbolKind = kind;
+    }
+
+    public SymbolKind getSymbolKind() {
+        return symbolKind;
+    }
+
+    public SymbolDocumentation getDocumentation() {
+        return documentation;
+    }
+}

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/LSExtensionTestUtil.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/LSExtensionTestUtil.java
@@ -28,8 +28,11 @@ import org.ballerinalang.langserver.extensions.ballerina.document.BallerinaSynta
 import org.ballerinalang.langserver.extensions.ballerina.document.BallerinaSyntaxTreeResponse;
 import org.ballerinalang.langserver.extensions.ballerina.document.SyntaxApiCallsRequest;
 import org.ballerinalang.langserver.extensions.ballerina.document.SyntaxApiCallsResponse;
+import org.ballerinalang.langserver.extensions.ballerina.symbol.SymbolInfoRequest;
+import org.ballerinalang.langserver.extensions.ballerina.symbol.SymbolInfoResponse;
 import org.ballerinalang.langserver.util.FileUtils;
 import org.ballerinalang.langserver.util.TestUtil;
+import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.jsonrpc.Endpoint;
 
@@ -52,6 +55,7 @@ public class LSExtensionTestUtil {
     private static final String SYNTAX_API_QUOTE = "ballerinaDocument/syntaxApiCalls";
     private static final String GET_CONNECTORS = "ballerinaConnector/connectors";
     private static final String GET_CONNECTOR = "ballerinaConnector/connector";
+    private static final String GET_SYMBOL = "ballerinaSymbol/getSymbol";
     private static final Gson GSON = new Gson();
     private static final JsonParser parser = new JsonParser();
 
@@ -167,6 +171,22 @@ public class LSExtensionTestUtil {
                 .resolve(UUID.randomUUID() + ".bal");
         Files.copy(filePath, tempFilePath, StandardCopyOption.REPLACE_EXISTING);
         return tempFilePath;
+    }
+
+    /**
+     * Get the ballerinaDocument/getSymbol response.
+     *
+     * @param filePath        Path of the Bal file
+     * @param serviceEndpoint Service Endpoint to Language Server
+     * @param position Position of the function to get documentation
+     * @return {@link String}   Response as String
+     */
+    public static SymbolInfoResponse getSymbolDocumentation(String filePath, Position position, Endpoint serviceEndpoint) {
+        SymbolInfoRequest symbolInfoRequest = new SymbolInfoRequest();
+        symbolInfoRequest.setPosition(position);
+        symbolInfoRequest.setTextDocumentIdentifier(TestUtil.getTextDocumentIdentifier(filePath));
+        CompletableFuture result = serviceEndpoint.request(GET_SYMBOL, symbolInfoRequest);
+        return GSON.fromJson(getResult(result), SymbolInfoResponse.class);
     }
 
 }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/LSExtensionTestUtil.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/LSExtensionTestUtil.java
@@ -178,10 +178,11 @@ public class LSExtensionTestUtil {
      *
      * @param filePath        Path of the Bal file
      * @param serviceEndpoint Service Endpoint to Language Server
-     * @param position Position of the function to get documentation
+     * @param position        Position of the function to get documentation
      * @return {@link String}   Response as String
      */
-    public static SymbolInfoResponse getSymbolDocumentation(String filePath, Position position, Endpoint serviceEndpoint) {
+    public static SymbolInfoResponse getSymbolDocumentation(String filePath, Position position,
+                                                            Endpoint serviceEndpoint) {
         SymbolInfoRequest symbolInfoRequest = new SymbolInfoRequest();
         symbolInfoRequest.setPosition(position);
         symbolInfoRequest.setTextDocumentIdentifier(TestUtil.getTextDocumentIdentifier(filePath));

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/symbol/SymbolDocumentationTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/symbol/SymbolDocumentationTest.java
@@ -54,6 +54,7 @@ public class SymbolDocumentationTest {
         SymbolInfoResponse symbolInfoResponse = LSExtensionTestUtil.getSymbolDocumentation(
                 inputFile.toString(), functionPos, this.serviceEndpoint);
 
+        Assert.assertNotEquals(symbolInfoResponse.getDocumentation(), null);
         Assert.assertEquals(symbolInfoResponse.getDocumentation().getDescription(), "Adds two integers.");
         Assert.assertEquals(symbolInfoResponse.getDocumentation().getReturnValueDescription(),
                 "the sum of `x` and `y`");
@@ -66,25 +67,28 @@ public class SymbolDocumentationTest {
         TestUtil.closeDocument(this.serviceEndpoint, inputFile);
     }
 
-    @Test(description = "documentation response generated for ballerina standardLib function")
+    @Test(description = "documentation response generated for module function")
     public void testStandardLibSymbolDocumentation() throws IOException {
         Path inputFile = LSExtensionTestUtil.createTempFile(symbolDocumentBalFile);
         TestUtil.openDocument(serviceEndpoint, inputFile);
 
         Position functionPos = new Position();
         functionPos.setLine(16);
-        functionPos.setCharacter(16);
+        functionPos.setCharacter(20);
         SymbolInfoResponse symbolInfoResponse = LSExtensionTestUtil.getSymbolDocumentation(
                 inputFile.toString(), functionPos, this.serviceEndpoint);
 
+        Assert.assertNotEquals(symbolInfoResponse.getDocumentation(), null);
         Assert.assertEquals(symbolInfoResponse.getDocumentation().getDescription(),
-                "Prints info logs.\n```ballerina\nlog:printInfo(\"info message\", id = 845315)\n```\n");
-        Assert.assertEquals(symbolInfoResponse.getDocumentation().getParameters().get(0).name, "msg");
+                "This is function3 with input parameters\n");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getParameters().get(0).name, "param1");
         Assert.assertEquals(symbolInfoResponse.getDocumentation().getParameters().get(0).description,
-                "The message to be logged");
+                "param1 Parameter Description ");
         Assert.assertEquals(symbolInfoResponse.getDocumentation().getParameters().get(0).kind, "REQUIRED");
-        Assert.assertEquals(symbolInfoResponse.getDocumentation().getParameters().get(0).type, "string");
-        Assert.assertEquals(symbolInfoResponse.getDocumentation().getReturnValueDescription(), null);
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getParameters().get(0).type, "int");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getReturnValueDescription(), "Return Value Description");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getDeprecatedParams(), null);
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getDeprecatedDocumentation(), null);
 
         TestUtil.closeDocument(this.serviceEndpoint, inputFile);
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/symbol/SymbolDocumentationTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/symbol/SymbolDocumentationTest.java
@@ -54,12 +54,14 @@ public class SymbolDocumentationTest {
         SymbolInfoResponse symbolInfoResponse = LSExtensionTestUtil.getSymbolDocumentation(
                 inputFile.toString(), functionPos, this.serviceEndpoint);
 
-        Assert.assertEquals(symbolInfoResponse.getDocumentation().description, "Adds two integers.");
-        Assert.assertEquals(symbolInfoResponse.getDocumentation().returnValueDescription, "the sum of `x` and `y`");
-        Assert.assertEquals(symbolInfoResponse.getDocumentation().parameters.get(0).name, "x");
-        Assert.assertEquals(symbolInfoResponse.getDocumentation().parameters.get(0).description, "an integer");
-        Assert.assertEquals(symbolInfoResponse.getDocumentation().parameters.get(1).name, "y");
-        Assert.assertEquals(symbolInfoResponse.getDocumentation().parameters.get(1).description, "another integer");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getDescription(), "Adds two integers.");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getReturnValueDescription(),
+                "the sum of `x` and `y`");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getParameters().get(0).name, "x");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getParameters().get(0).description, "an integer");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getParameters().get(1).name, "y");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getParameters().get(1).description,
+                "another integer");
 
         TestUtil.closeDocument(this.serviceEndpoint, inputFile);
     }
@@ -75,14 +77,14 @@ public class SymbolDocumentationTest {
         SymbolInfoResponse symbolInfoResponse = LSExtensionTestUtil.getSymbolDocumentation(
                 inputFile.toString(), functionPos, this.serviceEndpoint);
 
-        Assert.assertEquals(symbolInfoResponse.getDocumentation().description,
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getDescription(),
                 "Prints info logs.\n```ballerina\nlog:printInfo(\"info message\", id = 845315)\n```\n");
-        Assert.assertEquals(symbolInfoResponse.getDocumentation().parameters.get(0).name, "msg");
-        Assert.assertEquals(symbolInfoResponse.getDocumentation().parameters.get(0).description,
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getParameters().get(0).name, "msg");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getParameters().get(0).description,
                 "The message to be logged");
-        Assert.assertEquals(symbolInfoResponse.getDocumentation().parameters.get(0).kind, "REQUIRED");
-        Assert.assertEquals(symbolInfoResponse.getDocumentation().parameters.get(0).type, "string");
-        Assert.assertEquals(symbolInfoResponse.getDocumentation().returnValueDescription, null);
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getParameters().get(0).kind, "REQUIRED");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getParameters().get(0).type, "string");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getReturnValueDescription(), null);
 
         TestUtil.closeDocument(this.serviceEndpoint, inputFile);
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/symbol/SymbolDocumentationTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/symbol/SymbolDocumentationTest.java
@@ -1,0 +1,71 @@
+package org.ballerinalang.langserver.extensions.symbol;
+
+import org.ballerinalang.langserver.extensions.LSExtensionTestUtil;
+import org.ballerinalang.langserver.extensions.ballerina.symbol.SymbolInfoResponse;
+import org.ballerinalang.langserver.util.FileUtils;
+import org.ballerinalang.langserver.util.TestUtil;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.jsonrpc.Endpoint;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+public class SymbolDocumentationTest {
+    private Endpoint serviceEndpoint;
+
+    private final Path symbolDocumentBalFile = FileUtils.RES_DIR.resolve("extensions")
+            .resolve("symbol")
+            .resolve("symbolDocumentation.bal");
+
+    @BeforeClass
+    public void startLangServer() throws IOException {
+        this.serviceEndpoint = TestUtil.initializeLanguageSever();
+    }
+
+    @Test(description = "documentation response generated for user defined documentation")
+    public void testUserDefinedSymbolDocumentation() throws IOException {
+        Path inputFile = LSExtensionTestUtil.createTempFile(symbolDocumentBalFile);
+        TestUtil.openDocument(serviceEndpoint, inputFile);
+
+        Position functionPos = new Position();
+        functionPos.setLine(15);
+        functionPos.setCharacter(19);
+        SymbolInfoResponse symbolInfoResponse = LSExtensionTestUtil.getSymbolDocumentation(
+                inputFile.toString(), functionPos, this.serviceEndpoint);
+
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().description,"Adds two integers.");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().returnValueDescription,"the sum of `x` and `y`");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().parameters.get(0).name,"x");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().parameters.get(0).description,"an integer");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().parameters.get(1).name,"y");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().parameters.get(1).description,"another integer");
+
+        TestUtil.closeDocument(this.serviceEndpoint, inputFile);
+    }
+
+    @Test(description = "documentation response generated for ballerina standardLib function")
+    public void testStandardLibSymbolDocumentation() throws IOException {
+        Path inputFile = LSExtensionTestUtil.createTempFile(symbolDocumentBalFile);
+        TestUtil.openDocument(serviceEndpoint, inputFile);
+
+        Position functionPos = new Position();
+        functionPos.setLine(16);
+        functionPos.setCharacter(16);
+        SymbolInfoResponse symbolInfoResponse = LSExtensionTestUtil.getSymbolDocumentation(
+                inputFile.toString(), functionPos, this.serviceEndpoint);
+
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().description,
+                "Prints info logs.\n```ballerina\nlog:printInfo(\"info message\", id = 845315)\n```\n");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().parameters.get(0).name,"msg");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().parameters.get(0).description,"The message to be logged");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().parameters.get(0).kind,"REQUIRED");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().parameters.get(0).type,"string");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().returnValueDescription,null);
+
+        TestUtil.closeDocument(this.serviceEndpoint, inputFile);
+
+    }
+}

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/symbol/SymbolDocumentationTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/symbol/SymbolDocumentationTest.java
@@ -86,7 +86,8 @@ public class SymbolDocumentationTest {
                 "param1 Parameter Description ");
         Assert.assertEquals(symbolInfoResponse.getDocumentation().getParameters().get(0).kind, "REQUIRED");
         Assert.assertEquals(symbolInfoResponse.getDocumentation().getParameters().get(0).type, "int");
-        Assert.assertEquals(symbolInfoResponse.getDocumentation().getReturnValueDescription(), "Return Value Description");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getReturnValueDescription(),
+                "Return Value Description");
         Assert.assertEquals(symbolInfoResponse.getDocumentation().getDeprecatedParams(), null);
         Assert.assertEquals(symbolInfoResponse.getDocumentation().getDeprecatedDocumentation(), null);
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/symbol/SymbolDocumentationTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/symbol/SymbolDocumentationTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.langserver.extensions.symbol;
 
+import io.ballerina.compiler.api.symbols.SymbolKind;
 import org.ballerinalang.langserver.extensions.LSExtensionTestUtil;
 import org.ballerinalang.langserver.extensions.ballerina.symbol.SymbolInfoResponse;
 import org.ballerinalang.langserver.util.FileUtils;
@@ -58,11 +59,13 @@ public class SymbolDocumentationTest {
         Assert.assertEquals(symbolInfoResponse.getDocumentation().getDescription(), "Adds two integers.");
         Assert.assertEquals(symbolInfoResponse.getDocumentation().getReturnValueDescription(),
                 "the sum of `x` and `y`");
-        Assert.assertEquals(symbolInfoResponse.getDocumentation().getParameters().get(0).name, "x");
-        Assert.assertEquals(symbolInfoResponse.getDocumentation().getParameters().get(0).description, "an integer");
-        Assert.assertEquals(symbolInfoResponse.getDocumentation().getParameters().get(1).name, "y");
-        Assert.assertEquals(symbolInfoResponse.getDocumentation().getParameters().get(1).description,
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getParameters().get(0).getName(), "x");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getParameters().get(0).getDescription(),
+                "an integer");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getParameters().get(1).getName(), "y");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getParameters().get(1).getDescription(),
                 "another integer");
+        Assert.assertEquals(symbolInfoResponse.getSymbolKind(), SymbolKind.FUNCTION);
 
         TestUtil.closeDocument(this.serviceEndpoint, inputFile);
     }
@@ -81,11 +84,11 @@ public class SymbolDocumentationTest {
         Assert.assertNotEquals(symbolInfoResponse.getDocumentation(), null);
         Assert.assertEquals(symbolInfoResponse.getDocumentation().getDescription(),
                 "This is function3 with input parameters\n");
-        Assert.assertEquals(symbolInfoResponse.getDocumentation().getParameters().get(0).name, "param1");
-        Assert.assertEquals(symbolInfoResponse.getDocumentation().getParameters().get(0).description,
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getParameters().get(0).getName(), "param1");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getParameters().get(0).getDescription(),
                 "param1 Parameter Description ");
-        Assert.assertEquals(symbolInfoResponse.getDocumentation().getParameters().get(0).kind, "REQUIRED");
-        Assert.assertEquals(symbolInfoResponse.getDocumentation().getParameters().get(0).type, "int");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getParameters().get(0).getKind(), "REQUIRED");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getParameters().get(0).getType(), "int");
         Assert.assertEquals(symbolInfoResponse.getDocumentation().getReturnValueDescription(),
                 "Return Value Description");
         Assert.assertEquals(symbolInfoResponse.getDocumentation().getDeprecatedParams(), null);
@@ -93,5 +96,21 @@ public class SymbolDocumentationTest {
 
         TestUtil.closeDocument(this.serviceEndpoint, inputFile);
 
+    }
+
+    @Test(description = "empty documentation response")
+    public void testEmptyDocumentationResponse() throws IOException {
+        Path inputFile = LSExtensionTestUtil.createTempFile(symbolDocumentBalFile);
+        TestUtil.openDocument(serviceEndpoint, inputFile);
+
+        Position functionPos = new Position();
+        functionPos.setLine(17);
+        functionPos.setCharacter(20);
+        SymbolInfoResponse symbolInfoResponse = LSExtensionTestUtil.getSymbolDocumentation(
+                inputFile.toString(), functionPos, this.serviceEndpoint);
+
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getDescription(), null);
+        Assert.assertEquals(symbolInfoResponse.getSymbolKind(), SymbolKind.FUNCTION);
+        TestUtil.closeDocument(this.serviceEndpoint, inputFile);
     }
 }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/symbol/SymbolDocumentationTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/symbol/SymbolDocumentationTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.ballerinalang.langserver.extensions.symbol;
 
 import org.ballerinalang.langserver.extensions.LSExtensionTestUtil;
@@ -13,6 +28,9 @@ import org.testng.annotations.Test;
 import java.io.IOException;
 import java.nio.file.Path;
 
+/**
+ * Test documentation info generated via getSymbol endpoint.
+ */
 public class SymbolDocumentationTest {
     private Endpoint serviceEndpoint;
 
@@ -36,12 +54,12 @@ public class SymbolDocumentationTest {
         SymbolInfoResponse symbolInfoResponse = LSExtensionTestUtil.getSymbolDocumentation(
                 inputFile.toString(), functionPos, this.serviceEndpoint);
 
-        Assert.assertEquals(symbolInfoResponse.getDocumentation().description,"Adds two integers.");
-        Assert.assertEquals(symbolInfoResponse.getDocumentation().returnValueDescription,"the sum of `x` and `y`");
-        Assert.assertEquals(symbolInfoResponse.getDocumentation().parameters.get(0).name,"x");
-        Assert.assertEquals(symbolInfoResponse.getDocumentation().parameters.get(0).description,"an integer");
-        Assert.assertEquals(symbolInfoResponse.getDocumentation().parameters.get(1).name,"y");
-        Assert.assertEquals(symbolInfoResponse.getDocumentation().parameters.get(1).description,"another integer");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().description, "Adds two integers.");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().returnValueDescription, "the sum of `x` and `y`");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().parameters.get(0).name, "x");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().parameters.get(0).description, "an integer");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().parameters.get(1).name, "y");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().parameters.get(1).description, "another integer");
 
         TestUtil.closeDocument(this.serviceEndpoint, inputFile);
     }
@@ -59,11 +77,12 @@ public class SymbolDocumentationTest {
 
         Assert.assertEquals(symbolInfoResponse.getDocumentation().description,
                 "Prints info logs.\n```ballerina\nlog:printInfo(\"info message\", id = 845315)\n```\n");
-        Assert.assertEquals(symbolInfoResponse.getDocumentation().parameters.get(0).name,"msg");
-        Assert.assertEquals(symbolInfoResponse.getDocumentation().parameters.get(0).description,"The message to be logged");
-        Assert.assertEquals(symbolInfoResponse.getDocumentation().parameters.get(0).kind,"REQUIRED");
-        Assert.assertEquals(symbolInfoResponse.getDocumentation().parameters.get(0).type,"string");
-        Assert.assertEquals(symbolInfoResponse.getDocumentation().returnValueDescription,null);
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().parameters.get(0).name, "msg");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().parameters.get(0).description,
+                "The message to be logged");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().parameters.get(0).kind, "REQUIRED");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().parameters.get(0).type, "string");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().returnValueDescription, null);
 
         TestUtil.closeDocument(this.serviceEndpoint, inputFile);
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/symbol/SymbolDocumentationTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/symbol/SymbolDocumentationTest.java
@@ -113,4 +113,24 @@ public class SymbolDocumentationTest {
         Assert.assertEquals(symbolInfoResponse.getSymbolKind(), SymbolKind.FUNCTION);
         TestUtil.closeDocument(this.serviceEndpoint, inputFile);
     }
+
+    @Test(description = "test deprecated params and description")
+    public void testDeprecatedParams() throws IOException {
+        Path inputFile = LSExtensionTestUtil.createTempFile(symbolDocumentBalFile);
+        TestUtil.openDocument(serviceEndpoint, inputFile);
+
+        Position functionPos = new Position();
+        functionPos.setLine(18);
+        functionPos.setCharacter(15);
+        SymbolInfoResponse symbolInfoResponse = LSExtensionTestUtil.getSymbolDocumentation(
+                inputFile.toString(), functionPos, this.serviceEndpoint);
+
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getDeprecatedDocumentation(),
+                "This function is deprecated in favour of `Person` type.");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getDeprecatedParams().get(0).getName(), "street");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getDeprecatedParams().get(0).getDescription(),
+                "deprecated for removal");
+        Assert.assertEquals(symbolInfoResponse.getSymbolKind(), SymbolKind.FUNCTION);
+        TestUtil.closeDocument(this.serviceEndpoint, inputFile);
+    }
 }

--- a/language-server/modules/langserver-core/src/test/resources/extensions/symbol/symbolDocumentation.bal
+++ b/language-server/modules/langserver-core/src/test/resources/extensions/symbol/symbolDocumentation.bal
@@ -16,4 +16,20 @@ public function main() returns error? {
     int result = add(2,3);
     module1:function3(1,2);
     module1:function1();
+    createPerson("test","colombo");
+}
+
+# Creates and returns a `Person` object given the parameters.
+#
+# + fname - First name of the person
+# + street - Street the person is living at
+# + return - A new Person string
+#
+# # Deprecated parameters
+# + street - deprecated for removal
+# # Deprecated
+# This function is deprecated in favour of `Person` type.
+@deprecated
+public function createPerson(string fname, @deprecated string street) returns string {
+    return "";
 }

--- a/language-server/modules/langserver-core/src/test/resources/extensions/symbol/symbolDocumentation.bal
+++ b/language-server/modules/langserver-core/src/test/resources/extensions/symbol/symbolDocumentation.bal
@@ -15,4 +15,5 @@ public function add(int x, int y)
 public function main() returns error? {
     int result = add(2,3);
     module1:function3(1,2);
+    module1:function1();
 }

--- a/language-server/modules/langserver-core/src/test/resources/extensions/symbol/symbolDocumentation.bal
+++ b/language-server/modules/langserver-core/src/test/resources/extensions/symbol/symbolDocumentation.bal
@@ -1,0 +1,18 @@
+import ballerina/log;
+
+# Adds two integers.
+
+# + x - an integer
+# + y - another integer
+
+# + return - the sum of `x` and `y`
+public function add(int x, int y)
+                    returns int {
+
+    return x + y;
+}
+
+public function main() returns error? {
+    int result = add(2,3);
+    log:printInfo(result.toString());
+}

--- a/language-server/modules/langserver-core/src/test/resources/extensions/symbol/symbolDocumentation.bal
+++ b/language-server/modules/langserver-core/src/test/resources/extensions/symbol/symbolDocumentation.bal
@@ -1,4 +1,4 @@
-import ballerina/log;
+import ballerina/module1;
 
 # Adds two integers.
 
@@ -14,5 +14,5 @@ public function add(int x, int y)
 
 public function main() returns error? {
     int result = add(2,3);
-    log:printInfo(result.toString());
+    module1:function3(1,2);
 }


### PR DESCRIPTION
## Purpose
With this pr, a new endpoint is added to get the documentation that is needed for the Statement-editor in low-code-editor.
Related to the issue https://github.com/wso2-enterprise/internal-support-ballerina/issues/73


## Remarks
PR sent to master https://github.com/ballerina-platform/ballerina-lang/pull/36027

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
