### PR TITLE
[Backport 2201.0.x] Disallow desugar query expression twice for method invocation

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -6402,6 +6402,11 @@ public class Desugar extends BLangNodeVisitor {
         reorderArguments(invocation);
 
         rewriteExprs(invocation.requiredArgs);
+        if (!invocation.requiredArgs.isEmpty() && invocation.langLibInvocation) {
+            invocation.expr = invocation.requiredArgs.get(0);
+        } else {
+            invocation.expr = rewriteExpr(invocation.expr);
+        }
         fixStreamTypeCastsInInvocationParams(invocation);
         fixNonRestArgTypeCastInTypeParamInvocation(invocation);
 
@@ -6414,7 +6419,6 @@ public class Desugar extends BLangNodeVisitor {
             visitFunctionPointerInvocation(invocation);
             return;
         }
-        invocation.expr = rewriteExpr(invocation.expr);
         result = invRef;
 
         BInvokableSymbol invSym = (BInvokableSymbol) invocation.symbol;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -6402,7 +6402,7 @@ public class Desugar extends BLangNodeVisitor {
         reorderArguments(invocation);
 
         rewriteExprs(invocation.requiredArgs);
-        if (!invocation.requiredArgs.isEmpty() && invocation.langLibInvocation) {
+        if (invocation.langLibInvocation && !invocation.requiredArgs.isEmpty()) {
             invocation.expr = invocation.requiredArgs.get(0);
         } else {
             invocation.expr = rewriteExpr(invocation.expr);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryExpressionWithVarTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryExpressionWithVarTypeTest.java
@@ -252,6 +252,11 @@ public class QueryExpressionWithVarTypeTest {
         BRunUtil.invoke(result, "testQueryConstructingTableWithVar");
     }
 
+    @Test(description = "Test method call expressions on query expressions")
+    public void testMethodCallExprsOnQueryExprs() {
+        BRunUtil.invoke(result, "testMethodCallExprsOnQueryExprs");
+    }
+
     @AfterClass
     public void tearDown() {
         result = null;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/simple-query-with-var-type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/simple-query-with-var-type.bal
@@ -403,6 +403,42 @@ function testQueryConstructingTableWithVar() returns error? {
     assertEquality({"user": u1}, result2.get(u1));
 }
 
+function testMethodCallExprsOnQueryExprs() {
+    string[] words = ["a", "b", "c"];
+    var len = (from string str in words
+        select str).length();
+    assertEquality(3, len);
+
+    len = (from string str in words
+        where str == "a"
+        select str).length();
+    assertEquality(1, len);
+
+    string word = (from string str in words
+        select str).pop();
+    assertEquality("c", word);
+
+    int? index = (from string str in words
+        select str).indexOf("b");
+    assertEquality(1, index);
+
+    boolean isReadonly = (from string str in words
+        select str).isReadOnly();
+    assertEquality(false, isReadonly);
+
+    word = (from string str in words
+        select str).remove(0);
+    assertEquality("a", word);
+
+    words = (from string str in words
+        select str).filter(w => w is string);
+    assertEquality(["a", "b", "c"], words);
+
+    words = (from string str in words
+        select str).reverse();
+    assertEquality(["c", "b", "a"], words);
+}
+
 function assertEquality(anydata expected, anydata actual) {
     if expected == actual {
         return;


### PR DESCRIPTION
## Purpose

Fixes #34225

## Approach
> Expression and first required argument is same for langlib methods. It is desugared twice. This change will restrict desugaring expression for langlib methods.

## Samples
After this change this code will not give the compilation error.
```
string[] words = ["a", "b", "c"];
    var len = (from string str in words
        select str).length();
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
