### PR TITLE
Avoid defining predeclared modules in the annotations module

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -399,7 +399,7 @@ public class SymbolEnter extends BLangNodeVisitor {
                 pkgEnv.scope.define(unresolvedPkgAlias, symbol);
             }
         }
-        if (!pkgEnv.scope.owner.pkgID.equals(PackageID.ANNOTATIONS)) {
+        if (!PackageID.ANNOTATIONS.equals(pkgNode.packageID)) {
             initPredeclaredModules(symTable.predeclaredModules, pkgNode.compUnits, pkgEnv);
         }
         // Define type definitions.

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -399,7 +399,9 @@ public class SymbolEnter extends BLangNodeVisitor {
                 pkgEnv.scope.define(unresolvedPkgAlias, symbol);
             }
         }
-        initPredeclaredModules(symTable.predeclaredModules, pkgNode.compUnits, pkgEnv);
+        if (!pkgEnv.scope.owner.pkgID.equals(PackageID.ANNOTATIONS)) {
+            initPredeclaredModules(symTable.predeclaredModules, pkgNode.compUnits, pkgEnv);
+        }
         // Define type definitions.
         this.typePrecedence = 0;
 
@@ -1152,11 +1154,13 @@ public class SymbolEnter extends BLangNodeVisitor {
                                        List<BLangCompilationUnit> compUnits, SymbolEnv env) {
         SymbolEnv prevEnv = this.env;
         this.env = env;
-        for (Name alias : predeclaredModules.keySet()) {
+        for (Map.Entry<Name, BPackageSymbol> predeclaredModuleEntry : predeclaredModules.entrySet()) {
+            Name alias = predeclaredModuleEntry.getKey();
+            BPackageSymbol packageSymbol = predeclaredModuleEntry.getValue();
             int index = 0;
             ScopeEntry entry = this.env.scope.lookup(alias);
             if (entry == NOT_FOUND_ENTRY && !compUnits.isEmpty()) {
-                this.env.scope.define(alias, dupPackageSymbolAndSetCompUnit(predeclaredModules.get(alias),
+                this.env.scope.define(alias, dupPackageSymbolAndSetCompUnit(packageSymbol,
                         new Name(compUnits.get(index++).name)));
                 entry = this.env.scope.lookup(alias);
             }
@@ -1174,7 +1178,7 @@ public class SymbolEnter extends BLangNodeVisitor {
                     entry = entry.next;
                 }
                 if (isUndefinedModule) {
-                    entry.next = new ScopeEntry(dupPackageSymbolAndSetCompUnit(predeclaredModules.get(alias),
+                    entry.next = new ScopeEntry(dupPackageSymbolAndSetCompUnit(packageSymbol,
                             new Name(compUnitName)), NOT_FOUND_ENTRY);
                 }
             }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/definition/DefinitionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/definition/DefinitionTest.java
@@ -158,7 +158,8 @@ public class DefinitionTest {
         return new Object[][]{
                 {"defProject8.json", "project"},
                 {"def_error_config2.json", "project"},
-                {"def_retry_spec_config1.json", "project"}
+                {"def_retry_spec_config1.json", "project"},
+                {"defProject13.json", "project"}
         };
     }
 

--- a/language-server/modules/langserver-core/src/test/resources/definition/expected/project/defProject13.json
+++ b/language-server/modules/langserver-core/src/test/resources/definition/expected/project/defProject13.json
@@ -1,0 +1,24 @@
+{
+  "source": {
+    "file": "defThread.bal"
+  },
+  "position": {
+    "line": 1,
+    "character": 8
+  },
+  "result": [
+    {
+      "range": {
+        "start": {
+          "line": 79,
+          "character": 0
+        },
+        "end": {
+          "line": 79,
+          "character": 36
+        }
+      },
+      "uri": "repo/bala/ballerina/lang.annotations/0.0.0/any/modules/lang.annotations/annotations.bal"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/definition/sources/defThread.bal
+++ b/language-server/modules/langserver-core/src/test/resources/definition/sources/defThread.bal
@@ -1,0 +1,3 @@
+public function main() {
+    Thread thread = "any";
+}


### PR DESCRIPTION
## Purpose
> Resolve the null point exception and class cast exception in the `annotation/Thread` type definition. The related issue is https://github.com/ballerina-platform/ballerina-lang/issues/32830

Fixes #32830

## Approach
> Check the owner of the scope before calling the `initPredeclaredModules` method in the /compiler/semantics/analyzer/SymbolEnter.java Class. If the owner is `annotation`, then skip the `initPredeclaredModules` method.

## Remarks
> Related PR - https://github.com/ballerina-platform/ballerina-lang/pull/36459

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
