### PR TITLE
Add traceId, spanId to non-sampled bSpanContexts as well

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/tracer/BSpan.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/tracer/BSpan.java
@@ -52,8 +52,6 @@ public class BSpan {
     private BMap<BString, Object> bSpanContext;
     private static final MapType IMMUTABLE_STRING_MAP_TYPE = TypeCreator.createMapType(
             PredefinedTypes.TYPE_STRING, true);
-    private static final BMap<BString, Object> EMPTY_BSPAN_CONTEXT = ValueCreator.createMapValue(
-            IMMUTABLE_STRING_MAP_TYPE);
 
     private static PropagatingParentContextGetter getter = new PropagatingParentContextGetter();
     private static PropagatingParentContextSetter setter = new PropagatingParentContextSetter();
@@ -178,19 +176,15 @@ public class BSpan {
 
         if (bSpanContext == null) {
             SpanContext spanContext = span.getSpanContext();
-            if (spanContext.isSampled()) {
-                BMapInitialValueEntry[] values = new BMapInitialValueEntry[]{
-                        new MappingInitialValueEntry.KeyValueEntry(
-                                TraceConstants.SPAN_CONTEXT_MAP_KEY_TRACE_ID,
-                                StringUtils.fromString(spanContext.getTraceId())),
-                        new MappingInitialValueEntry.KeyValueEntry(
-                                TraceConstants.SPAN_CONTEXT_MAP_KEY_SPAN_ID,
-                                StringUtils.fromString(spanContext.getSpanId()))
-                };
-                bSpanContext = ValueCreator.createMapValue(IMMUTABLE_STRING_MAP_TYPE, values);
-            } else {
-                bSpanContext = EMPTY_BSPAN_CONTEXT;
-            }
+            BMapInitialValueEntry[] values = new BMapInitialValueEntry[]{
+                    new MappingInitialValueEntry.KeyValueEntry(
+                            TraceConstants.SPAN_CONTEXT_MAP_KEY_TRACE_ID,
+                            StringUtils.fromString(spanContext.getTraceId())),
+                    new MappingInitialValueEntry.KeyValueEntry(
+                            TraceConstants.SPAN_CONTEXT_MAP_KEY_SPAN_ID,
+                            StringUtils.fromString(spanContext.getSpanId()))
+            };
+            bSpanContext = ValueCreator.createMapValue(IMMUTABLE_STRING_MAP_TYPE, values);
         }
         return bSpanContext;
     }


### PR DESCRIPTION
## Purpose
We need to add traceId and spanId to bSpanContext regardless of whether the request get sampled or not in order to add trace context into logs.

Fixes #<Issue Number>
https://github.com/ballerina-platform/ballerina-lang/issues/36952

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
