### PR TITLE
Fix the error that occurs when using member access on a type reference type for a tuple type

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -8514,8 +8514,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                 return checkTupleFieldType(tuple, getConstIndex(indexExpr).intValue());
             }
 
-            BTupleType tupleExpr = (BTupleType) accessExpr.expr.getBType();
-            LinkedHashSet<BType> tupleTypes = collectTupleFieldTypes(tupleExpr, new LinkedHashSet<>());
+            LinkedHashSet<BType> tupleTypes = collectTupleFieldTypes(tuple, new LinkedHashSet<>());
             return tupleTypes.size() == 1 ? tupleTypes.iterator().next() : BUnionType.create(null, tupleTypes);
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -8590,6 +8590,9 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                         memberTypes.add(memberType);
                     }
                 });
+        if (tupleType.restType != null) {
+            memberTypes.add(tupleType.restType);
+        }
         return memberTypes;
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/tuples/TupleAccessExprNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/tuples/TupleAccessExprNegativeTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.ballerinalang.test.types.tuples;
+
+import org.ballerinalang.test.BCompileUtil;
+import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.Test;
+
+import static org.ballerinalang.test.BAssertUtil.validateError;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Tuple access with indexes negative test.
+ */
+public class TupleAccessExprNegativeTest {
+
+    @Test
+    public void testTupleAccessExprNegative() {
+        CompileResult result = BCompileUtil
+                .compile("test-src/types/tuples/tuple_access_expr_negative.bal");
+        int index = 0;
+        validateError(result, index++, "incompatible types: expected 'string', found 'int'",
+                26, 16);
+        validateError(result, index++, "incompatible types: expected 'int', found 'string'",
+                27, 13);
+        validateError(result, index++, "incompatible types: expected 'string', found " +
+                "'(int|string|boolean)'", 29, 16);
+        validateError(result, index++, "incompatible types: expected 'int', found " +
+                "'(int|string|boolean)'", 30, 13);
+        validateError(result, index++, "incompatible types: expected 'string', found 'int'",
+                33, 16);
+        validateError(result, index++, "incompatible types: expected 'int', found 'string'",
+                36, 13);
+        validateError(result, index++, "incompatible types: expected 'string', found " +
+                "'(int|string|boolean)'", 39, 16);
+        validateError(result, index++, "incompatible types: expected 'int', found " +
+                "'(int|string|boolean)'", 42, 13);
+        validateError(result, index++, "incompatible types: expected 'string', found 'int'",
+                49, 16);
+        validateError(result, index++, "incompatible types: expected 'boolean', found 'int'",
+                50, 17);
+        validateError(result, index++, "incompatible types: expected 'int', found 'boolean'",
+                51, 13);
+        validateError(result, index++, "incompatible types: expected 'string', found 'int'",
+                53, 16);
+        validateError(result, index++, "incompatible types: expected 'boolean', found " +
+                "'(int|string|boolean)'", 54, 17);
+        validateError(result, index++, "incompatible types: expected 'int', found " +
+                "'(int|string|boolean)'", 55, 13);
+        validateError(result, index++, "incompatible types: expected 'string', found 'int'",
+                58, 16);
+        validateError(result, index++, "incompatible types: expected 'boolean', found 'int'",
+                61, 17);
+        validateError(result, index++, "incompatible types: expected 'int', found 'boolean'",
+                64, 13);
+        validateError(result, index++, "incompatible types: expected 'string', found 'int'",
+                67, 16);
+        validateError(result, index++, "incompatible types: expected 'boolean', found " +
+                "'(int|string|boolean)'", 70, 17);
+        validateError(result, index++, "incompatible types: expected 'int', found " +
+                "'(int|string|boolean)'", 73, 13);
+        validateError(result, index++, "incompatible types: expected 'string', found 'int'",
+                81, 16);
+        validateError(result, index++, "incompatible types: expected 'int', found 'string'",
+                82, 13);
+        validateError(result, index++, "incompatible types: expected 'string', found 'int'",
+                83, 16);
+        validateError(result, index++, "incompatible types: expected 'boolean', found 'int'",
+                84, 17);
+        validateError(result, index++, "incompatible types: expected 'int', found 'boolean'",
+                85, 13);
+        validateError(result, index++, "incompatible types: expected 'string', found " +
+                "'(int|string|boolean)'", 87, 16);
+        validateError(result, index++, "incompatible types: expected 'int', found " +
+                "'(int|string|boolean)'", 88, 13);
+        validateError(result, index++, "incompatible types: expected 'string', found 'int'",
+                89, 16);
+        validateError(result, index++, "incompatible types: expected 'boolean', found " +
+                "'(int|string|boolean)'", 90, 17);
+        validateError(result, index++, "incompatible types: expected 'int', found " +
+                "'(int|string|boolean)'", 91, 13);
+        validateError(result, index++, "incompatible types: expected 'string', found 'int'",
+                94, 16);
+        validateError(result, index++, "incompatible types: expected 'int', found 'string'",
+                97, 13);
+        validateError(result, index++, "incompatible types: expected 'string', found 'int'",
+                100, 16);
+        validateError(result, index++, "incompatible types: expected 'boolean', found 'int'",
+                103, 17);
+        validateError(result, index++, "incompatible types: expected 'int', found 'boolean'",
+                106, 13);
+        validateError(result, index++, "incompatible types: expected 'string', found " +
+                "'(int|string|boolean)'", 109, 16);
+        validateError(result, index++, "incompatible types: expected 'int', found " +
+                "'(int|string|boolean)'", 112, 13);
+        validateError(result, index++, "incompatible types: expected 'string', found 'int'",
+                115, 16);
+        validateError(result, index++, "incompatible types: expected 'boolean', found " +
+                "'(int|string|boolean)'", 118, 17);
+        validateError(result, index++, "incompatible types: expected 'int', found " +
+                "'(int|string|boolean)'", 121, 13);
+        assertEquals(result.getErrorCount(), index);
+    }
+}

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/tuples/TupleAccessExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/tuples/TupleAccessExprTest.java
@@ -207,6 +207,11 @@ public class TupleAccessExprTest {
         BRunUtil.invoke(compileResult, funcName);
     }
 
