### PR TITLE
Fix missing stackmap frame in async send

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) (2018-2022), WSO2 Inc. (http://www.wso2.com).
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -1165,7 +1165,7 @@ public class BIRGen extends BLangNodeVisitor {
     public void visit(BLangWorkerSend workerSend) {
         BIRBasicBlock thenBB = new BIRBasicBlock(this.env.nextBBId(names));
         addToTrapStack(thenBB);
-        this.env.enclBasicBlocks.add(thenBB);
+
         workerSend.expr.accept(this);
 
         String channelName = this.env.enclFunc.workerName.value + "->" + workerSend.workerIdentifier.value;
@@ -1175,6 +1175,7 @@ public class BIRGen extends BLangNodeVisitor {
                 workerSend.pos, names.fromString(channelName), this.env.targetOperand, isOnSameStrand, false, null,
                 thenBB, this.currentScope);
 
+        this.env.enclBasicBlocks.add(thenBB);
         this.env.enclBB = thenBB;
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) (2018-2022), WSO2 Inc. (http://www.wso2.com).
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerSyncSendTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerSyncSendTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) (2018-2022), WSO2 Inc. (http://www.wso2.com).
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except
@@ -96,7 +96,7 @@ public class WorkerSyncSendTest {
         }
         Assert.assertNotNull(expectedException);
         String result = "error: error3 {\"message\":\"msg3\"}\n" +
-                "\tat sync-send:$lambda$_15(sync-send.bal:295)";
+                "\tat sync-send:$lambda$_15(sync-send.bal:312)";
         Assert.assertEquals(expectedException.getMessage().trim(), result.trim());
     }
 
@@ -116,7 +116,7 @@ public class WorkerSyncSendTest {
         }
         Assert.assertNotNull(expectedException);
         String result = "error: err from panic from w2\n" +
-                "\tat sync-send:$lambda$_19(sync-send.bal:348)";
+                "\tat sync-send:$lambda$_19(sync-send.bal:365)";
         Assert.assertEquals(expectedException.getMessage().trim(), result.trim());
     }
 
@@ -130,7 +130,7 @@ public class WorkerSyncSendTest {
         }
         Assert.assertNotNull(expectedException);
         String result = "error: err from panic from w1 w1\n" +
-                "\tat sync-send:$lambda$_20(sync-send.bal:364)";
+                "\tat sync-send:$lambda$_20(sync-send.bal:381)";
         Assert.assertEquals(expectedException.getMessage().trim(), result.trim());
     }
 
@@ -144,7 +144,7 @@ public class WorkerSyncSendTest {
         }
         Assert.assertNotNull(expectedException);
         String result = "error: err from panic from w2\n" +
-                "\tat sync-send:$lambda$_23(sync-send.bal:396)";
+                "\tat sync-send:$lambda$_23(sync-send.bal:413)";
         Assert.assertEquals(expectedException.getMessage().trim(), result.trim());
     }
 
@@ -158,7 +158,7 @@ public class WorkerSyncSendTest {
         }
         Assert.assertNotNull(expectedException);
         String result = "error: err from panic from w3w3\n" +
-                "\tat sync-send:$lambda$_26(sync-send.bal:436)";
+                "\tat sync-send:$lambda$_26(sync-send.bal:453)";
         Assert.assertEquals(expectedException.getMessage().trim(), result.trim());
     }
 
@@ -182,6 +182,11 @@ public class WorkerSyncSendTest {
     @Test
     public void testSyncSendAfterSend() {
         BRunUtil.invoke(result, "testSyncSendAfterSend");
+    }
+
+    @Test
+    public void testAsyncSend() {
+        BRunUtil.invoke(result, "testAsyncSend");
     }
 
     @Test

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerSyncSendTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerSyncSendTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) (2018-2022), WSO2 Inc. (http://www.wso2.com).
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except

--- a/tests/jballerina-unit-test/src/test/resources/test-src/workers/sync-send.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/workers/sync-send.bal
@@ -1,3 +1,20 @@
+// Copyright (c) (2019-2022), WSO2 Inc. (http://www.wso2.com).
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
 import ballerina/jballerina.java;
 
 string append = "";
@@ -627,6 +644,56 @@ public function testFailureForReceiveWithError() returns boolean {
 
     record { boolean|E1|E2? w1; boolean|error? w2; } x = wait { w1, w2 };
     return x.w1 is E2 && x.w2 === true;
+}
+
+type recordType1 record {|
+    int a;
+    string b;
+|};
+
+function testAsyncSend() {
+    worker w1 {
+        int w1Count = 0;
+        2 -> w2;
+        w1Count += 1;
+        int[1] t1 = [1];
+        t1 -> w2;
+        w1Count += 1;
+        json t2 = [12, [4, 5]];
+        t2 -> w2;
+        [int, float] t3 = [10, 20];
+        t3 -> w2;
+        w1Count += 1;
+        map<()> p4 = <- w2;
+        record {
+            int a;
+            string b;
+        } p5 = <- w2;
+        w1Count += 1;
+        test:assertEquals(w1Count, 4);
+        test:assertEquals(p4, {a: ()});
+        test:assertEquals(p5, {a: 12, b: "strb"});
+    }
+
+    worker w2 {
+        int w2Count = 0;
+        int p1 = <- w1;
+        w2Count += 1;
+        int[1] p2 = <- w1;
+        w2Count += 1;
+        any p5 = <- w1;
+        w2Count += 1;
+        anydata p6 = <- w1;
+        map<()> p3 = {a: ()};
+        p3 -> w1;
+        recordType1 p4 = {a: 12, b: "strb"};
+        p4 -> w1;
+        test:assertEquals(w2Count, 3);
+        test:assertEquals(p1, 2);
+        test:assertEquals(p2, [1]);
+        test:assertEquals(p5, [12, [4, 5]]);
+        test:assertEquals(p6, [10, 20]);
+    }
 }
 
 function getFalse() returns boolean {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/workers/sync-send.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/workers/sync-send.bal
@@ -14,8 +14,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/test;
 import ballerina/jballerina.java;
+import ballerina/test;
 
 string append = "";
 function simpleSyncSend() returns string {


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues.

$title
Fixes #35858

## Approach
> Describe how you are implementing the solutions along with the design details.

This was caused due to the wrong order of basic blocks arrangement in the BIR. The code was changed to give the correct order in the BIR basic blocks list.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
