### PR TITLE
Fix bug in cache deletion when the dependency graph is updated

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Package.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Package.java
@@ -578,34 +578,58 @@ public class Package {
 
             DependencyGraph<ResolvedPackageDependency> newDepGraph = this.project.currentPackage().getResolution()
                     .dependencyGraph();
-            Set<ResolvedPackageDependency> diff = this.dependencyGraph.difference(newDepGraph);
+            cleanPackageCache(this.dependencyGraph, newDepGraph);
+            return this.project.currentPackage();
+        }
+
+        private void cleanPackageCache(DependencyGraph<ResolvedPackageDependency> oldGraph,
+                                       DependencyGraph<ResolvedPackageDependency> newGraph) {
+            io.ballerina.projects.environment.PackageCache environmentPackageCache =
+                    this.project.projectEnvironmentContext().environment().getService(
+                            io.ballerina.projects.environment.PackageCache.class);
+            Set<ResolvedPackageDependency> diff = oldGraph.difference(newGraph);
             if (!diff.isEmpty()) {
                 // A non-empty diff means deletion of nodes from the old graph is required
-                // to get the new graph, hence we remove these modules from the package caches.
-                CompilerContext compilerContext = project.projectEnvironmentContext()
-                        .getService(CompilerContext.class);
-                PackageCache packageCache = PackageCache.getInstance(compilerContext);
-
-                io.ballerina.projects.environment.PackageCache environmentPackageCache =
-                        project.projectEnvironmentContext().environment().getService(
-                        io.ballerina.projects.environment.PackageCache.class);
-
+                // to get the new graph, hence we remove these modules and its dependants from the package cache.
                 for (ResolvedPackageDependency dependency : diff) {
-                    for (ModuleId moduleId : dependency.packageInstance().moduleIds()) {
-                        if (!dependency.packageInstance().descriptor().isLangLibPackage()) {
-                            Module module = dependency.packageInstance().module(moduleId);
-                            PackageID packageID = module.descriptor().moduleCompilationId();
-                            // remove the module from the compiler packageCache
-                            packageCache.remove(packageID);
-                            // reset the module in the project environment packageCache to make the module recompile
-                            // and add symbols
-                            environmentPackageCache.removePackage(module.moduleId().packageId());
-                            module.moduleContext().setCompilationState(null);
-                        }
+                    environmentPackageCache.removePackage(dependency.packageInstance().packageId());
+                    deleteCaches(dependency, oldGraph);
+                }
+            }
+            diff = newGraph.difference(oldGraph);
+            if (!diff.isEmpty()) {
+                // A non-empty diff means there can be dependant nodes in the old graph that
+                // need to be recompiled. Hence we remove the dependant modules from the package cache.
+                for (ResolvedPackageDependency dependency : diff) {
+                    for (ResolvedPackageDependency directDependent : newGraph.getDirectDependents(dependency)) {
+                        deleteCaches(directDependent, newGraph);
                     }
                 }
             }
-            return this.project.currentPackage();
+        }
+
+        private void deleteCaches(ResolvedPackageDependency dependency,
+                                  DependencyGraph<ResolvedPackageDependency> graph) {
+            if (dependency.equals(graph.getRoot())) {
+                return;
+            }
+            CompilerContext compilerContext = project.projectEnvironmentContext()
+                    .getService(CompilerContext.class);
+            PackageCache packageCache = PackageCache.getInstance(compilerContext);
+            for (ModuleId moduleId : dependency.packageInstance().moduleIds()) {
+                if (!dependency.packageInstance().descriptor().isLangLibPackage()) {
+                    Module module = dependency.packageInstance().module(moduleId);
+                    PackageID packageID = module.descriptor().moduleCompilationId();
+                    // remove the module from the compiler packageCache
+                    packageCache.remove(packageID);
+                    // reset the module in the project environment packageCache to make the module recompile
+                    // and add symbols
+                    module.moduleContext().setCompilationState(null);
+                }
+            }
+            for (ResolvedPackageDependency directDependent : graph.getDirectDependents(dependency)) {
+                deleteCaches(directDependent, graph);
+            }
         }
 
         private void updatePackageManifest() {

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/DependencyGraphTests.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/DependencyGraphTests.java
@@ -39,6 +39,7 @@ import io.ballerina.projects.environment.PackageResolver;
 import io.ballerina.projects.environment.ResolutionOptions;
 import io.ballerina.projects.environment.ResolutionRequest;
 import io.ballerina.projects.environment.ResolutionResponse;
+import io.ballerina.projects.util.ProjectUtils;
 import org.ballerinalang.model.elements.PackageID;
 import org.ballerinalang.test.BCompileUtil;
 import org.testng.Assert;
@@ -94,6 +95,10 @@ public class DependencyGraphTests extends BaseTest {
 
     @Test
     public void testVersionChange() {
+        /* test_dependencies_package --> package_dep (0.1.0), package_c
+         * Specify minimum version for package_dep as 0.1.1
+         */
+
         // 1) load the project
         Path projectPath = RESOURCE_DIRECTORY.resolve("projects_for_edit_api_tests/package_test_dependencies_toml");
 
@@ -108,23 +113,31 @@ public class DependencyGraphTests extends BaseTest {
         PackageCache packageCache = PackageCache.getInstance(
                 project.projectEnvironmentContext().getService(CompilerContext.class));
         project.currentPackage().getCompilation();
-        ResolvedPackageDependency packageC = dependencyGraphOld.getNodes().stream().filter(resolvedPackageDependency ->
-                resolvedPackageDependency.packageInstance().packageName().toString()
-                        .equals("package_dep")).collect(Collectors.toList()).get(0);
-        PackageID packageID = new PackageID(new Name(packageC.packageInstance().packageOrg().value()),
-                new Name(packageC.packageInstance().getDefaultModule().moduleName().toString()),
-                new Name(packageC.packageInstance().packageVersion().toString()));
-        Assert.assertNotNull(packageCache.getSymbol(packageID));
 
-        // 2) update version of the package_c dependency in Dependencies.toml
-        project.currentPackage().dependenciesToml().get().modify().withContent(
-                        "[ballerina]\n" +
-                        "dependencies-toml-version = \"2\"\n" +
+        ResolvedPackageDependency packageDep = dependencyGraphOld.getNodes().stream().filter(
+                resolvedPackageDependency -> resolvedPackageDependency.packageInstance().packageName().toString()
+                        .equals("package_dep")).collect(Collectors.toList()).get(0);
+        PackageID packageDepPkgID = new PackageID(new Name(packageDep.packageInstance().packageOrg().value()),
+                new Name(packageDep.packageInstance().getDefaultModule().moduleName().toString()),
+                new Name(packageDep.packageInstance().packageVersion().toString()));
+        Assert.assertNotNull(packageCache.getSymbol(packageDepPkgID));
+
+        PackageID packageCPkgID = new PackageID(new Name("samjs"), new Name("package_c"), new Name("0.1.0"));
+        Assert.assertNotNull(packageCache.getSymbol(packageCPkgID));
+
+        // 2) update version of the package_dep dependency in Dependencies.toml
+        project.currentPackage().ballerinaToml().get().modify().withContent(
+                        "[package]\n" +
+                        "org = \"foo\"\n" +
+                        "name = \"test_dependencies_package\"\n" +
+                        "version = \"2.1.0\"\n" +
                         "\n" +
+                        "[build-options]\n" +
+                        "observabilityIncluded = false\n\n" +
                         "[[dependency]]\n" +
                         "org = \"foo\"\n" +
                         "name = \"package_dep\"\n" +
-                        "version = \"0.1.1\"\n").apply();
+                        "version = \"0.1.1\"").apply();
 
         // 3) compare dependency graphs before and after edit
         DependencyGraph<ResolvedPackageDependency> dependencyGraphNew =
@@ -132,12 +145,20 @@ public class DependencyGraphTests extends BaseTest {
         // dependency graph should contain self and package_c
         Assert.assertEquals(dependencyGraphNew.getNodes().size(), 3);
 
-        // verify that the package cache is flushed
-        Assert.assertNull(packageCache.getSymbol(packageID));
+        // verify that the package cache is cleaned
+        Assert.assertNull(packageCache.getSymbol(packageDepPkgID));
+        packageDepPkgID = new PackageID(new Name("foo"), new Name("package_dep"), new Name("0.1.1"));
+        Assert.assertNull(packageCache.getSymbol(packageDepPkgID));
+        Assert.assertNotNull(packageCache.getSymbol(packageCPkgID));
     }
 
     @Test
     public void testRemoveDependency() {
+        /*
+         * package_b.mod_b2 --> package_c.mod_c1
+         * Remove package_c dependency
+         */
+
         // 1) load the project
         Path projectDirPath = RESOURCE_DIRECTORY.resolve("projects_for_resolution_tests/package_b");
         BuildProject project = TestUtils.loadBuildProject(projectDirPath);
@@ -153,10 +174,10 @@ public class DependencyGraphTests extends BaseTest {
         ResolvedPackageDependency packageC = dependencyGraphOld.getNodes().stream().filter(resolvedPackageDependency ->
                 resolvedPackageDependency.packageInstance().packageName().toString().equals("package_c"))
                 .collect(Collectors.toList()).get(0);
-        PackageID packageID = new PackageID(new Name(packageC.packageInstance().packageOrg().value()),
+        PackageID packageCPkgID = new PackageID(new Name(packageC.packageInstance().packageOrg().value()),
                 new Name(packageC.packageInstance().getDefaultModule().moduleName().toString()),
                 new Name(packageC.packageInstance().packageVersion().toString()));
-        Assert.assertNotNull(packageCache.getSymbol(packageID));
+        Assert.assertNotNull(packageCache.getSymbol(packageCPkgID));
 
         // 2) update the mod_b2/mod2.bal file to remove package_c dependency
         Module modB2 = project.currentPackage().module(ModuleName.from(PackageName.from("package_b"), "mod_b2"));
@@ -169,12 +190,17 @@ public class DependencyGraphTests extends BaseTest {
         // dependency graph should contain only self
         Assert.assertEquals(dependencyGraphNew.getNodes().size(), 1);
 
-        // verify that the package cache is flushed
-        Assert.assertNull(packageCache.getSymbol(packageID));
+        // verify that the package cache is cleaned
+        Assert.assertNull(packageCache.getSymbol(packageCPkgID));
     }
 
     @Test
     public void testAddDependency() {
+        /*
+         * package_b.mod_b2 --> package_c.mod_c1
+         * Import package_e
+         */
+
         // 1) load the project
         Path projectDirPath = RESOURCE_DIRECTORY.resolve("projects_for_resolution_tests/package_b");
         BuildProject project = TestUtils.loadBuildProject(projectDirPath);
@@ -191,10 +217,10 @@ public class DependencyGraphTests extends BaseTest {
         ResolvedPackageDependency packageC = dependencyGraphOld.getNodes().stream().filter(resolvedPackageDependency ->
                 resolvedPackageDependency.packageInstance().packageName().toString().equals("package_c"))
                 .collect(Collectors.toList()).get(0);
-        PackageID packageID = new PackageID(new Name(packageC.packageInstance().packageOrg().value()),
+        PackageID packageCPkgID = new PackageID(new Name(packageC.packageInstance().packageOrg().value()),
                 new Name(packageC.packageInstance().getDefaultModule().moduleName().toString()),
                 new Name(packageC.packageInstance().packageVersion().toString()));
-        Assert.assertNotNull(packageCache.getSymbol(packageID));
+        Assert.assertNotNull(packageCache.getSymbol(packageCPkgID));
 
         // 2) update the mod_b2/mod2.bal file to add a new dependency
         Module modB2 = project.currentPackage().module(ModuleName.from(PackageName.from("package_b"), "mod_b2"));
@@ -214,12 +240,17 @@ public class DependencyGraphTests extends BaseTest {
         // dependency graph should contain self, package_c and package_e
         Assert.assertEquals(dependencyGraphNew.getNodes().size(), 3);
 
-        // verify that the package cache is not flushed
-        Assert.assertNotNull(packageCache.getSymbol(packageID));
+        // verify that package_c in package cache is unaffected
+        Assert.assertNotNull(packageCache.getSymbol(packageCPkgID));
     }
 
     @Test
     public void testRemoveAndAddDependencies() {
+        /*
+         * package_b.mod_b2 --> package_c.mod_c1
+         * Import package_e. remove pacakge_c.mod_c1
+         */
+
         // 1) load the project
         Path projectDirPath = RESOURCE_DIRECTORY.resolve("projects_for_resolution_tests/package_b");
         BuildProject project = TestUtils.loadBuildProject(projectDirPath);
@@ -251,12 +282,17 @@ public class DependencyGraphTests extends BaseTest {
                 project.currentPackage().getResolution().dependencyGraph();
         // dependency graph should contain self and package_e
         Assert.assertEquals(dependencyGraphNew.getNodes().size(), 2);
-        // verify that the package cache is flushed
+        // verify that the package cache is cleaned
         Assert.assertNull(packageCache.getSymbol(packageID));
     }
 
     @Test
     public void testUnaffectedEdit() {
+        /*
+         * package_b.mod_b2 --> package_c.mod_c1
+         * Import package_e
+         */
+
         // 1) load the project
         Path projectDirPath = RESOURCE_DIRECTORY.resolve("projects_for_resolution_tests/package_b");
         BuildProject project = TestUtils.loadBuildProject(projectDirPath);
@@ -272,12 +308,12 @@ public class DependencyGraphTests extends BaseTest {
         ResolvedPackageDependency packageC = dependencyGraphOld.getNodes().stream().filter(resolvedPackageDependency ->
                 resolvedPackageDependency.packageInstance().packageName().toString().equals("package_c"))
                 .collect(Collectors.toList()).get(0);
-        PackageID packageID = new PackageID(new Name(packageC.packageInstance().packageOrg().value()),
+        PackageID packageCPkgID = new PackageID(new Name(packageC.packageInstance().packageOrg().value()),
                 new Name(packageC.packageInstance().getDefaultModule().moduleName().toString()),
                 new Name(packageC.packageInstance().packageVersion().toString()));
-        Assert.assertNotNull(packageCache.getSymbol(packageID));
+        Assert.assertNotNull(packageCache.getSymbol(packageCPkgID));
 
-        // 2) update the mod_b2/mod2.bal file to remove package_c dependency
+        // 2) update the content in the default module
         Module defaultModule = project.currentPackage().getDefaultModule();
         Document document = defaultModule.document(defaultModule.documentIds().stream().findFirst().get());
         document.modify().withContent("public function func2() {\n" + "}").apply();
@@ -285,11 +321,82 @@ public class DependencyGraphTests extends BaseTest {
         // 3) compare dependency graphs before and after edit
         DependencyGraph<ResolvedPackageDependency> dependencyGraphNew =
                 project.currentPackage().getResolution().dependencyGraph();
-        // dependency graph should contain self and package_e
+        // dependency graph should contain self and package_c
         Assert.assertEquals(dependencyGraphNew.getNodes().size(), 2);
 
-        // verify that the package cache is not flushed
-        Assert.assertNotNull(packageCache.getSymbol(packageID));
+        // verify that the package_c in package cache is not affected
+        Assert.assertNotNull(packageCache.getSymbol(packageCPkgID));
+    }
+
+    @Test
+    public void testMissingTransitiveDependency() {
+        /*
+         * package_a --> package_b(0.1.0) --> package_c(0.1.0)
+         * Specify package_c(0.3.0) in Ballerina.toml
+         * Revert Ballerina.toml changes
+         */
+
+        Path projectDirPath = RESOURCE_DIRECTORY.resolve("projects_for_resolution_tests/package_a");
+        BuildProject project = TestUtils.loadBuildProject(projectDirPath);
+        DependencyGraph<ResolvedPackageDependency> dependencyGraphOld =
+                project.currentPackage().getResolution().dependencyGraph();
+        // dependency graph should contain self, package_b and package_c
+        Assert.assertEquals(dependencyGraphOld.getNodes().size(), 3);
+        project.currentPackage().getCompilation();
+
+        // verify that the compiler package cache contains package_b and package_c
+        PackageCache packageCache = PackageCache.getInstance(
+                project.projectEnvironmentContext().getService(CompilerContext.class));
+
+        PackageID packageBPkgID = new PackageID(new Name("samjs"), new Name("package_b"), new Name("0.1.0"));
+        Assert.assertNotNull(packageCache.getSymbol(packageBPkgID));
+        PackageID packageCPkgID = new PackageID(new Name("samjs"), new Name("package_c"), new Name("0.1.0"));
+        Assert.assertNotNull(packageCache.getSymbol(packageCPkgID));
+
+        // 1) update version of the package_c dependency in Ballerina.toml. 0.3.0 is unavailable
+        project.currentPackage().ballerinaToml().get().modify().withContent(
+                "[package]\n" +
+                "org = \"samjs\"\n" +
+                "name = \"package_a\"\n" +
+                "version = \"0.1.0\"\n\n" +
+                "[[dependency]]\n" +
+                "org = \"samjs\"\n" +
+                "name = \"package_c\"\n" +
+                "version = \"0.3.0\"").apply();
+
+        dependencyGraphOld = project.currentPackage().getResolution().dependencyGraph();
+        // dependency graph should contain self and package_b
+        Assert.assertEquals(dependencyGraphOld.getNodes().size(), 2);
+
+        // The bir of the direct dependency should be removed since the compiler throws
+        // an exception when compiling with the BIR
+        ProjectUtils.deleteDirectory(Paths.get("build/repo/cache/samjs/package_b/0.1.0"));
+
+        project.currentPackage().getCompilation();
+        // verify that the compiler package cache contains package_b but not package_c
+        Assert.assertNotNull(packageCache.getSymbol(packageBPkgID));
+        PackageID packageCPkgID2 = new PackageID(new Name("samjs"), new Name("package_c"), new Name("0.3.0"));
+        Assert.assertNull(packageCache.getSymbol(packageCPkgID2));
+
+        // 2) Revert Ballerina.toml changes and update the content in the default module to import package_c
+        project.currentPackage().ballerinaToml().get().modify().withContent(
+                "[package]\n" +
+                "org = \"samjs\"\n" +
+                "name = \"package_a\"\n" +
+                "version = \"0.1.0\"\n").apply();
+
+        // 3) check the new dependency graph. dependency graph should contain self package_b. package_c
+        DependencyGraph<ResolvedPackageDependency> dependencyGraphNew =
+                project.currentPackage().getResolution().dependencyGraph();
+        Assert.assertEquals(dependencyGraphNew.getNodes().size(), 3);
+
+        // verify that the package_c and package_b are not there in the package cache
+        // reason: when a transitive dependency changes, its dependant modules also should be recompiled
+        Assert.assertNull(packageCache.getSymbol(packageBPkgID));
+        Assert.assertNull(packageCache.getSymbol(packageCPkgID));
+
+        packageCPkgID = new PackageID(new Name("samjs"), new Name("package_c"), new Name("0.1.0"));
+        Assert.assertNull(packageCache.getSymbol(packageCPkgID));
     }
 
     @Test


### PR DESCRIPTION
## Purpose
> Fix bug in cache deletion when the dependency graph is updated

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/36068

## Approach
> Delete the cache of the dependant modules when a node is affected by the update.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [x] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
