### PR TITLE
Propagate crashes during BIR loading due to unresolved imports to common diagnostics

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/JBallerinaBackend.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/JBallerinaBackend.java
@@ -155,8 +155,9 @@ public class JBallerinaBackend extends CompilerBackend {
             // If modules from the current package are being processed
             // we do an overall check on the diagnostics of the package
             if (moduleContext.moduleId().packageId().equals(packageContext.packageId())) {
-                if (!packageCompilation.diagnosticResult().diagnostics().isEmpty()) {
-                    moduleDiagnostics.addAll(packageCompilation.diagnosticResult().diagnostics());
+                Collection<Diagnostic> pkgDiagnostics = packageCompilation.diagnosticResult().diagnostics();
+                if (!pkgDiagnostics.isEmpty()) {
+                    moduleDiagnostics.addAll(pkgDiagnostics);
                     if (packageCompilation.diagnosticResult().hasErrors()) {
                         break;
                     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/JBallerinaBackend.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/JBallerinaBackend.java
@@ -20,7 +20,6 @@ package io.ballerina.projects;
 import io.ballerina.projects.environment.PackageCache;
 import io.ballerina.projects.environment.ProjectEnvironment;
 import io.ballerina.projects.internal.DefaultDiagnosticResult;
-import io.ballerina.projects.internal.PackageDiagnostic;
 import io.ballerina.projects.internal.jballerina.JarWriter;
 import io.ballerina.projects.internal.model.Target;
 import io.ballerina.projects.util.ProjectConstants;
@@ -60,9 +59,11 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 import java.util.jar.JarInputStream;
@@ -149,7 +150,7 @@ public class JBallerinaBackend extends CompilerBackend {
         // add ballerina toml diagnostics
         diagnostics.addAll(this.packageContext.packageManifest().diagnostics().diagnostics());
         // collect compilation diagnostics
-        List<Diagnostic> moduleDiagnostics = new ArrayList<>();
+        Set<Diagnostic> moduleDiagnostics = new LinkedHashSet<>();
         for (ModuleContext moduleContext : pkgResolution.topologicallySortedModuleList()) {
             // If modules from the current package are being processed
             // we do an overall check on the diagnostics of the package
@@ -164,10 +165,6 @@ public class JBallerinaBackend extends CompilerBackend {
             if (hasNoErrors(moduleDiagnostics)) {
                 moduleContext.generatePlatformSpecificCode(compilerContext, this);
             }
-            for (Diagnostic diagnostic : moduleContext.diagnostics()) {
-                moduleDiagnostics.add(
-                        new PackageDiagnostic(diagnostic, moduleContext.descriptor(), moduleContext.project()));
-            }
         }
         // add compilation diagnostics
         diagnostics.addAll(moduleDiagnostics);
@@ -180,7 +177,7 @@ public class JBallerinaBackend extends CompilerBackend {
         codeGenCompleted = true;
     }
 
-    private boolean hasNoErrors(List<Diagnostic> diagnostics) {
+    private boolean hasNoErrors(Set<Diagnostic> diagnostics) {
         for (Diagnostic diagnostic : diagnostics) {
             if (diagnostic.diagnosticInfo().severity() == DiagnosticSeverity.ERROR) {
                 return false;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/JBallerinaBackend.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/JBallerinaBackend.java
@@ -155,9 +155,11 @@ public class JBallerinaBackend extends CompilerBackend {
             // If modules from the current package are being processed
             // we do an overall check on the diagnostics of the package
             if (moduleContext.moduleId().packageId().equals(packageContext.packageId())) {
-                if (packageCompilation.diagnosticResult().hasErrors()) {
+                if (!packageCompilation.diagnosticResult().diagnostics().isEmpty()) {
                     moduleDiagnostics.addAll(packageCompilation.diagnosticResult().diagnostics());
-                    break;
+                    if (packageCompilation.diagnosticResult().hasErrors()) {
+                        break;
+                    }
                 }
             }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ModuleContext.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ModuleContext.java
@@ -531,6 +531,7 @@ class ModuleContext {
         moduleContext.bLangPackage = pkgNode;
         moduleContext.bPackageSymbol.exported = moduleContext.isExported();
         moduleContext.bPackageSymbol.descriptor = moduleContext.descriptor();
+        pkgNode.symbol = moduleContext.bPackageSymbol;
         packageCache.putSymbol(pkgNode.packageID, moduleContext.bPackageSymbol);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ModuleContext.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ModuleContext.java
@@ -525,11 +525,13 @@ class ModuleContext {
                 org.wso2.ballerinalang.compiler.PackageCache.getInstance(compilerContext);
         BIRPackageSymbolEnter birPackageSymbolEnter = BIRPackageSymbolEnter.getInstance(compilerContext);
 
-        PackageID moduleCompilationId = moduleContext.descriptor().moduleCompilationId();
-        moduleContext.bPackageSymbol = birPackageSymbolEnter.definePackage(moduleCompilationId, moduleContext.birBytes);
+        BLangPackage pkgNode = (BLangPackage) TreeBuilder.createPackageNode();
+        pkgNode.packageID = moduleContext.descriptor().moduleCompilationId();
+        moduleContext.bPackageSymbol = birPackageSymbolEnter.definePackage(pkgNode, moduleContext.birBytes);
+        moduleContext.bLangPackage = pkgNode;
         moduleContext.bPackageSymbol.exported = moduleContext.isExported();
         moduleContext.bPackageSymbol.descriptor = moduleContext.descriptor();
-        packageCache.putSymbol(moduleCompilationId, moduleContext.bPackageSymbol);
+        packageCache.putSymbol(pkgNode.packageID, moduleContext.bPackageSymbol);
     }
 
     static void loadPlatformSpecificCodeInternal(ModuleContext moduleContext, CompilerBackend compilerBackend) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
@@ -239,7 +239,7 @@ public class BIRPackageSymbolEnter {
         // TODO Validate this pkdID with the requestedPackageID available in the env.
 
         // Define import packages.
-        defineSymbols(dataInStream, rethrow(dataInStream1 -> defineImportPackage(pkgNode, dataInStream1)));
+        defineSymbols(dataInStream, rethrow(dataInputStream -> defineImportPackage(pkgNode, dataInputStream)));
 
         // Define constants.
         defineSymbols(dataInStream, rethrow(this::defineConstant));

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
@@ -222,7 +222,8 @@ public class BIRPackageSymbolEnter {
         return definePackage(pkgNode, dataInStream, pkgCPIndex);
     }
 
-    private BPackageSymbol definePackage(BLangPackage pkgNode, DataInputStream dataInStream, int pkgCpIndex) throws IOException {
+    private BPackageSymbol definePackage(BLangPackage pkgNode, DataInputStream dataInStream,
+                                         int pkgCpIndex) throws IOException {
 
         PackageCPEntry pkgCpEntry = (PackageCPEntry) this.env.constantPool[pkgCpIndex];
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
@@ -196,8 +196,8 @@ public class BIRPackageSymbolEnter {
             this.env = prevEnv;
             return pkgSymbol;
         } catch (Throwable e) {
-            throw new BLangCompilerException("failed to load the module '" + pkgNode.packageID.toString() + "' from its BIR" +
-                    (e.getMessage() != null ? (" due to: " + e.getMessage()) : ""), e);
+            throw new BLangCompilerException("failed to load the module '" + pkgNode.packageID.toString()
+                    + "' from its BIR" + (e.getMessage() != null ? (" due to: " + e.getMessage()) : ""), e);
         }
     }
 


### PR DESCRIPTION
## Purpose
The below image shows how unresolved dependency diagnostics are being printed for `bir` and `bala` cases respectively.

> ![Screenshot 2022-06-30 at 12 29 28](https://user-images.githubusercontent.com/15815199/176616576-2ba9a7bd-8c61-4495-8475-5667cefd82ef.png)

Fixes #36393

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
