### PR TITLE
Set compileForBalPack to true in PackCommand

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PackCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PackCommand.java
@@ -239,7 +239,7 @@ public class PackCommand implements BLauncherCmd {
         TaskExecutor taskExecutor = new TaskExecutor.TaskBuilder()
                 .addTask(new CleanTargetDirTask(), isSingleFileBuild)
                 .addTask(new ResolveMavenDependenciesTask(outStream))
-                .addTask(new CompileTask(outStream, errStream))
+                .addTask(new CompileTask(outStream, errStream, true))
                 .addTask(new CreateBalaTask(outStream))
                 .addTask(new DumpBuildTimeTask(outStream), !project.buildOptions().dumpBuildTime())
                 .build();


### PR DESCRIPTION
## Purpose
Add logic missing in #37217
Change to use the `CompileTask` constructor with `compileForBalPack` was not included in the initial PR. This PR fixes that.

## Remarks
Automated tests and manually tests were done to ensure correct functionality.