### PR TITLE
Disallow SpreadField in table constructor

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -1310,11 +1310,10 @@ public class TypeChecker extends BLangNodeVisitor {
                 dlog.error(recordLiteral.pos,
                         DiagnosticErrorCode.KEY_SPECIFIER_FIELD_VALUE_MUST_BE_CONSTANT_EXPR, fieldName);
                 resultType = symTable.semanticError;
-                return false;
             }
         }
 
-        return true;
+        return resultType != symTable.semanticError;
     }
 
     private boolean isConstExpression(BLangExpression expression) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -1355,19 +1355,6 @@ public class TypeChecker extends BLangNodeVisitor {
                 if (fieldName.equals(((BLangRecordVarNameField) recordField).variableName.value)) {
                     return (BLangRecordLiteral.BLangRecordVarNameField) recordField;
                 }
-            } else if (recordField.getKind() == NodeKind.RECORD_LITERAL_SPREAD_OP) {
-                BLangRecordLiteral.BLangRecordSpreadOperatorField spreadOperatorField =
-                        (BLangRecordLiteral.BLangRecordSpreadOperatorField) recordField;
-                BType spreadOpExprType = Types.getReferredType(spreadOperatorField.expr.getBType());
-                if (spreadOpExprType.tag != TypeTags.RECORD) {
-                    continue;
-                }
-                BRecordType recordType = (BRecordType) spreadOpExprType;
-                for (BField recField : recordType.fields.values()) {
-                    if (fieldName.equals(recField.name.value)) {
-                        return recordLiteral;
-                    }
-                }
             }
         }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableNegativeTest.java
@@ -35,7 +35,6 @@ public class TableNegativeTest {
     @Test
     public void testTableNegativeCases() {
         CompileResult compileResult = BCompileUtil.compile("test-src/types/table/table-negative.bal");
-        Assert.assertEquals(compileResult.getErrorCount(), 43);
         int index = 0;
 
         validateError(compileResult, index++, "unknown type 'CusTable'",
@@ -109,6 +108,8 @@ public class TableNegativeTest {
                 "is not found in table constraint type 'CustomerDetail'", 230, 35);
         validateError(compileResult, index++, "value expression of key specifier 'id' must be " +
                 "a constant expression", 237, 9);
+        validateError(compileResult, index++, "value expression of key specifier 'id' must be " +
+                "a constant expression", 240, 9);
         validateError(compileResult, index++, "incompatible types: expected 'table<record {| string name?; |}>',"
                 + " found 'table<record {| (string|int|boolean) name?; (int|boolean)...; |}>'", 254, 41);
         validateError(compileResult, index++, "incompatible types: expected 'table<record {| string name?; |}>'," +
@@ -124,8 +125,27 @@ public class TableNegativeTest {
                 " found 'table<record {| (anydata|error) a; |}>'", 301, 13);
         validateError(compileResult, index++, "incompatible types: expected 'int'," +
                 " found 'table<record {| (any|error) a; |}>'", 311, 13);
-        validateError(compileResult, index, "incompatible types: expected 'int'," +
+        validateError(compileResult, index++, "incompatible types: expected 'int'," +
                 " found 'table<record {| (0|1|2|3) a; |}>'", 324, 13);
+        validateError(compileResult, index++, "value expression of key specifier 'x' must be a constant expression",
+                337, 9);
+        validateError(compileResult, index++, "value expression of key specifier 'x' must be a constant expression",
+                338, 9);
+        validateError(compileResult, index++, "value expression of key specifier 'x' must be a constant expression",
+                342, 9);
+        validateError(compileResult, index++, "value expression of key specifier 'x' must be a constant expression",
+                343, 9);
+        validateError(compileResult, index++, "value expression of key specifier 'x' must be a constant expression",
+                355, 9);
+        validateError(compileResult, index++, "value expression of key specifier 'y' must be a constant expression",
+                355, 9);
+        validateError(compileResult, index++, "value expression of key specifier 'x' must be a constant expression",
+                356, 9);
+        validateError(compileResult, index++, "value expression of key specifier 'y' must be a constant expression",
+                356, 9);
+        validateError(compileResult, index++, "value expression of key specifier 'z' must be a constant expression",
+                356, 9);
+        Assert.assertEquals(compileResult.getErrorCount(), index);
     }
 
     @Test

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/table/record-constraint-table-value.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/table/record-constraint-table-value.bal
@@ -467,23 +467,6 @@ type FooRec record {
 };
 
 public function testSpreadFieldInConstructor() {
-    string expected = "[{\"x\":1001,\"y\":20},{\"x\":1002,\"y\":30}]";
-    FooRec spreadField1 = {x: 1002, y: 30};
-
-    table<FooRec> tb1 = table key(x) [
-            {x: 1001, y: 20},
-            {...spreadField1}
-        ];
-    assertEquality(expected, tb1.toString());
-
-    var spreadField2 = {x: 1002, y: 30};
-
-    var tb2 = table key(x) [
-            {x: 1001, y: 20},
-            {...spreadField2}
-        ];
-    assertEquality(expected, tb2.toString());
-
     var spreadField3 = {id: 2, name: "Jo", age: 12};
     var tb3 = table [
             {id: 1, name: "Mary", salary: 100.0},

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/table/table-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/table/table-negative.bal
@@ -323,3 +323,35 @@ function testTableConstructorWithVar6() {
     var v1 = table [{a: f}];
     int _ = v1;
 }
+
+type FooRec record {
+    readonly int x;
+    int y;
+};
+
+FooRec spreadField1 = {x: 1002, y: 30};
+FooRec spreadField2 = {x: 1003, y: 25};
+
+table<FooRec> key(x) tb1 = table [
+        {x: 1001, y: 20},
+        {...spreadField1},
+        {...spreadField2}
+    ];
+
+table<FooRec> key(x) tb2 = table [
+        {...spreadField1},
+        {...spreadField2}
+    ];
+
+type BarRec record {
+    readonly int x;
+    readonly int y;
+    readonly string z;
+};
+
+int i = 1;
+BarRec spreadField3 = {x: 1003, y: 25, z: "a"};
+table<BarRec> key(x, y, z) tb3 = table [
+        {x: i, y: i, z: "a"},
+        {...spreadField3}
+    ];


### PR DESCRIPTION
## Purpose

Fixes #36474 

## Approach
> For every field-name in the key sequence of the inherent type every mapping-constructor-expr in the row-list must include a specific-field that has a value-expr that is a const-expr. Spread field is not allowed in table with key sequence. It is allowed in the current master. This PR will fix it.

## Samples
> 
```
type FooRec record {
    readonly int x;
    int y;
};

FooRec spreadField1 = {x: 1002, y: 30};
FooRec spreadField2 = {x: 1003, y: 25};

table<FooRec> key(x) tb1 = table [
            {x: 1001, y: 20},
            {...spreadField1},
            {...spreadField2}
        ];
```
This should give `value expression of key specifier 'x' must be a constant expression` as error at two spread fields.
## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
