### PR TITLE
Make strand dump test handle changed order in output

### DIFF
--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/troubleshoot/StrandDumpTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/troubleshoot/StrandDumpTest.java
@@ -133,15 +133,15 @@ public class StrandDumpTest extends BaseTest {
             expectedOutputRegEx = Files.lines(expectedOutputFilePath)
                     .filter(s -> !s.isBlank()).collect(Collectors.toList());
         } catch (IOException e) {
-            throw new BallerinaTestException("Failure to read from expected strand dump output file");
+            throw new BallerinaTestException("Failure to read from the expected strand dump output file");
         }
 
         for (String expectedRegEx : expectedOutputRegEx) {
             Pattern pattern = Pattern.compile(expectedRegEx);
             Matcher matcher = pattern.matcher(obtainedStrandDump);
             if (!matcher.find()) {
-                throw new BallerinaTestException("Failure to obtain the expected strand dump. Obtained strand dump:\n"
-                + obtainedStrandDump);
+                throw new BallerinaTestException("Failure to obtain the expected strand dump.\nExpected regular " +
+                        "expression: " + expectedRegEx + "\nObtained strand dump:\n" + obtainedStrandDump);
             }
         }
     }

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/troubleshoot/StrandDumpTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/troubleshoot/StrandDumpTest.java
@@ -128,16 +128,21 @@ public class StrandDumpTest extends BaseTest {
 
     private void verifyObtainedStrandDump(Path expectedOutputFilePath, String obtainedStrandDump)
             throws BallerinaTestException {
-        String expectedOutputRegEx;
+        List<String> expectedOutputRegEx;
         try {
-            expectedOutputRegEx = Files.readString(expectedOutputFilePath);
+            expectedOutputRegEx = Files.lines(expectedOutputFilePath)
+                    .filter(s -> !s.isBlank()).collect(Collectors.toList());
         } catch (IOException e) {
             throw new BallerinaTestException("Failure to read from expected strand dump output file");
         }
-        Pattern pattern = Pattern.compile(expectedOutputRegEx);
-        Matcher matcher = pattern.matcher(obtainedStrandDump);
-        if (!matcher.find()) {
-            throw new BallerinaTestException("Failure to obtain the expected strand dump");
+
+        for (String expectedRegEx : expectedOutputRegEx) {
+            Pattern pattern = Pattern.compile(expectedRegEx);
+            Matcher matcher = pattern.matcher(obtainedStrandDump);
+            if (!matcher.find()) {
+                throw new BallerinaTestException("Failure to obtain the expected strand dump. Obtained strand dump:\n"
+                + obtainedStrandDump);
+            }
         }
     }
 

--- a/tests/jballerina-integration-test/src/test/resources/troubleshoot/strandDump/singleBalFiles/balProgram1.bal
+++ b/tests/jballerina-integration-test/src/test/resources/troubleshoot/strandDump/singleBalFiles/balProgram1.bal
@@ -39,7 +39,7 @@ function bar() {
 
     @strand {thread: "any"}
     worker w2 {
-        runtime:sleep(2);
+        runtime:sleep(1.5);
         lock {
             globalVar = !globalVar;
         }

--- a/tests/jballerina-integration-test/src/test/resources/troubleshoot/strandDump/testPackageWithModules/main.bal
+++ b/tests/jballerina-integration-test/src/test/resources/troubleshoot/strandDump/testPackageWithModules/main.bal
@@ -70,7 +70,7 @@ function balfunc() {
 
     @strand {thread: "any"}
     worker w2 {
-        runtime:sleep(1);
+        runtime:sleep(1.5);
         lock {
             globalVar = !globalVar;
         }


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues.

Strands and strand group order in the strand dump output can be different at different times. Hence the strand dump test needs to be modified to support that also.

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
