### PR TITLE
Fix capability setters not being detected for several extended language server services

### DIFF
--- a/docs/language-server/ComposingServiceExtensions.md
+++ b/docs/language-server/ComposingServiceExtensions.md
@@ -4,6 +4,7 @@
     - <a href="#ServiceImplementation">Service Implementation</a>
     - <a href="#ServerCapability">Server Capability Registration</a>
     - <a href="#ClientCapability">Client Capability Registration</a>
+- <a href="#Checklist">Developer Checklist</a>
 
 <a name="WhatIsAService"></a>
 ## What is a Service?
@@ -158,3 +159,15 @@ public class CustomServiceClientCapabilitySetter
 
 __Note:__
 > It is important to note that the `nameOfService` which has been used in four places above, should be the same string value since the particular string value is used to correlate the capabilites with the services.
+
+<a name="Checklist"></a>
+# Developer Checklist
+
+When developing extended language services, please make sure the following points are checked by the end.
+
+- [ ] Add the full qualified class names of the implementations of `org.ballerinalang.langserver.commons.registration.BallerinaServerCapabilitySetter`
+  into a file named `src/main/resources/META-INF/services/org.ballerinalang.langserver.commons.registration.BallerinaServerCapabilitySetter`
+- [ ] Add the full qualified class names of the implementations of `org.ballerinalang.langserver.commons.registration.BallerinaClientCapabilitySetter`
+  into a file named `src/main/resources/META-INF/services/org.ballerinalang.langserver.commons.registration.BallerinaClientCapabilitySetter`
+
+> **_NOTE:_**  The above steps are to ensure that your SPI services are detected and loaded during the runtime by the language server

--- a/docs/language-server/README.md
+++ b/docs/language-server/README.md
@@ -1,0 +1,11 @@
+# Ballerina Language Server
+
+Welcome to the Ballerina Language Server documentation. This section contains,
+
+1. How to write extended features on top of the language server (like extended language server services and compiler
+   plugin code actions)
+2. Explanations to various designs used inside the language server (developer documentation)
+3. Best practices to followed when implementing language server features
+
+These documentations are intended for the developers who wish to understand the internals of the Ballerina language
+server implementation and for developers who are willing to write extended features.

--- a/docs/language-server/README.md
+++ b/docs/language-server/README.md
@@ -5,7 +5,7 @@ Welcome to the Ballerina Language Server documentation. This section contains,
 1. How to write extended features on top of the language server (like extended language server services and compiler
    plugin code actions)
 2. Explanations to various designs used inside the language server (developer documentation)
-3. Best practices to followed when implementing language server features
+3. Best practices to be followed when implementing language server features
 
 These documentations are intended for the developers who wish to understand the internals of the Ballerina language
 server implementation and for developers who are willing to write extended features.

