### PR TITLE
Improve error message for mismatching argument list with the parameter list of call langlib function

### DIFF
--- a/bvm/ballerina-runtime/src/main/resources/MessagesBundle.properties
+++ b/bvm/ballerina-runtime/src/main/resources/MessagesBundle.properties
@@ -19,7 +19,7 @@
 #the following will interpreted as: invalid type 'typName'
 invalid.type = invalid type ''{0}''
 incompatible.types = incompatible types: expected ''{0}'', found ''{1}''
-incompatible.arguments = arguments of incompatible types: expected argument(s) of type(s) ''{0}'', found ''{1}''
+incompatible.arguments = arguments of incompatible types: argument(s) of type(s) ''{0}'', cannot be passed to function expecting parameter(s) of type(s) ''{1}''
 redeclared.symbol = redeclared symbol ''{0}''
 incompatible.types.cannot.convert = incompatible types: ''{0}'' cannot be converted to ''{1}''
 cannot.convert.with.suggestion = incompatible types: ''{0}'' cannot be converted to ''{1}'', try casting

--- a/bvm/ballerina-runtime/src/main/resources/MessagesBundle.properties
+++ b/bvm/ballerina-runtime/src/main/resources/MessagesBundle.properties
@@ -19,7 +19,7 @@
 #the following will interpreted as: invalid type 'typName'
 invalid.type = invalid type ''{0}''
 incompatible.types = incompatible types: expected ''{0}'', found ''{1}''
-incompatible.arguments = arguments of incompatible types: argument(s) of type(s) ''{0}'', cannot be passed to function expecting parameter(s) of type(s) ''{1}''
+incompatible.arguments = arguments of incompatible types: argument list ''{0}'' cannot be passed to function expecting parameter list ''{1}''
 redeclared.symbol = redeclared symbol ''{0}''
 incompatible.types.cannot.convert = incompatible types: ''{0}'' cannot be converted to ''{1}''
 cannot.convert.with.suggestion = incompatible types: ''{0}'' cannot be converted to ''{1}'', try casting

--- a/bvm/ballerina-runtime/src/main/resources/MessagesBundle.properties
+++ b/bvm/ballerina-runtime/src/main/resources/MessagesBundle.properties
@@ -19,7 +19,7 @@
 #the following will interpreted as: invalid type 'typName'
 invalid.type = invalid type ''{0}''
 incompatible.types = incompatible types: expected ''{0}'', found ''{1}''
-incompatible.arguments = arguments of incompatible types: expected argument(s) of types ''{0}'', found ''{1}''
+incompatible.arguments = arguments of incompatible types: expected argument(s) of type(s) ''{0}'', found ''{1}''
 redeclared.symbol = redeclared symbol ''{0}''
 incompatible.types.cannot.convert = incompatible types: ''{0}'' cannot be converted to ''{1}''
 cannot.convert.with.suggestion = incompatible types: ''{0}'' cannot be converted to ''{1}'', try casting

--- a/langlib/lang.function/src/main/java/org/ballerinalang/langlib/function/Call.java
+++ b/langlib/lang.function/src/main/java/org/ballerinalang/langlib/function/Call.java
@@ -64,9 +64,8 @@ public class Call {
             throw ErrorCreator.createError(
                         getModulePrefixedReason(FUNCTION_LANG_LIB, INCOMPATIBLE_ARGUMENTS),
                         BLangExceptionHelper.getErrorDetails(RuntimeErrors.INCOMPATIBLE_ARGUMENTS,
-                        new BTupleType(paramTypes, restType, 0, false)
-                                .toString().replace("[", "").replace("]", ""),
-                        new BTupleType(argTypes).toString().replace("[", "").replace("]", "")));
+                        removeBracketsFromStringFormatOfTuple(new BTupleType(paramTypes, restType, 0, false)),
+                        removeBracketsFromStringFormatOfTuple(new BTupleType(argTypes))));
         }
 
         return func.asyncCall(argsList.toArray(), METADATA);
@@ -131,5 +130,10 @@ public class Call {
             }
         }
         return errored;
+    }
+
+    private static String removeBracketsFromStringFormatOfTuple(BTupleType tupleType) {
+        String stringValue = tupleType.toString();
+        return stringValue.substring(1, stringValue.length() - 1);
     }
 }

