### PR TITLE
Fix inconsistency behaviour in named-arg in error constructor and function-call

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -6459,7 +6459,6 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         for (BLangNamedArgsExpression namedArgsExpression : errorConstructorExpr.namedArgs) {
             BType target = checkErrCtrTargetTypeAndSetSymbol(namedArgsExpression, expectedType);
 
-            namedArgsExpression.cloneAttempt++;
             BLangNamedArgsExpression clone = nodeCloner.cloneNode(namedArgsExpression);
             BType type = checkExprSilent(clone, target, data);
             if (type == symTable.semanticError) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -6459,10 +6459,15 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         for (BLangNamedArgsExpression namedArgsExpression : errorConstructorExpr.namedArgs) {
             BType target = checkErrCtrTargetTypeAndSetSymbol(namedArgsExpression, expectedType);
 
+            namedArgsExpression.cloneAttempt++;
             BLangNamedArgsExpression clone = nodeCloner.cloneNode(namedArgsExpression);
-            BType type = checkExpr(clone, target, data);
+            BType type = checkExprSilent(clone, target, data);
             if (type == symTable.semanticError) {
-                checkExpr(namedArgsExpression, data);
+                if (Types.getReferredType(target).tag == TypeTags.RECORD) {
+                    checkExpr(namedArgsExpression, target, data);
+                } else {
+                    checkExpr(namedArgsExpression, data);
+                }
             } else {
                 checkExpr(namedArgsExpression, target, data);
             }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -3347,7 +3347,8 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                     }
                 } else {
                     missingRequiredFields.remove(namedArg.name.value);
-                    if (Types.getReferredType(field.type).tag == TypeTags.UNION && !types.isAssignable(namedArg.expr.getBType(), field.type)) {
+                    if (Types.getReferredType(field.type).tag == TypeTags.UNION &&
+                            !types.isAssignable(namedArg.expr.getBType(), field.type)) {
                         dlog.error(pos, DiagnosticErrorCode.INVALID_ERROR_DETAIL_ARG_TYPE,
                                    namedArg.name, field.type, namedArg.expr.getBType());
                     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -3318,7 +3318,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         if (Types.getReferredType(detailType).tag == TypeTags.MAP) {
             BType errorDetailTypeConstraint = ((BMapType) Types.getReferredType(detailType)).constraint;
             for (BLangNamedArgsExpression namedArgExpr: namedArgs) {
-                if (errorDetailTypeConstraint.tag == TypeTags.UNION &&
+                if (Types.getReferredType(errorDetailTypeConstraint).tag == TypeTags.UNION &&
                         !types.isAssignable(namedArgExpr.expr.getBType(), errorDetailTypeConstraint)) {
                     dlog.error(namedArgExpr.pos, DiagnosticErrorCode.INVALID_ERROR_DETAIL_ARG_TYPE,
                                namedArgExpr.name, errorDetailTypeConstraint, namedArgExpr.expr.getBType());
@@ -3347,7 +3347,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                     }
                 } else {
                     missingRequiredFields.remove(namedArg.name.value);
-                    if (field.type.tag == TypeTags.UNION && !types.isAssignable(namedArg.expr.getBType(), field.type)) {
+                    if (Types.getReferredType(field.type).tag == TypeTags.UNION && !types.isAssignable(namedArg.expr.getBType(), field.type)) {
                         dlog.error(pos, DiagnosticErrorCode.INVALID_ERROR_DETAIL_ARG_TYPE,
                                    namedArg.name, field.type, namedArg.expr.getBType());
                     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config29.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config29.json
@@ -13,6 +13,39 @@
       "filterText": "readonly",
       "insertText": "readonly ",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "name",
+      "kind": "Field",
+      "detail": "Application.name",
+      "sortText": "K",
+      "insertText": "name: ${1:\"\"}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "id",
+      "kind": "Field",
+      "detail": "Application.id",
+      "sortText": "K",
+      "insertText": "id: ${1:\"\"}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "version",
+      "kind": "Field",
+      "detail": "Application.version",
+      "sortText": "K",
+      "insertText": "'version: ${1:0}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Fill Application Required Fields",
+      "kind": "Property",
+      "detail": "Application",
+      "sortText": "R",
+      "filterText": "fill",
+      "insertText": "name: ${1:\"\"},\nid: ${2:\"\"},\nversion: ${3:0}",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
@@ -240,7 +240,8 @@ public class ErrorTest {
         BAssertUtil.validateError(negativeCompileResult, i++,
                 "error constructor does not accept additional detail args 'one' when error detail type 'Foo' " +
                         "contains individual field descriptors", 45, 58);
-        BAssertUtil.validateError(negativeCompileResult, i++, "incompatible types: expected 'int', found 'float'", 45, 64);
+        BAssertUtil.validateError(negativeCompileResult, i++, "incompatible types: expected 'int', found 'float'",
+                45, 64);
         BAssertUtil.validateError(negativeCompileResult, i++,
                 "invalid error detail type 'boolean', expected a subtype of " +
                         "'map<ballerina/lang.value:0.0.0:Cloneable>'", 48, 11);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
@@ -240,6 +240,7 @@ public class ErrorTest {
         BAssertUtil.validateError(negativeCompileResult, i++,
                 "error constructor does not accept additional detail args 'one' when error detail type 'Foo' " +
                         "contains individual field descriptors", 45, 58);
+        BAssertUtil.validateError(negativeCompileResult, i++, "incompatible types: expected 'int', found 'float'", 45, 64);
         BAssertUtil.validateError(negativeCompileResult, i++,
                 "invalid error detail type 'boolean', expected a subtype of " +
                         "'map<ballerina/lang.value:0.0.0:Cloneable>'", 48, 11);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/errorconstructorexpr/ErrorConstructorExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/errorconstructorexpr/ErrorConstructorExprTest.java
@@ -105,6 +105,16 @@ public class ErrorConstructorExprTest {
                 66, 18);
         validateError(negativeSemanticResult, i++, "compatible type for error constructor expression not " +
                 "found in type '(int|string)'", 67, 16);
+        validateError(negativeSemanticResult, i++, "invalid arg type in error detail field 'application', " +
+                "expected 'Application', found 'other'", 87, 66);
+        validateError(negativeSemanticResult, i++, "missing non-defaultable required record field 'id'", 87, 80);
+        validateError(negativeSemanticResult, i++, "missing non-defaultable required record field 'user'", 87, 80);
+        validateError(negativeSemanticResult, i++, "invalid arg type in error detail field 'application', " +
+                "expected 'Application', found 'other'", 88, 66);
+        validateError(negativeSemanticResult, i++, "missing non-defaultable required record field 'name'", 88, 97);
+        validateError(negativeSemanticResult, i++, "invalid arg type in error detail field 'application', " +
+                "expected 'Application', found 'other'", 89, 66);
+        validateError(negativeSemanticResult, i++, "missing identifier", 89, 80);
         Assert.assertEquals(negativeSemanticResult.getErrorCount(), i);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/errorconstructorexpr/ErrorConstructorExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/errorconstructorexpr/ErrorConstructorExprTest.java
@@ -87,13 +87,12 @@ public class ErrorConstructorExprTest {
         validateError(negativeSemanticResult, i++, "incompatible types: expected 'error?', found 'string'", 29, 34);
         validateError(negativeSemanticResult, i++, "additional positional arg in error constructor", 30, 47);
         validateError(negativeSemanticResult, i++, "undefined error type descriptor 'MyError'", 36, 26);
-        validateError(negativeSemanticResult, i++, "invalid arg type in error detail field 'c', expected " +
-                "'string', found 'int'", 37, 46);
-        validateError(negativeSemanticResult, i++, "invalid arg type in error detail field 'j', expected " +
-                "'string', found 'int'", 42, 33);
+        validateError(negativeSemanticResult, i++, "incompatible types: expected 'string', found 'int'" , 37, 50);
+        validateError(negativeSemanticResult, i++, "incompatible types: expected 'string', found 'int'", 42, 37);
         validateError(negativeSemanticResult, i++,
                 "error constructor does not accept additional detail args 'k' when error detail type " +
                         "'record {| int i; string j; anydata...; |}' contains individual field descriptors", 42, 40);
+        validateError(negativeSemanticResult, i++, "incompatible types: expected 'anydata', found 'error'", 42, 44);
         validateError(negativeSemanticResult, i++, "missing error detail arg for error detail field 'j'", 43, 14);
         validateError(negativeSemanticResult, i++, "cannot infer type of the error from '(ErrorA|ErrorB)'", 50, 20);
         validateError(negativeSemanticResult, i++, "cannot infer type of the error from '(ErrorA|ErrorB)'", 51, 20);
@@ -105,15 +104,9 @@ public class ErrorConstructorExprTest {
                 66, 18);
         validateError(negativeSemanticResult, i++, "compatible type for error constructor expression not " +
                 "found in type '(int|string)'", 67, 16);
-        validateError(negativeSemanticResult, i++, "invalid arg type in error detail field 'application', " +
-                "expected 'Application', found 'other'", 86, 66);
         validateError(negativeSemanticResult, i++, "missing non-defaultable required record field 'id'", 86, 80);
         validateError(negativeSemanticResult, i++, "missing non-defaultable required record field 'user'", 86, 80);
-        validateError(negativeSemanticResult, i++, "invalid arg type in error detail field 'application', " +
-                "expected 'Application', found 'other'", 87, 66);
         validateError(negativeSemanticResult, i++, "missing non-defaultable required record field 'name'", 87, 97);
-        validateError(negativeSemanticResult, i++, "invalid arg type in error detail field 'application', " +
-                "expected 'Application', found 'other'", 88, 66);
         validateError(negativeSemanticResult, i++, "missing identifier", 88, 80);
         Assert.assertEquals(negativeSemanticResult.getErrorCount(), i);
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/errorconstructorexpr/ErrorConstructorExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/errorconstructorexpr/ErrorConstructorExprTest.java
@@ -106,15 +106,15 @@ public class ErrorConstructorExprTest {
         validateError(negativeSemanticResult, i++, "compatible type for error constructor expression not " +
                 "found in type '(int|string)'", 67, 16);
         validateError(negativeSemanticResult, i++, "invalid arg type in error detail field 'application', " +
+                "expected 'Application', found 'other'", 86, 66);
+        validateError(negativeSemanticResult, i++, "missing non-defaultable required record field 'id'", 86, 80);
+        validateError(negativeSemanticResult, i++, "missing non-defaultable required record field 'user'", 86, 80);
+        validateError(negativeSemanticResult, i++, "invalid arg type in error detail field 'application', " +
                 "expected 'Application', found 'other'", 87, 66);
-        validateError(negativeSemanticResult, i++, "missing non-defaultable required record field 'id'", 87, 80);
-        validateError(negativeSemanticResult, i++, "missing non-defaultable required record field 'user'", 87, 80);
+        validateError(negativeSemanticResult, i++, "missing non-defaultable required record field 'name'", 87, 97);
         validateError(negativeSemanticResult, i++, "invalid arg type in error detail field 'application', " +
                 "expected 'Application', found 'other'", 88, 66);
-        validateError(negativeSemanticResult, i++, "missing non-defaultable required record field 'name'", 88, 97);
-        validateError(negativeSemanticResult, i++, "invalid arg type in error detail field 'application', " +
-                "expected 'Application', found 'other'", 89, 66);
-        validateError(negativeSemanticResult, i++, "missing identifier", 89, 80);
+        validateError(negativeSemanticResult, i++, "missing identifier", 88, 80);
         Assert.assertEquals(negativeSemanticResult.getErrorCount(), i);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/errorconstructorexpr/ErrorConstructorExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/errorconstructorexpr/ErrorConstructorExprTest.java
@@ -104,10 +104,12 @@ public class ErrorConstructorExprTest {
                 66, 18);
         validateError(negativeSemanticResult, i++, "compatible type for error constructor expression not " +
                 "found in type '(int|string)'", 67, 16);
-        validateError(negativeSemanticResult, i++, "missing non-defaultable required record field 'id'", 86, 80);
-        validateError(negativeSemanticResult, i++, "missing non-defaultable required record field 'user'", 86, 80);
-        validateError(negativeSemanticResult, i++, "missing non-defaultable required record field 'name'", 87, 97);
-        validateError(negativeSemanticResult, i++, "missing identifier", 88, 80);
+        validateError(negativeSemanticResult, i++, "missing non-defaultable required record field 'id'", 92, 82);
+        validateError(negativeSemanticResult, i++, "missing non-defaultable required record field 'user'", 92, 82);
+        validateError(negativeSemanticResult, i++, "missing non-defaultable required record field 'name'", 93, 99);
+        validateError(negativeSemanticResult, i++, "missing identifier", 94, 82);
+        validateError(negativeSemanticResult, i++, "missing non-defaultable required record field 'id'", 95, 83);
+        validateError(negativeSemanticResult, i++, "missing non-defaultable required record field 'user'", 95, 83);
         Assert.assertEquals(negativeSemanticResult.getErrorCount(), i);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/errorconstructorexpr/ErrorConstructorExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/errorconstructorexpr/ErrorConstructorExprTest.java
@@ -104,12 +104,14 @@ public class ErrorConstructorExprTest {
                 66, 18);
         validateError(negativeSemanticResult, i++, "compatible type for error constructor expression not " +
                 "found in type '(int|string)'", 67, 16);
-        validateError(negativeSemanticResult, i++, "missing non-defaultable required record field 'id'", 92, 82);
-        validateError(negativeSemanticResult, i++, "missing non-defaultable required record field 'user'", 92, 82);
-        validateError(negativeSemanticResult, i++, "missing non-defaultable required record field 'name'", 93, 99);
-        validateError(negativeSemanticResult, i++, "missing identifier", 94, 82);
-        validateError(negativeSemanticResult, i++, "missing non-defaultable required record field 'id'", 95, 83);
-        validateError(negativeSemanticResult, i++, "missing non-defaultable required record field 'user'", 95, 83);
+        validateError(negativeSemanticResult, i++, "missing non-defaultable required record field 'id'", 95, 82);
+        validateError(negativeSemanticResult, i++, "missing non-defaultable required record field 'user'", 95, 82);
+        validateError(negativeSemanticResult, i++, "missing non-defaultable required record field 'name'", 96, 99);
+        validateError(negativeSemanticResult, i++, "missing identifier", 97, 82);
+        validateError(negativeSemanticResult, i++, "missing non-defaultable required record field 'id'", 98, 83);
+        validateError(negativeSemanticResult, i++, "missing non-defaultable required record field 'user'", 98, 83);
+        validateError(negativeSemanticResult, i++, "invalid arg type in error detail field 'application'," +
+                " expected 'StringType', found 'record {| |} & readonly'", 99, 68);
         Assert.assertEquals(negativeSemanticResult.getErrorCount(), i);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/vardeclr/ModuleErrorVariableTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/vardeclr/ModuleErrorVariableTest.java
@@ -77,7 +77,7 @@ public class ModuleErrorVariableTest {
         validateError(compileResultNegetive, index++,
                 "incompatible types: expected 'string', found 'other'", 40, 69);
         validateError(compileResultNegetive, index++,
-                "invalid arg type in error detail field 'basicErrorNo', expected 'int', found 'other'", 40, 79);
+                "incompatible types: expected 'int', found 'other'", 40, 94);
         validateError(compileResultNegetive, index++,
                 "invalid record binding pattern with type '[int]'", 53, 33);
         validateError(compileResultNegetive, index++,

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/intersection/IntersectionTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/intersection/IntersectionTypeTest.java
@@ -157,6 +157,8 @@ public class IntersectionTypeTest {
                         "error detail type 'record {| string x; string...; |}' contains individual field descriptors",
                 56, 63);
         validateError(result, index++,
+                "incompatible types: expected 'string', found 'int'", 56, 67);
+        validateError(result, index++,
                       "incompatible types: expected 'DistinctErrorIntersection', found 'IntersectionErrorFour'", 57,
                       38);
         validateError(result, index++,
@@ -193,7 +195,7 @@ public class IntersectionTypeTest {
         validateError(result, index++, "error constructor does not accept additional detail args 'oth' when error " +
                 "detail type 'record {| boolean fatal?; int code; int...; |}' contains individual field descriptors",
                 96, 59);
-
+        validateError(result, index++, "incompatible types: expected 'int', found 'boolean'", 96, 65);
         assertEquals(result.getErrorCount(), index);
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bir/bir-dump/failLockWithinLock
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bir/bir-dump/failLockWithinLock
@@ -11,11 +11,10 @@ failLockWithinLock function() -> (int, string) {
     %19(TEMP) typeDesc<any|error>;
     %20(TEMP) map<ballerina/lang.value:0.0.0:Cloneable>;
     %21(TEMP) string;
-    %22(TEMP) ballerina/lang.value:0.0.0:Cloneable;
-    %23(TEMP) string;
-    %24(TEMP) map<ballerina/lang.value:0.0.0:Cloneable>;
-    %25(LOCAL) error;
-    %41(TEMP) int;
+    %22(TEMP) string;
+    %23(TEMP) map<ballerina/lang.value:0.0.0:Cloneable>;
+    %24(LOCAL) error;
+    %40(TEMP) int;
 
     bb0 {
         lock -> bb1;
@@ -52,20 +51,19 @@ failLockWithinLock function() -> (int, string) {
         %12 = <error> %18;
         %19 = newType map<ballerina/lang.value:0.0.0:Cloneable>;
         %21 = ConstLoad message;
-        %23 = ConstLoad error value;
-        %22 = <ballerina/lang.value:0.0.0:Cloneable> %23;
+        %22 = ConstLoad error value;
         %20 = NewMap %19;
-        %24 = cloneReadOnly(%20) -> bb8;
+        %23 = cloneReadOnly(%20) -> bb8;
     }
     bb8 {
-        %14 = error error(%16, %12, %24);
+        %14 = error error(%16, %12, %23);
         GOTO bb9;
     }
     bb9 {
         unlock -> bb10;
     }
     bb10 {
-        %25 = %14;
+        %24 = %14;
         lockWithinLockInt = ConstLoad 100;
         lockWithinLockString = ConstLoad Error caught;
         %18 = ConstLoad 0;
@@ -102,8 +100,8 @@ failLockWithinLock function() -> (int, string) {
         panic %12;
     }
     bb19 {
-        %41 = ConstLoad 2;
-        %0 = newArray (int, string)[%41];
+        %40 = ConstLoad 2;
+        %0 = newArray (int, string)[%40];
         GOTO bb20;
     }
     bb20 {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bir/bir-dump/failWithinOnFail
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bir/bir-dump/failWithinOnFail
@@ -11,9 +11,8 @@ failWithinOnFail function() -> string|error {
     %19(TEMP) typeDesc<any|error>;
     %20(TEMP) map<ballerina/lang.value:0.0.0:Cloneable>;
     %21(TEMP) string;
-    %22(TEMP) ballerina/lang.value:0.0.0:Cloneable;
-    %23(TEMP) string;
-    %24(TEMP) map<ballerina/lang.value:0.0.0:Cloneable>;
+    %22(TEMP) string;
+    %23(TEMP) map<ballerina/lang.value:0.0.0:Cloneable>;
 
     bb0 {
         %1 = ConstLoad 0;
@@ -35,21 +34,20 @@ failWithinOnFail function() -> string|error {
         %17 = <error> %18;
         %19 = newType map<ballerina/lang.value:0.0.0:Cloneable>;
         %21 = ConstLoad message;
-        %23 = ConstLoad error value;
-        %22 = <ballerina/lang.value:0.0.0:Cloneable> %23;
+        %22 = ConstLoad error value;
         %20 = NewMap %19;
-        %24 = cloneReadOnly(%20) -> bb3;
+        %23 = cloneReadOnly(%20) -> bb3;
     }
     bb3 {
-        %14 = error error(%9, %17, %24);
-        %23 = ConstLoad -> Error caught in inner on fail;
-        %3 = %3 + %23;
+        %14 = error error(%9, %17, %23);
+        %21 = ConstLoad -> Error caught in inner on fail;
+        %3 = %3 + %21;
         %0 = %14;
         GOTO bb6;
     }
     bb4 {
-        %21 = ConstLoad -> After do statement;
-        %3 = %3 + %21;
+        %22 = ConstLoad -> After do statement;
+        %3 = %3 + %22;
         GOTO bb1;
     }
     bb5 {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/errorconstructorexpr/error-constructor-expr-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/errorconstructorexpr/error-constructor-expr-negative.bal
@@ -65,3 +65,26 @@ error uc3 = error ErrorU3("Hello");
 
 int|string uc4 = error ErrorA("msg");
 int|string b = error("err");
+
+// Test cases for issue fix: https://github.com/ballerina-platform/ballerina-lang/issues/36356
+type ErrorData record {
+    string errorCode;
+    Application application;
+};
+
+type Application record{|
+        string id;
+        User user;
+|};
+
+type User record {|
+    string name;
+|};
+
+type ErrorR error<ErrorData>;
+
+function dummyTest() {
+    ErrorR er1 = error ErrorR("Custom error", errorCode = "104", application = {});
+    ErrorR er2 = error ErrorR("Custom error", errorCode = "104", application = {id : "1", user: {}});
+    ErrorR er3 = error ErrorR("Custom error", errorCode = "104", application = );
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/errorconstructorexpr/error-constructor-expr-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/errorconstructorexpr/error-constructor-expr-negative.bal
@@ -83,7 +83,7 @@ type User record {|
 
 type ErrorR error<ErrorData>;
 
-function dummyTest() {
+function customError() {
     ErrorR er1 = error ErrorR("Custom error", errorCode = "104", application = {});
     ErrorR er2 = error ErrorR("Custom error", errorCode = "104", application = {id : "1", user: {}});
     ErrorR er3 = error ErrorR("Custom error", errorCode = "104", application = );

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/errorconstructorexpr/error-constructor-expr-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/errorconstructorexpr/error-constructor-expr-negative.bal
@@ -66,7 +66,6 @@ error uc3 = error ErrorU3("Hello");
 int|string uc4 = error ErrorA("msg");
 int|string b = error("err");
 
-// Test cases for issue fix: https://github.com/ballerina-platform/ballerina-lang/issues/36356
 type ErrorData record {
     string errorCode;
     Application application;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/errorconstructorexpr/error-constructor-expr-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/errorconstructorexpr/error-constructor-expr-negative.bal
@@ -66,9 +66,14 @@ error uc3 = error ErrorU3("Hello");
 int|string uc4 = error ErrorA("msg");
 int|string b = error("err");
 
-type ErrorData record {
+type ErrorData1 record {
     string errorCode;
     Application application;
+};
+
+type ErrorData2 record {
+    string errorCode;
+    Application[] application;
 };
 
 type Application record{|
@@ -80,10 +85,12 @@ type User record {|
     string name;
 |};
 
-type ErrorR error<ErrorData>;
+type ErrorR1 error<ErrorData1>;
+type ErrorR2 error<ErrorData2>;
 
 function customError() {
-    ErrorR er1 = error ErrorR("Custom error", errorCode = "104", application = {});
-    ErrorR er2 = error ErrorR("Custom error", errorCode = "104", application = {id : "1", user: {}});
-    ErrorR er3 = error ErrorR("Custom error", errorCode = "104", application = );
+    ErrorR1 er1 = error ErrorR1("Custom error", errorCode = "104", application = {});
+    ErrorR1 er2 = error ErrorR1("Custom error", errorCode = "104", application = {id : "1", user: {}});
+    ErrorR1 er3 = error ErrorR1("Custom error", errorCode = "104", application = );
+    ErrorR2 er4 = error ErrorR2("Custom error", errorCode = "104", application = [{}]);
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/errorconstructorexpr/error-constructor-expr-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/errorconstructorexpr/error-constructor-expr-negative.bal
@@ -85,12 +85,16 @@ type User record {|
     string name;
 |};
 
+type StringType string|int;
+
 type ErrorR1 error<ErrorData1>;
 type ErrorR2 error<ErrorData2>;
+type ErrorR3 error<map<StringType>>;
 
 function customError() {
     ErrorR1 er1 = error ErrorR1("Custom error", errorCode = "104", application = {});
     ErrorR1 er2 = error ErrorR1("Custom error", errorCode = "104", application = {id : "1", user: {}});
     ErrorR1 er3 = error ErrorR1("Custom error", errorCode = "104", application = );
     ErrorR2 er4 = error ErrorR2("Custom error", errorCode = "104", application = [{}]);
+    ErrorR3 er5 = error ErrorR3("Custom error", errorCode = "104", application = {});
 }


### PR DESCRIPTION
## Purpose
Fixes #36356 

## Approach
> In the `checkProvidedErrorDetails` function in the `TypeChecker.java`, the `namedArgsExpression` should passed to `checkExpr(namedArgsExpression, target, data)` instead of `checkExpr(namedArgsExpression, data)` for record data type. To do that, introduced `if (Types.getReferredType(target).tag == TypeTags.RECORD)` to redirect to correct path for record data type. 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
