### PR TITLE
[2201.2.x] Add first param filtering for lang-libs

### DIFF
--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/symbol/SymbolDocumentationTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/extensions/symbol/SymbolDocumentationTest.java
@@ -50,7 +50,7 @@ public class SymbolDocumentationTest {
         TestUtil.openDocument(serviceEndpoint, inputFile);
 
         Position functionPos = new Position();
-        functionPos.setLine(15);
+        functionPos.setLine(16);
         functionPos.setCharacter(19);
         SymbolInfoResponse symbolInfoResponse = LSExtensionTestUtil.getSymbolDocumentation(
                 inputFile.toString(), functionPos, this.serviceEndpoint);
@@ -76,7 +76,7 @@ public class SymbolDocumentationTest {
         TestUtil.openDocument(serviceEndpoint, inputFile);
 
         Position functionPos = new Position();
-        functionPos.setLine(16);
+        functionPos.setLine(17);
         functionPos.setCharacter(20);
         SymbolInfoResponse symbolInfoResponse = LSExtensionTestUtil.getSymbolDocumentation(
                 inputFile.toString(), functionPos, this.serviceEndpoint);
@@ -104,7 +104,7 @@ public class SymbolDocumentationTest {
         TestUtil.openDocument(serviceEndpoint, inputFile);
 
         Position functionPos = new Position();
-        functionPos.setLine(17);
+        functionPos.setLine(18);
         functionPos.setCharacter(20);
         SymbolInfoResponse symbolInfoResponse = LSExtensionTestUtil.getSymbolDocumentation(
                 inputFile.toString(), functionPos, this.serviceEndpoint);
@@ -120,7 +120,7 @@ public class SymbolDocumentationTest {
         TestUtil.openDocument(serviceEndpoint, inputFile);
 
         Position functionPos = new Position();
-        functionPos.setLine(18);
+        functionPos.setLine(19);
         functionPos.setCharacter(15);
         SymbolInfoResponse symbolInfoResponse = LSExtensionTestUtil.getSymbolDocumentation(
                 inputFile.toString(), functionPos, this.serviceEndpoint);
@@ -140,7 +140,7 @@ public class SymbolDocumentationTest {
         TestUtil.openDocument(serviceEndpoint, inputFile);
 
         Position functionPos = new Position();
-        functionPos.setLine(19);
+        functionPos.setLine(20);
         functionPos.setCharacter(27);
         SymbolInfoResponse symbolInfoResponse = LSExtensionTestUtil.getSymbolDocumentation(
                 inputFile.toString(), functionPos, this.serviceEndpoint);
@@ -161,7 +161,7 @@ public class SymbolDocumentationTest {
         TestUtil.openDocument(serviceEndpoint, inputFile);
 
         Position functionPos = new Position();
-        functionPos.setLine(20);
+        functionPos.setLine(21);
         functionPos.setCharacter(28);
         SymbolInfoResponse symbolInfoResponse = LSExtensionTestUtil.getSymbolDocumentation(
                 inputFile.toString(), functionPos, this.serviceEndpoint);
@@ -182,12 +182,76 @@ public class SymbolDocumentationTest {
         TestUtil.openDocument(serviceEndpoint, inputFile);
 
         Position functionPos = new Position();
-        functionPos.setLine(21);
+        functionPos.setLine(22);
         functionPos.setCharacter(19);
         SymbolInfoResponse symbolInfoResponse = LSExtensionTestUtil.getSymbolDocumentation(
                 inputFile.toString(), functionPos, this.serviceEndpoint);
 
         Assert.assertEquals(symbolInfoResponse.getDocumentation(), null);
+        TestUtil.closeDocument(this.serviceEndpoint, inputFile);
+    }
+
+    @Test(description = "test lang-lib documentation with filtered first param")
+    public void testLangLibDocumentation() throws IOException {
+        Path inputFile = LSExtensionTestUtil.createTempFile(symbolDocumentBalFile);
+        TestUtil.openDocument(serviceEndpoint, inputFile);
+
+        Position functionPos = new Position();
+        functionPos.setLine(23);
+        functionPos.setCharacter(22);
+        SymbolInfoResponse symbolInfoResponse = LSExtensionTestUtil.getSymbolDocumentation(
+                inputFile.toString(), functionPos, this.serviceEndpoint);
+
+        Assert.assertNotEquals(symbolInfoResponse.getDocumentation(), null);
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getDescription(),
+                "Returns the length of the string.\n");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getReturnValueDescription(),
+                "the number of characters (code points) in parameter `str`");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getParameters(), null);
+        TestUtil.closeDocument(this.serviceEndpoint, inputFile);
+    }
+
+    @Test(description = "test lang-lib documentation with qualified identifier")
+    public void testLangLibDocumentationWithQualifiedIdentifier() throws IOException {
+        Path inputFile = LSExtensionTestUtil.createTempFile(symbolDocumentBalFile);
+        TestUtil.openDocument(serviceEndpoint, inputFile);
+
+        Position functionPos = new Position();
+        functionPos.setLine(24);
+        functionPos.setCharacter(26);
+        SymbolInfoResponse symbolInfoResponse = LSExtensionTestUtil.getSymbolDocumentation(
+                inputFile.toString(), functionPos, this.serviceEndpoint);
+
+        Assert.assertNotEquals(symbolInfoResponse.getDocumentation(), null);
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getDescription(),
+                "Returns the length of the string.\n");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getReturnValueDescription(),
+                "the number of characters (code points) in parameter `str`");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getParameters().get(0).getName(), "str");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getParameters().get(0).getDescription(),
+                "the string");
+        TestUtil.closeDocument(this.serviceEndpoint, inputFile);
+    }
+
+    @Test(description = "test documentation for remote-method-calls")
+    public void testDocumentationForRemoteActionMethodCall() throws IOException {
+        Path inputFile = LSExtensionTestUtil.createTempFile(symbolDocumentBalFile);
+        TestUtil.openDocument(serviceEndpoint, inputFile);
+
+        Position functionPos = new Position();
+        functionPos.setLine(26);
+        functionPos.setCharacter(30);
+        SymbolInfoResponse symbolInfoResponse = LSExtensionTestUtil.getSymbolDocumentation(
+                inputFile.toString(), functionPos, this.serviceEndpoint);
+
+        Assert.assertNotEquals(symbolInfoResponse.getDocumentation(), null);
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getDescription(),
+                "Set the Id of the student\n");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getReturnValueDescription(),
+                "Student id");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getParameters().get(0).getName(), "id");
+        Assert.assertEquals(symbolInfoResponse.getDocumentation().getParameters().get(0).getDescription(),
+                "Id of the student");
         TestUtil.closeDocument(this.serviceEndpoint, inputFile);
     }
 