--- a/langlib/lang.function/src/main/java/org/ballerinalang/langlib/function/Call.java
+++ b/langlib/lang.function/src/main/java/org/ballerinalang/langlib/function/Call.java
@@ -64,8 +64,8 @@ public class Call {
             throw ErrorCreator.createError(
                         getModulePrefixedReason(FUNCTION_LANG_LIB, INCOMPATIBLE_ARGUMENTS),
                         BLangExceptionHelper.getErrorDetails(RuntimeErrors.INCOMPATIBLE_ARGUMENTS,
-                        removeBracketsFromStringFormatOfTuple(new BTupleType(paramTypes, restType, 0, false)),
-                        removeBracketsFromStringFormatOfTuple(new BTupleType(argTypes))));
+                        removeBracketsFromStringFormatOfTuple(new BTupleType(argTypes)),
+                        removeBracketsFromStringFormatOfTuple(new BTupleType(paramTypes, restType, 0, false))));
         }
 
         return func.asyncCall(argsList.toArray(), METADATA);
@@ -134,6 +134,6 @@ public class Call {
 
     private static String removeBracketsFromStringFormatOfTuple(BTupleType tupleType) {
         String stringValue = tupleType.toString();
-        return stringValue.substring(1, stringValue.length() - 1);
+        return "(" + stringValue.substring(1, stringValue.length() - 1) + ")";
     }
 }

--- a/langlib/lang.function/src/main/java/org/ballerinalang/langlib/function/Call.java
+++ b/langlib/lang.function/src/main/java/org/ballerinalang/langlib/function/Call.java
@@ -64,7 +64,9 @@ public class Call {
             throw ErrorCreator.createError(
                         getModulePrefixedReason(FUNCTION_LANG_LIB, INCOMPATIBLE_ARGUMENTS),
                         BLangExceptionHelper.getErrorDetails(RuntimeErrors.INCOMPATIBLE_ARGUMENTS,
-                        new BTupleType(paramTypes, restType, 0, false), new BTupleType(argTypes)));
+                        new BTupleType(paramTypes, restType, 0, false)
+                                .toString().replace("[", "").replace("]", ""),
+                        new BTupleType(argTypes).toString().replace("[", "").replace("]", "")));
         }
 
         return func.asyncCall(argsList.toArray(), METADATA);

