### PR TITLE
Fix `Replace with` CA comment suggesting

### DIFF
--- a/compiler/linter-plugin/src/main/java/io/ballerina/compiler/linter/impl/codeactions/QualifiedIdentifierCodeAction.java
+++ b/compiler/linter-plugin/src/main/java/io/ballerina/compiler/linter/impl/codeactions/QualifiedIdentifierCodeAction.java
@@ -66,12 +66,12 @@ public class QualifiedIdentifierCodeAction extends LinterCodeAction {
         SyntaxKind kind = node.kind();
         if (kind == SyntaxKind.QUALIFIED_NAME_REFERENCE) {
             final QualifiedNameReferenceNode qualifiedNameReferenceNode = (QualifiedNameReferenceNode) node;
-            updatedText = qualifiedNameReferenceNode.modulePrefix().toSourceCode().strip()
+            updatedText = qualifiedNameReferenceNode.modulePrefix().text()
                     + qualifiedNameReferenceNode.colon().toSourceCode().strip()
                     + qualifiedNameReferenceNode.identifier().toSourceCode().strip();
         } else if (kind == SyntaxKind.XML_QUALIFIED_NAME) {
             final XMLQualifiedNameNode xmlQualifiedNameNode = (XMLQualifiedNameNode) node;
-            updatedText = xmlQualifiedNameNode.prefix().toSourceCode().strip()
+            updatedText = xmlQualifiedNameNode.prefix().name().text()
                     + xmlQualifiedNameNode.colon().toSourceCode().strip()
                     + xmlQualifiedNameNode.name().toSourceCode().strip();
         } else {

--- a/compiler/linter-plugin/src/test/java/io/ballerina/compiler/linter/codeactions/test/CodeActionTests.java
+++ b/compiler/linter-plugin/src/test/java/io/ballerina/compiler/linter/codeactions/test/CodeActionTests.java
@@ -63,7 +63,9 @@ public class CodeActionTests {
                 {"source/qname1.bal", LinePosition.from(2, 5), Constants.BCE_INTERVENING_WS},
                 {"source/qname2.bal", LinePosition.from(2, 5), Constants.BCE_INTERVENING_WS},
                 {"source/qname3.bal", LinePosition.from(2, 9), Constants.BCE_INTERVENING_WS},
-                {"source/qname4.bal", LinePosition.from(3, 4), Constants.BCE_INVALID_WS}
+                {"source/qname4.bal", LinePosition.from(3, 4), Constants.BCE_INVALID_WS},
+                {"source/qname5.bal", LinePosition.from(4, 7), Constants.BCE_INTERVENING_WS},
+                {"source/qname6.bal", LinePosition.from(4, 8), Constants.BCE_INTERVENING_WS}
         };
     }
 
@@ -74,7 +76,6 @@ public class CodeActionTests {
         final String expectedProvider = diagnosticCode + SLASH + Constants.CA_QUALIFIED_IDENTIFIER;
         testSingleDiagnosticCodeAction(file, cursorPos, expectedProvider);
     }
-
 
     @DataProvider
     public Object[] floatingNumberDP() {

--- a/compiler/linter-plugin/src/test/resources/source/qname5.bal
+++ b/compiler/linter-plugin/src/test/resources/source/qname5.bal
@@ -1,0 +1,6 @@
+function name() {
+    // no
+    // need to replace
+    // comments
+    io:
+}

--- a/compiler/linter-plugin/src/test/resources/source/qname5.bal.new
+++ b/compiler/linter-plugin/src/test/resources/source/qname5.bal.new
@@ -1,0 +1,6 @@
+function name() {
+    // no
+    // need to replace
+    // comments
+    io:
+}

--- a/compiler/linter-plugin/src/test/resources/source/qname6.bal
+++ b/compiler/linter-plugin/src/test/resources/source/qname6.bal
@@ -1,0 +1,6 @@
+function name() {
+    // no
+    // need to replace
+    // comments
+    xml:
+}

--- a/compiler/linter-plugin/src/test/resources/source/qname6.bal.new
+++ b/compiler/linter-plugin/src/test/resources/source/qname6.bal.new
@@ -1,0 +1,6 @@
+function name() {
+    // no
+    // need to replace
+    // comments
+    xml:
+}


### PR DESCRIPTION
## Purpose
$subject

Fixes #34908 

## Approach
In the `QualifiedIdentifierCodeAction` class when getting the code action info, the qualified name (syntax) should be selected. In the previous implementation the comments also getting selected due to usage of `node.modulePrefix().toSourceCode().strip()`. Change it to `node.modulePrefix().text()` so only the syntax getting selected.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
