### PR TITLE
[2201.2.x] Remove position of readonly record type definitions

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -8667,7 +8667,7 @@ public class Desugar extends BLangNodeVisitor {
                 || funcBody.stmts.get(funcBody.stmts.size() - 1).getKind() != NodeKind.RETURN)) {
             Location invPos = invokableNode.pos;
             Location returnStmtPos;
-            if (!invokableNode.name.value.contains(GENERATED_INIT_SUFFIX.value) && invPos != null) {
+            if (invPos != null && !invokableNode.name.value.contains(GENERATED_INIT_SUFFIX.value)) {
                 returnStmtPos = new BLangDiagnosticLocation(invPos.lineRange().filePath(),
                         invPos.lineRange().endLine().line(),
                         invPos.lineRange().endLine().line(),

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -8667,14 +8667,14 @@ public class Desugar extends BLangNodeVisitor {
                 || funcBody.stmts.get(funcBody.stmts.size() - 1).getKind() != NodeKind.RETURN)) {
             Location invPos = invokableNode.pos;
             Location returnStmtPos;
-            if (invokableNode.name.value.contains(GENERATED_INIT_SUFFIX.value)) {
-                returnStmtPos = null;
-            } else {
+            if (!invokableNode.name.value.contains(GENERATED_INIT_SUFFIX.value) && invPos != null) {
                 returnStmtPos = new BLangDiagnosticLocation(invPos.lineRange().filePath(),
                         invPos.lineRange().endLine().line(),
                         invPos.lineRange().endLine().line(),
                         invPos.lineRange().startLine().offset(),
                         invPos.lineRange().startLine().offset(), 0, 0);
+            } else {
+                returnStmtPos = null;
             }
             BLangReturn returnStmt = ASTBuilderUtil.createNilReturnStmt(returnStmtPos, symTable.nilType);
             funcBody.addStatement(returnStmt);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ImmutableTypeCloner.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ImmutableTypeCloner.java
@@ -600,7 +600,7 @@ public class ImmutableTypeCloner {
         immutableRecordType.tsymbol = recordSymbol;
 
         BLangRecordTypeNode recordTypeNode = TypeDefBuilderHelper.createRecordTypeNode(new ArrayList<>(),
-                                                                                       immutableRecordType, pos);
+                                                                                       immutableRecordType, null);
 
         populateImmutableStructureFields(types, symTable, anonymousModelHelper, names, recordTypeNode,
                                          immutableRecordType, origRecordType, pos, env, pkgID, unresolvedTypes);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ImmutableTypeCloner.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ImmutableTypeCloner.java
@@ -600,7 +600,7 @@ public class ImmutableTypeCloner {
         immutableRecordType.tsymbol = recordSymbol;
 
         BLangRecordTypeNode recordTypeNode = TypeDefBuilderHelper.createRecordTypeNode(new ArrayList<>(),
-                                                                                       immutableRecordType, null);
+                                                                                       immutableRecordType, pos);
 
         populateImmutableStructureFields(types, symTable, anonymousModelHelper, names, recordTypeNode,
                                          immutableRecordType, origRecordType, pos, env, pkgID, unresolvedTypes);
@@ -609,9 +609,7 @@ public class ImmutableTypeCloner {
                     unresolvedTypes);
 
         TypeDefBuilderHelper.createInitFunctionForRecordType(recordTypeNode, env, names, symTable);
-        BLangTypeDefinition typeDefinition = TypeDefBuilderHelper.addTypeDefinition(immutableRecordType, recordSymbol,
-                                                                                    recordTypeNode, env);
-        typeDefinition.pos = pos;
+        TypeDefBuilderHelper.addTypeDefinition(immutableRecordType, recordSymbol, recordTypeNode, env);
         return immutableRecordIntersectionType;
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/TypeDefBuilderHelper.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/TypeDefBuilderHelper.java
@@ -215,7 +215,6 @@ public class TypeDefBuilderHelper {
         typeDefinition.setBType(type);
         typeDefinition.symbol = symbol;
         typeDefinition.name = createIdentifier(symbol.pos, symbol.name.value);
-        typeDefinition.pos = typeNode.getPosition();
         env.enclPkg.addTypeDefinition(typeDefinition);
         return typeDefinition;
     }
@@ -359,7 +358,7 @@ public class TypeDefBuilderHelper {
         }
         BLangUserDefinedType origTypeRef = new BLangUserDefinedType(
                 ASTBuilderUtil.createIdentifier(pos,
-                        TypeDefBuilderHelper.getPackageAlias(env, pos.lineRange().filePath(),
+                        TypeDefBuilderHelper.getPackageAlias(env, null,
                                 origStructureType.tsymbol.pkgID)),
                 ASTBuilderUtil.createIdentifier(pos, origStructureType.tsymbol.name.value));
         origTypeRef.pos = pos;

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/CodeCoverageReportTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/CodeCoverageReportTest.java
@@ -181,14 +181,16 @@ public class CodeCoverageReportTest extends BaseTestCase {
     private HashMap<String, List<String>> getExpectedCoverageClasses() {
         HashMap<String, List<String>> coverageClassMap = new HashMap<>();
         coverageClassMap.put(multiModuleTestRoot,
-                Arrays.asList(new String[]{multiModuleTestRoot + "/main", multiModuleTestRoot + "/foo"}));
+                Arrays.asList(multiModuleTestRoot + "/main", multiModuleTestRoot + "/foo",
+                        multiModuleTestRoot + "/$value$Record", multiModuleTestRoot + "/$typedesc$Record",
+                        multiModuleTestRoot + "/$value$ABC"));
         coverageClassMap.put(multiModuleTestRoot + "/modules/bar",
-                Arrays.asList(new String[]{multiModuleTestRoot + "/modules/bar/main"}));
+                List.of(multiModuleTestRoot + "/modules/bar/main"));
         coverageClassMap.put(multiModuleTestRoot + "/modules/math",
-                Arrays.asList(new String[]{multiModuleTestRoot + "/modules/math/add", multiModuleTestRoot +
-                        "/modules/math/divide", multiModuleTestRoot + "/modules/math/foo$$$math"}));
+                Arrays.asList(multiModuleTestRoot + "/modules/math/add", multiModuleTestRoot +
+                        "/modules/math/divide", multiModuleTestRoot + "/modules/math/foo$$$math"));
         coverageClassMap.put(multiModuleTestRoot + "/modules/bar.tests",
-                Arrays.asList(new String[]{multiModuleTestRoot + "/modules/bar.tests/foo$$$bar$$$tests"}));
+                List.of(multiModuleTestRoot + "/modules/bar.tests/foo$$$bar$$$tests"));
         return coverageClassMap;
     }
 

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/TestReportTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/TestReportTest.java
@@ -88,7 +88,7 @@ public class TestReportTest extends BaseTestCase {
         runCommand(args);
 
         int mathTotal = 2, mathPassed = 2, mathFailed = 0, mathSkipped = 0;
-        int fooTotal = 2, fooPassed = 0, fooFailed = 1, fooSkipped = 1;
+        int fooTotal = 3, fooPassed = 1, fooFailed = 1, fooSkipped = 1;
         int bartestTotal = 1, bartestPassed = 1, bartestFailed = 0, bartestSkipped = 0;
 
         int[] mathStatus =  {mathTotal, mathPassed, mathFailed, mathSkipped};
@@ -207,7 +207,8 @@ public class TestReportTest extends BaseTestCase {
         float mathPercentage = (float) (Math.round(mathPercentageVal * 100.0) / 100.0);
 
         //foo module
-        int[] fooMainCovered = new int[]{19, 22, 23, 24, 29, 30, 36, 37}, fooMainMissed = new int[]{26};
+        int[] fooMainCovered = new int[]{19, 22, 23, 24, 29, 30, 36, 37,
+                42, 43, 52, 53, 54, 57, 58, 61, 62, 66, 67, 68, 71, 72}, fooMainMissed = new int[]{26};
         float fooMainPercentageVal =
                 (float) (fooMainCovered.length) / (fooMainCovered.length + fooMainMissed.length) * 100;
         float fooMainPercentage =
@@ -321,7 +322,8 @@ public class TestReportTest extends BaseTestCase {
         float mathPercentage = (float) (Math.round(mathPercentageVal * 100.0) / 100.0);
 
         //foo module
-        int[] fooMainCovered = new int[]{}, fooMainMissed = new int[]{19, 22, 23, 24, 26, 29, 30, 36, 37};
+        int[] fooMainCovered = new int[]{}, fooMainMissed = new int[]{19, 22, 23, 24, 26, 29, 30, 36, 37,
+                42, 43, 52, 53, 54, 57, 58, 61, 62, 66, 67, 68, 71, 72};
         float fooMainPercentageVal =
                 (float) (fooMainCovered.length) / (fooMainCovered.length + fooMainMissed.length) * 100;
         float fooMainPercentage = (float) (Math.round(fooMainPercentageVal * 100.0) / 100.0);

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/test-report-tests/main.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/test-report-tests/main.bal
@@ -35,3 +35,38 @@ public function incrementValue(int a) {
     // Prints hello
     int b = a + 1;
 }
+
+// Record type definition
+type Record record {
+    int i;
+    string description = "abc";
+};
+
+type INT int;
+
+class ABC {
+    private final readonly & Record rec;
+    private final readonly & INT num;
+
+    function init(int x) {
+        self.rec = createRec(x);
+        self.num = getInt(x);
+    }
+
+    function getRec() returns Record {
+        return self.rec;
+    }
+
+    function getNum() returns int {
+        return self.num;
+    }
+}
+
+function createRec(int x) returns readonly & Record {
+    readonly & Record rec = {i: x, description: "desc"};
+    return rec;
+}
+
+function getInt(int x) returns readonly & int {
+    return x;
+}

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/test-report-tests/tests/main_test.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/test-report-tests/tests/main_test.bal
@@ -31,3 +31,10 @@ function testFunction() {
     test:assertTrue(true, msg = "Failed!");
 }
 
+@test:Config {}
+function testFunc() {
+    ABC abc = new(5);
+    Record rec = {description: "desc", i: 5};
+    test:assertEquals(abc.getRec(), rec);
+    test:assertEquals(abc.getNum(), 5);
+}


### PR DESCRIPTION
## Purpose
> $Subject

Fixes #36914

## Approach
> Readonly record type definition position has been made as null in order to avoid its position is being added to the line number table.

## Samples
## Remarks
## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [x] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
