### PR TITLE
[2201.2.x] Fix NPE in SymbolFinder and ReferenceFinder in worker-flush expression when worker is missing

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/ReferenceFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/ReferenceFinder.java
@@ -1200,6 +1200,11 @@ public class ReferenceFinder extends BaseVisitor {
 
     @Override
     public void visit(BLangWorkerFlushExpr workerFlushExpr) {
+        // Ignore incomplete worker-flush expressions
+        // Ex: var a = flush;
+        if (workerFlushExpr.workerIdentifier == null) {
+            return;
+        }
         addIfSameSymbol(workerFlushExpr.workerSymbol, workerFlushExpr.workerIdentifier.pos);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
@@ -1518,6 +1518,11 @@ class SymbolFinder extends BaseVisitor {
 
     @Override
     public void visit(BLangWorkerFlushExpr workerFlushExpr) {
+        // Ignore incomplete worker-flush expressions
+        // Ex: var a = flush;
+        if (workerFlushExpr.workerIdentifier == null) {
+            return;
+        }
         setEnclosingNode(workerFlushExpr.workerSymbol, workerFlushExpr.workerIdentifier.pos);
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/visiblesymbols/VisibleSymbolsInWorkersTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/visiblesymbols/VisibleSymbolsInWorkersTest.java
@@ -47,7 +47,8 @@ public class VisibleSymbolsInWorkersTest extends BaseVisibleSymbolsTest {
                         from("aString", VARIABLE),
                         from("workerSendToWorker", FUNCTION),
                         from("testFork", FUNCTION),
-                        from("testWorkerSendReceive", FUNCTION)
+                        from("testWorkerSendReceive", FUNCTION),
+                        from("testFlushWithoutWorkerName", FUNCTION)
                 );
         List<ExpectedSymbolInfo> commonSyms = concat(expModuleSymbols,
                                                      from("w1", WORKER),
@@ -91,6 +92,10 @@ public class VisibleSymbolsInWorkersTest extends BaseVisibleSymbolsTest {
                         from("b", VARIABLE),
                         from("wrk1", WORKER),
                         from("wrk2", WORKER)
+                )},
+                {71, 26, concat(expModuleSymbols,
+                        from("err", VARIABLE),
+                        from("w2", WORKER)
                 )},
         };
     }

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/visiblesymbols/symbol_lookup_with_workers_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/visiblesymbols/symbol_lookup_with_workers_test.bal
@@ -65,3 +65,14 @@ function testWorkerSendReceive() {
         int b = <-
     }
 }
+
+function testFlushWithoutWorkerName() {
+    worker w1 {
+        10 -> w2;
+        error? err = flush ;
+    }
+
+    worker w2 {
+        int receivedVal = <- w1;
+    }
+}


### PR DESCRIPTION
## Purpose
$title

Fixes #36334

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
