### PR TITLE
Revert "Backport #36597 to 2201.1.x"

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -1350,10 +1350,11 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                 dlog.error(recordLiteral.pos,
                         DiagnosticErrorCode.KEY_SPECIFIER_FIELD_VALUE_MUST_BE_CONSTANT_EXPR, fieldName);
                 data.resultType = symTable.semanticError;
+                return false;
             }
         }
 
-        return data.resultType != symTable.semanticError;
+        return true;
     }
 
     private boolean isConstExpression(BLangExpression expression) {
@@ -1393,6 +1394,19 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
             } else if (recordField.getKind() == NodeKind.SIMPLE_VARIABLE_REF) {
                 if (fieldName.equals(((BLangRecordVarNameField) recordField).variableName.value)) {
                     return (BLangRecordLiteral.BLangRecordVarNameField) recordField;
+                }
+            } else if (recordField.getKind() == NodeKind.RECORD_LITERAL_SPREAD_OP) {
+                BLangRecordLiteral.BLangRecordSpreadOperatorField spreadOperatorField =
+                        (BLangRecordLiteral.BLangRecordSpreadOperatorField) recordField;
+                BType spreadOpExprType = Types.getReferredType(spreadOperatorField.expr.getBType());
+                if (spreadOpExprType.tag != TypeTags.RECORD) {
+                    continue;
+                }
+                BRecordType recordType = (BRecordType) spreadOpExprType;
+                for (BField recField : recordType.fields.values()) {
+                    if (fieldName.equals(recField.name.value)) {
+                        return recordLiteral;
+                    }
                 }
             }
         }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableNegativeTest.java
@@ -108,8 +108,6 @@ public class TableNegativeTest {
                 "is not found in table constraint type 'CustomerDetail'", 230, 35);
         validateError(compileResult, index++, "value expression of key specifier 'id' must be " +
                 "a constant expression", 237, 9);
-        validateError(compileResult, index++, "value expression of key specifier 'id' must be " +
-                "a constant expression", 240, 9);
         validateError(compileResult, index++, "incompatible types: expected 'table<record {| string name?; |}>',"
                 + " found 'table<record {| (string|int|boolean) name?; (int|boolean)...; |}>'", 254, 41);
         validateError(compileResult, index++, "incompatible types: expected 'table<record {| string name?; |}>'," +
@@ -155,25 +153,6 @@ public class TableNegativeTest {
         validateError(compileResult, index++, "cannot update 'table<Customer>' with member access expression", 434, 5);
         validateError(compileResult, index++, "incompatible types: expected '(table<Student>|int)', " +
                 "found 'table<record {| readonly int id; string firstName; string lastName; |}>'", 444, 28);
-        validateError(compileResult, index++, "value expression of key specifier 'x' must be a constant expression",
-                457, 9);
-        validateError(compileResult, index++, "value expression of key specifier 'x' must be a constant expression",
-                458, 9);
-        validateError(compileResult, index++, "value expression of key specifier 'x' must be a constant expression",
-                462, 9);
-        validateError(compileResult, index++, "value expression of key specifier 'x' must be a constant expression",
-                463, 9);
-        validateError(compileResult, index++, "value expression of key specifier 'x' must be a constant expression",
-                475, 9);
-        validateError(compileResult, index++, "value expression of key specifier 'y' must be a constant expression",
-                475, 9);
-        validateError(compileResult, index++, "value expression of key specifier 'x' must be a constant expression",
-                476, 9);
-        validateError(compileResult, index++, "value expression of key specifier 'y' must be a constant expression",
-                476, 9);
-        validateError(compileResult, index++, "value expression of key specifier 'z' must be a constant expression",
-                476, 9);
-        Assert.assertEquals(compileResult.getErrorCount(), index);
         Assert.assertEquals(compileResult.getErrorCount(), index);
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/table/record-constraint-table-value.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/table/record-constraint-table-value.bal
@@ -467,6 +467,23 @@ type FooRec record {
 };
 
 public function testSpreadFieldInConstructor() {
+    string expected = "[{\"x\":1001,\"y\":20},{\"x\":1002,\"y\":30}]";
+    FooRec spreadField1 = {x: 1002, y: 30};
+
+    table<FooRec> tb1 = table key(x) [
+            {x: 1001, y: 20},
+            {...spreadField1}
+        ];
+    assertEquality(expected, tb1.toString());
+
+    var spreadField2 = {x: 1002, y: 30};
+
+    var tb2 = table key(x) [
+            {x: 1001, y: 20},
+            {...spreadField2}
+        ];
+    assertEquality(expected, tb2.toString());
+
     var spreadField3 = {id: 2, name: "Jo", age: 12};
     var tb3 = table [
             {id: 1, name: "Mary", salary: 100.0},

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/table/table-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/table/table-negative.bal
@@ -443,35 +443,3 @@ function testIncompatibleTableTypeInAUnion() {
     string lastName = "Jayawickrama";
     table<Student>|int t = table key(id) [{id: 1, firstName: "Lochana", lastName}];
 }
-
-type FooRec record {
-    readonly int x;
-    int y;
-};
-
-FooRec spreadField1 = {x: 1002, y: 30};
-FooRec spreadField2 = {x: 1003, y: 25};
-
-table<FooRec> key(x) tb1 = table [
-        {x: 1001, y: 20},
-        {...spreadField1},
-        {...spreadField2}
-    ];
-
-table<FooRec> key(x) tb2 = table [
-        {...spreadField1},
-        {...spreadField2}
-    ];
-
-type BarRec record {
-    readonly int x;
-    readonly int y;
-    readonly string z;
-};
-
-int i = 1;
-BarRec spreadField3 = {x: 1003, y: 25, z: "a"};
-table<BarRec> key(x, y, z) tb3 = table [
-        {x: i, y: i, z: "a"},
-        {...spreadField3}
-    ];


### PR DESCRIPTION
Reverts ballerina-platform/ballerina-lang#36701

The fix restricts the behavior. Hence; a breaking change.

```ballerina
import ballerina/io;

type FooRec record {
    readonly int x;
    int y;
};

FooRec spreadField1 = {x: 1002, y: 30};
FooRec spreadField2 = {x: 1003, y: 25};

public function main() {
    table<FooRec> key(x) tb1 = table [
            {x: 1001, y: 20},
            {...spreadField1} // this will be restricted with the fix
            // {...spreadField2}
        ];
    io:println(tb1);
}
```