### PR TITLE
Avoid renaming on a compilation error

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/references/ReferencesUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/references/ReferencesUtil.java
@@ -138,9 +138,8 @@ public class ReferencesUtil {
             // right end column being excluded when searching. To overcome that, here we search for the symbol at 
             // (col - 1). Ideally this shouldn't be an issue, because if we had cursor at the start col or middle, the
             // 1st search (above) would have found that.
-            position = new Position(position.getLine(), position.getCharacter() - 1);
             symbolAtCursor = semanticModel.get().symbol(srcFile.get(),
-                    LinePosition.from(position.getLine(), position.getCharacter()));
+                    LinePosition.from(position.getLine(), position.getCharacter() - 1));
             if (symbolAtCursor.isEmpty()) {
                 return Optional.empty();
             }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/references/ReferencesUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/references/ReferencesUtil.java
@@ -41,46 +41,13 @@ public class ReferencesUtil {
     }
     
     public static Map<Module, List<Location>> getReferences(PositionedOperationContext context) {
-        Optional<Document> srcFile = context.currentDocument();
-        Optional<SemanticModel> semanticModel = context.currentSemanticModel();
-        
         Map<Module, List<Location>> moduleLocationMap = new HashMap<>();
-
-        if (semanticModel.isEmpty() || srcFile.isEmpty()) {
-            return moduleLocationMap;
-        }
-
-        Position position = context.getCursorPosition();
         Optional<Project> project = context.workspace().project(context.filePath());
-        if (project.isEmpty()) {
+        Optional<Symbol> symbol = getSymbolAtCursor(context);
+        if (project.isEmpty() || symbol.isEmpty()) {
             return moduleLocationMap;
         }
-
-        Optional<Symbol> symbolAtCursor = semanticModel.get().symbol(srcFile.get(),
-                LinePosition.from(position.getLine(), position.getCharacter()));
-
-        if (symbolAtCursor.isEmpty()) {
-            if (position.getCharacter() == 0) {
-                return moduleLocationMap;
-            }
-            
-            // If we did not find the symbol, there are 2 possibilities.
-            //  1. Cursor is at the end (RHS) of the symbol
-            //  2. Semantic API has a limitation
-            // Out of those, 2nd one is ignored assuming semantic API behaves correctly. 1st one is caused due to the
-            // right end column being excluded when searching. To overcome that, here we search for the symbol at 
-            // (col - 1). Ideally this shouldn't be an issue, because if we had cursor at the start col or middle, the
-            // 1st search (above) would have found that.
-            position = new Position(position.getLine(), position.getCharacter() - 1);
-            symbolAtCursor = semanticModel.get().symbol(srcFile.get(),
-                    LinePosition.from(position.getLine(), position.getCharacter()));
-            if (symbolAtCursor.isEmpty()) {
-                return moduleLocationMap;
-            }
-        }
-        
-        Symbol symbol = symbolAtCursor.get();
-        moduleLocationMap.putAll(getReferences(project.get(), symbol));
+        moduleLocationMap.putAll(getReferences(project.get(), symbol.get()));
         return moduleLocationMap;
     }
 
@@ -139,5 +106,47 @@ public class ReferencesUtil {
         Position end = new Position(
                 referencePos.lineRange().endLine().line(), referencePos.lineRange().endLine().offset());
         return new Range(start, end);
+    }
+    
+    /**
+     * Returns the symbol at cursor handling a special case where cursor position is at the RHS end of the symbol.
+     *
+     * @param context Project
+     * @param context Operation context triggered with a cursor position
+     * @return Symbol at cursor
+     */
+    public static Optional<Symbol> getSymbolAtCursor(PositionedOperationContext context) {
+        Optional<Document> srcFile = context.currentDocument();
+        Optional<SemanticModel> semanticModel = context.currentSemanticModel();
+
+        if (semanticModel.isEmpty() || srcFile.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Position position = context.getCursorPosition();
+        Optional<Symbol> symbolAtCursor = semanticModel.get().symbol(srcFile.get(),
+                LinePosition.from(position.getLine(), position.getCharacter()));
+
+        if (symbolAtCursor.isEmpty()) {
+            if (position.getCharacter() == 0) {
+                return Optional.empty();
+            }
+
+            // If we did not find the symbol, there are 2 possibilities.
+            //  1. Cursor is at the end (RHS) of the symbol
+            //  2. Semantic API has a limitation
+            // Out of those, 2nd one is ignored assuming semantic API behaves correctly. 1st one is caused due to the
+            // right end column being excluded when searching. To overcome that, here we search for the symbol at 
+            // (col - 1). Ideally this shouldn't be an issue, because if we had cursor at the start col or middle, the
+            // 1st search (above) would have found that.
+            position = new Position(position.getLine(), position.getCharacter() - 1);
+            symbolAtCursor = semanticModel.get().symbol(srcFile.get(),
+                    LinePosition.from(position.getLine(), position.getCharacter()));
+            if (symbolAtCursor.isEmpty()) {
+                return Optional.empty();
+            }
+        }
+
+        return symbolAtCursor;
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/references/ReferencesUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/references/ReferencesUtil.java
@@ -111,7 +111,6 @@ public class ReferencesUtil {
     /**
      * Returns the symbol at cursor handling a special case where cursor position is at the RHS end of the symbol.
      *
-     * @param context Project
      * @param context Operation context triggered with a cursor position
      * @return Symbol at cursor
      */

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/rename/RenameUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/rename/RenameUtil.java
@@ -101,6 +101,13 @@ public class RenameUtil {
                 || isSelfClassSymbol(context)) {
             return Optional.empty();
         }
+        
+        // Check if symbol at cursor is empty
+        Optional<Symbol> symbolAtCursor = ReferencesUtil.getSymbolAtCursor(context);
+        if (symbolAtCursor.isEmpty()) {
+            return Optional.empty();
+        }
+        
         Optional<Document> document = context.currentDocument();
         if (document.isEmpty()) {
             return Optional.empty();
@@ -108,12 +115,8 @@ public class RenameUtil {
 
         Range cursorPosRange = new Range(context.getCursorPosition(), context.getCursorPosition());
         NonTerminalNode nodeAtCursor = CommonUtil.findNode(cursorPosRange, document.get().syntaxTree());
-        Optional<SemanticModel> semanticModel = context.currentSemanticModel();
-        if (semanticModel.isEmpty()) {
-            return Optional.empty();
-        }
-        Optional<Symbol> symbolAtCursor = semanticModel.get().symbol(nodeAtCursor);
-        if (symbolAtCursor.isEmpty() || onImportDeclarationNode(context, nodeAtCursor)) {
+        
+        if (onImportDeclarationNode(context, nodeAtCursor)) {
             return Optional.empty();
         }
         

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/rename/RenameUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/rename/RenameUtil.java
@@ -108,8 +108,12 @@ public class RenameUtil {
 
         Range cursorPosRange = new Range(context.getCursorPosition(), context.getCursorPosition());
         NonTerminalNode nodeAtCursor = CommonUtil.findNode(cursorPosRange, document.get().syntaxTree());
-
-        if (onImportDeclarationNode(context, nodeAtCursor)) {
+        Optional<SemanticModel> semanticModel = context.currentSemanticModel();
+        if (semanticModel.isEmpty()) {
+            return Optional.empty();
+        }
+        Optional<Symbol> symbolAtCursor = semanticModel.get().symbol(nodeAtCursor);
+        if (symbolAtCursor.isEmpty() || onImportDeclarationNode(context, nodeAtCursor)) {
             return Optional.empty();
         }
         

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/rename/RenameUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/rename/RenameUtil.java
@@ -115,7 +115,7 @@ public class RenameUtil {
 
         Range cursorPosRange = new Range(context.getCursorPosition(), context.getCursorPosition());
         NonTerminalNode nodeAtCursor = CommonUtil.findNode(cursorPosRange, document.get().syntaxTree());
-        
+
         if (onImportDeclarationNode(context, nodeAtCursor)) {
             return Optional.empty();
         }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/rename/RenameTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/rename/RenameTest.java
@@ -70,6 +70,7 @@ public class RenameTest extends AbstractRenameTest {
                 {"rename_on_keyword1.json", "fn"},
                 {"rename_self.json", "this"},
                 {"rename_invalid_qname_ref.json", "io"},
+                {"rename_with_compilation_error.json", "NewTypeMap"},
         };
     }
 }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/rename/RenameTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/rename/RenameTest.java
@@ -70,7 +70,7 @@ public class RenameTest extends AbstractRenameTest {
                 {"rename_on_keyword1.json", "fn"},
                 {"rename_self.json", "this"},
                 {"rename_invalid_qname_ref.json", "io"},
-                {"rename_with_compilation_error.json", "NewTypeMap"},
+                {"rename_with_compilation_error.json", "NewTypeMap"}
         };
     }
 }

--- a/language-server/modules/langserver-core/src/test/resources/rename/expected/single/rename_with_compilation_error.json
+++ b/language-server/modules/langserver-core/src/test/resources/rename/expected/single/rename_with_compilation_error.json
@@ -1,0 +1,15 @@
+{
+  "source": {
+    "file": "rename_with_compilation_error.bal"
+  },
+  "position": {
+    "line": 3,
+    "character": 8
+  },
+  "prepareRename": {
+    "valid": false
+  },
+  "result": {
+    "changes": {}
+  } 
+}

--- a/language-server/modules/langserver-core/src/test/resources/rename/sources/single/rename_with_compilation_error.bal
+++ b/language-server/modules/langserver-core/src/test/resources/rename/sources/single/rename_with_compilation_error.bal
@@ -1,0 +1,5 @@
+type TypeMap map<>;
+
+public function main() {
+    TypeMap tt = {};
+}


### PR DESCRIPTION
## Purpose
This PR adds a check on the symbol at cursor to avoid renaming when there is a compilation error.

Fixes #34706 

## Samples
https://user-images.githubusercontent.com/27485094/169034253-60189cb3-30d2-4d94-89e6-ecef7a15d8ca.mov

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
