### PR TITLE
Validate balaDownloadResponse in pullPackage

### DIFF
--- a/cli/central-client/src/main/java/org/ballerinalang/central/client/CentralAPIClient.java
+++ b/cli/central-client/src/main/java/org/ballerinalang/central/client/CentralAPIClient.java
@@ -887,8 +887,7 @@ public class CentralAPIClient {
         Optional<ResponseBody> body = Optional.ofNullable(response.body());
         if (body.isPresent()) {
             // If search request was sent wrongly
-            if (response.code() == HTTP_BAD_REQUEST ||
-                    response.code() == HTTP_NOT_FOUND) {
+            if (response.code() == HTTP_BAD_REQUEST || response.code() == HTTP_NOT_FOUND) {
                 Error error = new Gson().fromJson(body.get().string(), Error.class);
                 if (error.getMessage() != null && !"".equals(error.getMessage())) {
                     throw new CentralClientException(error.getMessage());
@@ -900,18 +899,9 @@ public class CentralAPIClient {
                 handleUnauthorizedResponse(body);
             }
 
-            // If error occurred at remote repository
-            if (response.code() == HTTP_INTERNAL_ERROR ||
-                    response.code() == HTTP_UNAVAILABLE) {
-                Error error = new Gson().fromJson(body.get().string(), Error.class);
-                if (error.getMessage() != null && !"".equals(error.getMessage())) {
-                    throw new CentralClientException(msg + " reason:" + error.getMessage());
-                }
-            }
-
-            // If invalid/no response received at the gateway server
-            if (response.code() == HTTP_BAD_GATEWAY ||
-                    response.code() == HTTP_GATEWAY_TIMEOUT) {
+            // If error occurred at remote repository or invalid/no response received at the gateway server
+            if (response.code() == HTTP_INTERNAL_ERROR || response.code() == HTTP_UNAVAILABLE ||
+                    response.code() == HTTP_BAD_GATEWAY || response.code() == HTTP_GATEWAY_TIMEOUT) {
                 Error error = new Gson().fromJson(body.get().string(), Error.class);
                 if (error.getMessage() != null && !"".equals(error.getMessage())) {
                     throw new CentralClientException(msg + " reason:" + error.getMessage());

--- a/cli/central-client/src/main/java/org/ballerinalang/central/client/CentralAPIClient.java
+++ b/cli/central-client/src/main/java/org/ballerinalang/central/client/CentralAPIClient.java
@@ -58,7 +58,9 @@ import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.HttpsURLConnection;
 
+import static java.net.HttpURLConnection.HTTP_BAD_GATEWAY;
 import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
+import static java.net.HttpURLConnection.HTTP_GATEWAY_TIMEOUT;
 import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
 import static java.net.HttpURLConnection.HTTP_MOVED_TEMP;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
@@ -438,10 +440,17 @@ public class CentralAPIClient {
 
                     Call downloadBalaRequestCall = client.newCall(downloadBalaRequest);
                     Response balaDownloadResponse = downloadBalaRequestCall.execute();
-                    boolean isNightlyBuild = ballerinaVersion.contains("SNAPSHOT");
-                    createBalaInHomeRepo(balaDownloadResponse, packagePathInBalaCache, org, name, isNightlyBuild,
-                            balaUrl.get(), balaFileName.get(), enableOutputStream ? outStream : null, logFormatter);
-                    return;
+
+                    if (balaDownloadResponse.code() == HTTP_OK) {
+                        boolean isNightlyBuild = ballerinaVersion.contains("SNAPSHOT");
+                        createBalaInHomeRepo(balaDownloadResponse, packagePathInBalaCache, org, name, isNightlyBuild,
+                                balaUrl.get(), balaFileName.get(), enableOutputStream ? outStream : null, logFormatter);
+                        return;
+                    } else {
+                        String errorMessage = logFormatter.formatLog(ERR_CANNOT_PULL_PACKAGE + "'" + packageSignature +
+                                "'. BALA content download from '" + balaUrl.get() + "' failed.");
+                        handleResponseErrors(balaDownloadResponse, errorMessage);
+                    }
                 } else {
                     String errorMsg = logFormatter.formatLog(ERR_CANNOT_PULL_PACKAGE + "'" + packageSignature +
                             "' from the remote repository '" + url + "'. reason: bala file location is missing.");
@@ -896,7 +905,16 @@ public class CentralAPIClient {
                     response.code() == HTTP_UNAVAILABLE) {
                 Error error = new Gson().fromJson(body.get().string(), Error.class);
                 if (error.getMessage() != null && !"".equals(error.getMessage())) {
-                    throw new CentralClientException(msg + "' reason:" + error.getMessage());
+                    throw new CentralClientException(msg + " reason:" + error.getMessage());
+                }
+            }
+
+            // If invalid/no response received at the gateway server
+            if (response.code() == HTTP_BAD_GATEWAY ||
+                    response.code() == HTTP_GATEWAY_TIMEOUT) {
+                Error error = new Gson().fromJson(body.get().string(), Error.class);
+                if (error.getMessage() != null && !"".equals(error.getMessage())) {
+                    throw new CentralClientException(msg + " reason:" + error.getMessage());
                 }
             }
         }

--- a/cli/central-client/src/test/java/org/ballerinalang/central/client/TestCentralApiClient.java
+++ b/cli/central-client/src/test/java/org/ballerinalang/central/client/TestCentralApiClient.java
@@ -232,12 +232,12 @@ public class TestCentralApiClient extends CentralAPIClient {
 
         // invalidRequestErrorMessage here might not be identical to the actual HTTP response error message
         String invalidResponseErrorMessage = "package not found: foo/sf:*_any";
-        String errorWithNoResponseBodyMessage = "error: failed to pull the package: 'foo/sf:1.3.5'. " +
+        String unexpectedResponseErrorMessage = "error: failed to pull the package: 'foo/sf:1.3.5'. " +
                 "BALA content download from '" + this.balaUrl + "' failed.";
-        String remoteRepositoryErrorMessage = errorWithNoResponseBodyMessage + " reason:" + invalidResponseErrorMessage;
+        String remoteRepositoryErrorMessage = unexpectedResponseErrorMessage + " reason:" + invalidResponseErrorMessage;
         String responseString = "{\"message\": \"" + invalidResponseErrorMessage + "\"}";
 
-        Object[][] data = new Object[6][3];
+        Object[][] data = new Object[7][3];
         data[0] = new Object[]{HttpURLConnection.HTTP_NOT_FOUND, invalidResponseErrorMessage,
                 getResponseBody(responseString)};
         data[1] = new Object[]{HttpURLConnection.HTTP_INTERNAL_ERROR, remoteRepositoryErrorMessage,
@@ -249,8 +249,12 @@ public class TestCentralApiClient extends CentralAPIClient {
         data[4] = new Object[]{HttpURLConnection.HTTP_GATEWAY_TIMEOUT, remoteRepositoryErrorMessage,
                 getResponseBody(responseString)};
 
+        // test BALA download with a response status code not handled specifically
+        data[5] = new Object[]{HttpURLConnection.HTTP_FORBIDDEN, unexpectedResponseErrorMessage,
+                getResponseBody(responseString)};
+
         // test BALA download with no response body
-        data[5] = new Object[]{HttpURLConnection.HTTP_UNAVAILABLE, errorWithNoResponseBodyMessage, null};
+        data[6] = new Object[]{HttpURLConnection.HTTP_UNAVAILABLE, unexpectedResponseErrorMessage, null};
         return data;
     }
 

--- a/cli/central-client/src/test/java/org/ballerinalang/central/client/TestCentralApiClient.java
+++ b/cli/central-client/src/test/java/org/ballerinalang/central/client/TestCentralApiClient.java
@@ -40,6 +40,7 @@ import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.ByteArrayOutputStream;
@@ -84,6 +85,8 @@ public class TestCentralApiClient extends CentralAPIClient {
     private static final String OUTPUT_BALA = "output.bala";
     private static final String WINERY = "winery";
     private static final String ACCESS_TOKEN = "273cc9f6-c333-36ab-aa2q-f08e9513ff5y";
+    private final String balaUrl =
+            "https://fileserver.dev-central.ballerina.io/2.0/wso2/sf/1.3.5/sf-2020r2-any-1.3.5.bala";
     private final Call remoteCall = mock(Call.class);
     private final OkHttpClient client = mock(OkHttpClient.class);
 
@@ -135,7 +138,6 @@ public class TestCentralApiClient extends CentralAPIClient {
 
     @Test(description = "Test pull package", enabled = false)
     public void testPullPackage() throws IOException, CentralClientException {
-        final String balaUrl = "https://fileserver.dev-central.ballerina.io/2.0/wso2/sf/1.3.5/sf-2020r2-any-1.3.5.bala";
         Path balaPath = UTILS_TEST_RESOURCES.resolve(TEST_BALA_NAME);
         File balaFile = new File(String.valueOf(balaPath));
         InputStream balaStream = null;
@@ -153,7 +155,7 @@ public class TestCentralApiClient extends CentralAPIClient {
                     .request(mockRequest)
                     .protocol(Protocol.HTTP_1_1)
                     .code(HttpURLConnection.HTTP_MOVED_TEMP)
-                    .addHeader(LOCATION, balaUrl)
+                    .addHeader(LOCATION, this.balaUrl)
                     .addHeader(CONTENT_DISPOSITION, "attachment; filename=sf-2020r2-any-1.3.5.bala")
                     .message("")
                     .body(ResponseBody.create(
@@ -206,6 +208,93 @@ public class TestCentralApiClient extends CentralAPIClient {
         when(this.client.newCall(any())).thenReturn(this.remoteCall);
 
         this.pullPackage("foo", "sf", "1.3.5", TMP_DIR, ANY_PLATFORM, TEST_BAL_VERSION, false);
+    }
+
+    @DataProvider (name = "provideDataForBalaDownloadFailHttpCodes")
+    private Object[][] provideDataForBalaDownloadFailHttpCodes() {
+
+        // invalidRequestErrorMessage here might not be identical to the actual HTTP response error message
+        String invalidResponseErrorMessage = "package not found: foo/sf:*_any";
+        String errorWithNoResponseBodyMessage = "error: failed to pull the package: 'foo/sf:1.3.5'. " +
+                "BALA content download from '" + this.balaUrl + "' failed.";
+        String remoteRepositoryErrorMessage = errorWithNoResponseBodyMessage + " reason:" + invalidResponseErrorMessage;
+        String responseString = "{\"message\": \"" + invalidResponseErrorMessage + "\"}";
+
+        Object[][] data = new Object[6][3];
+        data[0] = new Object[]{HttpURLConnection.HTTP_NOT_FOUND, invalidResponseErrorMessage,
+                getResponseBody(responseString)};
+        data[1] = new Object[]{HttpURLConnection.HTTP_INTERNAL_ERROR, remoteRepositoryErrorMessage,
+                getResponseBody(responseString)};
+        data[2] = new Object[]{HttpURLConnection.HTTP_BAD_GATEWAY, remoteRepositoryErrorMessage,
+                getResponseBody(responseString)};
+        data[3] = new Object[]{HttpURLConnection.HTTP_UNAVAILABLE, remoteRepositoryErrorMessage,
+                getResponseBody(responseString)};
+        data[4] = new Object[]{HttpURLConnection.HTTP_GATEWAY_TIMEOUT, remoteRepositoryErrorMessage,
+                getResponseBody(responseString)};
+
+        // test BALA download with no response body
+        data[5] = new Object[]{HttpURLConnection.HTTP_UNAVAILABLE, errorWithNoResponseBodyMessage, null};
+        return data;
+    }
+
+    private ResponseBody getResponseBody(String responseString) {
+        return ResponseBody.create(MediaType.get(APPLICATION_JSON), responseString);
+    }
+
+    @Test(description = "Test pull package with different bala download failure response codes",
+            dataProvider = "provideDataForBalaDownloadFailHttpCodes")
+    public void testPullPackageWithBalaDownloadFailStatusCode(
+            int downloadBalaResponseCode, String errorMessage, ResponseBody responseBody)
+            throws IOException {
+        Path balaPath = UTILS_TEST_RESOURCES.resolve(TEST_BALA_NAME);
+        String balaFileName = "attachment; filename=sf-2020r2-any-1.3.5.bala";
+
+        try {
+            Request mockPullRequest = new Request.Builder()
+                    .get()
+                    .url("https://localhost:9090/registry/packages/foo/sf/1.3.5")
+                    .addHeader(ACCEPT_ENCODING, IDENTITY)
+                    .addHeader(ACCEPT, APPLICATION_OCTET_STREAM)
+                    .build();
+            Response mockPullResponse = new Response.Builder()
+                    .request(mockPullRequest)
+                    .protocol(Protocol.HTTP_1_1)
+                    .code(HttpURLConnection.HTTP_MOVED_TEMP)
+                    .addHeader(LOCATION, this.balaUrl)
+                    .addHeader(CONTENT_DISPOSITION, balaFileName)
+                    .message("")
+                    .body(ResponseBody.create(
+                            MediaType.get(APPLICATION_OCTET_STREAM),
+                            Files.readAllBytes(balaPath)
+                    ))
+                    .build();
+
+            Request mockDownloadBalaRequest = new Request.Builder()
+                    .get()
+                    .url(this.balaUrl)
+                    .header(ACCEPT_ENCODING, IDENTITY)
+                    .addHeader(CONTENT_DISPOSITION, balaFileName)
+                    .build();
+            Response mockDownloadBalaResponse = new Response.Builder()
+                    .request(mockDownloadBalaRequest)
+                    .protocol(Protocol.HTTP_1_1)
+                    .code(downloadBalaResponseCode)
+                    .message("")
+                    .body(responseBody)
+                    .build();
+
+            when(this.remoteCall.execute()).thenReturn(mockPullResponse, mockDownloadBalaResponse);
+            when(this.client.newCall(any())).thenReturn(this.remoteCall);
+
+            try {
+                this.pullPackage("foo", "sf", "1.3.5", TMP_DIR, ANY_PLATFORM, TEST_BAL_VERSION, false);
+                Assert.fail("pullPackage should throw a CentralClientException");
+            } catch (CentralClientException e) {
+                Assert.assertEquals(e.getMessage(), errorMessage);
+            }
+        } finally {
+            cleanTmpDir();
+        }
     }
 
     @Test(description = "Test get package")


### PR DESCRIPTION
## Purpose
Handle failures of the BALA download HTTP request in pullPackage method.

Fixes #37229

## Approach
Add validation that checks the response status code and throws errors.

## Remarks
Partially addresses https://github.com/wso2-enterprise/internal-support-ballerina/issues/150
