### PR TITLE
Remove GraphQL tool experimental feature note

### DIFF
--- a/cli/ballerina-cli/src/main/resources/cli-help/ballerina-graphql.help
+++ b/cli/ballerina-cli/src/main/resources/cli-help/ballerina-graphql.help
@@ -13,9 +13,6 @@ DESCRIPTION
     
        The generated Ballerina sources will be written into the provided output location.
 
-       Note: This is an experimental feature, which supports only a limited
-       set of functionalities.
-
 
 OPTIONS
         -i, --input <path>


### PR DESCRIPTION
## Purpose
> Previously, graphql command was identified as an experimental feature, but removing that now.

The GraphQL tool supports queries, mutations and the 80% use cases. But currently we do not support subscriptions which we do have some plans to bring this support in Update 2.
Based on this reason we thought of adding it as an experimental feature. But since the existing tool works well for the above features, we decided to remove this experimental note as discussed and agreed in the offline discussion.