--- a/language-server/modules/langserver-core/src/test/resources/extensions/symbol/symbolDocumentation.bal
+++ b/language-server/modules/langserver-core/src/test/resources/extensions/symbol/symbolDocumentation.bal
@@ -1,4 +1,5 @@
 import ballerina/module1;
+import ballerina/lang.'string;
 
 # Adds two integers.
 
@@ -20,6 +21,10 @@ public function main() returns error? {
     Counter counter = new (12);
     File f = check new File("test.txt", "Hello World");
     Person pr = new;
+    int leng = "test".length();
+    int length2 = 'string:length("test");
+    Student student = new("Ballerina");
+    int stId = student -> setId(1);
 }
 
 # Creates and returns a `Person` object given the parameters.
@@ -70,5 +75,22 @@ class Person {
 
     function getName() returns string {
         return self.name;
+    }
+}
+
+public client class Student {
+    string name;
+    int id;
+
+    function init(string name) {
+        self.name = name;
+    }
+    # Set the Id of the student
+    #
+    # + id - Id of the student
+    # + return - Student id
+    remote function setId(int id) returns int {
+        self.id = id;
+        return self.id;
     }
 }


### PR DESCRIPTION
## Purpose
Related issue -> https://github.com/ballerina-platform/ballerina-lang/issues/36728
With this pr first parameter is filtered for lang-lib method calls in BallerinaSymbolService's getSymbol service (service used to get documentation for low-code-editors parameters tab)


## Approach
If a Symbol is a function / method call we check if its a lang-lib using the lang-server-core common-utils isLangLib function

## Remarks
same pr sent to master branch -> https://github.com/ballerina-platform/ballerina-lang/pull/36781
2201.1.x -> https://github.com/ballerina-platform/ballerina-lang/pull/36780

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
