### PR TITLE
Add the line wrapping feature to the formatter

### DIFF
--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingEnv.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingEnv.java
@@ -17,6 +17,8 @@
  */
 package org.ballerinalang.formatter.core;
 
+import io.ballerina.compiler.syntax.tree.Node;
+
 /**
  * Environment that holds a set of properties related to the currently formatting node.
  *
@@ -78,4 +80,9 @@ public class FormattingEnv {
      * Flag indicating whether the token that is currently being formatted should preserve its user defined indentation.
      */
     boolean preserveIndentation = false;
+
+    /**
+     * Reference to the next node that needs to be wrapped.
+     */
+    Node nodeToWrap = null;
 }

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingOptions.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingOptions.java
@@ -28,15 +28,34 @@ public class FormattingOptions {
 
     private int columnLimit;
 
+    private boolean lineWrapping;
+
     FormattingOptions() {
         this.tabSize = 4;
         this.wsCharacter = " ";
         this.columnLimit = 120;
+        this.lineWrapping = false;
     }
 
-    FormattingOptions(int tabSize, String wsCharacter) {
+    public FormattingOptions(int tabSize, String wsCharacter) {
         this.tabSize = tabSize;
         this.wsCharacter = wsCharacter;
+        this.columnLimit = 120;
+        this.lineWrapping = false;
+    }
+
+    public FormattingOptions(boolean lineWrapping, int columnLimit) {
+        this.tabSize = 4;
+        this.wsCharacter = " ";
+        this.columnLimit = columnLimit;
+        this.lineWrapping = lineWrapping;
+    }
+
+    public FormattingOptions(int tabSize, String wsCharacter, boolean lineWrapping, int columnLimit) {
+        this.tabSize = tabSize;
+        this.wsCharacter = wsCharacter;
+        this.columnLimit = columnLimit;
+        this.lineWrapping = lineWrapping;
     }
 
     public int getTabSize() {
@@ -61,5 +80,13 @@ public class FormattingOptions {
 
     public int getColumnLimit() {
         return this.columnLimit;
+    }
+
+    public boolean getLineWrapping() {
+        return lineWrapping;
+    }
+
+    public void setLineWrapping(boolean lineWrapping) {
+        this.lineWrapping = lineWrapping;
     }
 }

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
@@ -3520,7 +3520,7 @@ public class FormattingTreeModifier extends TreeModifier {
 
             node = (T) node.apply(this);
 
-            if (shouldWrapLine(oldNode, parent) && options.getLineWrapping()) {
+            if (options.getLineWrapping() && shouldWrapLine(oldNode, parent)) {
                 node = wrapLine(oldNode, parent);
             }
 

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
@@ -3513,7 +3513,16 @@ public class FormattingTreeModifier extends TreeModifier {
             env.trailingNL = trailingNL;
             env.trailingWS = trailingWS;
 
+            // Cache the current node and parent before format.
+            // Because reference to the nodes will change after modifying.
+            T oldNode = node;
+            Node parent = node.parent();
+
             node = (T) node.apply(this);
+
+            if (shouldWrapLine(oldNode, parent) && options.getLineWrapping()) {
+                node = wrapLine(oldNode, parent);
+            }
 
             env.trailingNL = prevTrailingNL;
             env.trailingWS = prevTrailingWS;
@@ -3804,6 +3813,95 @@ public class FormattingTreeModifier extends TreeModifier {
         } else {
             env.lineLength = node.location().lineRange().endLine().offset();
         }
+    }
+
+    /**
+     * Check whether the current line should be wrapped.
+     *
+     * @param node Node that is being formatted
+     * @param parent
+     * @return Flag indicating whether to wrap the current line or not
+     */
+    private boolean shouldWrapLine(Node node, Node parent) {
+        boolean exceedsColumnLimit = env.lineLength > options.getColumnLimit();
+        boolean descendantNeedWrapping = env.nodeToWrap == node;
+        if (!exceedsColumnLimit && !descendantNeedWrapping) {
+            return false;
+        }
+
+        // Currently wrapping a line is supported at following levels:
+        SyntaxKind kind = node.kind();
+        switch (kind) {
+            case SIMPLE_NAME_REFERENCE:
+            case QUALIFIED_NAME_REFERENCE:
+                if (node.parent().kind() == SyntaxKind.ANNOTATION) {
+                    break;
+                }
+                return true;
+
+            // Parameters
+            case DEFAULTABLE_PARAM:
+            case REQUIRED_PARAM:
+            case REST_PARAM:
+
+                // Func-call arguments
+            case POSITIONAL_ARG:
+            case NAMED_ARG:
+            case REST_ARG:
+
+            case RETURN_TYPE_DESCRIPTOR:
+            case ANNOTATION_ATTACH_POINT:
+                return true;
+
+            // Template literals are multi line tokens, and newline are
+            // part of the content. Hence we cannot wrap those.
+            case XML_TEMPLATE_EXPRESSION:
+            case STRING_TEMPLATE_EXPRESSION:
+            case TEMPLATE_STRING:
+                break;
+            default:
+                // Expressions
+                if (SyntaxKind.BINARY_EXPRESSION.compareTo(kind) <= 0 &&
+                        SyntaxKind.OBJECT_CONSTRUCTOR.compareTo(kind) >= 0) {
+                    return true;
+                }
+
+                // Everything else is not supported
+                break;
+        }
+
+        // We reach here, if the current node exceeds the limit, but it is
+        // not a wrapping-point. Then we ask the parent to wrap itself.
+        env.nodeToWrap = parent;
+
+        return false;
+    }
+
+    /**
+     * Wrap the node. This is equivalent to adding a newline before the node and re-formatting the node. Wrapped content
+     * will start from the current level of indentation.
+     *
+     * @param <T> Node type
+     * @param node Node to be wrapped
+     * @param parent
+     * @return Wrapped node
+     */
+    @SuppressWarnings("unchecked")
+    private <T extends Node> T wrapLine(T node, Node parent) {
+        env.leadingNL += 1;
+        env.lineLength = 0;
+        env.hasNewline = true;
+        node = (T) node.apply(this);
+
+        // Sometimes wrapping the current node wouldn't be enough. Therefore, if the column
+        // length exceeds even after wrapping current node, then ask the parent node to warp.
+        if (env.lineLength > options.getColumnLimit()) {
+            env.nodeToWrap = parent;
+        } else {
+            env.nodeToWrap = null;
+        }
+
+        return node;
     }
 
     /**

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/FormatterTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/FormatterTest.java
@@ -67,6 +67,21 @@ public abstract class FormatterTest {
         }
     }
 
+    public void testWithOptions(String source, String sourcePath) throws IOException {
+        Path assertFilePath = Paths.get(resourceDirectory.toString(), sourcePath, ASSERT_DIR, source);
+        Path sourceFilePath = Paths.get(resourceDirectory.toString(), sourcePath, SOURCE_DIR, source);
+        String content = getSourceText(sourceFilePath);
+        TextDocument textDocument = TextDocuments.from(content);
+        SyntaxTree syntaxTree = SyntaxTree.from(textDocument);
+        FormattingOptions formattingOptions = new FormattingOptions(true, 120);
+        try {
+            SyntaxTree newSyntaxTree = Formatter.format(syntaxTree, formattingOptions);
+            Assert.assertEquals(newSyntaxTree.toSourceCode(), getSourceText(assertFilePath));
+        } catch (FormatterException e) {
+            Assert.fail(e.getMessage(), e);
+        }
+    }
+
     /**
      * Test the formatting functionality for parser test cases.
      *

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/misc/LineWrappingTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/misc/LineWrappingTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.formatter.core.misc;
+
+import org.ballerinalang.formatter.core.FormatterTest;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+
+/**
+ * Test the line wrapping.
+ *
+ * @since 2.0.0
+ */
+public class LineWrappingTest extends FormatterTest {
+
+    @Test(dataProvider = "test-file-provider")
+    public void test(String source, String sourcePath) throws IOException {
+        super.testWithOptions(source, sourcePath);
+    }
+
+    @DataProvider(name = "test-file-provider")
+    @Override
+    public Object[][] dataProvider() {
+        return this.getConfigsList();
+    }
+
+    @Override
+    public String getTestResourceDir() {
+        return Paths.get("misc", "linewrapping").toString();
+    }
+}

--- a/misc/formatter/modules/formatter-core/src/test/resources/misc/linewrapping/assert/line_wrapping_1.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/misc/linewrapping/assert/line_wrapping_1.bal
@@ -1,0 +1,21 @@
+function foo(int count, int count, int count, int count, int count, int count, int count, int count, 
+             int count = 999999999) {
+}
+
+public type Client client object {
+    remote function query(@untainted string|ParameterizedQuery sqlQuery, typedesc<record {}>? rowType = ())
+    returns @tainted stream<record {};, Error>;
+}
+
+function foo() {
+    ReportTable|error reportTable = table key(id) from var student in studentList
+        where student.gpa >= 2.0
+        let string degreeName = "Bachelor of Medicine", int graduationYear = calGraduationYear(student.intakeYear), int test = 
+        calGraduationYear(student.intakeYear)
+        select {id: student.id};
+}
+
+public function main() {
+    string stringVal = 
+    "this is a sample. this is a sample. this is a sample. this is a sample. this is a sample. this is a sample. " + " this is a sample. this is a sample. this is a sample." + "this is a sample. this is a sample. this is a sample. this is a sample. this is a sample. this is a sample. this is a sample." + " this is a sample. this is a sample.";
+}

--- a/misc/formatter/modules/formatter-core/src/test/resources/misc/linewrapping/source/line_wrapping_1.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/misc/linewrapping/source/line_wrapping_1.bal
@@ -1,0 +1,18 @@
+function foo(int count, int count, int count, int count, int count, int count, int count, int count, int count = 999999999) {
+}
+
+public type Client client object {
+    remote function query(@untainted string|ParameterizedQuery sqlQuery, typedesc<record { }>? rowType = ())
+    returns @tainted stream<record { };, Error>;
+}
+
+function foo() {
+        ReportTable|error reportTable = table key(id) from var student in studentList
+                                        where student.gpa >= 2.0
+                                        let string degreeName = "Bachelor of Medicine", int graduationYear = calGraduationYear(student.intakeYear), int test = calGraduationYear(student.intakeYear)
+                                        select {id: student.id};
+}
+
+public function main() {
+    string stringVal =  "this is a sample. this is a sample. this is a sample. this is a sample. this is a sample. this is a sample. " + " this is a sample. this is a sample. this is a sample." + "this is a sample. this is a sample. this is a sample. this is a sample. this is a sample. this is a sample. this is a sample." + " this is a sample. this is a sample.";
+}


### PR DESCRIPTION
## Purpose
Provides the line wrapping feature for the ballerina formatter, this can be used by passing the `FormattingOptions` parameter when calling the formatter API.

Fixes https://github.com/wso2-enterprise/internal-support-ballerina/issues/63

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
