### PR TITLE
Add missing `bal graphql` & `bal asyncapi` command help text in bal output

### DIFF
--- a/cli/ballerina-cli/src/main/resources/cli-help/ballerina-help.help
+++ b/cli/ballerina-cli/src/main/resources/cli-help/ballerina-help.help
@@ -40,8 +40,11 @@ COMMANDS
         format          Format Ballerina source files
         grpc            Generate the Ballerina sources for a given Protocol
                         Buffer definition
+        graphql         Generate Ballerina client sources
+                        for a given GraphQL schema(SDL) and GraphQL queries
         openapi         Generate the Ballerina sources for a given OpenAPI
                         definition and vice versa
+        asyncapi        Generate the Ballerina sources for a given AsyncAPI definition
         bindgen         Generate the Ballerina bindings for Java APIs
         shell           Run Ballerina interactive REPL
         version         Print the Ballerina version


### PR DESCRIPTION
## Purpose
> Add missing `bal graphql` & `bal asyncapi` command help text in bal output

## Approach
> Add `bal graphql` & `bal asyncapi`  command info in `ballerina-lang/cli/ballerina-cli/src/main/resources/cli-help/ballerina-help.help`

