### PR TITLE
Fix `testAsyncNonNativeBasic7` intermittent test failure

### DIFF
--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/async/basic-async-operations.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/async/basic-async-operations.bal
@@ -1,3 +1,20 @@
+// Copyright (c) (2019-2022), WSO2 Inc. (http://www.wso2.com).
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/lang.runtime;
 import ballerina/jballerina.java;
 
 int globalResult = 0;
@@ -133,6 +150,7 @@ function infiniteFunc() {
     int i = 0;
     while (true) {
         i = i + 1;
+        runtime:sleep(0.0001);
     }
 }
 


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues.

$title
Fixes #37081

## Approach
> Describe how you are implementing the solutions along with the design details.

This failed intermittently because sometimes when the `infiniteFunc()` starts, the cancel flag is already set (then the test get passed), and when it doesn’t, the test fails because `infiniteFunc()` does not yield to check the cancel flag.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
