### PR TITLE
Add `nil` support for configurables

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/configurable/ConfigResolver.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/configurable/ConfigResolver.java
@@ -92,6 +92,8 @@ public class ConfigResolver {
     private Optional<?> getConfigValue(Module module, VariableKey key) {
         Type type = key.type;
         switch (type.getTag()) {
+            case TypeTags.NULL_TAG:
+                return Optional.empty();
             case TypeTags.INT_TAG:
                 return getConfigValue(key, configProvider -> configProvider
                         .getAsIntAndMark(module, key));

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -1246,17 +1246,17 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
                 recordType.getFields().forEach((fieldName, field) -> {
                     BType fieldType = field.type;
                     String fieldString = varName + "." + fieldName;
-                    String message = "record field type '" + fieldType + "' of field '" + fieldString +
-                            "' is not supported";
                     if (invalidTypeSet.contains(fieldType)) {
-                        errors.add(message);
+                        errors.add("record field type '" + fieldType + "' of field '" + fieldString + "' is not " +
+                                "supported");
                         return;
                     }
                     if (isNilableDefaultField(field, fieldType)) {
                         return;
                     }
                     if (!isSupportedConfigType(fieldType, errors, fieldString, unresolvedTypes, isRequired)) {
-                        errors.add(message);
+                        errors.add("record field type '" + fieldType + "' of field '" + fieldString + "' is not " +
+                                "supported");
                         invalidTypeSet.add(fieldType);
                     }
                 });

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -1227,10 +1227,7 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
             case FINITE:
                 return types.isAnydata(type);
             case NIL:
-                if (isRequired) {
-                    return false;
-                }
-                break;
+                return !isRequired;
             case ARRAY:
                 BType elementType = Types.getReferredType(((BArrayType) type).eType);
 

--- a/tests/jballerina-integration-test/src/test/resources/configurables/configLibProject/modules/mod1/lib.bal
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/configLibProject/modules/mod1/lib.bal
@@ -78,7 +78,8 @@ public type Symbols record {|
     string symbol1 = symbol1;
     string symbol2 = symbol2;
     string symbol3 = getSymbol();
-    string symbol4;
+    string? symbol4 = ();
+    string symbol5;
 |};
 
 public isolated function getWord() returns string {

--- a/tests/jballerina-integration-test/src/test/resources/configurables/configStructuredTypesProject/Config_default_values.toml
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/configStructuredTypesProject/Config_default_values.toml
@@ -1,19 +1,22 @@
 word2 = "word 2"
 
 [words]
-word6 = "word 6"
+word7 = "word 7"
 
 [numbers]
 num5 = 5
+num6 = 6
 
 [symbols]
-symbol4 = "$"
+symbol5 = "$"
 
 [container.words]
 word6 = "word 6"
+word7 = "word 7"
 
 [[wordArr]]
-word6 = "word 7"
+word6 = "word 6"
+word7 = "word 7"
 
 [[wordArr]]
 word1 = "word 10"
@@ -21,29 +24,30 @@ word2 = "word 20"
 word3 = "word 30"
 word4 = "word 40"
 word5 = "word 50"
-word6 = "word 60"
+word7 = "word 70"
 
 [[numberArr]]
-num5 = 6
+num6 = 6
 
 [[numberArr]]
 num1 = 10
 num2 = 20
 num3 = 30
 num4 = 40
-num5 = 50
+num6 = 60
 
 [[symbolArr]]
-symbol4 = "%"
+symbol4 = "@"
+symbol5 = "%"
 
 [[symbolArr]]
 symbol1 = "^"
 symbol2 = "&"
 symbol3 = "*"
-symbol4 = "-"
+symbol5 = "-"
 
 [[containerArr]]
-words.word6 = "word 7"
+words.word7 = "word 7"
 
 [[containerArr]]
 words.word1 = "word 10"
@@ -51,10 +55,11 @@ words.word2 = "word 20"
 words.word3 = "word 30"
 words.word4 = "word 40"
 words.word5 = "word 50"
-words.word6 = "word 60"
+words.word7 = "word 70"
 
 [[wordTable]]
-word6 = "word 7"
+word6 = "word 6"
+word7 = "word 7"
 
 [[wordTable]]
 word1 = "word 10"
@@ -62,29 +67,31 @@ word2 = "word 20"
 word3 = "word 30"
 word4 = "word 40"
 word5 = "word 50"
-word6 = "word 60"
+word7 = "word 70"
 
 [[numberTable]]
-num5 = 6
+num5 = 5
+num6 = 6
 
 [[numberTable]]
 num1 = 10
 num2 = 20
 num3 = 30
 num4 = 40
-num5 = 50
+num6 = 60
 
 [[symbolTable]]
-symbol4 = "%"
+symbol5 = "%"
 
 [[symbolTable]]
 symbol1 = "^"
 symbol2 = "&"
 symbol3 = "*"
-symbol4 = "-"
+symbol4 = "@"
+symbol5 = "-"
 
 [[containerTable]]
-words.word6 = "word 7"
+words.word7 = "word 7"
 
 [[containerTable]]
 words.word1 = "word 10"
@@ -93,42 +100,45 @@ words.word3 = "word 30"
 words.word4 = "word 40"
 words.word5 = "word 50"
 words.word6 = "word 60"
+words.word7 = "word 70"
 
 [wordMap]
-entry1.word6 = "word 6"
+entry1.word7 = "word 7"
 entry2.word1 = "word 11"
 entry2.word2 = "word 22"
 entry2.word3 = "word 33"
 entry2.word4 = "word 44"
 entry2.word5 = "word 55"
 entry2.word6 = "word 66"
+entry2.word7 = "word 77"
 
 [numberMap]
-entry1.num5 = 55
+entry1.num6 = 66
 entry2.num1 = 11
 entry2.num2 = 22
 entry2.num3 = 33
 entry2.num4 = 44
 entry2.num5 = 55
+entry2.num6 = 66
 
 [symbolMap]
-entry1.symbol4 = "="
+entry1.symbol5 = "="
 entry2.symbol1 = "+"
 entry2.symbol2 = "|"
 entry2.symbol3 = "}"
-entry2.symbol4 = "?"
+entry2.symbol5 = "?"
 
 [containerMap]
-entry1.words.word6 = "word 6"
+entry1.words.word7 = "word 7"
 entry2.words.word1 = "word 11"
 entry2.words.word2 = "word 22"
 entry2.words.word3 = "word 33"
 entry2.words.word4 = "word 44"
 entry2.words.word5 = "word 55"
-entry2.words.word6 = "word 66"
+entry2.words.word7 = "word 77"
 
 [[wordTableMap.map1]]
-word6 = "word 7"
+word7 = "word 7"
 
 [[wordTableMap.map2]]
 word1 = "word 10"
@@ -136,29 +146,30 @@ word2 = "word 20"
 word3 = "word 30"
 word4 = "word 40"
 word5 = "word 50"
-word6 = "word 60"
+word7 = "word 70"
 
 [[numberTableMap.map1]]
-num5 = 6
+num6 = 6
 
 [[numberTableMap.map2]]
 num1 = 10
 num2 = 20
 num3 = 30
 num4 = 40
-num5 = 50
+num6 = 60
 
 [[symbolTableMap.map1]]
-symbol4 = "%"
+symbol4 = "@"
+symbol5 = "%"
 
 [[symbolTableMap.map2]]
 symbol1 = "^"
 symbol2 = "&"
 symbol3 = "*"
-symbol4 = "-"
+symbol5 = "-"
 
 [[containerTableMap.map1]]
-words.word6 = "word 7"
+words.word7 = "word 7"
 
 [[containerTableMap.map2]]
 words.word1 = "word 10"
@@ -166,7 +177,7 @@ words.word2 = "word 20"
 words.word3 = "word 30"
 words.word4 = "word 40"
 words.word5 = "word 50"
-words.word6 = "word 60"
+words.word7 = "word 70"
 
 [defaultValuesRecord.type_defs]
 num2 = 2

--- a/tests/jballerina-integration-test/src/test/resources/configurables/configStructuredTypesProject/Config_default_values_inline.toml
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/configStructuredTypesProject/Config_default_values_inline.toml
@@ -8,27 +8,27 @@ testOrg.configLib.mod1.symbol2 = "@"
 testOrg.configLib.mod1.symbol3 = "#"
 
 word2 = "word 2"
-words = { word6 = "word 6" }
-numbers = { num5 = 5 }
-symbols = { symbol4 = "$" }
-container = { words = { word6 = "word 6" } }
+words = { word7 = "word 7" }
+numbers = { num5 = 5 , num6 = 6 }
+symbols = { symbol5 = "$" }
+container = { words = {word6 = "word 6", word7 = "word 7" } }
 
-wordArr = [{ word6 = "word 7" }, { word1 = "word 10", word2 = "word 20", word3 = "word 30", word4 = "word 40", word5 = "word 50", word6 = "word 60" }]
-numberArr = [{ num5 = 6 }, { num1 = 10, num2 = 20, num3 = 30, num4 = 40, num5 = 50 }]
-symbolArr = [{ symbol4 = "%" }, { symbol1 = "^", symbol2 = "&", symbol3 = "*", symbol4 = "-" }]
-containerArr = [{ words = { word6 = "word 7" } }, { words = { word1 = "word 10", word2 = "word 20", word3 = "word 30", word4 = "word 40", word5 = "word 50", word6 = "word 60" } }]
+wordArr = [{word6 = "word 6", word7 = "word 7" }, { word1 = "word 10", word2 = "word 20", word3 = "word 30", word4 = "word 40", word5 = "word 50", word7 = "word 70" }]
+numberArr = [{ num6 = 6 }, { num1 = 10, num2 = 20, num3 = 30, num4 = 40, num6 = 60 }]
+symbolArr = [{symbol4 = "@", symbol5 = "%" }, { symbol1 = "^", symbol2 = "&", symbol3 = "*", symbol5 = "-" }]
+containerArr = [{ words = { word7 = "word 7" } }, { words = { word1 = "word 10", word2 = "word 20", word3 = "word 30", word4 = "word 40", word5 = "word 50", word7 = "word 70" } }]
 
-wordTable = [{ word6 = "word 7" }, { word1 = "word 10", word2 = "word 20", word3 = "word 30", word4 = "word 40", word5 = "word 50", word6 = "word 60" }]
-numberTable = [{ num5 = 6 }, { num1 = 10, num2 = 20, num3 = 30, num4 = 40, num5 = 50 }]
-symbolTable = [{ symbol4 = "%" }, { symbol1 = "^", symbol2 = "&", symbol3 = "*", symbol4 = "-" }]
-containerTable = [{ words = { word6 = "word 7" } }, { words = { word1 = "word 10", word2 = "word 20", word3 = "word 30", word4 = "word 40", word5 = "word 50", word6 = "word 60" } }]
+wordTable = [{ word6 = "word 6", word7 = "word 7" }, { word1 = "word 10", word2 = "word 20", word3 = "word 30", word4 = "word 40", word5 = "word 50", word7 = "word 70" }]
+numberTable = [{ num5 = 5, num6 = 6 }, { num1 = 10, num2 = 20, num3 = 30, num4 = 40, num6 = 60 }]
+symbolTable = [{ symbol5 = "%" }, { symbol1 = "^", symbol2 = "&", symbol3 = "*", symbol4 = "@", symbol5 = "-" }]
+containerTable = [{ words = { word7 = "word 7" } }, { words = { word1 = "word 10", word2 = "word 20", word3 = "word 30", word4 = "word 40", word5 = "word 50", word6 = "word 60", word7 = "word 70" } }]
 
-wordMap = { entry1 = { word6 = "word 6" }, entry2 = { word1 = "word 11", word2 = "word 22", word3 = "word 33", word4 = "word 44", word5 = "word 55", word6 = "word 66" } }
-numberMap = { entry1 = { num5 = 55 }, entry2 = { num1 = 11, num2 = 22, num3 = 33, num4 = 44, num5 = 55 } }
-symbolMap = { entry1 = { symbol4 = "=" }, entry2 = { symbol1 = "+", symbol2 = "|", symbol3 = "}", symbol4 = "?" } }
-containerMap = { entry1 = { words = { word6 = "word 6" } }, entry2 = { words = { word1 = "word 11", word2 = "word 22", word3 = "word 33", word4 = "word 44", word5 = "word 55", word6 = "word 66" } } }
+wordMap = { entry1 = { word7 = "word 7" }, entry2 = { word1 = "word 11", word2 = "word 22", word3 = "word 33", word4 = "word 44", word5 = "word 55", word6 = "word 66", word7 = "word 77" } }
+numberMap = { entry1 = { num6 = 66 }, entry2 = { num1 = 11, num2 = 22, num3 = 33, num4 = 44, num5 = 55, num6 = 66 } }
+symbolMap = { entry1 = { symbol5 = "=" }, entry2 = { symbol1 = "+", symbol2 = "|", symbol3 = "}", symbol5 = "?" } }
+containerMap = { entry1 = { words = { word7 = "word 7" } }, entry2 = { words = { word1 = "word 11", word2 = "word 22", word3 = "word 33", word4 = "word 44", word5 = "word 55", word7 = "word 77" } } }
 
-wordTableMap = { map1 = [{ word6 = "word 7" }], map2 = [{ word1 = "word 10", word2 = "word 20", word3 = "word 30", word4 = "word 40", word5 = "word 50", word6 = "word 60" }] }
-numberTableMap = { map1 = [{ num5 = 6 }], map2 = [{ num1 = 10, num2 = 20, num3 = 30, num4 = 40, num5 = 50 }] }
-symbolTableMap = { map1 = [{ symbol4 = "%" }], map2 = [{ symbol1 = "^", symbol2 = "&", symbol3 = "*", symbol4 = "-" }] }
-containerTableMap = { map1 = [{ words = { word6 = "word 7" } }], map2 = [{ words = { word1 = "word 10", word2 = "word 20", word3 = "word 30", word4 = "word 40", word5 = "word 50", word6 = "word 60" } }] }
+wordTableMap = { map1 = [{ word7 = "word 7" }], map2 = [{ word1 = "word 10", word2 = "word 20", word3 = "word 30", word4 = "word 40", word5 = "word 50", word7 = "word 70" }] }
+numberTableMap = { map1 = [{ num6 = 6 }], map2 = [{ num1 = 10, num2 = 20, num3 = 30, num4 = 40, num6 = 60 }] }
+symbolTableMap = { map1 = [{ symbol4 = "@", symbol5 = "%" }], map2 = [{ symbol1 = "^", symbol2 = "&", symbol3 = "*", symbol5 = "-" }] }
+containerTableMap = { map1 = [{ words = { word7 = "word 7" } }], map2 = [{ words = { word1 = "word 10", word2 = "word 20", word3 = "word 30", word4 = "word 40", word5 = "word 50", word7 = "word 70" } }] }

--- a/tests/jballerina-integration-test/src/test/resources/configurables/configStructuredTypesProject/defaultValuesRecord/main.bal
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/configStructuredTypesProject/defaultValuesRecord/main.bal
@@ -29,7 +29,8 @@ type Words record {|
     string word3 = getWord();
     string word4 = type_defs:getWord();
     string word5 = configLib:getWord();
-    string word6;
+    string? word6 = ();
+    string word7;
 |};
 
 type WordsContainer record {|
@@ -67,61 +68,68 @@ configurable map<table<configLib:Symbols>> symbolTableMap = ?;
 configurable map<table<WordsContainer>> containerTableMap = ?;
 
 function testDefaultValues() {
-    test:assertEquals(words.toString(), "{\"word1\":\"word 1\",\"word2\":\"word 2\",\"word3\":\"word 3\"," + 
-    "\"word4\":\"word 4\",\"word5\":\"word 5\",\"word6\":\"word 6\"}");
-    test:assertEquals(wordArr.toString(), "[{\"word1\":\"word 1\",\"word2\":\"word 2\",\"word3\":\"word 3\"," + 
-    "\"word4\":\"word 4\",\"word5\":\"word 5\",\"word6\":\"word 7\"},{\"word1\":\"word 10\",\"word2\":\"word 20\"," + 
-    "\"word3\":\"word 30\",\"word4\":\"word 40\",\"word5\":\"word 50\",\"word6\":\"word 60\"}]");
-    test:assertEquals(wordTable.toString(), "[{\"word1\":\"word 1\",\"word2\":\"word 2\",\"word3\":\"word 3\"," + 
-    "\"word4\":\"word 4\",\"word5\":\"word 5\",\"word6\":\"word 7\"},{\"word1\":\"word 10\",\"word2\":\"word 20\"," + 
-    "\"word3\":\"word 30\",\"word4\":\"word 40\",\"word5\":\"word 50\",\"word6\":\"word 60\"}]");
-    test:assertEquals(wordMap.toString(), "{\"entry1\":{\"word1\":\"word 1\",\"word2\":\"word 2\"," + 
-    "\"word3\":\"word 3\",\"word4\":\"word 4\",\"word5\":\"word 5\",\"word6\":\"word 6\"}," + 
-    "\"entry2\":{\"word1\":\"word 11\",\"word2\":\"word 22\",\"word3\":\"word 33\",\"word4\":\"word 44\"," + 
-    "\"word5\":\"word 55\",\"word6\":\"word 66\"}}");
-    test:assertEquals(wordTableMap.toString(), "{\"map1\":[{\"word1\":\"word 1\",\"word2\":\"word 2\"," + 
-    "\"word3\":\"word 3\",\"word4\":\"word 4\",\"word5\":\"word 5\",\"word6\":\"word 7\"}]," + 
-    "\"map2\":[{\"word1\":\"word 10\",\"word2\":\"word 20\",\"word3\":\"word 30\",\"word4\":\"word 40\"," + 
-    "\"word5\":\"word 50\",\"word6\":\"word 60\"}]}");
+    test:assertEquals(words.toString(), "{\"word1\":\"word 1\",\"word2\":\"word 2\",\"word3\":\"word 3\"," +
+    "\"word4\":\"word 4\",\"word5\":\"word 5\",\"word6\":null,\"word7\":\"word 7\"}");
+    test:assertEquals(wordArr.toString(), "[{\"word1\":\"word 1\",\"word2\":\"word 2\",\"word3\":\"word 3\"," +
+    "\"word4\":\"word 4\",\"word5\":\"word 5\",\"word6\":\"word 6\",\"word7\":\"word 7\"},{\"word1\":\"word 10\"," +
+    "\"word2\":\"word 20\",\"word3\":\"word 30\",\"word4\":\"word 40\",\"word5\":\"word 50\",\"word6\":null,\"word7\":\"word 70\"}]");
+    test:assertEquals(wordTable.toString(), "[{\"word1\":\"word 1\",\"word2\":\"word 2\",\"word3\":\"word 3\"," +
+    "\"word4\":\"word 4\",\"word5\":\"word 5\",\"word6\":\"word 6\",\"word7\":\"word 7\"},{\"word1\":\"word 10\"," +
+    "\"word2\":\"word 20\",\"word3\":\"word 30\",\"word4\":\"word 40\",\"word5\":\"word 50\",\"word6\":null," +
+    "\"word7\":\"word 70\"}]");
+    test:assertEquals(wordMap.toString(), "{\"entry1\":{\"word1\":\"word 1\",\"word2\":\"word 2\"," +
+    "\"word3\":\"word 3\",\"word4\":\"word 4\",\"word5\":\"word 5\",\"word6\":null,\"word7\":\"word 7\"}," +
+    "\"entry2\":{\"word1\":\"word 11\",\"word2\":\"word 22\",\"word3\":\"word 33\",\"word4\":\"word 44\"," +
+    "\"word5\":\"word 55\",\"word6\":\"word 66\",\"word7\":\"word 77\"}}");
+    test:assertEquals(wordTableMap.toString(), "{\"map1\":[{\"word1\":\"word 1\",\"word2\":\"word 2\"," +
+    "\"word3\":\"word 3\",\"word4\":\"word 4\",\"word5\":\"word 5\",\"word6\":null,\"word7\":\"word 7\"}]," +
+    "\"map2\":[{\"word1\":\"word 10\",\"word2\":\"word 20\",\"word3\":\"word 30\",\"word4\":\"word 40\"," +
+    "\"word5\":\"word 50\",\"word6\":null,\"word7\":\"word 70\"}]}");
 
-    test:assertEquals(numbers.toString(), "{\"num1\":1,\"num2\":2,\"num3\":3,\"num4\":4,\"num5\":5}");
-    test:assertEquals(numberArr.toString(), "[{\"num1\":1,\"num2\":2,\"num3\":3,\"num4\":4,\"num5\":6}," + 
-    "{\"num1\":10,\"num2\":20,\"num3\":30,\"num4\":40,\"num5\":50}]");
-    test:assertEquals(numberTable.toString(), "[{\"num1\":1,\"num2\":2,\"num3\":3,\"num4\":4,\"num5\":6}," + 
-    "{\"num1\":10,\"num2\":20,\"num3\":30,\"num4\":40,\"num5\":50}]");
-    test:assertEquals(numberMap.toString(), "{\"entry1\":{\"num1\":1,\"num2\":2,\"num3\":3,\"num4\":4," + 
-    "\"num5\":55},\"entry2\":{\"num1\":11,\"num2\":22,\"num3\":33,\"num4\":44,\"num5\":55}}");
-    test:assertEquals(numberTableMap.toString(), "{\"map1\":[{\"num1\":1,\"num2\":2,\"num3\":3,\"num4\":4," + 
-    "\"num5\":6}],\"map2\":[{\"num1\":10,\"num2\":20,\"num3\":30,\"num4\":40,\"num5\":50}]}");
+    test:assertEquals(numbers.toString(), "{\"num1\":1,\"num2\":2,\"num3\":3,\"num4\":4,\"num5\":5,\"num6\":6}");
+    test:assertEquals(numberArr.toString(), "[{\"num1\":1,\"num2\":2,\"num3\":3,\"num4\":4,\"num5\":null,\"num6\":6}," +
+    "{\"num1\":10,\"num2\":20,\"num3\":30,\"num4\":40,\"num5\":null,\"num6\":60}]");
+    test:assertEquals(numberTable.toString(), "[{\"num1\":1,\"num2\":2,\"num3\":3,\"num4\":4,\"num5\":5,\"num6\":6}," +
+    "{\"num1\":10,\"num2\":20,\"num3\":30,\"num4\":40,\"num5\":null,\"num6\":60}]");
+    test:assertEquals(numberMap.toString(), "{\"entry1\":{\"num1\":1,\"num2\":2,\"num3\":3,\"num4\":4,\"num5\":null," +
+    "\"num6\":66},\"entry2\":{\"num1\":11,\"num2\":22,\"num3\":33,\"num4\":44,\"num5\":55,\"num6\":66}}");
+    test:assertEquals(numberTableMap.toString(), "{\"map1\":[{\"num1\":1,\"num2\":2,\"num3\":3,\"num4\":4," +
+    "\"num5\":null,\"num6\":6}],\"map2\":[{\"num1\":10,\"num2\":20,\"num3\":30,\"num4\":40,\"num5\":null," +
+    "\"num6\":60}]}");
 
-    test:assertEquals(symbols.toString(), "{\"symbol1\":\"!\",\"symbol2\":\"@\",\"symbol3\":\"#\",\"symbol4\":\"$\"}");
-    test:assertEquals(symbolArr.toString(), "[{\"symbol1\":\"!\",\"symbol2\":\"@\",\"symbol3\":\"#\"," + 
-    "\"symbol4\":\"%\"},{\"symbol1\":\"^\",\"symbol2\":\"&\",\"symbol3\":\"*\",\"symbol4\":\"-\"}]");
-    test:assertEquals(symbolTable.toString(), "[{\"symbol1\":\"!\",\"symbol2\":\"@\",\"symbol3\":\"#\"," + 
-    "\"symbol4\":\"%\"},{\"symbol1\":\"^\",\"symbol2\":\"&\",\"symbol3\":\"*\",\"symbol4\":\"-\"}]");
-    test:assertEquals(symbolMap.toString(), "{\"entry1\":{\"symbol1\":\"!\",\"symbol2\":\"@\",\"symbol3\":\"#\"," + 
-    "\"symbol4\":\"=\"},\"entry2\":{\"symbol1\":\"+\",\"symbol2\":\"|\",\"symbol3\":\"}\",\"symbol4\":\"?\"}}");
-    test:assertEquals(symbolTableMap.toString(), "{\"map1\":[{\"symbol1\":\"!\",\"symbol2\":\"@\",\"symbol3\":\"#\"," + 
-    "\"symbol4\":\"%\"}],\"map2\":[{\"symbol1\":\"^\",\"symbol2\":\"&\",\"symbol3\":\"*\",\"symbol4\":\"-\"}]}");
+    test:assertEquals(symbols.toString(), "{\"symbol1\":\"!\",\"symbol2\":\"@\",\"symbol3\":\"#\",\"symbol4\":null," +
+    "\"symbol5\":\"$\"}");
+    test:assertEquals(symbolArr.toString(), "[{\"symbol1\":\"!\",\"symbol2\":\"@\",\"symbol3\":\"#\"," +
+    "\"symbol4\":\"@\",\"symbol5\":\"%\"},{\"symbol1\":\"^\",\"symbol2\":\"&\",\"symbol3\":\"*\",\"symbol4\":null," +
+    "\"symbol5\":\"-\"}]");
+    test:assertEquals(symbolTable.toString(), "[{\"symbol1\":\"!\",\"symbol2\":\"@\",\"symbol3\":\"#\"," +
+    "\"symbol4\":null,\"symbol5\":\"%\"},{\"symbol1\":\"^\",\"symbol2\":\"&\",\"symbol3\":\"*\",\"symbol4\":\"@\"," +
+    "\"symbol5\":\"-\"}]");
+    test:assertEquals(symbolMap.toString(), "{\"entry1\":{\"symbol1\":\"!\",\"symbol2\":\"@\",\"symbol3\":\"#\"," +
+    "\"symbol4\":null,\"symbol5\":\"=\"},\"entry2\":{\"symbol1\":\"+\",\"symbol2\":\"|\",\"symbol3\":\"}\"," +
+    "\"symbol4\":null,\"symbol5\":\"?\"}}");
+    test:assertEquals(symbolTableMap.toString(), "{\"map1\":[{\"symbol1\":\"!\",\"symbol2\":\"@\",\"symbol3\":\"#\"," +
+    "\"symbol4\":\"@\",\"symbol5\":\"%\"}],\"map2\":[{\"symbol1\":\"^\",\"symbol2\":\"&\",\"symbol3\":\"*\"," +
+    "\"symbol4\":null,\"symbol5\":\"-\"}]}");
 
     test:assertEquals(container.toString(), "{\"words\":{\"word1\":\"word 1\",\"word2\":\"word 2\"," +
-    "\"word3\":\"word 3\",\"word4\":\"word 4\",\"word5\":\"word 5\",\"word6\":\"word 6\"}}");
+    "\"word3\":\"word 3\",\"word4\":\"word 4\",\"word5\":\"word 5\",\"word6\":\"word 6\",\"word7\":\"word 7\"}}");
     test:assertEquals(containerArr.toString(), "[{\"words\":{\"word1\":\"word 1\",\"word2\":\"word 2\"," +
-    "\"word3\":\"word 3\",\"word4\":\"word 4\",\"word5\":\"word 5\",\"word6\":\"word 7\"}}," +
+    "\"word3\":\"word 3\",\"word4\":\"word 4\",\"word5\":\"word 5\",\"word6\":null,\"word7\":\"word 7\"}}," +
     "{\"words\":{\"word1\":\"word 10\",\"word2\":\"word 20\",\"word3\":\"word 30\",\"word4\":\"word 40\"," +
-    "\"word5\":\"word 50\",\"word6\":\"word 60\"}}]");
+    "\"word5\":\"word 50\",\"word6\":null,\"word7\":\"word 70\"}}]");
     test:assertEquals(containerTable.toString(), "[{\"words\":{\"word1\":\"word 1\",\"word2\":\"word 2\"," +
-    "\"word3\":\"word 3\",\"word4\":\"word 4\",\"word5\":\"word 5\",\"word6\":\"word 7\"}}," +
+    "\"word3\":\"word 3\",\"word4\":\"word 4\",\"word5\":\"word 5\",\"word6\":null,\"word7\":\"word 7\"}}," +
     "{\"words\":{\"word1\":\"word 10\",\"word2\":\"word 20\",\"word3\":\"word 30\",\"word4\":\"word 40\"," +
-    "\"word5\":\"word 50\",\"word6\":\"word 60\"}}]");
+    "\"word5\":\"word 50\",\"word6\":\"word 60\",\"word7\":\"word 70\"}}]");
     test:assertEquals(containerMap.toString(), "{\"entry1\":{\"words\":{\"word1\":\"word 1\",\"word2\":\"word 2\"," +
-    "\"word3\":\"word 3\",\"word4\":\"word 4\",\"word5\":\"word 5\",\"word6\":\"word 6\"}}," +
+    "\"word3\":\"word 3\",\"word4\":\"word 4\",\"word5\":\"word 5\",\"word6\":null,\"word7\":\"word 7\"}}," +
     "\"entry2\":{\"words\":{\"word1\":\"word 11\",\"word2\":\"word 22\",\"word3\":\"word 33\",\"word4\":\"word 44\"," +
-    "\"word5\":\"word 55\",\"word6\":\"word 66\"}}}");
+    "\"word5\":\"word 55\",\"word6\":null,\"word7\":\"word 77\"}}}");
     test:assertEquals(containerTableMap.toString(), "{\"map1\":[{\"words\":{\"word1\":\"word 1\"," +
-    "\"word2\":\"word 2\",\"word3\":\"word 3\",\"word4\":\"word 4\",\"word5\":\"word 5\",\"word6\":\"word 7\"}}]," +
-    "\"map2\":[{\"words\":{\"word1\":\"word 10\",\"word2\":\"word 20\",\"word3\":\"word 30\",\"word4\":\"word 40\"," +
-    "\"word5\":\"word 50\",\"word6\":\"word 60\"}}]}");
+    "\"word2\":\"word 2\",\"word3\":\"word 3\",\"word4\":\"word 4\",\"word5\":\"word 5\",\"word6\":null," +
+    "\"word7\":\"word 7\"}}],\"map2\":[{\"words\":{\"word1\":\"word 10\",\"word2\":\"word 20\",\"word3\":\"word 30\"," +
+    "\"word4\":\"word 40\",\"word5\":\"word 50\",\"word6\":null,\"word7\":\"word 70\"}}]}");
 }
 
 isolated function getWord() returns string {
@@ -134,7 +142,7 @@ public function main() {
     testArrayIteration();
     testMapIteration();
     testTableIteration();
-    
+
     util:print("Tests passed");
 }
 
@@ -157,9 +165,9 @@ function testMapIteration() {
 }
 
 function testRecordIteration() {
-    util:testRecordIterator(words, 6);
-    util:testRecordIterator(numbers, 5);
-    util:testRecordIterator(symbols, 4);
+    util:testRecordIterator(words, 7);
+    util:testRecordIterator(numbers, 6);
+    util:testRecordIterator(symbols, 5);
     util:testRecordIterator(container, 1);
 }
 

--- a/tests/jballerina-integration-test/src/test/resources/configurables/configStructuredTypesProject/defaultValuesRecord/modules/type_defs/type_defs.bal
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/configStructuredTypesProject/defaultValuesRecord/modules/type_defs/type_defs.bal
@@ -26,7 +26,8 @@ public type Numbers record {|
     int num2 = num2;
     int num3 = getNumber();
     int num4 = configLib:getNumber();
-    int num5;
+    int? num5 = ();
+    int num6;
 |};
 
 public isolated function getWord() returns string {

--- a/tests/jballerina-integration-test/src/test/resources/configurables/configurableProject/main/main.bal
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/configurableProject/main/main.bal
@@ -23,6 +23,7 @@ configurable float floatVar = 9.5;
 configurable string stringVar = ?;
 configurable boolean booleanVar = ?;
 configurable decimal decimalVar = 10.1;
+configurable () nilVar = ();
 
 configurable int[] & readonly intArr = ?;
 configurable byte[] & readonly byteArr = ?;
@@ -30,6 +31,7 @@ configurable float[] & readonly floatArr = [9.0, 5.3, 5.6];
 configurable string[] & readonly stringArr = ["apple", "orange", "banana"];
 configurable boolean[] & readonly booleanArr = [true, true];
 configurable decimal[] & readonly decimalArr = ?;
+configurable ()[] nilArr = [];
 
 configurable int[][] & readonly int2DArr = ?;
 configurable byte[][] & readonly byte2DArr = ?;
@@ -37,9 +39,11 @@ configurable float[][] & readonly float2DArr = ?;
 configurable string[][] & readonly string2DArr = ?;
 configurable boolean[][] & readonly boolean2DArr = ?;
 configurable decimal[][] & readonly decimal2DArr = ?;
+configurable ()[][] & readonly nil2DArr = [];
 configurable int[][][] & readonly int3DArr = ?;
 
 type CustomArrayType1 int[];
+
 type CustomArrayType2 int[][];
 
 configurable CustomArrayType1[] & readonly customType1Array = ?;
@@ -52,6 +56,7 @@ type AuthInfo record {|
     string password;
     string[] scopes?;
     boolean isAdmin = false;
+    () nilField = ();
 |};
 
 type Employee record {|
@@ -74,7 +79,7 @@ type PersonInfo readonly & record {|
 
 type EmployeeInfo record {|
     int id;
-    string name= "test";
+    string name = "test";
     float salary?;
 |};
 
@@ -90,7 +95,7 @@ type PersonInfoTable table<PersonInfo> & readonly;
 
 type EmpInfoTable table<EmployeeInfo>;
 
-configurable AuthInfo & readonly admin = ?;
+configurable AuthInfo & readonly admin = {username: "admin", password: "1234"};
 configurable UserTable & readonly users = ?;
 configurable PersonInfo personInfo = ?;
 configurable EmployeeInfo & readonly empInfo = ?;
@@ -130,6 +135,7 @@ function testSimpleValues() {
     test:assertEquals(3.5, floatVar);
     test:assertEquals("abc", stringVar);
     test:assertTrue(booleanVar);
+    test:assertEquals((), nilVar);
 
     decimal result = 24.87;
     test:assertEquals(result, decimalVar);
@@ -143,6 +149,7 @@ function testArrayValues() {
     test:assertEquals([9.0, 5.6], floatArr);
     test:assertEquals(["red", "yellow", "green"], stringArr);
     test:assertEquals([true, false, false, true], booleanArr);
+    test:assertEquals([], nilArr);
 
     decimal[] & readonly resultArr = [8.9, 4.5, 6.2];
     test:assertEquals(resultArr, decimalArr);
@@ -152,29 +159,31 @@ function testArrayValues() {
 }
 
 function testMultiDimentionalArrayValues() {
-    test:assertEquals([[1,2],[3,4]], int2DArr);
+    test:assertEquals([[1, 2], [3, 4]], int2DArr);
     test:assertEquals([[9.0, 5.6], [4.1, 56.7]], float2DArr);
     test:assertEquals([["red", "yellow", "green"], ["white", "purple"]], string2DArr);
     test:assertEquals([[true, false], [false, true]], boolean2DArr);
+    test:assertEquals([], nil2DArr);
 
     decimal[][] & readonly resultArr = [[8.9, 4.5, 6.2], [5.4, 8.5]];
     test:assertEquals(resultArr, decimal2DArr);
 
-    byte[][] & readonly resultArr2 = [[11,22,33,44],[55,66,77,88,99]];
+    byte[][] & readonly resultArr2 = [[11, 22, 33, 44], [55, 66, 77, 88, 99]];
     test:assertEquals(byte2DArr, resultArr2);
 }
 
 function testCustomArrayTypeValues() {
-    test:assertEquals([[[1,2],[3,4]],[[1,2],[3,4]]], int3DArr);
-    test:assertEquals([[1,2],[3,4]], customType1Array);
-    test:assertEquals([[5,6],[7,8]], customType2Array);
-    test:assertEquals([[[5,6],[7,8]],[[5,6],[7,8]]], customType3DArray);
+    test:assertEquals([[[1, 2], [3, 4]], [[1, 2], [3, 4]]], int3DArr);
+    test:assertEquals([[1, 2], [3, 4]], customType1Array);
+    test:assertEquals([[5, 6], [7, 8]], customType2Array);
+    test:assertEquals([[[5, 6], [7, 8]], [[5, 6], [7, 8]]], customType3DArray);
 }
 
 function testRecordValues() {
     test:assertEquals("jack", admin.username);
     test:assertEquals("password", admin.password);
     test:assertEquals(["write", "read", "execute"], admin["scopes"]);
+    test:assertEquals((), admin.nilField);
     test:assertTrue(admin.isAdmin);
 
     test:assertEquals("harry", personInfo.name);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/globalvar/GlobalVarNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/globalvar/GlobalVarNegativeTest.java
@@ -165,16 +165,21 @@ public class GlobalVarNegativeTest {
                 " & readonly)'\n\t" +
                 "tuple element type '(json & readonly)' is not supported", 97, 1);
         BAssertUtil.validateError(result, i++, "configurable variable currently not supported for '()'", 105, 1);
-        BAssertUtil.validateError(result, i++, "configurable variable currently not supported for '(()[] & readonly)'\n" +
-                "\tarray element type '()' is not supported", 106, 1);
-        BAssertUtil.validateError(result, i++, "configurable variable currently not supported for '(string? & readonly)'\n" +
-                "\tunion member type '()' is not supported", 107, 1);
-        BAssertUtil.validateError(result, i++, "configurable variable currently not supported for '(map<()> & readonly)'\n" +
-                "\tmap constraint type '()' is not supported", 108, 1);
-        BAssertUtil.validateError(result, i++, "configurable variable currently not supported for '(Person6 & readonly)'\n" +
-                "\tunion member type '()' is not supported", 109, 1);
-        BAssertUtil.validateError(result, i++, "configurable variable currently not supported for '(table<map<()>> & readonly)'\n" +
-                "\tmap constraint type '()' is not supported", 111, 1);
+        BAssertUtil.validateError(result, i++, "configurable variable currently not supported for " +
+                "'(()[] & readonly)'\n\t" +
+                "array element type '()' is not supported", 106, 1);
+        BAssertUtil.validateError(result, i++, "configurable variable currently not supported for " +
+                "'(string? & readonly)'\n\t" +
+                "union member type '()' is not supported", 107, 1);
+        BAssertUtil.validateError(result, i++, "configurable variable currently not supported for " +
+                "'(map<()> & readonly)'\n\t" +
+                "map constraint type '()' is not supported", 108, 1);
+        BAssertUtil.validateError(result, i++, "configurable variable currently not supported for" +
+                " '(Person6 & readonly)'\n\t" +
+                "record field type '()' of field 'nilRecord1.field1' is not supported", 109, 1);
+        BAssertUtil.validateError(result, i++, "configurable variable currently not supported for " +
+                "'(table<map<()>> & readonly)'\n\t" +
+                "map constraint type '()' is not supported", 110, 1);
 
         Assert.assertEquals(result.getErrorCount(), i);
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/globalvar/GlobalVarNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/globalvar/GlobalVarNegativeTest.java
@@ -164,6 +164,18 @@ public class GlobalVarNegativeTest {
         BAssertUtil.validateError(result, i++, "configurable variable currently not supported for '([int,string,json]" +
                 " & readonly)'\n\t" +
                 "tuple element type '(json & readonly)' is not supported", 97, 1);
+        BAssertUtil.validateError(result, i++, "configurable variable currently not supported for '()'", 105, 1);
+        BAssertUtil.validateError(result, i++, "configurable variable currently not supported for '(()[] & readonly)'\n" +
+                "\tarray element type '()' is not supported", 106, 1);
+        BAssertUtil.validateError(result, i++, "configurable variable currently not supported for '(string? & readonly)'\n" +
+                "\tunion member type '()' is not supported", 107, 1);
+        BAssertUtil.validateError(result, i++, "configurable variable currently not supported for '(map<()> & readonly)'\n" +
+                "\tmap constraint type '()' is not supported", 108, 1);
+        BAssertUtil.validateError(result, i++, "configurable variable currently not supported for '(Person6 & readonly)'\n" +
+                "\tunion member type '()' is not supported", 109, 1);
+        BAssertUtil.validateError(result, i++, "configurable variable currently not supported for '(table<map<()>> & readonly)'\n" +
+                "\tmap constraint type '()' is not supported", 111, 1);
+
         Assert.assertEquals(result.getErrorCount(), i);
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/variabledef/configurable_global_var_decl_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/variabledef/configurable_global_var_decl_negative.bal
@@ -107,5 +107,4 @@ configurable ()[] nilArr = ?;
 configurable string? nilUnion = ?;
 configurable map<()> nilMap = ?;
 configurable Person6 nilRecord1 = ?;
-// configurable Person6 nilRecord2 = {field1: (), field2: "abc"};
 configurable table<map<()>> nilTable = ?;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/variabledef/configurable_global_var_decl_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/variabledef/configurable_global_var_decl_negative.bal
@@ -95,3 +95,17 @@ configurable json unionVar2 = ?;
 
 // Unsupported tuple type
 configurable [int, string, json] tupleVar = ?;
+
+// Unsupported nil type
+type Person6 record {|
+    () field1;
+    string? field2;
+|};
+
+configurable () nilVar = ?;
+configurable ()[] nilArr = ?;
+configurable string? nilUnion = ?;
+configurable map<()> nilMap = ?;
+configurable Person6 nilRecord1 = ?;
+// configurable Person6 nilRecord2 = {field1: (), field2: "abc"};
+configurable table<map<()>> nilTable = ?;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/variabledef/configurable_var_positive.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/variabledef/configurable_var_positive.bal
@@ -61,3 +61,16 @@ type CyclicUnion int|CyclicUnion[];
 configurable CyclicUnion unionVar = ?;
 
 configurable [int, string, float, decimal, anydata] a = ?;
+
+type Student record {|
+    () field1 = ();
+    string? field2 = "default value";
+|};
+
+configurable () nilVar = ();
+configurable ()[] nilArr = [];
+configurable string? nilUnion = "abc";
+configurable map<()> nilMap = {};
+configurable Student nilRecord1 = ?;
+configurable Student nilRecord2 = {field1: (), field2: "abc"};
+configurable table<map<()>> nilTable = table [];


### PR DESCRIPTION
## Purpose
$subject
Fixes #37045 
Fixes #28098

## Approach
 - Removed compiler validations if there's a default value is provided if the type is `nilable`
 - Add runtime implementation for `nil` values

## Samples
```ballerina
type Student record {|
    () field1 = ();
    string? field2 = "default value";
|};

configurable () nilVar = ();
configurable ()[] nilArr = [];
configurable string? nilUnion = "abc";
configurable map<()> nilMap = {};
configurable Student nilRecord1 = ?;
configurable Student nilRecord2 = {field1: (), field2: "abc"};
configurable table<map<()>> nilTable = table [];
```
## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [x] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
