### PR TITLE
Expand getSymbol endpoint to support new-expr documentation 

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/symbol/BallerinaSymbolService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/symbol/BallerinaSymbolService.java
@@ -16,6 +16,7 @@
 package org.ballerinalang.langserver.extensions.ballerina.symbol;
 
 import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.ClassSymbol;
 import io.ballerina.compiler.api.symbols.Documentable;
 import io.ballerina.compiler.api.symbols.Documentation;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
@@ -27,11 +28,16 @@ import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
 import io.ballerina.compiler.api.symbols.VariableSymbol;
+import io.ballerina.compiler.syntax.tree.ExpressionNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NonTerminalNode;
 import io.ballerina.projects.Document;
 import io.ballerina.tools.text.LinePosition;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.LSClientLogger;
 import org.ballerinalang.langserver.LSContextOperation;
+import org.ballerinalang.langserver.codeaction.MatchedExpressionNodeResolver;
+import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.common.utils.NameUtil;
 import org.ballerinalang.langserver.common.utils.PathUtil;
 import org.ballerinalang.langserver.commons.DocumentServiceContext;
@@ -40,6 +46,7 @@ import org.ballerinalang.langserver.commons.service.spi.ExtendedLanguageServerSe
 import org.ballerinalang.langserver.commons.workspace.WorkspaceManagerProxy;
 import org.ballerinalang.langserver.contexts.ContextBuilder;
 import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
 import org.eclipse.lsp4j.jsonrpc.services.JsonSegment;
@@ -161,62 +168,19 @@ public class BallerinaSymbolService implements ExtendedLanguageServerService {
                 Optional<? extends Symbol> symbolAtCursor = semanticModel.get().symbol(srcFile.get(), linePosition);
 
                 if (symbolAtCursor.isEmpty()) {
+                    Range nodeRange = new Range(request.getPosition(), request.getPosition());
+                    NonTerminalNode nodeAtCursor = CommonUtil.findNode(nodeRange, srcFile.get().syntaxTree());
+                    if (nodeAtCursor != null) {
+                        MatchedExpressionNodeResolver exprResolver = new MatchedExpressionNodeResolver(nodeAtCursor);
+                        Optional<ExpressionNode> expr = exprResolver.findExpression(nodeAtCursor);
+                        if (expr.isPresent()) {
+                            return getDocMetadataForNewExpression(expr.get(), context, symbolInfoResponse);
+                        }
+                    }
                     return symbolInfoResponse;
                 }
 
-                Optional<Documentation> documentation = symbolAtCursor.get() instanceof Documentable ?
-                        ((Documentable) symbolAtCursor.get()).documentation() : Optional.empty();
-
-                if (documentation.isEmpty()) {
-                    return symbolInfoResponse;
-                }
-
-                List<SymbolDocumentation.ParameterInfo> symbolParams = new ArrayList<>();
-
-                if (symbolAtCursor.get() instanceof FunctionSymbol) {
-                    FunctionSymbol functionSymbol = (FunctionSymbol) symbolAtCursor.get();
-
-                    if (functionSymbol.typeDescriptor().params().isPresent()) {
-                        List<ParameterSymbol> parameterSymbolList = functionSymbol.typeDescriptor().params().get();
-
-                        parameterSymbolList.stream().filter((parameterSymbol) ->
-                                parameterSymbol.getName().isPresent())
-                                .forEach(parameterSymbol -> {
-
-                                    symbolParams.add(new SymbolDocumentation.ParameterInfo(
-                                            parameterSymbol.getName().get(),
-                                            documentation.get().parameterMap().get(parameterSymbol.getName().get()),
-                                            parameterSymbol.paramKind().name(),
-                                            NameUtil.getModifiedTypeName(context, parameterSymbol.typeDescriptor())));
-                                });
-                    }
-
-                    Optional<ParameterSymbol> restParam = functionSymbol.typeDescriptor().restParam();
-                    if (restParam.isPresent() && restParam.get().getName().isPresent()) {
-                        ParameterSymbol restParameter = restParam.get();
-                        symbolParams.add(new SymbolDocumentation.ParameterInfo(
-                                restParameter.getName().get(),
-                                documentation.get().parameterMap().get(restParameter.getName().get()),
-                                restParameter.paramKind().name(),
-                                NameUtil.getModifiedTypeName(context, restParameter.typeDescriptor())
-                        ));
-                    }
-                }
-
-                List<SymbolDocumentation.ParameterInfo> deprecatedParams = new ArrayList<>(
-                        documentation.get().deprecatedParametersMap().size());
-                Map<String, String> deprecatedParamMap = documentation.get().deprecatedParametersMap();
-                deprecatedParamMap.forEach((param, desc) -> {
-                    deprecatedParams.add(new SymbolDocumentation.ParameterInfo(param, desc));
-                });
-
-                SymbolDocumentation symbolDoc = new SymbolDocumentation(documentation.get(), symbolParams,
-                        deprecatedParams);
-
-                symbolInfoResponse.setSymbolDocumentation(symbolDoc);
-                symbolInfoResponse.setSymbolKind(symbolAtCursor.get().kind());
-
-                return symbolInfoResponse;
+                return getSymbolDocMetadata(symbolAtCursor.get(), symbolInfoResponse, context);
 
             } catch (Throwable e) {
                 String msg = "Operation 'ballerinaSymbol/getSymbol' failed!";
@@ -260,6 +224,101 @@ public class BallerinaSymbolService implements ExtendedLanguageServerService {
         }
 
         return allTypes;
+    }
+
+    private SymbolInfoResponse getDocMetadataForNewExpression(Node exprNode, DocumentServiceContext context,
+                                                             SymbolInfoResponse symbolInfoResponse) {
+        switch (exprNode.kind()) {
+            case IMPLICIT_NEW_EXPRESSION:
+            case EXPLICIT_NEW_EXPRESSION:
+                Optional<TypeSymbol> optionalTypeSymbol = context.currentSemanticModel()
+                        .flatMap(semanticModel -> semanticModel.typeOf(exprNode))
+                        .map(CommonUtil::getRawType);
+                if (optionalTypeSymbol.isEmpty()) {
+                    break;
+                }
+
+                TypeSymbol typeSymbol = optionalTypeSymbol.get();
+                if (typeSymbol.typeKind() == TypeDescKind.UNION) {
+                    UnionTypeSymbol unionTypeSymbol = (UnionTypeSymbol) typeSymbol;
+                    Optional<TypeSymbol> classTypeSymbol = unionTypeSymbol.memberTypeDescriptors().stream()
+                            .map(CommonUtil::getRawType)
+                            .filter(member -> member.typeKind() != TypeDescKind.ERROR)
+                            .findFirst();
+                    if (classTypeSymbol.isEmpty()) {
+                        break;
+                    }
+                    typeSymbol = classTypeSymbol.get();
+                }
+
+                if (typeSymbol instanceof ClassSymbol) {
+                    ClassSymbol classSymbol = (ClassSymbol) typeSymbol;
+                    if (classSymbol.initMethod().isEmpty()) {
+                        break;
+                    }
+
+                    MethodSymbol initMethodSymbol = classSymbol.initMethod().get();
+                    return getSymbolDocMetadata(initMethodSymbol, symbolInfoResponse, context);
+                }
+        }
+        return symbolInfoResponse;
+    }
+
+    private SymbolInfoResponse getSymbolDocMetadata(Symbol symbolAtCursor, SymbolInfoResponse symbolInfoResponse,
+                                                   DocumentServiceContext context) {
+        Optional<Documentation> documentation = symbolAtCursor instanceof Documentable ?
+                ((Documentable) symbolAtCursor).documentation() : Optional.empty();
+
+        if (documentation.isEmpty()) {
+            return symbolInfoResponse;
+        }
+
+        List<SymbolDocumentation.ParameterInfo> symbolParams = new ArrayList<>();
+
+        if (symbolAtCursor instanceof FunctionSymbol) {
+            FunctionSymbol functionSymbol = (FunctionSymbol) symbolAtCursor;
+
+            if (functionSymbol.typeDescriptor().params().isPresent()) {
+                List<ParameterSymbol> parameterSymbolList = functionSymbol.typeDescriptor().params().get();
+
+                parameterSymbolList.stream().filter((parameterSymbol) ->
+                        parameterSymbol.getName().isPresent())
+                        .forEach(parameterSymbol -> {
+
+                            symbolParams.add(new SymbolDocumentation.ParameterInfo(
+                                    parameterSymbol.getName().get(),
+                                    documentation.get().parameterMap().get(parameterSymbol.getName().get()),
+                                    parameterSymbol.paramKind().name(),
+                                    NameUtil.getModifiedTypeName(context, parameterSymbol.typeDescriptor())));
+                        });
+            }
+
+            Optional<ParameterSymbol> restParam = functionSymbol.typeDescriptor().restParam();
+            if (restParam.isPresent() && restParam.get().getName().isPresent()) {
+                ParameterSymbol restParameter = restParam.get();
+                symbolParams.add(new SymbolDocumentation.ParameterInfo(
+                        restParameter.getName().get(),
+                        documentation.get().parameterMap().get(restParameter.getName().get()),
+                        restParameter.paramKind().name(),
+                        NameUtil.getModifiedTypeName(context, restParameter.typeDescriptor())
+                ));
+            }
+        }
+
+        List<SymbolDocumentation.ParameterInfo> deprecatedParams = new ArrayList<>(
+                documentation.get().deprecatedParametersMap().size());
+        Map<String, String> deprecatedParamMap = documentation.get().deprecatedParametersMap();
+        deprecatedParamMap.forEach((param, desc) -> {
+            deprecatedParams.add(new SymbolDocumentation.ParameterInfo(param, desc));
+        });
+
+        SymbolDocumentation symbolDoc = new SymbolDocumentation(documentation.get(), symbolParams,
+                deprecatedParams);
+
+        symbolInfoResponse.setSymbolDocumentation(symbolDoc);
+        symbolInfoResponse.setSymbolKind(symbolAtCursor.kind());
+
+        return symbolInfoResponse;
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/symbol/SymbolDocumentationTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/symbol/SymbolDocumentationTest.java
@@ -133,4 +133,46 @@ public class SymbolDocumentationTest {
         Assert.assertEquals(symbolInfoResponse.getSymbolKind(), SymbolKind.FUNCTION);
         TestUtil.closeDocument(this.serviceEndpoint, inputFile);
     }
+
+    @Test(description = "test implicit-new-expression documentation")
+    public void testImplicitNewExprDocumentation() throws IOException {
+        Path inputFile = LSExtensionTestUtil.createTempFile(symbolDocumentBalFile);
+        TestUtil.openDocument(serviceEndpoint, inputFile);
+
+        Position functionPos = new Position();
+        functionPos.setLine(19);
+        functionPos.setCharacter(27);
+        SymbolInfoResponse symbolInfoResponse = LSExtensionTestUtil.getSymbolDocumentation(
+                inputFile.toString(), functionPos, this.serviceEndpoint);
+
+        Assert.assertNotEquals(symbolInfoResponse.getDocumentation(), null);
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getDescription(),
+                "Counter constructor.\n");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getParameters().get(0).getName(), "num");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getParameters().get(0).getDescription(),
+                "Number to increment");
+        Assert.assertEquals(symbolInfoResponse.getSymbolKind(), SymbolKind.METHOD);
+        TestUtil.closeDocument(this.serviceEndpoint, inputFile);
+    }
+
+    @Test(description = "test explicit-new-expression documentation")
+    public void testExplicitNewExprDocumentation() throws IOException {
+        Path inputFile = LSExtensionTestUtil.createTempFile(symbolDocumentBalFile);
+        TestUtil.openDocument(serviceEndpoint, inputFile);
+
+        Position functionPos = new Position();
+        functionPos.setLine(20);
+        functionPos.setCharacter(28);
+        SymbolInfoResponse symbolInfoResponse = LSExtensionTestUtil.getSymbolDocumentation(
+                inputFile.toString(), functionPos, this.serviceEndpoint);
+
+        Assert.assertNotEquals(symbolInfoResponse.getDocumentation(), null);
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getDescription(),
+                "File constructor.\n");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getParameters().get(0).getName(), "path");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getParameters().get(0).getDescription(),
+                "Path of the file");
+        Assert.assertEquals(symbolInfoResponse.getSymbolKind(), SymbolKind.METHOD);
+        TestUtil.closeDocument(this.serviceEndpoint, inputFile);
+    }
 }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/symbol/SymbolDocumentationTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/symbol/SymbolDocumentationTest.java
@@ -175,4 +175,20 @@ public class SymbolDocumentationTest {
         Assert.assertEquals(symbolInfoResponse.getSymbolKind(), SymbolKind.METHOD);
         TestUtil.closeDocument(this.serviceEndpoint, inputFile);
     }
+
+    @Test(description = "test implicit-new-expression documentation without init()")
+    public void testImplicitNewExprDocumentationWithoutInit() throws IOException {
+        Path inputFile = LSExtensionTestUtil.createTempFile(symbolDocumentBalFile);
+        TestUtil.openDocument(serviceEndpoint, inputFile);
+
+        Position functionPos = new Position();
+        functionPos.setLine(21);
+        functionPos.setCharacter(19);
+        SymbolInfoResponse symbolInfoResponse = LSExtensionTestUtil.getSymbolDocumentation(
+                inputFile.toString(), functionPos, this.serviceEndpoint);
+
+        Assert.assertEquals(symbolInfoResponse.getDocumentation(), null);
+        TestUtil.closeDocument(this.serviceEndpoint, inputFile);
+    }
+
 }

--- a/language-server/modules/langserver-core/src/test/resources/extensions/symbol/symbolDocumentation.bal
+++ b/language-server/modules/langserver-core/src/test/resources/extensions/symbol/symbolDocumentation.bal
@@ -17,6 +17,8 @@ public function main() returns error? {
     module1:function3(1,2);
     module1:function1();
     createPerson("test","colombo");
+    Counter counter = new (12);
+    File f = check new File("test.txt", "Hello World");
 }
 
 # Creates and returns a `Person` object given the parameters.
@@ -32,4 +34,32 @@ public function main() returns error? {
 @deprecated
 public function createPerson(string fname, @deprecated string street) returns string {
     return "";
+}
+
+
+public class Counter {
+    private int num;
+
+    # Counter constructor.
+    #
+    # + num - Number to increment
+    public function init(int num) {
+        self.num = num;
+    }
+}
+
+
+class File {
+    string path;
+    string contents;
+
+    # File constructor.
+    #
+    # + path - Path of the file
+    # + contents - Contents of the file
+    function init(string path, string? contents) returns error? {
+        self.path = path;
+        self.contents = check contents.ensureType(string);
+        return;
+    }
 }

--- a/language-server/modules/langserver-core/src/test/resources/extensions/symbol/symbolDocumentation.bal
+++ b/language-server/modules/langserver-core/src/test/resources/extensions/symbol/symbolDocumentation.bal
@@ -19,6 +19,7 @@ public function main() returns error? {
     createPerson("test","colombo");
     Counter counter = new (12);
     File f = check new File("test.txt", "Hello World");
+    Person pr = new;
 }
 
 # Creates and returns a `Person` object given the parameters.
@@ -35,7 +36,6 @@ public function main() returns error? {
 public function createPerson(string fname, @deprecated string street) returns string {
     return "";
 }
-
 
 public class Counter {
     private int num;
@@ -61,5 +61,14 @@ class File {
         self.path = path;
         self.contents = check contents.ensureType(string);
         return;
+    }
+}
+
+class Person {
+    string name = "";
+    int id = 123;
+
+    function getName() returns string {
+        return self.name;
     }
 }


### PR DESCRIPTION
## Purpose
This pr will add the documentation support for new-expr https://ballerina.io/spec/lang/2021R1/#new-expr, in BallerinaSymbolService's getSymbol endpoint

Fixes #
https://github.com/ballerina-platform/ballerina-lang/issues/36656


## Remarks
same pr send to 2201.1.x branch https://github.com/ballerina-platform/ballerina-lang/pull/36657

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
