### PR TITLE
Fix compiling annotation test always

### DIFF
--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/annotations/AnnotationRuntimeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/annotations/AnnotationRuntimeTest.java
@@ -44,11 +44,11 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral;
 @Test
 public class AnnotationRuntimeTest {
 
-    private CompileResult resultAccessNegative;
-    private final CompileResult resultOne = BCompileUtil.compile("test-src/annotations/annot_access.bal");
-
+    private CompileResult resultOne, resultAccessNegative;
+    
     @BeforeClass
     public void setup() {
+        resultOne = BCompileUtil.compile("test-src/annotations/annot_access.bal");
         resultAccessNegative = BCompileUtil.compile("test-src/annotations/annotation_access_negative.bal");
     }
 


### PR DESCRIPTION
## Purpose
> Avoid compiling `test-src/annotations/annot_access.bal` always although we run an unrelated specific test using `--tests` flag.

Fixes #<Issue Number>

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