+    @Test(dataProvider = "TupleWithRestTypesAccessFunctionList")
+    public void testTupleWithRestTypesAccess(String funcName) {
+        BRunUtil.invoke(compileResult, funcName);
+    }
+
     @DataProvider(name = "TupleAccessUsingCustomTypesFunctionList")
     public Object[][] getFunctionNames() {
         return new Object[][]{
@@ -215,6 +220,14 @@ public class TupleAccessExprTest {
                 {"testTupleAccessWithCustomUnionTypes"},
                 {"testTupleAccessWithCustomReadonlyUnionTypes"},
                 {"testModuleLevelTupleAccessWithCustomType"}
+        };
+    }
+
+    @DataProvider(name = "TupleWithRestTypesAccessFunctionList")
+    public Object[][] getTupleWithRestTypesFunctionNames() {
+        return new Object[][]{
+                {"testTupleWithRestTypesAccess"},
+                {"testCustomTupleWithRestTypesAccess"}
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/tuples/TupleAccessExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/tuples/TupleAccessExprTest.java
@@ -27,6 +27,7 @@ import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 /**
@@ -201,12 +202,20 @@ public class TupleAccessExprTest {
         BRunUtil.invoke(compileResult, "testTupleAccessUsingUnionWithFiniteTypesNegative");
     }
 
-    @Test
-    public void testTupleAccessUsingCustomTypes() {
-        BRunUtil.invoke(compileResult, "testTupleAccessWithCustomType");
-        BRunUtil.invoke(compileResult, "testTupleAccessWithCustomType2");
-        BRunUtil.invoke(compileResult, "testTupleAccessWithCustomUnionTypes");
-        BRunUtil.invoke(compileResult, "testTupleAccessWithCustomReadonlyUnionTypes");
+    @Test(dataProvider = "TupleAccessUsingCustomTypesFunctionList")
+    public void testTupleAccessUsingCustomTypes(String funcName) {
+        BRunUtil.invoke(compileResult, funcName);
+    }
+
+    @DataProvider(name = "TupleAccessUsingCustomTypesFunctionList")
+    public Object[][] getFunctionNames() {
+        return new Object[][]{
+                {"testTupleAccessWithCustomType"},
+                {"testTupleAccessWithCustomType2"},
+                {"testTupleAccessWithCustomUnionTypes"},
+                {"testTupleAccessWithCustomReadonlyUnionTypes"},
+                {"testModuleLevelTupleAccessWithCustomType"}
+        };
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/tuples/TupleAccessExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/tuples/TupleAccessExprTest.java
@@ -201,6 +201,14 @@ public class TupleAccessExprTest {
         BRunUtil.invoke(compileResult, "testTupleAccessUsingUnionWithFiniteTypesNegative");
     }
 
+    @Test
+    public void testTupleAccessUsingCustomTypes() {
+        BRunUtil.invoke(compileResult, "testTupleAccessWithCustomType");
+        BRunUtil.invoke(compileResult, "testTupleAccessWithCustomType2");
+        BRunUtil.invoke(compileResult, "testTupleAccessWithCustomUnionTypes");
+        BRunUtil.invoke(compileResult, "testTupleAccessWithCustomReadonlyUnionTypes");
+    }
+
     @AfterClass
     public void tearDown() {
         compileResult = null;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/tuples/tuple_access_expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/tuples/tuple_access_expr.bal
@@ -285,15 +285,27 @@ type CustomTuple [int, string, boolean];
 
 const int index = 0;
 
-[int...] expectedIntTuple = [1, 2, 3];
-[string...] expectedStringTuple = ["string 1", "string 2", "string 3"];
-[boolean...] expectedBooleanTuple = [true, false, true];
+[int...] moduleLevelIntTuple = [1, 2, 3];
+[string...] moduleLevelStringTuple = ["string 1", "string 2", "string 3"];
+[boolean...] moduleLevelBooleanTuple = [true, true, true];
+
+public function testModuleLevelTupleAccessWithCustomType() {
+    foreach int i in 0 ..< 3 {
+        assertEquals(moduleLevelIntTuple[i], i + 1);
+        assertEquals(moduleLevelStringTuple[i], string `string ${i + 1}`);
+        assertEquals(moduleLevelBooleanTuple[i], true);
+    }
+}
 
 public function testTupleAccessWithCustomType() {
     IntTuple intTuple = [1, 2, 3];
     StringTuple stringTuple = ["string 1", "string 2", "string 3"];
     BooleanTuple booleanTuple = [true, false, true];
     CustomTuple customTuple = [1, "string 1", true];
+
+    [int...] expectedIntTuple = [1, 2, 3];
+    [string...] expectedStringTuple = ["string 1", "string 2", "string 3"];
+    [boolean...] expectedBooleanTuple = [true, false, true];
 
     assertEquals(intTuple[index], 1);
     assertEquals(intTuple[index + 1], 2);
@@ -329,6 +341,10 @@ public function testTupleAccessWithCustomType2() {
     BooleanTuple2 booleanTuple = [true, false, true];
     CustomTuple2 customTuple = [1, "string 1", true];
 
+    [int...] expectedIntTuple = [1, 2, 3];
+    [string...] expectedStringTuple = ["string 1", "string 2", "string 3"];
+    [boolean...] expectedBooleanTuple = [true, false, true];
+
     assertEquals(intTuple[index], 1);
     assertEquals(intTuple[index + 1], 2);
     assertEquals(intTuple[index + 2], 3);
@@ -363,6 +379,10 @@ public function testTupleAccessWithCustomUnionTypes() {
     BooleanUnionIntTuple booleanUnionIntTuple = [true, false, true];
     CustomUnionTuple customUnionTuple = [1, "string 1", true];
 
+    [int...] expectedIntTuple = [1, 2, 3];
+    [string...] expectedStringTuple = ["string 1", "string 2", "string 3"];
+    [boolean...] expectedBooleanTuple = [true, false, true];
+
     assertEquals(intUnionStringTuple[index], 1);
     assertEquals(intUnionStringTuple[index + 1], 2);
     assertEquals(intUnionStringTuple[index + 2], 3);
@@ -396,6 +416,10 @@ public function testTupleAccessWithCustomReadonlyUnionTypes() {
     StringReadonlyTuple stringReadonlyTuple = ["string 1", "string 2", "string 3"];
     BooleanReadonlyTuple booleanReadonlyTuple = [true, false, true];
     CustomReadonlyTuple customReadonlyTuple = [1, "string 1", true];
+
+    [int...] expectedIntTuple = [1, 2, 3];
+    [string...] expectedStringTuple = ["string 1", "string 2", "string 3"];
+    [boolean...] expectedBooleanTuple = [true, false, true];
 
     assertEquals(intReadonlyTuple[index], 1);
     assertEquals(intReadonlyTuple[index + 1], 2);

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/tuples/tuple_access_expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/tuples/tuple_access_expr.bal
@@ -283,7 +283,7 @@ type StringTuple [string...];
 type BooleanTuple [boolean...];
 type CustomTuple [int, string, boolean];
 
-const int index = 0;
+int index = 0;
 
 [int...] moduleLevelIntTuple = [1, 2, 3];
 [string...] moduleLevelStringTuple = ["string 1", "string 2", "string 3"];
@@ -442,6 +442,67 @@ public function testTupleAccessWithCustomReadonlyUnionTypes() {
         assertEquals(stringReadonlyTuple[i], expectedStringTuple[i]);
         assertEquals(booleanReadonlyTuple[i], expectedBooleanTuple[i]);
     }
+}
+
+function testTupleWithRestTypesAccess() {
+    [int...] t1 = [1, 2, 3, 5];
+    [int, string, boolean...] t2 = [1, "a", true, true];
+
+    var x1 = t1[0];
+    int x2 = x1;
+    assertEquals(x2, 1);
+
+    var x3 = t2[0];
+    int x4 = x3;
+    assertEquals(x4, 1);
+
+    var x5 = t2[3];
+    boolean x6 = x5;
+    assertEquals(x6, true);
+
+    var x7 = t1[index];
+    int x8 = x1;
+    assertEquals(x8, 1);
+
+    var x9 = t2[index];
+    int x10 = x3;
+    assertEquals(x10, 1);
+
+    var x11 = t2[index + 2];
+    boolean x12 = x5;
+    assertEquals(x12, true);
+}
+
+type CustomTupleWithRestTypes1 [int...];
+type CustomTupleWithRestTypes2 [int, string, boolean...];
+
+function testCustomTupleWithRestTypesAccess() {
+    CustomTupleWithRestTypes1 t1 = [1, 2, 3, 5];
+    CustomTupleWithRestTypes2 t2 = [1, "a", true, true];
+
+    var x1 = t1[0];
+    int x2 = x1;
+    assertEquals(x2, 1);
+
+    var x3 = t2[0];
+    int x4 = x3;
+    assertEquals(x4, 1);
+
+    var x5 = t2[3];
+    boolean x6 = x5;
+    assertEquals(x6, true);
+
+    var x7 = t1[index];
+    int x8 = x1;
+    assertEquals(x8, 1);
+
+    var x9 = t2[index];
+    int x10 = x3;
+    assertEquals(x10, 1);
+
+    var x11 = t2[index + 2];
+    boolean x12 = x5;
+    assertEquals(x12, true);
 }
 
 function assertEquals(anydata expected, anydata actual) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/tuples/tuple_access_expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/tuples/tuple_access_expr.bal
@@ -277,3 +277,152 @@ function testTupleAccessUsingUnionWithFiniteTypesNegative() {
     string|boolean f1 = tuple[index0];
     var f2 = tuple[index1];
 }
+
+type IntTuple [int...];
+type StringTuple [string...];
+type BooleanTuple [boolean...];
+type CustomTuple [int, string, boolean];
+
+const int index = 0;
+
+[int...] expectedIntTuple = [1, 2, 3];
+[string...] expectedStringTuple = ["string 1", "string 2", "string 3"];
+[boolean...] expectedBooleanTuple = [true, false, true];
+
+public function testTupleAccessWithCustomType() {
+    IntTuple intTuple = [1, 2, 3];
+    StringTuple stringTuple = ["string 1", "string 2", "string 3"];
+    BooleanTuple booleanTuple = [true, false, true];
+    CustomTuple customTuple = [1, "string 1", true];
+
+    assertEquals(intTuple[index], 1);
+    assertEquals(intTuple[index + 1], 2);
+    assertEquals(intTuple[index + 2], 3);
+
+    assertEquals(stringTuple[index], "string 1");
+    assertEquals(stringTuple[index + 1], "string 2");
+    assertEquals(stringTuple[index + 2], "string 3");
+
+    assertEquals(booleanTuple[index], true);
+    assertEquals(booleanTuple[index + 1], false);
+    assertEquals(booleanTuple[index + 2], true);
+
+    assertEquals(customTuple[index], 1);
+    assertEquals(customTuple[index + 1], "string 1");
+    assertEquals(customTuple[index + 2], true);
+
+    foreach var i in 0 ..< intTuple.length() {
+        assertEquals(intTuple[i], expectedIntTuple[i]);
+        assertEquals(stringTuple[i], expectedStringTuple[i]);
+        assertEquals(booleanTuple[i], expectedBooleanTuple[i]);
+    }
+}
+
+type IntTuple2 [int, int, int];
+type StringTuple2 [string, string, string];
+type BooleanTuple2 [boolean, boolean, boolean];
+type CustomTuple2 [int, string, boolean];
+
+public function testTupleAccessWithCustomType2() {
+    IntTuple2 intTuple = [1, 2, 3];
+    StringTuple2 stringTuple = ["string 1", "string 2", "string 3"];
+    BooleanTuple2 booleanTuple = [true, false, true];
+    CustomTuple2 customTuple = [1, "string 1", true];
+
+    assertEquals(intTuple[index], 1);
+    assertEquals(intTuple[index + 1], 2);
+    assertEquals(intTuple[index + 2], 3);
+
+    assertEquals(stringTuple[index], "string 1");
+    assertEquals(stringTuple[index + 1], "string 2");
+    assertEquals(stringTuple[index + 2], "string 3");
+
+    assertEquals(booleanTuple[index], true);
+    assertEquals(booleanTuple[index + 1], false);
+    assertEquals(booleanTuple[index + 2], true);
+
+    assertEquals(customTuple[index], 1);
+    assertEquals(customTuple[index + 1], "string 1");
+    assertEquals(customTuple[index + 2], true);
+
+    foreach var i in 0 ..< intTuple.length() {
+        assertEquals(intTuple[i], expectedIntTuple[i]);
+        assertEquals(stringTuple[i], expectedStringTuple[i]);
+        assertEquals(booleanTuple[i], expectedBooleanTuple[i]);
+    }
+}
+
+type IntUnionStringTuple [int...]|[string...];
+type StringUnionBooleanTuple [boolean...]|[string...];
+type BooleanUnionIntTuple [boolean...]|[int...];
+type CustomUnionTuple [int...]|[string...]|[int, string, boolean]|[boolean...];
+
+public function testTupleAccessWithCustomUnionTypes() {
+    IntUnionStringTuple intUnionStringTuple = [1, 2, 3];
+    StringUnionBooleanTuple stringUnionBooleanTuple = ["string 1", "string 2", "string 3"];
+    BooleanUnionIntTuple booleanUnionIntTuple = [true, false, true];
+    CustomUnionTuple customUnionTuple = [1, "string 1", true];
+
+    assertEquals(intUnionStringTuple[index], 1);
+    assertEquals(intUnionStringTuple[index + 1], 2);
+    assertEquals(intUnionStringTuple[index + 2], 3);
+
+    assertEquals(stringUnionBooleanTuple[index], "string 1");
+    assertEquals(stringUnionBooleanTuple[index + 1], "string 2");
+    assertEquals(stringUnionBooleanTuple[index + 2], "string 3");
+
+    assertEquals(booleanUnionIntTuple[index], true);
+    assertEquals(booleanUnionIntTuple[index + 1], false);
+    assertEquals(booleanUnionIntTuple[index + 2], true);
+
+    assertEquals(customUnionTuple[index], 1);
+    assertEquals(customUnionTuple[index + 1], "string 1");
+    assertEquals(customUnionTuple[index + 2], true);
+
+    foreach var i in 0 ..< intUnionStringTuple.length() {
+        assertEquals(intUnionStringTuple[i], expectedIntTuple[i]);
+        assertEquals(stringUnionBooleanTuple[i], expectedStringTuple[i]);
+        assertEquals(booleanUnionIntTuple[i], expectedBooleanTuple[i]);
+    }
+}
+
+type IntReadonlyTuple ([int...] & readonly)|[string...];
+type StringReadonlyTuple [boolean...]|([string...] & readonly);
+type BooleanReadonlyTuple ([boolean...] & readonly)|[int...];
+type CustomReadonlyTuple [int...]|[string...]|([int, string, boolean] & readonly)|[boolean...];
+
+public function testTupleAccessWithCustomReadonlyUnionTypes() {
+    IntReadonlyTuple intReadonlyTuple = [1, 2, 3];
+    StringReadonlyTuple stringReadonlyTuple = ["string 1", "string 2", "string 3"];
+    BooleanReadonlyTuple booleanReadonlyTuple = [true, false, true];
+    CustomReadonlyTuple customReadonlyTuple = [1, "string 1", true];
+
+    assertEquals(intReadonlyTuple[index], 1);
+    assertEquals(intReadonlyTuple[index + 1], 2);
+    assertEquals(intReadonlyTuple[index + 2], 3);
+
+    assertEquals(stringReadonlyTuple[index], "string 1");
+    assertEquals(stringReadonlyTuple[index + 1], "string 2");
+    assertEquals(stringReadonlyTuple[index + 2], "string 3");
+
+    assertEquals(booleanReadonlyTuple[index], true);
+    assertEquals(booleanReadonlyTuple[index + 1], false);
+    assertEquals(booleanReadonlyTuple[index + 2], true);
+
+    assertEquals(customReadonlyTuple[index], 1);
+    assertEquals(customReadonlyTuple[index + 1], "string 1");
+    assertEquals(customReadonlyTuple[index + 2], true);
+
+    foreach var i in 0 ..< intReadonlyTuple.length() {
+        assertEquals(intReadonlyTuple[i], expectedIntTuple[i]);
+        assertEquals(stringReadonlyTuple[i], expectedStringTuple[i]);
+        assertEquals(booleanReadonlyTuple[i], expectedBooleanTuple[i]);
+    }
+}
+
+function assertEquals(anydata expected, anydata actual) {
+    if expected == actual {
+        return;
+    }
+    panic error(string `expected [${expected.toString()}], found [${actual.toString()}]`);
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/tuples/tuple_access_expr_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/tuples/tuple_access_expr_negative.bal
@@ -1,0 +1,122 @@
+// Copyright (c) 2022 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+type CustomTupleType [int, string, boolean];
+type CustomTupleType2 [int...];
+type CustomTupleType3 [int, string, boolean...];
+
+int index = 0;
+
+function testTupleAccessNegative() {
+    [int, string, boolean] t = [1, "a", true];
+
+    string _ = t[0];
+    int _ = t[1];
+
+    string _ = t[index];
+    int _ = t[index + 1];
+
+    var x1 = t[0];
+    string _ = x1;
+
+    var x2 = t[1];
+    int _ = x2;
+
+    var x3 = t[index];
+    string _ = x3;
+
+    var x4 = t[index + 1];
+    int _ = x4;
+}
+
+function testTupleWithRestTypesAccessNegative() {
+    [int...] t1 = [1, 2, 3, 5];
+    [int, string, boolean...] t2 = [1, "a", true, true];
+
+    string _ = t1[0];
+    boolean _ = t2[0];
+    int _ = t2[3];
+
+    string _ = t1[index];
+    boolean _ = t2[index];
+    int _ = t2[index + 3];
+
+    var x1 = t1[0];
+    string _ = x1;
+
+    var x2 = t2[0];
+    boolean _ = x2;
+
+    var x3 = t2[3];
+    int _ = x3;
+
+    var x4 = t1[index];
+    string _ = x4;
+
+    var x5 = t2[index];
+    boolean _ = x5;
+
+    var x6 = t2[index + 3];
+    int _ = x6;
+}
+
+function testCustomTupleTypesAccessNegative() {
+    CustomTupleType t1 = [1, "a", true];
+    CustomTupleType2 t2 = [1, 2, 3, 5];
+    CustomTupleType3 t3 = [1, "a", true, true];
+
+    string _ = t1[0];
+    int _ = t1[1];
+    string _ = t2[0];
+    boolean _ = t3[0];
+    int _ = t3[3];
+
+    string _ = t1[index];
+    int _ = t1[index + 1];
+    string _ = t2[index];
+    boolean _ = t3[index];
+    int _ = t3[index + 3];
+
+    var x1 = t1[0];
+    string _ = x1;
+
+    var x2 = t1[1];
+    int _ = x2;
+
+    var x3 = t2[0];
+    string _ = x3;
+
+    var x4 = t3[0];
+    boolean _ = x4;
+
+    var x5 = t3[3];
+    int _ = x5;
+
+    var x6 = t1[index];
+    string _ = x6;
+
+    var x7 = t1[index + 1];
+    int _ = x7;
+
+    var x8 = t2[index];
+    string _ = x8;
+
+    var x9 = t3[index];
+    boolean _ = x9;
+
+    var x10 = t3[index + 3];
+    int _ = x10;
+}


### PR DESCRIPTION
## Purpose
> Fix the Error that Occurs when Accessing Tuple Elements using Variable Expressions.

Fixes #36911
Fixes #36946

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
