### PR TITLE
Add rename popup to create variable code action

### DIFF
--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/capability/InitializationOptions.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/capability/InitializationOptions.java
@@ -56,5 +56,5 @@ public interface InitializationOptions {
      *
      * @return True if supported, false otherwise
      */
-    boolean isRenameSupported();
+    boolean isRefactorRename();
 }

--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/capability/InitializationOptions.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/capability/InitializationOptions.java
@@ -33,6 +33,11 @@ public interface InitializationOptions {
     String KEY_ENABLE_SEMANTIC_TOKENS = "enableSemanticHighlighting";
 
     /**
+     * Whether the client supports rename popup.
+     */
+    String KEY_RENAME_SUPPORT = "supportRenamePopup";
+
+    /**
      * Return if the client support bala URI scheme.
      *
      * @return True if bala URi scheme is supported.
@@ -45,4 +50,11 @@ public interface InitializationOptions {
      * @return True if supported, false otherwise
      */
     boolean isEnableSemanticTokens();
+
+    /**
+     * Returns if the client supports rename popup.
+     *
+     * @return True if supported, false otherwise
+     */
+    boolean isRenameSupported();
 }

--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/capability/InitializationOptions.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/capability/InitializationOptions.java
@@ -56,5 +56,5 @@ public interface InitializationOptions {
      *
      * @return True if supported, false otherwise
      */
-    boolean isRefactorRename();
+    boolean isRefactorRenameSupported();
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSClientCapabilitiesImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSClientCapabilitiesImpl.java
@@ -211,7 +211,7 @@ public class LSClientCapabilitiesImpl implements LSClientCapabilities {
         }
 
         @Override
-        public boolean isRenameSupported() {
+        public boolean isRefactorRename() {
             return supportRenamePopup;
         }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSClientCapabilitiesImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSClientCapabilitiesImpl.java
@@ -142,7 +142,7 @@ public class LSClientCapabilitiesImpl implements LSClientCapabilities {
         initializationOptions.setEnableSemanticTokens(enableSemanticTokens);
 
         Object renameSupport = initOptions.get(InitializationOptions.KEY_RENAME_SUPPORT);
-        boolean enableRenameSupport = renameSupport == null ||
+        boolean enableRenameSupport = renameSupport != null &&
                 Boolean.parseBoolean(String.valueOf(renameSupport));
         initializationOptions.setSupportRenamePopup(enableRenameSupport);
 
@@ -211,7 +211,7 @@ public class LSClientCapabilitiesImpl implements LSClientCapabilities {
         }
 
         @Override
-        public boolean isRefactorRename() {
+        public boolean isRefactorRenameSupported() {
             return supportRenamePopup;
         }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSClientCapabilitiesImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSClientCapabilitiesImpl.java
@@ -141,6 +141,11 @@ public class LSClientCapabilitiesImpl implements LSClientCapabilities {
                 Boolean.parseBoolean(String.valueOf(semanticTokensSupport));
         initializationOptions.setEnableSemanticTokens(enableSemanticTokens);
 
+        Object renameSupport = initOptions.get(InitializationOptions.KEY_RENAME_SUPPORT);
+        boolean enableRenameSupport = renameSupport == null ||
+                Boolean.parseBoolean(String.valueOf(renameSupport));
+        initializationOptions.setSupportRenamePopup(enableRenameSupport);
+
         return initializationOptions;
     }
 
@@ -186,6 +191,7 @@ public class LSClientCapabilitiesImpl implements LSClientCapabilities {
     public static class InitializationOptionsImpl implements InitializationOptions {
         private boolean supportBalaScheme = false;
         private boolean enableSemanticTokens = false;
+        private boolean supportRenamePopup = false;
         
         @Override
         public boolean isBalaSchemeSupported() {
@@ -202,6 +208,15 @@ public class LSClientCapabilitiesImpl implements LSClientCapabilities {
 
         public void setEnableSemanticTokens(boolean enableSemanticTokens) {
             this.enableSemanticTokens = enableSemanticTokens;
+        }
+
+        @Override
+        public boolean isRenameSupported() {
+            return supportRenamePopup;
+        }
+
+        public void setSupportRenamePopup(boolean supportRenamePopup) {
+            this.supportRenamePopup = supportRenamePopup;
         }
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionUtil.java
@@ -145,7 +145,21 @@ public class CodeActionUtil {
     }
 
     /**
-     * Returns a list of possible types for this type descriptor.
+     * Returns first possible type for this type descriptor.
+     *
+     * @param typeDescriptor  {@link TypeSymbol}
+     * @param context         {@link CodeActionContext}
+     * @param importsAcceptor imports acceptor
+     * @return a list of possible type list
+     */
+    public static Optional<String> getPossibleType(TypeSymbol typeDescriptor, CodeActionContext context,
+                                                   ImportsAcceptor importsAcceptor) {
+        List<String> possibleTypes = getPossibleTypes(typeDescriptor, context, importsAcceptor);
+        return possibleTypes.isEmpty() ? Optional.empty() : Optional.of(possibleTypes.get(0));
+    }
+
+    /**
+     * Returns first possible type for this type descriptor.
      *
      * @param typeDescriptor {@link TypeSymbol}
      * @param importEdits    a list of import {@link TextEdit}
@@ -154,10 +168,25 @@ public class CodeActionUtil {
      */
     public static List<String> getPossibleTypes(TypeSymbol typeDescriptor, List<TextEdit> importEdits,
                                                 CodeActionContext context) {
+        ImportsAcceptor importsAcceptor = new ImportsAcceptor(context);
+        List<String> possibleTypes = getPossibleTypes(typeDescriptor, context, importsAcceptor);
+        importEdits.addAll(importsAcceptor.getNewImportTextEdits());
+        return possibleTypes;
+    }
+
+    /**
+     * Returns a list of possible types for this type descriptor.
+     *
+     * @param typeDescriptor  {@link TypeSymbol}
+     * @param context         {@link CodeActionContext}
+     * @param importsAcceptor imports acceptor
+     * @return a list of possible type list
+     */
+    public static List<String> getPossibleTypes(TypeSymbol typeDescriptor, CodeActionContext context,
+                                                ImportsAcceptor importsAcceptor) {
         if (typeDescriptor.getName().isPresent() && typeDescriptor.getName().get().startsWith("$")) {
             typeDescriptor = CommonUtil.getRawType(typeDescriptor);
         }
-        ImportsAcceptor importsAcceptor = new ImportsAcceptor(context);
 
         List<String> types = new ArrayList<>();
         if (typeDescriptor.typeKind() == TypeDescKind.RECORD) {
@@ -264,7 +293,7 @@ public class CodeActionUtil {
         } else if (typeDescriptor.typeKind() == TypeDescKind.ARRAY) {
             // Handle ambiguous array element types eg. record[], json[], map[]
             ArrayTypeSymbol arrayTypeSymbol = (ArrayTypeSymbol) typeDescriptor;
-            return getPossibleTypes(arrayTypeSymbol.memberTypeDescriptor(), importEdits, context).stream()
+            return getPossibleTypes(arrayTypeSymbol.memberTypeDescriptor(), context, importsAcceptor).stream()
                     .map(m -> {
                         switch (arrayTypeSymbol.memberTypeDescriptor().typeKind()) {
                             case UNION:
@@ -280,7 +309,6 @@ public class CodeActionUtil {
             types.add(FunctionGenerator.generateTypeSignature(importsAcceptor, typeDescriptor, context));
         }
 
-        importEdits.addAll(importsAcceptor.getNewImportTextEdits());
         return types;
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionUtil.java
@@ -150,7 +150,7 @@ public class CodeActionUtil {
      * @param typeDescriptor  {@link TypeSymbol}
      * @param context         {@link CodeActionContext}
      * @param importsAcceptor imports acceptor
-     * @return a list of possible type list
+     * @return possible type for given type descriptor
      */
     public static Optional<String> getPossibleType(TypeSymbol typeDescriptor, CodeActionContext context,
                                                    ImportsAcceptor importsAcceptor) {
@@ -180,7 +180,7 @@ public class CodeActionUtil {
      * @param typeDescriptor  {@link TypeSymbol}
      * @param context         {@link CodeActionContext}
      * @param importsAcceptor imports acceptor
-     * @return a list of possible type list
+     * @return a list of possible types
      */
     public static List<String> getPossibleTypes(TypeSymbol typeDescriptor, CodeActionContext context,
                                                 ImportsAcceptor importsAcceptor) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/CreateVariableCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/CreateVariableCodeAction.java
@@ -30,6 +30,7 @@ import org.ballerinalang.langserver.common.constants.CommandConstants;
 import org.ballerinalang.langserver.common.utils.NameUtil;
 import org.ballerinalang.langserver.common.utils.PositionUtil;
 import org.ballerinalang.langserver.commons.CodeActionContext;
+import org.ballerinalang.langserver.commons.capability.LSClientCapabilities;
 import org.ballerinalang.langserver.commons.codeaction.spi.DiagBasedPositionDetails;
 import org.ballerinalang.langserver.commons.codeaction.spi.DiagnosticBasedCodeActionProvider;
 import org.eclipse.lsp4j.CodeAction;
@@ -205,8 +206,11 @@ public class CreateVariableCodeAction implements DiagnosticBasedCodeActionProvid
         }
 
         startPos = startPos + sum + renamePosition;
-        codeAction.setCommand(new Command("Rename Variable", "ballerina.action.rename",
-                List.of(context.fileUri(), startPos)));
+        LSClientCapabilities lsClientCapabilities = context.languageServercontext().get(LSClientCapabilities.class);
+        if (lsClientCapabilities.getInitializationOptions().isRenameSupported()) {
+            codeAction.setCommand(new Command("Rename Variable", "ballerina.action.rename",
+                    List.of(context.fileUri(), startPos)));
+        }
         return codeAction;
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/CreateVariableCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/CreateVariableCodeAction.java
@@ -27,6 +27,7 @@ import org.ballerinalang.langserver.codeaction.CodeActionNodeValidator;
 import org.ballerinalang.langserver.codeaction.CodeActionUtil;
 import org.ballerinalang.langserver.common.ImportsAcceptor;
 import org.ballerinalang.langserver.common.constants.CommandConstants;
+import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.common.utils.NameUtil;
 import org.ballerinalang.langserver.common.utils.PositionUtil;
 import org.ballerinalang.langserver.commons.CodeActionContext;
@@ -56,6 +57,7 @@ import java.util.stream.Collectors;
 public class CreateVariableCodeAction implements DiagnosticBasedCodeActionProvider {
 
     public static final String NAME = "Create Variable";
+    private static final String RENAME_COMMAND = "Rename Variable";
 
     /**
      * {@inheritDoc}
@@ -208,10 +210,10 @@ public class CreateVariableCodeAction implements DiagnosticBasedCodeActionProvid
 
         // Taking the start position of the first text edit assuming that the variable creation edit is the first edit
         // in the list.
-        int startPos = PositionUtil.getTextEdit(syntaxTree.get(), textEdits.get(0)).range().startOffset();
+        int startPos = CommonUtil.getTextEdit(syntaxTree.get(), textEdits.get(0)).range().startOffset();
         int sum = 0;
         for (TextEdit textEdit : textEdits) {
-            io.ballerina.tools.text.TextEdit edits = PositionUtil.getTextEdit(syntaxTree.get(), textEdit);
+            io.ballerina.tools.text.TextEdit edits = CommonUtil.getTextEdit(syntaxTree.get(), textEdit);
             if (edits.range().startOffset() < startPos) {
                 sum = sum + edits.text().length();
             }
@@ -219,8 +221,8 @@ public class CreateVariableCodeAction implements DiagnosticBasedCodeActionProvid
 
         startPos = startPos + sum + renameOffset;
         LSClientCapabilities lsClientCapabilities = context.languageServercontext().get(LSClientCapabilities.class);
-        if (lsClientCapabilities.getInitializationOptions().isRefactorRename()) {
-            codeAction.setCommand(new Command("Rename Variable", "ballerina.action.rename",
+        if (lsClientCapabilities.getInitializationOptions().isRefactorRenameSupported()) {
+            codeAction.setCommand(new Command(RENAME_COMMAND, "ballerina.action.rename",
                     List.of(context.fileUri(), startPos)));
         }
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/CreateVariableCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/CreateVariableCodeAction.java
@@ -95,7 +95,8 @@ public class CreateVariableCodeAction implements DiagnosticBasedCodeActionProvid
         for (int i = 0; i < types.size(); i++) {
             String commandTitle = CommandConstants.CREATE_VARIABLE_TITLE;
             List<TextEdit> edits = new ArrayList<>();
-            edits.add(createVarTextEdits.edits.get(i));
+            TextEdit variableEdit = createVarTextEdits.edits.get(i);
+            edits.add(variableEdit);
             edits.addAll(createVarTextEdits.imports);
             String type = types.get(i);
             if (createVarTextEdits.types.size() > 1) {
@@ -106,7 +107,7 @@ public class CreateVariableCodeAction implements DiagnosticBasedCodeActionProvid
             }
 
             CodeAction codeAction = CodeActionUtil.createCodeAction(commandTitle, edits, uri, CodeActionKind.QuickFix);
-            addRenamePopup(context, edits, codeAction, createVarTextEdits.renamePositions.get(i));
+            addRenamePopup(context, edits, variableEdit, codeAction, createVarTextEdits.renamePositions.get(i));
             actions.add(codeAction);
         }
         return actions;
@@ -189,7 +190,7 @@ public class CreateVariableCodeAction implements DiagnosticBasedCodeActionProvid
         }
     }
 
-    public void addRenamePopup(CodeActionContext context, List<TextEdit> textEdits,
+    public void addRenamePopup(CodeActionContext context, List<TextEdit> textEdits, TextEdit variableEdit,
                                CodeAction codeAction, int renameOffset) {
         Optional<SyntaxTree> syntaxTree = context.currentSyntaxTree();
         if (syntaxTree.isEmpty()) {
@@ -208,9 +209,7 @@ public class CreateVariableCodeAction implements DiagnosticBasedCodeActionProvid
            variable. In the example the renameOffset will be the length of "int ".
         */
 
-        // Taking the start position of the first text edit assuming that the variable creation edit is the first edit
-        // in the list.
-        int startPos = CommonUtil.getTextEdit(syntaxTree.get(), textEdits.get(0)).range().startOffset();
+        int startPos = CommonUtil.getTextEdit(syntaxTree.get(), variableEdit).range().startOffset();
         int sum = 0;
         for (TextEdit textEdit : textEdits) {
             io.ballerina.tools.text.TextEdit edits = CommonUtil.getTextEdit(syntaxTree.get(), textEdit);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/ErrorHandleInsideCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/ErrorHandleInsideCodeAction.java
@@ -90,8 +90,8 @@ public class ErrorHandleInsideCodeAction extends CreateVariableCodeAction {
         createVarTextEdits.imports.stream().filter(edit -> !edits.contains(edit)).forEach(edits::add);
 
         CodeAction codeAction = CodeActionUtil.createCodeAction(commandTitle, edits, uri, CodeActionKind.QuickFix);
-        return Collections.singletonList(addRenamePopup(context, edits, codeAction,
-                createVarTextEdits.renamePositions.get(0)));
+        addRenamePopup(context, edits, codeAction, createVarTextEdits.renamePositions.get(0));
+        return Collections.singletonList(codeAction);
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/ErrorHandleInsideCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/ErrorHandleInsideCodeAction.java
@@ -90,7 +90,8 @@ public class ErrorHandleInsideCodeAction extends CreateVariableCodeAction {
         createVarTextEdits.imports.stream().filter(edit -> !edits.contains(edit)).forEach(edits::add);
 
         CodeAction codeAction = CodeActionUtil.createCodeAction(commandTitle, edits, uri, CodeActionKind.QuickFix);
-        addRenamePopup(context, edits, codeAction, createVarTextEdits.renamePositions.get(0));
+        addRenamePopup(context, edits, createVarTextEdits.edits.get(0), codeAction,
+                createVarTextEdits.renamePositions.get(0));
         return Collections.singletonList(codeAction);
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/ErrorHandleInsideCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/ErrorHandleInsideCodeAction.java
@@ -22,6 +22,7 @@ import io.ballerina.tools.diagnostics.Diagnostic;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.codeaction.CodeActionNodeValidator;
 import org.ballerinalang.langserver.codeaction.CodeActionUtil;
+import org.ballerinalang.langserver.common.ImportsAcceptor;
 import org.ballerinalang.langserver.common.constants.CommandConstants;
 import org.ballerinalang.langserver.common.utils.PositionUtil;
 import org.ballerinalang.langserver.commons.CodeActionContext;
@@ -31,6 +32,7 @@ import org.eclipse.lsp4j.CodeActionKind;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextEdit;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -76,21 +78,19 @@ public class ErrorHandleInsideCodeAction extends CreateVariableCodeAction {
 
         Range range = PositionUtil.toRange(diagnostic.location().lineRange());
         CreateVariableOut createVarTextEdits = getCreateVariableTextEdits(range, positionDetails, typeDescriptor.get(),
-                context);
+                context, new ImportsAcceptor(context));
 
         // Add type guard code action
         String commandTitle = CommandConstants.CREATE_VAR_TYPE_GUARD_TITLE;
-        List<TextEdit> edits = CodeActionUtil.getTypeGuardCodeActionEdits(createVarTextEdits.name, range, unionType,
-                context);
-        if (edits.isEmpty()) {
-            return Collections.emptyList();
-        }
-
+        List<TextEdit> edits = new ArrayList<>();
         edits.add(createVarTextEdits.edits.get(0));
+        edits.addAll(CodeActionUtil.getTypeGuardCodeActionEdits(createVarTextEdits.name, range, unionType, context));
+
         // Add all the import text edits excluding duplicates
         createVarTextEdits.imports.stream().filter(edit -> !edits.contains(edit)).forEach(edits::add);
-        return Collections.singletonList(CodeActionUtil.createCodeAction(commandTitle, edits, uri,
-                CodeActionKind.QuickFix));
+
+        CodeAction codeAction = CodeActionUtil.createCodeAction(commandTitle, edits, uri, CodeActionKind.QuickFix);
+        return Collections.singletonList(addRenamePopup(context, edits, createVarTextEdits.types.get(0), codeAction));
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/ErrorHandleInsideCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/ErrorHandleInsideCodeAction.java
@@ -90,7 +90,8 @@ public class ErrorHandleInsideCodeAction extends CreateVariableCodeAction {
         createVarTextEdits.imports.stream().filter(edit -> !edits.contains(edit)).forEach(edits::add);
 
         CodeAction codeAction = CodeActionUtil.createCodeAction(commandTitle, edits, uri, CodeActionKind.QuickFix);
-        return Collections.singletonList(addRenamePopup(context, edits, createVarTextEdits.types.get(0), codeAction));
+        return Collections.singletonList(addRenamePopup(context, edits, codeAction,
+                createVarTextEdits.renamePositions.get(0)));
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/ErrorHandleOutsideCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/ErrorHandleOutsideCodeAction.java
@@ -48,6 +48,7 @@ import java.util.stream.Collectors;
 public class ErrorHandleOutsideCodeAction extends CreateVariableCodeAction {
 
     public static final String NAME = "Error Handle Outside";
+    public static final int UNION_ERROR_CHAR_OFFSET = 6;
 
     /**
      * {@inheritDoc}
@@ -97,7 +98,7 @@ public class ErrorHandleOutsideCodeAction extends CreateVariableCodeAction {
                 positionDetails.matchedNode(), context));
 
         String commandTitle = CommandConstants.CREATE_VAR_ADD_CHECK_TITLE;
-        int renamePosition = modifiedTextEdits.renamePositions.get(0) - 6;
+        int renamePosition = modifiedTextEdits.renamePositions.get(0) - UNION_ERROR_CHAR_OFFSET;
         edits.addAll(importsAcceptor.getNewImportTextEdits());
         CodeAction codeAction = CodeActionUtil.createCodeAction(commandTitle, edits, uri, CodeActionKind.QuickFix);
         return Collections.singletonList(addRenamePopup(context, edits, codeAction, renamePosition));

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/ErrorHandleOutsideCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/ErrorHandleOutsideCodeAction.java
@@ -101,7 +101,8 @@ public class ErrorHandleOutsideCodeAction extends CreateVariableCodeAction {
         int renamePosition = modifiedTextEdits.renamePositions.get(0) - UNION_ERROR_CHAR_OFFSET;
         edits.addAll(importsAcceptor.getNewImportTextEdits());
         CodeAction codeAction = CodeActionUtil.createCodeAction(commandTitle, edits, uri, CodeActionKind.QuickFix);
-        return Collections.singletonList(addRenamePopup(context, edits, codeAction, renamePosition));
+        addRenamePopup(context, edits, codeAction, renamePosition);
+        return Collections.singletonList(codeAction);
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/ErrorHandleOutsideCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/ErrorHandleOutsideCodeAction.java
@@ -101,7 +101,7 @@ public class ErrorHandleOutsideCodeAction extends CreateVariableCodeAction {
         int renamePosition = modifiedTextEdits.renamePositions.get(0) - UNION_ERROR_CHAR_OFFSET;
         edits.addAll(importsAcceptor.getNewImportTextEdits());
         CodeAction codeAction = CodeActionUtil.createCodeAction(commandTitle, edits, uri, CodeActionKind.QuickFix);
-        addRenamePopup(context, edits, codeAction, renamePosition);
+        addRenamePopup(context, edits, modifiedTextEdits.edits.get(0), codeAction, renamePosition);
         return Collections.singletonList(codeAction);
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -604,4 +604,22 @@ public class CommonUtil {
         return CommonUtil.isLangLib(functionSymbol.getModule().get().id())
                 && nodeAtCursor.kind() != SyntaxKind.QUALIFIED_NAME_REFERENCE;
     }
+
+
+    /**
+     * Returns ballerina text edit for a given lsp4j text edit.
+     *
+     * @param syntaxTree syntax tree
+     * @param textEdit   lsp4j text edit
+     * @return Ballerina text edit
+     */
+    public static io.ballerina.tools.text.TextEdit getTextEdit(SyntaxTree syntaxTree,
+                                                               org.eclipse.lsp4j.TextEdit textEdit) {
+        TextDocument textDocument = syntaxTree.textDocument();
+        Position startPos = textEdit.getRange().getStart();
+        Position endPos = textEdit.getRange().getEnd();
+        int start = textDocument.textPositionFrom(LinePosition.from(startPos.getLine(), startPos.getCharacter()));
+        int end = textDocument.textPositionFrom(LinePosition.from(endPos.getLine(), endPos.getCharacter()));
+        return io.ballerina.tools.text.TextEdit.from(TextRange.from(start, end - start), textEdit.getNewText());
+    }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/PositionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/PositionUtil.java
@@ -23,8 +23,6 @@ import io.ballerina.projects.Document;
 import io.ballerina.tools.text.LinePosition;
 import io.ballerina.tools.text.LineRange;
 import io.ballerina.tools.text.TextDocument;
-import io.ballerina.tools.text.TextEdit;
-import io.ballerina.tools.text.TextRange;
 import org.ballerinalang.langserver.commons.DocumentServiceContext;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
@@ -187,21 +185,5 @@ public class PositionUtil {
     public static int getPositionOffset(Position position, SyntaxTree syntaxTree) {
         LinePosition linePos = LinePosition.from(position.getLine(), position.getCharacter());
         return syntaxTree.textDocument().textPositionFrom(linePos);
-    }
-
-    /**
-     * Returns ballerina text edit for a given lsp4j text edit.
-     *
-     * @param syntaxTree syntax tree
-     * @param textEdit   lsp4j text edit
-     * @return Ballerina text edit
-     */
-    public static TextEdit getTextEdit(SyntaxTree syntaxTree, org.eclipse.lsp4j.TextEdit textEdit) {
-        TextDocument textDocument = syntaxTree.textDocument();
-        Position startPos = textEdit.getRange().getStart();
-        Position endPos = textEdit.getRange().getEnd();
-        int start = textDocument.textPositionFrom(LinePosition.from(startPos.getLine(), startPos.getCharacter()));
-        int end = textDocument.textPositionFrom(LinePosition.from(endPos.getLine(), endPos.getCharacter()));
-        return TextEdit.from(TextRange.from(start, end - start), textEdit.getNewText());
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/PositionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/PositionUtil.java
@@ -202,6 +202,6 @@ public class PositionUtil {
         Position endPos = textEdit.getRange().getEnd();
         int start = textDocument.textPositionFrom(LinePosition.from(startPos.getLine(), startPos.getCharacter()));
         int end = textDocument.textPositionFrom(LinePosition.from(endPos.getLine(), endPos.getCharacter()));
-        return TextEdit.from(TextRange.from(start, end-start), textEdit.getNewText());
+        return TextEdit.from(TextRange.from(start, end - start), textEdit.getNewText());
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/PositionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/PositionUtil.java
@@ -23,6 +23,8 @@ import io.ballerina.projects.Document;
 import io.ballerina.tools.text.LinePosition;
 import io.ballerina.tools.text.LineRange;
 import io.ballerina.tools.text.TextDocument;
+import io.ballerina.tools.text.TextEdit;
+import io.ballerina.tools.text.TextRange;
 import org.ballerinalang.langserver.commons.DocumentServiceContext;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
@@ -185,5 +187,21 @@ public class PositionUtil {
     public static int getPositionOffset(Position position, SyntaxTree syntaxTree) {
         LinePosition linePos = LinePosition.from(position.getLine(), position.getCharacter());
         return syntaxTree.textDocument().textPositionFrom(linePos);
+    }
+
+    /**
+     * Returns ballerina text edit for a given lsp4j text edit.
+     *
+     * @param syntaxTree syntax tree
+     * @param textEdit   lsp4j text edit
+     * @return Ballerina text edit
+     */
+    public static TextEdit getTextEdit(SyntaxTree syntaxTree, org.eclipse.lsp4j.TextEdit textEdit) {
+        TextDocument textDocument = syntaxTree.textDocument();
+        Position startPos = textEdit.getRange().getStart();
+        Position endPos = textEdit.getRange().getEnd();
+        int start = textDocument.textPositionFrom(LinePosition.from(startPos.getLine(), startPos.getCharacter()));
+        int end = textDocument.textPositionFrom(LinePosition.from(endPos.getLine(), endPos.getCharacter()));
+        return TextEdit.from(TextRange.from(start, end-start), textEdit.getNewText());
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/TestUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/TestUtil.java
@@ -881,6 +881,7 @@ public class TestUtil {
             Map<String, Object> initializationOptions = new HashMap<>();
             initializationOptions.put(InitializationOptions.KEY_ENABLE_SEMANTIC_TOKENS, true);
             initializationOptions.put(InitializationOptions.KEY_BALA_SCHEME_SUPPORT, true);
+            initializationOptions.put(InitializationOptions.KEY_RENAME_SUPPORT, true);
             if (!initOptions.isEmpty()) {
                 initializationOptions.putAll(initOptions);
             }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVarInSendAction1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVarInSendAction1.json
@@ -13,19 +13,6 @@
           "range": {
             "start": {
               "line": 9,
-              "character": 15
-            },
-            "end": {
-              "line": 9,
-              "character": 15
-            }
-          },
-          "newText": "\n        if unionResult is error {\n\n        }"
-        },
-        {
-          "range": {
-            "start": {
-              "line": 9,
               "character": 8
             },
             "end": {
@@ -34,6 +21,19 @@
             }
           },
           "newText": "error? unionResult = "
+        },
+        {
+          "range": {
+            "start": {
+              "line": 9,
+              "character": 15
+            },
+            "end": {
+              "line": 9,
+              "character": 15
+            }
+          },
+          "newText": "\n        if unionResult is error {\n\n        }"
         }
       ]
     },

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableInClassMethod.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableInClassMethod.json
@@ -13,19 +13,6 @@
           "range": {
             "start": {
               "line": 7,
-              "character": 28
-            },
-            "end": {
-              "line": 7,
-              "character": 28
-            }
-          },
-          "newText": "\n        if intWithError is int {\n\n        }"
-        },
-        {
-          "range": {
-            "start": {
-              "line": 7,
               "character": 8
             },
             "end": {
@@ -34,6 +21,19 @@
             }
           },
           "newText": "int|error intWithError \u003d "
+        },
+        {
+          "range": {
+            "start": {
+              "line": 7,
+              "character": 28
+            },
+            "end": {
+              "line": 7,
+              "character": 28
+            }
+          },
+          "newText": "\n        if intWithError is int {\n\n        }"
         }
       ]
     },

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableInServiceMethod.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableInServiceMethod.json
@@ -13,19 +13,6 @@
           "range": {
             "start": {
               "line": 10,
-              "character": 28
-            },
-            "end": {
-              "line": 10,
-              "character": 28
-            }
-          },
-          "newText": "\n        if intWithError is int {\n\n        }"
-        },
-        {
-          "range": {
-            "start": {
-              "line": 10,
               "character": 8
             },
             "end": {
@@ -34,6 +21,19 @@
             }
           },
           "newText": "int|error intWithError \u003d "
+        },
+        {
+          "range": {
+            "start": {
+              "line": 10,
+              "character": 28
+            },
+            "end": {
+              "line": 10,
+              "character": 28
+            }
+          },
+          "newText": "\n        if intWithError is int {\n\n        }"
         }
       ]
     },

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableInServiceRemoteMethod.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableInServiceRemoteMethod.json
@@ -13,19 +13,6 @@
           "range": {
             "start": {
               "line": 14,
-              "character": 28
-            },
-            "end": {
-              "line": 14,
-              "character": 28
-            }
-          },
-          "newText": "\n        if intWithError is int {\n\n        }"
-        },
-        {
-          "range": {
-            "start": {
-              "line": 14,
               "character": 8
             },
             "end": {
@@ -34,6 +21,19 @@
             }
           },
           "newText": "int|error intWithError \u003d "
+        },
+        {
+          "range": {
+            "start": {
+              "line": 14,
+              "character": 28
+            },
+            "end": {
+              "line": 14,
+              "character": 28
+            }
+          },
+          "newText": "\n        if intWithError is int {\n\n        }"
         }
       ]
     },

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithRemoteMethodInvocation.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithRemoteMethodInvocation.json
@@ -13,6 +13,19 @@
           "range": {
             "start": {
               "line": 22,
+              "character": 4
+            },
+            "end": {
+              "line": 22,
+              "character": 4
+            }
+          },
+          "newText": "HelloReply|E1 sayHello \u003d "
+        },
+        {
+          "range": {
+            "start": {
+              "line": 22,
               "character": 38
             },
             "end": {
@@ -34,19 +47,6 @@
             }
           },
           "newText": "\n    if sayHello is E1 {\n\n    }"
-        },
-        {
-          "range": {
-            "start": {
-              "line": 22,
-              "character": 4
-            },
-            "end": {
-              "line": 22,
-              "character": 4
-            }
-          },
-          "newText": "HelloReply|E1 sayHello \u003d "
         }
       ]
     },

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithTuple1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithTuple1.json
@@ -32,19 +32,6 @@
           "range": {
             "start": {
               "line": 1,
-              "character": 15
-            },
-            "end": {
-              "line": 1,
-              "character": 15
-            }
-          },
-          "newText": "\n    if tuple is [int, string...] {\n\n    }"
-        },
-        {
-          "range": {
-            "start": {
-              "line": 1,
               "character": 4
             },
             "end": {
@@ -53,6 +40,19 @@
             }
           },
           "newText": "[int, string...]|error tuple \u003d "
+        },
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 15
+            },
+            "end": {
+              "line": 1,
+              "character": 15
+            }
+          },
+          "newText": "\n    if tuple is [int, string...] {\n\n    }"
         }
       ]
     },

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/projectVariableAssignmentRequiredCodeAction2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/projectVariableAssignmentRequiredCodeAction2.json
@@ -12,6 +12,19 @@
         {
           "range": {
             "start": {
+              "line": 7,
+              "character": 4
+            },
+            "end": {
+              "line": 7,
+              "character": 4
+            }
+          },
+          "newText": "module2:Country|error countryWithError \u003d "
+        },
+        {
+          "range": {
+            "start": {
               "line": 0,
               "character": 0
             },
@@ -34,19 +47,6 @@
             }
           },
           "newText": "\n    if countryWithError is module2:Country {\n\n    }"
-        },
-        {
-          "range": {
-            "start": {
-              "line": 7,
-              "character": 4
-            },
-            "end": {
-              "line": 7,
-              "character": 4
-            }
-          },
-          "newText": "module2:Country|error countryWithError \u003d "
         }
       ]
     },
@@ -54,19 +54,6 @@
       "title": "Create variable and check error",
       "kind": "quickfix",
       "edits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import testproject.module2;\n"
-        },
         {
           "range": {
             "start": {
@@ -105,6 +92,19 @@
             }
           },
           "newText": " returns error?"
+        },
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import testproject.module2;\n"
         }
       ]
     },

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/type-guard/config/typeGuardCodeAction2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/type-guard/config/typeGuardCodeAction2.json
@@ -12,19 +12,6 @@
           "range": {
             "start": {
               "line": 4,
-              "character": 13
-            },
-            "end": {
-              "line": 4,
-              "character": 13
-            }
-          },
-          "newText": "\n    if bar is error {\n\n    }"
-        },
-        {
-          "range": {
-            "start": {
-              "line": 4,
               "character": 4
             },
             "end": {
@@ -33,6 +20,19 @@
             }
           },
           "newText": "error? bar \u003d "
+        },
+        {
+          "range": {
+            "start": {
+              "line": 4,
+              "character": 13
+            },
+            "end": {
+              "line": 4,
+              "character": 13
+            }
+          },
+          "newText": "\n    if bar is error {\n\n    }"
         }
       ]
     }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/type-guard/config/typeGuardCodeAction3.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/type-guard/config/typeGuardCodeAction3.json
