### PR TITLE
[Debugger] Introduces the run in terminal feature

### DIFF
--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/ExecutionContext.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/ExecutionContext.java
@@ -41,6 +41,7 @@ public class ExecutionContext {
     private Process launchedProcess;
     private DebugInstruction lastInstruction;
     private boolean terminateRequestReceived;
+    private boolean supportsRunInTerminalRequest;
 
     ExecutionContext(JBallerinaDebugServer adapter) {
         this.adapter = adapter;
@@ -149,6 +150,14 @@ public class ExecutionContext {
 
     public void setSourceProjectRoot(String sourceProjectRoot) {
         this.sourceProjectRoot = sourceProjectRoot;
+    }
+
+    public void setSupportsRunInTerminalRequest(boolean supportsRunInTerminalRequest) {
+        this.supportsRunInTerminalRequest = supportsRunInTerminalRequest;
+    }
+
+    public boolean getSupportsRunInTerminalRequest() {
+        return supportsRunInTerminalRequest;
     }
 
     /**

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JBallerinaDebugServer.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JBallerinaDebugServer.java
@@ -71,6 +71,8 @@ import org.eclipse.lsp4j.debug.ExitedEventArguments;
 import org.eclipse.lsp4j.debug.InitializeRequestArguments;
 import org.eclipse.lsp4j.debug.NextArguments;
 import org.eclipse.lsp4j.debug.PauseArguments;
+import org.eclipse.lsp4j.debug.RunInTerminalRequestArguments;
+import org.eclipse.lsp4j.debug.RunInTerminalResponse;
 import org.eclipse.lsp4j.debug.Scope;
 import org.eclipse.lsp4j.debug.ScopesArguments;
 import org.eclipse.lsp4j.debug.ScopesResponse;
@@ -95,7 +97,9 @@ import org.eclipse.lsp4j.debug.VariablesArguments;
 import org.eclipse.lsp4j.debug.VariablesResponse;
 import org.eclipse.lsp4j.debug.services.IDebugProtocolClient;
 import org.eclipse.lsp4j.debug.services.IDebugProtocolServer;
+import org.eclipse.lsp4j.jsonrpc.Endpoint;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.eclipse.lsp4j.jsonrpc.services.GenericEndpoint;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -112,6 +116,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
@@ -156,6 +161,8 @@ public class JBallerinaDebugServer implements IDebugProtocolServer {
     private static final String VALUE_UNKNOWN = "unknown";
     private static final String EVAL_ARGS_CONTEXT_VARIABLES = "variables";
     private static final String COMPILATION_ERROR_MESSAGE = "error: compilation contains errors";
+    private static final String TERMINAL_TITLE = "Ballerina Debug Terminal";
+    private static final String RUN_IN_TERMINAL_REQUEST = "runInTerminal";
 
     public JBallerinaDebugServer() {
         context = new ExecutionContext(this);
@@ -197,6 +204,8 @@ public class JBallerinaDebugServer implements IDebugProtocolServer {
         capabilities.setSupportsExceptionInfoRequest(false);
 
         context.setClient(client);
+        context.setSupportsRunInTerminalRequest(args.getSupportsRunInTerminalRequest() != null &&
+                args.getSupportsRunInTerminalRequest());
         eventProcessor = new JDIEventProcessor(context);
         client.initialized();
         this.outputLogger = new DebugOutputLogger(client);
@@ -248,8 +257,12 @@ public class JBallerinaDebugServer implements IDebugProtocolServer {
                     new BSingleFileRunner((ClientLaunchConfigHolder) clientConfigHolder, sourceProjectRoot) :
                     new BPackageRunner((ClientLaunchConfigHolder) clientConfigHolder, sourceProjectRoot);
 
-            context.setLaunchedProcess(programRunner.start());
-            startListeningToProgramOutput();
+            if (context.getSupportsRunInTerminalRequest() && clientConfigHolder.getRunInTerminalKind() != null) {
+                launchInTerminal(programRunner);
+            } else {
+                context.setLaunchedProcess(programRunner.start());
+                startListeningToProgramOutput();
+            }
             return CompletableFuture.completedFuture(null);
         } catch (Exception e) {
             outputLogger.sendErrorOutput("Failed to launch the ballerina program due to: " + e);
@@ -582,6 +595,67 @@ public class JBallerinaDebugServer implements IDebugProtocolServer {
         context.setTerminateRequestReceived(true);
         terminateDebugServer(true, true);
         return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<RunInTerminalResponse> runInTerminal(RunInTerminalRequestArguments args) {
+        Endpoint endPoint = new GenericEndpoint(context.getClient());
+        endPoint.request(RUN_IN_TERMINAL_REQUEST, args).thenApply((response) -> {
+            int tryCounter = 0;
+
+            // attach to target VM
+            while (context.getDebuggeeVM() == null && tryCounter < 6) {
+                try {
+                    attachToRemoteVM("", clientConfigHolder.getDebuggePort());
+                } catch (IOException ignored) {
+                    try {
+                        tryCounter++;
+                        TimeUnit.SECONDS.sleep(10);
+                    } catch (Exception exception) {
+                        throw new RuntimeException(exception);
+                    }
+                } catch (IllegalConnectorArgumentsException | ClientConfigurationException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            // if the VM is not attached within 60 seconds
+            if (context.getDebuggeeVM() == null) {
+                // shut down debug server
+                outputLogger.sendErrorOutput("Failed to attach to the target VM");
+                terminateDebugServer(false, true);
+
+                // shut down client terminal
+                int shellProcessId = ((RunInTerminalResponse) response).getShellProcessId();
+                ProcessHandle.of(shellProcessId).ifPresent(ProcessHandle::destroyForcibly);
+            } else {
+                outputLogger.sendDebugServerOutput("Attached to target VM");
+            }
+            return CompletableFuture.completedFuture(null);
+        });
+
+        return CompletableFuture.completedFuture(null);
+    }
+
+    /**
+     * Launches the debug process in a separate terminal by setting the required request params and calling the request.
+     *
+     * @param programRunner - the instantiated Ballerina program runner for the source
+     */
+    private void launchInTerminal(BProgramRunner programRunner) throws ClientConfigurationException {
+        String sourceProjectRoot = context.getSourceProjectRoot();
+        RunInTerminalRequestArguments runInTerminalRequestArguments = new RunInTerminalRequestArguments();
+
+        runInTerminalRequestArguments.setKind(clientConfigHolder.getRunInTerminalKind());
+        runInTerminalRequestArguments.setTitle(TERMINAL_TITLE);
+        runInTerminalRequestArguments.setCwd(sourceProjectRoot);
+
+        String[] command = new String[programRunner.getBallerinaCommand(sourceProjectRoot).size()];
+        programRunner.getBallerinaCommand(sourceProjectRoot).toArray(command);
+        runInTerminalRequestArguments.setArgs(command);
+
+        outputLogger.sendConsoleOutput("Launching debugger in terminal");
+        context.getAdapter().runInTerminal(runInTerminalRequestArguments);
     }
 
     /**

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/config/ClientConfigHolder.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/config/ClientConfigHolder.java
@@ -16,6 +16,9 @@
 
 package org.ballerinalang.debugadapter.config;
 
+import org.eclipse.lsp4j.debug.RunInTerminalRequestArgumentsKind;
+
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
@@ -37,6 +40,9 @@ public class ClientConfigHolder {
     protected static final String ARG_DEBUGGEE_PORT = "debuggeePort";
     private static final String ARG_CAPABILITIES = "capabilities";
     private static final String ARG_SUPPORT_READONLY_EDITOR = "supportsReadOnlyEditors";
+    private static final String ARG_TERMINAL_KIND = "terminal";
+    private static final String INTEGRATED_TERMINAL_KIND = "INTEGRATED";
+    private static final String EXTERNAL_TERMINAL_KIND = "EXTERNAL";
 
     protected ClientConfigHolder(Map<String, Object> clientRequestArgs, ClientConfigKind kind) {
         this.clientRequestArgs = clientRequestArgs;
@@ -84,6 +90,17 @@ public class ClientConfigHolder {
         }
 
         return Optional.ofNullable(extendedClientCapabilities);
+    }
+
+    public RunInTerminalRequestArgumentsKind getRunInTerminalKind() {
+        if (clientRequestArgs.get(ARG_TERMINAL_KIND) != null) {
+            String terminalConfig = clientRequestArgs.get(ARG_TERMINAL_KIND).toString().toUpperCase(Locale.ENGLISH);
+            // To Do - enable the run in external terminal option
+            if (terminalConfig.equals(INTEGRATED_TERMINAL_KIND) || terminalConfig.equals(EXTERNAL_TERMINAL_KIND)) {
+                return RunInTerminalRequestArgumentsKind.INTEGRATED;
+            }
+        }
+        return null;
     }
 
     protected void failIfConfigMissing(String configName) throws ClientConfigurationException {

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/runner/BProgramRunner.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/runner/BProgramRunner.java
@@ -55,7 +55,7 @@ public abstract class BProgramRunner {
      */
     public abstract Process start() throws Exception;
 
-    protected ArrayList<String> getBallerinaCommand(String balFile) throws ClientConfigurationException {
+    public ArrayList<String> getBallerinaCommand(String balFile) throws ClientConfigurationException {
 
         List<String> ballerinaExec = new ArrayList<>();
         if (OSUtils.isWindows()) {

--- a/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/DebugTestRunner.java
+++ b/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/DebugTestRunner.java
@@ -88,6 +88,7 @@ public class DebugTestRunner {
     private DebugHitListener hitListener;
     private AssertionMode assertionMode;
     private SoftAssert softAsserter;
+    private final boolean isProjectBasedTest;
 
     private static final int SCHEDULER_INTERVAL_MS = 1000;
     private static final Logger LOGGER = LoggerFactory.getLogger(DebugTestRunner.class);
@@ -101,6 +102,7 @@ public class DebugTestRunner {
             testEntryFilePath = testSingleFileBaseDir.resolve(testModuleFileName);
         }
 
+        this.isProjectBasedTest = isProjectBasedTest;
         // Hard assertions will be used by default.
         assertionMode = AssertionMode.HARD_ASSERT;
     }
@@ -142,11 +144,28 @@ public class DebugTestRunner {
      * @throws BallerinaTestException if any exception is occurred during initialization.
      */
     public void initDebugSession(DebugUtils.DebuggeeExecutionKind executionKind) throws BallerinaTestException {
+        initDebugSession(executionKind, "");
+    }
+
+    /**
+     * Initialize test debug session.
+     *
+     * @param executionKind Defines ballerina command type to be used to launch the debuggee.(If set to null, adapter
+     *                      will try to attach to the debuggee, instead of launching)
+     * @param terminalKind The terminal type, if the debug session should be launched in a separate terminal
+     * @throws BallerinaTestException if any exception is occurred during initialization.
+     */
+    public boolean initDebugSession(DebugUtils.DebuggeeExecutionKind executionKind, String terminalKind)
+            throws BallerinaTestException {
         HashMap<String, Object> launchConfigs = new HashMap<>();
         HashMap<String, Object> extendedCapabilities = new HashMap<>();
         extendedCapabilities.put("supportsReadOnlyEditors", true);
         launchConfigs.put("capabilities", extendedCapabilities);
+        if (!terminalKind.isEmpty()) {
+            launchConfigs.put("terminal", terminalKind);
+        }
         initDebugSession(executionKind, launchConfigs);
+        return debugClientConnector.getRequestManager().getDidRunInIntegratedTerminal();
     }
 
     /**
@@ -204,6 +223,7 @@ public class DebugTestRunner {
         if (executionKind == DebugUtils.DebuggeeExecutionKind.BUILD) {
             attachToDebuggee();
         } else {
+            debugClientConnector.getRequestManager().setIsProjectBasedTest(isProjectBasedTest);
             launchDebuggee(executionKind, launchArgs);
         }
     }

--- a/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/client/DAPClient.java
+++ b/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/client/DAPClient.java
@@ -23,10 +23,15 @@ import org.eclipse.lsp4j.debug.LoadedSourceEventArguments;
 import org.eclipse.lsp4j.debug.ModuleEventArguments;
 import org.eclipse.lsp4j.debug.OutputEventArguments;
 import org.eclipse.lsp4j.debug.ProcessEventArguments;
+import org.eclipse.lsp4j.debug.RunInTerminalRequestArguments;
+import org.eclipse.lsp4j.debug.RunInTerminalResponse;
 import org.eclipse.lsp4j.debug.StoppedEventArguments;
 import org.eclipse.lsp4j.debug.TerminatedEventArguments;
 import org.eclipse.lsp4j.debug.ThreadEventArguments;
 import org.eclipse.lsp4j.debug.services.IDebugProtocolClient;
+import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
+
+import java.util.concurrent.CompletableFuture;
 
 /**
  * IDebugProtocolClient implementation.
@@ -98,4 +103,9 @@ public class DAPClient implements IDebugProtocolClient {
         this.requestManager = requestManager;
     }
 
+    @JsonRequest
+    public CompletableFuture<RunInTerminalResponse> runInTerminal(RunInTerminalRequestArguments args)
+            throws Exception {
+        return requestManager.runInTerminal(args);
+    }
 }

--- a/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/client/DAPClientConnector.java
+++ b/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/client/DAPClientConnector.java
@@ -96,6 +96,10 @@ public class DAPClientConnector {
         return projectPath;
     }
 
+    public Path getEntryFilePath() {
+        return entryFilePath;
+    }
+
     public int getPort() {
         return port;
     }
@@ -128,6 +132,7 @@ public class DAPClientConnector {
 
             InitializeRequestArguments initParams = new InitializeRequestArguments();
             initParams.setAdapterID("BallerinaDebugClient");
+            initParams.setSupportsRunInTerminalRequest(true);
 
             debugServer.initialize(initParams).thenApply(res -> {
                 initializeResult = res;

--- a/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/client/DAPRequestManager.java
+++ b/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/client/DAPRequestManager.java
@@ -34,6 +34,9 @@ import org.eclipse.lsp4j.debug.NextArguments;
 import org.eclipse.lsp4j.debug.OutputEventArguments;
 import org.eclipse.lsp4j.debug.PauseArguments;
 import org.eclipse.lsp4j.debug.ProcessEventArguments;
+import org.eclipse.lsp4j.debug.RunInTerminalRequestArguments;
+import org.eclipse.lsp4j.debug.RunInTerminalRequestArgumentsKind;
+import org.eclipse.lsp4j.debug.RunInTerminalResponse;
 import org.eclipse.lsp4j.debug.ScopesArguments;
 import org.eclipse.lsp4j.debug.ScopesResponse;
 import org.eclipse.lsp4j.debug.SetBreakpointsArguments;
@@ -51,6 +54,7 @@ import org.eclipse.lsp4j.debug.VariablesResponse;
 import org.eclipse.lsp4j.debug.services.IDebugProtocolServer;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -61,6 +65,8 @@ public class DAPRequestManager {
 
     private final DAPClientConnector clientConnector;
     private final IDebugProtocolServer server;
+    private boolean didRunInIntegratedTerminal;
+    private boolean isProjectBasedTest;
 
     public DAPRequestManager(DAPClientConnector clientConnector, DAPClient client, IDebugProtocolServer server,
                              Capabilities serverCapabilities) {
@@ -334,6 +340,31 @@ public class DAPRequestManager {
 
     private boolean checkStatus() {
         return clientConnector != null && clientConnector.isConnected();
+    }
+
+    public CompletableFuture<RunInTerminalResponse> runInTerminal(RunInTerminalRequestArguments args) throws Exception {
+        if (checkStatus()) {
+            // check whether it is a project based test or single file test, and get the cwd respectively
+            String cwd = isProjectBasedTest ? clientConnector.getProjectPath().toString() :
+                    clientConnector.getEntryFilePath().toString();
+
+            if (args.getKind() == RunInTerminalRequestArgumentsKind.INTEGRATED && Objects.equals(args.getCwd(), cwd)) {
+                this.didRunInIntegratedTerminal = true;
+                return CompletableFuture.completedFuture(null);
+            } else {
+                throw new Exception("RunInTerminal request failed");
+            }
+        } else {
+            throw new IllegalStateException("DAP request manager is not active");
+        }
+    }
+
+    public void setIsProjectBasedTest(Boolean isProjectBasedTest) {
+        this.isProjectBasedTest = isProjectBasedTest;
+    }
+
+    public boolean getDidRunInIntegratedTerminal() {
+        return this.didRunInIntegratedTerminal;
     }
 
     private enum DefaultTimeouts {

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/runinterminal/ProjectBasedRunInTerminalTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/runinterminal/ProjectBasedRunInTerminalTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2022 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.ballerinalang.debugger.test.adapter.runinterminal;
+
+import org.ballerinalang.debugger.test.utils.DebugTestRunner;
+import org.ballerinalang.debugger.test.utils.DebugUtils;
+import org.ballerinalang.test.context.BallerinaTestException;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Test class to test the runInTerminal feature for project based sources.
+ */
+public class ProjectBasedRunInTerminalTest {
+    DebugTestRunner debugTestRunner;
+    boolean didRunInIntegratedTerminal;
+
+    @BeforeMethod(alwaysRun = true)
+    public void setup() throws BallerinaTestException {
+        String testFolderName = "basic-project";
+        String testSingleFileName = "hello_world.bal";
+        debugTestRunner = new DebugTestRunner(testFolderName, testSingleFileName, true);
+    }
+
+    @Test(description = "Debug launch test in integrated terminal for project based source")
+    public void testRunInIntegratedTerminal() throws BallerinaTestException {
+        String integratedTerminal = "integrated";
+        didRunInIntegratedTerminal = debugTestRunner.initDebugSession(DebugUtils.DebuggeeExecutionKind.RUN,
+                integratedTerminal);
+        Assert.assertTrue(didRunInIntegratedTerminal);
+    }
+
+    @Test(description = "Debug launch test in external terminal for project based source")
+    public void testRunInExternalTerminal() throws BallerinaTestException {
+        String externalTerminal = "external";
+        didRunInIntegratedTerminal = debugTestRunner.initDebugSession(DebugUtils.DebuggeeExecutionKind.RUN,
+                externalTerminal);
+
+        // returned value should be true since external terminal requests are also handled as integrated terminal
+        // requests, as of now.
+        Assert.assertTrue(didRunInIntegratedTerminal);
+    }
+
+    @Test(description = "Debug launch test with invalid terminal kind")
+    public void testRunInInvalidTerminal() throws BallerinaTestException {
+        String invalidTerminalKind = "internal";
+        didRunInIntegratedTerminal = debugTestRunner.initDebugSession(DebugUtils.DebuggeeExecutionKind.RUN,
+                invalidTerminalKind);
+
+        // returned value should be false since internal is not a terminal kind that is accommodated for the
+        // runinterminal request
+        Assert.assertFalse(didRunInIntegratedTerminal);
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void cleanUp() {
+        debugTestRunner.terminateDebugSession();
+    }
+}

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/runinterminal/SingleFileRunInTerminalTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/runinterminal/SingleFileRunInTerminalTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2022 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.ballerinalang.debugger.test.adapter.runinterminal;
+
+import org.ballerinalang.debugger.test.BaseTestCase;
+import org.ballerinalang.debugger.test.utils.DebugTestRunner;
+import org.ballerinalang.debugger.test.utils.DebugUtils;
+import org.ballerinalang.test.context.BallerinaTestException;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Test class to test the runInTerminal feature for single files.
+ */
+public class SingleFileRunInTerminalTest extends BaseTestCase {
+    DebugTestRunner debugTestRunner;
+    boolean didRunInIntegratedTerminal;
+
+    @BeforeMethod(alwaysRun = true)
+    public void setup() throws BallerinaTestException {
+        String testFolderName = "basic-project";
+        String testSingleFileName = "hello_world.bal";
+        debugTestRunner = new DebugTestRunner(testFolderName, testSingleFileName, false);
+    }
+
+    @Test(description = "Debug launch test in integrated terminal for single file")
+    public void testRunInIntegratedTerminal() throws BallerinaTestException {
+        String integratedTerminal = "integrated";
+        didRunInIntegratedTerminal = debugTestRunner.initDebugSession(DebugUtils.DebuggeeExecutionKind.RUN,
+                integratedTerminal);
+        Assert.assertTrue(didRunInIntegratedTerminal);
+    }
+
+    @Test(description = "Debug launch test in external terminal for single file")
+    public void testRunInExternalTerminal() throws BallerinaTestException {
+        String externalTerminal = "external";
+        didRunInIntegratedTerminal = debugTestRunner.initDebugSession(DebugUtils.DebuggeeExecutionKind.RUN,
+                externalTerminal);
+
+        // returned value should be true since external terminal requests are also handled as integrated terminal
+        // requests, as of now.
+        Assert.assertTrue(didRunInIntegratedTerminal);
+    }
+
+    @Test(description = "Debug launch test with invalid terminal kind")
+    public void testRunInInvalidTerminal() throws BallerinaTestException {
+        String invalidTerminalKind = "internal";
+        didRunInIntegratedTerminal = debugTestRunner.initDebugSession(DebugUtils.DebuggeeExecutionKind.RUN,
+                invalidTerminalKind);
+
+        // returned value should be false since internal is not a terminal kind that is accommodated for the
+        // runinterminal request
+        Assert.assertFalse(didRunInIntegratedTerminal);
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void cleanUp() {
+        debugTestRunner.terminateDebugSession();
+    }
+}

--- a/tests/jballerina-debugger-integration-test/src/test/resources/testng.xml
+++ b/tests/jballerina-debugger-integration-test/src/test/resources/testng.xml
@@ -65,6 +65,10 @@ under the License.
             <class name="org.ballerinalang.debugger.test.adapter.RecursiveDebugTest"/>
             <class name="org.ballerinalang.debugger.test.adapter.BreakpointVerificationTest"/>
             <class name="org.ballerinalang.debugger.test.adapter.completions.DebugCompletionTest"/>
+
+            <!--Debugger RunInTerminal Tests-->
+            <class name="org.ballerinalang.debugger.test.adapter.runinterminal.SingleFileRunInTerminalTest"/>
+            <class name="org.ballerinalang.debugger.test.adapter.runinterminal.ProjectBasedRunInTerminalTest"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
## Purpose
> In the current implementation of the debugger, the users cannot bal programs that take user input in the general debug mode. As a solution to this, this PR introduces the run in terminal feature that launches the program execution in a separate integrated VSCode terminal, while the user can perform evaluations in the debug console: as usual.

Fixes #36561

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [x] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