--- a/misc/ls-extensions/modules/json-to-record-converter/src/main/java/module-info.java
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/main/java/module-info.java
@@ -1,4 +1,10 @@
 module io.ballerina.LSExtensions.jsonToRecordConverter {
+    uses org.ballerinalang.langserver.commons.service.spi.ExtendedLanguageServerService;
+    uses org.ballerinalang.langserver.commons.registration.BallerinaServerCapability;
+    uses org.ballerinalang.langserver.commons.registration.BallerinaClientCapability;
+    uses org.ballerinalang.langserver.commons.registration.BallerinaServerCapabilitySetter;
+    uses org.ballerinalang.langserver.commons.registration.BallerinaClientCapabilitySetter;
+
     requires com.fasterxml.jackson.core;
     requires com.fasterxml.jackson.databind;
     requires io.ballerina.formatter.core;

--- a/misc/ls-extensions/modules/json-to-record-converter/src/main/resources/META-INF/services/org.ballerinalang.langserver.commons.registration.BallerinaClientCapabilitySetter
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/main/resources/META-INF/services/org.ballerinalang.langserver.commons.registration.BallerinaClientCapabilitySetter
@@ -1,0 +1,1 @@
+io.ballerina.converters.JsonToRecordConverterClientCapabilitySetter

--- a/misc/ls-extensions/modules/json-to-record-converter/src/main/resources/META-INF/services/org.ballerinalang.langserver.commons.registration.BallerinaServerCapabilitySetter
+++ b/misc/ls-extensions/modules/json-to-record-converter/src/main/resources/META-INF/services/org.ballerinalang.langserver.commons.registration.BallerinaServerCapabilitySetter
@@ -1,0 +1,1 @@
+io.ballerina.converters.JsonToRecordConverterServerCapabilitySetter

--- a/misc/ls-extensions/modules/performance-analyzer-services/src/main/java/module-info.java
+++ b/misc/ls-extensions/modules/performance-analyzer-services/src/main/java/module-info.java
@@ -1,4 +1,9 @@
 module io.ballerina.LSExtensions.PerformanceAnalyzerService {
+    uses org.ballerinalang.langserver.commons.service.spi.ExtendedLanguageServerService;
+    uses org.ballerinalang.langserver.commons.registration.BallerinaServerCapability;
+    uses org.ballerinalang.langserver.commons.registration.BallerinaClientCapability;
+    uses org.ballerinalang.langserver.commons.registration.BallerinaServerCapabilitySetter;
+    uses org.ballerinalang.langserver.commons.registration.BallerinaClientCapabilitySetter;
     requires io.ballerina.lang;
     requires org.eclipse.lsp4j.jsonrpc;
     requires io.ballerina.language.server.commons;

--- a/misc/ls-extensions/modules/performance-analyzer-services/src/main/resources/META-INF/services/org.ballerinalang.langserver.commons.registration.BallerinaClientCapabilitySetter
+++ b/misc/ls-extensions/modules/performance-analyzer-services/src/main/resources/META-INF/services/org.ballerinalang.langserver.commons.registration.BallerinaClientCapabilitySetter
@@ -1,0 +1,1 @@
+io.ballerina.PerformanceAnalyzerClientCapabilitySetter

--- a/misc/ls-extensions/modules/performance-analyzer-services/src/main/resources/META-INF/services/org.ballerinalang.langserver.commons.registration.BallerinaServerCapabilitySetter
+++ b/misc/ls-extensions/modules/performance-analyzer-services/src/main/resources/META-INF/services/org.ballerinalang.langserver.commons.registration.BallerinaServerCapabilitySetter
@@ -1,0 +1,1 @@
+io.ballerina.PerformanceAnalyzerServerCapabilitySetter

--- a/misc/ls-extensions/modules/trigger-service/src/main/java/module-info.java
+++ b/misc/ls-extensions/modules/trigger-service/src/main/java/module-info.java
@@ -1,4 +1,9 @@
 module io.ballerina.LSExtensions.BallerinaTriggerService {
+    uses org.ballerinalang.langserver.commons.service.spi.ExtendedLanguageServerService;
+    uses org.ballerinalang.langserver.commons.registration.BallerinaServerCapability;
+    uses org.ballerinalang.langserver.commons.registration.BallerinaClientCapability;
+    uses org.ballerinalang.langserver.commons.registration.BallerinaServerCapabilitySetter;
+    uses org.ballerinalang.langserver.commons.registration.BallerinaClientCapabilitySetter;
     requires io.ballerina.lang;
     requires com.google.gson;
     requires io.ballerina.central.client;

--- a/misc/ls-extensions/modules/trigger-service/src/main/resources/META-INF/services/org.ballerinalang.langserver.commons.registration.BallerinaClientCapabilitySetter
+++ b/misc/ls-extensions/modules/trigger-service/src/main/resources/META-INF/services/org.ballerinalang.langserver.commons.registration.BallerinaClientCapabilitySetter
@@ -1,0 +1,1 @@
+io.ballerina.trigger.BallerinaTriggerServiceClientCapabilitySetter

--- a/misc/ls-extensions/modules/trigger-service/src/main/resources/META-INF/services/org.ballerinalang.langserver.commons.registration.BallerinaServerCapabilitySetter
+++ b/misc/ls-extensions/modules/trigger-service/src/main/resources/META-INF/services/org.ballerinalang.langserver.commons.registration.BallerinaServerCapabilitySetter
@@ -1,0 +1,1 @@
+io.ballerina.trigger.BallerinaTriggerServiceServerCapabilitySetter


### PR DESCRIPTION
## Purpose
$subject

Fixes #36448

## Approach
Implemented services were not registered in `META-INF/services` folder under `resources`. This caused those services to not be detected by LS during runtime.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
