### PR TITLE
Add create function support for lhs in conditional expression

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/visitors/FunctionCallExpressionTypeFinder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/visitors/FunctionCallExpressionTypeFinder.java
@@ -429,8 +429,7 @@ public class FunctionCallExpressionTypeFinder extends NodeVisitor {
     @Override
     public void visit(ConditionalExpressionNode conditionalExpressionNode) {
 
-        if (this.functionCallExpressionNode != null &&
-                PositionUtil.isWithinLineRange(this.functionCallExpressionNode.lineRange(),
+        if (PositionUtil.isWithinLineRange(this.functionCallExpressionNode.lineRange(),
                 conditionalExpressionNode.lhsExpression().lineRange())) {
             checkAndSetTypeDescResult(TypeDescKind.BOOLEAN);
             return;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/visitors/FunctionCallExpressionTypeFinder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/visitors/FunctionCallExpressionTypeFinder.java
@@ -429,7 +429,8 @@ public class FunctionCallExpressionTypeFinder extends NodeVisitor {
     @Override
     public void visit(ConditionalExpressionNode conditionalExpressionNode) {
 
-        if (PositionUtil.isWithinLineRange(this.functionCallExpressionNode.lineRange(),
+        if (this.functionCallExpressionNode != null &&
+                PositionUtil.isWithinLineRange(this.functionCallExpressionNode.lineRange(),
                 conditionalExpressionNode.lhsExpression().lineRange())) {
             checkAndSetTypeDescResult(TypeDescKind.BOOLEAN);
             return;

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/command/CreateFunctionCommandExecTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/command/CreateFunctionCommandExecTest.java
@@ -151,6 +151,7 @@ public class CreateFunctionCommandExecTest extends AbstractCommandExecutionTest 
                 {"createUndefinedFunctionInPanicStatement.json"},
                 {"createUndefinedFunctionInCheckpanicExpression1.json"},
                 {"createUndefinedFunctionInCheckpanicExpression2.json"},
+                {"create_function_in_conditional_expression.json"},
         };
     }
 

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/create_function_in_conditional_expression.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/create_function_in_conditional_expression.json
@@ -11,6 +11,7 @@
       }
     }
   },
+  "source": "create_function_in_conditional_expression.bal",
   "expected": {
     "result": {
       "edit": {

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/create_function_in_conditional_expression.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/create_function_in_conditional_expression.json
@@ -1,0 +1,40 @@
+{
+  "arguments": {
+    "node.range": {
+      "start": {
+        "line": 1,
+        "character": 17
+      },
+      "end": {
+        "line": 1,
+        "character": 39
+      }
+    }
+  },
+  "expected": {
+    "result": {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "range": {
+                  "start": {
+                    "line": 2,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 2,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction isGreaterThanZero(int i) returns boolean {\n    return false;\n}\n"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "jsonrpc": "2.0"
+  }
+}

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/source/create_function_in_conditional_expression.bal
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/source/create_function_in_conditional_expression.bal
@@ -1,0 +1,3 @@
+function testConditional3(int arg) {
+    string res = isGreaterThanZero(arg) ? "a" : "b";
+}


### PR DESCRIPTION
## Purpose
Create function code action doesn't work in lhs expression in ternary conditional expression

Fixes #36321

## Approach
Check if the current cursor position is within the range of the functionalCallExpressionNode and the lhsExpression of the conditionalExpressionNode.
If True, type Boolean is returned. Otherwise the existing procedure follows.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 

- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ]   Spec Conformance Tests
  - [ ]   Integration Tests
  - [ ]   Ballerina By Example Tests
- [x]   Increased Test Coverage
- [ ] Added necessary documentation
  - [ ]   API documentation
  - [ ]   Module documentation in Module.md files
  - [ ]   Ballerina By Examples
