### PR TITLE
Support type reference for function parameters - stage

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTypeGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTypeGen.java
@@ -938,7 +938,7 @@ public class JvmTypeGen {
             mv.visitLdcInsn(paramSymbol.name.value);
             mv.visitLdcInsn(paramSymbol.isDefaultable);
             mv.visitMethodInsn(INVOKESTATIC, BOOLEAN_VALUE, VALUE_OF_METHOD, BOOLEAN_VALUE_OF_METHOD, false);
-            loadType(mv, paramSymbol.type);
+            loadLocalType(mv, paramSymbol.type);
             mv.visitMethodInsn(INVOKESPECIAL, FUNCTION_PARAMETER, JVM_INIT_METHOD, INIT_FUCNTION_PARAM, false);
             mv.visitInsn(AASTORE);
         }
@@ -958,7 +958,7 @@ public class JvmTypeGen {
             mv.visitLdcInsn("");
             mv.visitLdcInsn(false);
             mv.visitMethodInsn(INVOKESTATIC, BOOLEAN_VALUE, VALUE_OF_METHOD, BOOLEAN_VALUE_OF_METHOD, false);
-            loadType(mv, paramTypes.get(i));
+            loadLocalType(mv, paramTypes.get(i));
             mv.visitMethodInsn(INVOKESPECIAL, FUNCTION_PARAMETER, JVM_INIT_METHOD, INIT_FUCNTION_PARAM, false);
             mv.visitInsn(AASTORE);
         }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
@@ -20,12 +20,14 @@ package org.ballerinalang.nativeimpl.jvm.runtime.api.tests;
 
 import io.ballerina.runtime.api.Module;
 import io.ballerina.runtime.api.PredefinedTypes;
+import io.ballerina.runtime.api.TypeTags;
 import io.ballerina.runtime.api.creators.ErrorCreator;
 import io.ballerina.runtime.api.creators.TypeCreator;
 import io.ballerina.runtime.api.creators.ValueCreator;
 import io.ballerina.runtime.api.flags.SymbolFlags;
 import io.ballerina.runtime.api.types.AnnotatableType;
 import io.ballerina.runtime.api.types.Field;
+import io.ballerina.runtime.api.types.FunctionType;
 import io.ballerina.runtime.api.types.IntersectableReferenceType;
 import io.ballerina.runtime.api.types.IntersectionType;
 import io.ballerina.runtime.api.types.MethodType;
