### PR TITLE
Sort documents of a module

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Module.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Module.java
@@ -18,9 +18,11 @@
 package io.ballerina.projects;
 
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -28,6 +30,7 @@ import java.util.Set;
 import java.util.Spliterator;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * {@code Module} represents a Ballerina module.
@@ -259,6 +262,7 @@ public class Module {
         public Modifier addDocument(DocumentConfig documentConfig) {
             DocumentContext newDocumentContext = DocumentContext.from(documentConfig);
             this.srcDocContextMap.put(newDocumentContext.documentId(), newDocumentContext);
+            this.srcDocContextMap = sortDocuments(this.srcDocContextMap);
             return this;
         }
 
@@ -271,6 +275,7 @@ public class Module {
         public Modifier addTestDocument(DocumentConfig documentConfig) {
             DocumentContext newDocumentContext = DocumentContext.from(documentConfig);
             this.testDocContextMap.put(newDocumentContext.documentId(), newDocumentContext);
+            this.testDocContextMap = sortDocuments(this.testDocContextMap);
             return this;
         }
 
@@ -319,7 +324,7 @@ public class Module {
 
 
         private Map<DocumentId, DocumentContext> copySrcDocs(Module oldModule, Collection<DocumentId> documentIds) {
-            Map<DocumentId, DocumentContext> srcDocContextMap = new HashMap<>();
+            Map<DocumentId, DocumentContext> srcDocContextMap = new LinkedHashMap<>();
             for (DocumentId documentId : documentIds) {
                 srcDocContextMap.put(documentId, oldModule.moduleContext.documentContext(documentId));
             }
@@ -380,6 +385,14 @@ public class Module {
             }
 
             return dependants;
+        }
+
+        private Map<DocumentId, DocumentContext> sortDocuments(Map<DocumentId, DocumentContext> docContextMap) {
+            return docContextMap.entrySet()
+                    .stream()
+                    .sorted(Comparator.comparing(entry -> entry.getValue().name()))
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue,
+                            (e1, e2) -> e1, LinkedHashMap::new));
         }
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ModuleContext.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ModuleContext.java
@@ -44,8 +44,10 @@ import org.wso2.ballerinalang.programfile.PackageFileWriter;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -105,9 +107,9 @@ class ModuleContext {
         this.moduleDescriptor = moduleDescriptor;
         this.isDefaultModule = isDefaultModule;
         this.srcDocContextMap = srcDocContextMap;
-        this.srcDocIds = Collections.unmodifiableCollection(srcDocContextMap.keySet());
+        this.srcDocIds = sortDocuments(srcDocContextMap);
         this.testDocContextMap = testDocContextMap;
-        this.testSrcDocIds = Collections.unmodifiableCollection(testDocContextMap.keySet());
+        this.testSrcDocIds = sortDocuments(testDocContextMap);
         this.moduleMdContext = moduleMd;
         this.moduleDescDependencies = Collections.unmodifiableList(moduleDescDependencies);
         this.resourceContextMap = resourceContextMap;
@@ -554,6 +556,15 @@ class ModuleContext {
         return new ModuleContext(project, this.moduleId, this.moduleDescriptor, this.isDefaultModule,
                 srcDocContextMap, testDocContextMap, this.moduleMdContext().orElse(null),
                 this.moduleDescDependencies, this.resourceContextMap, this.testResourceContextMap);
+    }
+
+    private Collection<DocumentId> sortDocuments(Map<DocumentId, DocumentContext> docContextMap) {
+        List<Map.Entry<DocumentId, DocumentContext>> entries = new ArrayList<>(docContextMap.entrySet());
+        entries.sort(Comparator.comparing(object -> object.getValue().name()));
+
+        List<DocumentId> sortedList = new ArrayList<>();
+        entries.forEach(entry -> sortedList.add(entry.getKey()));
+        return Collections.unmodifiableCollection(sortedList);
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ModuleContext.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ModuleContext.java
@@ -44,12 +44,11 @@ import org.wso2.ballerinalang.programfile.PackageFileWriter;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -107,9 +106,9 @@ class ModuleContext {
         this.moduleDescriptor = moduleDescriptor;
         this.isDefaultModule = isDefaultModule;
         this.srcDocContextMap = srcDocContextMap;
-        this.srcDocIds = sortDocuments(srcDocContextMap);
+        this.srcDocIds = Collections.unmodifiableCollection(srcDocContextMap.keySet());
         this.testDocContextMap = testDocContextMap;
-        this.testSrcDocIds = sortDocuments(testDocContextMap);
+        this.testSrcDocIds = Collections.unmodifiableCollection(testDocContextMap.keySet());
         this.moduleMdContext = moduleMd;
         this.moduleDescDependencies = Collections.unmodifiableList(moduleDescDependencies);
         this.resourceContextMap = resourceContextMap;
@@ -123,12 +122,12 @@ class ModuleContext {
     }
 
     static ModuleContext from(Project project, ModuleConfig moduleConfig) {
-        Map<DocumentId, DocumentContext> srcDocContextMap = new HashMap<>();
+        Map<DocumentId, DocumentContext> srcDocContextMap = new LinkedHashMap<>();
         for (DocumentConfig sourceDocConfig : moduleConfig.sourceDocs()) {
             srcDocContextMap.put(sourceDocConfig.documentId(), DocumentContext.from(sourceDocConfig));
         }
 
-        Map<DocumentId, DocumentContext> testDocContextMap = new HashMap<>();
+        Map<DocumentId, DocumentContext> testDocContextMap = new LinkedHashMap<>();
         for (DocumentConfig testSrcDocConfig : moduleConfig.testSourceDocs()) {
             testDocContextMap.put(testSrcDocConfig.documentId(), DocumentContext.from(testSrcDocConfig));
         }
@@ -542,13 +541,13 @@ class ModuleContext {
     }
 
     ModuleContext duplicate(Project project) {
-        Map<DocumentId, DocumentContext> srcDocContextMap = new HashMap<>();
+        Map<DocumentId, DocumentContext> srcDocContextMap = new LinkedHashMap<>();
         for (DocumentId documentId : this.srcDocumentIds()) {
             DocumentContext documentContext = this.documentContext(documentId);
             srcDocContextMap.put(documentId, documentContext.duplicate());
         }
 
-        Map<DocumentId, DocumentContext> testDocContextMap = new HashMap<>();
+        Map<DocumentId, DocumentContext> testDocContextMap = new LinkedHashMap<>();
         for (DocumentId documentId : this.testSrcDocumentIds()) {
             DocumentContext documentContext = this.documentContext(documentId);
             testDocContextMap.put(documentId, documentContext.duplicate());
@@ -556,15 +555,6 @@ class ModuleContext {
         return new ModuleContext(project, this.moduleId, this.moduleDescriptor, this.isDefaultModule,
                 srcDocContextMap, testDocContextMap, this.moduleMdContext().orElse(null),
                 this.moduleDescDependencies, this.resourceContextMap, this.testResourceContextMap);
-    }
-
-    private Collection<DocumentId> sortDocuments(Map<DocumentId, DocumentContext> docContextMap) {
-        List<Map.Entry<DocumentId, DocumentContext>> entries = new ArrayList<>(docContextMap.entrySet());
-        entries.sort(Comparator.comparing(object -> object.getValue().name()));
-
-        List<DocumentId> sortedList = new ArrayList<>();
-        entries.forEach(entry -> sortedList.add(entry.getKey()));
-        return Collections.unmodifiableCollection(sortedList);
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Package.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Package.java
@@ -15,6 +15,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -641,12 +642,12 @@ public class Package {
                         packageDescriptor.name(), oldModuleContext.moduleName().moduleNamePart());
                 ModuleDescriptor moduleDescriptor = ModuleDescriptor.from(moduleName, packageDescriptor);
 
-                Map<DocumentId, DocumentContext> srcDocContextMap = new HashMap<>();
+                Map<DocumentId, DocumentContext> srcDocContextMap = new LinkedHashMap<>();
                 for (DocumentId documentId : oldModuleContext.srcDocumentIds()) {
                     srcDocContextMap.put(documentId, oldModuleContext.documentContext(documentId));
                 }
 
-                Map<DocumentId, DocumentContext> testDocContextMap = new HashMap<>();
+                Map<DocumentId, DocumentContext> testDocContextMap = new LinkedHashMap<>();
                 for (DocumentId documentId : oldModuleContext.testSrcDocumentIds()) {
                     testDocContextMap.put(documentId, oldModuleContext.documentContext(documentId));
                 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/PackageConfigCreator.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/PackageConfigCreator.java
@@ -39,6 +39,7 @@ import io.ballerina.projects.util.ProjectConstants;
 
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -215,6 +216,7 @@ public class PackageConfigCreator {
     private static List<DocumentConfig> getDocumentConfigs(ModuleId moduleId, List<DocumentData> documentData) {
         return documentData
                 .stream()
+                .sorted(Comparator.comparing(DocumentData::name))
                 .map(srcDoc -> createDocumentConfig(srcDoc, moduleId))
                 .collect(Collectors.toList());
     }

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProject.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProject.java
@@ -2091,6 +2091,84 @@ public class TestBuildProject extends BaseTest {
         Files.deleteIfExists(projectPath.resolve(DEPENDENCIES_TOML));
     }
 
+    @Test(description = "tests the order of module documents")
+    public void testDocumentsOrder() {
+        Path projectPath = RESOURCE_DIRECTORY.resolve("project_documents");
+        String sourceFileName = "types.bal";
+        String testFileName = "tests/types.bal";
+        String newFileContent = "type Integer 1|2";
+
+        // Initialize the project and load the package
+        BuildProject project = loadBuildProject(projectPath);
+        Package currentPackage = project.currentPackage();
+
+        // Obtain the service module and check the documents order at project creation
+        Module serviceModule = currentPackage.module(ModuleName.from(currentPackage.packageName(), "services"));
+        List<String> expectedServiceFileNames = Arrays.asList("auth.bal", "subscribe.bal", "update.bal");
+        List<String> actualServiceFileNames = getDocumentFileNames(serviceModule, serviceModule.documentIds());
+
+        assertEquals(actualServiceFileNames.size(), 3);
+        assertEquals(actualServiceFileNames, expectedServiceFileNames);
+
+        // Obtain the modifier of the default module
+        Module oldDefaultModule = currentPackage.getDefaultModule();
+        Module.Modifier oldDefaultModuleModifier = oldDefaultModule.modify();
+
+        // Add types.bal and test_types.bal to the module
+        oldDefaultModuleModifier.addDocument(DocumentConfig.from(DocumentId.create(
+                sourceFileName, oldDefaultModule.moduleId()), newFileContent, sourceFileName));
+
+        oldDefaultModuleModifier.addTestDocument(DocumentConfig.from(DocumentId.create(
+                testFileName, oldDefaultModule.moduleId()), newFileContent, testFileName));
+
+        Module newDefaultModule = oldDefaultModuleModifier.apply();
+
+        // Check the document order after adding a new module
+        // Check the order of source documents
+        List<String> expectedSourceFileNames = Arrays.asList("main.bal", sourceFileName, "utils.bal");
+        List<String> actualSourceFileNames = getDocumentFileNames(newDefaultModule, newDefaultModule.documentIds());
+
+        assertEquals(actualSourceFileNames.size(), 3);
+        assertEquals(actualSourceFileNames, expectedSourceFileNames);
+
+        // Check the order of test documents
+        List<String> expectedTestFileNames = Arrays.asList(
+                "tests/main_test.bal",
+                testFileName,
+                "tests/utils_test.bal");
+        List<String> actualTestFileNames = getDocumentFileNames(newDefaultModule, newDefaultModule.testDocumentIds());
+
+        assertEquals(actualTestFileNames.size(), 3);
+        assertEquals(actualTestFileNames, expectedTestFileNames);
+
+        // Check the order of diagnostics
+        PackageCompilation compilation = currentPackage.getCompilation();
+
+        List<String> actualDiagnosticPaths = compilation.diagnosticResult().diagnostics().stream().map(diagnostic ->
+                diagnostic.location().lineRange().filePath()).distinct().collect(Collectors.toList());
+
+        List<String> expectedDiagnosticPaths = Arrays.asList(
+                "main.bal", Paths.get("tests").resolve("main_test.bal").toString(),
+                Paths.get("tests").resolve("utils_test.bal").toString(), "utils.bal",
+                Paths.get("modules").resolve("services").resolve("auth.bal").toString(),
+                Paths.get("modules").resolve("services").resolve("subscribe.bal").toString(),
+                Paths.get("modules").resolve("services").resolve("update.bal").toString(),
+                Paths.get("modules").resolve("storage").resolve("db.bal").toString(),
+                Paths.get("modules").resolve("storage").resolve("tests").resolve("db_test.bal").toString(),
+                Paths.get("modules").resolve("utils").resolve("utils.bal").toString());
+
+        assertEquals(actualDiagnosticPaths.size(), 10);
+        assertEquals(actualDiagnosticPaths, expectedDiagnosticPaths);
+    }
+
+    private List<String> getDocumentFileNames(Module module, Collection<DocumentId> documentIds) {
+        List<String> actualFileNames = new ArrayList<>();
+        for (DocumentId documentId : documentIds) {
+            actualFileNames.add(module.document(documentId).name());
+        }
+        return actualFileNames;
+    }
+
     @AfterClass (alwaysRun = true)
     public void reset() {
         Path projectPath = RESOURCE_DIRECTORY.resolve("project_no_permission");

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProject.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProject.java
@@ -2123,7 +2123,7 @@ public class TestBuildProject extends BaseTest {
 
         Module newDefaultModule = oldDefaultModuleModifier.apply();
 
-        // Check the document order after adding a new module
+        // Check the documents order after adding documents to a module
         // Check the order of source documents
         List<String> expectedSourceFileNames = Arrays.asList("main.bal", sourceFileName, "utils.bal");
         List<String> actualSourceFileNames = getDocumentFileNames(newDefaultModule, newDefaultModule.documentIds());

--- a/project-api/project-api-test/src/test/resources/project_documents/Ballerina.toml
+++ b/project-api/project-api-test/src/test/resources/project_documents/Ballerina.toml
@@ -1,0 +1,8 @@
+[package]
+distribution = "2201.0.2"
+org = "doc"
+name = "project_documents"
+version = "0.1.0"
+
+[build-options]
+observabilityIncluded = true

--- a/project-api/project-api-test/src/test/resources/project_documents/main.bal
+++ b/project-api/project-api-test/src/test/resources/project_documents/main.bal
@@ -1,0 +1,3 @@
+public function main() {
+    print("project_documents")
+}

--- a/project-api/project-api-test/src/test/resources/project_documents/modules/services/Module.md
+++ b/project-api/project-api-test/src/test/resources/project_documents/modules/services/Module.md
@@ -1,0 +1,2 @@
+# Module Overview
+Provides an overview about the module when generating the API documentations.

--- a/project-api/project-api-test/src/test/resources/project_documents/modules/services/auth.bal
+++ b/project-api/project-api-test/src/test/resources/project_documents/modules/services/auth.bal
@@ -1,0 +1,3 @@
+function login(user:Credential credentials) {
+    user:authenticate(credentials);   
+}

--- a/project-api/project-api-test/src/test/resources/project_documents/modules/services/subscribe.bal
+++ b/project-api/project-api-test/src/test/resources/project_documents/modules/services/subscribe.bal
@@ -1,0 +1,3 @@
+function subscribe(http:Request req) {
+    observers.push(req)
+}

--- a/project-api/project-api-test/src/test/resources/project_documents/modules/services/update.bal
+++ b/project-api/project-api-test/src/test/resources/project_documents/modules/services/update.bal
@@ -1,0 +1,1 @@
+function update() {

--- a/project-api/project-api-test/src/test/resources/project_documents/modules/storage/db.bal
+++ b/project-api/project-api-test/src/test/resources/project_documents/modules/storage/db.bal
@@ -1,0 +1,4 @@
+public function initDatabase() {
+    // Syntactic error
+    int k = 10
+}

--- a/project-api/project-api-test/src/test/resources/project_documents/modules/storage/tests/db_test.bal
+++ b/project-api/project-api-test/src/test/resources/project_documents/modules/storage/tests/db_test.bal
@@ -1,0 +1,3 @@
+public function testInitDatabase() {
+    int k = "a";
+}

--- a/project-api/project-api-test/src/test/resources/project_documents/modules/utils/utils.bal
+++ b/project-api/project-api-test/src/test/resources/project_documents/modules/utils/utils.bal
@@ -1,0 +1,4 @@
+public function initDatabase() {
+    int a = 5;
+    int a = 5;
+}

--- a/project-api/project-api-test/src/test/resources/project_documents/tests/main_test.bal
+++ b/project-api/project-api-test/src/test/resources/project_documents/tests/main_test.bal
@@ -1,0 +1,3 @@
+function testMain {
+    int j = 32
+}

--- a/project-api/project-api-test/src/test/resources/project_documents/tests/utils_test.bal
+++ b/project-api/project-api-test/src/test/resources/project_documents/tests/utils_test.bal
@@ -1,0 +1,1 @@
+function testUtils

--- a/project-api/project-api-test/src/test/resources/project_documents/utils.bal
+++ b/project-api/project-api-test/src/test/resources/project_documents/utils.bal
@@ -1,0 +1,1 @@
+function openFile() {


### PR DESCRIPTION
## Purpose
The order of the documents is not consistent at project creation or when adding a new module. This list should retain the sort at each build.

Fixes #31082 

## Approach
Sort the `DocumentId`s based on the document path when extracting the keyset from the context map.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [x] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
