### PR TITLE
Add Support for Optional Attribute access in an xml:Element

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -81,6 +81,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BTupleType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BTypeIdSet;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BTypedescType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BTypeReferenceType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BUnionType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BXMLSubType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BXMLType;
@@ -8140,6 +8141,9 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
             fieldAccessExpr.originalType = fieldAccessExpr.leafNode || !nillableExprType ? actualType :
                     types.getTypeWithoutNil(actualType);
         } else if (types.isLax(effectiveType)) {
+            if (effectiveType instanceof BTypeReferenceType) {
+                effectiveType = ((BTypeReferenceType) effectiveType).referredType;
+            }
             BType laxFieldAccessType = getLaxFieldAccessType(effectiveType);
             actualType = accessCouldResultInError(effectiveType) ?
                     BUnionType.create(null, laxFieldAccessType, symTable.errorType) : laxFieldAccessType;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLAttributeAccessTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLAttributeAccessTest.java
@@ -47,6 +47,12 @@ public class XMLAttributeAccessTest {
     }
 
     @Test
+    public void testBasicOptionalAttributeAccessSyntax() {
+        Object result = BRunUtil.invoke(compileResult, "getOptionalElementAttrBasic");
+        Assert.assertEquals(result.toString(), "attr-val");
+    }
+
+    @Test
     public void testAttributeAccessSyntaxWithNS() {
         Object result = BRunUtil.invoke(compileResult, "getElementAttrWithNSPrefix");
         Assert.assertEquals(result.toString(), "attr-with-ns-val");

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-attribute-access-syntax.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-attribute-access-syntax.bal
@@ -6,6 +6,10 @@ function getElementAttrBasic() returns string|error? {
     return val;
 }
 
+function getOptionalElementAttrBasic() returns string|error? {
+    xml:Element x3 = xml `<elem xmlns="ns-uri" attr="attr-val" xml:space="default"></elem>`;
+    return x3?.attr;
+}
 
 function getAttrOfASequence() returns string|error? {
     xml x = xml `<root attr="attr-val"><a attr="a-attr"></a><b attr="b-attr"></b></root>`;


### PR DESCRIPTION
## Purpose
> Add support for optional attribute access in an xml:Element

Fixes #35190

## Approach
> Add a type cast expression for `BTypeReferenceType` in `getLaxFieldAccessType` method 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
