### PR TITLE
Add missing `bal graphql` command help text in `bal` output

### DIFF
--- a/cli/ballerina-cli/src/main/resources/cli-help/ballerina-graphql.help
+++ b/cli/ballerina-cli/src/main/resources/cli-help/ballerina-graphql.help
@@ -1,7 +1,6 @@
 NAME
-       ballerina-graphql - Generate Ballerina sources from a GraphQL config file 
+       ballerina-graphql - Generate Ballerina client sources from a GraphQL config file 
                         configured with GraphQL schemas(SDL) and GraphQL queries.
-
 
 SYNOPSIS
        bal graphql [-i | --input] <graphql-configuration-file-path> [-o | --output] <output-location> 

--- a/cli/ballerina-cli/src/main/resources/cli-help/ballerina-help.help
+++ b/cli/ballerina-cli/src/main/resources/cli-help/ballerina-help.help
@@ -36,6 +36,8 @@ COMMANDS
         clean           Clean the artifacts generated during the build
         format          Format Ballerina source files
         grpc            Generate the Ballerina sources for a given Protocol Buffer definition
+        graphql         Generate the Ballerina client sources
+                        for a given GraphQL schema(SDL) and GraphQL queries
         openapi         Generate the Ballerina sources for a given OpenAPI definition and 
                         vice versa
         bindgen         Generate the Ballerina bindings for Java APIs


### PR DESCRIPTION
## Purpose
> Add Missing `bal graphql` command help text in `bal` output

Fixes #36251

## Approach
> Add `bal graphql` command info in `ballerina-lang/cli/ballerina-cli/src/main/resources/cli-help/ballerina-help.help` 
