### PR TITLE
Fix getting wrong symbol via SymbolFinder

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
@@ -22,6 +22,7 @@ import io.ballerina.tools.diagnostics.Location;
 import io.ballerina.tools.text.LinePosition;
 import org.ballerinalang.model.clauses.OrderKeyNode;
 import org.ballerinalang.model.elements.Flag;
+import org.ballerinalang.model.symbols.SymbolOrigin;
 import org.ballerinalang.model.tree.AnnotatableNode;
 import org.ballerinalang.model.tree.AnnotationAttachmentNode;
 import org.ballerinalang.model.tree.DocumentableNode;
@@ -374,7 +375,8 @@ class SymbolFinder extends BaseVisitor {
     @Override
     public void visit(BLangAnnotationAttachment annAttachmentNode) {
         if (annAttachmentNode.annotationSymbol != null
-                && setEnclosingNode(annAttachmentNode.annotationSymbol.owner, annAttachmentNode.pkgAlias.pos)) {
+                && (setEnclosingNode(annAttachmentNode.annotationSymbol.owner, annAttachmentNode.pkgAlias.pos) ||
+                        annAttachmentNode.annotationSymbol.getOrigin().equals(SymbolOrigin.BUILTIN))) {
             return;
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/AnnotationDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/AnnotationDesugar.java
@@ -24,6 +24,7 @@ import org.ballerinalang.model.elements.AttachPoint;
 import org.ballerinalang.model.elements.Flag;
 import org.ballerinalang.model.elements.PackageID;
 import org.ballerinalang.model.symbols.SymbolKind;
+import org.ballerinalang.model.symbols.SymbolOrigin;
 import org.ballerinalang.model.tree.AnnotatableNode;
 import org.ballerinalang.model.tree.AnnotationAttachmentNode;
 import org.ballerinalang.model.tree.BlockNode;
@@ -302,6 +303,7 @@ public class AnnotationDesugar {
         final SymbolEnv pkgEnv = symTable.pkgEnvMap.get(serviceClass.symbol.getEnclosingSymbol());
         BSymbol annSymbol = symResolver.lookupSymbolInAnnotationSpace(symTable.pkgEnvMap.get(symTable.rootPkgSymbol),
                 names.fromString(SERVICE_INTROSPECTION_INFO_ANN));
+        annSymbol.origin = SymbolOrigin.BUILTIN;
         if (annSymbol instanceof BAnnotationSymbol) {
             annoAttachment.annotationSymbol = (BAnnotationSymbol) annSymbol;
         }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolBIRTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolBIRTest.java
@@ -19,12 +19,14 @@ package io.ballerina.semantic.api.test;
 
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.impl.symbols.BallerinaModule;
+import io.ballerina.compiler.api.symbols.AnnotationSymbol;
 import io.ballerina.compiler.api.symbols.ClassFieldSymbol;
 import io.ballerina.compiler.api.symbols.ClassSymbol;
 import io.ballerina.compiler.api.symbols.ModuleSymbol;
 import io.ballerina.compiler.api.symbols.ObjectTypeSymbol;
 import io.ballerina.compiler.api.symbols.RecordFieldSymbol;
 import io.ballerina.compiler.api.symbols.RecordTypeSymbol;
+import io.ballerina.compiler.api.symbols.ServiceDeclarationSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeDefinitionSymbol;
@@ -56,6 +58,7 @@ import static io.ballerina.compiler.api.symbols.SymbolKind.ANNOTATION;
 import static io.ballerina.compiler.api.symbols.SymbolKind.CONSTANT;
 import static io.ballerina.compiler.api.symbols.SymbolKind.FUNCTION;
 import static io.ballerina.compiler.api.symbols.SymbolKind.MODULE;
+import static io.ballerina.compiler.api.symbols.SymbolKind.SERVICE_DECLARATION;
 import static io.ballerina.compiler.api.symbols.SymbolKind.TYPE_DEFINITION;
 import static io.ballerina.compiler.api.symbols.SymbolKind.VARIABLE;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.INT;
@@ -151,7 +154,7 @@ public class SymbolBIRTest {
         
         SemanticAPITestUtils.assertList(fooModule.typeDefinitions(), List.of("HumanObj", "ApplicationResponseError", 
                 "Person", "BasicType", "Digit", "FileNotFoundError", "EofError", "Error", "Pet", "Student", "Cat", 
-                "Annot", "Detail"));
+                "Annot", "Detail", "Service"));
         
         SemanticAPITestUtils.assertList(fooModule.classes(), List.of("PersonObj", "Dog", "EmployeeObj", "Human"));
         SemanticAPITestUtils.assertList(fooModule.enums(), List.of("Colour"));
@@ -232,6 +235,28 @@ public class SymbolBIRTest {
                 {37, 24, "walkFunction", SymbolKind.METHOD},
                 {38, 17, "age", SymbolKind.OBJECT_FIELD},
         };
+    }
+
+    @Test
+    public void testServiceDecl() {
+        Optional<Symbol> optionalSymbol = model.symbol(srcFile, from(46, 0));
+        assertTrue(optionalSymbol.isPresent());
+        assertEquals(optionalSymbol.get().kind(), SERVICE_DECLARATION);
+        ServiceDeclarationSymbol symbol = (ServiceDeclarationSymbol) optionalSymbol.get();
+
+        // Annotations
+        assertEquals(symbol.annotations().size(), 1);
+        AnnotationSymbol annotationSymbol = symbol.annotations().get(0);
+        assertEquals(annotationSymbol.getName().get(), "ServiceAnnot");
+        assertTrue(annotationSymbol.typeDescriptor().isPresent());
+        assertEquals(annotationSymbol.typeDescriptor().get().typeKind(), TYPE_REFERENCE);
+        TypeReferenceTypeSymbol typeRefSymbol = (TypeReferenceTypeSymbol) annotationSymbol.typeDescriptor().get();
+        assertEquals(typeRefSymbol.typeDescriptor().typeKind(), RECORD);
+        assertTrue(((RecordTypeSymbol) typeRefSymbol.typeDescriptor()).fieldDescriptors().containsKey("serviceName"));
+
+        // Fields and methods
+        assertTrue(symbol.fieldDescriptors().containsKey("count"));
+        assertTrue(symbol.methods().isEmpty());
     }
 
     // util methods

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol_at_cursor_import_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol_at_cursor_import_test.bal
@@ -38,3 +38,30 @@ function testMethodsInAbstractObject() {
     int walkResult = ho.walkFunction();
     int age = ho.age;
 }
+
+listener HTTPListener ep = new ();
+
+@testproject:ServiceAnnot {
+    serviceName: "hello-service"
+}
+service Service "hello" on ep {
+    int count = 0;
+}
+
+public class HTTPListener {
+
+    public function attach(Service svc, string[]|string? name = ()) returns error? {
+    }
+
+    public isolated function detach(Service svc) returns error? {
+    }
+
+    public function 'start() returns error? {
+    }
+
+    public isolated function gracefulStop() returns error? {
+    }
+
+    public isolated function immediateStop() returns error? {
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/testproject/annotations.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/testproject/annotations.bal
@@ -15,3 +15,10 @@
 // under the License.
 
 public annotation Annot Config on function;
+
+public annotation ServiceAttributes ServiceAnnot on service;
+
+// helpers
+type ServiceAttributes record {|
+    string serviceName;
+|};

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/testproject/type_defs.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/testproject/type_defs.bal
@@ -132,3 +132,6 @@ public function testAnonTypeDefSymbolsIsNotVisible() {
     ApplicationResponseError err = error("",  severity = 1);
     Detail _ = err.detail();
 }
+
+public type Service distinct service object {
+};


### PR DESCRIPTION
## Purpose
Here, with this [code,](https://gist.github.com/xlight05/cee9c186a8cf372032cafb97f1f12f00) we get the wrong symbol (`IntrospectionDocConfig` annotation symbol) when finding the service symbol with a correct cursor position.

Here we differentiate the annotations attached in the desugaring phase using the `origin` attribute

Fixes #36041

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR. 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [x] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