@@ -12,19 +12,6 @@
           "range": {
             "start": {
               "line": 5,
-              "character": 19
-            },
-            "end": {
-              "line": 5,
-              "character": 19
-            }
-          },
-          "newText": "\n    if apple is int {\n\n    }"
-        },
-        {
-          "range": {
-            "start": {
-              "line": 5,
               "character": 4
             },
             "end": {
@@ -33,6 +20,19 @@
             }
           },
           "newText": "int|error apple \u003d "
+        },
+        {
+          "range": {
+            "start": {
+              "line": 5,
+              "character": 19
+            },
+            "end": {
+              "line": 5,
+              "character": 19
+            }
+          },
+          "newText": "\n    if apple is int {\n\n    }"
         }
       ]
     }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/type-guard/config/typeGuardWithTuple1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/type-guard/config/typeGuardWithTuple1.json
@@ -12,19 +12,6 @@
           "range": {
             "start": {
               "line": 1,
-              "character": 15
-            },
-            "end": {
-              "line": 1,
-              "character": 15
-            }
-          },
-          "newText": "\n    if tuple is [int, string...] {\n\n    }"
-        },
-        {
-          "range": {
-            "start": {
-              "line": 1,
               "character": 4
             },
             "end": {
@@ -33,6 +20,19 @@
             }
           },
           "newText": "[int, string...]|error tuple \u003d "
+        },
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 15
+            },
+            "end": {
+              "line": 1,
+              "character": 15
+            }
+          },
+          "newText": "\n    if tuple is [int, string...] {\n\n    }"
         }
       ]
     }


### PR DESCRIPTION
## Purpose
This PR adds the rename popup to create variable code actions which allows the users to change the variable name when creating a variable.

Fixes #36139
VSCode plugin PR: https://github.com/wso2-enterprise/ballerina-plugin-vscode/pull/493

## Samples

https://user-images.githubusercontent.com/61020198/181171878-f2282c75-5e5f-4c3f-a1c9-85eb9872340d.mov


## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
