### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/daily_build.yml
+++ b/.github/workflows/daily_build.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron:  '0 */12 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   ubuntu_build:
     name: Build with tests on Ubuntu

--- a/.github/workflows/daily_spec_conformance_test_runner.yml
+++ b/.github/workflows/daily_spec_conformance_test_runner.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: "0 2 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   conformance_test:
     name: Run conformance test suite on latest Ubuntu

--- a/.github/workflows/language_server_simulator.yml
+++ b/.github/workflows/language_server_simulator.yml
@@ -5,6 +5,9 @@ on:
     - cron:  '0 */12 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   run_simulator:
     name: Run LS Simulator

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -3,6 +3,9 @@ name: Publish release
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   publish-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish_timestamped_release_master.yml
+++ b/.github/workflows/publish_timestamped_release_master.yml
@@ -6,6 +6,9 @@ on:
       - master
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   publish-ballerina-lang:
     name: Build and Publish Ballerina Lang

--- a/.github/workflows/publish_timestamped_release_patch.yml
+++ b/.github/workflows/publish_timestamped_release_patch.yml
@@ -7,6 +7,9 @@ on:
       - 2201.1.x
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   publish-ballerina-lang:
     name: Build and Publish Ballerina Lang

--- a/.github/workflows/pull_request_ubuntu_build.yml
+++ b/.github/workflows/pull_request_ubuntu_build.yml
@@ -11,6 +11,9 @@ on:
       - stage-swan-lake
       - 2201.[0-9]+.x
 
+permissions:
+  contents: read
+
 jobs:
   ubuntu_build:
     name: Build with all tests on Ubuntu

--- a/.github/workflows/stale_check.yml
+++ b/.github/workflows/stale_check.yml
@@ -5,8 +5,14 @@ on:
     - cron: '30 19 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   stale:
+    permissions:
+      issues: write  # for actions/stale to close stale issues
+      pull-requests: write  # for actions/stale to close stale PRs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v3

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron:  '0 0 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   ubuntu_build:
     name: Build on Ubuntu


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>
