### PR TITLE
 Disallow desugar query expression twice for method invocation

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -6407,6 +6407,11 @@ public class Desugar extends BLangNodeVisitor {
         reorderArguments(invocation);
 
         rewriteExprs(invocation.requiredArgs);
+        if (!invocation.requiredArgs.isEmpty() && invocation.langLibInvocation) {
+            invocation.expr = invocation.requiredArgs.get(0);
+        } else {
+            invocation.expr = rewriteExpr(invocation.expr);
+        }
         fixStreamTypeCastsInInvocationParams(invocation);
         fixNonRestArgTypeCastInTypeParamInvocation(invocation);
 
@@ -6419,7 +6424,6 @@ public class Desugar extends BLangNodeVisitor {
             visitFunctionPointerInvocation(invocation);
             return;
         }
-        invocation.expr = rewriteExpr(invocation.expr);
         result = invRef;
 
         BInvokableSymbol invSym = (BInvokableSymbol) invocation.symbol;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -6407,7 +6407,7 @@ public class Desugar extends BLangNodeVisitor {
         reorderArguments(invocation);
 
         rewriteExprs(invocation.requiredArgs);
-        if (!invocation.requiredArgs.isEmpty() && invocation.langLibInvocation) {
+        if (invocation.langLibInvocation && !invocation.requiredArgs.isEmpty()) {
             invocation.expr = invocation.requiredArgs.get(0);
         } else {
             invocation.expr = rewriteExpr(invocation.expr);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryExpressionWithVarTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryExpressionWithVarTypeTest.java
@@ -253,6 +253,11 @@ public class QueryExpressionWithVarTypeTest {
         BRunUtil.invoke(result, "testQueryConstructingTableWithVar");
     }
 
+    @Test(description = "Test method call expressions on query expressions")
+    public void testMethodCallExprsOnQueryExprs() {
+        BRunUtil.invoke(result, "testMethodCallExprsOnQueryExprs");
+    }
+
     @Test(dataProvider = "dataToTestQueryExprWithVar")
     public void testQueryExprWithVar(String functionName) {
         BRunUtil.invoke(result, functionName);

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/simple-query-with-var-type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/simple-query-with-var-type.bal
@@ -530,6 +530,42 @@ function testUsingAnIntersectionTypeInQueryExpr2() {
     assertEquality([{email : "peter@abc.com", teamId: 2}], j);
 }
 
+function testMethodCallExprsOnQueryExprs() {
+    string[] words = ["a", "b", "c"];
+    var len = (from string str in words
+        select str).length();
+    assertEquality(3, len);
+
+    len = (from string str in words
+        where str == "a"
+        select str).length();
+    assertEquality(1, len);
+
+    string word = (from string str in words
+        select str).pop();
+    assertEquality("c", word);
+
+    int? index = (from string str in words
+        select str).indexOf("b");
+    assertEquality(1, index);
+
+    boolean isReadonly = (from string str in words
+        select str).isReadOnly();
+    assertEquality(false, isReadonly);
+
+    word = (from string str in words
+        select str).remove(0);
+    assertEquality("a", word);
+
+    words = (from string str in words
+        select str).filter(w => w is string);
+    assertEquality(["a", "b", "c"], words);
+
+    words = (from string str in words
+        select str).reverse();
+    assertEquality(["c", "b", "a"], words);
+}
+
 function assertEquality(anydata expected, anydata actual) {
     if expected == actual {
         return;


### PR DESCRIPTION
## Purpose

Fixes #34225

## Approach
> The return from `query desugar` is `BLangStatementExpression`. The `desugared` flag is set true for the `stmtExpr`.  In this change, we disallow desugar `queryExpr` twice for method invocation by checking `stmtExpr`.

## Samples
After this change this code will not give the compilation error.
```
string[] words = ["a", "b", "c"];
    var len = (from string str in words
        select str).length();
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