@@ -54,6 +56,7 @@ import io.ballerina.runtime.internal.types.BArrayType;
 import io.ballerina.runtime.internal.types.BFunctionType;
 import io.ballerina.runtime.internal.types.BRecordType;
 import org.ballerinalang.langlib.value.FromJsonWithType;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -72,6 +75,9 @@ public class Values {
     private static final Module objectModule = new Module("testorg", "runtime_api.objects", "1");
     private static final Module recordModule = new Module("testorg", "runtime_api.records", "1");
     private static final Module invalidValueModule = new Module("testorg", "invalid_values", "1");
+    private static final BString intAnnotation = StringUtils.fromString("testorg/runtime_api_types.typeref:1:Int");
+    private static final BError constraintError =
+            ErrorCreator.createError(StringUtils.fromString("Validation failed for 'minValue' constraint(s)."));
 
     public static BMap<BString, Object> getRecord(BString recordName) {
         HashMap<String, Object> address = new HashMap<>();
@@ -265,28 +271,25 @@ public class Values {
     public static Object validate(Object value, BTypedesc typedesc) {
         Type describingType = typedesc.getDescribingType();
         BMap<BString, Object> annotations = ((AnnotatableType) describingType).getAnnotations();
-        BString annotKey = StringUtils.fromString("testorg/runtime_api_types.typeref:1:Int");
-        if (annotations.containsKey(annotKey)) {
-            Object annotValue = annotations.get(annotKey);
+        if (annotations.containsKey(intAnnotation)) {
+            Object annotValue = annotations.get(intAnnotation);
             Long minValue = (Long) ((BMap) annotValue).get(StringUtils.fromString("minValue"));
             if (((Long) value) >= minValue) {
                 return value;
             }
         }
-        return ErrorCreator.createError(StringUtils.fromString("Validation failed for 'minValue' constraint(s)."));
+        return constraintError;
     }
 
     public static Object validateRecord(Object value, BTypedesc typedesc) {
         Type describingType = typedesc.getDescribingType();
         Long age = ((BMap) value).getIntValue(StringUtils.fromString("age"));
-        BString annotKey = StringUtils.fromString("testorg/runtime_api_types.typeref:1:Int");
         for (Field field : ((BRecordType) describingType).getFields().values()) {
             BMap<BString, Object> annotations = ((AnnotatableType) field.getFieldType()).getAnnotations();
-            if (annotations.containsKey(annotKey)) {
-                Long minValue = (Long) ((BMap) annotations.get(annotKey)).get(StringUtils.fromString("minValue"));
+            if (annotations.containsKey(intAnnotation)) {
+                Long minValue = (Long) ((BMap) annotations.get(intAnnotation)).get(StringUtils.fromString("minValue"));
                 if (age < minValue) {
-                    return ErrorCreator.createError(
-                            StringUtils.fromString("Validation failed for 'minValue' constraint(s)."));
+                    return constraintError;
                 }
             }
         }
@@ -296,9 +299,8 @@ public class Values {
     public static Object validateArrayElements(Object value, BTypedesc typedesc) {
         Type describingType = typedesc.getDescribingType();
         BMap<BString, Object> annotations = ((AnnotatableType) describingType).getAnnotations();
-        BString annotKey = StringUtils.fromString("testorg/runtime_api_types.typeref:1:Int");
-        if (annotations.containsKey(annotKey)) {
-            Object annotValue = annotations.get(annotKey);
+        if (annotations.containsKey(intAnnotation)) {
+            Object annotValue = annotations.get(intAnnotation);
             Long minValue = (Long) ((BMap) annotValue).get(StringUtils.fromString("minValue"));
             for (Object element : ((BArray) value).getValues()) {
                 if (((Long) element) >= minValue) {
@@ -306,7 +308,7 @@ public class Values {
                 }
             }
         }
-        return ErrorCreator.createError(StringUtils.fromString("Validation failed for 'minValue' constraint(s)."));
+        return constraintError;
     }
 
     public static Object validateArrayConstraint(Object value, BTypedesc typedesc) {
@@ -323,22 +325,49 @@ public class Values {
             }
             AnnotatableType eType = (AnnotatableType) ((ReferenceType) ((BArrayType) ((ReferenceType) describingType)
                     .getReferredType()).getElementType()).getReferredType();
-            annotKey = StringUtils.fromString("testorg/runtime_api_types.typeref:1:Int");
             annotations = eType.getAnnotations();
-            if (!annotations.containsKey(annotKey)) {
-                return ErrorCreator.createError(
-                        StringUtils.fromString("Validation failed for 'minValue' constraint(s)."));
+            if (!annotations.containsKey(intAnnotation)) {
+                return constraintError;
             }
-            annotValue = annotations.get(annotKey);
+            annotValue = annotations.get(intAnnotation);
             Long minValue = (Long) ((BMap) annotValue).get(StringUtils.fromString("minValue"));
             for (int i = 0; i < array.getLength(); i++) {
                 if (((Long) array.get(i)) < minValue) {
-                    return ErrorCreator.createError(
-                            StringUtils.fromString("Validation failed for 'minValue' constraint(s)."));
+                    return constraintError;
                 }
             }
         }
         return value;
+    }
+
+    public static Object validateFunctionParameterExtern(BFunctionPointer fpValue) {
+        return validateFunctionType((FunctionType) fpValue.getType());
+    }
+
+    @Nullable
+    private static BError validateFunctionType(FunctionType functionType) {
+        Parameter[] parameters = functionType.getParameters();
+        assert parameters[0].type.getTag() == TypeTags.TYPE_REFERENCED_TYPE_TAG;
+        AnnotatableType annotatableType = (AnnotatableType) parameters[0].type;
+        if (annotatableType.getAnnotation(intAnnotation) == null) {
+            return constraintError;
+        }
+        assert parameters[1].type.getTag() == TypeTags.TYPE_REFERENCED_TYPE_TAG;
+        annotatableType = (AnnotatableType) parameters[1].type;
+        if (annotatableType.getAnnotation(intAnnotation) == null) {
+            return constraintError;
+        }
+        return null;
+    }
+
+    public static Object validateFunctionParameterFromObject(BObject object) {
+        ObjectType type = object.getType();
+        for (MethodType methodType : type.getMethods()) {
+            if (methodType.getName() == "testFunction") {
+                return validateFunctionType(methodType.getType());
+            }
+        }
+        return constraintError;
     }
 
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/types/modules/typeref/typeref.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/types/modules/typeref/typeref.bal
@@ -70,12 +70,32 @@ type Employee2 record {
 
 type EmpError error<Employee>;
 
+public class Service {
+    function testFunction(PositiveInt intVal, Foo arr = []) returns string {
+        return intVal.toString();
+    }
+
+}
+
 public function validateTypeRef() {
     validateType();
     validateRecordField();
     validateTypeAnnotations();
     testRuntimeTypeRef();
     validateArray();
+    validateFunctionParameters();
+}
+
+function validateFunctionParameters() {
+    test:assertEquals(testFunction(25), "25");
+    test:assertEquals(validateFunctionParameterExtern(testFunction), ());
+
+    Service s = new ();
+    test:assertEquals(validateFunctionParameterFromObject(s), ());
+}
+
+function testFunction(PositiveInt intVal, Foo arr = []) returns string {
+    return intVal.toString();
 }
 
 function testRuntimeTypeRef() {
@@ -441,5 +461,13 @@ public isolated function validateArrayElements(anydata value, typedesc<anydata> 
 # + td - The type descriptor of the value to be constrained
 # + return - The type descriptor of the value which is validated or else an `constraint:Error` in case of an error
 public isolated function validateArrayConstraint(anydata value, typedesc<anydata> td = <>) returns td|error = @java:Method {
+    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
+} external;
+
+public isolated function validateFunctionParameterExtern(function value) returns error? = @java:Method {
+    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
+} external;
+
+public isolated function validateFunctionParameterFromObject(Service value) returns error? = @java:Method {
     'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
 } external;


### PR DESCRIPTION
## Purpose
$subject
Fixes #36991

## Approach
Add code generation changes for support type reference type for `getParameters()` API for function types.

## Samples
```ballerina
type Data string;

function validateFunctionParameters() returns error? {
    check validateFunctionParameterExtern(testFunction);
}

function testFunction(Data data) returns string {
    return data.toString();
}
```

The `FunctionType` for the `FunctionPointer` instance of `testFunction` should contain a parameter `data` with `BTypeReferenceType` as type.

## Remarks
sub-task of #36855

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
