### PR TITLE
Update visible endpoint generation with union return types

### DIFF
--- a/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/SyntaxTreeMapGenerator.java
+++ b/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/SyntaxTreeMapGenerator.java
@@ -255,6 +255,19 @@ public class SyntaxTreeMapGenerator extends NodeTransformer<JsonElement> {
                 updateVisibleEP(node, rawType, false);
             }
         }
+        if (rawType.typeKind() == TypeDescKind.UNION) {
+            UnionTypeSymbol unionTypeSymbol = (UnionTypeSymbol) rawType;
+            unionTypeSymbol.memberTypeDescriptors().forEach(member -> {
+                TypeSymbol memberRawType = getRawType(member);
+                if (memberRawType.typeKind() == TypeDescKind.OBJECT) {
+                    ObjectTypeSymbol objectTypeSymbol = (ObjectTypeSymbol) memberRawType;
+                    if (objectTypeSymbol.qualifiers().contains(Qualifier.CLIENT)) {
+                        symbolJson.addProperty("isEndpoint", true);
+                        updateVisibleEP(node, memberRawType, false);
+                    }
+                }
+            });
+        }
     }
 
     private void markVisibleEp(VariableSymbol variableSymbol, JsonObject symbolJson, Node node,

--- a/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/SyntaxTreeMapGenerator.java
+++ b/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/SyntaxTreeMapGenerator.java
@@ -259,12 +259,10 @@ public class SyntaxTreeMapGenerator extends NodeTransformer<JsonElement> {
             UnionTypeSymbol unionTypeSymbol = (UnionTypeSymbol) rawType;
             unionTypeSymbol.memberTypeDescriptors().forEach(member -> {
                 TypeSymbol memberRawType = getRawType(member);
-                if (memberRawType.typeKind() == TypeDescKind.OBJECT) {
-                    ObjectTypeSymbol objectTypeSymbol = (ObjectTypeSymbol) memberRawType;
-                    if (objectTypeSymbol.qualifiers().contains(Qualifier.CLIENT)) {
-                        symbolJson.addProperty("isEndpoint", true);
-                        updateVisibleEP(node, memberRawType, false);
-                    }
+                if (memberRawType.typeKind() == TypeDescKind.OBJECT
+                        && ((ObjectTypeSymbol) memberRawType).qualifiers().contains(Qualifier.CLIENT)) {
+                    symbolJson.addProperty("isEndpoint", true);
+                    updateVisibleEP(node, memberRawType, false);
                 }
             });
         }

--- a/misc/diagram-util/src/test/java/org/ballerinalang/diagramutil/SyntaxTreeGenTest.java
+++ b/misc/diagram-util/src/test/java/org/ballerinalang/diagramutil/SyntaxTreeGenTest.java
@@ -607,7 +607,7 @@ public class SyntaxTreeGenTest {
                 "fourthFunc");
         JsonObject fourthFunctionBody = fourthFunction.get("functionBody").getAsJsonObject();
         JsonArray fourthFunctionVEp = fourthFunctionBody.get("VisibleEndpoints").getAsJsonArray();
-        Assert.assertTrue(fourthFunctionVEp.size() == 2);
+        Assert.assertTrue(fourthFunctionVEp.size() == 3);
 
         // Verify fourthFunc function visible endpoints
         Assert.assertEquals(fourthFunctionVEp.get(0).getAsJsonObject().get("name").getAsString(), "exEp0");
@@ -625,5 +625,18 @@ public class SyntaxTreeGenTest {
         JsonObject exEpP2Position = exEpP2.get("position").getAsJsonObject();
         Assert.assertEquals(exEpP2Position.get("startLine").getAsInt(), 61);
         Assert.assertEquals(exEpP2Position.get("endLine").getAsInt(), 61);
+
+        JsonObject exEp10 = fourthFunctionVEp.get(2).getAsJsonObject();
+        Assert.assertEquals(exEp10.get("name").getAsString(), "exEp10");
+        Assert.assertEquals(exEp10.get("typeName").getAsString(), "ExternalClient");
+        Assert.assertEquals(exEp10.get("orgName").getAsString(), "gayanOrg");
+        Assert.assertEquals(exEp10.get("packageName").getAsString(), "testEps");
+        Assert.assertEquals(exEp10.get("moduleName").getAsString(), "testEps");
+        Assert.assertEquals(exEp10.get("version").getAsString(), "0.1.0");
+        Assert.assertEquals(exEp10.get("isModuleVar").getAsBoolean(), false);
+        Assert.assertEquals(exEp10.get("isExternal").getAsBoolean(), false);
+        JsonObject exEp10Position = exEp10.get("position").getAsJsonObject();
+        Assert.assertEquals(exEp10Position.get("startLine").getAsInt(), 65);
+        Assert.assertEquals(exEp10Position.get("endLine").getAsInt(), 65);
     }
 }

--- a/misc/diagram-util/src/test/resources/multiLevelEndpoints/main.bal
+++ b/misc/diagram-util/src/test/resources/multiLevelEndpoints/main.bal
@@ -62,5 +62,8 @@ function thirdFunc() returns boolean {
 function fourthFunc(ExternalClient exEpP2) returns boolean {
     var temp;
     temp = exEpP2;
+
+    ExternalClient|error exEp10 = new ("http://example.com/2");
+
     return true;
 }


### PR DESCRIPTION
## Purpose
Update visible endpoint generation with union return types.

Fixes https://github.com/wso2-enterprise/internal-support-ballerina/issues/86

## Approach
if the variable contains a Client qualifier we will mark that node as an endpoint. 
Previous logic only handles the SimpleNameReference types.
Here I have updated the same logic to check Union type and update the visibleEndpoint list.

## Original PR
- https://github.com/ballerina-platform/ballerina-lang/pull/36108

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