--- a/langlib/langlib-test/src/test/resources/test-src/functionlib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/functionlib_test.bal
@@ -47,6 +47,7 @@ function testCallFunctionWithRequiredParameters() {
     assertEquality(function:call(value1, 20, 20, 10), 50);
     assertEquality(function:call(value1, 10, 10), 35);
     assertEquality(function:call(value2, 10, 20, 30), 60);
+    assertEquality(function:call(test21), 10);
 }
 
 function value3(int a = 10, int b = 15, int c = 20) returns int {
@@ -64,6 +65,10 @@ function testCallFunctionWithDefaultParameters() {
     assertEquality(function:call(value3, a, b), 45);
     assertEquality(function:call(value3, 10, 10, 10), 30);
     assertEquality(function:call(value3, a, b, c), 55);
+    assertEquality(function:call(test22), 10);
+    assertEquality(function:call(test22, 15), 15);
+    assertEquality(function:call(test23), 25);
+    assertEquality(function:call(test23, 15), 30);
 }
 
 function value4(int a, int b, int... c) returns int {
@@ -181,6 +186,18 @@ function test20(string... details) returns string {
     return details[0];
 }
 
+function test21() returns int {
+    return 10;
+}
+
+function test22(int k = 10) returns int {
+    return k;
+}
+
+function test23(int k = 10, int l = 15) returns int {
+    return k + l;
+}
+
 function testCallFunctionWithFunctionPointers() {
     assertEquality(test16(), 3);
     assertEquality(test17(), "sum is 3");
@@ -192,22 +209,32 @@ function testCallFunctionWithInvalidArguments() {
     any|error a1 = trap function:call(value1, 10);
     assertEquality(true, a1 is error);
     assertEquality("{ballerina/lang.function}IncompatibleArguments", (<error> a1).message());
-    assertEquality("arguments of incompatible types: argument(s) of type(s) 'int,int,int', cannot be passed to function expecting parameter(s) of type(s) 'int'", (<error> a1).detail()["message"]);
+    assertEquality("arguments of incompatible types: argument list '(int)' cannot be passed to function expecting parameter list '(int,int,int)'", (<error> a1).detail()["message"]);
+    
+    a1 = trap function:call(value1);
+    assertEquality(true, a1 is error);
+    assertEquality("{ballerina/lang.function}IncompatibleArguments", (<error> a1).message());
+    assertEquality("arguments of incompatible types: argument list '()' cannot be passed to function expecting parameter list '(int,int,int)'", (<error> a1).detail()["message"]);
 
     a1 = trap function:call(value1, 10, "10");
     assertEquality(true, a1 is error);
     assertEquality("{ballerina/lang.function}IncompatibleArguments", (<error> a1).message());
-    assertEquality("arguments of incompatible types: argument(s) of type(s) 'int,int,int', cannot be passed to function expecting parameter(s) of type(s) 'int,string'", (<error> a1).detail()["message"]);
+    assertEquality("arguments of incompatible types: argument list '(int,string)' cannot be passed to function expecting parameter list '(int,int,int)'", (<error> a1).detail()["message"]);
 
     a1 = trap function:call(value2, 10, 10, 10, 10);
     assertEquality(true, a1 is error);
     assertEquality("{ballerina/lang.function}IncompatibleArguments", (<error> a1).message());
-    assertEquality("arguments of incompatible types: argument(s) of type(s) 'int,int,int', cannot be passed to function expecting parameter(s) of type(s) 'int,int,int,int'", (<error> a1).detail()["message"]);
+    assertEquality("arguments of incompatible types: argument list '(int,int,int,int)' cannot be passed to function expecting parameter list '(int,int,int)'", (<error> a1).detail()["message"]);
 
     a1 = trap function:call(value2, 10, 10);
     assertEquality(true, a1 is error);
     assertEquality("{ballerina/lang.function}IncompatibleArguments", (<error> a1).message());
-    assertEquality("arguments of incompatible types: argument(s) of type(s) 'int,int,int', cannot be passed to function expecting parameter(s) of type(s) 'int,int'", (<error> a1).detail()["message"]);
+    assertEquality("arguments of incompatible types: argument list '(int,int)' cannot be passed to function expecting parameter list '(int,int,int)'", (<error> a1).detail()["message"]);
+
+    a1 = trap function:call(value2);
+    assertEquality(true, a1 is error);
+    assertEquality("{ballerina/lang.function}IncompatibleArguments", (<error> a1).message());
+    assertEquality("arguments of incompatible types: argument list '()' cannot be passed to function expecting parameter list '(int,int,int)'", (<error> a1).detail()["message"]);
 
     a1 = trap function:call(value4, 10, 10);
     assertEquality(true, a1 is error);
@@ -232,34 +259,48 @@ function testCallFunctionWithInvalidArguments() {
     a1 = trap function:call(value8, "");
     assertEquality(true, a1 is error);
     assertEquality("{ballerina/lang.function}IncompatibleArguments", (<error> a1).message());
-    assertEquality("arguments of incompatible types: argument(s) of type(s) 'int...', cannot be passed to function expecting parameter(s) of type(s) 'string'", (<error> a1).detail()["message"]);
+    assertEquality("arguments of incompatible types: argument list '(string)' cannot be passed to function expecting parameter list '(int...)'", (<error> a1).detail()["message"]);
 
     a1 = trap function:call(value8, "", "");
     assertEquality(true, a1 is error);
     assertEquality("{ballerina/lang.function}IncompatibleArguments", (<error> a1).message());
-    assertEquality("arguments of incompatible types: argument(s) of type(s) 'int...', cannot be passed to function expecting parameter(s) of type(s) 'string,string'", (<error> a1).detail()["message"]);
+    assertEquality("arguments of incompatible types: argument list '(string,string)' cannot be passed to function expecting parameter list '(int...)'", (<error> a1).detail()["message"]);
 
     a1 = trap function:call(value1, 10);
     assertEquality(true, a1 is error);
     assertEquality("{ballerina/lang.function}IncompatibleArguments", (<error> a1).message());
-    assertEquality("arguments of incompatible types: argument(s) of type(s) 'int,int,int', cannot be passed to function expecting parameter(s) of type(s) 'int'", (<error> a1).detail()["message"]);
+    assertEquality("arguments of incompatible types: argument list '(int)' cannot be passed to function expecting parameter list '(int,int,int)'", (<error> a1).detail()["message"]);
 
     NewPerson person = {firstName: "chiran", secondName: "sachintha"};
     a1 = trap function:call(test10, person);
     assertEquality(true, a1 is error);
     assertEquality("{ballerina/lang.function}IncompatibleArguments", (<error> a1).message());
-    assertEquality("arguments of incompatible types: argument(s) of type(s) 'string,NewPerson', cannot be passed to function expecting parameter(s) of type(s) 'NewPerson'", (<error> a1).detail()["message"]);
+    assertEquality("arguments of incompatible types: argument list '(NewPerson)' cannot be passed to function expecting parameter list '(string,NewPerson)'", (<error> a1).detail()["message"]);
 
     a1 = trap function:call(test11, {});
     assertEquality(true, a1 is error);
     assertEquality("{ballerina/lang.function}IncompatibleArguments", (<error> a1).message());
-    assertEquality("arguments of incompatible types: argument(s) of type(s) 'NewStudent', cannot be passed to function expecting parameter(s) of type(s) 'map<(any|error)>'", (<error> a1).detail()["message"]);
+    assertEquality("arguments of incompatible types: argument list '(map<(any|error)>)' cannot be passed to function expecting parameter list '(NewStudent)'", (<error> a1).detail()["message"]);
     
     a1 = trap function:call(test20, 10);
     assertEquality(true, a1 is error);
     assertEquality("{ballerina/lang.function}IncompatibleArguments", (<error> a1).message());
-    assertEquality("arguments of incompatible types: argument(s) of type(s) 'string...', cannot be passed to function expecting parameter(s) of type(s) 'int'", (<error> a1).detail()["message"]);
+    assertEquality("arguments of incompatible types: argument list '(int)' cannot be passed to function expecting parameter list '(string...)'", (<error> a1).detail()["message"]);
 
+    a1 = trap function:call(test21, 10);
+    assertEquality(true, a1 is error);
+    assertEquality("{ballerina/lang.function}IncompatibleArguments", (<error> a1).message());
+    assertEquality("arguments of incompatible types: argument list '(int)' cannot be passed to function expecting parameter list '()'", (<error> a1).detail()["message"]);
+
+    a1 = trap function:call(test21, 10, 10);
+    assertEquality(true, a1 is error);
+    assertEquality("{ballerina/lang.function}IncompatibleArguments", (<error> a1).message());
+    assertEquality("arguments of incompatible types: argument list '(int,int)' cannot be passed to function expecting parameter list '()'", (<error> a1).detail()["message"]);
+
+    a1 = trap function:call(test22, "10");
+    assertEquality(true, a1 is error);
+    assertEquality("{ballerina/lang.function}IncompatibleArguments", (<error> a1).message());
+    assertEquality("arguments of incompatible types: argument list '(string)' cannot be passed to function expecting parameter list '(int)'", (<error> a1).detail()["message"]);
 }
 
 function assertEquality(any|error expected, any|error actual) {

--- a/langlib/langlib-test/src/test/resources/test-src/functionlib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/functionlib_test.bal
@@ -188,22 +188,22 @@ function testCallFunctionWithInvalidArguments() {
     any|error a1 = trap function:call(value1, 10);
     assertEquality(true, a1 is error);
     assertEquality("{ballerina/lang.function}IncompatibleArguments", (<error> a1).message());
-    assertEquality("arguments of incompatible types: expected argument(s) of type(s) 'int,int,int', found 'int'", (<error> a1).detail()["message"]);
+    assertEquality("arguments of incompatible types: argument(s) of type(s) 'int,int,int', cannot be passed to function expecting parameter(s) of type(s) 'int'", (<error> a1).detail()["message"]);
 
     a1 = trap function:call(value1, 10, "10");
     assertEquality(true, a1 is error);
     assertEquality("{ballerina/lang.function}IncompatibleArguments", (<error> a1).message());
-    assertEquality("arguments of incompatible types: expected argument(s) of type(s) 'int,int,int', found 'int,string'", (<error> a1).detail()["message"]);
+    assertEquality("arguments of incompatible types: argument(s) of type(s) 'int,int,int', cannot be passed to function expecting parameter(s) of type(s) 'int,string'", (<error> a1).detail()["message"]);
 
     a1 = trap function:call(value2, 10, 10, 10, 10);
     assertEquality(true, a1 is error);
     assertEquality("{ballerina/lang.function}IncompatibleArguments", (<error> a1).message());
-    assertEquality("arguments of incompatible types: expected argument(s) of type(s) 'int,int,int', found 'int,int,int,int'", (<error> a1).detail()["message"]);
+    assertEquality("arguments of incompatible types: argument(s) of type(s) 'int,int,int', cannot be passed to function expecting parameter(s) of type(s) 'int,int,int,int'", (<error> a1).detail()["message"]);
 
     a1 = trap function:call(value2, 10, 10);
     assertEquality(true, a1 is error);
     assertEquality("{ballerina/lang.function}IncompatibleArguments", (<error> a1).message());
-    assertEquality("arguments of incompatible types: expected argument(s) of type(s) 'int,int,int', found 'int,int'", (<error> a1).detail()["message"]);
+    assertEquality("arguments of incompatible types: argument(s) of type(s) 'int,int,int', cannot be passed to function expecting parameter(s) of type(s) 'int,int'", (<error> a1).detail()["message"]);
 
     a1 = trap function:call(value4, 10, 10);
     assertEquality(true, a1 is error);
@@ -228,28 +228,28 @@ function testCallFunctionWithInvalidArguments() {
     a1 = trap function:call(value8, "");
     assertEquality(true, a1 is error);
     assertEquality("{ballerina/lang.function}IncompatibleArguments", (<error> a1).message());
-    assertEquality("arguments of incompatible types: expected argument(s) of type(s) 'int...', found 'string'", (<error> a1).detail()["message"]);
+    assertEquality("arguments of incompatible types: argument(s) of type(s) 'int...', cannot be passed to function expecting parameter(s) of type(s) 'string'", (<error> a1).detail()["message"]);
 
     a1 = trap function:call(value8, "", "");
     assertEquality(true, a1 is error);
     assertEquality("{ballerina/lang.function}IncompatibleArguments", (<error> a1).message());
-    assertEquality("arguments of incompatible types: expected argument(s) of type(s) 'int...', found 'string,string'", (<error> a1).detail()["message"]);
+    assertEquality("arguments of incompatible types: argument(s) of type(s) 'int...', cannot be passed to function expecting parameter(s) of type(s) 'string,string'", (<error> a1).detail()["message"]);
 
     a1 = trap function:call(value1, 10);
     assertEquality(true, a1 is error);
     assertEquality("{ballerina/lang.function}IncompatibleArguments", (<error> a1).message());
-    assertEquality("arguments of incompatible types: expected argument(s) of type(s) 'int,int,int', found 'int'", (<error> a1).detail()["message"]);
+    assertEquality("arguments of incompatible types: argument(s) of type(s) 'int,int,int', cannot be passed to function expecting parameter(s) of type(s) 'int'", (<error> a1).detail()["message"]);
 
     NewPerson person = {firstName: "chiran", secondName: "sachintha"};
     a1 = trap function:call(test10, person);
     assertEquality(true, a1 is error);
     assertEquality("{ballerina/lang.function}IncompatibleArguments", (<error> a1).message());
-    assertEquality("arguments of incompatible types: expected argument(s) of type(s) 'string,NewPerson', found 'NewPerson'", (<error> a1).detail()["message"]);
+    assertEquality("arguments of incompatible types: argument(s) of type(s) 'string,NewPerson', cannot be passed to function expecting parameter(s) of type(s) 'NewPerson'", (<error> a1).detail()["message"]);
 
     a1 = trap function:call(test11, {});
     assertEquality(true, a1 is error);
     assertEquality("{ballerina/lang.function}IncompatibleArguments", (<error> a1).message());
-    assertEquality("arguments of incompatible types: expected argument(s) of type(s) 'NewStudent', found 'map<(any|error)>'", (<error> a1).detail()["message"]);
+    assertEquality("arguments of incompatible types: argument(s) of type(s) 'NewStudent', cannot be passed to function expecting parameter(s) of type(s) 'map<(any|error)>'", (<error> a1).detail()["message"]);
 }
 
 function assertEquality(any|error expected, any|error actual) {

--- a/langlib/langlib-test/src/test/resources/test-src/functionlib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/functionlib_test.bal
@@ -177,6 +177,10 @@ function func3() returns function(string a, string b) returns string {
                                     };
 }
 
+function test20(string... details) returns string {
+    return details[0];
+}
+
 function testCallFunctionWithFunctionPointers() {
     assertEquality(test16(), 3);
     assertEquality(test17(), "sum is 3");
@@ -250,6 +254,12 @@ function testCallFunctionWithInvalidArguments() {
     assertEquality(true, a1 is error);
     assertEquality("{ballerina/lang.function}IncompatibleArguments", (<error> a1).message());
     assertEquality("arguments of incompatible types: argument(s) of type(s) 'NewStudent', cannot be passed to function expecting parameter(s) of type(s) 'map<(any|error)>'", (<error> a1).detail()["message"]);
+    
+    a1 = trap function:call(test20, 10);
+    assertEquality(true, a1 is error);
+    assertEquality("{ballerina/lang.function}IncompatibleArguments", (<error> a1).message());
+    assertEquality("arguments of incompatible types: argument(s) of type(s) 'string...', cannot be passed to function expecting parameter(s) of type(s) 'int'", (<error> a1).detail()["message"]);
+
 }
 
 function assertEquality(any|error expected, any|error actual) {

--- a/langlib/langlib-test/src/test/resources/test-src/functionlib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/functionlib_test.bal
@@ -188,22 +188,22 @@ function testCallFunctionWithInvalidArguments() {
     any|error a1 = trap function:call(value1, 10);
     assertEquality(true, a1 is error);
     assertEquality("{ballerina/lang.function}IncompatibleArguments", (<error> a1).message());
-    assertEquality("arguments of incompatible types: expected argument(s) of types '[int,int,int]', found '[int]'", (<error> a1).detail()["message"]);
+    assertEquality("arguments of incompatible types: expected argument(s) of type(s) '[int,int,int]', found '[int]'", (<error> a1).detail()["message"]);
 
     a1 = trap function:call(value1, 10, "10");
     assertEquality(true, a1 is error);
     assertEquality("{ballerina/lang.function}IncompatibleArguments", (<error> a1).message());
-    assertEquality("arguments of incompatible types: expected argument(s) of types '[int,int,int]', found '[int,string]'", (<error> a1).detail()["message"]);
+    assertEquality("arguments of incompatible types: expected argument(s) of type(s) '[int,int,int]', found '[int,string]'", (<error> a1).detail()["message"]);
 
     a1 = trap function:call(value2, 10, 10, 10, 10);
     assertEquality(true, a1 is error);
     assertEquality("{ballerina/lang.function}IncompatibleArguments", (<error> a1).message());
-    assertEquality("arguments of incompatible types: expected argument(s) of types '[int,int,int]', found '[int,int,int,int]'", (<error> a1).detail()["message"]);
+    assertEquality("arguments of incompatible types: expected argument(s) of type(s) '[int,int,int]', found '[int,int,int,int]'", (<error> a1).detail()["message"]);
 
     a1 = trap function:call(value2, 10, 10);
     assertEquality(true, a1 is error);
     assertEquality("{ballerina/lang.function}IncompatibleArguments", (<error> a1).message());
-    assertEquality("arguments of incompatible types: expected argument(s) of types '[int,int,int]', found '[int,int]'", (<error> a1).detail()["message"]);
+    assertEquality("arguments of incompatible types: expected argument(s) of type(s) '[int,int,int]', found '[int,int]'", (<error> a1).detail()["message"]);
 
     a1 = trap function:call(value4, 10, 10);
     assertEquality(true, a1 is error);
@@ -228,28 +228,28 @@ function testCallFunctionWithInvalidArguments() {
     a1 = trap function:call(value8, "");
     assertEquality(true, a1 is error);
     assertEquality("{ballerina/lang.function}IncompatibleArguments", (<error> a1).message());
-    assertEquality("arguments of incompatible types: expected argument(s) of types '[int...]', found '[string]'", (<error> a1).detail()["message"]);
+    assertEquality("arguments of incompatible types: expected argument(s) of type(s) '[int...]', found '[string]'", (<error> a1).detail()["message"]);
 
     a1 = trap function:call(value8, "", "");
     assertEquality(true, a1 is error);
     assertEquality("{ballerina/lang.function}IncompatibleArguments", (<error> a1).message());
-    assertEquality("arguments of incompatible types: expected argument(s) of types '[int...]', found '[string,string]'", (<error> a1).detail()["message"]);
+    assertEquality("arguments of incompatible types: expected argument(s) of type(s) '[int...]', found '[string,string]'", (<error> a1).detail()["message"]);
 
     a1 = trap function:call(value1, 10);
     assertEquality(true, a1 is error);
     assertEquality("{ballerina/lang.function}IncompatibleArguments", (<error> a1).message());
-    assertEquality("arguments of incompatible types: expected argument(s) of types '[int,int,int]', found '[int]'", (<error> a1).detail()["message"]);
+    assertEquality("arguments of incompatible types: expected argument(s) of type(s) '[int,int,int]', found '[int]'", (<error> a1).detail()["message"]);
 
     NewPerson person = {firstName: "chiran", secondName: "sachintha"};
     a1 = trap function:call(test10, person);
     assertEquality(true, a1 is error);
     assertEquality("{ballerina/lang.function}IncompatibleArguments", (<error> a1).message());
-    assertEquality("arguments of incompatible types: expected argument(s) of types '[string,NewPerson]', found '[NewPerson]'", (<error> a1).detail()["message"]);
+    assertEquality("arguments of incompatible types: expected argument(s) of type(s) '[string,NewPerson]', found '[NewPerson]'", (<error> a1).detail()["message"]);
 
     a1 = trap function:call(test11, {});
     assertEquality(true, a1 is error);
     assertEquality("{ballerina/lang.function}IncompatibleArguments", (<error> a1).message());
-    assertEquality("arguments of incompatible types: expected argument(s) of types '[NewStudent]', found '[map<(any|error)>]'", (<error> a1).detail()["message"]);
+    assertEquality("arguments of incompatible types: expected argument(s) of type(s) '[NewStudent]', found '[map<(any|error)>]'", (<error> a1).detail()["message"]);
 }
 
 function assertEquality(any|error expected, any|error actual) {

--- a/langlib/langlib-test/src/test/resources/test-src/functionlib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/functionlib_test.bal
@@ -188,22 +188,22 @@ function testCallFunctionWithInvalidArguments() {
     any|error a1 = trap function:call(value1, 10);
     assertEquality(true, a1 is error);
     assertEquality("{ballerina/lang.function}IncompatibleArguments", (<error> a1).message());
-    assertEquality("arguments of incompatible types: expected argument(s) of type(s) '[int,int,int]', found '[int]'", (<error> a1).detail()["message"]);
+    assertEquality("arguments of incompatible types: expected argument(s) of type(s) 'int,int,int', found 'int'", (<error> a1).detail()["message"]);
 
     a1 = trap function:call(value1, 10, "10");
     assertEquality(true, a1 is error);
     assertEquality("{ballerina/lang.function}IncompatibleArguments", (<error> a1).message());
-    assertEquality("arguments of incompatible types: expected argument(s) of type(s) '[int,int,int]', found '[int,string]'", (<error> a1).detail()["message"]);
+    assertEquality("arguments of incompatible types: expected argument(s) of type(s) 'int,int,int', found 'int,string'", (<error> a1).detail()["message"]);
 
     a1 = trap function:call(value2, 10, 10, 10, 10);
     assertEquality(true, a1 is error);
     assertEquality("{ballerina/lang.function}IncompatibleArguments", (<error> a1).message());
-    assertEquality("arguments of incompatible types: expected argument(s) of type(s) '[int,int,int]', found '[int,int,int,int]'", (<error> a1).detail()["message"]);
+    assertEquality("arguments of incompatible types: expected argument(s) of type(s) 'int,int,int', found 'int,int,int,int'", (<error> a1).detail()["message"]);
 
     a1 = trap function:call(value2, 10, 10);
     assertEquality(true, a1 is error);
     assertEquality("{ballerina/lang.function}IncompatibleArguments", (<error> a1).message());
-    assertEquality("arguments of incompatible types: expected argument(s) of type(s) '[int,int,int]', found '[int,int]'", (<error> a1).detail()["message"]);
+    assertEquality("arguments of incompatible types: expected argument(s) of type(s) 'int,int,int', found 'int,int'", (<error> a1).detail()["message"]);
 
     a1 = trap function:call(value4, 10, 10);
     assertEquality(true, a1 is error);
@@ -228,28 +228,28 @@ function testCallFunctionWithInvalidArguments() {
     a1 = trap function:call(value8, "");
     assertEquality(true, a1 is error);
     assertEquality("{ballerina/lang.function}IncompatibleArguments", (<error> a1).message());
-    assertEquality("arguments of incompatible types: expected argument(s) of type(s) '[int...]', found '[string]'", (<error> a1).detail()["message"]);
+    assertEquality("arguments of incompatible types: expected argument(s) of type(s) 'int...', found 'string'", (<error> a1).detail()["message"]);
 
     a1 = trap function:call(value8, "", "");
     assertEquality(true, a1 is error);
     assertEquality("{ballerina/lang.function}IncompatibleArguments", (<error> a1).message());
-    assertEquality("arguments of incompatible types: expected argument(s) of type(s) '[int...]', found '[string,string]'", (<error> a1).detail()["message"]);
+    assertEquality("arguments of incompatible types: expected argument(s) of type(s) 'int...', found 'string,string'", (<error> a1).detail()["message"]);
 
     a1 = trap function:call(value1, 10);
     assertEquality(true, a1 is error);
     assertEquality("{ballerina/lang.function}IncompatibleArguments", (<error> a1).message());
-    assertEquality("arguments of incompatible types: expected argument(s) of type(s) '[int,int,int]', found '[int]'", (<error> a1).detail()["message"]);
+    assertEquality("arguments of incompatible types: expected argument(s) of type(s) 'int,int,int', found 'int'", (<error> a1).detail()["message"]);
 
     NewPerson person = {firstName: "chiran", secondName: "sachintha"};
     a1 = trap function:call(test10, person);
     assertEquality(true, a1 is error);
     assertEquality("{ballerina/lang.function}IncompatibleArguments", (<error> a1).message());
-    assertEquality("arguments of incompatible types: expected argument(s) of type(s) '[string,NewPerson]', found '[NewPerson]'", (<error> a1).detail()["message"]);
+    assertEquality("arguments of incompatible types: expected argument(s) of type(s) 'string,NewPerson', found 'NewPerson'", (<error> a1).detail()["message"]);
 
     a1 = trap function:call(test11, {});
     assertEquality(true, a1 is error);
     assertEquality("{ballerina/lang.function}IncompatibleArguments", (<error> a1).message());
-    assertEquality("arguments of incompatible types: expected argument(s) of type(s) '[NewStudent]', found '[map<(any|error)>]'", (<error> a1).detail()["message"]);
+    assertEquality("arguments of incompatible types: expected argument(s) of type(s) 'NewStudent', found 'map<(any|error)>'", (<error> a1).detail()["message"]);
 }
 
 function assertEquality(any|error expected, any|error actual) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/imports/OverriddenPredeclaredImportsTestProject/overridden-predeclared-modules.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/imports/OverriddenPredeclaredImportsTestProject/overridden-predeclared-modules.bal
@@ -55,7 +55,7 @@ function testStartsWithFunctionInString() returns boolean {
     return 'strings:startsWith(str, "Hello");
 }
 
-function testCallInFunction()returns any|error {
+function testCallInFunction() returns any|error {
     return func:call(testSumFunctionInDecimal, 10.5d, 20.5d);
 }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/imports/PredeclaredImportsTestProject/predeclared-modules.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/imports/PredeclaredImportsTestProject/predeclared-modules.bal
@@ -53,7 +53,7 @@ function testTrxInfoRecordTypeUse() returns boolean {
     return true;
 }
 
-function testCallInFunction()returns any|error {
+function testCallInFunction() returns any|error {
     return function:call(testSumFunctionInDecimal, 10.5d, 20.5d);
 }
 


### PR DESCRIPTION
## Purpose
> $title.

Fixes #<Issue Number>

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
