### PR TITLE
Invalidate the environment in project when the compiler crashes

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Project.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Project.java
@@ -18,7 +18,6 @@
 package io.ballerina.projects;
 
 import io.ballerina.projects.environment.ProjectEnvironment;
-import org.wso2.ballerinalang.compiler.PackageCache;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.CompilerOptions;
 
@@ -36,7 +35,7 @@ public abstract class Project {
     protected final Path sourceRoot;
     private Package currentPackage;
     private BuildOptions buildOptions;
-    private final ProjectEnvironment projectEnvironment;
+    protected ProjectEnvironment projectEnvironment;
     private final ProjectKind projectKind;
 
     protected Project(ProjectKind projectKind,
@@ -110,13 +109,7 @@ public abstract class Project {
      * (i.e. package resolution caches, compilation caches)
      * generated during project compilation will be discarded.
      */
-    public void clearCaches() {
-        cloneProject(this);
-        CompilerContext compilerContext = this.projectEnvironmentContext()
-                .getService(CompilerContext.class);
-        PackageCache packageCache = PackageCache.getInstance(compilerContext);
-        packageCache.flush();
-    }
+    public abstract void clearCaches();
 
     /**
      * Creates a new Project instance which has the same structure as this Project.
@@ -128,7 +121,7 @@ public abstract class Project {
      */
     public abstract Project duplicate();
 
-    protected Project cloneProject(Project project) {
+    protected Project resetPackage(Project project) {
         Package clone = this.currentPackage.duplicate(project);
         project.setCurrentPackage(clone);
         return project;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/bala/BalaProject.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/bala/BalaProject.java
@@ -64,11 +64,19 @@ public class BalaProject extends Project {
     }
 
     @Override
+    public void clearCaches() {
+        resetPackage(this);
+        ProjectEnvironmentBuilder projectEnvironmentBuilder = ProjectEnvironmentBuilder.getDefaultBuilder();
+        projectEnvironmentBuilder.addCompilationCacheFactory(TempDirCompilationCache::from);
+        this.projectEnvironment = projectEnvironmentBuilder.build(this);
+    }
+
+    @Override
     public Project duplicate() {
         ProjectEnvironmentBuilder projectEnvironmentBuilder = ProjectEnvironmentBuilder.getDefaultBuilder();
         projectEnvironmentBuilder.addCompilationCacheFactory(TempDirCompilationCache::from);
         BalaProject balaProject = new BalaProject(projectEnvironmentBuilder, this.sourceRoot);
-        return cloneProject(balaProject);
+        return resetPackage(balaProject);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/directory/BuildProject.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/directory/BuildProject.java
@@ -156,11 +156,17 @@ public class BuildProject extends Project {
     }
 
     @Override
+    public void clearCaches() {
+        resetPackage(this);
+        this.projectEnvironment = ProjectEnvironmentBuilder.getDefaultBuilder().build(this);
+    }
+
+    @Override
     public Project duplicate() {
         BuildOptions duplicateBuildOptions = BuildOptions.builder().build().acceptTheirs(buildOptions());
         BuildProject buildProject = new BuildProject(
                 ProjectEnvironmentBuilder.getDefaultBuilder(), this.sourceRoot, duplicateBuildOptions);
-        return cloneProject(buildProject);
+        return resetPackage(buildProject);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/directory/SingleFileProject.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/directory/SingleFileProject.java
@@ -25,6 +25,7 @@ import io.ballerina.projects.ProjectEnvironmentBuilder;
 import io.ballerina.projects.ProjectException;
 import io.ballerina.projects.ProjectKind;
 import io.ballerina.projects.internal.PackageConfigCreator;
+import io.ballerina.projects.repos.TempDirCompilationCache;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -83,11 +84,19 @@ public class SingleFileProject extends Project {
     }
 
     @Override
+    public void clearCaches() {
+        resetPackage(this);
+        ProjectEnvironmentBuilder projectEnvironmentBuilder = ProjectEnvironmentBuilder.getDefaultBuilder();
+        projectEnvironmentBuilder.addCompilationCacheFactory(TempDirCompilationCache::from);
+        this.projectEnvironment = projectEnvironmentBuilder.build(this);
+    }
+
+    @Override
     public Project duplicate() {
         BuildOptions duplicateBuildOptions = BuildOptions.builder().build().acceptTheirs(buildOptions());
         SingleFileProject singleFileProject = new SingleFileProject(
                 ProjectEnvironmentBuilder.getDefaultBuilder(), this.sourceRoot, duplicateBuildOptions);
-        return cloneProject(singleFileProject);
+        return resetPackage(singleFileProject);
     }
 
     @Override


### PR DESCRIPTION
## Purpose
> Invalidate the environment in project when the compiler crashes
Fixes #36231

## Approach
> The project environment will be reloaded when there is a compiler crash.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
