### PR TITLE
Fix PackCommandTest failing test cases

### DIFF
--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/PackCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/PackCommandTest.java
@@ -219,15 +219,17 @@ public class PackCommandTest extends BaseCommandTest {
     }
 
     @Test(description = "Pack an empty package with empty Non Default")
-    public void testPackEmptyNonDefaultModule() {
+    public void testPackEmptyNonDefaultModule() throws IOException {
         Path projectPath = this.testResources.resolve("emptyNonDefaultModule");
         System.setProperty("user.dir", projectPath.toString());
 
         PackCommand packCommand = new PackCommand(projectPath, printStream, printStream, false, true);
         new CommandLine(packCommand).parseArgs();
         packCommand.execute();
+        String buildLog = readOutput(true);
 
-        Assert.assertTrue(projectPath.resolve("target").resolve("bala")
+        Assert.assertEquals(buildLog.replaceAll("\r", ""), getOutput("build-empty-nondefault-module.txt"));
+        Assert.assertFalse(projectPath.resolve("target").resolve("bala")
                 .resolve("wso2-emptyNonDefaultModule-any-0.1.0.bala").toFile().exists());
     }
 

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/PackCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/PackCommandTest.java
@@ -52,7 +52,7 @@ public class PackCommandTest extends BaseCommandTest {
         System.setProperty("user.dir", projectPath.toString());
 
         PackCommand packCommand = new PackCommand(projectPath, printStream, printStream, false, true);
-        new CommandLine(packCommand).parse();
+        new CommandLine(packCommand).parseArgs();
         packCommand.execute();
         String buildLog = readOutput(true);
 
@@ -67,7 +67,7 @@ public class PackCommandTest extends BaseCommandTest {
         System.setProperty("user.dir", projectPath.toString());
 
         PackCommand packCommand = new PackCommand(projectPath, printStream, printStream, false, true);
-        new CommandLine(packCommand).parse();
+        new CommandLine(packCommand).parseArgs();
         packCommand.execute();
         String buildLog = readOutput(true);
 
@@ -85,7 +85,7 @@ public class PackCommandTest extends BaseCommandTest {
         Path projectPath = this.testResources.resolve("validApplicationProject");
         System.setProperty("user.dir", projectPath.toString());
         PackCommand packCommand = new PackCommand(projectPath, printStream, printStream, false, true);
-        new CommandLine(packCommand).parse();
+        new CommandLine(packCommand).parseArgs();
         try {
             packCommand.execute();
         } catch (BLauncherException e) {
@@ -99,7 +99,7 @@ public class PackCommandTest extends BaseCommandTest {
         Path projectPath = this.testResources.resolve("valid-bal-file").resolve("hello_world.bal");
         System.setProperty("user.dir", this.testResources.resolve("valid-bal-file").toString());
         PackCommand packCommand = new PackCommand(projectPath, printStream, printStream, false, true);
-        new CommandLine(packCommand).parse();
+        new CommandLine(packCommand).parseArgs();
         try {
             packCommand.execute();
         } catch (BLauncherException e) {
@@ -113,7 +113,7 @@ public class PackCommandTest extends BaseCommandTest {
         Path projectPath = this.testResources.resolve("validProjectWithPlatformLibs");
         System.setProperty("user.dir", projectPath.toString());
         PackCommand packCommand = new PackCommand(projectPath, printStream, printStream, false, true);
-        new CommandLine(packCommand).parse();
+        new CommandLine(packCommand).parseArgs();
         packCommand.execute();
         String buildLog = readOutput(true);
 
@@ -128,7 +128,7 @@ public class PackCommandTest extends BaseCommandTest {
         Path projectPath = this.testResources.resolve("validProjectWithDependenciesToml");
         System.setProperty("user.dir", projectPath.toString());
         PackCommand packCommand = new PackCommand(projectPath, printStream, printStream, false, true);
-        new CommandLine(packCommand).parse();
+        new CommandLine(packCommand).parseArgs();
         packCommand.execute();
         String buildLog = readOutput(true);
 
@@ -150,7 +150,7 @@ public class PackCommandTest extends BaseCommandTest {
         Path projectPath = this.testResources.resolve("validProjectWoRootPkgInDepsToml");
         System.setProperty("user.dir", projectPath.toString());
         PackCommand packCommand = new PackCommand(projectPath, printStream, printStream, false, true);
-        new CommandLine(packCommand).parse();
+        new CommandLine(packCommand).parseArgs();
         packCommand.execute();
         String buildLog = readOutput(true);
 
@@ -169,7 +169,7 @@ public class PackCommandTest extends BaseCommandTest {
         System.setProperty("user.dir", projectPath.toString());
 
         PackCommand packCommand = new PackCommand(projectPath, printStream, printStream, false, true);
-        new CommandLine(packCommand).parse();
+        new CommandLine(packCommand).parseArgs();
         packCommand.execute();
         String buildLog = readOutput(true);
 
@@ -185,7 +185,7 @@ public class PackCommandTest extends BaseCommandTest {
         System.setProperty("user.dir", projectPath.toString());
 
         PackCommand packCommand = new PackCommand(projectPath, printStream, printStream, false, true);
-        new CommandLine(packCommand).parse();
+        new CommandLine(packCommand).parseArgs();
         packCommand.execute();
 
         Assert.assertTrue(projectPath.resolve("target").resolve("bala")
@@ -198,7 +198,7 @@ public class PackCommandTest extends BaseCommandTest {
         System.setProperty("user.dir", projectPath.toString());
 
         PackCommand packCommand = new PackCommand(projectPath, printStream, printStream, false, true);
-        new CommandLine(packCommand).parse();
+        new CommandLine(packCommand).parseArgs();
         packCommand.execute();
 
         Assert.assertTrue(projectPath.resolve("target").resolve("bala")
@@ -211,7 +211,7 @@ public class PackCommandTest extends BaseCommandTest {
         System.setProperty("user.dir", projectPath.toString());
 
         PackCommand packCommand = new PackCommand(projectPath, printStream, printStream, false, true);
-        new CommandLine(packCommand).parse();
+        new CommandLine(packCommand).parseArgs();
         packCommand.execute();
 
         Assert.assertTrue(projectPath.resolve("target").resolve("bala")
@@ -224,7 +224,7 @@ public class PackCommandTest extends BaseCommandTest {
         System.setProperty("user.dir", projectPath.toString());
 
         PackCommand packCommand = new PackCommand(projectPath, printStream, printStream, false, true);
-        new CommandLine(packCommand).parse();
+        new CommandLine(packCommand).parseArgs();
         packCommand.execute();
 
         Assert.assertTrue(projectPath.resolve("target").resolve("bala")
@@ -239,7 +239,7 @@ public class PackCommandTest extends BaseCommandTest {
 
         PackCommand packCommand = new PackCommand(projectPath, printStream, printStream, false, true,
                 customTargetDir);
-        new CommandLine(packCommand).parse();
+        new CommandLine(packCommand).parseArgs();
         packCommand.execute();
         String buildLog = readOutput(true);
 
@@ -260,7 +260,7 @@ public class PackCommandTest extends BaseCommandTest {
 
         PackCommand packCommand = new PackCommand(projectPath, printStream, printStream, false, true,
                 customTargetDir);
-        new CommandLine(packCommand).parse();
+        new CommandLine(packCommand).parseArgs();
         packCommand.execute();
         String buildLog = readOutput(true);
 
@@ -279,7 +279,7 @@ public class PackCommandTest extends BaseCommandTest {
         System.setProperty("user.dir", projectPath.toString());
 
         PackCommand packCommand = new PackCommand(projectPath, printStream, printStream, false, true);
-        new CommandLine(packCommand).parse();
+        new CommandLine(packCommand).parseArgs();
         packCommand.execute();
 
         String buildLog = readOutput(true);
@@ -293,7 +293,7 @@ public class PackCommandTest extends BaseCommandTest {
         System.setProperty("user.dir", projectPath.toString());
 
         PackCommand packCommand = new PackCommand(projectPath, printStream, printStream, false, true);
-        new CommandLine(packCommand).parse();
+        new CommandLine(packCommand).parseArgs();
         packCommand.execute();
 
         String buildLog = readOutput(true);

--- a/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/unix/build-project-wo-root-pkg-in-deps-toml.txt
+++ b/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/unix/build-project-wo-root-pkg-in-deps-toml.txt
@@ -1,5 +1,6 @@
 Compiling source
 	foo/winery:0.1.0
+WARNING [main.bal:(6:4,6:58)] unused variable 'isSuccess'
 
 Creating bala
 	target/bala/foo-winery-java11-0.1.0.bala

--- a/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/windows/build-project-wo-root-pkg-in-deps-toml.txt
+++ b/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/windows/build-project-wo-root-pkg-in-deps-toml.txt
@@ -1,5 +1,6 @@
 Compiling source
 	foo/winery:0.1.0
+WARNING [main.bal:(6:4,6:58)] unused variable 'isSuccess'
 
 Creating bala
 	target\bala\foo-winery-java11-0.1.0.bala


### PR DESCRIPTION
## Purpose
Fix `testPackEmptyNonDefaultModule` and `testPackageWithoutRootPackageInDependenciesToml`

Fixes #37262

## Approach

- testPackEmptyNonDefaultModule

The test checks if a BALA file is created for an empty package with no .bal files. This failed due to a new change made to the pack command. The change is throwing an error if a package do not contain any bal files. Hence changed the logic of the test to check if the correct error is thrown.

- testPackageWithoutRootPackageInDependenciesToml

Here the output of the `PackCommand.execute()` command produces a warning for an unused variable. However the log file that is compared against this output does not contain the warning. Added the warning to both unix/windows output log files to fix this test.

## Samples
N/A.

## Remarks
Replaced depricated parse() in PackCommandTest with parseArgs().

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
