### PR TITLE
Fix not getting `getContent()` as lang-lib functions for `xml:ProcessingInstruction` and `xml:Comment`

### DIFF
--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/LangLibFunctionTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/LangLibFunctionTest.java
@@ -243,7 +243,8 @@ public class LangLibFunctionTest {
 
         List<String> elementFuncs = List.of("getName", "setName", "getChildren", "setChildren", "getAttributes",
                                             "getDescendants");
-        List<String> piFuncs = List.of("getTarget");
+        List<String> piFuncs = List.of("getTarget", "getContent");
+        List<String> commentFuncs = List.of("getContent");
 
         return new Object[][]{
                 {67, 8, XML, expFunctions},
@@ -251,7 +252,8 @@ public class LangLibFunctionTest {
                         .collect(Collectors.toList())},
                 {76, 31, TYPE_REFERENCE, Stream.concat(expFunctions.stream(), piFuncs.stream())
                         .collect(Collectors.toList())},
-                {77, 17, TYPE_REFERENCE, expFunctions},
+                {77, 17, TYPE_REFERENCE, Stream.concat(expFunctions.stream(), commentFuncs.stream())
+                        .collect(Collectors.toList())},
                 {78, 14, TYPE_REFERENCE, expFunctions},
         };
     }


### PR DESCRIPTION
## Purpose
$Title

Fixes #34646

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
