### PR TITLE
Fix CCE when using a foreach statement with xml<T> when T is not a BXMLType

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -1543,32 +1543,27 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
         BType constraintType = Types.getReferredType(type);
         int constrainedTag = constraintType.tag;
 
+        if (constrainedTag == TypeTags.INTERSECTION) {
+            constraintType = ((BIntersectionType) constraintType).getEffectiveType();
+            constrainedTag = constraintType.tag;
+        }
+
         if (constrainedTag == TypeTags.UNION) {
             checkUnionTypeForXMLSubTypes((BUnionType) constraintType, pos);
             return;
         }
 
-        if (constrainedTag == TypeTags.INTERSECTION) {
-            checkIntersectionTypeForXMLSubTypes((BIntersectionType) constraintType, pos);
-            return;
-        }
-
         if (!TypeTags.isXMLTypeTag(constrainedTag) && constrainedTag != TypeTags.NEVER) {
-            dlog.error(pos, DiagnosticErrorCode.INCOMPATIBLE_TYPE_CONSTRAINT, symTable.xmlType, constraintType);
-        }
-    }
-
-    private void checkIntersectionTypeForXMLSubTypes(BIntersectionType constraintIntersectionType, Location pos) {
-        BType effectiveType = Types.getReferredType(constraintIntersectionType.getEffectiveType());
-        if (!TypeTags.isXMLTypeTag(effectiveType.tag)) {
-            dlog.error(pos, DiagnosticErrorCode.INCOMPATIBLE_TYPE_CONSTRAINT, symTable.xmlType,
-                    constraintIntersectionType);
+            dlog.error(pos, DiagnosticErrorCode.INCOMPATIBLE_TYPE_CONSTRAINT, symTable.xmlType, type);
         }
     }
 
     private void checkUnionTypeForXMLSubTypes(BUnionType constraintUnionType, Location pos) {
         for (BType memberType : constraintUnionType.getMemberTypes()) {
             memberType = Types.getReferredType(memberType);
+            if (memberType.tag == TypeTags.INTERSECTION) {
+                memberType = ((BIntersectionType) memberType).getEffectiveType();
+            }
             if (memberType.tag == TypeTags.UNION) {
                 checkUnionTypeForXMLSubTypes((BUnionType) memberType, pos);
             }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -1548,8 +1548,21 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
             return;
         }
 
+        if (constrainedTag == TypeTags.INTERSECTION) {
+            checkIntersectionTypeForXMLSubTypes((BIntersectionType) constraintType, pos);
+            return;
+        }
+
         if (!TypeTags.isXMLTypeTag(constrainedTag) && constrainedTag != TypeTags.NEVER) {
             dlog.error(pos, DiagnosticErrorCode.INCOMPATIBLE_TYPE_CONSTRAINT, symTable.xmlType, constraintType);
+        }
+    }
+
+    private void checkIntersectionTypeForXMLSubTypes(BIntersectionType constraintIntersectionType, Location pos) {
+        BType effectiveType = Types.getReferredType(constraintIntersectionType.getEffectiveType());
+        if (!TypeTags.isXMLTypeTag(effectiveType.tag)) {
+            dlog.error(pos, DiagnosticErrorCode.INCOMPATIBLE_TYPE_CONSTRAINT, symTable.xmlType,
+                    constraintIntersectionType);
         }
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -1765,7 +1765,6 @@ public class Types {
                                         collectionTypesInSymTable.add(symTable.xmlPIType);
                                         break;
                                 }
-                                
                             }
                             varType = BUnionType.create(null, collectionTypesInSymTable);
                         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -1739,14 +1739,10 @@ public class Types {
                     case TypeTags.NEVER:
                         varType = symTable.neverType;
                         break;
-                    case TypeTags.ARRAY:
-                        BArrayType xmlItemArrayType = (BArrayType) constraint;
-                        varType = xmlItemArrayType.eType;
-                        break;
                     case TypeTags.INTERSECTION:
                         varType = getReferredType(((BIntersectionType) constraint).getEffectiveType());
                         break;
-                    default:
+                    case TypeTags.UNION:
                         Set<BType> collectionTypes = getEffectiveMemberTypes((BUnionType) constraint);
                         Set<BType> builtinXMLConstraintTypes = getEffectiveMemberTypes
                                 ((BUnionType) ((BXMLType) symTable.xmlType).constraint);
@@ -1769,10 +1765,16 @@ public class Types {
                                         collectionTypesInSymTable.add(symTable.xmlPIType);
                                         break;
                                 }
-
+                                
                             }
                             varType = BUnionType.create(null, collectionTypesInSymTable);
                         }
