### PR TITLE
Add `graphql-client` template for `bal new` command

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/CommandUtil.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/CommandUtil.java
@@ -91,6 +91,10 @@ public class CommandUtil {
     public static final String GITIGNORE = "gitignore";
     public static final String DEVCONTAINER = "devcontainer";
     public static final String NEW_CMD_DEFAULTS = "new_cmd_defaults";
+    public static final String VSCODE_FOLDER_NAME = ".vscode";
+    public static final String VSCODE_EXTENSIONS_FILE_NAME = "extensions.json";
+    public static final String VSCODE_EXTENSIONS = "vscode/extensions.json";
+    public static final String GRAPHQL_CLIENT_TEMPLATE_DEFAULTS = "graphql_client_template_defaults";
     public static final String CREATE_CMD_TEMPLATES = "create_cmd_templates";
     private static FileSystem jarFs;
     private static Map<String, String> env;
@@ -691,6 +695,22 @@ public class CommandUtil {
             Path source = path.resolve("lib.bal");
             Files.move(source, source.resolveSibling(guessPkgName(packageName, template) + ".bal"),
                     StandardCopyOption.REPLACE_EXISTING);
+        } else if (template.equalsIgnoreCase("graphql-client")) {
+            // package_name/
+            // - Ballerina.toml
+            // - Package.md
+            // - Module.md
+            // - resources
+            //      - .keep
+            // - .devcontainer.json
+            // - .gitignore                  <- git ignore file
+            // - .vscode
+            //      - extensions.json        <- recommended extensions file
+            // - queries
+            //      - query-country.graphql  <- GraphQL document file with queries/mutations
+            // - graphql.config.yaml         <- GraphQL configuration file
+            initGraphqlClientPackage(path, packageName);
+            createRecommendedVscodeExtensions(path);
         } else {
             initPackage(path, packageName);
         }
@@ -715,6 +735,20 @@ public class CommandUtil {
         String defaultDevContainer = FileUtils.readFileAsString(NEW_CMD_DEFAULTS + "/" + DEVCONTAINER);
         defaultDevContainer = defaultDevContainer.replace("latest", RepoUtils.getBallerinaVersion());
         Files.write(devContainer, defaultDevContainer.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static void createRecommendedVscodeExtensions(Path path) throws IOException {
+        Path vscodeDir = path.resolve(VSCODE_FOLDER_NAME);
+        if (Files.notExists(vscodeDir)) {
+            Files.createDirectory(vscodeDir);
+        }
+        Path vscodeExtensions = vscodeDir.resolve(VSCODE_EXTENSIONS_FILE_NAME);
+        if (Files.notExists(vscodeExtensions)) {
+            Files.createFile(vscodeExtensions);
+        }
+        String recommendedVscodeExtensions = FileUtils.readFileAsString(GRAPHQL_CLIENT_TEMPLATE_DEFAULTS + "/" +
+                VSCODE_EXTENSIONS);
+        Files.write(vscodeExtensions, recommendedVscodeExtensions.getBytes(StandardCharsets.UTF_8));
     }
 
     /**
@@ -818,6 +852,20 @@ public class CommandUtil {
         // Create Package.md
         String packageMd = FileUtils.readFileAsString(NEW_CMD_DEFAULTS + "/Package.md");
         write(path.resolve(ProjectConstants.PACKAGE_MD_FILE_NAME), packageMd.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static void initGraphqlClientPackage(Path path, String packageName) throws IOException {
+        Path ballerinaToml = path.resolve(ProjectConstants.BALLERINA_TOML);
+        Files.createFile(ballerinaToml);
+
+        String defaultManifest = FileUtils.readFileAsString(NEW_CMD_DEFAULTS + "/" + "manifest-lib.toml");
+        // replace manifest org and name with a guessed value.
+        defaultManifest = defaultManifest
+                .replaceAll(ORG_NAME, ProjectUtils.guessOrgName())
+                .replaceAll(PKG_NAME, packageName)
+                .replaceAll(DIST_VERSION, RepoUtils.getBallerinaShortVersion());
+
+        write(ballerinaToml, defaultManifest.getBytes(StandardCharsets.UTF_8));
     }
 
     protected static PackageVersion findLatest(List<PackageVersion> packageVersions) {

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/NewCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/NewCommand.java
@@ -57,8 +57,8 @@ public class NewCommand implements BLauncherCmd {
     @CommandLine.Option(names = {"--help", "-h"}, hidden = true)
     private boolean helpFlag;
 
-    @CommandLine.Option(names = {"--template", "-t"}, description = "Acceptable values: [main, service, lib] " +
-            "default: default")
+    @CommandLine.Option(names = {"--template", "-t"}, description = "Acceptable values: [main, service, lib, " +
+            "graphql-client] default: default")
     public String template = "default";
 
     public NewCommand() {

--- a/cli/ballerina-cli/src/main/resources/create_cmd_templates/graphql-client/Module.md
+++ b/cli/ballerina-cli/src/main/resources/create_cmd_templates/graphql-client/Module.md
@@ -1,0 +1,3 @@
+# Module Overview
+Provides an overview about the GraphQL client module when generating the API documentations.
+For example, refer to https://lib.ballerina.io/ballerina/graphql/latest

--- a/cli/ballerina-cli/src/main/resources/create_cmd_templates/graphql-client/Package.md
+++ b/cli/ballerina-cli/src/main/resources/create_cmd_templates/graphql-client/Package.md
@@ -1,0 +1,3 @@
+# Package Overview
+Provides an overview about the GraphQL client package in the Ballerina central documentation.
+For example, refer to https://central.ballerina.io/ballerina/graphql

--- a/cli/ballerina-cli/src/main/resources/create_cmd_templates/graphql-client/graphql.config.yaml
+++ b/cli/ballerina-cli/src/main/resources/create_cmd_templates/graphql-client/graphql.config.yaml
@@ -1,0 +1,13 @@
+## The GraphQL schema. Ex: https://countries.trevorblades.com or ./schemas/country.graphql
+schema: https://countries.trevorblades.com
+
+## The GraphQL documents that have queries/mutations
+documents:
+   - ./queries/query-country.graphql
+
+## If the GraphQL API is secured, add the extensions section with the relevant tokens/headers. The schema must be Web URL in this case.
+# extensions:
+#   endpoints:
+#     default:
+#       headers:
+#         { "HeaderKey1": "HeaderValue1", "HeaderKey2": "HeaderValue2" }

--- a/cli/ballerina-cli/src/main/resources/create_cmd_templates/graphql-client/queries/query-country.graphql
+++ b/cli/ballerina-cli/src/main/resources/create_cmd_templates/graphql-client/queries/query-country.graphql
@@ -1,0 +1,7 @@
+## Add the queries and mutations here.
+
+query countryByCode($code: ID!) {
+    country(code: $code) {
+        name
+    }
+}

--- a/cli/ballerina-cli/src/main/resources/graphql_client_template_defaults/vscode/extensions.json
+++ b/cli/ballerina-cli/src/main/resources/graphql_client_template_defaults/vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "GraphQL.vscode-graphql"
+    ]
+}

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/NewCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/NewCommandTest.java
@@ -53,6 +53,13 @@ public class NewCommandTest extends BaseCommandTest {
     Path testResources;
     Path centralCache;
 
+    // graphql-client template (`bal new <package_name> -t graphql-client`) specific constants
+    private static final String GRAPHQL_CONFIG_FILE_NAME = "graphql.config.yaml";
+    private static final String GRAPHQL_QUERIES_FOLDER_NAME = "queries";
+    private static final String GRAPHQL_QUERIES_FILE_NAME = "query-country.graphql";
+    private static final String VSCODE_FOLDER_NAME = ".vscode";
+    private static final String VSCODE_EXTENSIONS_FILE_NAME = "extensions.json";
+
     @DataProvider(name = "invalidProjectNames")
     public Object[][] provideInvalidProjectNames() {
         return new Object[][] {
@@ -222,6 +229,57 @@ public class NewCommandTest extends BaseCommandTest {
         Assert.assertTrue(Files.exists(packageDir.resolve("lib_sample.bal")));
         Assert.assertTrue(Files.exists(packageDir.resolve(ProjectConstants.TEST_DIR_NAME)));
         Assert.assertTrue(Files.exists(packageDir.resolve(ProjectConstants.RESOURCE_DIR_NAME)));
+
+        Assert.assertTrue(readOutput().contains("Created new package"));
+    }
+
+    @Test(description = "Test new command with graphql-client template")
+    public void testNewCommandWithGraphqlClient() throws IOException {
+        // Test if no arguments was passed in
+        String[] args = {"graphql_client_sample", "-t", "graphql-client"};
+        NewCommand newCommand = new NewCommand(tmpDir, printStream, false);
+        new CommandLine(newCommand).parseArgs(args);
+        newCommand.execute();
+        // package_name/
+        // - Ballerina.toml
+        // - Package.md
+        // - Module.md
+        // - resources
+        //      - .keep
+        // - .devcontainer.json
+        // - .gitignore                  <- git ignore file
+        // - .vscode
+        //      - extensions.json        <- recommended extensions file
+        // - queries
+        //      - query-country.graphql  <- GraphQL document file with queries/mutations
+        // - graphql.config.yaml         <- GraphQL configuration file
+
+        Path packageDir = tmpDir.resolve("graphql_client_sample");
+        Assert.assertTrue(Files.exists(packageDir));
+        Assert.assertTrue(Files.isDirectory(packageDir));
+        Assert.assertTrue(Files.exists(packageDir.resolve(ProjectConstants.BALLERINA_TOML)));
+
+        String tomlContent = Files.readString(
+                packageDir.resolve(ProjectConstants.BALLERINA_TOML), StandardCharsets.UTF_8);
+
+        String expectedTomlContent = "[package]\n" +
+                "org = \"" + System.getProperty("user.name").replaceAll("[^a-zA-Z0-9_]", "_") + "\"\n" +
+                "name = \"graphql_client_sample\"\n" +
+                "version = \"0.1.0\"\n" +
+                "distribution = \"" + RepoUtils.getBallerinaShortVersion() + "\"" +
+                "\n";
+        Assert.assertTrue(tomlContent.contains(expectedTomlContent));
+        Assert.assertTrue(Files.exists(packageDir.resolve(ProjectConstants.PACKAGE_MD_FILE_NAME)));
+        Assert.assertTrue(Files.exists(packageDir.resolve(ProjectConstants.RESOURCE_DIR_NAME)));
+
+        Assert.assertTrue(Files.exists(packageDir.resolve(GRAPHQL_CONFIG_FILE_NAME)));
+        Path graphqlQueriesDir = packageDir.resolve(GRAPHQL_QUERIES_FOLDER_NAME);
+        Assert.assertTrue(Files.exists(graphqlQueriesDir));
+        Assert.assertTrue(Files.isDirectory(graphqlQueriesDir));
+        Assert.assertTrue(Files.exists(graphqlQueriesDir.resolve(GRAPHQL_QUERIES_FILE_NAME)));
+        Path vscodeDir = packageDir.resolve(VSCODE_FOLDER_NAME);
+        Assert.assertTrue(Files.exists(vscodeDir));
+        Assert.assertTrue(Files.exists(vscodeDir.resolve(VSCODE_EXTENSIONS_FILE_NAME)));
 
         Assert.assertTrue(readOutput().contains("Created new package"));
     }


### PR DESCRIPTION
## Purpose
> 
Add support for  a new template tag `graphql-client` for the new Ballerina project creation command to generate prototypes necessary to use the GraphQL client generation tool.

Fixes #35889

## Approach
> 

```
    bal new <package_name> -t graphql-client
```

will generate a Ballerina package with GraphQL client generation tool related prototypes. Something similar to

```
bal new <package_name> -t lib
```
The structure of the new Ballerina project when this tag is used should be as follows.

Directory structure:
![Screenshot from 2022-04-28 11-34-33](https://user-images.githubusercontent.com/44081958/165687633-f5b80f9d-d421-4d3a-801f-7804f593e694.png)

GraphQL config file:

graphql.config.yaml
```
## The GraphQL schema. Ex: https://countries.trevorblades.com or ./schemas/country.graphql
schema: https://countries.trevorblades.com

## The GraphQL documents that have queries/mutations
documents:
   - ./queries/query-country.graphql

## If the GraphQL API is secured, add the extensions section with the relevant tokens/headers. The schema must be Web URL in this case.
# extensions:
#   endpoints:
#     default:
#       headers:
#         { "HeaderKey1": "HeaderValue1", "HeaderKey2": "HeaderValue2" }
```

GraphQL document:

query-country.graphql
```
## Add the queries and mutations here.

query countryByCode($code: ID!) {
    country(code: $code) {
        name
    }
}
```

GraphQL schema (SDL):

country.graphql
```
## Please add the GraphQL schema (SDL) of the relevant GraphQL API.
```
Module.md:

Module.md
```
# Module Overview
Provides an overview about the GraphQL client module when generating the API documentations.
For example, refer to https://lib.ballerina.io/ballerina/graphql/latest
```

Package.md:

Package.md
```
# Package Overview
Provides an overview about the GraphQL client package in the Ballerina central documentation.
For example, refer to https://central.ballerina.io/ballerina/graphql
```

extensions.json:

extensions.json
```
{
   "recommendations": [
       "GraphQL.vscode-graphql"
   ]
}
```
Users will be recommended with a pop up to install the GraphQL plugin as a prerequisite for GraphQL query validation and execution in VS Code.

You can find more details [here](https://docs.google.com/document/d/1x36FEnTryp0amhbWZ858JtSQB0S9PZHpu9ZfcuH3DyY/edit?usp=sharing).

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
