### PR TITLE
Add test-cases for `jVM generation is not supported` compile time error in match clauses with error types.

### DIFF
--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStmtErrorMatchPatternTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStmtErrorMatchPatternTest.java
@@ -34,6 +34,7 @@ public class MatchStmtErrorMatchPatternTest {
     private CompileResult result, restPatternResult, resultNegative, moduleResult;
     private String patternNotMatched = "pattern will not be matched";
     private String unreachablePattern = "unreachable pattern";
+    private String unnecessaryCondition = "unnecessary condition: expression will always evaluate to 'true'";
 
     @BeforeClass
     public void setup() {
@@ -125,6 +126,11 @@ public class MatchStmtErrorMatchPatternTest {
     }
 
     @Test
+    public void testErrorMatchPattern17() {
+        BRunUtil.invoke(result, "testErrorMatchPattern17");
+    }
+
+    @Test
     public void testErrorMatchPatternWithRestPattern1() {
         BRunUtil.invoke(restPatternResult, "testErrorMatchPattern1");
     }
@@ -149,22 +155,44 @@ public class MatchStmtErrorMatchPatternTest {
         Assert.assertEquals(resultNegative.getErrorCount(), 1);
         //Assert.assertEquals(resultNegative.getWarnCount(), 10);
         int i = 0;
-        BAssertUtil.validateWarning(resultNegative, i++, patternNotMatched, 23, 9);
-        BAssertUtil.validateWarning(resultNegative, i++, patternNotMatched, 28, 9);
-        BAssertUtil.validateWarning(resultNegative, i++, patternNotMatched, 33, 9);
-        BAssertUtil.validateWarning(resultNegative, i++, unreachablePattern, 40, 19);
-        BAssertUtil.validateWarning(resultNegative, i++, unreachablePattern, 41, 28);
-        BAssertUtil.validateWarning(resultNegative, i++, unreachablePattern, 42, 20);
+        BAssertUtil.validateWarning(resultNegative, i++, patternNotMatched, 31, 9);
+        BAssertUtil.validateWarning(resultNegative, i++, patternNotMatched, 36, 9);
+        BAssertUtil.validateWarning(resultNegative, i++, patternNotMatched, 41, 9);
+        BAssertUtil.validateWarning(resultNegative, i++, unreachablePattern, 48, 19);
+        BAssertUtil.validateWarning(resultNegative, i++, unreachablePattern, 49, 28);
+        BAssertUtil.validateWarning(resultNegative, i++, unreachablePattern, 50, 20);
         BAssertUtil.validateError(resultNegative, i++, "all match patterns should contain the same set of variables",
-                43, 9);
-        BAssertUtil.validateWarning(resultNegative, i++, "unused variable 'a'", 43, 9);
-        BAssertUtil.validateWarning(resultNegative, i++, "unused variable 'b'", 43, 9);
-        BAssertUtil.validateWarning(resultNegative, i++, unreachablePattern, 43, 24);
-        BAssertUtil.validateWarning(resultNegative, i++, unreachablePattern, 44, 42);
-        BAssertUtil.validateWarning(resultNegative, i++, unreachablePattern, 45, 49);
-        BAssertUtil.validateWarning(resultNegative, i++, unreachablePattern, 47, 44);
-        BAssertUtil.validateWarning(resultNegative, i++, "unused variable 'errorA'", 54, 9);
-        BAssertUtil.validateWarning(resultNegative, i++, "unused variable 'errorB'", 55, 9);
+                51, 9);
+        BAssertUtil.validateWarning(resultNegative, i++, "unused variable 'a'", 51, 9);
+        BAssertUtil.validateWarning(resultNegative, i++, "unused variable 'b'", 51, 9);
+        BAssertUtil.validateWarning(resultNegative, i++, unreachablePattern, 51, 24);
+        BAssertUtil.validateWarning(resultNegative, i++, unreachablePattern, 52, 42);
+        BAssertUtil.validateWarning(resultNegative, i++, unreachablePattern, 53, 49);
+        BAssertUtil.validateWarning(resultNegative, i++, unreachablePattern, 55, 44);
+        BAssertUtil.validateWarning(resultNegative, i++, "unused variable 'errorA'", 62, 9);
+        BAssertUtil.validateWarning(resultNegative, i++, "unused variable 'errorB'", 63, 9);
+        BAssertUtil.validateWarning(resultNegative, i++, "unused variable 'errorC'", 68, 9);
+        BAssertUtil.validateWarning(resultNegative, i++, "unused variable 'errorD'", 69, 9);
+        BAssertUtil.validateWarning(resultNegative, i++, "unused variable 'errorA'", 76, 9);
+        BAssertUtil.validateHint(resultNegative, i++, unnecessaryCondition, 76, 23);
+        BAssertUtil.validateWarning(resultNegative, i++, unreachablePattern, 78, 9);
+        BAssertUtil.validateWarning(resultNegative, i++, "unused variable 'errorB'", 78, 9);
+        BAssertUtil.validateHint(resultNegative, i++, unnecessaryCondition, 78, 23);
+        BAssertUtil.validateWarning(resultNegative, i++, "unused variable 'errorC'", 84, 9);
+        BAssertUtil.validateWarning(resultNegative, i++, unreachablePattern, 85, 9);
+        BAssertUtil.validateWarning(resultNegative, i++, "unused variable 'errorD'", 85, 9);
+        BAssertUtil.validateWarning(resultNegative, i++, "unused variable 'errorA'", 92, 9);
+        BAssertUtil.validateWarning(resultNegative, i++, "unused variable 'errorB'", 93, 9);
+        BAssertUtil.validateWarning(resultNegative, i++, "unused variable 'errorC'", 98, 9);
+        BAssertUtil.validateWarning(resultNegative, i++, "unused variable 'errorD'", 99, 9);
+        BAssertUtil.validateWarning(resultNegative, i++, "unused variable 'errorA'", 106, 9);
+        BAssertUtil.validateWarning(resultNegative, i++, "unused variable 'errorB'", 107, 9);
+        BAssertUtil.validateWarning(resultNegative, i++, "unused variable 'errorC'", 112, 9);
+        BAssertUtil.validateWarning(resultNegative, i++, "unused variable 'errorD'", 113, 9);
+        BAssertUtil.validateWarning(resultNegative, i++, "unused variable 'errorA'", 120, 9);
+        BAssertUtil.validateWarning(resultNegative, i++, "unused variable 'errorB'", 121, 9);
+        BAssertUtil.validateWarning(resultNegative, i++, "unused variable 'errorC'", 126, 9);
+        BAssertUtil.validateWarning(resultNegative, i++, "unused variable 'errorD'", 127, 9);
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/matchstmt/error_match_pattern.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/matchstmt/error_match_pattern.bal
@@ -16,6 +16,11 @@
 
 import ballerina/lang.value;
 
+type CustomError1 distinct error;
+type CustomError2 distinct error;
+type CustomError3 error<record { int x; }>;
+type CustomError4 error<record { int y; }>;
+
 const MSG = "Const Message";
 
 function errorMatchPattern1(any|error e) returns string {
@@ -310,6 +315,16 @@ function testErrorMatchPattern16() {
     errorMatchPattern19(err7));
 }
 
+function testErrorMatchPattern17() {
+    assertEquals("match1", errorMatchPattern20(error CustomError1("error: CustomError1")));
+    assertEquals("match2", errorMatchPattern20(error CustomError2("error: CustomError2")));
+    assertEquals("match3", errorMatchPattern20(error CustomError3("error: CustomError3", x = 1)));
+    assertEquals("match4", errorMatchPattern20(error CustomError4("error: CustomError4", y = 2)));
+    assertEquals("no match", errorMatchPattern20(error("error")));
+    assertEquals("no match", errorMatchPattern20(()));
+    assertEquals("no match", errorMatchPattern20("string"));
+}
+
 function errorMatchPattern16(any|error x) returns string {
     match x {
         error(var m, var c, code1 = var d, code2 = var e) => {
@@ -396,6 +411,24 @@ function errorMatchPattern19(any|error x) returns string {
     }
 
     return "Default";
+}
+
+function errorMatchPattern20(any|error? e) returns string {
+    match e {
+        var errorA if e is CustomError1 => {
+            return "match1";
+        }
+        var errorB if e is CustomError2 => {
+            return "match2";
+        }
+        var errorB if e is CustomError3 => {
+            return "match3";
+        }
+        var errorB if e is CustomError4 => {
+            return "match4";
+        }
+    }
+    return "no match";
 }
 
 function assertEquals(anydata expected, anydata actual) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/matchstmt/error_match_pattern_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/matchstmt/error_match_pattern_negative.bal
@@ -16,6 +16,14 @@
 
 type MyError1 error<record { int x; }>;
 type MyError2 error<record { int y; }>;
+type MyError3 error;
+type MyError4 error;
+type MyError5 distinct error;
+type MyError6 distinct error;
+type MyError7 distinct error & readonly;
+type MyError8 distinct error & readonly;
+type MyError9 distinct error|int;
+type MyError10 distinct error|int;
 
 function testNegative1() {
     int v1 = 0;
@@ -49,10 +57,74 @@ function testNegative2() {
 }
 
 function testNegative3() {
-    error v = getCustomError();
-    match v {
-        var errorA if v is MyError1 => { } // unused variable 'errorA'
-        var errorB if v is MyError2 => { } // unused variable 'errorB'
+    error v1 = getCustomError();
+    match v1 {
+        var errorA if v1 is MyError1 => { } // unused variable 'errorA'
+        var errorB if v1 is MyError2 => { } // unused variable 'errorB'
+    }
+
+    error? v2 = getCustomError();
+    match v2 {
+        var errorC if v2 is MyError1 => { } // unused variable 'errorC'
+        var errorD if v2 is MyError2 => { } // unused variable 'errorD'
+    }
+}
+
+function testNegative4() {
+    error v1 = getCustomError();
+    match v1 {
+        var errorA if v1 is MyError3 => { } // unused variable 'errorA'
+                                            // unnecessary condition: expression will always evaluate to 'true'
+        var errorB if v1 is MyError4 => { } // unused variable 'errorB', unreachable pattern
+                                            // unnecessary condition: expression will always evaluate to 'true'
+    }
+
+    error? v2 = getCustomError();
+    match v2 {
+        var errorC if v2 is MyError3 => { } // unused variable 'errorC'
+        var errorD if v2 is MyError4 => { } // unused variable 'errorD', unreachable pattern
+    }
+}
+
+function testNegative5() {
+    error v1 = getCustomError();
+    match v1 {
+        var errorA if v1 is MyError5 => { } // unused variable 'errorA'
+        var errorB if v1 is MyError6 => { } // unused variable 'errorB'
+    }
+
+    error? v2 = getCustomError();
+    match v2 {
+        var errorC if v2 is MyError5 => { } // unused variable 'errorC'
+        var errorD if v2 is MyError6 => { } // unused variable 'errorD'
+    }
+}
+
+function testNegative6() {
+    error v1 = getCustomError();
+    match v1 {
+        var errorA if v1 is MyError7 => { } // unused variable 'errorA'
+        var errorB if v1 is MyError8 => { } // unused variable 'errorB'
+    }
+
+    error? v2 = getCustomError();
+    match v2 {
+        var errorC if v2 is MyError7 => { } // unused variable 'errorC'
+        var errorD if v2 is MyError8 => { } // unused variable 'errorD'
+    }
+}
+
+function testNegative7() {
+    error v1 = getCustomError();
+    match v1 {
+        var errorA if v1 is MyError9 => { } // unused variable 'errorA'
+        var errorB if v1 is MyError10 => { } // unused variable 'errorB'
+    }
+
+    error? v2 = getCustomError();
+    match v2 {
+        var errorC if v2 is MyError9 => { } // unused variable 'errorC'
+        var errorD if v2 is MyError10 => { } // unused variable 'errorD'
     }
 }
 


### PR DESCRIPTION
## Purpose
> Add test-cases for issue: #32819

Fixes #32819

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
