### PR TITLE
[master] Fix rest-binding-pattern with closed records

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -3092,7 +3092,7 @@ public class SymbolEnter extends BLangNodeVisitor {
         } else {
             restConstraintType = BUnionType.create(null, constraintTypes);
         }
-        return (restVarSymbolMapType.tag == TypeTags.NONE) ?
+        return restVarSymbolMapType.tag == TypeTags.NONE ?
                 restConstraintType : this.types.mergeTypes(restVarSymbolMapType, restConstraintType);
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -3078,7 +3078,8 @@ public class SymbolEnter extends BLangNodeVisitor {
 
         if (!recordType.sealed) {
             BType restFieldType = recordType.restFieldType;
-            if (!this.types.isNeverTypeOrStructureTypeWithARequiredNeverMember(restFieldType)) {
+            if (!this.types.isNeverTypeOrStructureTypeWithARequiredNeverMember(restFieldType) &&
+                    (restFieldType.tag != TypeTags.NONE)) {
                 constraintTypes.add(restFieldType);
             }
         }
@@ -3091,7 +3092,8 @@ public class SymbolEnter extends BLangNodeVisitor {
         } else {
             restConstraintType = BUnionType.create(null, constraintTypes);
         }
-        return this.types.mergeTypes(restVarSymbolMapType, restConstraintType);
+        return (restVarSymbolMapType.tag == TypeTags.NONE) ?
+                restConstraintType : this.types.mergeTypes(restVarSymbolMapType, restConstraintType);
     }
 
     BRecordType createRecordTypeForRestField(Location pos, SymbolEnv env, BRecordType recordType,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -3079,8 +3079,7 @@ public class SymbolEnter extends BLangNodeVisitor {
 
         if (!recordType.sealed) {
             BType restFieldType = recordType.restFieldType;
-            if (!this.types.isNeverTypeOrStructureTypeWithARequiredNeverMember(restFieldType) &&
-                    (restFieldType.tag != TypeTags.NONE)) {
+            if (!this.types.isNeverTypeOrStructureTypeWithARequiredNeverMember(restFieldType)) {
                 constraintTypes.add(restFieldType);
             }
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -78,6 +78,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BFutureType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BIntersectionType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BInvokableType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BMapType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BNoType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BObjectType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BRecordType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BStructureType;
@@ -3108,7 +3109,11 @@ public class SymbolEnter extends BLangNodeVisitor {
             }
         }};
 
-        setRestRecordFields(pos, env, unMappedFields, variableList, restConstraint, recordVarType);
+        if (recordType.sealed && (restConstraint.tag == TypeTags.NONE)) {
+            setRestRecordFields(pos, env, unMappedFields, variableList, null, recordVarType);
+        } else {
+            setRestRecordFields(pos, env, unMappedFields, variableList, restConstraint, recordVarType);
+        }
 
         BLangRecordTypeNode recordTypeNode = TypeDefBuilderHelper.createRecordTypeNode(recordVarType,
                 env.enclPkg.packageID, symTable, pos);
@@ -3163,7 +3168,12 @@ public class SymbolEnter extends BLangNodeVisitor {
         }
 
         targetRestRecType.fields = fields;
-        targetRestRecType.restFieldType = restConstraint;
+        if (restConstraint == null) {
+            targetRestRecType.restFieldType = new BNoType(TypeTags.NONE);
+            targetRestRecType.sealed = true;
+        } else {
+            targetRestRecType.restFieldType = restConstraint;
+        }
     }
 
     private long setSymbolAsOptional(long existingFlags) {

--- a/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
@@ -2838,15 +2838,19 @@ function testEnsureTypeWithInferredArgument() {
     int|error age = p.age.ensureType();
     assertEquality(24, age);
 
-    // https://github.com/ballerina-platform/ballerina-lang/issues/29219
-    //any a = <string[]> ["hello", "world"];
-    //string[] strArray = checkpanic a.ensureType();
-    //assertEquality(a, strArray);
-    //string[]|error strArray2 = value:ensureType(a);
-    //assertEquality(a, strArray2);
+    any a = <string[]> ["hello", "world"];
+    string[] strArray = checkpanic a.ensureType();
+    assertEquality(a, strArray);
+    string[]|error strArray2 = value:ensureType(a);
+    assertEquality(a, strArray2);
 
-    //int[]|error intArr = a.ensureType();
-    //assertEquality(a, intArr);
+    int[]|error intArr = a.ensureType();
+    assertTrue(intArr is error);
+    if (intArr is error) {
+        assertEquality("{ballerina}TypeCastError", intArr.message());
+        assertEquality("incompatible types: 'string[]' cannot be cast to 'int[]'",
+        <string> checkpanic intArr.detail()["message"]);
+    }
 }
 
 function testEnsureTypeFloatToIntNegative() {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/varbindingpatternmatchpattern/MappingBindingPatternTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/varbindingpatternmatchpattern/MappingBindingPatternTest.java
@@ -22,6 +22,7 @@ import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 /**
@@ -41,149 +42,56 @@ public class MappingBindingPatternTest {
                 "/mapping_binding_pattern_with_rest_binding_pattern.bal");
     }
 
-    @Test
-    public void testMappingBindingPattern1() {
-        BRunUtil.invoke(result, "testMappingBindingPattern1");
+    @Test(dataProvider = "functionsToTestMappingBindingPattern")
+    public void testMappingBindingPattern(String functionName) {
+        BRunUtil.invoke(result, functionName);
     }
 
-    @Test
-    public void testMappingBindingPattern2() {
-        BRunUtil.invoke(result, "testMappingBindingPattern2");
+    @DataProvider
+    public Object[] functionsToTestMappingBindingPattern() {
+        return new Object[]{
+                "testMappingBindingPattern1",
+                "testMappingBindingPattern2",
+                "testMappingBindingPattern3",
+                "testMappingBindingPattern4",
+                "testMappingBindingPattern5",
+                "testMappingBindingPattern6",
+                "testMappingBindingPattern7",
+                "testMappingBindingPattern8",
+                "testMappingBindingPattern9",
+                "testMappingBindingPattern10",
+                "testMappingBindingPattern11",
+                "testMappingBindingPattern12",
+                "testMappingBindingPattern13",
+                "testMappingBindingPattern14",
+                "testMappingBindingPattern15",
+                "testMappingBindingPattern16",
+                "testMappingBindingPattern17",
+                "testMappingBindingToRecordWithDefaultValue"
+        };
     }
 
-    @Test
-    public void testMappingBindingPattern3() {
-        BRunUtil.invoke(result, "testMappingBindingPattern3");
+    @Test(dataProvider = "functionsToTestMappingBindingPatternWithRest")
+    public void testMappingBindingPatternWithRest(String functionName) {
+        BRunUtil.invoke(restMatchPatternResult, functionName);
     }
 
-    @Test
-    public void testMappingBindingPattern4() {
-        BRunUtil.invoke(result, "testMappingBindingPattern4");
-    }
-
-    @Test
-    public void testMappingBindingPattern5() {
-        BRunUtil.invoke(result, "testMappingBindingPattern5");
-    }
-
-    @Test
-    public void testMappingBindingPattern6() {
-        BRunUtil.invoke(result, "testMappingBindingPattern6");
-    }
-
-    @Test
-    public void testMappingBindingPattern7() {
-        BRunUtil.invoke(result, "testMappingBindingPattern7");
-    }
-
-    @Test
-    public void testMappingBindingPattern8() {
-        BRunUtil.invoke(result, "testMappingBindingPattern8");
-    }
-
-    @Test
-    public void testMappingBindingPattern9() {
-        BRunUtil.invoke(result, "testMappingBindingPattern9");
-    }
-
-    @Test
-    public void testMappingBindingPattern10() {
-        BRunUtil.invoke(result, "testMappingBindingPattern10");
-    }
-
-    @Test
-    public void testMappingBindingPattern11() {
-        BRunUtil.invoke(result, "testMappingBindingPattern11");
-    }
-
-    @Test
-    public void testMappingBindingPattern12() {
-        BRunUtil.invoke(result, "testMappingBindingPattern12");
-    }
-
-    @Test
-    public void testMappingBindingPattern13() {
-        BRunUtil.invoke(result, "testMappingBindingPattern13");
-    }
-
-    @Test
-    public void testMappingBindingPattern14() {
-        BRunUtil.invoke(result, "testMappingBindingPattern14");
-    }
-
-    @Test
-    public void testMappingBindingPattern15() {
-        BRunUtil.invoke(result, "testMappingBindingPattern15");
-    }
-
-    @Test
-    public void testMappingBindingPattern16() {
-        BRunUtil.invoke(result, "testMappingBindingPattern16");
-    }
-
-    @Test
-    public void testMappingBindingPattern17() {
-        BRunUtil.invoke(result, "testMappingBindingPattern17");
-    }
-
-    @Test
-    public void testMappingBindingToRecordWithDefaultValue() {
-        BRunUtil.invoke(result, "testMappingBindingToRecordWithDefaultValue");
-    }
-
-    @Test
-    public void testMappingBindingPatternWithRest1() {
-        BRunUtil.invoke(restMatchPatternResult, "testMappingBindingPatternWithRest1");
-    }
-
-    @Test
-    public void testMappingBindingPatternWithRest2() {
-        BRunUtil.invoke(restMatchPatternResult, "testMappingBindingPatternWithRest2");
-    }
-
-    @Test
-    public void testMappingBindingPatternWithRest3() {
-        BRunUtil.invoke(restMatchPatternResult, "testMappingBindingPatternWithRest3");
-    }
-
-    @Test
-    public void testMappingBindingPatternWithRest4() {
-        BRunUtil.invoke(restMatchPatternResult, "testMappingBindingPatternWithRest4");
-    }
-
-    @Test
-    public void testMappingBindingPatternWithRest5() {
-        BRunUtil.invoke(restMatchPatternResult, "testMappingBindingPatternWithRest5");
-    }
-
-    @Test
-    public void testMappingBindingPatternWithRest6() {
-        BRunUtil.invoke(restMatchPatternResult, "testMappingBindingPatternWithRest6");
-    }
-
-    @Test
-    public void testMappingBindingPatternWithRest7() {
-        BRunUtil.invoke(restMatchPatternResult, "testMappingBindingPatternWithRest7");
-    }
-
-    @Test
-    public void testMappingBindingPatternWithRest8() {
-        BRunUtil.invoke(restMatchPatternResult, "testMappingBindingPatternWithRest8");
-    }
-
-    @Test
-    public void testRestMappingAtRuntime() {
-        BRunUtil.invoke(restMatchPatternResult, "testRestMappingAtRuntime");
-    }
-
-    @Test
-    public void testRestRecordPattern() {
-        BRunUtil.invoke(restMatchPatternResult, "testRestRecordPattern");
-    }
-
-    @Test
-    public void testReachableMappingBinding() {
-        BRunUtil.invoke(restMatchPatternResult, "testReachableMappingBinding");
+    @DataProvider
+    public Object[] functionsToTestMappingBindingPatternWithRest() {
+        return new Object[]{
+                "testMappingBindingPatternWithRest1",
+                "testMappingBindingPatternWithRest2",
+                "testMappingBindingPatternWithRest3",
+                "testMappingBindingPatternWithRest4",
+                "testMappingBindingPatternWithRest5",
+                "testMappingBindingPatternWithRest6",
+                "testMappingBindingPatternWithRest7",
+                "testMappingBindingPatternWithRest8",
+                "testRestMappingAtRuntime",
+                "testRestRecordPattern",
+                "testReachableMappingBinding",
+                "testRestBindingPatternWithRecords"
+        };
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/constant/constant-access.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/constant/constant-access.bal
@@ -45,16 +45,15 @@ function testTypeFromAnotherPackage() returns test_project:XY {
 
 // -----------------------------------------------------------
 
-// Todo - Enable after fixing https://github.com/ballerina-platform/ballerina-lang/issues/11183.
-//type M record { string f; }|Z;
-//
-//M m1 = { f: "test_project" };
-//
-//M m2 = "V";
-//
-//M m3 = "W";
-//
-//M m4 = "X";
+type M record { string f; }|Z;
+
+M m1 = { f: "test_project" };
+
+M m2 = "V";
+
+M m3 = "W";
+
+M m4 = "X";
 
 type Y X;
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/types/test_tuple_type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/types/test_tuple_type.bal
@@ -128,12 +128,11 @@ function testTupleWithVar() {
     var [...g] = tuples:getTupleWithRestDescOnly();
     assertEquality(<[string...]> ["hello", "world"], g);
 
-    // https://github.com/ballerina-platform/ballerina-lang/issues/28326
-    //var [...h] = tuples:getTupleWithMemberAndRestDesc();
-    //(int|string)[] i = h;
-    //[int, string...] j = h;
-    //assertEquality(<(int|string)[]> [1, "hello", "world"], i);
-    //assertEquality(<(int|string)[]> [1, "hello", "world"], j);
+    var [...h] = tuples:getTupleWithMemberAndRestDesc();
+    (int|string)[] i = h;
+    [int, string...] j = h;
+    assertEquality(<(int|string)[]> [1, "hello", "world"], i);
+    assertEquality(<(int|string)[]> [1, "hello", "world"], j);
 }
 
 function assertTrue(any|error actual) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/isolation-analysis/isolation_inference_with_objects_runtime_negative_1.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/isolation-analysis/isolation_inference_with_objects_runtime_negative_1.bal
@@ -641,11 +641,11 @@ public class Listener {
 
 int[] x = [];
 
-//function testInvalidCopyInWithNonObjectSelf1(int[] 'self) {
-//    lock {
-//        x = 'self;
-//    }
-//}
+function testInvalidCopyInWithNonObjectSelf1(int[] 'self) {
+    lock {
+        x = 'self;
+    }
+}
 
 function testInvalidCopyInWithNonObjectSelf2() {
     lock {
@@ -882,8 +882,7 @@ function testIsolatedInference() {
     assertFalse(isResourceIsolated(q, "get", "corge"));
     assertFalse(isMethodIsolated(q, "quuz"));
 
-    // https://github.com/ballerina-platform/ballerina-lang/issues/31365.
-    // assertFalse(<any> testInvalidCopyInWithNonObjectSelf1 is isolated function);
+    assertFalse(<any> testInvalidCopyInWithNonObjectSelf1 is isolated function);
     assertFalse(<any> testInvalidCopyInWithNonObjectSelf2 is isolated function);
 
     NonIsolatedClassWithInvalidCopyInInMethodCall r = new;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/dependently_typed_functions_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/dependently_typed_functions_test.bal
@@ -532,8 +532,8 @@ public function testStartActionWithDependentlyTypedFunctions() {
     };
     future<int|string|error> a = start getWithUnion("", IntOrString);
     assert1(a);
-    //future<int|string|error> b = start cl.get("", IntOrString);
-    //assert1(b);
+    future<int|string|error> b = start cl.get("", IntOrString);
+    assert1(b);
     future<int|string|error> c = start cl->remoteGet("", IntOrString);
     assert1(c);
 
@@ -544,10 +544,10 @@ public function testStartActionWithDependentlyTypedFunctions() {
     };
     future<int|error> d = start getWithUnion("hello", int);
     assert2(d, 5);
-    //future<int|error> e = start cl.get(3, int);
-    //assert2(e, 4);
-    //future<int|error> f = start cl.get("");
-    //assert2(f, 0);
+    future<int|error> e = start cl.get(3, int);
+    assert2(e, 4);
+    future<int|error> ff = start cl.get("");
+    assert2(ff, 0);
     future<int|error> g = start cl->remoteGet("hi", int);
     assert2(g, 2);
 
@@ -558,8 +558,8 @@ public function testStartActionWithDependentlyTypedFunctions() {
     };
     future<string|error> h = start getWithUnion("hello", string);
     assert3(h, "hello");
-    //future<string|error> i = start cl.get(1, string);
-    //assert3(i, "1");
+    future<string|error> i = start cl.get(1, string);
+    assert3(i, "1");
     future<string|error> j = start cl->remoteGet("", string);
     assert3(j, "");
 }
@@ -571,11 +571,10 @@ function getWithUnion(int|string x, typedesc<int|string> y) returns y|error =
     } external;
 
 client class Client {
-    // https://github.com/ballerina-platform/ballerina-lang/issues/28740
-    //function get(int|string x, typedesc<int|string> y = int) returns y|error = @java:Method {
-    //    'class: "org.ballerinalang.nativeimpl.jvm.tests.VariableReturnType",
-    //    name: "clientGetWithUnion"
-    //} external;
+    function get(int|string x, typedesc<int|string> y = int) returns y|error = @java:Method {
+        'class: "org.ballerinalang.nativeimpl.jvm.tests.VariableReturnType",
+        name: "clientGetWithUnion"
+    } external;
 
     remote function remoteGet(int|string x, typedesc<int|string> y) returns y|error = @java:Method {
         'class: "org.ballerinalang.nativeimpl.jvm.tests.VariableReturnType",

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/matchstmt/mapping-match-pattern-with-rest-match-pattern.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/matchstmt/mapping-match-pattern-with-rest-match-pattern.bal
@@ -285,10 +285,9 @@ function mappingMatchPattern14(RecTwo rec)
         {p: var p, ...var q} => {
             return [p, q];
         }
-        // https://github.com/ballerina-platform/ballerina-lang/issues/30196
-        // {a: var a, b: var b, ...var c} => {
-        //     return [a, b, c];
-        // }
+        {a: var a, b: var b, ...var c} => {
+         return [a, b, c];
+        }
         {m: var m, ...var n} => {
             return [m, n];
         }
@@ -309,18 +308,17 @@ public function testRestMappingAtRuntime() {
     assertEquals(2, m1.length());
     assertEquals(<RecTwo> {m: 101, "p": "hello", "q": "world"}, rec);
 
-    // https://github.com/ballerina-platform/ballerina-lang/issues/30196
-    // RecTwo rec2 = {m: 202, "a": "hello", "b": "world", "c": "ballerina"};
-    // var r2 = mappingMatchPattern14(rec2);
-    // assertEquals(true, r2 is [string, string, map<int|string>]);
-    // var v2 = <[string, string, map<int|string>]> r2;
-    // assertEquals("hello", v2[0]);
-    // assertEquals("world", v2[1]);
-    // var m2 = v2[2];
-    // assertEquals("ballerina", m2["c"]);
-    // assertEquals(202, m2["m"]);
-    // assertEquals(2, m2.length());
-    // assertEquals(<RecTwo> {m: 202, "a": "hello", "b": "world", "c": "ballerina"}, rec2);
+    RecTwo rec2 = {m: 202, "a": "hello", "b": "world", "c": "ballerina"};
+    var r2 = mappingMatchPattern14(rec2);
+    assertEquals(true, r2 is [string, string, map<int|string>]);
+    var v2 = <[string, string, map<int|string>]> r2;
+    assertEquals("hello", v2[0]);
+    assertEquals("world", v2[1]);
+    var m2 = v2[2];
+    assertEquals("ballerina", m2["c"]);
+    assertEquals(202, m2["m"]);
+    assertEquals(2, m2.length());
+    assertEquals(<RecTwo> {m: 202, "a": "hello", "b": "world", "c": "ballerina"}, rec2);
 
     RecTwo rec3 = {m: 303, "b": "ballerina"};
     var r3 = mappingMatchPattern14(rec3);

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/matchstmt/varbindingpatternmatchpattern/mapping_binding_pattern_with_rest_binding_pattern.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/matchstmt/varbindingpatternmatchpattern/mapping_binding_pattern_with_rest_binding_pattern.bal
@@ -14,6 +14,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/test;
+
 function mappingBindingPatternRest1(any v) returns any|error {
     match v {
         var {w: a, x: b, y: c,  ...r} => {
@@ -263,10 +265,9 @@ function mappingBindingPatternRest12(RecTwo rec)
         var {p, ...q} => {
             return [p, q];
         }
-        // https://github.com/ballerina-platform/ballerina-lang/issues/30196
-        // var {a, b, ...c} => {
-        //     return [a, b, c];
-        // }
+        var {a, b, ...c} => {
+         return [a, b, c];
+        }
         var {m, ...n} => {
             return [m, n];
         }
@@ -286,18 +287,17 @@ public function testRestMappingAtRuntime() {
     assertEquals(2, m1.length());
     assertEquals(<RecTwo> {m: 101, "p": "hello", "q": "world"}, rec);
 
-    // https://github.com/ballerina-platform/ballerina-lang/issues/30196
-    // RecTwo rec2 = {m: 202, "a": "hello", "b": "world", "c": "ballerina"};
-    // var r2 = mappingBindingPatternRest12(rec2);
-    // assertEquals(true, r2 is [string, string, map<int|string>]);
-    // var v2 = <[string, string, map<int|string>]> r2;
-    // assertEquals("hello", v2[0]);
-    // assertEquals("world", v2[1]);
-    // var m2 = v2[2];
-    // assertEquals("ballerina", m2["c"]);
-    // assertEquals(202, m2["m"]);
-    // assertEquals(2, m2.length());
-    // assertEquals(<RecTwo> {m: 202, "a": "hello", "b": "world", "c": "ballerina"}, rec2);
+    RecTwo rec2 = {m: 202, "a": "hello", "b": "world", "c": "ballerina"};
+    var r2 = mappingBindingPatternRest12(rec2);
+    assertEquals(true, r2 is [string, string, map<int|string>]);
+    var v2 = <[string, string, map<int|string>]> r2;
+    assertEquals("hello", v2[0]);
+    assertEquals("world", v2[1]);
+    var m2 = v2[2];
+    assertEquals("ballerina", m2["c"]);
+    assertEquals(202, m2["m"]);
+    assertEquals(2, m2.length());
+    assertEquals(<RecTwo> {m: 202, "a": "hello", "b": "world", "c": "ballerina"}, rec2);
 
     RecTwo rec3 = {m: 303, "b": "ballerina"};
     var r3 = mappingBindingPatternRest12(rec3);
@@ -351,6 +351,32 @@ function testRestRecordPattern() {
              assertEquals(true, rest?.employed);
          }
      }
+}
+
+type PersonClosed record {|
+    int id;
+    string name;
+    boolean aged;
+|};
+
+type PersonOpen record {
+    int id;
+    string name;
+    boolean aged;
+};
+
+function testRestBindingPatternWithRecords() {
+    PersonOpen person1 = {id: 456, name: "yourName", aged: false, "address": "yourAddress"};
+    PersonOpen {id: personId1, ...otherDetails1} = person1;
+    test:assertEquals(personId1, 456);
+    test:assertEquals(otherDetails1, {"name":"yourName","aged":false,"address":"yourAddress"});
+    test:assertTrue(otherDetails1 is record {| never id?; string name; boolean aged; anydata...; |});
+
+    PersonClosed person2 = {id: 123, name: "myName", aged: true};
+    PersonClosed {id: personId2, ...otherDetails2} = person2;
+    test:assertEquals(personId2, 123);
+    test:assertEquals(otherDetails2, {"name":"myName","aged":true});
+    test:assertTrue(otherDetails2 is record {| never id?; string name; boolean aged; |});
 }
 
 type Record record {| int m; string...; |};

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/constant/simple-literal-constant.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/constant/simple-literal-constant.bal
@@ -381,19 +381,32 @@ function testLabeling() returns string {
 
 // -----------------------------------------------------------
 
-// Todo - Enable after fixing https://github.com/ballerina-platform/ballerina-lang/issues/11183.
-//type M record { string f; }|Z;
-//
-//Z z1 = "V";
-//
-//Z z2 = "W";
-//
-//Z z3 = "X";
-//
-//
-//const string W = "W";
-//
-//const string X = "X";
+type M record { string f; }|Z;
+
+M m1 = { f: "test_project" };
+
+M m2 = "V";
+
+M m3 = "W";
+
+M m4 = "X";
+
+type Y X;
+
+type Z "V"|W|X;
+
+Y y = "X";
+
+Z z1 = "V";
+
+Z z2 = "W";
+
+Z z3 = "X";
+
+
+const string W = "W";
+
+const string X = "X";
 
 // -----------------------------------------------------------
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/readonly/test_selectively_immutable_type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/readonly/test_selectively_immutable_type.bal
@@ -1112,8 +1112,7 @@ function testReadOnlyIntersectionWithRecordThatHasANeverReadOnlyRestField() {
     assertTrue(b is record {| int a?; |});
     assertTrue(b is record {| int a?; never...; |});
 
-    // https://github.com/ballerina-platform/ballerina-lang/issues/33785
-    // record {| int a; |} _ = a;
+    record {| int a; |} _ = a;
 
     record {| int a; never...; |} _ = a;
     record { int a; } _ = a;


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues.

Duplicate PR #36934
$title
Fixes #36282

## Approach
> Describe how you are implementing the solutions along with the design details.

When `getRestMatchPatternConstraintType` is called a record's rest field type type is passed as the `restVarSymbolMapType`. A record's rest field type can be `BNoType`. When creating a union type with `BNoType`, it can be neglected and in this fix it is done as such.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

Newly added test, which is relevant for the fix is only `testRestBindingPatternWithRecords`.
Others are just the commented out tests for the issues which have been already fixed.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