+                        break;
+                    default:
+                        foreachNode.varType = symTable.semanticError;
+                        foreachNode.resultType = symTable.semanticError;
+                        foreachNode.nillableResultType = symTable.semanticError;
+                        return;
                 }
                 break;
             case TypeTags.XML_TEXT:

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -1739,6 +1739,13 @@ public class Types {
                     case TypeTags.NEVER:
                         varType = symTable.neverType;
                         break;
+                    case TypeTags.ARRAY:
+                        BArrayType xmlItemArrayType = (BArrayType) constraint;
+                        varType = xmlItemArrayType.eType;
+                        break;
+                    case TypeTags.INTERSECTION:
+                        varType = getReferredType(((BIntersectionType) constraint).getEffectiveType());
+                        break;
                     default:
                         Set<BType> collectionTypes = getEffectiveMemberTypes((BUnionType) constraint);
                         Set<BType> builtinXMLConstraintTypes = getEffectiveMemberTypes

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLIterationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLIterationTest.java
@@ -117,6 +117,9 @@ public class XMLIterationTest {
         BAssertUtil.validateError(negative, index++,
                 "incompatible types: 'xml' cannot be constrained with '(xml:Element[] & readonly)'",
                 85, 5);
+        BAssertUtil.validateError(negative, index++,
+                "incompatible types: 'xml' cannot be constrained with '[int,string]'",
+                93, 5);
     }
 
     @Test
@@ -147,7 +150,9 @@ public class XMLIterationTest {
             "xmlTypeParamElementIter",
             "xmlTypeParamPIIter",
             "testSequenceOfSequenceOfXmlElementIteration",
-            "testSequenceOfSequenceOfReadonlyXmlElementIteration"
+            "testSequenceOfSequenceOfReadonlyXmlElementIteration",
+            "testSequenceOfXmlReadonlyUnionIteration",
+            "testSequenceOfXmlReadonlyUnionIteration2"
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLIterationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLIterationTest.java
@@ -151,8 +151,8 @@ public class XMLIterationTest {
             "xmlTypeParamPIIter",
             "testSequenceOfSequenceOfXmlElementIteration",
             "testSequenceOfSequenceOfReadonlyXmlElementIteration",
-            "testSequenceOfXmlReadonlyUnionIteration",
-            "testSequenceOfXmlReadonlyUnionIteration2"
+            "testSequenceOfReadOnlyXmlSubTypeUnionIteration",
+            "testSequenceOfReadOnlyXmlSubTypeUnionIteration2"
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLIterationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLIterationTest.java
@@ -111,6 +111,12 @@ public class XMLIterationTest {
         BAssertUtil.validateError(negative, index++,
                 "xml langlib functions does not support union types as their arguments",
                 73, 68);
+        BAssertUtil.validateError(negative, index++,
+                "incompatible types: 'xml' cannot be constrained with 'xml:Element[]'",
+                77, 5);
+        BAssertUtil.validateError(negative, index++,
+                "incompatible types: 'xml' cannot be constrained with '(xml:Element[] & readonly)'",
+                85, 5);
     }
 
     @Test
@@ -140,7 +146,9 @@ public class XMLIterationTest {
             "xmlTypeParamCommentIter",
             "xmlTypeParamElementIter",
             "xmlTypeParamPIIter",
-            "testSequenceOfSequenceOfXmlElementIteration"
+            "testSequenceOfSequenceOfXmlElementIteration",
+            "testSequenceOfSequenceOfReadonlyXmlElementIteration",
+            "testSequenceOfSequenceOfReadonlyXmlElementIteration2"
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLIterationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLIterationTest.java
@@ -147,8 +147,7 @@ public class XMLIterationTest {
             "xmlTypeParamElementIter",
             "xmlTypeParamPIIter",
             "testSequenceOfSequenceOfXmlElementIteration",
-            "testSequenceOfSequenceOfReadonlyXmlElementIteration",
-            "testSequenceOfSequenceOfReadonlyXmlElementIteration2"
+            "testSequenceOfSequenceOfReadonlyXmlElementIteration"
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml_iteration.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml_iteration.bal
@@ -324,6 +324,24 @@ function testSequenceOfSequenceOfReadonlyXmlElementIteration() {
     validateValues(arr);
 }
 
+function testSequenceOfXmlReadonlyUnionIteration() {
+    xml<(xml:Element|xml:Comment) & readonly> elements = xml `<foo/><bar>value</bar><baz>1</baz>`;
+    xml:Element[] arr = [];
+    foreach (xml:Element|xml:Comment) & readonly e1 in elements {
+        arr.push(<xml:Element> e1);
+    }
+    validateValues(arr);
+}
+
+function testSequenceOfXmlReadonlyUnionIteration2() {
+    xml<(xml:Element & readonly | xml:Comment & readonly)> elements = xml `<foo/><bar>value</bar><baz>1</baz>`;
+    xml:Element[] arr = [];
+    foreach var e1 in elements {
+        arr.push(<xml:Element> e1);
+    }
+    validateValues(arr);
+}
+
 function validateValues(xml:Element[] arr) {
     assert(arr.length(), 3);
     assert(arr[0], xml `<foo/>`);

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml_iteration.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml_iteration.bal
@@ -316,23 +316,7 @@ function testSequenceOfSequenceOfReadonlyXmlElementIteration() {
     }
     validateValues(arr);
 
-    xml<xml<XmlElement>> elements2 = xml `<foo/><bar>value</bar><baz>1</baz>`;
-    arr = [];
-    foreach var e2 in elements2 {
-        arr.push(e2);
-    }
-    validateValues(arr);
-}
-
-function testSequenceOfSequenceOfReadonlyXmlElementIteration2() {
-    xml<xml:Element & readonly> elements = xml `<foo/><bar>value</bar><baz>1</baz>`;
-    xml:Element[] arr = [];
-    foreach var e1 in elements {
-        arr.push(e1);
-    }
-    validateValues(arr);
-
-    xml<xml<XmlElement>> elements2 = xml `<foo/><bar>value</bar><baz>1</baz>`;
+    xml<xml:Element & readonly> elements2 = xml `<foo/><bar>value</bar><baz>1</baz>`;
     arr = [];
     foreach var e2 in elements2 {
         arr.push(e2);

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml_iteration.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml_iteration.bal
@@ -308,6 +308,38 @@ function testSequenceOfSequenceOfXmlElementIteration() {
     validateValues(arr);
 }
 
+function testSequenceOfSequenceOfReadonlyXmlElementIteration() {
+    xml<xml<xml:Element & readonly>> elements = xml `<foo/><bar>value</bar><baz>1</baz>`;
+    xml:Element[] arr = [];
+    foreach var e1 in elements {
+        arr.push(e1);
+    }
+    validateValues(arr);
+
+    xml<xml<XmlElement>> elements2 = xml `<foo/><bar>value</bar><baz>1</baz>`;
+    arr = [];
+    foreach var e2 in elements2 {
+        arr.push(e2);
+    }
+    validateValues(arr);
+}
+
+function testSequenceOfSequenceOfReadonlyXmlElementIteration2() {
+    xml<xml:Element & readonly> elements = xml `<foo/><bar>value</bar><baz>1</baz>`;
+    xml:Element[] arr = [];
+    foreach var e1 in elements {
+        arr.push(e1);
+    }
+    validateValues(arr);
+
+    xml<xml<XmlElement>> elements2 = xml `<foo/><bar>value</bar><baz>1</baz>`;
+    arr = [];
+    foreach var e2 in elements2 {
+        arr.push(e2);
+    }
+    validateValues(arr);
+}
+
 function validateValues(xml:Element[] arr) {
     assert(arr.length(), 3);
     assert(arr[0], xml `<foo/>`);

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml_iteration.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml_iteration.bal
@@ -324,7 +324,7 @@ function testSequenceOfSequenceOfReadonlyXmlElementIteration() {
     validateValues(arr);
 }
 
-function testSequenceOfXmlReadonlyUnionIteration() {
+function testSequenceOfReadOnlyXmlSubTypeUnionIteration() {
     xml<(xml:Element|xml:Comment) & readonly> elements = xml `<foo/><bar>value</bar><baz>1</baz>`;
     xml:Element[] arr = [];
     foreach (xml:Element|xml:Comment) & readonly e1 in elements {
@@ -333,8 +333,8 @@ function testSequenceOfXmlReadonlyUnionIteration() {
     validateValues(arr);
 }
 
-function testSequenceOfXmlReadonlyUnionIteration2() {
-    xml<(xml:Element & readonly | xml:Comment & readonly)> elements = xml `<foo/><bar>value</bar><baz>1</baz>`;
+function testSequenceOfReadOnlyXmlSubTypeUnionIteration2() {
+    xml<(xml:Element & readonly|xml:Comment & readonly)> elements = xml `<foo/><bar>value</bar><baz>1</baz>`;
     xml:Element[] arr = [];
     foreach var e1 in elements {
         arr.push(<xml:Element> e1);

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml_iteration_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml_iteration_negative.bal
@@ -88,3 +88,11 @@ function xmlElementArrayIntersectionWithReadonlyTypeIter() {
         concatString(element.toString());
     }
 }
+
+public function xmlTupleTypeIter() {
+    xml<[int, string]> elements = xml ``;
+
+    foreach var element in elements {
+        concatString(element.toString());
+    }
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml_iteration_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml_iteration_negative.bal
@@ -72,3 +72,19 @@ function xmlTypeParamUnionIter() {
     record {| 'xml:Element|'xml:Text value; |}? nextUnionXMLVal2 = el2.iterator().next();
     record {| 'xml:Element|'xml:Text value; |}? nextUnionXMLVal3 = el3.iterator().next();
 }
+
+function xmlElementTypeArrayIter() {
+    xml<xml:Element[]> elements = xml ``;
+
+    foreach var element in elements {
+        concatString(element.toString());
+    }
+}
+
+function xmlElementArrayIntersectionWithReadonlyTypeIter() {
+    xml<xml:Element[] & readonly> elements = xml ``;
+
+    foreach var element in elements {
+        concatString(element.toString());
+    }
+}


### PR DESCRIPTION
## Purpose
> Fix Class cast exception when using a foreach statement with xml<T> when T is not a BXMLType

Fixes #35473, #36550

## Approach
> Add separate conditions for intersections and arrays inside a xml tag.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
