### PR TITLE
Fix object reference type checking

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -750,13 +750,13 @@ public class TypeChecker {
             return checkIsType(sourceType, targetType);
         }
 
-        if (targetTypeTag == TypeTags.INTERSECTION_TAG) {
-            targetType = ((BIntersectionType) targetType).getEffectiveType();
+        if (targetTypeTag == TypeTags.TYPE_REFERENCED_TYPE_TAG) {
+            targetType = getReferredType(targetType);
             targetTypeTag = targetType.getTag();
         }
 
-        if (targetTypeTag == TypeTags.TYPE_REFERENCED_TYPE_TAG) {
-            targetType = getReferredType(targetType);
+        if (targetTypeTag == TypeTags.INTERSECTION_TAG) {
+            targetType = ((BIntersectionType) targetType).getEffectiveType();
             targetTypeTag = targetType.getTag();
         }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectTypeReferenceTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectTypeReferenceTest.java
@@ -404,4 +404,9 @@ public class ObjectTypeReferenceTest {
     public void testCreatingObjectWithOverriddenMethods() {
         BRunUtil.invoke(compileResult, "testCreatingObjectWithOverriddenMethods");
     }
+
+    @Test
+    public void testObjectReferenceRecordUpdate() {
+        BRunUtil.invoke(compileResult, "testObjectReferenceRecordUpdate");
+    }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/object-type-reference.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/object-type-reference.bal
@@ -261,6 +261,31 @@ function testCreatingObjectWithOverriddenMethods() {
     assertEquality(dummyPerson.getName(), "Hello Doe");
 }
 
+public type Groups readonly & object {
+    isolated function get(int index) returns int?;
+};
+
+public type Match record {|
+    Groups groups;
+|};
+
+readonly class MatchGroups {
+    *Groups;
+
+    isolated function get(int index) returns int? {
+        return index;
+    }
+}
+
+function testObjectReferenceRecordUpdate() {
+    Match matched = {
+        groups: new MatchGroups()
+    };
+    assertEquality(matched.groups is MatchGroups, true);
+    assertEquality(matched.groups is Groups, true);
+    assertEquality(matched.groups.get(8), 8);
+}
+
 const ASSERTION_ERROR_REASON = "AssertionError";
 
 function assertEquality(any|error expected, any|error actual) {


### PR DESCRIPTION
## Purpose
$subject

Fixes #36691

## Approach
Change the typechecker validation order.

## Samples
```ballerina
public type Groups readonly & object {
    isolated function get(int index) returns int?;
};

public type Match record {|
    Groups groups;
|};

readonly class MatchGroups {
    *Groups;

    isolated function get(int index) returns int? {
        return 0;
    }
}

public function main() {
    Match matched = {
        groups: new MatchGroups(2)
    };
}
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
