### PR TITLE
Improve AfterBefore functionality for DataDriven Tests

### DIFF
--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/BTestRunner.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/BTestRunner.java
@@ -437,6 +437,7 @@ public class BTestRunner {
 
     private void executeBeforeFunction(Test test, TestSuite suite, ClassLoader classLoader, Scheduler scheduler,
                                        AtomicBoolean shouldSkip, AtomicBoolean shouldSkipTest)  {
+        if (!shouldSkip.get()) {
             // run before tests
             String errorMsg;
             try {
@@ -453,6 +454,7 @@ public class BTestRunner {
                         test, formatErrorMessage(e));
                 errStream.println(errorMsg);
             }
+        }
     }
 
     /**

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/BTestRunner.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/BTestRunner.java
@@ -589,6 +589,12 @@ public class BTestRunner {
                             // run the after tests
                             executeAfterFunction(test, suite, classLoader, scheduler, shouldSkip, shouldSkipTest,
                                     failedAfterFuncTests);
+                        } else {
+                            // If the test function is skipped lets add it to the failed test list
+                            failedOrSkippedTests.add(test.getTestName());
+                            // report the test result
+                            functionResult = new TesterinaResult(test.getTestName(), false, true, null);
+                            tReport.addFunctionResult(packageName, functionResult);
                         }
                     }
                 }
@@ -613,6 +619,12 @@ public class BTestRunner {
                             // run the after tests
                             executeAfterFunction(test, suite, classLoader, scheduler, shouldSkip, shouldSkipTest,
                                     failedAfterFuncTests);
+                        } else {
+                            // If the test function is skipped lets add it to the failed test list
+                            failedOrSkippedTests.add(test.getTestName());
+                            // report the test result
+                            functionResult = new TesterinaResult(test.getTestName(), false, true, null);
+                            tReport.addFunctionResult(packageName, functionResult);
                         }
                     }
                 }

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/BTestRunner.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/BTestRunner.java
@@ -359,20 +359,21 @@ public class BTestRunner {
         }
         suite.getTests().forEach(test -> {
             AtomicBoolean shouldSkipTest = new AtomicBoolean(false);
-
             // execute the before groups functions
             executeBeforeGroupFunctions(test, suite, classLoader, scheduler, shouldSkip,
                     shouldSkipTest, shouldSkipAfterGroups);
-
             // run the before each tests
             executeBeforeEachFunction(test, suite, classLoader, scheduler, shouldSkip);
-            // run the before tests
-            executeBeforeFunction(test, suite, classLoader, scheduler, shouldSkip, shouldSkipTest);
-            // run the test
-            executeFunction(test, suite, packageName, classLoader, scheduler, shouldSkip, shouldSkipTest,
-                    failedOrSkippedTests, failedAfterFuncTests);
-            // run the after tests
-            executeAfterFunction(test, suite, classLoader, scheduler, shouldSkip, shouldSkipTest, failedAfterFuncTests);
+            // Check if the test we are dealing with is a data driven test
+            if (test.getDataProvider() != null) {
+                // Data-driven test
+                executeDataDrivenTestFunction(test, suite, packageName, classLoader, scheduler, shouldSkip,
+                        shouldSkipTest, failedOrSkippedTests, failedAfterFuncTests);
+            } else {
+                // Normal test
+                executeTestFunction(test, suite, packageName, classLoader, scheduler, shouldSkip, shouldSkipTest,
+                        failedOrSkippedTests, failedAfterFuncTests);
+            }
             // run the after each tests
             executeAfterEachFunction(test, suite, classLoader, scheduler, shouldSkip, shouldSkipTest);
             // execute the after groups functions
@@ -436,7 +437,6 @@ public class BTestRunner {
 
     private void executeBeforeFunction(Test test, TestSuite suite, ClassLoader classLoader, Scheduler scheduler,
                                        AtomicBoolean shouldSkip, AtomicBoolean shouldSkipTest)  {
-        if (!shouldSkip.get() && !shouldSkipTest.get()) {
             // run before tests
             String errorMsg;
             try {
@@ -453,7 +453,6 @@ public class BTestRunner {
                         test, formatErrorMessage(e));
                 errStream.println(errorMsg);
             }
-        }
     }
 
     /**
@@ -517,61 +516,110 @@ public class BTestRunner {
         }
     }
 
-    private void executeFunction(Test test, TestSuite suite, String packageName, ClassLoader classLoader,
-                                 Scheduler scheduler, AtomicBoolean shouldSkip, AtomicBoolean shouldSkipTest,
-                                 List<String> failedOrSkippedTests, List<String> failedAfterFuncTests) {
+    private void executeTestFunction(Test test, TestSuite suite, String packageName, ClassLoader classLoader,
+                                     Scheduler scheduler, AtomicBoolean shouldSkip, AtomicBoolean shouldSkipTest,
+                                     List<String> failedOrSkippedTests, List<String> failedAfterFuncTests) {
         TesterinaResult functionResult;
-
+        executeBeforeFunction(test, suite, classLoader, scheduler, shouldSkip, shouldSkipTest);
+        // Check if the test depends on other failed test functions or after functions
         if (isTestDependsOnFailedFunctions(test.getDependsOnTestFunctions(), failedOrSkippedTests) ||
                 isTestDependsOnFailedFunctions(test.getDependsOnTestFunctions(), failedAfterFuncTests)) {
             shouldSkipTest.set(true);
         }
-
-        // Check whether the this test depends on any failed or skipped functions
+        // Check if test should be skipped
         if (!shouldSkip.get() && !shouldSkipTest.get()) {
-            Object valueSets = null;
-            if (test.getDataProvider() != null) {
-                valueSets = invokeTestFunction(suite, test.getDataProvider(), classLoader, scheduler);
-            }
-            if (valueSets == null) {
-                valueSets = invokeTestFunction(suite, test.getTestName(), classLoader, scheduler);
-                computeFunctionResult(test.getTestName(), packageName, shouldSkip, failedOrSkippedTests, valueSets);
-            } else {
-                if (valueSets instanceof BMap) {
-                    // Handle map data sets
-                    if (((BMap) valueSets).isEmpty()) {
-                        computeFunctionResult(test.getTestName(), packageName, shouldSkip, failedOrSkippedTests,
-                                new Error("The provided data set is empty."));
-                    } else {
-                        List<String> keyValues = getKeyValues((BMap) valueSets);
-                        Class<?>[] argTypes = extractArgumentTypes((BMap) valueSets);
-                        List<Object[]> argList = extractArguments((BMap) valueSets);
-                        for (int i = 0, argListSize = argList.size(); i < argListSize; i++) {
+            Object valueSets = invokeTestFunction(suite, test.getTestName(), classLoader, scheduler);
+            computeFunctionResult(test.getTestName(), packageName, shouldSkip, failedOrSkippedTests, valueSets);
+        } else {
+            // If the test function is skipped lets add it to the failed test list
+            failedOrSkippedTests.add(test.getTestName());
+            // report the test result
+            functionResult = new TesterinaResult(test.getTestName(), false, true, null);
+            tReport.addFunctionResult(packageName, functionResult);
+        }
+        // Increment group-name count
+        for (String groupName : test.getGroups()) {
+            suite.getGroups().get(groupName).incrementExecutedCount();
+        }
+        // Write failed tests to json
+        if (!packageName.equals(TesterinaConstants.DOT)) {
+            Path jsonPath = Paths.get(this.targetPath.toString(), TesterinaConstants.RERUN_TEST_JSON_FILE);
+            File jsonFile = new File(jsonPath.toString());
+            writeFailedTestsToJson(failedOrSkippedTests, jsonFile);
+        }
+        executeAfterFunction(test, suite, classLoader, scheduler, shouldSkip, shouldSkipTest, failedAfterFuncTests);
+    }
+
+    private void executeDataDrivenTestFunction(Test test, TestSuite suite, String packageName, ClassLoader classLoader,
+                                               Scheduler scheduler, AtomicBoolean shouldSkip,
+                                               AtomicBoolean shouldSkipTest, List<String> failedOrSkippedTests,
+                                               List<String> failedAfterFuncTests) {
+        TesterinaResult functionResult;
+        // Check if the test depends on other failed test functions or after functions
+        if (isTestDependsOnFailedFunctions(test.getDependsOnTestFunctions(), failedOrSkippedTests) ||
+                isTestDependsOnFailedFunctions(test.getDependsOnTestFunctions(), failedAfterFuncTests)) {
+            shouldSkipTest.set(true);
+        }
+        // Check if test should be skipped
+        if (!shouldSkip.get() && !shouldSkipTest.get()) {
+            Object valueSets = invokeTestFunction(suite, test.getDataProvider(), classLoader, scheduler);
+            // Handle map datasets
+            if (valueSets instanceof BMap) {
+                // Handle map data sets
+                if (((BMap) valueSets).isEmpty()) {
+                    computeFunctionResult(test.getTestName(), packageName, shouldSkip, failedOrSkippedTests,
+                            new Error("The provided data set is empty."));
+                } else {
+                    List<String> keyValues = getKeyValues((BMap) valueSets);
+                    Class<?>[] argTypes = extractArgumentTypes((BMap) valueSets);
+                    List<Object[]> argList = extractArguments((BMap) valueSets);
+                    for (int i = 0, argListSize = argList.size(); i < argListSize; i++) {
+                        // Reset shouldSkipTest for each iteration, since Before function may not fail for other
+                        // iterations
+                        shouldSkipTest.set(false);
+                        // run the before tests
+                        executeBeforeFunction(test, suite, classLoader, scheduler, shouldSkip, shouldSkipTest);
+                        // ShouldSkip may be set for
+                        if (!shouldSkipTest.get()) {
                             invokeDataDrivenTest(suite, test.getTestName(), escapeSpecialCharacters(keyValues.get(i)),
                                     classLoader, scheduler, shouldSkip, packageName, argList.get(i), argTypes,
                                     failedOrSkippedTests);
+                            // run the after tests
+                            executeAfterFunction(test, suite, classLoader, scheduler, shouldSkip, shouldSkipTest,
+                                    failedAfterFuncTests);
                         }
                     }
-                } else if (valueSets instanceof BArray) {
-                    if (((BArray) valueSets).isEmpty()) {
-                        computeFunctionResult(test.getTestName(), packageName, shouldSkip, failedOrSkippedTests,
-                                new Error("The provided data set is empty."));
-                    } else {
-                        // Handle array data sets
-                        Class<?>[] argTypes = extractArgumentTypes((BArray) valueSets);
-                        List<Object[]> argList = extractArguments((BArray) valueSets);
-                        for (int i = 0, argListSize = argList.size(); i < argListSize; i++) {
+                }
+            } else if (valueSets instanceof BArray) {
+                if (((BArray) valueSets).isEmpty()) {
+                    computeFunctionResult(test.getTestName(), packageName, shouldSkip, failedOrSkippedTests,
+                            new Error("The provided data set is empty."));
+                } else {
+                    // Handle array data sets
+                    Class<?>[] argTypes = extractArgumentTypes((BArray) valueSets);
+                    List<Object[]> argList = extractArguments((BArray) valueSets);
+                    for (int i = 0, argListSize = argList.size(); i < argListSize; i++) {
+                        // Reset shouldSkipTest for each iteration, since Before function may not fail for other
+                        // iterations
+                        shouldSkipTest.set(false);
+                        // run the before tests
+                        executeBeforeFunction(test, suite, classLoader, scheduler, shouldSkip, shouldSkipTest);
+                        // ShouldSkip may be set for
+                        if (!shouldSkipTest.get()) {
                             invokeDataDrivenTest(suite, test.getTestName(), String.valueOf(i), classLoader, scheduler,
                                     shouldSkip, packageName, argList.get(i), argTypes, failedOrSkippedTests);
+                            // run the after tests
+                            executeAfterFunction(test, suite, classLoader, scheduler, shouldSkip, shouldSkipTest,
+                                    failedAfterFuncTests);
                         }
                     }
-                } else if (valueSets instanceof Error || valueSets instanceof Exception) {
-                    computeFunctionResult(test.getTestName(), packageName, shouldSkip, failedOrSkippedTests,
-                            valueSets);
-                } else {
-                    computeFunctionResult(test.getTestName(), packageName, shouldSkip, failedOrSkippedTests,
-                            new Error("The provided data set does not match the supported formats."));
                 }
+            } else if (valueSets instanceof Error || valueSets instanceof Exception) {
+                computeFunctionResult(test.getTestName(), packageName, shouldSkip, failedOrSkippedTests,
+                        valueSets);
+            } else {
+                computeFunctionResult(test.getTestName(), packageName, shouldSkip, failedOrSkippedTests,
+                        new Error("The provided data set does not match the supported formats."));
             }
         } else {
             // If the test function is skipped lets add it to the failed test list
@@ -580,16 +628,16 @@ public class BTestRunner {
             functionResult = new TesterinaResult(test.getTestName(), false, true, null);
             tReport.addFunctionResult(packageName, functionResult);
         }
+        // Increment group-name count
         for (String groupName : test.getGroups()) {
             suite.getGroups().get(groupName).incrementExecutedCount();
         }
-
+        // Write failed tests to json
         if (!packageName.equals(TesterinaConstants.DOT)) {
             Path jsonPath = Paths.get(this.targetPath.toString(), TesterinaConstants.RERUN_TEST_JSON_FILE);
             File jsonFile = new File(jsonPath.toString());
             writeFailedTestsToJson(failedOrSkippedTests, jsonFile);
         }
-
     }
 
     private void computeFunctionResult(String testName, String packageName, AtomicBoolean shouldSkip,

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/DataProviderTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/DataProviderTest.java
@@ -184,6 +184,7 @@ public class DataProviderTest extends BaseTestCase {
 
     @Test
     public void testMapValueDataProvider() throws BallerinaTestException {
+
         String msg1 = "1 passing";
         String msg2 = "1 failing";
         String[] args = mergeCoverageArgs(new String[]{"--tests", "testGetState", "data-providers"});
@@ -191,6 +192,60 @@ public class DataProviderTest extends BaseTestCase {
                 new HashMap<>(), projectPath, false);
         if (!output.contains(msg1) || !output.contains(msg2)) {
             Assert.fail("Test failed due to multi module single test exec failure with array based data provider.");
+        }
+    }
+
+    @Test
+    public void testValidDataProviderWithBeforeAfterFunctions() throws BallerinaTestException {
+        String msg1 = "6 passing";
+        String msg2 = "0 failing";
+        String[] args = mergeCoverageArgs(new String[]{"--tests", "testExecutionOfBeforeAfter", "data-providers"});
+        String output = balClient.runMainAndReadStdOut("test", args,
+                new HashMap<>(), projectPath, false);
+        if (!output.contains(msg1) || !output.contains(msg2)) {
+            Assert.fail("Test failed due to map based data provider failure.");
+        }
+    }
+
+    @Test
+    public void testValidDataProviderWithBeforeFailing() throws BallerinaTestException {
+        String msg1 = "5 passing";
+        String msg2 = "0 failing";
+        String msg3 = "1 skipped";
+        String[] args = mergeCoverageArgs(new String[]{"--tests",
+                "testDividingValuesWithBeforeFailing,testExecutionOfBeforeFailing", "data-providers"});
+        String output = balClient.runMainAndReadStdOut("test", args,
+                new HashMap<>(), projectPath, false);
+        if (!output.contains(msg1) || !output.contains(msg2) || !output.contains(msg3)) {
+            Assert.fail("Test failed due to map based data provider failure.");
+        }
+    }
+
+    @Test
+    public void testValidDataProviderWithAfterFailing() throws BallerinaTestException {
+        String msg1 = "6 passing";
+        String msg2 = "0 failing";
+        String msg3 = "0 skipped";
+        String[] args = mergeCoverageArgs(new String[]{"--tests",
+                "testDividingValuesWithAfterFailing,testExecutionOfAfterFailing", "data-providers"});
+        String output = balClient.runMainAndReadStdOut("test", args,
+                new HashMap<>(), projectPath, false);
+        if (!output.contains(msg1) || !output.contains(msg2) || !output.contains(msg3)) {
+            Assert.fail("Test failed due to map based data provider failure.");
+        }
+    }
+
+    @Test
+    public void testDataProviderSingleFailure() throws BallerinaTestException {
+        String msg1 = "5 passing";
+        String msg2 = "1 failing";
+        String msg3 = "0 skipped";
+        String[] args = mergeCoverageArgs(new String[]{"--tests",
+                "testExecutionOfDataValueFailing", "data-providers"});
+        String output = balClient.runMainAndReadStdOut("test", args,
+                new HashMap<>(), projectPath, false);
+        if (!output.contains(msg1) || !output.contains(msg2) || !output.contains(msg3)) {
+            Assert.fail("Test failed due to map based data provider failure.");
         }
     }
 }


### PR DESCRIPTION
## Purpose
After and Before functions for Data-driven tests do not execute after each value is being run. 

Fixes #36529

## Approach
- Split the execution of the 'normal test function' and the 'data-driven test' to new functions `executeTestFunction()` and `executeDataDrivenTestFunction()` 
- Move the 'after' and 'before' functions to the respective places inside the new functions

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
