### PR TITLE
Fix wrong type reference type passing 

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/JvmAnnotationsGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/JvmAnnotationsGen.java
@@ -130,17 +130,20 @@ public class JvmAnnotationsGen {
         String pkgClassName = pkgName.equals(".") || pkgName.equals("") ? MODULE_INIT_CLASS_NAME :
                 jvmPackageGen.lookupGlobalVarClassName(pkgName, ANNOTATION_MAP_NAME);
         mv.visitFieldInsn(GETSTATIC, pkgClassName, ANNOTATION_MAP_NAME, JvmSignatures.GET_MAP_VALUE);
-        loadLocalType(mv, typeDef, jvmTypeGen);
+        BType refType = typeDef.referenceType == null || typeDef.type.tag == TypeTags.RECORD ? typeDef.type :
+                typeDef.referenceType;
+        loadLocalType(mv, refType, jvmTypeGen);
         mv.visitMethodInsn(INVOKESTATIC, ANNOTATION_UTILS, "processAnnotations",
                 JvmSignatures.PROCESS_ANNOTATIONS, false);
+
     }
 
-    void loadLocalType(MethodVisitor mv, BIRNode.BIRTypeDefinition typeDefinition, JvmTypeGen jvmTypeGen) {
-        if (typeDefinition.type.tag == TypeTags.TYPEREFDESC) {
-            jvmConstantsGen.generateGetBTypeRefType(mv, jvmConstantsGen.getTypeConstantsVar(typeDefinition.type,
-                                                                                            jvmPackageGen.symbolTable));
+    void loadLocalType(MethodVisitor mv, BType type, JvmTypeGen jvmTypeGen) {
+        if (type.tag == TypeTags.TYPEREFDESC) {
+            jvmConstantsGen.generateGetBTypeRefType(mv, jvmConstantsGen.getTypeConstantsVar(type,
+                    jvmPackageGen.symbolTable));
         } else {
-            jvmTypeGen.loadType(mv, typeDefinition.type);
+            jvmTypeGen.loadType(mv, type);
         }
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
@@ -288,4 +288,21 @@ public class Values {
         }
         return ErrorCreator.createError(StringUtils.fromString("Validation failed for 'minValue' constraint(s)."));
     }
+
+    public static Object validateArray(Object value, BTypedesc typedesc) {
+        Type describingType = typedesc.getDescribingType();
+        BMap<BString, Object> annotations = ((AnnotatableType) describingType).getAnnotations();
+        BString annotKey = StringUtils.fromString("testorg/runtime_api_types.typeref:1:Int");
+        if (annotations.containsKey(annotKey)) {
+            Object annotValue = annotations.get(annotKey);
+            Long minValue = (Long) ((BMap) annotValue).get(StringUtils.fromString("minValue"));
+            for (Object element : ((BArray) value).getValues()) {
+                if (((Long) element) >= minValue) {
+                    return value;
+                }
+            }
+        }
+        return ErrorCreator.createError(StringUtils.fromString("Validation failed for 'minValue' constraint(s)."));
+    }
+
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/types/modules/typeref/typeref.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/types/modules/typeref/typeref.bal
@@ -34,6 +34,9 @@ type '\ \/\:\@\[\`\{\~\u{03C0}_123_ƮέŞŢ_Int int;
 @X
 type Nil ();
 
+@Int {minValue: 0}
+type Foo anydata[];
+
 type Person record {
     @Int {
         minValue: 18
@@ -85,6 +88,14 @@ function validateType() {
     } else {
         test:assertFail("Expected error not found.");
     }
+
+    anydata[] a = [1, 2, 3];
+    Foo|error val = validateArray(a);
+    if val is Foo {
+        test:assertEquals(val, [1, 2, 3]);
+    } else {
+        test:assertFail("Expected error not found.");
+    }
 }
 
 function validateRecordField() {
@@ -128,5 +139,14 @@ public isolated function validate(anydata value, typedesc<anydata> td = <>) retu
 # + td - The type descriptor of the value to be constrained
 # + return - The type descriptor of the value which is validated or else an `constraint:Error` in case of an error
 public isolated function validateRecord(anydata value, typedesc<anydata> td = <>) returns td|error = @java:Method {
+    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
+} external;
+
+# Validates the provided array value against the configured annotations for field.
+#
+# + value - The `anydata` type value to be constrained
+# + td - The type descriptor of the value to be constrained
+# + return - The type descriptor of the value which is validated or else an `constraint:Error` in case of an error
+public isolated function validateArray(anydata value, typedesc<anydata> td = <>) returns td|error = @java:Method {
     'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
 } external;


### PR DESCRIPTION
## Purpose
$subject
bug related to #36408 

## Samples
```ballerina
@Int {minValue: 0}
type Foo anydata[];

public function main() {
    Foo[] a = [1, 2, 3]; // type annotations should be passed for 'Foo'
}
```

## Remarks
This is a temporary fix. Needs to be fixed from compiler FE. 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
