### PR TITLE
Skip compiler plugins for template packages during bal pack command execution

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PackCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PackCommand.java
@@ -236,7 +236,7 @@ public class PackCommand implements BLauncherCmd {
         TaskExecutor taskExecutor = new TaskExecutor.TaskBuilder()
                 .addTask(new CleanTargetDirTask(), isSingleFileBuild)
                 .addTask(new ResolveMavenDependenciesTask(outStream))
-                .addTask(new CompileTask(outStream, errStream))
+                .addTask(new CompileTask(outStream, errStream, true))
                 .addTask(new CreateBalaTask(outStream))
                 .addTask(new DumpBuildTimeTask(outStream), !project.buildOptions().dumpBuildTime())
                 .build();

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/CompileTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/CompileTask.java
@@ -46,10 +46,16 @@ import static io.ballerina.cli.launcher.LauncherUtils.createLauncherException;
 public class CompileTask implements Task {
     private final transient PrintStream out;
     private final transient PrintStream err;
+    private final boolean compileForBalPack;
 
     public CompileTask(PrintStream out, PrintStream err) {
+        this(out, err, false);
+    }
+
+    public CompileTask(PrintStream out, PrintStream err, boolean compileForBalPack) {
         this.out = out;
         this.err = err;
+        this.compileForBalPack = compileForBalPack;
     }
 
     @Override
@@ -98,9 +104,12 @@ public class CompileTask implements Task {
             // We only continue with next steps if package resolution does not have errors.
             // Errors in package resolution denotes version incompatibility errors. Hence we do not continue further.
             if (!project.currentPackage().getResolution().diagnosticResult().hasErrors()) {
-                if (!project.kind().equals(ProjectKind.BALA_PROJECT)) {
-                    // BalaProject is a read-only project.
-                    // Hence we run the code generators/ modifiers only for BuildProject and SingleFileProject
+                if (!project.kind().equals(ProjectKind.BALA_PROJECT) && !isPackCmdForATemplatePkg(project)) {
+                    // SingleFileProject cannot hold additional sources or resources
+                    // and BalaProjects is a read-only project.
+                    // Hence, we run the code generators only for BuildProject.
+                    // If the project is a template package using PackCommand,
+                    // the bala should contain unmodified source-code. Therefore, the code generators are ignored.
                     DiagnosticResult codeGenAndModifyDiagnosticResult = project.currentPackage()
                             .runCodeGenAndModifyPlugins();
                     if (codeGenAndModifyDiagnosticResult != null) {
@@ -160,5 +169,9 @@ public class CompileTask implements Task {
         } catch (ProjectException e) {
             throw createLauncherException("compilation failed: " + e.getMessage());
         }
+    }
+
+    private boolean isPackCmdForATemplatePkg(Project project) {
+        return compileForBalPack && project.currentPackage().manifest().template();
     }
 }

--- a/cli/ballerina-cli/src/test/resources/test-resources/compiler-plugins/package_comp_plugin_code_modify_add_function/Ballerina.toml
+++ b/cli/ballerina-cli/src/test/resources/test-resources/compiler-plugins/package_comp_plugin_code_modify_add_function/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "samjs"
+name = "package_comp_plugin_code_modify_add_function"
+version = "0.1.0"

--- a/cli/ballerina-cli/src/test/resources/test-resources/compiler-plugins/package_comp_plugin_code_modify_add_function/CompilerPlugin.toml
+++ b/cli/ballerina-cli/src/test/resources/test-resources/compiler-plugins/package_comp_plugin_code_modify_add_function/CompilerPlugin.toml
@@ -1,0 +1,8 @@
+[plugin]
+class = "io.samjs.plugins.init.codemodify.CodeModifyFunctionPlugin"
+
+[[dependency]]
+path = "../init-function-code-modify-compiler-plugin-1.0.0.jar"
+
+[[dependency]]
+path = "../diagnostic-utils-lib-1.0.0.jar"

--- a/cli/ballerina-cli/src/test/resources/test-resources/compiler-plugins/package_comp_plugin_code_modify_add_function/Package.md
+++ b/cli/ballerina-cli/src/test/resources/test-resources/compiler-plugins/package_comp_plugin_code_modify_add_function/Package.md
@@ -1,0 +1,1 @@
+Package

--- a/cli/ballerina-cli/src/test/resources/test-resources/compiler-plugins/package_comp_plugin_code_modify_add_function/main.bal
+++ b/cli/ballerina-cli/src/test/resources/test-resources/compiler-plugins/package_comp_plugin_code_modify_add_function/main.bal
@@ -1,0 +1,3 @@
+public function doSomething() {
+    // Do nothing
+}

--- a/cli/ballerina-cli/src/test/resources/test-resources/projects-using-compiler-plugins/package_plugin_code_modify_user_not_template/Ballerina.toml
+++ b/cli/ballerina-cli/src/test/resources/test-resources/projects-using-compiler-plugins/package_plugin_code_modify_user_not_template/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "samjs"
+name = "package_plugin_code_modify_user_not_template"
+version = "0.1.0"

--- a/cli/ballerina-cli/src/test/resources/test-resources/projects-using-compiler-plugins/package_plugin_code_modify_user_not_template/main.bal
+++ b/cli/ballerina-cli/src/test/resources/test-resources/projects-using-compiler-plugins/package_plugin_code_modify_user_not_template/main.bal
@@ -1,0 +1,10 @@
+import samjs/package_comp_plugin_code_modify_add_function as _;
+
+public function main() {
+}
+
+function foo() {
+}
+
+function bar() {
+}

--- a/cli/ballerina-cli/src/test/resources/test-resources/projects-using-compiler-plugins/package_plugin_code_modify_user_template/Ballerina.toml
+++ b/cli/ballerina-cli/src/test/resources/test-resources/projects-using-compiler-plugins/package_plugin_code_modify_user_template/Ballerina.toml
@@ -1,0 +1,5 @@
+[package]
+org = "samjs"
+name = "package_plugin_code_modify_user_template"
+version = "0.1.0"
+template = true

--- a/cli/ballerina-cli/src/test/resources/test-resources/projects-using-compiler-plugins/package_plugin_code_modify_user_template/main.bal
+++ b/cli/ballerina-cli/src/test/resources/test-resources/projects-using-compiler-plugins/package_plugin_code_modify_user_template/main.bal
@@ -1,0 +1,10 @@
+import samjs/package_comp_plugin_code_modify_add_function as _;
+
+public function main() {
+}
+
+function foo() {
+}
+
+function bar() {
+}


### PR DESCRIPTION
## Purpose
Avoid the inclusion of code modified by compiler plugins into a BALA if the package is a template package. This causes the new package created using the template package to contain code modified by compiler plugins.

Fixes #37125, https://github.com/wso2-enterprise/internal-support-ballerina/issues/145

## Approach
Skip the code generators/ modifiers of the `CompileTask` if,
- `PackCommand` is calling the `CompilerTask` **AND**,
- `template=true` in Ballerina.toml

## Samples

Source file inside BALA for a template package w/ compiler plugin

- Before

``` ballerina
import ballerina/graphql;

# A service representing a network-accessible GraphQL API
@graphql:ServiceConfig{schemaString:"rO0ABXNyADhpbyJEu..."}service /graphql on new graphql:Listener(8090) {

    // removed for brevity
}
```
- After
``` ballerina
import ballerina/graphql;

# A service representing a network-accessible GraphQL API
service /graphql on new graphql:Listener(8090) {

    // removed for brevity
}
```

## Remarks
Using a template package as a normal dependency will produce an error resolution after this change.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
