### PR TITLE
Add `isEmpty()` check for `invalidNodeInfoStack` in parser

### DIFF
--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/AbstractParser.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/AbstractParser.java
@@ -129,6 +129,10 @@ public abstract class AbstractParser {
         this.insertedToken = null;
     }
 
+    protected boolean isInvalidNodeStackEmpty() {
+        return this.invalidNodeInfoStack.isEmpty();
+    }
+
     protected void startContext(ParserRuleContext context) {
         this.errorHandler.startContext(context);
     }

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/BallerinaParser.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/BallerinaParser.java
@@ -6915,7 +6915,7 @@ public class BallerinaParser extends AbstractParser {
         STToken nextToken = peek();
         switch (nextToken.kind) {
             case IDENTIFIER_TOKEN:
-                if (isFirstSegment && nextToken.isMissing() && peek(0).kind == SyntaxKind.IDENTIFIER_TOKEN &&
+                if (isFirstSegment && nextToken.isMissing() && isInvalidNodeStackEmpty() &&
                         getNextNextToken().kind == SyntaxKind.SLASH_TOKEN) {
                     // special case `[MISSING]/` to improve the error message for `/hello`
                     removeInsertedToken(); // to ignore current missing identifier diagnostic


### PR DESCRIPTION
## Purpose
$title

Related to https://github.com/ballerina-platform/ballerina-lang/pull/36586#discussion_r901238377

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
