### PR TITLE
Fix create function in return stmts in block nodes

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/CreateFunctionCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/CreateFunctionCodeAction.java
@@ -137,8 +137,8 @@ public class CreateFunctionCodeAction implements DiagnosticBasedCodeActionProvid
 
     private boolean isInvalidReturnType(CodeActionContext context, FunctionCallExpressionNode callExpr) {
         SemanticModel semanticModel = context.currentSemanticModel().get();
-        FunctionCallExpressionTypeFinder typeFinder = new FunctionCallExpressionTypeFinder(semanticModel);
-        typeFinder.findTypeOf(callExpr);
+        FunctionCallExpressionTypeFinder typeFinder = new FunctionCallExpressionTypeFinder(semanticModel, callExpr);
+        callExpr.accept(typeFinder);
         Optional<TypeSymbol> returnTypeSymbol = typeFinder.getReturnTypeSymbol();
         Optional<TypeDescKind> returnTypeDescKind = typeFinder.getReturnTypeDescKind();
         

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/CreateFunctionExecutor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/CreateFunctionExecutor.java
@@ -192,8 +192,9 @@ public class CreateFunctionExecutor implements LSCommandExecutor {
             insertRange = new Range(new Position(endLine, endCol), new Position(endLine, endCol));
         }
 
-        FunctionCallExpressionTypeFinder typeFinder = new FunctionCallExpressionTypeFinder(semanticModel);
-        typeFinder.findTypeOf(fnCallExprNode.get());
+        FunctionCallExpressionTypeFinder typeFinder =
+                new FunctionCallExpressionTypeFinder(semanticModel, fnCallExprNode.get());
+        fnCallExprNode.get().accept(typeFinder);
         Optional<TypeSymbol> returnTypeSymbol = typeFinder.getReturnTypeSymbol();
         Optional<TypeDescKind> returnTypeDescKind = typeFinder.getReturnTypeDescKind();
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/visitors/FunctionCallExpressionTypeFinder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/visitors/FunctionCallExpressionTypeFinder.java
@@ -89,13 +89,10 @@ public class FunctionCallExpressionTypeFinder extends NodeVisitor {
     private TypeDescKind returnTypeDescKind;
     private boolean resultFound = false;
 
-    public FunctionCallExpressionTypeFinder(SemanticModel semanticModel) {
+    public FunctionCallExpressionTypeFinder(SemanticModel semanticModel, 
+                                            FunctionCallExpressionNode functionCallExpr) {
         this.semanticModel = semanticModel;
-    }
-
-    public void findTypeOf(FunctionCallExpressionNode functionCallExpressionNode) {
-        this.functionCallExpr = functionCallExpressionNode;
-        functionCallExpressionNode.accept(this);
+        this.functionCallExpr = functionCallExpr;
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/CreateFunctionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/CreateFunctionTest.java
@@ -72,6 +72,7 @@ public class CreateFunctionTest extends AbstractCodeActionTest {
                 {"undefinedFunctionInCheckpanicExpression1.json"},
                 {"undefinedFunctionInCheckpanicExpression2.json"},
                 {"undefinedFunctionInPanicStatement.json"},
+                {"undefinedFunctionInReturn1.json"},
         };
     }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/command/CreateFunctionCommandExecTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/command/CreateFunctionCommandExecTest.java
@@ -138,6 +138,7 @@ public class CreateFunctionCommandExecTest extends AbstractCommandExecutionTest 
                 {"create_function_which_returns_error1.json"},
                 {"create_function_in_fail1.json"},
                 {"create_function_in_return1.json"},
+                {"create_function_in_return2.json"},
                 
                 // Named Args
                 {"create_function_with_named_args1.json"},

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/undefinedFunctionInReturn1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/undefinedFunctionInReturn1.json
@@ -1,0 +1,33 @@
+{
+  "position": {
+    "line": 2,
+    "character": 16
+  },
+  "source": "createUndefinedFunctionInReturn1.bal",
+  "description": "Create undefined function in a return statement within another block statement node",
+  "expected": [
+    {
+      "title": "Create function 'getReturnVal(...)'",
+      "kind": "quickfix",
+      "command": {
+        "title": "Create function 'getReturnVal(...)'",
+        "command": "CREATE_FUNC",
+        "arguments": [
+          {
+            "key": "node.range",
+            "value": {
+              "start": {
+                "line": 2,
+                "character": 11
+              },
+              "end": {
+                "line": 2,
+                "character": 26
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/source/createUndefinedFunctionInReturn1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/source/createUndefinedFunctionInReturn1.bal
@@ -1,0 +1,7 @@
+function isPositive(int a) returns int {
+  if a > 0 {
+    return getReturnVal(a);
+  }
+
+  return a/2;
+}

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/create_function_in_return2.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/create_function_in_return2.json
@@ -1,0 +1,42 @@
+{
+  "arguments": {
+    "node.range": {
+      "start": {
+        "line": 2,
+        "character": 11
+      },
+      "end": {
+        "line": 2,
+        "character": 26
+      }
+    }
+  },
+  "source": "create_function_in_return2.bal",
+  "description": "Create undefined function in a return statement within another block statement node",
+  "expected": {
+    "result": {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "range": {
+                  "start": {
+                    "line": 6,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 6,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction getReturnVal(int i) returns int {\n    return 0;\n}\n"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "jsonrpc": "2.0"
+  }
+}

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/source/create_function_in_return2.bal
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/source/create_function_in_return2.bal
@@ -1,0 +1,7 @@
+function isPositive(int a) returns int {
+  if a > 0 {
+    return getReturnVal(a);
+  }
+
+  return a/2;
+}


### PR DESCRIPTION
## Purpose
$subject

Fixes #36628

## Approach
`FunctionCallExpressionTypeFinder` did not override the `visit(BlockStatementNode)` method. Overridden that. Next, updated `if` and `while` statement node visit methods to check whether the function call expression is inside the `condition.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
