### PR TITLE
Update java distribution to `temurin` in workflows

### DIFF
--- a/.github/workflows/daily_build.yml
+++ b/.github/workflows/daily_build.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt' 
+          distribution: 'temurin'
           java-version: '11'
 
       - name: Initialize sub-modules

--- a/.github/workflows/daily_spec_conformance_test_runner.yml
+++ b/.github/workflows/daily_spec_conformance_test_runner.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
-          distribution: "adopt"
+          distribution: "temurin"
           java-version: "11"
 
       - name: Initialize sub-modules

--- a/.github/workflows/observe_package_push.yaml
+++ b/.github/workflows/observe_package_push.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '11'
       - name: Build with Gradle
         env:

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt' 
+          distribution: 'temurin'
           java-version: '11'
       - name: Set version env variable
         run: |

--- a/.github/workflows/publish_timestamped_release_master.yml
+++ b/.github/workflows/publish_timestamped_release_master.yml
@@ -19,7 +19,7 @@ jobs:
       -   name: Set up JDK 11
           uses: actions/setup-java@v2
           with:
-            distribution: 'adopt'
+            distribution: 'temurin'
             java-version: '11'
 
       -   name: Initialize Sub Modules

--- a/.github/workflows/publish_timestamped_release_patch.yml
+++ b/.github/workflows/publish_timestamped_release_patch.yml
@@ -19,7 +19,7 @@ jobs:
       -   name: Set up JDK 11
           uses: actions/setup-java@v2
           with:
-            distribution: 'adopt'
+            distribution: 'temurin'
             java-version: '11'
 
       -   name: Initialize Sub Modules

--- a/.github/workflows/pull_request_ubuntu_build.yml
+++ b/.github/workflows/pull_request_ubuntu_build.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt' 
+          distribution: 'temurin'
           java-version: '11'
 
       - name: Initialize sub-modules

--- a/.github/workflows/pull_request_windows_build.yml
+++ b/.github/workflows/pull_request_windows_build.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt' 
+          distribution: 'temurin'
           java-version: '11'
 
       - name: configure Pagefile

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '11'
       - name: Initialize sub-modules
         run: git submodule update --init


### PR DESCRIPTION
## Purpose
$subject

Since `adopt` OpenJDK is deprecated now. See the [notice](https://blog.adoptopenjdk.net/2021/03/transition-to-eclipse-an-update/).

[Adoptium](https://adoptium.net) is the rebranded version

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
