### PR TITLE
Update code action node validator and update qNameRef code action to check for validity of resultant node

### DIFF
--- a/compiler/linter-plugin/src/main/java/io/ballerina/compiler/linter/impl/codeactions/QualifiedIdentifierCodeAction.java
+++ b/compiler/linter-plugin/src/main/java/io/ballerina/compiler/linter/impl/codeactions/QualifiedIdentifierCodeAction.java
@@ -17,6 +17,8 @@
  */
 package io.ballerina.compiler.linter.impl.codeactions;
 
+import io.ballerina.compiler.api.symbols.ModuleSymbol;
+import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.syntax.tree.NonTerminalNode;
 import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
@@ -65,10 +67,31 @@ public class QualifiedIdentifierCodeAction extends LinterCodeAction {
         final String updatedText;
         SyntaxKind kind = node.kind();
         if (kind == SyntaxKind.QUALIFIED_NAME_REFERENCE) {
-            final QualifiedNameReferenceNode qualifiedNameReferenceNode = (QualifiedNameReferenceNode) node;
-            updatedText = qualifiedNameReferenceNode.modulePrefix().toSourceCode().strip()
-                    + qualifiedNameReferenceNode.colon().toSourceCode().strip()
-                    + qualifiedNameReferenceNode.identifier().toSourceCode().strip();
+            final QualifiedNameReferenceNode qNameRefNode = (QualifiedNameReferenceNode) node;
+            // If identifier is missing, we don't provide the code action. Here's an example scenario
+            // function myFunction() {
+            //      http:<cursor>    
+            // }
+            if (qNameRefNode.identifier().isMissing() || context.cursorPosition().isEmpty()) {
+                return Optional.empty();
+            }
+            // Check if the resulting qualified name reference (once space is removed), is a valid type. i.e if the 
+            // resultant type exists in the target module
+            boolean validQName = context.currentSemanticModel()
+                    .visibleSymbols(context.currentDocument(), context.cursorPosition().get()).stream()
+                    .filter(symbol -> symbol.kind() == SymbolKind.MODULE)
+                    .map(symbol -> (ModuleSymbol) symbol)
+                    .filter(moduleSymbol -> qNameRefNode.modulePrefix().text().equals(moduleSymbol.id().modulePrefix()))
+                    .anyMatch(moduleSymbol -> moduleSymbol.allSymbols().stream()
+                            .filter(symbol -> symbol.getName().isPresent())
+                            .anyMatch(symbol -> symbol.getName().get().equals(qNameRefNode.identifier().text())));
+            if (!validQName) {
+                return Optional.empty();
+            }
+
+            updatedText = qNameRefNode.modulePrefix().toSourceCode().strip()
+                    + qNameRefNode.colon().toSourceCode().strip()
+                    + qNameRefNode.identifier().toSourceCode().strip();
         } else if (kind == SyntaxKind.XML_QUALIFIED_NAME) {
             final XMLQualifiedNameNode xmlQualifiedNameNode = (XMLQualifiedNameNode) node;
             updatedText = xmlQualifiedNameNode.prefix().toSourceCode().strip()

--- a/compiler/linter-plugin/src/test/java/io/ballerina/compiler/linter/codeactions/test/CodeActionTests.java
+++ b/compiler/linter-plugin/src/test/java/io/ballerina/compiler/linter/codeactions/test/CodeActionTests.java
@@ -54,25 +54,27 @@ public class CodeActionTests {
     void testCheckUsageCodeAction(final String file, final LinePosition cursorPos) throws IOException {
 
         final String expectedProvider = Constants.BCE_INVALID_CHECK + SLASH + Constants.CA_CHECK_USAGE;
-        testSingleDiagnosticCodeAction(file, cursorPos, expectedProvider);
+        testSingleDiagnosticCodeAction(file, cursorPos, expectedProvider, false);
     }
 
     @DataProvider
     public Object[] checkQNameDP() {
         return new Object[][]{
-                {"source/qname1.bal", LinePosition.from(2, 5), Constants.BCE_INTERVENING_WS},
-                {"source/qname2.bal", LinePosition.from(2, 5), Constants.BCE_INTERVENING_WS},
-                {"source/qname3.bal", LinePosition.from(2, 9), Constants.BCE_INTERVENING_WS},
-                {"source/qname4.bal", LinePosition.from(3, 4), Constants.BCE_INVALID_WS}
+                {"source/qname1.bal", LinePosition.from(2, 5), Constants.BCE_INTERVENING_WS, false},
+                {"source/qname2.bal", LinePosition.from(2, 5), Constants.BCE_INTERVENING_WS, false},
+                {"source/qname3.bal", LinePosition.from(2, 9), Constants.BCE_INTERVENING_WS, false},
+                {"source/qname4.bal", LinePosition.from(3, 4), Constants.BCE_INVALID_WS, false},
+                {"source/qnameNegative1.bal", LinePosition.from(3, 9), Constants.BCE_INTERVENING_WS, true},
+                {"source/qnameNegative2.bal", LinePosition.from(9, 3), Constants.BCE_INTERVENING_WS, true},
         };
     }
 
     @Test(dataProvider = "checkQNameDP")
     void testQNameCodeAction(final String file, final LinePosition cursorPos,
-                             final String diagnosticCode) throws IOException {
+                             final String diagnosticCode, boolean negative) throws IOException {
 
         final String expectedProvider = diagnosticCode + SLASH + Constants.CA_QUALIFIED_IDENTIFIER;
-        testSingleDiagnosticCodeAction(file, cursorPos, expectedProvider);
+        testSingleDiagnosticCodeAction(file, cursorPos, expectedProvider, negative);
     }
 
 
@@ -93,22 +95,27 @@ public class CodeActionTests {
                                               final String diagnosticCode) throws IOException {
 
         final String expectedProvider = diagnosticCode + SLASH + Constants.CA_FLOATING_POINT;
-        testSingleDiagnosticCodeAction(file, cursorPos, expectedProvider);
+        testSingleDiagnosticCodeAction(file, cursorPos, expectedProvider, false);
     }
 
     private void testSingleDiagnosticCodeAction(final String file, final LinePosition cursorPos,
-                                                final String expectedProvider) throws IOException {
+                                                final String expectedProvider, boolean negative) throws IOException {
 
         final Path filePath = CodeActionUtils.getProjectPath(file);
         final Project project = BCompileUtil.loadProject(file);
 
         final List<CodeActionInfo> codeActions = CodeActionUtils.getCodeActions(project, filePath, cursorPos);
-        Assert.assertTrue(codeActions.size() > 0, "Expect at least 1 code action");
+        Assert.assertTrue(codeActions.size() > 0 || negative, "Expect at least 1 code action");
 
         final Optional<CodeActionInfo> found = codeActions.stream()
                 .filter(info -> expectedProvider.equals(info.getProviderName()))
                 .findFirst();
-        Assert.assertTrue(found.isPresent(), "Code Action not found:" + expectedProvider);
+        if (negative) {
+            Assert.assertTrue(found.isEmpty(), "Code Action not expected:" + expectedProvider);
+            return;
+        } else {
+            Assert.assertTrue(found.isPresent(), "Code Action not found:" + expectedProvider);
+        }
 
         final List<DocumentEdit> actualEdits = CodeActionUtils.executeCodeAction(project, filePath, found.get());
         Assert.assertEquals(actualEdits.size(), 1, "Expected changes to n files");

--- a/compiler/linter-plugin/src/test/resources/source/qnameNegative1.bal
+++ b/compiler/linter-plugin/src/test/resources/source/qnameNegative1.bal
@@ -1,0 +1,5 @@
+import ballerina/http;
+
+function test() {
+    http:
+}

--- a/compiler/linter-plugin/src/test/resources/source/qnameNegative2.bal
+++ b/compiler/linter-plugin/src/test/resources/source/qnameNegative2.bal
@@ -1,0 +1,14 @@
+import ballerina/io;
+
+type Teacher record {
+    string name;
+    int age;
+};
+
+public function main() {
+
+io:
+
+Teacher[] x = [];
+
+}

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionNodeValidator.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionNodeValidator.java
@@ -20,8 +20,13 @@ import io.ballerina.compiler.syntax.tree.BasicLiteralNode;
 import io.ballerina.compiler.syntax.tree.BinaryExpressionNode;
 import io.ballerina.compiler.syntax.tree.CaptureBindingPatternNode;
 import io.ballerina.compiler.syntax.tree.CheckExpressionNode;
+import io.ballerina.compiler.syntax.tree.ClassDefinitionNode;
+import io.ballerina.compiler.syntax.tree.ExpressionFunctionBodyNode;
 import io.ballerina.compiler.syntax.tree.FieldAccessExpressionNode;
+import io.ballerina.compiler.syntax.tree.FunctionBodyBlockNode;
 import io.ballerina.compiler.syntax.tree.FunctionCallExpressionNode;
+import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
+import io.ballerina.compiler.syntax.tree.FunctionSignatureNode;
 import io.ballerina.compiler.syntax.tree.KeySpecifierNode;
 import io.ballerina.compiler.syntax.tree.LetExpressionNode;
 import io.ballerina.compiler.syntax.tree.LetVariableDeclarationNode;
@@ -267,6 +272,52 @@ public class CodeActionNodeValidator extends NodeTransformer<Boolean> {
         return isVisited(node) || !node.isKeyword().isMissing()
                 && node.typeDescriptor().apply(this)
                 && node.expression().apply(this);
+    }
+
+    @Override
+    public Boolean transform(FunctionDefinitionNode node) {
+        return isVisited(node) || !node.functionKeyword().isMissing()
+                && !node.functionName().isMissing()
+                && node.leadingInvalidTokens().isEmpty()
+                && node.trailingInvalidTokens().isEmpty()
+                && node.functionSignature().apply(this)
+                && node.functionBody().apply(this)
+                && node.parent().apply(this);
+    }
+
+    @Override
+    public Boolean transform(FunctionSignatureNode node) {
+        return isVisited(node) || !node.openParenToken().isMissing()
+                && !node.closeParenToken().isMissing()
+                && node.leadingInvalidTokens().isEmpty()
+                && node.trailingInvalidTokens().isEmpty()
+                && node.parameters().stream().allMatch(parameterNode -> parameterNode.apply(this));
+    }
+
+    @Override
+    public Boolean transform(FunctionBodyBlockNode node) {
+        return isVisited(node) || !node.isMissing()
+                && !node.openBraceToken().isMissing()
+                && !node.closeBraceToken().isMissing()
+                && node.leadingInvalidTokens().isEmpty()
+                && node.trailingInvalidTokens().isEmpty();
+    }
+
+    @Override
+    public Boolean transform(ExpressionFunctionBodyNode node) {
+        return isVisited(node) || !node.rightDoubleArrow().isMissing()
+                && !node.expression().isMissing();
+    }
+
+    @Override
+    public Boolean transform(ClassDefinitionNode node) {
+        return isVisited(node) || !node.classKeyword().isMissing()
+                && !node.className().isMissing()
+                && !node.openBrace().isMissing()
+                && !node.closeBrace().isMissing()
+                && node.leadingInvalidTokens().isEmpty()
+                && node.trailingInvalidTokens().isEmpty()
+                && node.members().stream().allMatch(member -> member.apply(this));
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/docs/AddDocumentationCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/docs/AddDocumentationCodeAction.java
@@ -18,6 +18,7 @@ package org.ballerinalang.langserver.codeaction.providers.docs;
 import io.ballerina.compiler.syntax.tree.NonTerminalNode;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import org.ballerinalang.annotation.JavaSPIService;
+import org.ballerinalang.langserver.codeaction.CodeActionNodeValidator;
 import org.ballerinalang.langserver.command.executors.AddDocumentationExecutor;
 import org.ballerinalang.langserver.common.constants.CommandConstants;
 import org.ballerinalang.langserver.common.utils.PositionUtil;
@@ -64,18 +65,20 @@ public class AddDocumentationCodeAction implements RangeBasedCodeActionProvider 
         return 999;
     }
 
+    @Override
+    public boolean validate(CodeActionContext context, RangeBasedPositionDetails positionDetails) {
+        return positionDetails.matchedDocumentableNode().isPresent() 
+                && !hasDocs(positionDetails.matchedDocumentableNode().get())
+                && CodeActionNodeValidator.validate(positionDetails.matchedCodeActionNode());
+    }
+
     /**
      * {@inheritDoc}
      */
     @Override
-    public List<CodeAction> getCodeActions(CodeActionContext context,
-                                           RangeBasedPositionDetails posDetails) {
+    public List<CodeAction> getCodeActions(CodeActionContext context, RangeBasedPositionDetails posDetails) {
         String docUri = context.fileUri();
         Optional<NonTerminalNode> documentableNode = posDetails.matchedDocumentableNode();
-
-        if (documentableNode.isEmpty() || hasDocs(documentableNode.get())) {
-            return Collections.emptyList();
-        }
 
         CommandArgument docUriArg = CommandArgument.from(CommandConstants.ARG_KEY_DOC_URI, docUri);
         CommandArgument lineStart = CommandArgument.from(CommandConstants.ARG_KEY_NODE_RANGE,

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/AddDocumentationTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/AddDocumentationTest.java
@@ -34,10 +34,16 @@ public class AddDocumentationTest extends AbstractCodeActionTest {
         return "add-documentation";
     }
 
-    @Override
     @Test(dataProvider = "codeaction-data-provider")
+    @Override
     public void test(String config) throws IOException, WorkspaceDocumentException {
         super.test(config);
+    }
+
+    @Test(dataProvider = "negativeDataProvider")
+    @Override
+    public void negativeTest(String config) throws IOException, WorkspaceDocumentException {
+        super.negativeTest(config);
     }
 
     @DataProvider(name = "codeaction-data-provider")
@@ -60,6 +66,13 @@ public class AddDocumentationTest extends AbstractCodeActionTest {
                 {"serviceDocumentation1.json"},
                 // Already documented nodes
                 {"documentAlreadyDocumentedConfig1.json"},
+        };
+    }
+
+    @DataProvider
+    public Object[][] negativeDataProvider() {
+        return new Object[][]{
+                {"negativeDocGeneration1.json"},
         };
     }
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/add-documentation/config/negativeDocGeneration1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/add-documentation/config/negativeDocGeneration1.json
@@ -1,0 +1,12 @@
+{
+  "position": {
+    "line": 1,
+    "character": 17
+  },
+  "source": "negativeDocGenerationSource.bal",
+  "expected": [
+    {
+      "title": "Document this"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/add-documentation/source/negativeDocGenerationSource.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/add-documentation/source/negativeDocGenerationSource.bal
@@ -1,0 +1,5 @@
+class className {
+    className.function name() {
+        
+    }
+}


### PR DESCRIPTION
## Purpose
$subject

Fixes #34714
Fixes #36632
Fixes #36660

## Approach
Added missing transform methods to code action node validator and update qNameRef code action to validate the resultant text edit.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
