### PR TITLE
Fix code actions which are not supported in the code but passes the tests, to work

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionNodeValidator.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionNodeValidator.java
@@ -276,8 +276,8 @@ public class CodeActionNodeValidator extends NodeTransformer<Boolean> {
             ex: "io<cursor>:" hence we have special cased typed binding pattern.
          */
         return isVisited(node) || !node.colon().isMissing() && !node.modulePrefix().isMissing()
-                && node.parent() != null && node.parent().kind() != SyntaxKind.TYPED_BINDING_PATTERN
-                ? node.parent().apply(this) : true;
+                && node.parent() != null
+                && (node.parent().kind() == SyntaxKind.TYPED_BINDING_PATTERN || node.parent().apply(this));
     }
 
     /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionNodeValidator.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionNodeValidator.java
@@ -271,8 +271,13 @@ public class CodeActionNodeValidator extends NodeTransformer<Boolean> {
 
     @Override
     public Boolean transform(QualifiedNameReferenceNode node) {
+        /*
+            We need to suggest import module code action when,
+            ex: "io<cursor>:" hence we have special cased typed binding pattern.
+         */
         return isVisited(node) || !node.colon().isMissing() && !node.modulePrefix().isMissing()
-                && node.parent() != null ? node.parent().apply(this) : true;
+                && node.parent() != null && node.parent().kind() != SyntaxKind.TYPED_BINDING_PATTERN
+                ? node.parent().apply(this) : true;
     }
 
     /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/MakeConstructPublicCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/MakeConstructPublicCodeAction.java
@@ -53,7 +53,7 @@ import java.util.Optional;
 @JavaSPIService("org.ballerinalang.langserver.commons.codeaction.spi.LSCodeActionProvider")
 public class MakeConstructPublicCodeAction implements DiagnosticBasedCodeActionProvider {
     public static final String NAME = "Make Construct Public";
-    public static final String DIAGNOSTIC_CODE = "BCE2038";
+    public static final String DIAGNOSTIC_CODE = "BCE20022";
 
     @Override
     public boolean validate(Diagnostic diagnostic, DiagBasedPositionDetails positionDetails,

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/AbstractCodeActionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/AbstractCodeActionTest.java
@@ -198,7 +198,8 @@ public abstract class AbstractCodeActionTest extends AbstractLSTest {
         String cursorEndStr = range.getEnd().getLine() + ":" + range.getEnd().getCharacter();
         if (!mismatchedCodeActions.isEmpty()) {
 //            updateConfig(testConfig, mismatchedCodeActions, configJsonPath);
-            Assert.fail(String.format("Cannot find expected code action(s) for: '%s', range from [%s] to [%s] in '%s': %s",
+            Assert.fail(
+                    String.format("Cannot find expected code action(s) for: '%s', range from [%s] to [%s] in '%s': %s",
                     Arrays.toString(mismatchedCodeActions.toArray()),
                     cursorStartStr, cursorEndStr, sourcePath, testConfig.description));
         }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/AbstractCodeActionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/AbstractCodeActionTest.java
@@ -204,7 +204,8 @@ public abstract class AbstractCodeActionTest extends AbstractLSTest {
         }
 
         if (matchedCodeActionsCount != testConfig.expected.size()) {
-            Assert.fail(String.format("Cannot find expected code action(s) for: '%s', range from [%s] to [%s] in '%s': %s",
+            Assert.fail(
+                    String.format("Cannot find expected code action(s) for: '%s', range from [%s] to [%s] in '%s': %s",
                     Arrays.toString(mismatchedCodeActions.toArray()),
                     cursorStartStr, cursorEndStr, sourcePath, testConfig.description));
         }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/AbstractCodeActionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/AbstractCodeActionTest.java
@@ -99,6 +99,7 @@ public abstract class AbstractCodeActionTest extends AbstractLSTest {
         String res = getResponse(sourcePath, finalRange, codeActionContext);
 
         List<CodeActionObj> mismatchedCodeActions = new ArrayList<>();
+        int matchedCodeActionsCount = 0;
         for (CodeActionObj expected : testConfig.expected) {
             // Create an object to keep track of the actual code action received
             CodeActionObj actual = new CodeActionObj();
@@ -116,7 +117,7 @@ public abstract class AbstractCodeActionTest extends AbstractLSTest {
                 if (!expected.title.equals(actualTitle)) {
                     continue;
                 }
-
+                matchedCodeActionsCount++;
                 // We have to make sure the title is a match since we are checking against all the
                 // code actions received.
                 actual.title = actualTitle;
@@ -193,12 +194,19 @@ public abstract class AbstractCodeActionTest extends AbstractLSTest {
         }
         TestUtil.closeDocument(getServiceEndpoint(), sourcePath);
 
-        String cursorStr = range.getStart().getLine() + ":" + range.getEnd().getCharacter();
+        String cursorStartStr = range.getStart().getLine() + ":" + range.getStart().getCharacter();
+        String cursorEndStr = range.getEnd().getLine() + ":" + range.getEnd().getCharacter();
         if (!mismatchedCodeActions.isEmpty()) {
 //            updateConfig(testConfig, mismatchedCodeActions, configJsonPath);
-            Assert.fail(String.format("Cannot find expected code action(s) for: '%s', cursor at [%s] in '%s': %s",
+            Assert.fail(String.format("Cannot find expected code action(s) for: '%s', range from [%s] to [%s] in '%s': %s",
                     Arrays.toString(mismatchedCodeActions.toArray()),
-                    cursorStr, sourcePath, testConfig.description));
+                    cursorStartStr, cursorEndStr, sourcePath, testConfig.description));
+        }
+
+        if (matchedCodeActionsCount != testConfig.expected.size()) {
+            Assert.fail(String.format("Cannot find expected code action(s) for: '%s', range from [%s] to [%s] in '%s': %s",
+                    Arrays.toString(mismatchedCodeActions.toArray()),
+                    cursorStartStr, cursorEndStr, sourcePath, testConfig.description));
         }
     }
 
@@ -262,7 +270,7 @@ public abstract class AbstractCodeActionTest extends AbstractLSTest {
         responseJson.remove("id");
         return responseJson;
     }
-    
+
     @BeforeClass
     public void setup() {
         workspaceManager = new BallerinaWorkspaceManager(new LanguageServerContextImpl());
@@ -295,7 +303,7 @@ public abstract class AbstractCodeActionTest extends AbstractLSTest {
     public abstract Object[][] dataProvider();
 
     public abstract String getResourceDir();
-    
+
     @AfterClass
     public void cleanUp() {
         this.serverContext = null;

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/CreateVariableTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/CreateVariableTest.java
@@ -130,7 +130,8 @@ public class CreateVariableTest extends AbstractCodeActionTest {
     public Object[][] negativeDataProvider() {
         return new Object[][]{
                 {"createVariableNegative1.json"},
-                {"createVariableNegative2.json"}
+                {"createVariableNegative2.json"},
+                {"createVariableNegative3.json"}
         };
     }
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableNegative3.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableNegative3.json
@@ -1,0 +1,12 @@
+{
+  "position": {
+    "line": 3,
+    "character": 16
+  },
+  "source": "createVariableNegative2.bal",
+  "expected": [
+    {
+      "title": "Create variable"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithRemoteMethodInvocation.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithRemoteMethodInvocation.json
@@ -113,25 +113,6 @@
           "newText": "HelloReply|E1 sayHello \u003d "
         }
       ]
-    },
-    {
-      "title": "Ignore return value",
-      "kind": "quickfix",
-      "edits": [
-        {
-          "range": {
-            "start": {
-              "line": 22,
-              "character": 4
-            },
-            "end": {
-              "line": 22,
-              "character": 4
-            }
-          },
-          "newText": "_ \u003d "
-        }
-      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/config/fixReturnTypeInUnionContext3.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/config/fixReturnTypeInUnionContext3.json
@@ -3,7 +3,7 @@
     "line": 10,
     "character": 12
   },
-  "source": "fixReturnTypeInUnionContext1.bal",
+  "source": "fixReturnTypeInUnionContext2.bal",
   "expected": [
     {
       "title": "Change return type to 'boolean|json|int'",

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/config/fixReturnTypeInUnionContext4.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/config/fixReturnTypeInUnionContext4.json
@@ -3,7 +3,7 @@
     "line": 10,
     "character": 12
   },
-  "source": "fixReturnTypeInUnionContext1.bal",
+  "source": "fixReturnTypeInUnionContext2.bal",
   "expected": [
     {
       "title": "Change return type to 'boolean|map<int>|int'",


### PR DESCRIPTION
## Purpose
> Some tests are passing in the `AbstractCodeActionTest` but they do not support the code action. With the fix, `AbstractCodeActionTest` is fixed to not pass tests which are not actually passing and fixes the code action logic of `CodeActionNodeValidator`,  `MakeConstructPublicCodeAction`.

Fixes #37128

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
