### PR TITLE
Improve LS package loader to update on pull module event

### DIFF
--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/eventsync/EventKind.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/eventsync/EventKind.java
@@ -23,5 +23,6 @@ package org.ballerinalang.langserver.commons.eventsync;
  * @since 2201.1.1
  */
 public enum EventKind {
-    PROJECT_UPDATE
+    PROJECT_UPDATE,
+    PULL_MODULE
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSPackageLoader.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSPackageLoader.java
@@ -30,7 +30,6 @@ import io.ballerina.projects.internal.environment.BallerinaUserHome;
 import io.ballerina.projects.internal.environment.DefaultEnvironment;
 import org.ballerinalang.langserver.commons.DocumentServiceContext;
 import org.ballerinalang.langserver.commons.LanguageServerContext;
-import org.ballerinalang.langserver.completions.providers.context.util.ServiceTemplateGenerator;
 import org.wso2.ballerinalang.compiler.util.Names;
 
 import java.nio.file.Path;
@@ -187,10 +186,10 @@ public class LSPackageLoader {
         return packages;
     }
 
-    public void updatePackageMapOnPullModuleEvent(DocumentServiceContext context) {
+    public List<PackageInfo> updatePackageMap(DocumentServiceContext context) {
         Optional<Project> project = context.workspace().project(context.filePath());
         if (project.isEmpty()) {
-            return;
+            return Collections.emptyList();
         }
         BallerinaUserHome ballerinaUserHome = BallerinaUserHome
                 .from(project.get().projectEnvironmentContext().environment());
@@ -200,8 +199,7 @@ public class LSPackageLoader {
                         this.remoteRepoPackages.stream().map(PackageInfo::packageIdentifier)
                                 .collect(Collectors.toSet()));
         this.remoteRepoPackages.addAll(packageInfos);
-        ServiceTemplateGenerator.getInstance(context.languageServercontext())
-                .updateListenerMetaDataMap(packageInfos, context.languageServercontext());
+        return packageInfos;
     }
 
     /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSPackageLoader.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSPackageLoader.java
@@ -30,6 +30,7 @@ import io.ballerina.projects.internal.environment.BallerinaUserHome;
 import io.ballerina.projects.internal.environment.DefaultEnvironment;
 import org.ballerinalang.langserver.commons.DocumentServiceContext;
 import org.ballerinalang.langserver.commons.LanguageServerContext;
+import org.ballerinalang.langserver.completions.providers.context.util.ServiceTemplateGenerator;
 import org.wso2.ballerinalang.compiler.util.Names;
 
 import java.nio.file.Path;
@@ -40,6 +41,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Loads the Ballerina builtin core and builtin packages.
@@ -50,8 +53,8 @@ public class LSPackageLoader {
             new LanguageServerContext.Key<>();
 
     private final List<PackageInfo> distRepoPackages;
-    private List<PackageInfo> remoteRepoPackages;
-    private List<PackageInfo> localRepoPackages;
+    private List<PackageInfo> remoteRepoPackages = new ArrayList<>();
+    private List<PackageInfo> localRepoPackages = new ArrayList<>();
 
     public static LSPackageLoader getInstance(LanguageServerContext context) {
         LSPackageLoader lsPackageLoader = context.get(LS_PACKAGE_LOADER_KEY);
@@ -73,10 +76,11 @@ public class LSPackageLoader {
      * @return {@link List} of local repo packages
      */
     public List<PackageInfo> getLocalRepoPackages(PackageRepository repository) {
-        if (this.localRepoPackages != null) {
+        if (!this.localRepoPackages.isEmpty()) {
             return this.localRepoPackages;
         }
-        this.localRepoPackages = getPackagesFromRepository(repository, Collections.emptyList());
+        this.localRepoPackages.addAll(checkAndResolvePackagesFromRepository(repository, Collections.emptyList(),
+                this.distRepoPackages.stream().map(PackageInfo::packageIdentifier).collect(Collectors.toSet())));
         return localRepoPackages;
     }
 
@@ -86,10 +90,11 @@ public class LSPackageLoader {
      * @return {@link List} of remote repo packages
      */
     public List<PackageInfo> getRemoteRepoPackages(PackageRepository repository) {
-        if (this.remoteRepoPackages != null) {
+        if (!this.remoteRepoPackages.isEmpty()) {
             return this.remoteRepoPackages;
         }
-        this.remoteRepoPackages = getPackagesFromRepository(repository, Collections.emptyList());
+        this.remoteRepoPackages.addAll(checkAndResolvePackagesFromRepository(repository, Collections.emptyList(),
+                this.remoteRepoPackages.stream().map(PackageInfo::packageIdentifier).collect(Collectors.toSet())));
         return this.remoteRepoPackages;
     }
 
@@ -108,7 +113,8 @@ public class LSPackageLoader {
         BallerinaDistribution ballerinaDistribution = BallerinaDistribution.from(environment);
         PackageRepository packageRepository = ballerinaDistribution.packageRepository();
         List<String> skippedLangLibs = Arrays.asList("lang.annotations", "lang.__internal", "lang.query");
-        return Collections.unmodifiableList(getPackagesFromRepository(packageRepository, skippedLangLibs));
+        return Collections.unmodifiableList(checkAndResolvePackagesFromRepository(packageRepository, skippedLangLibs,
+                Collections.emptySet()));
     }
 
     /**
@@ -128,6 +134,7 @@ public class LSPackageLoader {
 
     /**
      * Returns the list of packages that reside in the BallerinaUserHome (.ballerina) directory.
+     *
      * @param ctx Document service context.
      * @return {@link List<PackageInfo>} List of package info.
      */
@@ -146,7 +153,8 @@ public class LSPackageLoader {
         return packagesList;
     }
 
-    private List<PackageInfo> getPackagesFromRepository(PackageRepository repository, List<String> skipList) {
+    private List<PackageInfo> checkAndResolvePackagesFromRepository(PackageRepository repository, List<String> skipList,
+                                                                    Set<String> loadedPackages) {
         Map<String, List<String>> packageMap = repository.getPackages();
         List<PackageInfo> packages = new ArrayList<>();
         packageMap.forEach((key, value) -> {
@@ -162,6 +170,10 @@ public class LSPackageLoader {
                 String version = components[1];
                 PackageOrg packageOrg = PackageOrg.from(key);
                 PackageName packageName = PackageName.from(nameComponent);
+                String packageIdentifier = packageOrg.toString() + "/" + packageName;
+                if (loadedPackages.contains(packageIdentifier)) {
+                    return;
+                }
                 PackageVersion pkgVersion = PackageVersion.from(version);
                 PackageDescriptor pkdDesc = PackageDescriptor.from(packageOrg, packageName, pkgVersion);
                 ResolutionRequest request = ResolutionRequest.from(pkdDesc, PackageDependencyScope.DEFAULT);
@@ -173,6 +185,23 @@ public class LSPackageLoader {
         });
 
         return packages;
+    }
+
+    public void updatePackageMapOnPullModuleEvent(DocumentServiceContext context) {
+        Optional<Project> project = context.workspace().project(context.filePath());
+        if (project.isEmpty()) {
+            return;
+        }
+        BallerinaUserHome ballerinaUserHome = BallerinaUserHome
+                .from(project.get().projectEnvironmentContext().environment());
+        PackageRepository remoteRepository = ballerinaUserHome.remotePackageRepository();
+        List<PackageInfo> packageInfos =
+                checkAndResolvePackagesFromRepository(remoteRepository, Collections.emptyList(),
+                        this.remoteRepoPackages.stream().map(PackageInfo::packageIdentifier)
+                                .collect(Collectors.toSet()));
+        this.remoteRepoPackages.addAll(packageInfos);
+        ServiceTemplateGenerator.getInstance(context.languageServercontext())
+                .updateListenerMetaDataMap(packageInfos, context.languageServercontext());
     }
 
     /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/util/ServiceTemplateGenerator.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/util/ServiceTemplateGenerator.java
@@ -236,6 +236,16 @@ public class ServiceTemplateGenerator {
     }
 
     /**
+     * Update the module listener meta data map.
+     * @param newPackages packages list
+     * @param context language server context
+     */
+    public void updateListenerMetaDataMap(List<LSPackageLoader.PackageInfo> newPackages, 
+                                          LanguageServerContext context) {
+        this.loadListenersFromPackages(newPackages, context);
+    }
+
+    /**
      * Given a module symbol, find and populate service metadata into the moduleServiceTemplateMap cache.
      * Used to dynamically add new entries to the cache.
      *

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/eventsync/publishers/PullModulePublisher.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/eventsync/publishers/PullModulePublisher.java
@@ -1,0 +1,35 @@
+package org.ballerinalang.langserver.eventsync.publishers;
+
+import org.ballerinalang.annotation.JavaSPIService;
+import org.ballerinalang.langserver.commons.DocumentServiceContext;
+import org.ballerinalang.langserver.commons.LanguageServerContext;
+import org.ballerinalang.langserver.commons.client.ExtendedLanguageClient;
+import org.ballerinalang.langserver.commons.eventsync.EventKind;
+import org.ballerinalang.langserver.eventsync.AbstractEventPublisher;
+
+/**
+ * Publishes the pull module event.
+ *
+ * @since 2201.2.1
+ */
+@JavaSPIService("org.ballerinalang.langserver.eventsync.EventPublisher")
+public class PullModulePublisher extends AbstractEventPublisher {
+
+    public static final String NAME = "Pull module event publisher";
+
+    @Override
+    public EventKind getKind() {
+        return EventKind.PULL_MODULE;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public void publish(ExtendedLanguageClient client, LanguageServerContext serverContext,
+                        DocumentServiceContext context) {
+        subscribers.forEach(subscriber -> subscriber.onEvent(client, context, serverContext));
+    }
+}

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/eventsync/publishers/PullModulePublisher.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/eventsync/publishers/PullModulePublisher.java
@@ -1,3 +1,20 @@
+/*
+ *  Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
 package org.ballerinalang.langserver.eventsync.publishers;
 
 import org.ballerinalang.annotation.JavaSPIService;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/eventsync/subscribers/PullModuleSubscriber.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/eventsync/subscribers/PullModuleSubscriber.java
@@ -1,0 +1,36 @@
+package org.ballerinalang.langserver.eventsync.subscribers;
+
+import org.ballerinalang.annotation.JavaSPIService;
+import org.ballerinalang.langserver.LSPackageLoader;
+import org.ballerinalang.langserver.commons.DocumentServiceContext;
+import org.ballerinalang.langserver.commons.LanguageServerContext;
+import org.ballerinalang.langserver.commons.client.ExtendedLanguageClient;
+import org.ballerinalang.langserver.commons.eventsync.EventKind;
+import org.ballerinalang.langserver.commons.eventsync.spi.EventSubscriber;
+
+/**
+ * Updates the package map in LSPackage loader.
+ *
+ * @since 2201.2.1
+ */
+@JavaSPIService("org.ballerinalang.langserver.commons.eventsync.spi.EventSubscriber")
+public class PullModuleSubscriber implements EventSubscriber {
+
+    public static final String NAME = "Pull module subscriber";
+
+    @Override
+    public EventKind eventKind() {
+        return EventKind.PULL_MODULE;
+    }
+
+    @Override
+    public void onEvent(ExtendedLanguageClient client, DocumentServiceContext context,
+                        LanguageServerContext languageServerContext) {
+        LSPackageLoader.getInstance(languageServerContext).updatePackageMapOnPullModuleEvent(context);
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+}

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/eventsync/subscribers/PullModuleSubscriber.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/eventsync/subscribers/PullModuleSubscriber.java
@@ -1,3 +1,20 @@
+/*
+ *  Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
 package org.ballerinalang.langserver.eventsync.subscribers;
 
 import org.ballerinalang.annotation.JavaSPIService;
@@ -7,6 +24,9 @@ import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.commons.client.ExtendedLanguageClient;
 import org.ballerinalang.langserver.commons.eventsync.EventKind;
 import org.ballerinalang.langserver.commons.eventsync.spi.EventSubscriber;
+import org.ballerinalang.langserver.completions.providers.context.util.ServiceTemplateGenerator;
+
+import java.util.List;
 
 /**
  * Updates the package map in LSPackage loader.
@@ -26,7 +46,10 @@ public class PullModuleSubscriber implements EventSubscriber {
     @Override
     public void onEvent(ExtendedLanguageClient client, DocumentServiceContext context,
                         LanguageServerContext languageServerContext) {
-        LSPackageLoader.getInstance(languageServerContext).updatePackageMapOnPullModuleEvent(context);
+        List<LSPackageLoader.PackageInfo> packageInfos =
+                LSPackageLoader.getInstance(languageServerContext).updatePackageMap(context);
+        ServiceTemplateGenerator.getInstance(context.languageServercontext())
+                .updateListenerMetaDataMap(packageInfos, context.languageServercontext());
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/AbstractLSTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/AbstractLSTest.java
@@ -98,7 +98,7 @@ public abstract class AbstractLSTest {
         Mockito.when(this.lsPackageLoader.getPackagesFromBallerinaUserHome(Mockito.any())).thenCallRealMethod();
     }
 
-    private static List<Package> getPackages(Map<String, String> projects,
+    protected static List<Package> getPackages(Map<String, String> projects,
                                              WorkspaceManager workspaceManager,
                                              LanguageServerContext context)
             throws WorkspaceDocumentException, IOException {
@@ -132,5 +132,21 @@ public abstract class AbstractLSTest {
 
     public Endpoint getServiceEndpoint() {
         return this.serviceEndpoint;
+    }
+
+    public void setLsPackageLoader(LSPackageLoader lsPackageLoader) {
+        this.lsPackageLoader = lsPackageLoader;
+    }
+
+    public LSPackageLoader getLSPackageLoader() {
+        return this.lsPackageLoader;
+    }
+
+    public static List<LSPackageLoader.PackageInfo> getLocalPackages() {
+        return LOCAL_PACKAGES;
+    }
+
+    public static List<LSPackageLoader.PackageInfo> getRemotePackages() {
+        return REMOTE_PACKAGES;
     }
 }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/lspackageloader/LSPackageLoaderTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/lspackageloader/LSPackageLoaderTest.java
@@ -66,7 +66,7 @@ public class LSPackageLoaderTest extends AbstractLSTest {
         TestUtil.openDocument(endpoint, sourcePath);
 
         BallerinaLanguageServer languageServer = this.getLanguageServer();
-        EventSyncPubSubHolder eventSyncPubSubHolder = 
+        EventSyncPubSubHolder eventSyncPubSubHolder =
                 EventSyncPubSubHolder.getInstance(languageServer.getServerContext());
         DocumentServiceContext documentServiceContext =
                 ContextBuilder.buildDocumentServiceContext(sourcePath.toUri().toString(),
@@ -105,6 +105,7 @@ public class LSPackageLoaderTest extends AbstractLSTest {
                         .map(LSPackageLoader.PackageInfo::new)
                         .collect(Collectors.toList()).get(0);
                 this.remoteRepoPackages.add(packageInfo);
+                return List.of(packageInfo);
             }
             return null;
         }).when(lsPackageLoader).updatePackageMap(Mockito.any());

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/lspackageloader/LSPackageLoaderTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/lspackageloader/LSPackageLoaderTest.java
@@ -107,7 +107,7 @@ public class LSPackageLoaderTest extends AbstractLSTest {
                 this.remoteRepoPackages.add(packageInfo);
             }
             return null;
-        }).when(lsPackageLoader).updatePackageMapOnPullModuleEvent(Mockito.any());
+        }).when(lsPackageLoader).updatePackageMap(Mockito.any());
     }
 
     private List<LSPackageLoader.PackageInfo> getLoadedPackagesFromLoader(DocumentServiceContext context) {

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/lspackageloader/LSPackageLoaderTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/lspackageloader/LSPackageLoaderTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.langserver.lspackageloader;
+
+import io.ballerina.projects.Project;
+import io.ballerina.projects.environment.PackageRepository;
+import io.ballerina.projects.internal.environment.BallerinaUserHome;
+import org.ballerinalang.langserver.AbstractLSTest;
+import org.ballerinalang.langserver.BallerinaLanguageServer;
+import org.ballerinalang.langserver.LSContextOperation;
+import org.ballerinalang.langserver.LSPackageLoader;
+import org.ballerinalang.langserver.commons.DocumentServiceContext;
+import org.ballerinalang.langserver.commons.eventsync.EventKind;
+import org.ballerinalang.langserver.commons.eventsync.exceptions.EventSyncException;
+import org.ballerinalang.langserver.commons.workspace.WorkspaceDocumentException;
+import org.ballerinalang.langserver.contexts.ContextBuilder;
+import org.ballerinalang.langserver.eventsync.EventSyncPubSubHolder;
+import org.ballerinalang.langserver.util.FileUtils;
+import org.ballerinalang.langserver.util.TestUtil;
+import org.eclipse.lsp4j.jsonrpc.Endpoint;
+import org.mockito.Mockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Tests {@link org.ballerinalang.langserver.LSPackageLoader}.
+ *
+ * @since 2201.2.1
+ */
+@PrepareForTest({LSPackageLoader.class})
+public class LSPackageLoaderTest extends AbstractLSTest {
+
+    private final Path testRoot = FileUtils.RES_DIR.resolve("lspackageloader");
+    private static final Map<String, String> REMOTE_PROJECTS = Map.of("project3", "main.bal");
+    private List<LSPackageLoader.PackageInfo> remoteRepoPackages = new ArrayList<>(getRemotePackages());
+
+    @Test(dataProvider = "data-provider")
+    public void test(String source) throws IOException, EventSyncException, WorkspaceDocumentException {
+        //Open the source text document and load project
+        Path sourcePath = testRoot.resolve("source").resolve(source);
+        Endpoint endpoint = getServiceEndpoint();
+        TestUtil.openDocument(endpoint, sourcePath);
+
+        BallerinaLanguageServer languageServer = this.getLanguageServer();
+        EventSyncPubSubHolder eventSyncPubSubHolder = 
+                EventSyncPubSubHolder.getInstance(languageServer.getServerContext());
+        DocumentServiceContext documentServiceContext =
+                ContextBuilder.buildDocumentServiceContext(sourcePath.toUri().toString(),
+                        languageServer.getWorkspaceManager(), LSContextOperation.WS_EXEC_CMD,
+                        languageServer.getServerContext());
+        //PackageInfo count before adding a new package
+        int packageCount = getLoadedPackagesFromLoader(documentServiceContext).size();
+
+        //Publish a mock event using pull module publisher.
+        eventSyncPubSubHolder.getPublisher(EventKind.PULL_MODULE).publish(this.getLanguageServer().getClient(),
+                languageServer.getServerContext(), documentServiceContext);
+
+        //Assert if the package info map is updated with the newly added package.
+        int packageCountAfterPullModule = getLoadedPackagesFromLoader(documentServiceContext).size();
+        Assert.assertTrue(packageCount < packageCountAfterPullModule);
+    }
+
+    @Override
+    public void setUp() {
+        LSPackageLoader lsPackageLoader = Mockito.mock(LSPackageLoader.class, Mockito.withSettings().stubOnly());
+        setLsPackageLoader(lsPackageLoader);
+        this.getLanguageServer().getServerContext().put(LSPackageLoader.LS_PACKAGE_LOADER_KEY, getLSPackageLoader());
+        Mockito.when(lsPackageLoader.getRemoteRepoPackages(Mockito.any()))
+                .thenAnswer(invocation -> getRemoteRepoPackages());
+        Mockito.when(lsPackageLoader.getLocalRepoPackages(Mockito.any())).thenReturn(getLocalPackages());
+        Mockito.when(lsPackageLoader.getDistributionRepoPackages()).thenCallRealMethod();
+        Mockito.when(lsPackageLoader.getAllVisiblePackages(Mockito.any())).thenCallRealMethod();
+        Mockito.when(lsPackageLoader.getPackagesFromBallerinaUserHome(Mockito.any())).thenCallRealMethod();
+        Mockito.doAnswer(invocation -> {
+            invocation.getArguments();
+            Object[] arguments = invocation.getArguments();
+            if (arguments != null && arguments.length == 1 && arguments[0] != null) {
+                DocumentServiceContext context = (DocumentServiceContext) arguments[0];
+                LSPackageLoader.PackageInfo packageInfo = getPackages(REMOTE_PROJECTS,
+                        context.workspace(), context.languageServercontext()).stream()
+                        .map(LSPackageLoader.PackageInfo::new)
+                        .collect(Collectors.toList()).get(0);
+                this.remoteRepoPackages.add(packageInfo);
+            }
+            return null;
+        }).when(lsPackageLoader).updatePackageMapOnPullModuleEvent(Mockito.any());
+    }
+
+    private List<LSPackageLoader.PackageInfo> getLoadedPackagesFromLoader(DocumentServiceContext context) {
+        Optional<Project> project = context.workspace().project(context.filePath());
+        if (project.isEmpty()) {
+            return Collections.emptyList();
+        }
+        BallerinaUserHome ballerinaUserHome = BallerinaUserHome
+                .from(project.get().projectEnvironmentContext().environment());
+        PackageRepository remoteRepository = ballerinaUserHome.remotePackageRepository();
+        return getLSPackageLoader().getRemoteRepoPackages(remoteRepository);
+    }
+
+    @DataProvider(name = "data-provider")
+    public Object[][] dataProvider() {
+        return new Object[][]{
+                {"pull_module_event_source.bal"}
+        };
+    }
+
+    @Override
+    public boolean loadMockedPackages() {
+        return true;
+    }
+
+    public List<LSPackageLoader.PackageInfo> getRemoteRepoPackages() {
+        return remoteRepoPackages;
+    }
+}

--- a/language-server/modules/langserver-core/src/test/resources/repository_projects/project3/Ballerina.toml
+++ b/language-server/modules/langserver-core/src/test/resources/repository_projects/project3/Ballerina.toml
@@ -1,0 +1,5 @@
+[package]
+org="test"
+name="project3"
+version="0.0.1"
+

--- a/language-server/modules/langserver-core/src/test/resources/repository_projects/project3/main.bal
+++ b/language-server/modules/langserver-core/src/test/resources/repository_projects/project3/main.bal
@@ -1,0 +1,3 @@
+public function main() {
+    io:println("Hello, World!");
+}

--- a/language-server/modules/langserver-core/src/test/resources/testng.xml
+++ b/language-server/modules/langserver-core/src/test/resources/testng.xml
@@ -53,6 +53,7 @@ under the License.
             <package name="org.ballerinalang.langserver.workspace.*"/>
             <package name="org.ballerinalang.langserver.exprscheme.*"/>
             <package name="org.ballerinalang.langserver.eventsync.*"/>
+            <package name="org.ballerinalang.langserver.lspackageloader.*"/>
         </packages>
         <classes>
             <class name="org.ballerinalang.langserver.extensions.document.SyntaxTreeByRangeTest"/>


### PR DESCRIPTION
## Purpose
To update the remote repository package cache in the LSPackageLoader when a package(s) is pulled from the central using pull module code-action.
 

Fixes #36661 


## Samples


## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
