### PR TITLE
Support annotations for type referenced type at runtime

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/TypeTags.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/TypeTags.java
@@ -84,6 +84,7 @@ public class TypeTags {
     public static final int READONLY_TAG = HANDLE_TAG + 1;
 
     public static final int PARAMETERIZED_TYPE_TAG = READONLY_TAG + 1;
+    public static final int TYPE_REFERENCED_TYPE_TAG = PARAMETERIZED_TYPE_TAG + 1;
 
     public static boolean isIntegerTypeTag(int tag) {
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/utils/TypeUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/utils/TypeUtils.java
@@ -51,6 +51,9 @@ import static io.ballerina.runtime.api.PredefinedTypes.TYPE_XML_ATTRIBUTES;
  */
 public class TypeUtils {
 
+    private TypeUtils() {
+    }
+
     public static boolean isValueType(Type type) {
         if (type == TYPE_INT || type == TYPE_BYTE ||
                 type == TYPE_FLOAT ||
@@ -136,6 +139,12 @@ public class TypeUtils {
         return TypeChecker.isSameType(sourceType, targetType);
     }
 
+    /**
+     * Retrieve the referred type if a given type is a type reference type.
+     *
+     * @param type type to retrieve referred
+     * @return the referred type if provided with a type reference type, else returns the original type
+     */
     public static Type getReferredType(Type type) {
         Type constraint = type;
         if (type.getTag() == TypeTags.TYPE_REFERENCED_TYPE_TAG) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/utils/TypeUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/utils/TypeUtils.java
@@ -24,6 +24,7 @@ import io.ballerina.runtime.internal.TypeChecker;
 import io.ballerina.runtime.internal.types.BArrayType;
 import io.ballerina.runtime.internal.types.BFiniteType;
 import io.ballerina.runtime.internal.types.BType;
+import io.ballerina.runtime.internal.types.BTypeReferenceType;
 
 import static io.ballerina.runtime.api.PredefinedTypes.TYPE_ANY;
 import static io.ballerina.runtime.api.PredefinedTypes.TYPE_ANYDATA;
@@ -134,4 +135,13 @@ public class TypeUtils {
     public static boolean isSameType(Type sourceType, Type targetType) {
         return TypeChecker.isSameType(sourceType, targetType);
     }
+
+    public static Type getReferredType(Type type) {
+        Type constraint = type;
+        if (type.getTag() == TypeTags.TYPE_REFERENCED_TYPE_TAG) {
+            constraint = getReferredType(((BTypeReferenceType) type).getReferredType());
+        }
+        return constraint;
+    }
+
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeConverter.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeConverter.java
@@ -79,7 +79,7 @@ import static io.ballerina.runtime.internal.TypeChecker.isSimpleBasicType;
 import static io.ballerina.runtime.internal.TypeChecker.isUnsigned16LiteralValue;
 import static io.ballerina.runtime.internal.TypeChecker.isUnsigned32LiteralValue;
 import static io.ballerina.runtime.internal.TypeChecker.isUnsigned8LiteralValue;
-import static io.ballerina.runtime.internal.util.RuntimeUtils.getReferredType;
+import static io.ballerina.runtime.api.utils.TypeUtils.getReferredType;
 import static io.ballerina.runtime.internal.values.DecimalValue.isDecimalWithinIntRange;
 
 /**

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeConverter.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeConverter.java
@@ -62,6 +62,7 @@ import java.util.function.Supplier;
 import static io.ballerina.runtime.api.PredefinedTypes.TYPE_STRING;
 import static io.ballerina.runtime.api.constants.RuntimeConstants.BINT_MAX_VALUE_DOUBLE_RANGE_MAX;
 import static io.ballerina.runtime.api.constants.RuntimeConstants.BINT_MIN_VALUE_DOUBLE_RANGE_MIN;
+import static io.ballerina.runtime.api.utils.TypeUtils.getReferredType;
 import static io.ballerina.runtime.internal.TypeChecker.anyToSigned16;
 import static io.ballerina.runtime.internal.TypeChecker.anyToSigned32;
 import static io.ballerina.runtime.internal.TypeChecker.anyToSigned8;
@@ -79,7 +80,6 @@ import static io.ballerina.runtime.internal.TypeChecker.isSimpleBasicType;
 import static io.ballerina.runtime.internal.TypeChecker.isUnsigned16LiteralValue;
 import static io.ballerina.runtime.internal.TypeChecker.isUnsigned32LiteralValue;
 import static io.ballerina.runtime.internal.TypeChecker.isUnsigned8LiteralValue;
-import static io.ballerina.runtime.api.utils.TypeUtils.getReferredType;
 import static io.ballerina.runtime.internal.values.DecimalValue.isDecimalWithinIntRange;
 
 /**

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BTypeReferenceType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BTypeReferenceType.java
@@ -83,4 +83,9 @@ public class BTypeReferenceType extends BAnnotatableType implements ReferenceTyp
         return this.referredType.isNilable();
     }
 
+    @Override
+    public boolean isReadOnly() {
+        return this.referredType.isReadOnly();
+    }
+
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BTypeReferenceType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BTypeReferenceType.java
@@ -1,0 +1,86 @@
+/*
+ *  Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.runtime.internal.types;
+
+import io.ballerina.identifier.Utils;
+import io.ballerina.runtime.api.Module;
+import io.ballerina.runtime.api.TypeTags;
+import io.ballerina.runtime.api.types.ReferenceType;
+import io.ballerina.runtime.api.types.Type;
+
+/**
+ * {@code TypeReferencedType} represents a type description which refers to another type.
+ *
+ * @since 2.1.0
+ */
+public class BTypeReferenceType extends BAnnotatableType implements ReferenceType {
+
+    private Type referredType;
+
+    public BTypeReferenceType(String typeName, Module pkg, Class<?> valueClass) {
+        super(typeName, pkg, valueClass);
+    }
+
+    public BTypeReferenceType(String typeName, Type referredType) {
+        super(typeName, null, Object.class);
+        this.referredType = referredType;
+    }
+
+    public Type getReferredType() {
+        return referredType;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (obj instanceof BTypeReferenceType) {
+            return this.referredType.equals(((BTypeReferenceType) obj).getReferredType());
+        }
+        return false;
+    }
+
+    @Override
+    public String getAnnotationKey() {
+        return Utils.decodeIdentifier(this.typeName);
+    }
+
+    @Override
+    public <V> V getZeroValue() {
+        return this.referredType.getZeroValue();
+    }
+
+    @Override
+    public <V> V getEmptyValue() {
+        return this.referredType.getEmptyValue();
+    }
+
+    @Override
+    public int getTag() {
+        return TypeTags.TYPE_REFERENCED_TYPE_TAG;
+    }
+
+    @Override
+    public boolean isNilable() {
+        return this.referredType.isNilable();
+    }
+
+}

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BTypeReferenceType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BTypeReferenceType.java
@@ -31,14 +31,10 @@ import io.ballerina.runtime.api.types.Type;
  */
 public class BTypeReferenceType extends BAnnotatableType implements ReferenceType {
 
-    private Type referredType;
+    private final Type referredType;
 
-    public BTypeReferenceType(String typeName, Module pkg, Class<?> valueClass) {
-        super(typeName, pkg, valueClass);
-    }
-
-    public BTypeReferenceType(String typeName, Type referredType) {
-        super(typeName, null, Object.class);
+    public BTypeReferenceType(String typeName, Module pkg, Type referredType) {
+        super(typeName, pkg, Object.class);
         this.referredType = referredType;
     }
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BTypeReferenceType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BTypeReferenceType.java
@@ -27,7 +27,7 @@ import io.ballerina.runtime.api.types.Type;
 /**
  * {@code TypeReferencedType} represents a type description which refers to another type.
  *
- * @since 2.1.0
+ * @since 2201.2.0
  */
 public class BTypeReferenceType extends BAnnotatableType implements ReferenceType {
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BTypedescType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BTypedescType.java
@@ -71,6 +71,9 @@ public class BTypedescType extends BType implements TypedescType {
     }
 
     public Type getConstraint() {
+        if (constraint.getTag() == TypeTags.TYPE_REFERENCED_TYPE_TAG) {
+            return ((BTypeReferenceType) constraint).getReferredType();
+        }
         return constraint;
     }
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/util/RuntimeUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/util/RuntimeUtils.java
@@ -29,7 +29,6 @@ import io.ballerina.runtime.internal.ErrorUtils;
 import io.ballerina.runtime.internal.TypeConverter;
 import io.ballerina.runtime.internal.diagnostics.RuntimeDiagnosticLog;
 import io.ballerina.runtime.internal.types.BArrayType;
-import io.ballerina.runtime.internal.types.BTypeReferenceType;
 import io.ballerina.runtime.internal.values.ArrayValue;
 import io.ballerina.runtime.internal.values.ArrayValueImpl;
 import io.ballerina.runtime.internal.values.ErrorValue;
@@ -244,14 +243,6 @@ public class RuntimeUtils {
     private static boolean isInvalidBallerinaValue(Object value) {
         return (value != null && !(value instanceof Number) && !(value instanceof Boolean) &&
                 !(value instanceof BValue));
-    }
-
-    public static Type getReferredType(Type type) {
-        Type constraint = type;
-        if (type.getTag() == TypeTags.TYPE_REFERENCED_TYPE_TAG) {
-            constraint = getReferredType(((BTypeReferenceType) type).getReferredType());
-        }
-        return constraint;
     }
 
     private RuntimeUtils() {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/util/RuntimeUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/util/RuntimeUtils.java
@@ -29,6 +29,7 @@ import io.ballerina.runtime.internal.ErrorUtils;
 import io.ballerina.runtime.internal.TypeConverter;
 import io.ballerina.runtime.internal.diagnostics.RuntimeDiagnosticLog;
 import io.ballerina.runtime.internal.types.BArrayType;
+import io.ballerina.runtime.internal.types.BTypeReferenceType;
 import io.ballerina.runtime.internal.values.ArrayValue;
 import io.ballerina.runtime.internal.values.ArrayValueImpl;
 import io.ballerina.runtime.internal.values.ErrorValue;
@@ -243,6 +244,14 @@ public class RuntimeUtils {
     private static boolean isInvalidBallerinaValue(Object value) {
         return (value != null && !(value instanceof Number) && !(value instanceof Boolean) &&
                 !(value instanceof BValue));
+    }
+
+    public static Type getReferredType(Type type) {
+        Type constraint = type;
+        if (type.getTag() == TypeTags.TYPE_REFERENCED_TYPE_TAG) {
+            constraint = getReferredType(((BTypeReferenceType) type).getReferredType());
+        }
+        return constraint;
     }
 
     private RuntimeUtils() {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValueImpl.java
@@ -63,10 +63,10 @@ import java.util.StringJoiner;
 import java.util.stream.Collectors;
 
 import static io.ballerina.runtime.api.constants.RuntimeConstants.MAP_LANG_LIB;
+import static io.ballerina.runtime.api.utils.TypeUtils.getReferredType;
 import static io.ballerina.runtime.internal.JsonUtils.mergeJson;
 import static io.ballerina.runtime.internal.ValueUtils.createSingletonTypedesc;
 import static io.ballerina.runtime.internal.ValueUtils.getTypedescValue;
-import static io.ballerina.runtime.api.utils.TypeUtils.getReferredType;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.INVALID_UPDATE_ERROR_IDENTIFIER;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.MAP_KEY_NOT_FOUND_ERROR;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.getModulePrefixedReason;

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValueImpl.java
@@ -66,7 +66,7 @@ import static io.ballerina.runtime.api.constants.RuntimeConstants.MAP_LANG_LIB;
 import static io.ballerina.runtime.internal.JsonUtils.mergeJson;
 import static io.ballerina.runtime.internal.ValueUtils.createSingletonTypedesc;
 import static io.ballerina.runtime.internal.ValueUtils.getTypedescValue;
-import static io.ballerina.runtime.internal.util.RuntimeUtils.getReferredType;
+import static io.ballerina.runtime.api.utils.TypeUtils.getReferredType;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.INVALID_UPDATE_ERROR_IDENTIFIER;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.MAP_KEY_NOT_FOUND_ERROR;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.getModulePrefixedReason;

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValueImpl.java
@@ -66,6 +66,7 @@ import static io.ballerina.runtime.api.constants.RuntimeConstants.MAP_LANG_LIB;
 import static io.ballerina.runtime.internal.JsonUtils.mergeJson;
 import static io.ballerina.runtime.internal.ValueUtils.createSingletonTypedesc;
 import static io.ballerina.runtime.internal.ValueUtils.getTypedescValue;
+import static io.ballerina.runtime.internal.util.RuntimeUtils.getReferredType;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.INVALID_UPDATE_ERROR_IDENTIFIER;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.MAP_KEY_NOT_FOUND_ERROR;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.getModulePrefixedReason;
@@ -105,13 +106,13 @@ public class MapValueImpl<K, V> extends LinkedHashMap<K, V> implements RefValue,
 
     public MapValueImpl(Type type) {
         super();
-        this.type = type;
+        this.type = getReferredType(type);
         this.typedesc = getTypedescValue(type, this);
     }
 
     public MapValueImpl(Type type, BMapInitialValueEntry[] initialValues) {
         super();
-        this.type = type;
+        this.type = getReferredType(type);
         populateInitialValues(initialValues);
         if (!type.isReadOnly()) {
             this.typedesc = new TypedescValueImpl(type);

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TypedescValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TypedescValueImpl.java
@@ -29,7 +29,7 @@ import io.ballerina.runtime.internal.util.exceptions.BallerinaException;
 
 import java.util.Map;
 
-import static io.ballerina.runtime.internal.util.RuntimeUtils.getReferredType;
+import static io.ballerina.runtime.api.utils.TypeUtils.getReferredType;
 
 /**
  * <p>

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TypedescValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TypedescValueImpl.java
@@ -29,6 +29,8 @@ import io.ballerina.runtime.internal.util.exceptions.BallerinaException;
 
 import java.util.Map;
 
+import static io.ballerina.runtime.internal.util.RuntimeUtils.getReferredType;
+
 /**
  * <p>
  * Ballerina runtime value representation of a *type*. This class will be extended by the generated
@@ -83,11 +85,12 @@ public class TypedescValueImpl implements  TypedescValue {
 
     @Override
     public Object instantiate(Strand s, BInitialValueEntry[] initialValues) {
-        if (describingType.getTag() == TypeTags.MAP_TAG) {
-            return new MapValueImpl(describingType, (BMapInitialValueEntry[]) initialValues);
+        Type referredType = getReferredType(this.describingType);
+        if (referredType.getTag() == TypeTags.MAP_TAG) {
+            return new MapValueImpl(referredType, (BMapInitialValueEntry[]) initialValues);
         }
         // This method will be overridden for user-defined types, therefor this line shouldn't be reached.
-        throw new BallerinaException("Given type can't be instantiated at runtime : " + describingType);
+        throw new BallerinaException("Given type can't be instantiated at runtime : " + this.describingType);
     }
 
     @Override

--- a/bvm/ballerina-runtime/src/main/java/module-info.java
+++ b/bvm/ballerina-runtime/src/main/java/module-info.java
@@ -55,7 +55,8 @@ module io.ballerina.runtime {
             io.ballerina.lang.integer, io.ballerina.lang.floatingpoint, io.ballerina.lang.array,
             io.ballerina.lang.table, io.ballerina.java, io.ballerina.lang.map, io.ballerina.lang.string,
             io.ballerina.lang.xml, io.ballerina.lang.bool, io.ballerina.lang.error, io.ballerina.lang.internal,
-            io.ballerina.auth, io.ballerina.runtime.api, io.ballerina.cli.utils, io.ballerina.cli;
+            io.ballerina.lang.value, io.ballerina.auth, io.ballerina.runtime.api, io.ballerina.cli.utils,
+            io.ballerina.cli;
     exports io.ballerina.runtime.internal.util.exceptions to io.ballerina.lang.value, io.ballerina.lang.integer,
             io.ballerina.java, io.ballerina.lang.internal, io.ballerina.lang.array, io.ballerina.lang.bool,
             io.ballerina.lang.floatingpoint, io.ballerina.lang.map, io.ballerina.lang.string, io.ballerina.lang.table,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -2171,7 +2171,9 @@ public class BIRGen extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangSimpleVarRef.BLangTypeLoad typeLoad) {
-        visitTypedesc(typeLoad.pos, typeLoad.symbol.type, Collections.emptyList());
+        BType type = typeLoad.symbol.tag == SymTag.TYPE_DEF ?
+                ((BTypeDefinitionSymbol) typeLoad.symbol).referenceType : typeLoad.symbol.type;
+        visitTypedesc(typeLoad.pos, type, Collections.emptyList());
     }
 
     private void visitTypedesc(Location pos, BType type, List<BIROperand> varDcls) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
@@ -156,12 +156,14 @@ public class JvmConstants {
     public static final String REMOTE_METHOD_TYPE_IMPL = "io/ballerina/runtime/internal/types/BRemoteMethodType";
     public static final String FINITE_TYPE_IMPL = "io/ballerina/runtime/internal/types/BFiniteType";
     public static final String FUTURE_TYPE_IMPL = "io/ballerina/runtime/internal/types/BFutureType";
+    public static final String TYPE_REF_TYPE_IMPL = "io/ballerina/runtime/internal/types/BTypeReferenceType";
     public static final String MODULE = "io/ballerina/runtime/api/Module";
     public static final String CURRENT_MODULE_VAR_NAME = "$moduleName";
     public static final String B_STRING_VAR_PREFIX = "$bString";
     public static final String LARGE_STRING_VAR_PREFIX = "$stringChunk";
     public static final String GET_SURROGATE_ARRAY_METHOD_PREFIX = "getSurrogateArray";
     public static final String UNION_TYPE_VAR_PREFIX = "$unionType";
+    public static final String TYPEREF_TYPE_VAR_PREFIX = "$typeRefType$";
     public static final String TUPLE_TYPE_VAR_PREFIX = "$tupleType";
     public static final String ARRAY_TYPE_VAR_PREFIX = "$arrayType";
     public static final String MODULE_VAR_PREFIX = "$module";
@@ -276,6 +278,7 @@ public class JvmConstants {
     public static final String UNION_TYPE_CONSTANT_CLASS_NAME = "constants/$_bunion_type_constants";
     public static final String TUPLE_TYPE_CONSTANT_CLASS_NAME = "constants/$_tuple_type_constants";
     public static final String ARRAY_TYPE_CONSTANT_CLASS_NAME = "constants/$_array_type_constants";
+    public static final String TYPEREF_TYPE_CONSTANT_CLASS_NAME = "constants/$_typeref_type_constants";
     public static final String MODULE_STRING_CONSTANT_CLASS_NAME = "constants/$_string_constants";
     public static final String MODULE_SURROGATES_CLASS_NAME = "constants/$_surrogate_methods";
     public static final String MODULE_CONSTANT_CLASS_NAME = "constants/$_module_constants";
@@ -295,6 +298,7 @@ public class JvmConstants {
     public static final String B_UNION_TYPE_INIT_METHOD_PREFIX = "$union_type_init";
     public static final String B_TUPLE_TYPE_INIT_METHOD_PREFIX = "$tuple_type_init";
     public static final String B_ARRAY_TYPE_INIT_METHOD_PREFIX = "$array_type_init";
+    public static final String B_TYPEREF_TYPE_INIT_METHOD_PREFIX = "$typeref_type_init";
     public static final String MODULE_INIT_METHOD_PREFIX = "$module_init";
     public static final String CONSTANT_INIT_METHOD_PREFIX = "$constant_init";
     public static final String ANNOTATIONS_METHOD_PREFIX = "$process_annotations";

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
@@ -1962,7 +1962,7 @@ public class JvmInstructionGen {
             String fieldName = jvmTypeGen.getTypedescFieldName(toNameString(type));
             mv.visitFieldInsn(GETSTATIC, typeOwner, fieldName, GET_TYPEDESC);
         } else {
-            generateNewTypedescCreate(type, closureVars);
+            generateNewTypedescCreate(newTypeDesc.type, closureVars);
         }
         this.storeToVar(newTypeDesc.lhsOp.variableDcl);
     }
@@ -1975,7 +1975,11 @@ public class JvmInstructionGen {
         }
         this.mv.visitTypeInsn(NEW, className);
         this.mv.visitInsn(DUP);
-        jvmTypeGen.loadType(this.mv, type);
+        if (btype.tag == TypeTags.TYPEREFDESC) {
+            jvmConstantsGen.generateGetBTypeRefType(mv, jvmConstantsGen.getTypeConstantsVar(btype));
+        } else {
+            jvmTypeGen.loadType(this.mv, type);
+        }
 
         mv.visitIntInsn(BIPUSH, closureVars.size());
         mv.visitTypeInsn(ANEWARRAY, MAP_VALUE);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmSignatures.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmSignatures.java
@@ -303,7 +303,7 @@ public class JvmSignatures {
     public static final String INIT_WITH_BOOLEAN = "(L" + TYPE + ";Z)V";
     public static final String INIT_WITH_STRING = "(L" + STRING_VALUE + ";)V";
     public static final String INITIAL_METHOD_DESC = "(L" + STRAND_CLASS + ";";
-    public static final String INIT_TYPE_REF = "(L" + STRING_VALUE + ";L" + TYPE + ";)V";
+    public static final String INIT_TYPE_REF = "(L" + STRING_VALUE + ";L" + MODULE + ";L" + TYPE + ";)V";
     public static final String INSTANTIATE = "(L" + STRAND_CLASS + ";[L" + B_INITIAL_VALUE_ENTRY + ";)L" + OBJECT + ";";
     public static final String INT_VALUE_OF_METHOD = "(I)L" + INT_VALUE + ";";
     public static final String INTI_VARIABLE_KEY =

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmSignatures.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmSignatures.java
@@ -104,6 +104,7 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.TUPLE_TYP
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.TYPE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.TYPEDESC_VALUE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.TYPE_ID_SET;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.TYPE_REF_TYPE_IMPL;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.UNION_TYPE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.UNION_TYPE_IMPL;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.VALUE_CREATOR;
@@ -239,6 +240,7 @@ public class JvmSignatures {
     public static final String GET_TYPEDESC = "L" + TYPEDESC_VALUE + ";";
     public static final String GET_TYPEDESC_OF_OBJECT = "(L" + OBJECT + ";)L" + TYPEDESC_VALUE + ";";
     public static final String GET_UNION_TYPE_IMPL = "L" + UNION_TYPE_IMPL + ";";
+    public static final String GET_TYPE_REF_TYPE_IMPL = "L" + TYPE_REF_TYPE_IMPL + ";";
     public static final String GET_WD_CHANNELS = "L" + WD_CHANNELS + ";";
     public static final String GET_WORKER_DATA_CHANNEL = "(L" + STRING_VALUE + ";)L" + WORKER_DATA_CHANNEL + ";";
     public static final String GET_XML = "L" + XML_VALUE + ";";
@@ -301,6 +303,7 @@ public class JvmSignatures {
     public static final String INIT_WITH_BOOLEAN = "(L" + TYPE + ";Z)V";
     public static final String INIT_WITH_STRING = "(L" + STRING_VALUE + ";)V";
     public static final String INITIAL_METHOD_DESC = "(L" + STRAND_CLASS + ";";
+    public static final String INIT_TYPE_REF = "(L" + STRING_VALUE + ";L" + TYPE + ";)V";
     public static final String INSTANTIATE = "(L" + STRAND_CLASS + ";[L" + B_INITIAL_VALUE_ENTRY + ";)L" + OBJECT + ";";
     public static final String INT_VALUE_OF_METHOD = "(I)L" + INT_VALUE + ";";
     public static final String INTI_VARIABLE_KEY =

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/JvmAnnotationsGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/JvmAnnotationsGen.java
@@ -60,13 +60,16 @@ public class JvmAnnotationsGen {
     private final String annotationsClass;
     private final JvmPackageGen jvmPackageGen;
     private final JvmTypeGen jvmTypeGen;
+    private final JvmConstantsGen jvmConstantsGen;
     private final BIRNode.BIRPackage module;
 
-    public JvmAnnotationsGen(BIRNode.BIRPackage module, JvmPackageGen jvmPackageGen, JvmTypeGen jvmTypeGen) {
+    public JvmAnnotationsGen(BIRNode.BIRPackage module, JvmPackageGen jvmPackageGen, JvmTypeGen jvmTypeGen,
+                             JvmConstantsGen jvmConstantsGen) {
         this.annotationsClass = getModuleLevelClassName(module.packageID, MODULE_ANNOTATIONS_CLASS_NAME);
         this.jvmPackageGen = jvmPackageGen;
         this.jvmTypeGen = jvmTypeGen;
         this.module = module;
+        this.jvmConstantsGen = jvmConstantsGen;
     }
 
     public void generateAnnotationsClass(Map<String, byte[]> jarEntries) {
@@ -133,7 +136,11 @@ public class JvmAnnotationsGen {
     }
 
     void loadLocalType(MethodVisitor mv, BIRNode.BIRTypeDefinition typeDefinition, JvmTypeGen jvmTypeGen) {
-        jvmTypeGen.loadType(mv, typeDefinition.type);
+        if (typeDefinition.type.tag == TypeTags.TYPEREFDESC) {
+            jvmConstantsGen.generateGetBTypeRefType(mv, jvmConstantsGen.getTypeConstantsVar(typeDefinition.type));
+        } else {
+            jvmTypeGen.loadType(mv, typeDefinition.type);
+        }
     }
 
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/JvmConstantsGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/JvmConstantsGen.java
@@ -25,6 +25,7 @@ import org.wso2.ballerinalang.compiler.bir.codegen.split.constants.JvmBStringCon
 import org.wso2.ballerinalang.compiler.bir.codegen.split.constants.JvmBallerinaConstantsGen;
 import org.wso2.ballerinalang.compiler.bir.codegen.split.constants.JvmModuleConstantsGen;
 import org.wso2.ballerinalang.compiler.bir.codegen.split.constants.JvmTupleTypeConstantsGen;
+import org.wso2.ballerinalang.compiler.bir.codegen.split.constants.JvmTypeRefTypeConstantsGen;
 import org.wso2.ballerinalang.compiler.bir.codegen.split.constants.JvmUnionTypeConstantsGen;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode;
 import org.wso2.ballerinalang.compiler.semantics.analyzer.TypeHashVisitor;
@@ -32,6 +33,7 @@ import org.wso2.ballerinalang.compiler.semantics.analyzer.Types;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BArrayType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BTupleType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BTypeReferenceType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BUnionType;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 
@@ -56,6 +58,8 @@ public class JvmConstantsGen {
 
     private final JvmArrayTypeConstantsGen arrayTypeConstantsGen;
 
+    private final JvmTypeRefTypeConstantsGen typeRefTypeConstantsGen;
+
     public final BTypeHashComparator bTypeHashComparator;
 
     public JvmConstantsGen(BIRNode.BIRPackage module, String moduleInitClass, Types types,
@@ -67,6 +71,7 @@ public class JvmConstantsGen {
         this.unionTypeConstantsGen = new JvmUnionTypeConstantsGen(module.packageID, bTypeHashComparator);
         this.tupleTypeConstantsGen = new JvmTupleTypeConstantsGen(module.packageID, bTypeHashComparator);
         this.arrayTypeConstantsGen = new JvmArrayTypeConstantsGen(module.packageID, bTypeHashComparator, types);
+        this.typeRefTypeConstantsGen = new JvmTypeRefTypeConstantsGen(module.packageID, bTypeHashComparator);
     }
 
     public String getBStringConstantVar(String value) {
@@ -81,6 +86,7 @@ public class JvmConstantsGen {
         unionTypeConstantsGen.setJvmUnionTypeGen(jvmCreateTypeGen.getJvmUnionTypeGen());
         tupleTypeConstantsGen.setJvmTupleTypeGen(jvmCreateTypeGen.getJvmTupleTypeGen());
         arrayTypeConstantsGen.setJvmArrayTypeGen(jvmCreateTypeGen.getJvmArrayTypeGen());
+        typeRefTypeConstantsGen.setJvmTypeRefTypeGen(jvmCreateTypeGen.getJvmTypeRefTypeGen());
     }
 
     public void generateConstants(Map<String, byte[]> jarEntries) {
@@ -90,6 +96,7 @@ public class JvmConstantsGen {
         stringConstantsGen.generateConstantInit(jarEntries);
         tupleTypeConstantsGen.generateClass(jarEntries);
         arrayTypeConstantsGen.generateClass(jarEntries);
+        typeRefTypeConstantsGen.generateClass(jarEntries);
     }
 
     public void generateGetBUnionType(MethodVisitor mv, String varName) {
@@ -100,12 +107,18 @@ public class JvmConstantsGen {
         tupleTypeConstantsGen.generateGetBTupleType(mv, varName);
     }
 
+    public void generateGetBTypeRefType(MethodVisitor mv, String varName) {
+        typeRefTypeConstantsGen.generateGetBTypeRefType(mv, varName);
+    }
+
     public String getTypeConstantsVar(BType type) {
         switch (type.tag) {
             case TypeTags.ARRAY:
                 return arrayTypeConstantsGen.add((BArrayType) type);
             case TypeTags.TUPLE:
                 return tupleTypeConstantsGen.add((BTupleType) type);
+            case TypeTags.TYPEREFDESC:
+                return typeRefTypeConstantsGen.add((BTypeReferenceType) type);
             default:
                 return unionTypeConstantsGen.add((BUnionType) type);
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/JvmConstantsGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/JvmConstantsGen.java
@@ -24,8 +24,8 @@ import org.wso2.ballerinalang.compiler.bir.codegen.split.constants.JvmArrayTypeC
 import org.wso2.ballerinalang.compiler.bir.codegen.split.constants.JvmBStringConstantsGen;
 import org.wso2.ballerinalang.compiler.bir.codegen.split.constants.JvmBallerinaConstantsGen;
 import org.wso2.ballerinalang.compiler.bir.codegen.split.constants.JvmModuleConstantsGen;
-import org.wso2.ballerinalang.compiler.bir.codegen.split.constants.JvmTupleTypeConstantsGen;
 import org.wso2.ballerinalang.compiler.bir.codegen.split.constants.JvmRefTypeConstantsGen;
+import org.wso2.ballerinalang.compiler.bir.codegen.split.constants.JvmTupleTypeConstantsGen;
 import org.wso2.ballerinalang.compiler.bir.codegen.split.constants.JvmUnionTypeConstantsGen;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode;
 import org.wso2.ballerinalang.compiler.semantics.analyzer.TypeHashVisitor;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/JvmConstantsGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/JvmConstantsGen.java
@@ -25,7 +25,7 @@ import org.wso2.ballerinalang.compiler.bir.codegen.split.constants.JvmBStringCon
 import org.wso2.ballerinalang.compiler.bir.codegen.split.constants.JvmBallerinaConstantsGen;
 import org.wso2.ballerinalang.compiler.bir.codegen.split.constants.JvmModuleConstantsGen;
 import org.wso2.ballerinalang.compiler.bir.codegen.split.constants.JvmTupleTypeConstantsGen;
-import org.wso2.ballerinalang.compiler.bir.codegen.split.constants.JvmTypeRefTypeConstantsGen;
+import org.wso2.ballerinalang.compiler.bir.codegen.split.constants.JvmRefTypeConstantsGen;
 import org.wso2.ballerinalang.compiler.bir.codegen.split.constants.JvmUnionTypeConstantsGen;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode;
 import org.wso2.ballerinalang.compiler.semantics.analyzer.TypeHashVisitor;
@@ -58,7 +58,7 @@ public class JvmConstantsGen {
 
     private final JvmArrayTypeConstantsGen arrayTypeConstantsGen;
 
-    private final JvmTypeRefTypeConstantsGen typeRefTypeConstantsGen;
+    private final JvmRefTypeConstantsGen refTypeConstantsGen;
 
     public final BTypeHashComparator bTypeHashComparator;
 
@@ -71,7 +71,7 @@ public class JvmConstantsGen {
         this.unionTypeConstantsGen = new JvmUnionTypeConstantsGen(module.packageID, bTypeHashComparator);
         this.tupleTypeConstantsGen = new JvmTupleTypeConstantsGen(module.packageID, bTypeHashComparator);
         this.arrayTypeConstantsGen = new JvmArrayTypeConstantsGen(module.packageID, bTypeHashComparator, types);
-        this.typeRefTypeConstantsGen = new JvmTypeRefTypeConstantsGen(module.packageID, bTypeHashComparator);
+        this.refTypeConstantsGen = new JvmRefTypeConstantsGen(module.packageID, bTypeHashComparator);
     }
 
     public String getBStringConstantVar(String value) {
@@ -86,7 +86,7 @@ public class JvmConstantsGen {
         unionTypeConstantsGen.setJvmUnionTypeGen(jvmCreateTypeGen.getJvmUnionTypeGen());
         tupleTypeConstantsGen.setJvmTupleTypeGen(jvmCreateTypeGen.getJvmTupleTypeGen());
         arrayTypeConstantsGen.setJvmArrayTypeGen(jvmCreateTypeGen.getJvmArrayTypeGen());
-        typeRefTypeConstantsGen.setJvmTypeRefTypeGen(jvmCreateTypeGen.getJvmTypeRefTypeGen());
+        refTypeConstantsGen.setJvmTypeRefTypeGen(jvmCreateTypeGen.getJvmTypeRefTypeGen());
     }
 
     public void generateConstants(Map<String, byte[]> jarEntries) {
@@ -96,7 +96,7 @@ public class JvmConstantsGen {
         stringConstantsGen.generateConstantInit(jarEntries);
         tupleTypeConstantsGen.generateClass(jarEntries);
         arrayTypeConstantsGen.generateClass(jarEntries);
-        typeRefTypeConstantsGen.generateClass(jarEntries);
+        refTypeConstantsGen.generateClass(jarEntries);
     }
 
     public void generateGetBUnionType(MethodVisitor mv, String varName) {
@@ -108,7 +108,7 @@ public class JvmConstantsGen {
     }
 
     public void generateGetBTypeRefType(MethodVisitor mv, String varName) {
-        typeRefTypeConstantsGen.generateGetBTypeRefType(mv, varName);
+        refTypeConstantsGen.generateGetBTypeRefType(mv, varName);
     }
 
     public String getTypeConstantsVar(BType type) {
@@ -118,7 +118,7 @@ public class JvmConstantsGen {
             case TypeTags.TUPLE:
                 return tupleTypeConstantsGen.add((BTupleType) type);
             case TypeTags.TYPEREFDESC:
-                return typeRefTypeConstantsGen.add((BTypeReferenceType) type);
+                return refTypeConstantsGen.add((BTypeReferenceType) type);
             default:
                 return unionTypeConstantsGen.add((BUnionType) type);
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/JvmCreateTypeGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/JvmCreateTypeGen.java
@@ -33,6 +33,7 @@ import org.wso2.ballerinalang.compiler.bir.codegen.split.types.JvmErrorTypeGen;
 import org.wso2.ballerinalang.compiler.bir.codegen.split.types.JvmObjectTypeGen;
 import org.wso2.ballerinalang.compiler.bir.codegen.split.types.JvmRecordTypeGen;
 import org.wso2.ballerinalang.compiler.bir.codegen.split.types.JvmTupleTypeGen;
+import org.wso2.ballerinalang.compiler.bir.codegen.split.types.JvmTypeRefTypeGen;
 import org.wso2.ballerinalang.compiler.bir.codegen.split.types.JvmUnionTypeGen;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRTypeDefinition;
@@ -127,6 +128,7 @@ public class JvmCreateTypeGen {
     private final JvmUnionTypeGen jvmUnionTypeGen;
     private final JvmTupleTypeGen jvmTupleTypeGen;
     private final JvmArrayTypeGen jvmArrayTypeGen;
+    private final JvmTypeRefTypeGen jvmTypeRefTypeGen;
     private final TypeHashVisitor typeHashVisitor;
     public final TypeDefHashComparator typeDefHashComparator;
     private final String typesClass;
@@ -145,6 +147,7 @@ public class JvmCreateTypeGen {
         this.jvmUnionTypeGen = new JvmUnionTypeGen(this, jvmTypeGen, jvmConstantsGen, packageID);
         this.jvmTupleTypeGen = new JvmTupleTypeGen(this, jvmTypeGen, jvmConstantsGen, packageID);
         this.jvmArrayTypeGen = new JvmArrayTypeGen(jvmTypeGen);
+        this.jvmTypeRefTypeGen = new JvmTypeRefTypeGen(jvmTypeGen, jvmConstantsGen, packageID);
         this.typesCw = new BallerinaClassWriter(COMPUTE_FRAMES);
         this.typeHashVisitor =  typeHashVisitor;
         this.typeDefHashComparator = new TypeDefHashComparator(typeHashVisitor);
@@ -662,6 +665,10 @@ public class JvmCreateTypeGen {
 
     public JvmArrayTypeGen getJvmArrayTypeGen() {
         return jvmArrayTypeGen;
+    }
+
+    public JvmTypeRefTypeGen getJvmTypeRefTypeGen() {
+        return jvmTypeRefTypeGen;
     }
 
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/JvmCreateTypeGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/JvmCreateTypeGen.java
@@ -147,7 +147,7 @@ public class JvmCreateTypeGen {
         this.jvmUnionTypeGen = new JvmUnionTypeGen(this, jvmTypeGen, jvmConstantsGen, packageID);
         this.jvmTupleTypeGen = new JvmTupleTypeGen(this, jvmTypeGen, jvmConstantsGen, packageID);
         this.jvmArrayTypeGen = new JvmArrayTypeGen(jvmTypeGen);
-        this.jvmTypeRefTypeGen = new JvmTypeRefTypeGen(jvmTypeGen);
+        this.jvmTypeRefTypeGen = new JvmTypeRefTypeGen(jvmTypeGen, jvmConstantsGen);
         this.typesCw = new BallerinaClassWriter(COMPUTE_FRAMES);
         this.typeHashVisitor =  typeHashVisitor;
         this.typeDefHashComparator = new TypeDefHashComparator(typeHashVisitor);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/JvmCreateTypeGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/JvmCreateTypeGen.java
@@ -147,7 +147,7 @@ public class JvmCreateTypeGen {
         this.jvmUnionTypeGen = new JvmUnionTypeGen(this, jvmTypeGen, jvmConstantsGen, packageID);
         this.jvmTupleTypeGen = new JvmTupleTypeGen(this, jvmTypeGen, jvmConstantsGen, packageID);
         this.jvmArrayTypeGen = new JvmArrayTypeGen(jvmTypeGen);
-        this.jvmTypeRefTypeGen = new JvmTypeRefTypeGen(jvmTypeGen, jvmConstantsGen, packageID);
+        this.jvmTypeRefTypeGen = new JvmTypeRefTypeGen(jvmTypeGen);
         this.typesCw = new BallerinaClassWriter(COMPUTE_FRAMES);
         this.typeHashVisitor =  typeHashVisitor;
         this.typeDefHashComparator = new TypeDefHashComparator(typeHashVisitor);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/JvmMethodsSplitter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/JvmMethodsSplitter.java
@@ -46,7 +46,7 @@ public class JvmMethodsSplitter {
         this.moduleInitClass = moduleInitClass;
         JvmTypeGen jvmTypeGen = new JvmTypeGen(jvmConstantsGen, module.packageID, typeHashVisitor);
         this.jvmCreateTypeGen = new JvmCreateTypeGen(jvmTypeGen, jvmConstantsGen, module.packageID, typeHashVisitor);
-        this.jvmAnnotationsGen = new JvmAnnotationsGen(module, jvmPackageGen, jvmTypeGen);
+        this.jvmAnnotationsGen = new JvmAnnotationsGen(module, jvmPackageGen, jvmTypeGen, jvmConstantsGen);
         this.jvmValueCreatorGen = new JvmValueCreatorGen(module.packageID);
         jvmConstantsGen.setJvmCreateTypeGen(jvmCreateTypeGen);
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/constants/JvmArrayTypeConstantsGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/constants/JvmArrayTypeConstantsGen.java
@@ -39,17 +39,13 @@ import java.util.TreeMap;
 
 import static org.objectweb.asm.ClassWriter.COMPUTE_FRAMES;
 import static org.objectweb.asm.Opcodes.ACC_FINAL;
-import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
 import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
 import static org.objectweb.asm.Opcodes.ACC_STATIC;
-import static org.objectweb.asm.Opcodes.ACC_SUPER;
-import static org.objectweb.asm.Opcodes.ALOAD;
 import static org.objectweb.asm.Opcodes.GETSTATIC;
-import static org.objectweb.asm.Opcodes.INVOKESPECIAL;
 import static org.objectweb.asm.Opcodes.INVOKESTATIC;
-import static org.objectweb.asm.Opcodes.RETURN;
-import static org.objectweb.asm.Opcodes.V1_8;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.GET_ARRAY_TYPE_IMPL;
+import static org.wso2.ballerinalang.compiler.bir.codegen.split.constants.JvmConstantGenCommons.genMethodReturn;
+import static org.wso2.ballerinalang.compiler.bir.codegen.split.constants.JvmConstantGenCommons.generateConstantsClassInit;
 
 /**
  * Generates Jvm class for the ballerina array types as constants for a given module.
@@ -71,7 +67,8 @@ public class JvmArrayTypeConstantsGen {
     public JvmArrayTypeConstantsGen(PackageID packageID, BTypeHashComparator bTypeHashComparator, Types types) {
         this.arrayConstantsClass =
                 JvmCodeGenUtil.getModuleLevelClassName(packageID, JvmConstants.ARRAY_TYPE_CONSTANT_CLASS_NAME);
-        generateArrayTypeConstantsClassInit();
+        cw = new BallerinaClassWriter(COMPUTE_FRAMES);
+        generateConstantsClassInit(cw, arrayConstantsClass);
         visitArrayTypeInitMethod();
         this.arrayTypeVarMap = new TreeMap<>(bTypeHashComparator);
         this.funcNames = new ArrayList<>();
@@ -80,23 +77,6 @@ public class JvmArrayTypeConstantsGen {
 
     public void setJvmArrayTypeGen(JvmArrayTypeGen jvmArrayTypeGen) {
         this.jvmArrayTypeGen = jvmArrayTypeGen;
-    }
-
-    private void generateArrayTypeConstantsClassInit() {
-        cw = new BallerinaClassWriter(COMPUTE_FRAMES);
-        cw.visit(V1_8, ACC_PUBLIC | ACC_SUPER, arrayConstantsClass, null, JvmConstants.OBJECT, null);
-
-        MethodVisitor methodVisitor = cw.visitMethod(ACC_PRIVATE, JvmConstants.JVM_INIT_METHOD, "()V", null, null);
-        methodVisitor.visitCode();
-        methodVisitor.visitVarInsn(ALOAD, 0);
-        methodVisitor.visitMethodInsn(INVOKESPECIAL, JvmConstants.OBJECT, JvmConstants.JVM_INIT_METHOD, "()V", false);
-        genMethodReturn(methodVisitor);
-    }
-
-    private void genMethodReturn(MethodVisitor methodVisitor) {
-        methodVisitor.visitInsn(RETURN);
-        methodVisitor.visitMaxs(0, 0);
-        methodVisitor.visitEnd();
     }
 
     private void visitArrayTypeInitMethod() {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/constants/JvmConstantGenCommons.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/constants/JvmConstantGenCommons.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.ballerinalang.compiler.bir.codegen.split.constants;
+
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.MethodVisitor;
+import org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants;
+
+import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
+import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
+import static org.objectweb.asm.Opcodes.ACC_SUPER;
+import static org.objectweb.asm.Opcodes.ALOAD;
+import static org.objectweb.asm.Opcodes.INVOKESPECIAL;
+import static org.objectweb.asm.Opcodes.RETURN;
+import static org.objectweb.asm.Opcodes.V1_8;
+
+/**
+ * The common functions used in jvm constants generation.
+ */
+public class JvmConstantGenCommons {
+
+    private JvmConstantGenCommons() {
+    }
+
+    public static void generateConstantsClassInit(ClassWriter cw, String constantsClass) {
+        cw.visit(V1_8, ACC_PUBLIC | ACC_SUPER, constantsClass, null, JvmConstants.OBJECT, null);
+
+        MethodVisitor methodVisitor = cw.visitMethod(ACC_PRIVATE, JvmConstants.JVM_INIT_METHOD, "()V", null, null);
+        methodVisitor.visitCode();
+        methodVisitor.visitVarInsn(ALOAD, 0);
+        methodVisitor.visitMethodInsn(INVOKESPECIAL, JvmConstants.OBJECT, JvmConstants.JVM_INIT_METHOD, "()V", false);
+        genMethodReturn(methodVisitor);
+    }
+
+    public static void genMethodReturn(MethodVisitor methodVisitor) {
+        methodVisitor.visitInsn(RETURN);
+        methodVisitor.visitMaxs(0, 0);
+        methodVisitor.visitEnd();
+    }
+
+}

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/constants/JvmConstantGenCommons.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/constants/JvmConstantGenCommons.java
@@ -32,6 +32,8 @@ import static org.objectweb.asm.Opcodes.V1_8;
 
 /**
  * The common functions used in jvm constants generation.
+ *
+ * @since 2201.2.0
  */
 public class JvmConstantGenCommons {
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/constants/JvmRefTypeConstantsGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/constants/JvmRefTypeConstantsGen.java
@@ -48,9 +48,9 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.split.constants.JvmCon
 /**
  * Generates Jvm class for the ballerina type reference types as constants for a given module.
  *
- * @since 2.0.0
+ * @since 2201.2.0
  */
-public class JvmTypeRefTypeConstantsGen {
+public class JvmRefTypeConstantsGen {
 
     private final String typeRefVarConstantsClass;
     private JvmTypeRefTypeGen jvmTypeRefTypeGen;
@@ -59,7 +59,7 @@ public class JvmTypeRefTypeConstantsGen {
     private int methodCount;
     private final Map<BTypeReferenceType, String> typeRefVarMap;
 
-    public JvmTypeRefTypeConstantsGen(PackageID packageID, BTypeHashComparator bTypeHashComparator) {
+    public JvmRefTypeConstantsGen(PackageID packageID, BTypeHashComparator bTypeHashComparator) {
         typeRefVarConstantsClass = JvmCodeGenUtil.getModuleLevelClassName(packageID,
                 JvmConstants.TYPEREF_TYPE_CONSTANT_CLASS_NAME);
         cw = new BallerinaClassWriter(COMPUTE_FRAMES);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/constants/JvmTupleTypeConstantsGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/constants/JvmTupleTypeConstantsGen.java
@@ -40,20 +40,14 @@ import java.util.TreeMap;
 
 import static org.objectweb.asm.ClassWriter.COMPUTE_FRAMES;
 import static org.objectweb.asm.Opcodes.ACC_FINAL;
-import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
 import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
 import static org.objectweb.asm.Opcodes.ACC_STATIC;
-import static org.objectweb.asm.Opcodes.ACC_SUPER;
-import static org.objectweb.asm.Opcodes.ALOAD;
 import static org.objectweb.asm.Opcodes.GETSTATIC;
-import static org.objectweb.asm.Opcodes.INVOKESPECIAL;
 import static org.objectweb.asm.Opcodes.INVOKESTATIC;
-import static org.objectweb.asm.Opcodes.RETURN;
-import static org.objectweb.asm.Opcodes.V1_8;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.B_TUPLE_TYPE_INIT_METHOD_PREFIX;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.JVM_INIT_METHOD;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.OBJECT;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.GET_TUPLE_TYPE_IMPL;
+import static org.wso2.ballerinalang.compiler.bir.codegen.split.constants.JvmConstantGenCommons.genMethodReturn;
+import static org.wso2.ballerinalang.compiler.bir.codegen.split.constants.JvmConstantGenCommons.generateConstantsClassInit;
 
 /**
  * Generates Jvm class for the ballerina tuple types as constants for a given module.
@@ -75,7 +69,8 @@ public class JvmTupleTypeConstantsGen {
     public JvmTupleTypeConstantsGen(PackageID packageID, BTypeHashComparator bTypeHashComparator) {
         tupleVarConstantsClass = JvmCodeGenUtil.getModuleLevelClassName(packageID,
                 JvmConstants.TUPLE_TYPE_CONSTANT_CLASS_NAME);
-        generateTupleTypeConstantsClassInit();
+        cw = new BallerinaClassWriter(COMPUTE_FRAMES);
+        generateConstantsClassInit(cw, tupleVarConstantsClass);
         visitTupleTypeInitMethod();
         funcNames = new ArrayList<>();
         queue = new LinkedList<>();
@@ -88,17 +83,6 @@ public class JvmTupleTypeConstantsGen {
 
     public String add(BTupleType type) {
         return tupleTypeVarMap.computeIfAbsent(type, str -> generateBTupleInits(type));
-    }
-
-    private void generateTupleTypeConstantsClassInit() {
-        cw = new BallerinaClassWriter(COMPUTE_FRAMES);
-        cw.visit(V1_8, ACC_PUBLIC | ACC_SUPER, tupleVarConstantsClass, null, OBJECT, null);
-
-        MethodVisitor methodVisitor = cw.visitMethod(ACC_PRIVATE, JVM_INIT_METHOD, "()V", null, null);
-        methodVisitor.visitCode();
-        methodVisitor.visitVarInsn(ALOAD, 0);
-        methodVisitor.visitMethodInsn(INVOKESPECIAL, OBJECT, JVM_INIT_METHOD, "()V", false);
-        genMethodReturn(methodVisitor);
     }
 
     private void visitTupleTypeInitMethod() {
@@ -174,9 +158,4 @@ public class JvmTupleTypeConstantsGen {
         genMethodReturn(methodVisitor);
     }
 
-    private void genMethodReturn(MethodVisitor methodVisitor) {
-        methodVisitor.visitInsn(RETURN);
-        methodVisitor.visitMaxs(0, 0);
-        methodVisitor.visitEnd();
-    }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/constants/JvmTypeRefTypeConstantsGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/constants/JvmTypeRefTypeConstantsGen.java
@@ -59,9 +59,6 @@ public class JvmTypeRefTypeConstantsGen {
     private int methodCount;
     private final Map<BTypeReferenceType, String> typeRefVarMap;
 
-    /**
-     * Stack keeps track of recursion in typeref types. The method creation is performed only if recursion is completed.
-     */
     public JvmTypeRefTypeConstantsGen(PackageID packageID, BTypeHashComparator bTypeHashComparator) {
         typeRefVarConstantsClass = JvmCodeGenUtil.getModuleLevelClassName(packageID,
                 JvmConstants.TYPEREF_TYPE_CONSTANT_CLASS_NAME);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/constants/JvmTypeRefTypeConstantsGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/constants/JvmTypeRefTypeConstantsGen.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.ballerinalang.compiler.bir.codegen.split.constants;
+
+import org.ballerinalang.model.elements.PackageID;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.wso2.ballerinalang.compiler.bir.codegen.BallerinaClassWriter;
+import org.wso2.ballerinalang.compiler.bir.codegen.JvmCodeGenUtil;
+import org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants;
+import org.wso2.ballerinalang.compiler.bir.codegen.internal.BTypeHashComparator;
+import org.wso2.ballerinalang.compiler.bir.codegen.split.types.JvmTypeRefTypeGen;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BTypeReferenceType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import static org.objectweb.asm.ClassWriter.COMPUTE_FRAMES;
+import static org.objectweb.asm.Opcodes.ACC_FINAL;
+import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
+import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
+import static org.objectweb.asm.Opcodes.ACC_STATIC;
+import static org.objectweb.asm.Opcodes.ACC_SUPER;
+import static org.objectweb.asm.Opcodes.ALOAD;
+import static org.objectweb.asm.Opcodes.GETSTATIC;
+import static org.objectweb.asm.Opcodes.INVOKESPECIAL;
+import static org.objectweb.asm.Opcodes.INVOKESTATIC;
+import static org.objectweb.asm.Opcodes.RETURN;
+import static org.objectweb.asm.Opcodes.V1_8;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.B_TYPEREF_TYPE_INIT_METHOD_PREFIX;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.JVM_INIT_METHOD;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.OBJECT;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.GET_TYPE_REF_TYPE_IMPL;
+
+/**
+ * Generates Jvm class for the ballerina type reference types as constants for a given module.
+ *
+ * @since 2.0.0
+ */
+public class JvmTypeRefTypeConstantsGen {
+
+    private final String typeRefVarConstantsClass;
+    private JvmTypeRefTypeGen jvmTypeRefTypeGen;
+    private ClassWriter cw;
+    private MethodVisitor mv;
+    private int methodCount;
+    private final List<String> funcNames;
+    private final Map<BTypeReferenceType, String> typeRefVarMap;
+
+    /**
+     * Stack keeps track of recursion in union types. The method creation is performed only if recursion is completed.
+     */
+    public JvmTypeRefTypeConstantsGen(PackageID packageID, BTypeHashComparator bTypeHashComparator) {
+        typeRefVarConstantsClass = JvmCodeGenUtil.getModuleLevelClassName(packageID,
+                JvmConstants.TYPEREF_TYPE_CONSTANT_CLASS_NAME);
+        generateUnionTypeConstantsClassInit();
+        visitTypeRefTypeInitMethod();
+        funcNames = new ArrayList<>();
+        typeRefVarMap = new TreeMap<>(bTypeHashComparator);
+    }
+
+    public void setJvmTypeRefTypeGen(JvmTypeRefTypeGen jvmTypeRefTypeGen) {
+        this.jvmTypeRefTypeGen = jvmTypeRefTypeGen;
+    }
+
+    public String add(BTypeReferenceType type) {
+        return typeRefVarMap.computeIfAbsent(type, str -> generateTypeRefInits(type));
+    }
+
+    private void generateUnionTypeConstantsClassInit() {
+        cw = new BallerinaClassWriter(COMPUTE_FRAMES);
+        cw.visit(V1_8, ACC_PUBLIC | ACC_SUPER, typeRefVarConstantsClass, null, OBJECT, null);
+
+        MethodVisitor methodVisitor = cw.visitMethod(ACC_PRIVATE, JVM_INIT_METHOD, "()V", null, null);
+        methodVisitor.visitCode();
+        methodVisitor.visitVarInsn(ALOAD, 0);
+        methodVisitor.visitMethodInsn(INVOKESPECIAL, OBJECT, JVM_INIT_METHOD, "()V", false);
+        genMethodReturn(methodVisitor);
+    }
+
+    private void visitTypeRefTypeInitMethod() {
+        mv = cw.visitMethod(ACC_STATIC, B_TYPEREF_TYPE_INIT_METHOD_PREFIX + methodCount++, "()V", null, null);
+    }
+
+    private String generateTypeRefInits(BTypeReferenceType type) {
+        String varName = JvmConstants.TYPEREF_TYPE_VAR_PREFIX + type.tsymbol.name;
+        visitTypeRefField(varName);
+        createTypeRefType(mv, type, varName);
+        return varName;
+    }
+
+    private void createTypeRefType(MethodVisitor mv, BTypeReferenceType type, String varName) {
+        jvmTypeRefTypeGen.createTypeRefType(mv, type);
+        mv.visitFieldInsn(Opcodes.PUTSTATIC, typeRefVarConstantsClass, varName,
+                GET_TYPE_REF_TYPE_IMPL);
+    }
+
+    private void visitTypeRefField(String varName) {
+        FieldVisitor fv = cw.visitField(ACC_PUBLIC + ACC_FINAL + ACC_STATIC, varName,
+                GET_TYPE_REF_TYPE_IMPL, null, null);
+        fv.visitEnd();
+    }
+
+    public void generateGetBTypeRefType(MethodVisitor mv, String varName) {
+        mv.visitFieldInsn(GETSTATIC, typeRefVarConstantsClass, varName, GET_TYPE_REF_TYPE_IMPL);
+    }
+
+    public void generateClass(Map<String, byte[]> jarEntries) {
+        genMethodReturn(mv);
+        visitTypeRefTypeInitMethod();
+        for (String funcName : funcNames) {
+            mv.visitMethodInsn(INVOKESTATIC, typeRefVarConstantsClass, funcName, "()V", false);
+        }
+        genMethodReturn(mv);
+        generateStaticInitializer(cw);
+        cw.visitEnd();
+        jarEntries.put(typeRefVarConstantsClass + ".class", cw.toByteArray());
+    }
+
+    private void generateStaticInitializer(ClassWriter cw) {
+        MethodVisitor methodVisitor = cw.visitMethod(ACC_STATIC, "<clinit>", "()V", null, null);
+        for (int i = 0; i < methodCount; i++) {
+            methodVisitor.visitMethodInsn(INVOKESTATIC, typeRefVarConstantsClass,
+                    B_TYPEREF_TYPE_INIT_METHOD_PREFIX + i, "()V", false);
+        }
+        genMethodReturn(methodVisitor);
+    }
+
+    private void genMethodReturn(MethodVisitor methodVisitor) {
+        methodVisitor.visitInsn(RETURN);
+        methodVisitor.visitMaxs(0, 0);
+        methodVisitor.visitEnd();
+    }
+
+}

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/constants/JvmTypeRefTypeConstantsGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/constants/JvmTypeRefTypeConstantsGen.java
@@ -37,20 +37,14 @@ import java.util.TreeMap;
 
 import static org.objectweb.asm.ClassWriter.COMPUTE_FRAMES;
 import static org.objectweb.asm.Opcodes.ACC_FINAL;
-import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
 import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
 import static org.objectweb.asm.Opcodes.ACC_STATIC;
-import static org.objectweb.asm.Opcodes.ACC_SUPER;
-import static org.objectweb.asm.Opcodes.ALOAD;
 import static org.objectweb.asm.Opcodes.GETSTATIC;
-import static org.objectweb.asm.Opcodes.INVOKESPECIAL;
 import static org.objectweb.asm.Opcodes.INVOKESTATIC;
-import static org.objectweb.asm.Opcodes.RETURN;
-import static org.objectweb.asm.Opcodes.V1_8;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.B_TYPEREF_TYPE_INIT_METHOD_PREFIX;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.JVM_INIT_METHOD;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.OBJECT;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.GET_TYPE_REF_TYPE_IMPL;
+import static org.wso2.ballerinalang.compiler.bir.codegen.split.constants.JvmConstantGenCommons.genMethodReturn;
+import static org.wso2.ballerinalang.compiler.bir.codegen.split.constants.JvmConstantGenCommons.generateConstantsClassInit;
 
 /**
  * Generates Jvm class for the ballerina type reference types as constants for a given module.
@@ -68,12 +62,13 @@ public class JvmTypeRefTypeConstantsGen {
     private final Map<BTypeReferenceType, String> typeRefVarMap;
 
     /**
-     * Stack keeps track of recursion in union types. The method creation is performed only if recursion is completed.
+     * Stack keeps track of recursion in typeref types. The method creation is performed only if recursion is completed.
      */
     public JvmTypeRefTypeConstantsGen(PackageID packageID, BTypeHashComparator bTypeHashComparator) {
         typeRefVarConstantsClass = JvmCodeGenUtil.getModuleLevelClassName(packageID,
                 JvmConstants.TYPEREF_TYPE_CONSTANT_CLASS_NAME);
-        generateUnionTypeConstantsClassInit();
+        cw = new BallerinaClassWriter(COMPUTE_FRAMES);
+        generateConstantsClassInit(cw, typeRefVarConstantsClass);
         visitTypeRefTypeInitMethod();
         funcNames = new ArrayList<>();
         typeRefVarMap = new TreeMap<>(bTypeHashComparator);
@@ -85,17 +80,6 @@ public class JvmTypeRefTypeConstantsGen {
 
     public String add(BTypeReferenceType type) {
         return typeRefVarMap.computeIfAbsent(type, str -> generateTypeRefInits(type));
-    }
-
-    private void generateUnionTypeConstantsClassInit() {
-        cw = new BallerinaClassWriter(COMPUTE_FRAMES);
-        cw.visit(V1_8, ACC_PUBLIC | ACC_SUPER, typeRefVarConstantsClass, null, OBJECT, null);
-
-        MethodVisitor methodVisitor = cw.visitMethod(ACC_PRIVATE, JVM_INIT_METHOD, "()V", null, null);
-        methodVisitor.visitCode();
-        methodVisitor.visitVarInsn(ALOAD, 0);
-        methodVisitor.visitMethodInsn(INVOKESPECIAL, OBJECT, JVM_INIT_METHOD, "()V", false);
-        genMethodReturn(methodVisitor);
     }
 
     private void visitTypeRefTypeInitMethod() {
@@ -144,12 +128,6 @@ public class JvmTypeRefTypeConstantsGen {
                     B_TYPEREF_TYPE_INIT_METHOD_PREFIX + i, "()V", false);
         }
         genMethodReturn(methodVisitor);
-    }
-
-    private void genMethodReturn(MethodVisitor methodVisitor) {
-        methodVisitor.visitInsn(RETURN);
-        methodVisitor.visitMaxs(0, 0);
-        methodVisitor.visitEnd();
     }
 
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/types/JvmTypeRefTypeGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/types/JvmTypeRefTypeGen.java
@@ -18,10 +18,8 @@
 
 package org.wso2.ballerinalang.compiler.bir.codegen.split.types;
 
-import org.ballerinalang.model.elements.PackageID;
 import org.objectweb.asm.MethodVisitor;
 import org.wso2.ballerinalang.compiler.bir.codegen.JvmTypeGen;
-import org.wso2.ballerinalang.compiler.bir.codegen.split.JvmConstantsGen;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BTypeReferenceType;
 
 import static org.objectweb.asm.Opcodes.DUP;
@@ -40,8 +38,7 @@ public class JvmTypeRefTypeGen {
 
     private final JvmTypeGen jvmTypeGen;
 
-    public JvmTypeRefTypeGen(JvmTypeGen jvmTypeGen, JvmConstantsGen jvmConstantsGen,
-                             PackageID packageID) {
+    public JvmTypeRefTypeGen(JvmTypeGen jvmTypeGen) {
         this.jvmTypeGen = jvmTypeGen;
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/types/JvmTypeRefTypeGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/types/JvmTypeRefTypeGen.java
@@ -20,13 +20,16 @@ package org.wso2.ballerinalang.compiler.bir.codegen.split.types;
 
 import org.objectweb.asm.MethodVisitor;
 import org.wso2.ballerinalang.compiler.bir.codegen.JvmTypeGen;
+import org.wso2.ballerinalang.compiler.bir.codegen.split.JvmConstantsGen;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BTypeReferenceType;
 
 import static org.objectweb.asm.Opcodes.DUP;
+import static org.objectweb.asm.Opcodes.GETSTATIC;
 import static org.objectweb.asm.Opcodes.INVOKESPECIAL;
 import static org.objectweb.asm.Opcodes.NEW;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.JVM_INIT_METHOD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.TYPE_REF_TYPE_IMPL;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.GET_MODULE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.INIT_TYPE_REF;
 
 /**
@@ -37,9 +40,11 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.INIT_TYP
 public class JvmTypeRefTypeGen {
 
     private final JvmTypeGen jvmTypeGen;
+    private final JvmConstantsGen jvmConstantsGen;
 
-    public JvmTypeRefTypeGen(JvmTypeGen jvmTypeGen) {
+    public JvmTypeRefTypeGen(JvmTypeGen jvmTypeGen, JvmConstantsGen jvmConstantsGen) {
         this.jvmTypeGen = jvmTypeGen;
+        this.jvmConstantsGen = jvmConstantsGen;
     }
 
     /**
@@ -52,6 +57,8 @@ public class JvmTypeRefTypeGen {
         mv.visitTypeInsn(NEW, TYPE_REF_TYPE_IMPL);
         mv.visitInsn(DUP);
         mv.visitLdcInsn(typeRefType.tsymbol.name.value);
+        String varName = jvmConstantsGen.getModuleConstantVar(typeRefType.tsymbol.pkgID);
+        mv.visitFieldInsn(GETSTATIC, jvmConstantsGen.getModuleConstantClass(), varName, GET_MODULE);
         jvmTypeGen.loadType(mv, typeRefType.referredType);
         mv.visitMethodInsn(INVOKESPECIAL, TYPE_REF_TYPE_IMPL, JVM_INIT_METHOD, INIT_TYPE_REF, false);
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/types/JvmTypeRefTypeGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/types/JvmTypeRefTypeGen.java
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.ballerinalang.compiler.bir.codegen.split.types;
+
+import org.ballerinalang.model.elements.PackageID;
+import org.objectweb.asm.MethodVisitor;
+import org.wso2.ballerinalang.compiler.bir.codegen.JvmTypeGen;
+import org.wso2.ballerinalang.compiler.bir.codegen.split.JvmConstantsGen;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BTypeReferenceType;
+
+import static org.objectweb.asm.Opcodes.DUP;
+import static org.objectweb.asm.Opcodes.INVOKESPECIAL;
+import static org.objectweb.asm.Opcodes.NEW;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.JVM_INIT_METHOD;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.TYPE_REF_TYPE_IMPL;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.INIT_TYPE_REF;
+
+/**
+ * BIR Type reference types to JVM byte code generation class.
+ *
+ * @since 2.0.0
+ */
+public class JvmTypeRefTypeGen {
+
+    private final JvmTypeGen jvmTypeGen;
+
+    public JvmTypeRefTypeGen(JvmTypeGen jvmTypeGen, JvmConstantsGen jvmConstantsGen,
+                             PackageID packageID) {
+        this.jvmTypeGen = jvmTypeGen;
+    }
+
+    /**
+     * Create a runtime type instance for type reference type.
+     *
+     * @param mv          method visitor
+     * @param typeRefType type reference type
+     */
+    public void createTypeRefType(MethodVisitor mv, BTypeReferenceType typeRefType) {
+        mv.visitTypeInsn(NEW, TYPE_REF_TYPE_IMPL);
+        mv.visitInsn(DUP);
+        mv.visitLdcInsn(typeRefType.tsymbol.name.value);
+        jvmTypeGen.loadType(mv, typeRefType.referredType);
+        mv.visitMethodInsn(INVOKESPECIAL, TYPE_REF_TYPE_IMPL, JVM_INIT_METHOD, INIT_TYPE_REF, false);
+    }
+
+}

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/types/JvmTypeRefTypeGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/types/JvmTypeRefTypeGen.java
@@ -35,7 +35,7 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.INIT_TYP
 /**
  * BIR Type reference types to JVM byte code generation class.
  *
- * @since 2.0.0
+ * @since 2201.2.0
  */
 public class JvmTypeRefTypeGen {
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/emit/TypeEmitter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/emit/TypeEmitter.java
@@ -212,7 +212,7 @@ class TypeEmitter {
     private static String emitTypeRefDesc(BTypeReferenceType bType, int tabs) {
         String str = "typeRefDesc";
         str += "<";
-        str += emitTypeRef(bType.referredType, 0);
+        str += getTypeName(bType);
         str += ">";
         return str;
     }
@@ -455,7 +455,7 @@ class TypeEmitter {
         if (bType.tag == TypeTags.RECORD || bType.tag == TypeTags.OBJECT) {
             return bType.tsymbol.toString();
         }
-        return emitType(bType, tabs);
+        return emitType(type, tabs);
     }
 }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -58,6 +58,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.BOperatorSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BPackageSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BRecordTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BTypeDefinitionSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BVarSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BXMLNSSymbol;
@@ -5876,6 +5877,8 @@ public class Desugar extends BLangNodeVisitor {
             }
         }
 
+        BType type = varRefExpr.getBType();
+
         BSymbol ownerSymbol = varRefExpr.symbol.owner;
         if ((varRefExpr.symbol.tag & SymTag.FUNCTION) == SymTag.FUNCTION &&
                 Types.getReferredType(varRefExpr.symbol.type).tag == TypeTags.INVOKABLE) {
@@ -5883,6 +5886,9 @@ public class Desugar extends BLangNodeVisitor {
         } else if ((varRefExpr.symbol.tag & SymTag.TYPE) == SymTag.TYPE &&
                 !((varRefExpr.symbol.tag & SymTag.CONSTANT) == SymTag.CONSTANT)) {
             genVarRefExpr = new BLangTypeLoad(varRefExpr.symbol);
+            if (varRefExpr.symbol.tag == SymTag.TYPE_DEF) {
+                type = ((BTypeDefinitionSymbol) varRefExpr.symbol).referenceType;
+            }
         } else if ((ownerSymbol.tag & SymTag.INVOKABLE) == SymTag.INVOKABLE ||
                 (ownerSymbol.tag & SymTag.LET) == SymTag.LET) {
             // Local variable in a function/resource/action/worker/let
@@ -5917,7 +5923,7 @@ public class Desugar extends BLangNodeVisitor {
             }
         }
 
-        genVarRefExpr.setBType(varRefExpr.getBType());
+        genVarRefExpr.setBType(type);
         genVarRefExpr.pos = varRefExpr.pos;
 
         if ((varRefExpr.isLValue)

--- a/langlib/lang.typedesc/src/main/java/org/ballerinalang/langlib/typedesc/TypeIds.java
+++ b/langlib/lang.typedesc/src/main/java/org/ballerinalang/langlib/typedesc/TypeIds.java
@@ -34,6 +34,7 @@ import io.ballerina.runtime.internal.types.BErrorType;
 import io.ballerina.runtime.internal.types.BIntersectionType;
 import io.ballerina.runtime.internal.types.BObjectType;
 import io.ballerina.runtime.internal.types.BTypeIdSet;
+import io.ballerina.runtime.internal.types.BTypeReferenceType;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -94,6 +95,10 @@ public class TypeIds {
             case TypeTags.INTERSECTION_TAG:
                 BIntersectionType intersectionType = (BIntersectionType) describingType;
                 typeIdSet = getTypeIdSetForType(intersectionType.getEffectiveType());
+                break;
+            case TypeTags.TYPE_REFERENCED_TYPE_TAG:
+                BTypeReferenceType referenceType = (BTypeReferenceType) describingType;
+                typeIdSet = getTypeIdSetForType(referenceType.getReferredType());
                 break;
             default:
                 return null;

--- a/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/CloneWithType.java
+++ b/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/CloneWithType.java
@@ -57,7 +57,7 @@ import java.util.Set;
 
 import static io.ballerina.runtime.api.creators.ErrorCreator.createError;
 import static io.ballerina.runtime.internal.ErrorUtils.createConversionError;
-import static io.ballerina.runtime.internal.util.RuntimeUtils.getReferredType;
+import static io.ballerina.runtime.api.utils.TypeUtils.getReferredType;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.VALUE_LANG_LIB_CONVERSION_ERROR;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.VALUE_LANG_LIB_CYCLIC_VALUE_REFERENCE_ERROR;
 

--- a/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/CloneWithType.java
+++ b/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/CloneWithType.java
@@ -56,8 +56,8 @@ import java.util.Map;
 import java.util.Set;
 
 import static io.ballerina.runtime.api.creators.ErrorCreator.createError;
-import static io.ballerina.runtime.internal.ErrorUtils.createConversionError;
 import static io.ballerina.runtime.api.utils.TypeUtils.getReferredType;
+import static io.ballerina.runtime.internal.ErrorUtils.createConversionError;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.VALUE_LANG_LIB_CONVERSION_ERROR;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.VALUE_LANG_LIB_CYCLIC_VALUE_REFERENCE_ERROR;
 

--- a/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/CloneWithType.java
+++ b/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/CloneWithType.java
@@ -57,6 +57,7 @@ import java.util.Set;
 
 import static io.ballerina.runtime.api.creators.ErrorCreator.createError;
 import static io.ballerina.runtime.internal.ErrorUtils.createConversionError;
+import static io.ballerina.runtime.internal.util.RuntimeUtils.getReferredType;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.VALUE_LANG_LIB_CONVERSION_ERROR;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.VALUE_LANG_LIB_CYCLIC_VALUE_REFERENCE_ERROR;
 
@@ -68,13 +69,7 @@ import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReason
 public class CloneWithType {
 
     public static Object cloneWithType(Object v, BTypedesc t) {
-        Type describingType = t.getDescribingType();
-        // typedesc<json>.constructFrom like usage
-        if (describingType.getTag() == TypeTags.TYPEDESC_TAG) {
-            return convert(((TypedescType) t.getDescribingType()).getConstraint(), v, t);
-        }
-        // json.constructFrom like usage
-        return convert(describingType, v, t);
+        return convert(t.getDescribingType(), v, t);
     }
 
     public static Object convert(Type convertType, Object inputValue) {
@@ -100,7 +95,7 @@ public class CloneWithType {
     private static Object convert(Object value, Type targetType, List<TypeValuePair> unresolvedValues,
                                   boolean allowAmbiguity, BTypedesc t) {
         if (value == null) {
-            if (targetType.isNilable()) {
+            if (getTargetFromTypeDesc(targetType).isNilable()) {
                 return null;
             }
             return createError(VALUE_LANG_LIB_CONVERSION_ERROR,
@@ -134,6 +129,14 @@ public class CloneWithType {
         }
 
         return convert((BRefValue) value, matchingType, unresolvedValues, t);
+    }
+
+    private static Type getTargetFromTypeDesc(Type targetType) {
+        Type referredType = getReferredType(targetType);
+        if (referredType.getTag() == TypeTags.TYPEDESC_TAG) {
+            return ((TypedescType) referredType).getConstraint();
+        }
+        return targetType;
     }
 
     private static Object convert(BRefValue value, Type targetType, List<TypeValuePair> unresolvedValues,

--- a/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/EnsureType.java
+++ b/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/EnsureType.java
@@ -23,6 +23,8 @@ import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.api.values.BTypedesc;
 import io.ballerina.runtime.internal.TypeChecker;
 
+import static io.ballerina.runtime.internal.util.RuntimeUtils.getReferredType;
+
 /**
  * Extern function lang.values:ensureType.
  *
@@ -33,7 +35,7 @@ public class EnsureType {
         if (TypeChecker.getType(value).getTag() == TypeTags.ERROR_TAG) {
             return value;
         }
-        return convert(type.getDescribingType(), value);
+        return convert(getReferredType(type.getDescribingType()), value);
     }
 
     public static Object convert(Type convertType, Object inputValue) {

--- a/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/EnsureType.java
+++ b/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/EnsureType.java
@@ -23,7 +23,7 @@ import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.api.values.BTypedesc;
 import io.ballerina.runtime.internal.TypeChecker;
 
-import static io.ballerina.runtime.internal.util.RuntimeUtils.getReferredType;
+import static io.ballerina.runtime.api.utils.TypeUtils.getReferredType;
 
 /**
  * Extern function lang.values:ensureType.

--- a/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/FromJsonWithType.java
+++ b/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/FromJsonWithType.java
@@ -53,6 +53,7 @@ import java.util.Map;
 
 import static io.ballerina.runtime.api.creators.ErrorCreator.createError;
 import static io.ballerina.runtime.internal.ErrorUtils.createConversionError;
+import static io.ballerina.runtime.internal.util.RuntimeUtils.getReferredType;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.VALUE_LANG_LIB_CONVERSION_ERROR;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.VALUE_LANG_LIB_CYCLIC_VALUE_REFERENCE_ERROR;
 
@@ -111,7 +112,7 @@ public class FromJsonWithType {
             throw CloneUtils.createConversionError(value, targetType, errors);
         }
 
-        Type matchingType = convertibleTypes.get(0);
+        Type matchingType = getReferredType(convertibleTypes.get(0));
 
         Object newValue;
         switch (sourceType.getTag()) {

--- a/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/FromJsonWithType.java
+++ b/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/FromJsonWithType.java
@@ -52,8 +52,8 @@ import java.util.List;
 import java.util.Map;
 
 import static io.ballerina.runtime.api.creators.ErrorCreator.createError;
-import static io.ballerina.runtime.internal.ErrorUtils.createConversionError;
 import static io.ballerina.runtime.api.utils.TypeUtils.getReferredType;
+import static io.ballerina.runtime.internal.ErrorUtils.createConversionError;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.VALUE_LANG_LIB_CONVERSION_ERROR;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.VALUE_LANG_LIB_CYCLIC_VALUE_REFERENCE_ERROR;
 

--- a/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/FromJsonWithType.java
+++ b/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/FromJsonWithType.java
@@ -53,7 +53,7 @@ import java.util.Map;
 
 import static io.ballerina.runtime.api.creators.ErrorCreator.createError;
 import static io.ballerina.runtime.internal.ErrorUtils.createConversionError;
-import static io.ballerina.runtime.internal.util.RuntimeUtils.getReferredType;
+import static io.ballerina.runtime.api.utils.TypeUtils.getReferredType;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.VALUE_LANG_LIB_CONVERSION_ERROR;
 import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.VALUE_LANG_LIB_CYCLIC_VALUE_REFERENCE_ERROR;
 

--- a/langlib/langlib-test/src/test/resources/test-src/typedesclib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/typedesclib_test.bal
@@ -81,7 +81,8 @@ function assertSingleTypeId(typedesc:TypeId[]? tids, (string|int)[] localIds) {
             }
         }
     } else {
-        panic error("Assertion error: expected array of: " + typedesc:TypeId.toString() + "found: " + (typeof tids).toString());
+        panic error("Assertion error: expected array of: " + typedesc:TypeId.toString() + " found: " + (typeof tids)
+        .toString());
     }
 }
 

--- a/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
@@ -653,7 +653,7 @@ function testCloneWithTypeAmbiguousTargetType() {
     var message = bbe.detail()["message"];
     string messageString = message is error? message.toString(): message.toString();
     assert(bbe.message(), "{ballerina/lang.value}ConversionError");
-    assert(messageString, "'Foo' value cannot be converted to '(Bar|Baz)': \n\t\t" +
+    assert(messageString, "'Foo' value cannot be converted to 'BarOrBaz': \n\t\t" +
     "value '{\"s\":\"test string\"}' cannot be converted to '(Bar|Baz)': ambiguous target type");
 }
 
@@ -1914,7 +1914,7 @@ function testCloneWithTypeNestedStructuredTypesNegative() {
         "\n\t\tmap field '[1][1].second' should be of type 'Journey', found '2'" +
         "\n\t\tarray element '[2][2]' should be of type '()', found '0'" +
         "\n\t\ttuple element '[3]' should be of type 'int', found '\"1234567890123456789...'";
-    string errorMsg = "'json[]' value cannot be converted to '[map<float>,[Journey,map<Journey>],()[],int...]': " +
+    string errorMsg = "'json[]' value cannot be converted to 'tupleType': " +
         errorMsgContent2;
     assert(<string> checkpanic err.detail()["message"], errorMsg);
     assert(err.message(),"{ballerina/lang.value}ConversionError");

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
@@ -24,6 +24,7 @@ import io.ballerina.runtime.api.creators.ErrorCreator;
 import io.ballerina.runtime.api.creators.TypeCreator;
 import io.ballerina.runtime.api.creators.ValueCreator;
 import io.ballerina.runtime.api.flags.SymbolFlags;
+import io.ballerina.runtime.api.types.AnnotatableType;
 import io.ballerina.runtime.api.types.Field;
 import io.ballerina.runtime.api.types.IntersectableReferenceType;
 import io.ballerina.runtime.api.types.IntersectionType;
@@ -80,7 +81,7 @@ public class Values {
     public static BObject getObject(BString objectName) {
         BMap<BString, Object> address = getRecord(StringUtils.fromString("Address"));
         return ValueCreator.createObjectValue(objectModule, objectName.getValue(), StringUtils.fromString("Waruna"),
-                                              14, address);
+                14, address);
     }
 
     public static BArray getParameters(BObject object, BString methodName) {
@@ -226,7 +227,7 @@ public class Values {
         ArrayList<Integer> arrayList = new ArrayList<>(Arrays.asList(1, 2, 3, 4, 5));
         Map<String, Object> map = Map.ofEntries(
                 Map.entry("arrList", arrayList)
-        );
+                                               );
         return ValueCreator.createRecordValue(recordModule, recordName.getValue(), map);
     }
 
@@ -234,7 +235,7 @@ public class Values {
         ArrayList<Integer> arrayList = new ArrayList<>(Arrays.asList(1, 2, 3, 4, 5));
         Map<String, Object> map = Map.ofEntries(
                 Map.entry("arrList", arrayList)
-        );
+                                               );
         return ValueCreator.createRecordValue(recordModule, recordName.getValue(), null);
     }
 
@@ -242,10 +243,10 @@ public class Values {
         Map<String, Integer> map = Map.ofEntries(
                 Map.entry("a", 1),
                 Map.entry("b", 2)
-        );
+                                                );
         Map<String, Object> valueMap = Map.ofEntries(
                 Map.entry("valueMap", map)
-        );
+                                                    );
         return ValueCreator.createRecordValue(recordModule, recordName.getValue(), valueMap);
     }
 
@@ -256,5 +257,35 @@ public class Values {
         values[0] = 1;
         values[1] = "abc";
         return ValueCreator.createRecordValue(map, values);
+    }
+
+    public static Object validate(Object value, BTypedesc typedesc) {
+        Type describingType = typedesc.getDescribingType();
+        BMap<BString, Object> annotations = ((AnnotatableType) describingType).getAnnotations();
+        BString annotKey = StringUtils.fromString("testorg/runtime_api_types.typeref:1:Int");
+        if (annotations.containsKey(annotKey)) {
+            Object annotValue = annotations.get(annotKey);
+            Long minValue = (Long) ((BMap) annotValue).get(StringUtils.fromString("minValue"));
+            if (((Long) value) >= minValue) {
+                return value;
+            }
+        }
+        return ErrorCreator.createError(StringUtils.fromString("Validation failed for 'minValue' constraint(s)."));
+    }
+
+    public static Object validateRecord(Object value, BTypedesc typedesc) {
+        Type describingType = typedesc.getDescribingType();
+        Long age = ((BMap) value).getIntValue(StringUtils.fromString("age"));
+        BMap<BString, Object> annotations = ((AnnotatableType) describingType).getAnnotations();
+        BString fieldKey = StringUtils.fromString("$field$.age");
+        BString annotKey = StringUtils.fromString("testorg/runtime_api_types.typeref:1:Int");
+        if (annotations.containsKey(fieldKey)) {
+            BMap annotValue = (BMap) ((BMap) annotations.get(fieldKey)).get(annotKey);
+            Long minValue = (Long) annotValue.get(StringUtils.fromString("minValue"));
+            if (age >= minValue) {
+                return value;
+            }
+        }
+        return ErrorCreator.createError(StringUtils.fromString("Validation failed for 'minValue' constraint(s)."));
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/VariableReturnType.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/VariableReturnType.java
@@ -65,7 +65,7 @@ import static io.ballerina.runtime.api.TypeTags.RECORD_TYPE_TAG;
 import static io.ballerina.runtime.api.TypeTags.STRING_TAG;
 import static io.ballerina.runtime.api.TypeTags.XML_COMMENT_TAG;
 import static io.ballerina.runtime.api.TypeTags.XML_ELEMENT_TAG;
-import static io.ballerina.runtime.internal.util.RuntimeUtils.getReferredType;
+import static io.ballerina.runtime.api.utils.TypeUtils.getReferredType;
 
 /**
  * Native methods for testing functions with variable return types.

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/VariableReturnType.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/VariableReturnType.java
@@ -65,6 +65,7 @@ import static io.ballerina.runtime.api.TypeTags.RECORD_TYPE_TAG;
 import static io.ballerina.runtime.api.TypeTags.STRING_TAG;
 import static io.ballerina.runtime.api.TypeTags.XML_COMMENT_TAG;
 import static io.ballerina.runtime.api.TypeTags.XML_ELEMENT_TAG;
+import static io.ballerina.runtime.internal.util.RuntimeUtils.getReferredType;
 
 /**
  * Native methods for testing functions with variable return types.
@@ -234,11 +235,12 @@ public class VariableReturnType {
     }
 
     public static BXml getXml(BTypedesc td, BXml val) {
-        if (td.getDescribingType().getTag() == XML_ELEMENT_TAG) {
+        Type describingType = getReferredType(td.getDescribingType());
+        if (describingType.getTag() == XML_ELEMENT_TAG) {
             return val;
         }
 
-        assert td.getDescribingType().getTag() == XML_COMMENT_TAG : td.getDescribingType();
+        assert describingType.getTag() == XML_COMMENT_TAG : describingType;
         return val;
     }
 
@@ -449,7 +451,7 @@ public class VariableReturnType {
     }
 
     public static Object funcReturningUnionWithBuiltInRefType(Object strm, BTypedesc td) {
-        int tag = ((BStreamType) td.getDescribingType()).getConstrainedType().getTag();
+        int tag = ((BStreamType) getReferredType(td.getDescribingType())).getConstrainedType().getTag();
 
         if (tag == INT_TAG) {
             return strm;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/conversion/NativeConversionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/conversion/NativeConversionTest.java
@@ -596,7 +596,7 @@ public class NativeConversionTest {
     @Test(description = "Test converting json to constrained map",
             expectedExceptions = {BLangRuntimeException.class},
             expectedExceptionsMessageRegExp = ".*'map<json>' " +
-                    "value cannot be converted to 'map<T1>'.*")
+                    "value cannot be converted to 'T1Map'.*")
     public void testJsonToMapConstrainedFail() {
 
         BRunUtil.invoke(compileResult, "testJsonToMapConstrainedFail");
@@ -666,7 +666,7 @@ public class NativeConversionTest {
     @Test(description = "Test an invalid json to array conversion",
             expectedExceptions = {BLangRuntimeException.class},
             expectedExceptionsMessageRegExp = ".*'map<json>' value cannot" +
-                    " be converted to 'int\\[\\]'.*")
+                    " be converted to 'IntArrayType'.*")
     public void testJsonToArrayFail() {
 
         BRunUtil.invoke(compileResult, "testJsonToArrayFail");

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/JSONStampInbuiltFunctionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/JSONStampInbuiltFunctionTest.java
@@ -287,7 +287,7 @@ public class JSONStampInbuiltFunctionTest {
         Assert.assertEquals(
                 ((BMap<String, BString>) ((BError) results).getDetails()).get(StringUtils.fromString("message"))
                         .toString(),
-                "'map<json>' value cannot be converted to 'map<string>': " +
+                "'map<json>' value cannot be converted to 'StringMap': " +
                         "\n\t\tmap field 'age' should be of type 'string', found '23'");
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/RecordStampInbuiltFunctionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/RecordStampInbuiltFunctionTest.java
@@ -541,7 +541,7 @@ public class RecordStampInbuiltFunctionTest {
         Assert.assertEquals(
                 ((BMap<String, BString>) ((BError) results).getDetails()).get(StringUtils.fromString("message"))
                         .toString(),
-                "'Teacher' value cannot be converted to 'map<string>': " +
+                "'Teacher' value cannot be converted to 'StringMap': " +
                         "\n\t\tmap field 'age' should be of type 'string', found '25'");
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/StampInbuiltFunctionNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/StampInbuiltFunctionNegativeTest.java
@@ -156,8 +156,7 @@ public class StampInbuiltFunctionNegativeTest {
         Assert.assertEquals(
                 ((BMap<String, BString>) ((BError) results).getDetails()).get(StringUtils.fromString("message"))
                         .toString(),
-                "'Employee' value cannot be converted to 'xml<(lang.xml:Element" +
-                        "|lang.xml:Comment|lang.xml:ProcessingInstruction|lang.xml:Text)>'");
+                "'Employee' value cannot be converted to 'XmlType'");
     }
 
     @Test
@@ -195,7 +194,7 @@ public class StampInbuiltFunctionNegativeTest {
         Assert.assertEquals(
                 ((BMap<String, BString>) ((BError) results).getDetails()).get(StringUtils.fromString("message"))
                         .toString(),
-                "'Person' value cannot be converted to 'map<string>': " +
+                "'Person' value cannot be converted to 'StringMap': " +
                         "\n\t\tmap field 'age' should be of type 'string', found '25'");
     }
 
@@ -208,7 +207,7 @@ public class StampInbuiltFunctionNegativeTest {
         Assert.assertEquals(
                 ((BMap<String, BString>) ((BError) results).getDetails()).get(StringUtils.fromString("message"))
                         .toString(),
-                "'Employee' value cannot be converted to 'string[]'");
+                "'Employee' value cannot be converted to 'StringArray'");
     }
 
     @Test
@@ -220,7 +219,7 @@ public class StampInbuiltFunctionNegativeTest {
         Assert.assertEquals(
                 ((BMap<String, BString>) ((BError) results).getDetails()).get(StringUtils.fromString("message"))
                         .toString(),
-                "'Employee' value cannot be converted to '[string,string]'");
+                "'Employee' value cannot be converted to 'StringString'");
     }
 
     //----------------------------- JSON NegativeTest cases ------------------------------------------------------
@@ -234,8 +233,7 @@ public class StampInbuiltFunctionNegativeTest {
         Assert.assertEquals(
                 ((BMap<String, BString>) ((BError) results).getDetails()).get(StringUtils.fromString("message"))
                         .toString(),
-                "'map<json>' value cannot be converted to 'xml<(lang.xml:Element|" +
-                        "lang.xml:Comment|lang.xml:ProcessingInstruction|lang.xml:Text)>'");
+                "'map<json>' value cannot be converted to 'XmlType'");
     }
 
     @Test
@@ -285,7 +283,7 @@ public class StampInbuiltFunctionNegativeTest {
         Assert.assertEquals(
                 ((BMap<String, BString>) ((BError) results).getDetails()).get(StringUtils.fromString("message"))
                         .toString(),
-                "'lang.xml:Element' value cannot be converted to 'map<anydata>'");
+                "'lang.xml:Element' value cannot be converted to 'AnydataMap'");
     }
 
     @Test
@@ -297,7 +295,7 @@ public class StampInbuiltFunctionNegativeTest {
         Assert.assertEquals(
                 ((BMap<String, BString>) ((BError) results).getDetails()).get(StringUtils.fromString("message"))
                         .toString(),
-                "'lang.xml:Element' value cannot be converted to 'BookRecord[]'");
+                "'lang.xml:Element' value cannot be converted to 'BookRecordArray'");
     }
 
     @Test
@@ -323,8 +321,7 @@ public class StampInbuiltFunctionNegativeTest {
         Assert.assertEquals(
                 ((BMap<String, BString>) ((BError) results).getDetails()).get(StringUtils.fromString("message"))
                         .toString(),
-                "'map<anydata>' value cannot be converted to 'xml<(lang.xml:Element|" +
-                        "lang.xml:Comment|lang.xml:ProcessingInstruction|lang.xml:Text)>'");
+                "'map<anydata>' value cannot be converted to 'XmlType'");
     }
 
     @Test
@@ -336,7 +333,7 @@ public class StampInbuiltFunctionNegativeTest {
         Assert.assertEquals(
                 ((BMap<String, BString>) ((BError) results).getDetails()).get(StringUtils.fromString("message"))
                         .toString(),
-                "'map<anydata>' value cannot be converted to 'string[]'");
+                "'map<anydata>' value cannot be converted to 'StringArray'");
     }
 
     @Test
@@ -348,7 +345,7 @@ public class StampInbuiltFunctionNegativeTest {
         Assert.assertEquals(
                 ((BMap<String, BString>) ((BError) results).getDetails()).get(StringUtils.fromString("message"))
                         .toString(),
-                "'map<anydata>' value cannot be converted to '[string,string]'");
+                "'map<anydata>' value cannot be converted to 'StringString'");
     }
 
     //----------------------------- Array NegativeTest cases ------------------------------------------------------
@@ -373,8 +370,7 @@ public class StampInbuiltFunctionNegativeTest {
         Assert.assertEquals(
                 ((BMap<String, BString>) ((BError) results).getDetails()).get(StringUtils.fromString("message"))
                         .toString(),
-                "'anydata[]' value cannot be converted to 'xml<(lang.xml:Element|" +
-                        "lang.xml:Comment|lang.xml:ProcessingInstruction|lang.xml:Text)>'");
+                "'anydata[]' value cannot be converted to 'XmlType'");
     }
 
     //----------------------------- Tuple NegativeTest cases ------------------------------------------------------
@@ -400,8 +396,7 @@ public class StampInbuiltFunctionNegativeTest {
         Assert.assertEquals(
                 ((BMap<String, BString>) ((BError) results).getDetails()).get(StringUtils.fromString("message"))
                         .toString(),
-                "'[string,string,string]' value cannot be converted to 'xml<(lang.xml:Element" +
-                        "|lang.xml:Comment|lang.xml:ProcessingInstruction|lang.xml:Text)>'");
+                "'[string,string,string]' value cannot be converted to 'XmlType'");
     }
 
     @Test
@@ -413,7 +408,7 @@ public class StampInbuiltFunctionNegativeTest {
         Assert.assertEquals(
                 ((BMap<String, BString>) ((BError) results).getDetails()).get(StringUtils.fromString("message"))
                         .toString(),
-                "'[string,string,string]' value cannot be converted to 'map<anydata>'");
+                "'[string,string,string]' value cannot be converted to 'AnydataMap'");
     }
 
     //----------------------------- Union NegativeTest cases ------------------------------------------------------
@@ -439,7 +434,7 @@ public class StampInbuiltFunctionNegativeTest {
         Assert.assertEquals(
                 ((BMap<String, BString>) ((BError) results).getDetails()).get(StringUtils.fromString("message"))
                         .toString(),
-                "'int' value cannot be converted to '(float|decimal|[string,int])': \n" +
+                "'int' value cannot be converted to 'UnionTypedesc': \n" +
                         "\t\tvalue '2' cannot be converted to '(float|decimal|[string,int])': ambiguous target type");
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExprTest.java
@@ -462,7 +462,7 @@ public class TypeCastExprTest {
         BError error = (BError) returns;
         String errorMsg =
                 ((BMap<String, BString>) error.getDetails()).get(StringUtils.fromString("message")).toString();
-        Assert.assertEquals(errorMsg, "'B' value cannot be converted to 'A': " +
+        Assert.assertEquals(errorMsg, "'B' value cannot be converted to 'ATypedesc': " +
                 "\n\t\tmissing required field 'y' of type 'int' in record 'A'");
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/basic/JavaCastTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/basic/JavaCastTest.java
@@ -46,6 +46,13 @@ public class JavaCastTest {
         Assert.assertEquals(returns.toString(), "cast this object");
     }
 
+    @Test(description = "Test java:cast function in ballerina/jballerina.java")
+    public void testJavaCastMethod2() {
+        Object returns = BRunUtil.invoke(result, "testJavaCastFunction2");
+
+        Assert.assertEquals(returns.toString(), "cast this object");
+    }
+
     @Test(description = "Test java:cast function in ballerina/jballerina.java for an incorrect Java cast")
     public void testIncorrectJavaCast() {
         Object returns = BRunUtil.invoke(result, "testIncorrectJavaCast");

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/json/BJSONValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/json/BJSONValueTest.java
@@ -428,7 +428,7 @@ public class BJSONValueTest {
         String errorMsg =
                 ((BMap<String, BString>) ((BError) returns).getDetails()).get(StringUtils.fromString("message"))
                         .toString();
-        Assert.assertEquals(errorMsg, "'json[]' value cannot be converted to 'json[][][]': " +
+        Assert.assertEquals(errorMsg, "'json[]' value cannot be converted to 'Json3DArray': " +
                 "\n\t\tarray element '[0][0]' should be of type 'json[]', found '1'" +
                 "\n\t\tarray element '[0][1]' should be of type 'json[]', found '2'" +
                 "\n\t\tarray element '[0][2]' should be of type 'json[]', found '3'" +
@@ -500,7 +500,7 @@ public class BJSONValueTest {
 
     @Test(expectedExceptions = {BLangRuntimeException.class},
             expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.value\\}ConversionError " +
-                    "\\{\"message\":\"cannot convert '\\(\\)' to type 'map<json>'.*")
+                    "\\{\"message\":\"cannot convert '\\(\\)' to type 'JsonMap'.*")
     public void testNullJsonToMap() {
         BRunUtil.invoke(compileResult, "testNullJsonToMap");
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/typedesc/TypedescTests.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/typedesc/TypedescTests.java
@@ -100,15 +100,15 @@ public class TypedescTests {
     public void testArrayTypes() {
         BArray returns = (BArray) BRunUtil.invoke(result, "testArrayTypes");
         Assert.assertEquals(returns.size(), 2);
-        Assert.assertEquals(returns.get(0).toString(), "typedesc int[]");
-        Assert.assertEquals(returns.get(1).toString(), "typedesc int[][]");
+        Assert.assertEquals(returns.get(0).toString(), "typedesc intArray");
+        Assert.assertEquals(returns.get(1).toString(), "typedesc intArrayArray");
     }
 
     @Test(description = "Test tuple/union types")
     public void testTupleUnionTypes() {
         BArray returns = (BArray) BRunUtil.invoke(result, "testTupleUnionTypes");
         Assert.assertEquals(returns.size(), 2);
-        Assert.assertEquals(returns.get(0).toString(), "typedesc [string,Person]");
+        Assert.assertEquals(returns.get(0).toString(), "typedesc stringOrPerson");
         Assert.assertEquals(returns.get(1).toString(), "typedesc intOrString");
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/java_cast_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/java_cast_test.bal
@@ -11,6 +11,15 @@ public function testJavaCastFunction() returns string|error {
     return castedValue.toString();
 }
 
+public function testJavaCastFunction2() returns string|error {
+    ArrayList1 arrayList = newArrayList1();
+    StringRef strValue = newString1("cast this object");
+    _ = arrayList.add(strValue);
+    Object1 result = arrayList.get(0);
+    String1 castedValue = check java:cast(result);
+    return castedValue.toString();
+}
+
 // Incorrect Java class cast.
 public function testIncorrectJavaCast() returns string|error {
     String1 strValue = newString1("cast this object");
@@ -95,6 +104,8 @@ public class String1 {
         return java:toString(self.jObj) ?: "null";
     }
 }
+
+type StringRef String1;
 
 // Object Case1: Correct object
 @java:Binding {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/types/main.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/types/main.bal
@@ -16,10 +16,12 @@
 
 import ballerina/test;
 import testorg/runtime_api_types.objects;
+import runtime_api_types.typeref;
 
 objects:PublicClientObject obj = new ();
 
 public function main() {
+    typeref:validateTypeRef();
     testRemoteFunctionParameters();
     testFunctionToString();
     testParamTypesString();

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/types/modules/typeref/typeref.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/types/modules/typeref/typeref.bal
@@ -1,0 +1,110 @@
+// Copyright (c) 2022 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+import ballerina/jballerina.java;
+
+public annotation IntConstraints Int on type, record field;
+
+type IntConstraints record {|
+    int minValue?;
+|};
+
+@Int {minValue: 0}
+type PositiveInt int;
+
+type Person record {
+    @Int {
+        minValue: 18
+    }
+    PositiveInt age;
+};
+
+public function validateTypeRef() {
+    validateType();
+    validateRecordField();
+}
+
+
+function validateType() {
+    PositiveInt value = 2;
+    PositiveInt|error validation = validate(value);
+    if validation is PositiveInt {
+        test:assertEquals(validation, 2);
+    } else {
+        test:assertFail("Expected error not found.");
+    }
+
+    value = 0;
+    validation = validate(value);
+    if validation is PositiveInt {
+        test:assertEquals(validation, 0);
+    } else {
+        test:assertFail("Expected error not found.");
+    }
+
+    value = -2;
+    validation = validate(value);
+    if validation is error {
+        test:assertEquals(validation.message(), "Validation failed for 'minValue' constraint(s).");
+    } else {
+        test:assertFail("Expected error not found.");
+    }
+}
+
+function validateRecordField() {
+    Person person = {age: 23};
+    Person|error validation = validateRecord(person);
+    if validation is Person {
+        test:assertEquals(validation.age, 23);
+    } else {
+        test:assertFail("Expected error not found." + validation.toString());
+    }
+
+    person = {age: 18};
+    validation = validateRecord(person);
+    if validation is Person {
+        test:assertEquals(validation.age, 18);
+    } else {
+        test:assertFail("Expected error not found.");
+    }
+
+    person = {age: 15};
+    validation = validateRecord(person);
+    if validation is error {
+        test:assertEquals(validation.message(), "Validation failed for 'minValue' constraint(s).");
+    } else {
+        test:assertFail("Expected error not found.");
+    }
+}
+
+# Validates the provided value against the configured annotations.
+#
+# + value - The `anydata` type value to be constrained
+# + td - The type descriptor of the value to be constrained
+# + return - The type descriptor of the value which is validated or else an `constraint:Error` in case of an error
+public isolated function validate(anydata value, typedesc<anydata> td = <>) returns td|error = @java:Method {
+    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
+} external;
+
+# Validates the provided record value against the configured annotations for field.
+#
+# + value - The `anydata` type value to be constrained
+# + td - The type descriptor of the value to be constrained
+# + return - The type descriptor of the value which is validated or else an `constraint:Error` in case of an error
+public isolated function validateRecord(anydata value, typedesc<anydata> td = <>) returns td|error = @java:Method {
+    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
+} external;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/types/modules/typeref/typeref.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/types/modules/typeref/typeref.bal
@@ -19,12 +19,20 @@ import ballerina/jballerina.java;
 
 public annotation IntConstraints Int on type, record field;
 
+public annotation X on type;
+
 type IntConstraints record {|
     int minValue?;
 |};
 
 @Int {minValue: 0}
 type PositiveInt int;
+
+@Int {minValue: 0}
+type '\ \/\:\@\[\`\{\~\u{03C0}_123_ƮέŞŢ_Int int;
+
+@X
+type Nil ();
 
 type Person record {
     @Int {
@@ -36,8 +44,14 @@ type Person record {
 public function validateTypeRef() {
     validateType();
     validateRecordField();
+    validateTypeAnnotations();
 }
 
+function validateTypeAnnotations() {
+    typedesc<()> nilTd = Nil;
+    test:assertTrue(nilTd.@X is true);
+    test:assertTrue(Nil.@X is true);
+}
 
 function validateType() {
     PositiveInt value = 2;
@@ -58,6 +72,14 @@ function validateType() {
 
     value = -2;
     validation = validate(value);
+    if validation is error {
+        test:assertEquals(validation.message(), "Validation failed for 'minValue' constraint(s).");
+    } else {
+        test:assertFail("Expected error not found.");
+    }
+
+    '\ \/\:\@\[\`\{\~\u{03C0}_123_ƮέŞŢ_Int value1 = -2;
+    validation = validate(value1);
     if validation is error {
         test:assertEquals(validation.message(), "Validation failed for 'minValue' constraint(s).");
     } else {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/typedesc/typedesc_positive.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/typedesc/typedesc_positive.bal
@@ -23,10 +23,10 @@ function testRefTypes(){
 
     [typedesc<any>, typedesc<any>, typedesc<any>, typedesc<any>] tupleValue = [a, b, c, d];
 
-    assertEquality("typedesc xml<(lang.xml:Element|lang.xml:Comment|lang.xml:ProcessingInstruction|lang.xml:Text)>", tupleValue[0].toString());
+    assertEquality("typedesc XmlType", tupleValue[0].toString());
     assertEquality("typedesc json", b.toString());
-    assertEquality("typedesc map", c.toString());
-    assertEquality("typedesc table<Employee>", d.toString());
+    assertEquality("typedesc mapOfAny", c.toString());
+    assertEquality("typedesc tableOfEmployee", d.toString());
 }
 
 class Pet { public string name = ""; }
@@ -153,7 +153,7 @@ function testArrayTypesWithoutTypedescConstraint() {
     typedesc a = intArray;
     typedesc b = intArrayArray;
 
-    assertEquality("typedesc int[]", a.toString());
+    assertEquality("typedesc intArray", a.toString());
 }
 
 function testRecordTypesWithoutTypedescConstraint() {
@@ -296,7 +296,8 @@ function testTypeDefWithFunctionTypeDescAsTypedesc() {
     typedesc d = typeof c;
 
     assertEquality(false, a.toString() == b.toString());
-    assertEquality(true, b.toString() == d.toString());
+    assertEquality("typedesc FunctionTypeTwo", b.toString());
+    assertEquality("typedesc function () returns (string)", d.toString());
 }
 
 const ASSERTION_ERROR_REASON = "AssertionError";


### PR DESCRIPTION
## Purpose
$subject
Fixes #36408

## Approach
Add runtime support for type referenced type to pass annotations when it was passed as `typedesc` value.

## Samples
```ballerina
public annotation IntConstraints Int on type, record field;

type IntConstraints record {|
    int minValue?;
|};

@Int {minValue: 0}
type PositiveInt int;

type Person record {
    @Int {
        minValue: 18
    }
    PositiveInt age;
};

public function main() {
    typedesc<PositiveInt> td = PositiveInt;
    io:println(td.@Int is ()); // false
    io:println(td.@Int); // {"minValue":0}
}
```
The annotations should contain the relevant values.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
