### PR TITLE
Fix xml template interpolated expr type checking

### DIFF
--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLLiteralTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLLiteralTest.java
@@ -192,14 +192,14 @@ public class XMLLiteralTest {
         BAssertUtil.validateError(negativeResult, index++, "missing xml CDATA end token", 128, 49);
         BAssertUtil.validateError(negativeResult, index++, "xml namespaces cannot be interpolated", 133, 45);
         BAssertUtil.validateError(negativeResult, index++,
-                "incompatible types: expected 'xml', found 'string'", 140, 60);
+                "incompatible types: expected '(int|float|decimal|string|boolean|xml)', found 'string[]'", 140, 25);
         BAssertUtil.validateError(negativeResult, index++,
-                "incompatible types: expected 'xml', found 'string'", 141, 60);
+                "incompatible types: expected '(int|float|decimal|string|boolean|xml)', found 'string[]'", 141, 25);
         BAssertUtil.validateError(negativeResult, index++,
-                "incompatible types: expected 'xml', found 'int'", 142, 69);
+                "incompatible types: expected '(int|float|decimal|string|boolean|xml)', found 'int[]'", 142, 38);
         BAssertUtil.validateError(negativeResult, index++,
-                "invalid literal for type 'xml': raw templates can only be assigned to " +
-                        "abstract subtypes of 'ballerina/lang.object:0.0.0:RawTemplate'", 143, 52);
+                "incompatible types: expected '(int|float|decimal|string|boolean|xml)', " +
+                        "found 'ballerina/lang.object:0.0.0:RawTemplate[]'", 143, 25);
         BAssertUtil.validateError(negativeResult, index++,
                 "incompatible types: 'ballerina/lang.object:0.0.0:RawTemplate[]' cannot be cast to 'string'", 144, 25);
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-literals.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-literals.bal
@@ -398,4 +398,7 @@ function testQueryInXMLTemplateExpr() {
 
     var x7 = xml `<doc>${(from string s in ["a", "b", "c"] select xml `${s}z`)}</doc>`;
     test:assertEquals(x7.toString(), "<doc>azbzcz</doc>");
+
+    // var x8 = xml `<doc>${xml `foo` + (from string s in ["a", "b"] select xml `${s}z`)}</doc>`; // issue #36541
+    // test:assertEquals(x8.toString(), "<doc>fooazbz</doc>")
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-literals.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-literals.bal
@@ -395,4 +395,7 @@ function testQueryInXMLTemplateExpr() {
 
     string str3 = "<doc><doc><num>1</num><num>2</num><num>3</num></doc></doc>";
     test:assertEquals(x6.toString(), str3);
+
+    var x7 = xml `<doc>${(from string s in ["a", "b", "c"] select xml `${s}z`)}</doc>`;
+    test:assertEquals(x7.toString(), "<doc>azbzcz</doc>");
 }


### PR DESCRIPTION
## Purpose
$subject.

Fixes #36479 

## Approach
N/A

## Samples
N/A

## Remarks
The preferred CET is xml. Hence, first silent type check with xml (to guide the type that is chosen for expressions that can have multiple types). If it fails type check with noType.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples