### PR TITLE
Detect cyclic module dependencies

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/DependencyGraph.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/DependencyGraph.java
@@ -142,7 +142,7 @@ public class DependencyGraph<T> {
     }
 
     public List<T> toTopologicallySortedListWithCycles() {
-        if (topologicallySortedNodes != null && cyclicDependencies != null) {
+        if (cyclicDependencies != null) {
             return topologicallySortedNodes;
         }
 
@@ -183,20 +183,21 @@ public class DependencyGraph<T> {
 
         for (T node : new TreeSet<>(dependencies.get(vertex))) {
             if (ancestors.contains(node)) {
-                List<T> cyclic = new ArrayList<>(ancestors.subList(ancestors.indexOf(node), ancestors.size()));
+                List<T> newCycle = new ArrayList<>(ancestors.subList(ancestors.indexOf(node), ancestors.size()));
 
                 boolean contains = false;
                 for (List<T> cycle: cyclicDependencies) {
-                    if (new HashSet<>(cycle).equals(new HashSet<>(cyclic))) {
+                    if (new HashSet<>(cycle).equals(new HashSet<>(newCycle))) {
                         contains = true;
                         break;
                     }
                 }
                 if (!contains) {
-                    cyclicDependencies.add(cyclic);
+                    cyclicDependencies.add(newCycle);
                 }
+
                 topologicallySortedNodes = null;
-            } else {
+            } else if (!visited.contains(node) || !cyclicDependencies.isEmpty()) {
                 sortTopologicallyWithCycles(node, visited, ancestors);
             }
         }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/DependencyGraph.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/DependencyGraph.java
@@ -63,6 +63,9 @@ public class DependencyGraph<T> {
     }
 
     public Set<List<T>> findCycles() {
+        if (cyclicDependencies == null) {
+            toTopologicallySortedList();
+        }
         return cyclicDependencies;
     }
 
@@ -135,17 +138,6 @@ public class DependencyGraph<T> {
             return topologicallySortedNodes;
         }
 
-        List<T> sorted = new ArrayList<>();
-        sortTopologically(new TreeSet<>(dependencies.keySet()), new HashSet<>(), sorted);
-        topologicallySortedNodes = Collections.unmodifiableList(sorted);
-        return topologicallySortedNodes;
-    }
-
-    public List<T> toTopologicallySortedListWithCycles() {
-        if (topologicallySortedNodes != null) {
-            return topologicallySortedNodes;
-        }
-
         cyclicDependencies = new LinkedHashSet<>();
         List<T> visited = new ArrayList<>();
         List<T> ancestors = new ArrayList<>();
@@ -153,7 +145,7 @@ public class DependencyGraph<T> {
 
         for (T node : new TreeSet<>(dependencies.keySet())) {
             if (!visited.contains(node) && !ancestors.contains(node)) {
-                sortTopologicallyWithCycles(node, visited, ancestors, sorted);
+                sortTopologically(node, visited, ancestors, sorted);
             }
         }
 
@@ -166,17 +158,7 @@ public class DependencyGraph<T> {
         return this == EMPTY_GRAPH;
     }
 
-    private void sortTopologically(Collection<T> nodesToSort, Set<T> visited, List<T> sorted) {
-        for (T node : nodesToSort) {
-            if (!visited.contains(node)) {
-                visited.add(node);
-                sortTopologically(new TreeSet<>(dependencies.get(node)), visited, sorted);
-                sorted.add(node);
-            }
-        }
-    }
-
-    private void sortTopologicallyWithCycles(T vertex, List<T> visited, List<T> ancestors, List<T> sorted) {
+    private void sortTopologically(T vertex, List<T> visited, List<T> ancestors, List<T> sorted) {
         ancestors.add(vertex);
 
         for (T node : new TreeSet<>(dependencies.get(vertex))) {
@@ -199,7 +181,7 @@ public class DependencyGraph<T> {
 
                 topologicallySortedNodes = null;
             } else if (!visited.contains(node) || !cyclicDependencies.isEmpty()) {
-                sortTopologicallyWithCycles(node, visited, ancestors, sorted);
+                sortTopologically(node, visited, ancestors, sorted);
             }
         }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageResolution.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageResolution.java
@@ -396,7 +396,7 @@ public class PackageResolution {
         // Compile the module and collect diagnostics.
         // Repeat this for each module in each package in the package dependency graph.
         List<ModuleContext> sortedModuleList = new ArrayList<>();
-        List<ResolvedPackageDependency> sortedPackages = dependencyGraph.toTopologicallySortedListWithCycles();
+        List<ResolvedPackageDependency> sortedPackages = dependencyGraph.toTopologicallySortedList();
         if (dependencyGraph.findCycles().size() > 0) {
             for (List<ResolvedPackageDependency> cycle: dependencyGraph.findCycles()) {
                 DiagnosticInfo diagnosticInfo = new DiagnosticInfo(
@@ -416,7 +416,7 @@ public class PackageResolution {
             resolvedPackage.packageContext().resolveDependencies(dependencyResolution);
             DependencyGraph<ModuleDescriptor> moduleDependencyGraph = resolvedPackage.moduleDependencyGraph();
             List<ModuleDescriptor> sortedModuleDescriptors
-                    = moduleDependencyGraph.toTopologicallySortedListWithCycles();
+                    = moduleDependencyGraph.toTopologicallySortedList();
             if (moduleDependencyGraph.findCycles().size() > 0) {
                 for (List<ModuleDescriptor> cycle: moduleDependencyGraph.findCycles()) {
                     DiagnosticInfo diagnosticInfo = new DiagnosticInfo(

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageResolution.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageResolution.java
@@ -33,6 +33,7 @@ import io.ballerina.projects.internal.ImportModuleResponse;
 import io.ballerina.projects.internal.ModuleResolver;
 import io.ballerina.projects.internal.PackageContainer;
 import io.ballerina.projects.internal.PackageDiagnostic;
+import io.ballerina.projects.internal.PackageResolutionDiagnostic;
 import io.ballerina.projects.internal.ResolutionEngine;
 import io.ballerina.projects.internal.ResolutionEngine.DependencyNode;
 import io.ballerina.projects.internal.model.BuildJson;
@@ -42,6 +43,7 @@ import io.ballerina.tools.diagnostics.DiagnosticFactory;
 import io.ballerina.tools.diagnostics.DiagnosticInfo;
 import io.ballerina.tools.diagnostics.DiagnosticSeverity;
 import io.ballerina.tools.diagnostics.Location;
+import org.ballerinalang.util.diagnostic.DiagnosticErrorCode;
 import org.wso2.ballerinalang.compiler.util.Names;
 import org.wso2.ballerinalang.util.RepoUtils;
 
@@ -399,10 +401,26 @@ public class PackageResolution {
             Package resolvedPackage = pkgDependency.packageInstance();
             resolvedPackage.packageContext().resolveDependencies(dependencyResolution);
             DependencyGraph<ModuleDescriptor> moduleDependencyGraph = resolvedPackage.moduleDependencyGraph();
-            List<ModuleDescriptor> sortedModuleDescriptors = moduleDependencyGraph.toTopologicallySortedList();
-            for (ModuleDescriptor moduleDescriptor : sortedModuleDescriptors) {
-                ModuleContext moduleContext = resolvedPackage.module(moduleDescriptor.name()).moduleContext();
-                sortedModuleList.add(moduleContext);
+            List<ModuleDescriptor> sortedModuleDescriptors
+                    = moduleDependencyGraph.toTopologicallySortedListWithCycles();
+            if (sortedModuleDescriptors == null) {
+                for (List<ModuleDescriptor> cycle: moduleDependencyGraph.findCycles()) {
+                    DiagnosticInfo diagnosticInfo = new DiagnosticInfo(
+                            DiagnosticErrorCode.CYCLIC_MODULE_IMPORTS_DETECTED.diagnosticId(),
+                            "cyclic module imports detected ''"
+                                    + cycle.stream()
+                                    .map(desc -> desc.name().toString() + ":" + desc.version().toString())
+                                    .collect(Collectors.joining(" -> ")) + "''",
+                            DiagnosticErrorCode.CYCLIC_MODULE_IMPORTS_DETECTED.severity());
+                    PackageResolutionDiagnostic diagnostic = new PackageResolutionDiagnostic(diagnosticInfo,
+                            resolvedPackage.descriptor().toString());
+                    diagnosticList.add(diagnostic);
+                }
+            } else {
+                for (ModuleDescriptor moduleDescriptor : sortedModuleDescriptors) {
+                    ModuleContext moduleContext = resolvedPackage.module(moduleDescriptor.name()).moduleContext();
+                    sortedModuleList.add(moduleContext);
+                }
             }
         }
         this.topologicallySortedModuleList = Collections.unmodifiableList(sortedModuleList);

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/CyclicDependenciesTest.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/CyclicDependenciesTest.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package io.ballerina.projects;
 
 import guru.nidi.graphviz.model.MutableGraph;
@@ -32,7 +50,7 @@ public class CyclicDependenciesTest {
         DependencyGraph<ResolutionEngine.DependencyNode> dependencyGraph =
                 DotGraphUtils.createDependencyNodeGraph(mutableGraph);
         List<ResolutionEngine.DependencyNode> sortedDependencies =
-                dependencyGraph.toTopologicallySortedListWithCycles();
+                dependencyGraph.toTopologicallySortedList();
 
         Assert.assertEquals(dependencyGraph.findCycles().size(), 0);
         Assert.assertNotNull(sortedDependencies);
@@ -44,8 +62,6 @@ public class CyclicDependenciesTest {
         MutableGraph mutableGraph = DotGraphUtils.createGraph(RESOURCE_DIRECTORY.resolve(testCase + ".dot"));
         DependencyGraph<ResolutionEngine.DependencyNode> dependencyGraph =
                 DotGraphUtils.createDependencyNodeGraph(mutableGraph);
-
-        dependencyGraph.toTopologicallySortedListWithCycles();
         Set<List<ResolutionEngine.DependencyNode>> actualCycles = dependencyGraph.findCycles();
 
         Assert.assertNotNull(actualCycles);

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/CyclicDependenciesTest.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/CyclicDependenciesTest.java
@@ -58,7 +58,6 @@ public class CyclicDependenciesTest {
         return new Object[][]{
                 {"case001", List.of(
                         Arrays.asList(PACKAGE_01, PACKAGE_02, PACKAGE_04, PACKAGE_01),
-                        Arrays.asList(PACKAGE_06, PACKAGE_06),
                         Arrays.asList(PACKAGE_01, PACKAGE_04, PACKAGE_01)
                 )},
                 {"case002", List.of(

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/CyclicDependenciesTest.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/CyclicDependenciesTest.java
@@ -26,8 +26,21 @@ public class CyclicDependenciesTest {
     private static final ResolutionEngine.DependencyNode PACKAGE_05 = createNode("wso2", "database", "3.2.2");
     private static final ResolutionEngine.DependencyNode PACKAGE_06 = createNode("wso2", "thread", "1.0.0");
 
-    @Test(dataProvider = "cases")
-    public void test(String testCase, List<List<ResolutionEngine.DependencyNode>> expectedCycles) {
+    @Test
+    public void testAcyclicDependencies() {
+        MutableGraph mutableGraph = DotGraphUtils.createGraph(RESOURCE_DIRECTORY.resolve("case000.dot"));
+        DependencyGraph<ResolutionEngine.DependencyNode> dependencyGraph =
+                DotGraphUtils.createDependencyNodeGraph(mutableGraph);
+        List<ResolutionEngine.DependencyNode> sortedDependencies =
+                dependencyGraph.toTopologicallySortedListWithCycles();
+
+        Assert.assertEquals(dependencyGraph.findCycles().size(), 0);
+        Assert.assertNotNull(sortedDependencies);
+        Assert.assertEquals(sortedDependencies, List.of(PACKAGE_04, PACKAGE_02, PACKAGE_06, PACKAGE_01));
+    }
+
+    @Test(dataProvider = "provideCyclicDependencies")
+    public void testCyclicDependencies(String testCase, List<List<ResolutionEngine.DependencyNode>> expectedCycles) {
         MutableGraph mutableGraph = DotGraphUtils.createGraph(RESOURCE_DIRECTORY.resolve(testCase + ".dot"));
         DependencyGraph<ResolutionEngine.DependencyNode> dependencyGraph =
                 DotGraphUtils.createDependencyNodeGraph(mutableGraph);
@@ -40,8 +53,8 @@ public class CyclicDependenciesTest {
         actualCycles.forEach(cycle -> Assert.assertTrue(expectedCycles.contains(cycle)));
     }
 
-    @DataProvider(name = "cases")
-    private Object[][] cases() {
+    @DataProvider(name = "provideCyclicDependencies")
+    private Object[][] provideCyclicDependencies() {
         return new Object[][]{
                 {"case001", List.of(
                         Arrays.asList(PACKAGE_01, PACKAGE_02, PACKAGE_04, PACKAGE_01),

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/CyclicDependenciesTest.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/CyclicDependenciesTest.java
@@ -1,0 +1,88 @@
+package io.ballerina.projects;
+
+import guru.nidi.graphviz.model.MutableGraph;
+import io.ballerina.projects.internal.ResolutionEngine;
+import io.ballerina.projects.test.resolution.packages.internal.DotGraphUtils;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Contains test cases to validate the detection of cyclic dependencies in {@code DependencyGraph}.
+ */
+public class CyclicDependenciesTest {
+    private static final Path RESOURCE_DIRECTORY = Paths.get("src", "test", "resources", "cyclic-graphs");
+
+    private static final ResolutionEngine.DependencyNode PACKAGE_01 = createNode("nipyf", "js", "1.0.2");
+    private static final ResolutionEngine.DependencyNode PACKAGE_02 = createNode("nipyf", "toml", "1.0.0");
+    private static final ResolutionEngine.DependencyNode PACKAGE_03 = createNode("nipyf", "yaml", "0.1.0");
+    private static final ResolutionEngine.DependencyNode PACKAGE_04 = createNode("wso2", "cache", "2.0.1");
+    private static final ResolutionEngine.DependencyNode PACKAGE_05 = createNode("wso2", "database", "3.2.2");
+    private static final ResolutionEngine.DependencyNode PACKAGE_06 = createNode("wso2", "thread", "1.0.0");
+
+    @Test(dataProvider = "cases")
+    public void test(String testCase, List<List<ResolutionEngine.DependencyNode>> expectedCycles) {
+        MutableGraph mutableGraph = DotGraphUtils.createGraph(RESOURCE_DIRECTORY.resolve(testCase + ".dot"));
+        DependencyGraph<ResolutionEngine.DependencyNode> dependencyGraph =
+                DotGraphUtils.createDependencyNodeGraph(mutableGraph);
+
+        dependencyGraph.toTopologicallySortedListWithCycles();
+        Set<List<ResolutionEngine.DependencyNode>> actualCycles = dependencyGraph.findCycles();
+
+        Assert.assertNotNull(actualCycles);
+        Assert.assertEquals(actualCycles.size(), expectedCycles.size());
+        actualCycles.forEach(cycle -> Assert.assertTrue(expectedCycles.contains(cycle)));
+    }
+
+    @DataProvider(name = "cases")
+    private Object[][] cases() {
+        return new Object[][]{
+                {"case001", List.of(
+                        Arrays.asList(PACKAGE_01, PACKAGE_02, PACKAGE_04, PACKAGE_01),
+                        Arrays.asList(PACKAGE_06, PACKAGE_06),
+                        Arrays.asList(PACKAGE_01, PACKAGE_04, PACKAGE_01)
+                )},
+                {"case002", List.of(
+                        Arrays.asList(PACKAGE_01, PACKAGE_02, PACKAGE_03, PACKAGE_01),
+                        Arrays.asList(PACKAGE_04, PACKAGE_05, PACKAGE_04),
+                        Arrays.asList(PACKAGE_01, PACKAGE_04, PACKAGE_05, PACKAGE_03, PACKAGE_01)
+                )},
+                {"case003", List.of(
+                        Arrays.asList(PACKAGE_04, PACKAGE_02, PACKAGE_04)
+                )},
+                {"case004", List.of(
+                        Arrays.asList(PACKAGE_01, PACKAGE_02, PACKAGE_03, PACKAGE_01),
+                        Arrays.asList(PACKAGE_01, PACKAGE_02, PACKAGE_04, PACKAGE_01),
+                        Arrays.asList(PACKAGE_01, PACKAGE_02, PACKAGE_05, PACKAGE_01),
+                        Arrays.asList(PACKAGE_01, PACKAGE_02, PACKAGE_06, PACKAGE_01)
+                )},
+                {"case005", List.of(
+                        Arrays.asList(PACKAGE_01, PACKAGE_02, PACKAGE_01)
+                )},
+                {"case006", List.of(
+                        Arrays.asList(PACKAGE_01, PACKAGE_02, PACKAGE_04, PACKAGE_01),
+                        Arrays.asList(PACKAGE_02, PACKAGE_04, PACKAGE_03, PACKAGE_02),
+                        Arrays.asList(PACKAGE_01, PACKAGE_03, PACKAGE_02, PACKAGE_04, PACKAGE_01)
+                )},
+                {"case007", List.of(
+                        Arrays.asList(PACKAGE_01, PACKAGE_02, PACKAGE_03, PACKAGE_01),
+                        Arrays.asList(PACKAGE_01, PACKAGE_05, PACKAGE_02, PACKAGE_03, PACKAGE_01),
+                        Arrays.asList(PACKAGE_02, PACKAGE_03, PACKAGE_02),
+                        Arrays.asList(PACKAGE_02, PACKAGE_03, PACKAGE_04, PACKAGE_05, PACKAGE_02),
+                        Arrays.asList(PACKAGE_02, PACKAGE_03, PACKAGE_06, PACKAGE_04, PACKAGE_05, PACKAGE_02)
+                )}
+        };
+    }
+
+    private static ResolutionEngine.DependencyNode createNode(String org, String name, String version) {
+        return new ResolutionEngine.DependencyNode(PackageDescriptor.from(
+                PackageOrg.from(org), PackageName.from(name), PackageVersion.from(version)
+        ));
+    }
+}

--- a/compiler/ballerina-lang/src/test/resources/cyclic-graphs/case000.dot
+++ b/compiler/ballerina-lang/src/test/resources/cyclic-graphs/case000.dot
@@ -1,0 +1,6 @@
+digraph "case001" {
+    "nipyf/js:1.0.2" -> "nipyf/toml:1.0.0"
+    "nipyf/js:1.0.2" -> "wso2/thread:1.0.0"
+    "wso2/thread:1.0.0" -> "nipyf/toml:1.0.0"
+    "nipyf/toml:1.0.0" -> "wso2/cache:2.0.1"
+}

--- a/compiler/ballerina-lang/src/test/resources/cyclic-graphs/case001.dot
+++ b/compiler/ballerina-lang/src/test/resources/cyclic-graphs/case001.dot
@@ -1,0 +1,8 @@
+digraph "case001" {
+    "nipyf/js:1.0.2" -> "nipyf/toml:1.0.0"
+    "nipyf/js:1.0.2" -> "wso2/cache:2.0.1"
+    "nipyf/toml:1.0.0" -> "wso2/cache:2.0.1"
+    "wso2/cache:2.0.1" -> "wso2/thread:1.0.0"
+    "wso2/cache:2.0.1" -> "nipyf/js:1.0.2"
+    "wso2/thread:1.0.0" -> "wso2/thread:1.0.0"
+}

--- a/compiler/ballerina-lang/src/test/resources/cyclic-graphs/case002.dot
+++ b/compiler/ballerina-lang/src/test/resources/cyclic-graphs/case002.dot
@@ -1,0 +1,10 @@
+digraph "case002" {
+    "wso2/thread:1.0.0" -> "nipyf/js:1.0.2"
+    "nipyf/js:1.0.2" -> "wso2/cache:2.0.1"
+    "nipyf/js:1.0.2" -> "nipyf/toml:1.0.0"
+    "wso2/cache:2.0.1" -> "wso2/database:3.2.2"
+    "wso2/database:3.2.2" -> "wso2/cache:2.0.1"
+    "wso2/database:3.2.2" -> "nipyf/yaml:0.1.0"
+    "nipyf/yaml:0.1.0" -> "nipyf/js:1.0.2"
+    "nipyf/toml:1.0.0" -> "nipyf/yaml:0.1.0"
+}

--- a/compiler/ballerina-lang/src/test/resources/cyclic-graphs/case003.dot
+++ b/compiler/ballerina-lang/src/test/resources/cyclic-graphs/case003.dot
@@ -1,0 +1,6 @@
+digraph "case003" {
+    "nipyf/js:1.0.2" -> "wso2/cache:2.0.1"
+    "wso2/cache:2.0.1" -> "nipyf/toml:1.0.0"
+    "nipyf/toml:1.0.0" -> "nipyf/yaml:0.1.0"
+    "nipyf/toml:1.0.0" -> "wso2/cache:2.0.1"
+}

--- a/compiler/ballerina-lang/src/test/resources/cyclic-graphs/case004.dot
+++ b/compiler/ballerina-lang/src/test/resources/cyclic-graphs/case004.dot
@@ -1,0 +1,11 @@
+digraph "case003" {
+    "nipyf/js:1.0.2" -> "nipyf/toml:1.0.0"
+    "nipyf/toml:1.0.0" -> "nipyf/yaml:0.1.0"
+    "nipyf/toml:1.0.0" -> "wso2/cache:2.0.1"
+    "nipyf/toml:1.0.0" -> "wso2/database:3.2.2"
+    "nipyf/toml:1.0.0" -> "wso2/thread:1.0.0"
+    "nipyf/yaml:0.1.0" -> "nipyf/js:1.0.2"
+    "wso2/cache:2.0.1" -> "nipyf/js:1.0.2"
+    "wso2/database:3.2.2" -> "nipyf/js:1.0.2"
+    "wso2/thread:1.0.0" -> "nipyf/js:1.0.2"
+}

--- a/compiler/ballerina-lang/src/test/resources/cyclic-graphs/case005.dot
+++ b/compiler/ballerina-lang/src/test/resources/cyclic-graphs/case005.dot
@@ -1,0 +1,4 @@
+digraph "case005" {
+    "nipyf/js:1.0.2" -> "nipyf/toml:1.0.0"
+    "nipyf/toml:1.0.0" -> "nipyf/js:1.0.2"
+}

--- a/compiler/ballerina-lang/src/test/resources/cyclic-graphs/case006.dot
+++ b/compiler/ballerina-lang/src/test/resources/cyclic-graphs/case006.dot
@@ -1,0 +1,8 @@
+digraph "case006" {
+    "nipyf/js:1.0.2" -> "nipyf/toml:1.0.0"
+    "nipyf/js:1.0.2" -> "nipyf/yaml:0.1.0"
+    "nipyf/toml:1.0.0" -> "wso2/cache:2.0.1"
+    "nipyf/yaml:0.1.0" -> "nipyf/toml:1.0.0"
+    "wso2/cache:2.0.1" -> "nipyf/js:1.0.2"
+    "wso2/cache:2.0.1" -> "nipyf/yaml:0.1.0"
+}

--- a/compiler/ballerina-lang/src/test/resources/cyclic-graphs/case007.dot
+++ b/compiler/ballerina-lang/src/test/resources/cyclic-graphs/case007.dot
@@ -1,0 +1,12 @@
+digraph "case007" {
+    "nipyf/js:1.0.2" -> "nipyf/toml:1.0.0"
+    "nipyf/js:1.0.2" -> "wso2/database:3.2.2"
+    "nipyf/toml:1.0.0" -> "nipyf/yaml:0.1.0"
+    "nipyf/yaml:0.1.0" -> "nipyf/js:1.0.2"
+    "nipyf/yaml:0.1.0" -> "nipyf/toml:1.0.0"
+    "nipyf/yaml:0.1.0" -> "wso2/cache:2.0.1"
+    "nipyf/yaml:0.1.0" -> "wso2/thread:1.0.0"
+    "wso2/cache:2.0.1" -> "wso2/database:3.2.2"
+    "wso2/database:3.2.2" -> "nipyf/toml:1.0.0"
+    "wso2/thread:1.0.0" -> "wso2/cache:2.0.1"
+}

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProject.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProject.java
@@ -1285,7 +1285,7 @@ public class TestBuildProject extends BaseTest {
                 .contains("unknown type 'PersonalDetails'"));
     }
 
-    @Test(enabled = false)
+    @Test
     public void testEditPackageWithCyclicDependency() {
         Path projectPath = RESOURCE_DIRECTORY
                 .resolve("projects_for_edit_api_tests/package_with_cyclic_dependencies");
@@ -1300,7 +1300,7 @@ public class TestBuildProject extends BaseTest {
 
         // 3) Compile the package
         PackageCompilation compilation = currentPackage.getCompilation();
-        Assert.assertEquals(compilation.diagnosticResult().diagnosticCount(), 4);
+        Assert.assertEquals(compilation.diagnosticResult().diagnosticCount(), 5);
 
         // 4) Edit a module that is used by another module
         Module module = currentPackage.module(ModuleName.from(PackageName.from("myproject"), "util"));
@@ -1309,12 +1309,17 @@ public class TestBuildProject extends BaseTest {
 
         PackageCompilation compilation1 = project.currentPackage().getCompilation();
         DiagnosticResult diagnosticResult = compilation1.diagnosticResult();
-        Assert.assertEquals(diagnosticResult.diagnosticCount(), 1);
+        Assert.assertEquals(diagnosticResult.diagnosticCount(), 2);
 
-        Assert.assertEquals(diagnosticResult.diagnostics().stream().findAny().get().location().lineRange().filePath(),
+        Iterator<Diagnostic> diagnosticIterator = diagnosticResult.diagnostics().iterator();
+        Diagnostic firstDiagnostic = diagnosticIterator.next();
+        Assert.assertEquals(firstDiagnostic.message(), "cyclic module imports detected " +
+                "'foo/myproject.schema:0.1.0 -> foo/myproject.storage:0.1.0 -> foo/myproject.schema:0.1.0'");
+
+        Diagnostic secondDiagnostic = diagnosticIterator.next();
+        Assert.assertEquals(secondDiagnostic.location().lineRange().filePath(),
                 Paths.get("modules").resolve("schema").resolve("schema.bal").toString());
-        Assert.assertTrue(diagnosticResult.diagnostics().stream().findAny().get().message()
-                .contains("unknown type 'PersonalDetails'"));
+        Assert.assertTrue(secondDiagnostic.message().contains("unknown type 'PersonalDetails'"));
     }
 
     /**

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProject.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProject.java
@@ -1285,7 +1285,7 @@ public class TestBuildProject extends BaseTest {
                 .contains("unknown type 'PersonalDetails'"));
     }
 
-    @Test
+    @Test(enabled = false)
     public void testEditPackageWithCyclicDependency() {
         Path projectPath = RESOURCE_DIRECTORY
                 .resolve("projects_for_edit_api_tests/package_with_cyclic_dependencies");

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/imports/ImportsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/imports/ImportsTest.java
@@ -41,20 +41,20 @@ public class ImportsTest {
     }
 
     // https://github.com/ballerina-platform/ballerina-lang/issues/27371
-    @Test(description = "Test cyclic imports", enabled = false)
+    @Test(description = "Test cyclic imports")
     public void testCyclicImports() {
         CompileResult result = BCompileUtil.compile("test-src/imports/cyclic-imports");
         assertEquals(result.getErrorCount(), 3);
-        validateError(result, 0, "cyclic module imports detected " +
-                                 "'cyclic_imports/def:1.0.0 -> cyclic_imports/ghi:1.0.0 -> cyclic_imports/def:1.0.0'",
-                2, 1);
+        validateError(result, 0, "cyclic module imports detected 'cyclic_imports.abc:0.1.0 -> " +
+                        "cyclic_imports.def:0.1.0 -> cyclic_imports.ghi:0.1.0 -> cyclic_imports.abc:0.1.0'",
+                1, 1);
         validateError(result, 1, "cyclic module imports detected " +
-                                 "'cyclic_imports/abc:1.0.0 -> cyclic_imports/def:1.0.0 -> " +
-                                 "cyclic_imports/ghi:1.0.0 -> cyclic_imports/jkl:1.0.0 -> cyclic_imports/abc:1.0.0'",
-                2, 1);
-        validateError(result, 2, "cyclic module imports detected 'cyclic_imports/abc:1.0.0 -> " +
-                                 "cyclic_imports/def:1.0.0 -> cyclic_imports/ghi:1.0.0 -> cyclic_imports/abc:1.0.0'",
-                3, 1);
+                        "'cyclic_imports.def:0.1.0 -> cyclic_imports.ghi:0.1.0 -> cyclic_imports.def:0.1.0'",
+                1, 1);
+        validateError(result, 2, "cyclic module imports detected " +
+                                 "'cyclic_imports.abc:0.1.0 -> cyclic_imports.def:0.1.0 -> " +
+                                 "cyclic_imports.ghi:0.1.0 -> cyclic_imports.jkl:0.1.0 -> cyclic_imports.abc:0.1.0'",
+                1, 1);
     }
 
     @Test(description = "Test importing same module name but with different org names")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/imports/ImportsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/imports/ImportsTest.java
@@ -37,14 +37,13 @@ public class ImportsTest {
         CompileResult result = BCompileUtil.compile("test-src/imports/SelfImportTestProject");
         assertEquals(result.getErrorCount(), 1);
         validateError(result, 0, "cyclic module imports detected " +
-                        "'testorg/selfimport.foo:1.0.0 -> testorg/selfimport.foo:1.0.0'", 1, 1);
+                        "'testorg/selfimport.foo:1.0.0 -> testorg/selfimport.foo:1.0.0'", 2, 1);
     }
 
     // https://github.com/ballerina-platform/ballerina-lang/issues/27371
     @Test(description = "Test cyclic module imports")
     public void testCyclicModuleImports() {
         CompileResult result = BCompileUtil.compile("test-src/imports/cyclic-imports");
-        assertEquals(result.getErrorCount(), 3);
         validateError(result, 0, "cyclic module imports detected 'testorg/cyclic_imports.abc:0.1.0 -> " +
                 "testorg/cyclic_imports.def:0.1.0 -> testorg/cyclic_imports.ghi:0.1.0 -> " +
                 "testorg/cyclic_imports.abc:0.1.0'", 1, 1);
@@ -62,7 +61,6 @@ public class ImportsTest {
         BCompileUtil.compileAndCacheBala("test-src/imports/cyclic-packages/package_a");
         CompileResult result = BCompileUtil.compile("test-src/imports/cyclic-packages/package_c_2");
 
-        assertEquals(result.getErrorCount(), 2);
         validateError(result, 0, "cyclic module imports detected 'wso2/a:1.0.0 -> " +
                 "wso2/b:1.9.2 -> wso2/c:0.1.1 -> wso2/a:1.0.0'", 1, 1);
         validateError(result, 1, "cyclic module imports detected 'wso2/b:1.9.2 -> " +

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/imports/ImportsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/imports/ImportsTest.java
@@ -37,24 +37,36 @@ public class ImportsTest {
         CompileResult result = BCompileUtil.compile("test-src/imports/SelfImportTestProject");
         assertEquals(result.getErrorCount(), 1);
         validateError(result, 0, "cyclic module imports detected " +
-                        "'testorg/selfimport.foo:1.0.0 -> testorg/selfimport.foo:1.0.0'", 2, 1);
+                        "'testorg/selfimport.foo:1.0.0 -> testorg/selfimport.foo:1.0.0'", 1, 1);
     }
 
     // https://github.com/ballerina-platform/ballerina-lang/issues/27371
-    @Test(description = "Test cyclic imports")
-    public void testCyclicImports() {
+    @Test(description = "Test cyclic module imports")
+    public void testCyclicModuleImports() {
         CompileResult result = BCompileUtil.compile("test-src/imports/cyclic-imports");
         assertEquals(result.getErrorCount(), 3);
-        validateError(result, 0, "cyclic module imports detected 'cyclic_imports.abc:0.1.0 -> " +
-                        "cyclic_imports.def:0.1.0 -> cyclic_imports.ghi:0.1.0 -> cyclic_imports.abc:0.1.0'",
-                1, 1);
-        validateError(result, 1, "cyclic module imports detected " +
-                        "'cyclic_imports.def:0.1.0 -> cyclic_imports.ghi:0.1.0 -> cyclic_imports.def:0.1.0'",
-                1, 1);
-        validateError(result, 2, "cyclic module imports detected " +
-                                 "'cyclic_imports.abc:0.1.0 -> cyclic_imports.def:0.1.0 -> " +
-                                 "cyclic_imports.ghi:0.1.0 -> cyclic_imports.jkl:0.1.0 -> cyclic_imports.abc:0.1.0'",
-                1, 1);
+        validateError(result, 0, "cyclic module imports detected 'testorg/cyclic_imports.abc:0.1.0 -> " +
+                "testorg/cyclic_imports.def:0.1.0 -> testorg/cyclic_imports.ghi:0.1.0 -> " +
+                "testorg/cyclic_imports.abc:0.1.0'", 1, 1);
+        validateError(result, 1, "cyclic module imports detected 'testorg/cyclic_imports.def:0.1.0 -> " +
+                "testorg/cyclic_imports.ghi:0.1.0 -> testorg/cyclic_imports.def:0.1.0'", 1, 1);
+        validateError(result, 2, "cyclic module imports detected 'testorg/cyclic_imports.abc:0.1.0 -> " +
+                "testorg/cyclic_imports.def:0.1.0 -> testorg/cyclic_imports.ghi:0.1.0 -> " +
+                "testorg/cyclic_imports.jkl:0.1.0 -> testorg/cyclic_imports.abc:0.1.0'", 1, 1);
+    }
+
+    @Test(description = "Test cyclic imports between packages")
+    public void testCyclicPackageImports() {
+        BCompileUtil.compileAndCacheBala("test-src/imports/cyclic-packages/package_c_1");
+        BCompileUtil.compileAndCacheBala("test-src/imports/cyclic-packages/package_b");
+        BCompileUtil.compileAndCacheBala("test-src/imports/cyclic-packages/package_a");
+        CompileResult result = BCompileUtil.compile("test-src/imports/cyclic-packages/package_c_2");
+
+        assertEquals(result.getErrorCount(), 2);
+        validateError(result, 0, "cyclic module imports detected 'wso2/a:1.0.0 -> " +
+                "wso2/b:1.9.2 -> wso2/c:0.1.1 -> wso2/a:1.0.0'", 1, 1);
+        validateError(result, 1, "cyclic module imports detected 'wso2/b:1.9.2 -> " +
+                "wso2/c:0.1.1 -> wso2/b:1.9.2'", 1, 1);
     }
 
     @Test(description = "Test importing same module name but with different org names")

--- a/tests/jballerina-unit-test/src/test/resources/test-src/imports/cyclic-imports/Ballerina.toml
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/imports/cyclic-imports/Ballerina.toml
@@ -1,3 +1,4 @@
-[project]
-org-name = "cyclic_imports"
-version = "1.0.0"
+[package]
+org = "testorg"
+name = "cyclic_imports"
+version = "0.1.0"

--- a/tests/jballerina-unit-test/src/test/resources/test-src/imports/cyclic-packages/package_a/Ballerina.toml
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/imports/cyclic-packages/package_a/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+name = "a"
+org = "wso2"
+version = "1.0.0"

--- a/tests/jballerina-unit-test/src/test/resources/test-src/imports/cyclic-packages/package_a/main.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/imports/cyclic-packages/package_a/main.bal
@@ -1,0 +1,5 @@
+import wso2/b;
+
+public function funcA() {
+    b:funcB();
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/imports/cyclic-packages/package_b/Ballerina.toml
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/imports/cyclic-packages/package_b/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+name = "b"
+org = "wso2"
+version = "1.9.2"

--- a/tests/jballerina-unit-test/src/test/resources/test-src/imports/cyclic-packages/package_b/main.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/imports/cyclic-packages/package_b/main.bal
@@ -1,0 +1,5 @@
+import wso2/c;
+
+public function funcB() {
+    c:funcC();
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/imports/cyclic-packages/package_c_1/Ballerina.toml
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/imports/cyclic-packages/package_c_1/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+name = "c"
+org = "wso2"
+version = "0.1.0"

--- a/tests/jballerina-unit-test/src/test/resources/test-src/imports/cyclic-packages/package_c_1/main.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/imports/cyclic-packages/package_c_1/main.bal
@@ -1,0 +1,5 @@
+import c.d;
+
+public function funcC() {
+    d:funcCD();    
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/imports/cyclic-packages/package_c_1/modules/d/d.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/imports/cyclic-packages/package_c_1/modules/d/d.bal
@@ -1,0 +1,3 @@
+public function funcCD() {
+    
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/imports/cyclic-packages/package_c_2/Ballerina.toml
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/imports/cyclic-packages/package_c_2/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+name = "c"
+org = "wso2"
+version = "0.1.1"

--- a/tests/jballerina-unit-test/src/test/resources/test-src/imports/cyclic-packages/package_c_2/main.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/imports/cyclic-packages/package_c_2/main.bal
@@ -1,0 +1,7 @@
+import c.d;
+import wso2/b;
+
+public function funcC() {
+    d:funcCD();
+    b:funcB();    
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/imports/cyclic-packages/package_c_2/modules/d/d.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/imports/cyclic-packages/package_c_2/modules/d/d.bal
@@ -1,0 +1,5 @@
+import wso2/a;
+
+public function funcCD() {
+    a:funcA();    
+}


### PR DESCRIPTION
## Purpose
The topological sort cannot have an output if the dependency graph is not acyclic. Hence, all the cyclic dependencies are diagnosed at the package resolution.

Fixes #27371 

## Approach
The topological sort algorithm is extended to detect cycles through back edges in DFS.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [x] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
