### PR TITLE
Remove keyless keyword in error msgs for table<Type>

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
@@ -505,7 +505,7 @@ public enum DiagnosticErrorCode implements DiagnosticCode {
     TABLE_KEY_SPECIFIER_MISMATCH("BCE3301", "table.key.specifier.mismatch"),
     KEY_SPECIFIER_SIZE_MISMATCH_WITH_KEY_CONSTRAINT("BCE3302", "key.specifier.size.mismatch.with.key.constraint"),
     KEY_SPECIFIER_MISMATCH_WITH_KEY_CONSTRAINT("BCE3303", "key.specifier.mismatch.with.key.constraint"),
-    MEMBER_ACCESS_NOT_SUPPORT_FOR_TABLE("BCE3305", "member.access.not.supported.table"),
+    MEMBER_ACCESS_NOT_SUPPORTED_FOR_TABLE("BCE3305", "member.access.not.supported.for.table"),
     INVALID_FIELD_NAMES_IN_KEY_SPECIFIER("BCE3306", "invalid.field.name.in.key.specifier"),
     MULTI_KEY_MEMBER_ACCESS_NOT_SUPPORTED("BCE3307", "multi.key.member.access.not.supported"),
     KEY_SPECIFIER_FIELD_MUST_BE_READONLY("BCE3308", "key.specifier.field.must.be.readonly"),

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
@@ -505,7 +505,7 @@ public enum DiagnosticErrorCode implements DiagnosticCode {
     TABLE_KEY_SPECIFIER_MISMATCH("BCE3301", "table.key.specifier.mismatch"),
     KEY_SPECIFIER_SIZE_MISMATCH_WITH_KEY_CONSTRAINT("BCE3302", "key.specifier.size.mismatch.with.key.constraint"),
     KEY_SPECIFIER_MISMATCH_WITH_KEY_CONSTRAINT("BCE3303", "key.specifier.mismatch.with.key.constraint"),
-    MEMBER_ACCESS_NOT_SUPPORT_FOR_KEYLESS_TABLE("BCE3305", "member.access.not.supported.keyless.table"),
+    MEMBER_ACCESS_NOT_SUPPORT_FOR_TABLE("BCE3305", "member.access.not.supported.table"),
     INVALID_FIELD_NAMES_IN_KEY_SPECIFIER("BCE3306", "invalid.field.name.in.key.specifier"),
     MULTI_KEY_MEMBER_ACCESS_NOT_SUPPORTED("BCE3307", "multi.key.member.access.not.supported"),
     KEY_SPECIFIER_FIELD_MUST_BE_READONLY("BCE3308", "key.specifier.field.must.be.readonly"),

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
@@ -505,7 +505,7 @@ public enum DiagnosticErrorCode implements DiagnosticCode {
     TABLE_KEY_SPECIFIER_MISMATCH("BCE3301", "table.key.specifier.mismatch"),
     KEY_SPECIFIER_SIZE_MISMATCH_WITH_KEY_CONSTRAINT("BCE3302", "key.specifier.size.mismatch.with.key.constraint"),
     KEY_SPECIFIER_MISMATCH_WITH_KEY_CONSTRAINT("BCE3303", "key.specifier.mismatch.with.key.constraint"),
-    MEMBER_ACCESS_NOT_SUPPORTED_FOR_TABLE("BCE3305", "member.access.not.supported.for.table"),
+    MEMBER_ACCESS_NOT_SUPPORTED_FOR_KEYLESS_TABLE("BCE3305", "member.access.not.supported.for.keyless.table"),
     INVALID_FIELD_NAMES_IN_KEY_SPECIFIER("BCE3306", "invalid.field.name.in.key.specifier"),
     MULTI_KEY_MEMBER_ACCESS_NOT_SUPPORTED("BCE3307", "multi.key.member.access.not.supported"),
     KEY_SPECIFIER_FIELD_MUST_BE_READONLY("BCE3308", "key.specifier.field.must.be.readonly"),

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -8541,7 +8541,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
 
                 if (keyTypeConstraint == symTable.semanticError) {
                     dlog.error(indexBasedAccessExpr.pos,
-                               DiagnosticErrorCode.MEMBER_ACCESS_NOT_SUPPORT_FOR_TABLE,
+                               DiagnosticErrorCode.MEMBER_ACCESS_NOT_SUPPORTED_FOR_TABLE,
                                indexBasedAccessExpr.expr);
                     return symTable.semanticError;
                 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -8541,7 +8541,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
 
                 if (keyTypeConstraint == symTable.semanticError) {
                     dlog.error(indexBasedAccessExpr.pos,
-                               DiagnosticErrorCode.MEMBER_ACCESS_NOT_SUPPORTED_FOR_TABLE,
+                               DiagnosticErrorCode.MEMBER_ACCESS_NOT_SUPPORTED_FOR_KEYLESS_TABLE,
                                indexBasedAccessExpr.expr);
                     return symTable.semanticError;
                 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -8541,7 +8541,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
 
                 if (keyTypeConstraint == symTable.semanticError) {
                     dlog.error(indexBasedAccessExpr.pos,
-                               DiagnosticErrorCode.MEMBER_ACCESS_NOT_SUPPORT_FOR_KEYLESS_TABLE,
+                               DiagnosticErrorCode.MEMBER_ACCESS_NOT_SUPPORT_FOR_TABLE,
                                indexBasedAccessExpr.expr);
                     return symTable.semanticError;
                 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -6868,7 +6868,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         if (Types.getReferredType(bType).tag == TypeTags.TABLE) {
             BType keyconstraint = ((BTableType) Types.getReferredType(iExpr.expr.getBType())).keyTypeConstraint;
             if (keyconstraint != null && keyconstraint.tag == TypeTags.NEVER) {
-                switch (funcName.value){
+                switch (funcName.value) {
                     case "remove":
                     case "filter":
                     case "get":

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -6864,6 +6864,23 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         SymbolEnv enclEnv = data.env;
         data.env = SymbolEnv.createInvocationEnv(iExpr, data.env);
         iExpr.argExprs.add(0, iExpr.expr);
+
+        if (Types.getReferredType(bType).tag == TypeTags.TABLE) {
+            BType keyconstraint = ((BTableType) Types.getReferredType(iExpr.expr.getBType())).keyTypeConstraint;
+            if (keyconstraint != null && keyconstraint.tag == TypeTags.NEVER) {
+                switch (funcName.value){
+                    case "remove":
+                    case "filter":
+                    case "get":
+                    case "removeIfHasKey":
+                    case "hasKey":
+                    case "keys":
+                    case "nextKey":
+                        data.resultType = symTable.semanticError;
+                        return symTable.notFoundSymbol;
+                }
+            }
+        }
         checkInvocationParamAndReturnType(iExpr, data);
         data.env = enclEnv;
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -6864,23 +6864,6 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         SymbolEnv enclEnv = data.env;
         data.env = SymbolEnv.createInvocationEnv(iExpr, data.env);
         iExpr.argExprs.add(0, iExpr.expr);
-
-        if (Types.getReferredType(bType).tag == TypeTags.TABLE) {
-            BType keyconstraint = ((BTableType) Types.getReferredType(iExpr.expr.getBType())).keyTypeConstraint;
-            if (keyconstraint != null && keyconstraint.tag == TypeTags.NEVER) {
-                switch (funcName.value) {
-                    case "remove":
-                    case "filter":
-                    case "get":
-                    case "removeIfHasKey":
-                    case "hasKey":
-                    case "keys":
-                    case "nextKey":
-                        data.resultType = symTable.semanticError;
-                        return symTable.notFoundSymbol;
-                }
-            }
-        }
         checkInvocationParamAndReturnType(iExpr, data);
         data.env = enclEnv;
 

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1375,8 +1375,8 @@ error.cannot.update.table.using.member.access.lvexpr = \
 error.multi.key.member.access.not.supported = \
   invalid member access with ''{0}'': member access with multi-key expression is only allowed with subtypes of ''table''
 
-error.member.access.not.supported.keyless.table = \
-  member access is not supported for keyless table ''{0}''
+error.member.access.not.supported.table = \
+  member access is not supported for table ''{0}''
 
 error.invalid.field.name.in.key.specifier = \
   field name ''{0}'' used in key specifier is not found in table constraint type ''{1}''

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1375,7 +1375,7 @@ error.cannot.update.table.using.member.access.lvexpr = \
 error.multi.key.member.access.not.supported = \
   invalid member access with ''{0}'': member access with multi-key expression is only allowed with subtypes of ''table''
 
-error.member.access.not.supported.for.table = \
+error.member.access.not.supported.for.keyless.table = \
   member access is not supported for table ''{0}''
 
 error.invalid.field.name.in.key.specifier = \

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1375,7 +1375,7 @@ error.cannot.update.table.using.member.access.lvexpr = \
 error.multi.key.member.access.not.supported = \
   invalid member access with ''{0}'': member access with multi-key expression is only allowed with subtypes of ''table''
 
-error.member.access.not.supported.table = \
+error.member.access.not.supported.for.table = \
   member access is not supported for table ''{0}''
 
 error.invalid.field.name.in.key.specifier = \

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableNegativeTest.java
@@ -184,7 +184,8 @@ public class TableNegativeTest {
         validateError(compileResult, index++, "incompatible types: expected " +
                 "'table<ballerina/lang.table:0.0.0:MapType> key<ballerina/lang.table:0.0.0:KeyType>', " +
                 "found 'table<Employee2>'", 539, 9);
-        validateError(compileResult, index++, "incompatible types: expected 'never', found 'int'", 551, 29);
+        validateError(compileResult, index++, "undefined function 'remove' in type 'table<Employee2> key<never>'",
+                551, 22);
         validateError(compileResult, index++, "incompatible types: expected " +
                 "'table<ballerina/lang.table:0.0.0:MapType> key<ballerina/lang.table:0.0.0:KeyType>', " +
                 "found 'table<record {| int id; string name; |}>'", 563, 9);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableNegativeTest.java
@@ -180,11 +180,17 @@ public class TableNegativeTest {
                 520, 5);
         validateError(compileResult, index++, "incompatible types: expected " +
                 "'table<ballerina/lang.table:0.0.0:MapType> key<ballerina/lang.table:0.0.0:KeyType>', " +
-                "found 'table<Employee2>'", 549, 9);
+                "found 'table<Employee2>'", 533, 9);
         validateError(compileResult, index++, "incompatible types: expected " +
                 "'table<ballerina/lang.table:0.0.0:MapType> key<ballerina/lang.table:0.0.0:KeyType>', " +
-                "found 'table<Employee2>'", 550, 9);
-        validateError(compileResult, index++, "incompatible types: expected 'never', found 'int'", 552, 29);
+                "found 'table<Employee2>'", 539, 9);
+        validateError(compileResult, index++, "incompatible types: expected 'never', found 'int'", 551, 29);
+        validateError(compileResult, index++, "incompatible types: expected " +
+                "'table<ballerina/lang.table:0.0.0:MapType> key<ballerina/lang.table:0.0.0:KeyType>', " +
+                "found 'table<record {| int id; string name; |}>'", 563, 9);
+        validateError(compileResult, index++, "incompatible types: expected " +
+                "'table<ballerina/lang.table:0.0.0:MapType> key<ballerina/lang.table:0.0.0:KeyType>', " +
+                "found 'table<record {| int id; |}>'", 566, 9);
         Assert.assertEquals(compileResult.getErrorCount(), index);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableNegativeTest.java
@@ -184,8 +184,7 @@ public class TableNegativeTest {
         validateError(compileResult, index++, "incompatible types: expected " +
                 "'table<ballerina/lang.table:0.0.0:MapType> key<ballerina/lang.table:0.0.0:KeyType>', " +
                 "found 'table<Employee2>'", 539, 9);
-        validateError(compileResult, index++, "undefined function 'remove' in type 'table<Employee2> key<never>'",
-                551, 22);
+        validateError(compileResult, index++, "incompatible types: expected 'never', found 'int'", 551, 29);
         validateError(compileResult, index++, "incompatible types: expected " +
                 "'table<ballerina/lang.table:0.0.0:MapType> key<ballerina/lang.table:0.0.0:KeyType>', " +
                 "found 'table<record {| int id; string name; |}>'", 563, 9);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableNegativeTest.java
@@ -47,7 +47,7 @@ public class TableNegativeTest {
                 "key constraint type '[string]'", 30, 26);
         validateError(compileResult, index++, "table key specifier mismatch. expected: '[id]' but " +
                 "found '[address]'", 35, 44);
-        validateError(compileResult, index++, "member access is not supported for keyless table " +
+        validateError(compileResult, index++, "member access is not supported for table " +
                 "'customerTable'", 45, 21);
         validateError(compileResult, index++, "invalid constraint type. expected subtype of " +
                 "'map<any|error>' but found 'int'", 47, 7);
@@ -59,7 +59,7 @@ public class TableNegativeTest {
                 "field", 75, 28);
         validateError(compileResult, index++, "value expression of key specifier 'id' must be a " +
                 "constant expression", 82, 41);
-        validateError(compileResult, index++, "member access is not supported for keyless table " +
+        validateError(compileResult, index++, "member access is not supported for table " +
                 "'keylessCusTab'", 87, 27);
         validateError(compileResult, index++, "value expression of key specifier 'id' must be a " +
                 "constant expression", 90, 33);
@@ -127,13 +127,13 @@ public class TableNegativeTest {
                 " found 'table<record {| (any|error) a; |}>'", 311, 13);
         validateError(compileResult, index++, "incompatible types: expected 'int'," +
                 " found 'table<record {| (0|1|2|3) a; |}>'", 324, 13);
-        validateError(compileResult, index++, "member access is not supported for keyless table 'tbl1'", 334, 9);
-        validateError(compileResult, index++, "member access is not supported for keyless table 'tbl2'", 340, 9);
-        validateError(compileResult, index++, "member access is not supported for keyless table 'tbl3'", 346, 9);
-        validateError(compileResult, index++, "member access is not supported for keyless table 'tbl4'", 352, 9);
-        validateError(compileResult, index++, "member access is not supported for keyless table 'tbl5'", 358, 9);
-        validateError(compileResult, index++, "member access is not supported for keyless table 'tbl6'", 364, 9);
-        validateError(compileResult, index++, "member access is not supported for keyless table 'tbl7'", 370, 9);
+        validateError(compileResult, index++, "member access is not supported for table 'tbl1'", 334, 9);
+        validateError(compileResult, index++, "member access is not supported for table 'tbl2'", 340, 9);
+        validateError(compileResult, index++, "member access is not supported for table 'tbl3'", 346, 9);
+        validateError(compileResult, index++, "member access is not supported for table 'tbl4'", 352, 9);
+        validateError(compileResult, index++, "member access is not supported for table 'tbl5'", 358, 9);
+        validateError(compileResult, index++, "member access is not supported for table 'tbl6'", 364, 9);
+        validateError(compileResult, index++, "member access is not supported for table 'tbl7'", 370, 9);
         validateError(compileResult, index++, "cannot update 'table<Customer>' with member access expression", 378, 5);
         validateError(compileResult, index++, "cannot update 'table<Customer>' with member access expression", 384, 5);
         validateError(compileResult, index++, "cannot update 'table<record {| string name?; |}>' with " +
@@ -151,7 +151,7 @@ public class TableNegativeTest {
                 422, 76);
         validateError(compileResult, index++, "incompatible types: expected 'CustomerTable', " +
                         "found 'CustomerEmptyKeyedTbl'", 424, 23);
-        validateError(compileResult, index++, "member access is not supported for keyless table 'tbl2'", 433, 9);
+        validateError(compileResult, index++, "member access is not supported for table 'tbl2'", 433, 9);
         validateError(compileResult, index++, "cannot update 'table<Customer>' with member access expression", 434, 5);
         validateError(compileResult, index++, "incompatible types: expected '(table<Student>|int)', " +
                 "found 'table<record {| readonly int id; string firstName; string lastName; |}>'", 444, 28);
@@ -178,6 +178,13 @@ public class TableNegativeTest {
                 520, 5);
         validateError(compileResult, index++, "value expression of key specifier 'z' must be a constant expression",
                 520, 5);
+        validateError(compileResult, index++, "incompatible types: expected " +
+                "'table<ballerina/lang.table:0.0.0:MapType> key<ballerina/lang.table:0.0.0:KeyType>', " +
+                "found 'table<Employee2>'", 549, 9);
+        validateError(compileResult, index++, "incompatible types: expected " +
+                "'table<ballerina/lang.table:0.0.0:MapType> key<ballerina/lang.table:0.0.0:KeyType>', " +
+                "found 'table<Employee2>'", 550, 9);
+        validateError(compileResult, index++, "incompatible types: expected 'never', found 'int'", 552, 29);
         Assert.assertEquals(compileResult.getErrorCount(), index);
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/table/table-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/table/table-negative.bal
@@ -530,24 +530,38 @@ function testKeyConstraint() {
         {id: 0, name: "a"},
         {id: 1, name: "b"}
     ];
+    _ = superTable1.remove(0); // error
 
     table<Employee2> superTable2 = table [
         {id: 0, name: "a"},
         {id: 1, name: "b"}
     ];
+    _ = superTable2.remove(0); // error
 
     table<Employee2> key<int> keyTable = table key(id) [
         {id: 0, name: "a"},
         {id: 1, name: "b"}
     ];
+    _ = keyTable.remove(0);
 
     table<Employee2> key<never> keylessTable = table [
         {id: 0, name: "a"},
         {id: 1, name: "b"}
     ];
+    _ = keylessTable.remove(0); // error
 
-    _ = superTable1.remove(0);
-    _ = superTable2.remove(0);
-    _ = keyTable.remove(0);
-    _ = keylessTable.remove(0);
+    var keyTable1 = table key(id) [
+        {id: 0, name: "a"},
+        {id: 1, name: "b"}
+    ];
+    _ = keyTable1.remove(0);
+
+    var keylessTable1 = table [
+            {id: 0, name: "a"},
+            {id: 1, name: "b"}
+        ];
+    _ = keylessTable1.remove(0); // error
+
+    var ids = from var {id} in keylessTable select {id};
+    _ = ids.remove(0); // error
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/table/table-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/table/table-negative.bal
@@ -519,3 +519,35 @@ table<BarRec> key(x, y, z) tb3 = table [
     {x: i, y: i, z: "a"},
     {...spreadField3}
 ];
+
+type Employee2 record {
+    readonly int id;
+    string name;
+};
+
+function testKeyConstraint() {
+    table<Employee2> superTable1 = table key(id) [
+        {id: 0, name: "a"},
+        {id: 1, name: "b"}
+    ];
+
+    table<Employee2> superTable2 = table [
+        {id: 0, name: "a"},
+        {id: 1, name: "b"}
+    ];
+
+    table<Employee2> key<int> keyTable = table key(id) [
+        {id: 0, name: "a"},
+        {id: 1, name: "b"}
+    ];
+
+    table<Employee2> key<never> keylessTable = table [
+        {id: 0, name: "a"},
+        {id: 1, name: "b"}
+    ];
+
+    _ = superTable1.remove(0);
+    _ = superTable2.remove(0);
+    _ = keyTable.remove(0);
+    _ = keylessTable.remove(0);
+}


### PR DESCRIPTION
## Purpose

Fixes #35576 

## Approach
> A `table<Type>` is a super type that can have both key-ed and keyless tables. So, implementation is correct. `Keyless` keyword in the error msgs is removed to fix the issue.

## Samples
> 
```
type Employee2 record {
    readonly int id;
    string name;
};

table<Employee2> superTable1 = table key(id) [
    {id: 0, name: "a"},
    {id: 1, name: "b"}
];

table<Employee2> superTable2 = table [
    {id: 0, name: "a"},
    {id: 1, name: "b"}
];

table<Employee2> key<int> keyTable = table key(id) [
    {id: 0, name: "a"},
    {id: 1, name: "b"}
];

table<Employee2> key<never> keylessTable = table [
    {id: 0, name: "a"},
    {id: 1, name: "b"}
];
```
`superTable1.remove(0)` - not allowed
`superTable2.remove(0)` - not allowed
`keyTable.remove(0)` - allowed
`keylessTable.remove(0)` - not allowed

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
