### PR TITLE
Disallow SpreadField in table constructor 

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -1395,19 +1395,6 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                 if (fieldName.equals(((BLangRecordVarNameField) recordField).variableName.value)) {
                     return (BLangRecordLiteral.BLangRecordVarNameField) recordField;
                 }
-            } else if (recordField.getKind() == NodeKind.RECORD_LITERAL_SPREAD_OP) {
-                BLangRecordLiteral.BLangRecordSpreadOperatorField spreadOperatorField =
-                        (BLangRecordLiteral.BLangRecordSpreadOperatorField) recordField;
-                BType spreadOpExprType = Types.getReferredType(spreadOperatorField.expr.getBType());
-                if (spreadOpExprType.tag != TypeTags.RECORD) {
-                    continue;
-                }
-                BRecordType recordType = (BRecordType) spreadOpExprType;
-                for (BField recField : recordType.fields.values()) {
-                    if (fieldName.equals(recField.name.value)) {
-                        return recordLiteral;
-                    }
-                }
             }
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -1350,11 +1350,10 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                 dlog.error(recordLiteral.pos,
                         DiagnosticErrorCode.KEY_SPECIFIER_FIELD_VALUE_MUST_BE_CONSTANT_EXPR, fieldName);
                 data.resultType = symTable.semanticError;
-                return false;
             }
         }
 
-        return true;
+        return data.resultType != symTable.semanticError;
     }
 
     private boolean isConstExpression(BLangExpression expression) {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableNegativeTest.java
@@ -108,6 +108,8 @@ public class TableNegativeTest {
                 "is not found in table constraint type 'CustomerDetail'", 230, 35);
         validateError(compileResult, index++, "value expression of key specifier 'id' must be " +
                 "a constant expression", 237, 9);
+        validateError(compileResult, index++, "value expression of key specifier 'id' must be " +
+                "a constant expression", 240, 9);
         validateError(compileResult, index++, "incompatible types: expected 'table<record {| string name?; |}>',"
                 + " found 'table<record {| (string|int|boolean) name?; (int|boolean)...; |}>'", 254, 41);
         validateError(compileResult, index++, "incompatible types: expected 'table<record {| string name?; |}>'," +
@@ -153,6 +155,25 @@ public class TableNegativeTest {
         validateError(compileResult, index++, "cannot update 'table<Customer>' with member access expression", 434, 5);
         validateError(compileResult, index++, "incompatible types: expected '(table<Student>|int)', " +
                 "found 'table<record {| readonly int id; string firstName; string lastName; |}>'", 444, 28);
+        validateError(compileResult, index++, "value expression of key specifier 'x' must be a constant expression",
+                457, 9);
+        validateError(compileResult, index++, "value expression of key specifier 'x' must be a constant expression",
+                458, 9);
+        validateError(compileResult, index++, "value expression of key specifier 'x' must be a constant expression",
+                462, 9);
+        validateError(compileResult, index++, "value expression of key specifier 'x' must be a constant expression",
+                463, 9);
+        validateError(compileResult, index++, "value expression of key specifier 'x' must be a constant expression",
+                475, 9);
+        validateError(compileResult, index++, "value expression of key specifier 'y' must be a constant expression",
+                475, 9);
+        validateError(compileResult, index++, "value expression of key specifier 'x' must be a constant expression",
+                476, 9);
+        validateError(compileResult, index++, "value expression of key specifier 'y' must be a constant expression",
+                476, 9);
+        validateError(compileResult, index++, "value expression of key specifier 'z' must be a constant expression",
+                476, 9);
+        Assert.assertEquals(compileResult.getErrorCount(), index);
         Assert.assertEquals(compileResult.getErrorCount(), index);
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/table/record-constraint-table-value.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/table/record-constraint-table-value.bal
@@ -467,23 +467,6 @@ type FooRec record {
 };
 
 public function testSpreadFieldInConstructor() {
-    string expected = "[{\"x\":1001,\"y\":20},{\"x\":1002,\"y\":30}]";
-    FooRec spreadField1 = {x: 1002, y: 30};
-
-    table<FooRec> tb1 = table key(x) [
-            {x: 1001, y: 20},
-            {...spreadField1}
-        ];
-    assertEquality(expected, tb1.toString());
-
-    var spreadField2 = {x: 1002, y: 30};
-
-    var tb2 = table key(x) [
-            {x: 1001, y: 20},
-            {...spreadField2}
-        ];
-    assertEquality(expected, tb2.toString());
-
     var spreadField3 = {id: 2, name: "Jo", age: 12};
     var tb3 = table [
             {id: 1, name: "Mary", salary: 100.0},

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/table/table-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/table/table-negative.bal
@@ -443,3 +443,35 @@ function testIncompatibleTableTypeInAUnion() {
     string lastName = "Jayawickrama";
     table<Student>|int t = table key(id) [{id: 1, firstName: "Lochana", lastName}];
 }
+
+type FooRec record {
+    readonly int x;
+    int y;
+};
+
+FooRec spreadField1 = {x: 1002, y: 30};
+FooRec spreadField2 = {x: 1003, y: 25};
+
+table<FooRec> key(x) tb1 = table [
+        {x: 1001, y: 20},
+        {...spreadField1},
+        {...spreadField2}
+    ];
+
+table<FooRec> key(x) tb2 = table [
+        {...spreadField1},
+        {...spreadField2}
+    ];
+
+type BarRec record {
+    readonly int x;
+    readonly int y;
+    readonly string z;
+};
+
+int i = 1;
+BarRec spreadField3 = {x: 1003, y: 25, z: "a"};
+table<BarRec> key(x, y, z) tb3 = table [
+        {x: i, y: i, z: "a"},
+        {...spreadField3}
+    ];


### PR DESCRIPTION
## Purpose

Fixes #36474 

## Approach
> For every field-name in the key sequence of the inherent type every mapping-constructor-expr in the row-list must include a specific-field that has a value-expr that is a const-expr. Spread field is not allowed in table with key sequence. It is allowed in the current master. This PR will fix it.

## Samples
> 
```
type FooRec record {
    readonly int x;
    int y;
};

FooRec spreadField1 = {x: 1002, y: 30};
FooRec spreadField2 = {x: 1003, y: 25};

table<FooRec> key(x) tb1 = table [
            {x: 1001, y: 20},
            {...spreadField1},
            {...spreadField2}
        ];
```
This should give `value expression of key specifier 'x' must be a constant expression` as error at two spread fields.
## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
