### PR TITLE
Disable debugger test `localVariableChildrenVisibilityTest`

### DIFF
--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/variables/VariableVisibilityTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/variables/VariableVisibilityTest.java
@@ -328,7 +328,8 @@ public class VariableVisibilityTest extends BaseTestCase {
         debugTestRunner.assertVariable(localVariables, "letVar", "\"Hello Ballerina!\"", "string");
     }
 
-    @Test(description = "Child variable visibility test for local variables at the last line of main() method")
+    @Test(enabled = false, description = "Child variable visibility test for local variables at the last line of main" +
+            "() method")
     public void localVariableChildrenVisibilityTest() throws BallerinaTestException {
         debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 326));
         debugTestRunner.initDebugSession(DebugUtils.DebuggeeExecutionKind.RUN);


### PR DESCRIPTION
## Purpose
$subject

## Approach
This seems to be intermittently failing in the build. 
https://github.com/ballerina-platform/ballerina-lang/runs/7148360049?check_suite_focus=true

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
