### PR TITLE
Remove the note on identifying asyncapi command as an experimental feature

### DIFF
--- a/cli/ballerina-cli/src/main/resources/cli-help/ballerina-asyncapi.help
+++ b/cli/ballerina-cli/src/main/resources/cli-help/ballerina-asyncapi.help
@@ -20,9 +20,6 @@ DESCRIPTION
        The generated Ballerina sources will be written into the provided output
        location.
 
-       Note: This is an experimental feature, which supports only a limited
-       set of functionalities.
-
 
 OPTIONS
         -i, --input <asyncapi-contract-file-path>


### PR DESCRIPTION
## Purpose
> Previously, asyncapi command was identified as an experimental feature, but removing that now
