### PR TITLE
Fix create var code action in async send action

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/CreateVariableCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/CreateVariableCodeAction.java
@@ -141,7 +141,8 @@ public class CreateVariableCodeAction extends AbstractCodeActionProvider {
      */
     protected Optional<TypeSymbol> getExpectedTypeSymbol(DiagBasedPositionDetails positionDetails) {
         Optional<Symbol> symbol = positionDetails.diagnosticProperty(
-                DiagBasedPositionDetails.DIAG_PROP_VAR_ASSIGN_SYMBOL_INDEX);
+                CodeActionUtil.getDiagPropertyFilterFunction(
+                        DiagBasedPositionDetails.DIAG_PROP_VAR_ASSIGN_SYMBOL_INDEX));
         if (symbol.isEmpty()) {
             return Optional.empty();
         }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/CreateVariableCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/CreateVariableCodeAction.java
@@ -76,7 +76,7 @@ public class CreateVariableCodeAction extends AbstractCodeActionProvider {
                                                     DiagBasedPositionDetails positionDetails,
                                                     CodeActionContext context) {
         Optional<TypeSymbol> typeSymbol = getExpectedTypeSymbol(positionDetails);
-        if (typeSymbol.isEmpty() || typeSymbol.get().typeKind() == TypeDescKind.NONE){
+        if (typeSymbol.isEmpty() || typeSymbol.get().typeKind() == TypeDescKind.NONE) {
             return Collections.emptyList();
         }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/CreateVariableCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/CreateVariableCodeAction.java
@@ -16,8 +16,10 @@
 package org.ballerinalang.langserver.codeaction.providers.createvar;
 
 import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.api.symbols.WorkerSymbol;
 import io.ballerina.tools.diagnostics.Diagnostic;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.codeaction.CodeActionNodeValidator;
@@ -35,6 +37,7 @@ import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextEdit;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -72,11 +75,9 @@ public class CreateVariableCodeAction extends AbstractCodeActionProvider {
     public List<CodeAction> getDiagBasedCodeActions(Diagnostic diagnostic,
                                                     DiagBasedPositionDetails positionDetails,
                                                     CodeActionContext context) {
-        List<CodeAction> actions = new ArrayList<>();
-        Optional<TypeSymbol> typeSymbol = positionDetails.diagnosticProperty(
-                DiagBasedPositionDetails.DIAG_PROP_VAR_ASSIGN_SYMBOL_INDEX);
-        if (typeSymbol.isEmpty() || typeSymbol.get().typeKind() == TypeDescKind.NONE) {
-            return actions;
+        Optional<TypeSymbol> typeSymbol = getExpectedTypeSymbol(positionDetails);
+        if (typeSymbol.isEmpty() || typeSymbol.get().typeKind() == TypeDescKind.NONE){
+            return Collections.emptyList();
         }
 
         String uri = context.fileUri();
@@ -84,6 +85,7 @@ public class CreateVariableCodeAction extends AbstractCodeActionProvider {
         CreateVariableOut createVarTextEdits = getCreateVariableTextEdits(range, positionDetails, typeSymbol.get(),
                 context);
         List<String> types = createVarTextEdits.types;
+        List<CodeAction> actions = new ArrayList<>();
         for (int i = 0; i < types.size(); i++) {
             String commandTitle = CommandConstants.CREATE_VARIABLE_TITLE;
             List<TextEdit> edits = new ArrayList<>();
@@ -106,7 +108,7 @@ public class CreateVariableCodeAction extends AbstractCodeActionProvider {
         return NAME;
     }
 
-    CreateVariableOut getCreateVariableTextEdits(Range range, DiagBasedPositionDetails positionDetails,
+    protected CreateVariableOut getCreateVariableTextEdits(Range range, DiagBasedPositionDetails positionDetails,
                                                  TypeSymbol typeDescriptor, CodeActionContext context) {
         Symbol matchedSymbol = positionDetails.matchedSymbol();
 
@@ -128,6 +130,33 @@ public class CreateVariableCodeAction extends AbstractCodeActionProvider {
             edits.add(new TextEdit(new Range(insertPos, insertPos), edit));
         }
         return new CreateVariableOut(name, types, edits, importEdits);
+    }
+
+    /**
+     * Given the position details, this method will determine the expected type symbol for the required variable
+     * assignment from diagnostic properties.
+     *
+     * @param positionDetails Position details
+     * @return Optional expected type symbol
+     */
+    protected Optional<TypeSymbol> getExpectedTypeSymbol(DiagBasedPositionDetails positionDetails) {
+        Optional<Symbol> symbol = positionDetails.diagnosticProperty(
+                DiagBasedPositionDetails.DIAG_PROP_VAR_ASSIGN_SYMBOL_INDEX);
+        if (symbol.isEmpty()) {
+            return Optional.empty();
+        }
+
+        TypeSymbol typeSymbol = null;
+        if (symbol.get() instanceof TypeSymbol) {
+            typeSymbol = (TypeSymbol) symbol.get();
+        }
+
+        if (symbol.get().kind() == SymbolKind.WORKER) {
+            WorkerSymbol workerSymbol = (WorkerSymbol) symbol.get();
+            typeSymbol = workerSymbol.returnType();
+        }
+
+        return Optional.ofNullable(typeSymbol);
     }
 
     static class CreateVariableOut {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/ErrorHandleInsideCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/ErrorHandleInsideCodeAction.java
@@ -67,8 +67,7 @@ public class ErrorHandleInsideCodeAction extends CreateVariableCodeAction {
                                                     DiagBasedPositionDetails positionDetails,
                                                     CodeActionContext context) {
 
-        Optional<TypeSymbol> typeDescriptor = positionDetails.diagnosticProperty(
-                DiagBasedPositionDetails.DIAG_PROP_VAR_ASSIGN_SYMBOL_INDEX);
+        Optional<TypeSymbol> typeDescriptor = getExpectedTypeSymbol(positionDetails);
         if (typeDescriptor.isEmpty() || typeDescriptor.get().typeKind() != TypeDescKind.UNION) {
             return Collections.emptyList();
         }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/ErrorHandleOutsideCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/ErrorHandleOutsideCodeAction.java
@@ -73,8 +73,7 @@ public class ErrorHandleOutsideCodeAction extends CreateVariableCodeAction {
                                                     CodeActionContext context) {
         String uri = context.fileUri();
 
-        Optional<TypeSymbol> typeSymbol = positionDetails.diagnosticProperty(
-                DiagBasedPositionDetails.DIAG_PROP_VAR_ASSIGN_SYMBOL_INDEX);
+        Optional<TypeSymbol> typeSymbol = getExpectedTypeSymbol(positionDetails);
         if (typeSymbol.isEmpty() || typeSymbol.get().typeKind() != TypeDescKind.UNION) {
             return Collections.emptyList();
         }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/IgnoreReturnCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/IgnoreReturnCodeAction.java
@@ -21,8 +21,10 @@ import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
 import io.ballerina.tools.diagnostics.Diagnostic;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.codeaction.CodeActionNodeValidator;
+import org.ballerinalang.langserver.codeaction.CodeActionUtil;
 import org.ballerinalang.langserver.codeaction.providers.AbstractCodeActionProvider;
 import org.ballerinalang.langserver.common.constants.CommandConstants;
+import org.ballerinalang.langserver.common.utils.SymbolUtil;
 import org.ballerinalang.langserver.common.utils.PositionUtil;
 import org.ballerinalang.langserver.commons.CodeActionContext;
 import org.ballerinalang.langserver.commons.codeaction.spi.DiagBasedPositionDetails;
@@ -43,7 +45,7 @@ import java.util.Optional;
  * @since 2.0.0
  */
 @JavaSPIService("org.ballerinalang.langserver.commons.codeaction.spi.LSCodeActionProvider")
-public class IgnoreReturnCodeAction extends AbstractCodeActionProvider {
+public class IgnoreReturnCodeAction extends CreateVariableCodeAction {
 
     public static final String NAME = "Ignore Return Type";
 
@@ -61,8 +63,7 @@ public class IgnoreReturnCodeAction extends AbstractCodeActionProvider {
     public List<CodeAction> getDiagBasedCodeActions(Diagnostic diagnostic,
                                                     DiagBasedPositionDetails positionDetails,
                                                     CodeActionContext context) {
-        Optional<TypeSymbol> typeDescriptor = positionDetails.diagnosticProperty(
-                DiagBasedPositionDetails.DIAG_PROP_VAR_ASSIGN_SYMBOL_INDEX);
+        Optional<TypeSymbol> typeDescriptor = getExpectedTypeSymbol(positionDetails);
         if (typeDescriptor.isEmpty()) {
             return Collections.emptyList();
         }
@@ -88,7 +89,7 @@ public class IgnoreReturnCodeAction extends AbstractCodeActionProvider {
             return true;
         } else if (typeSymbol.typeKind() == TypeDescKind.UNION) {
             UnionTypeSymbol unionType = (UnionTypeSymbol) typeSymbol;
-            return unionType.memberTypeDescriptors().stream().anyMatch(s -> s.typeKind() == TypeDescKind.ERROR);
+            return CodeActionUtil.hasErrorMemberType(unionType);
         }
         return false;
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/IgnoreReturnCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/IgnoreReturnCodeAction.java
@@ -22,7 +22,6 @@ import io.ballerina.tools.diagnostics.Diagnostic;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.codeaction.CodeActionNodeValidator;
 import org.ballerinalang.langserver.codeaction.CodeActionUtil;
-import org.ballerinalang.langserver.codeaction.providers.AbstractCodeActionProvider;
 import org.ballerinalang.langserver.common.constants.CommandConstants;
 import org.ballerinalang.langserver.common.utils.SymbolUtil;
 import org.ballerinalang.langserver.common.utils.PositionUtil;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/IgnoreReturnCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/IgnoreReturnCodeAction.java
@@ -23,7 +23,6 @@ import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.codeaction.CodeActionNodeValidator;
 import org.ballerinalang.langserver.codeaction.CodeActionUtil;
 import org.ballerinalang.langserver.common.constants.CommandConstants;
-import org.ballerinalang.langserver.common.utils.SymbolUtil;
 import org.ballerinalang.langserver.common.utils.PositionUtil;
 import org.ballerinalang.langserver.commons.CodeActionContext;
 import org.ballerinalang.langserver.commons.codeaction.spi.DiagBasedPositionDetails;

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/CreateVariableTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/CreateVariableTest.java
@@ -115,9 +115,9 @@ public class CreateVariableTest extends AbstractCodeActionTest {
                 {"createVariableWithFunctionCall2.json"},
                 {"createVariableNegative1.json"},
                 {"createVariableWithRemoteMethodInvocation.json"},
-                
+
                 // Async send action
-                {"createVarInSendAction1.json", "createVarInSendAction1.bal"}
+                {"createVarInSendAction1.json"}
         };
     }
 }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/CreateVariableTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/CreateVariableTest.java
@@ -114,7 +114,10 @@ public class CreateVariableTest extends AbstractCodeActionTest {
                 {"createVariableWithFunctionCall1.json"},
                 {"createVariableWithFunctionCall2.json"},
                 {"createVariableNegative1.json"},
-                {"createVariableWithRemoteMethodInvocation.json"}
+                {"createVariableWithRemoteMethodInvocation.json"},
+                
+                // Async send action
+                {"createVarInSendAction1.json", "createVarInSendAction1.bal"}
         };
     }
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVarInSendAction1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVarInSendAction1.json
@@ -1,0 +1,58 @@
+{
+  "line": 9,
+  "character": 11,
+  "expected": [
+    {
+      "title": "Create variable and type guard",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 9,
+              "character": 15
+            },
+            "end": {
+              "line": 9,
+              "character": 15
+            }
+          },
+          "newText": "\n        if unionResult is error {\n\n        }"
+        },
+        {
+          "range": {
+            "start": {
+              "line": 9,
+              "character": 8
+            },
+            "end": {
+              "line": 9,
+              "character": 8
+            }
+          },
+          "newText": "error? unionResult = "
+        }
+      ]
+    },
+    {
+      "title": "Create variable",
+      "kind": "quickfix",
+      "diagnostics": [],
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 9,
+              "character": 8
+            },
+            "end": {
+              "line": 9,
+              "character": 8
+            }
+          },
+          "newText": "error? unionResult = "
+        }
+      ]
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVarInSendAction1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVarInSendAction1.json
@@ -1,6 +1,9 @@
 {
-  "line": 9,
-  "character": 11,
+  "position": {
+    "line": 9,
+    "character": 11
+  },
+  "source": "createVarInSendAction1.bal",
   "expected": [
     {
       "title": "Create variable and type guard",

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/source/createVarInSendAction1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/source/createVarInSendAction1.bal
@@ -1,0 +1,22 @@
+int x = 5;
+public function main() {
+    func();
+
+}
+
+function func() {
+    @strand {thread: "any"}
+    worker A {
+        1 ->> B;
+    }
+
+    @strand {thread: "any"}
+    worker B returns error?{
+        x-=1;
+        if (x>1) {
+            return error("err");
+        }
+        int x1 = <- A;
+    }
+
+}


### PR DESCRIPTION
## Purpose
$subject

Fixes #36078

## Approach
The diagnostic property includes the `WorkerSymbol` instead of the `FutureTypeSymbol`. This cause a class cast exception. Fixed it.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
