### PR TITLE
Fix formatter to work properly with function signatures

### DIFF
--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormatterUtils.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormatterUtils.java
@@ -29,7 +29,7 @@ class FormatterUtils {
 
     static final String NEWLINE_SYMBOL = System.getProperty("line.separator");
 
-    static boolean isInLineRange(Node node, LineRange lineRange) {
+    static boolean isInlineRange(Node node, LineRange lineRange) {
         if (lineRange == null) {
             return true;
         }

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingEnv.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingEnv.java
@@ -64,7 +64,7 @@ public class FormattingEnv {
     /**
      * Flag indicating whether the annotations should be inline.
      */
-    boolean inLineAnnotation = false;
+    boolean inlineAnnotation = false;
 
     /**
      * Previous token's trailing whitespaces.

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
@@ -354,7 +354,7 @@ public class FormattingTreeModifier extends TreeModifier {
         indent(2);
         SeparatedNodeList<ParameterNode> parameters =
                 formatSeparatedNodeList(functionSignatureNode.parameters(), 0, 0, 0, 0, 0, 0, true);
-        unindent(2);
+        unIndent(2);
 
         Token closePara;
         ReturnTypeDescriptorNode returnTypeDesc = null;
@@ -427,7 +427,7 @@ public class FormattingTreeModifier extends TreeModifier {
         NamedWorkerDeclarator namedWorkerDeclarator =
                 formatNode(functionBodyBlockNode.namedWorkerDeclarator().orElse(null), 0, 1);
 
-        unindent(); // reset the indentation
+        unIndent(); // reset the indentation
         Token closeBrace = formatToken(functionBodyBlockNode.closeBraceToken(), env.trailingWS, env.trailingNL);
 
         return functionBodyBlockNode.modify()
@@ -529,7 +529,7 @@ public class FormattingTreeModifier extends TreeModifier {
         Token openBrace = formatToken(blockStatementNode.openBraceToken(), 0, 1);
         indent(); // start an indentation
         NodeList<StatementNode> statements = formatNodeList(blockStatementNode.statements(), 0, 1, 0, 1);
-        unindent(); // end the indentation
+        unIndent(); // end the indentation
         Token closeBrace = formatToken(blockStatementNode.closeBraceToken(), env.trailingWS, env.trailingNL);
 
         return blockStatementNode.modify()
@@ -557,7 +557,7 @@ public class FormattingTreeModifier extends TreeModifier {
                 0, fieldTrailingNL);
         RecordRestDescriptorNode recordRestDescriptor =
                 formatNode(recordTypeDesc.recordRestDescriptor().orElse(null), fieldTrailingWS, fieldTrailingNL);
-        unindent(); // Revert indentation for record fields
+        unIndent(); // Revert indentation for record fields
         Token bodyEndDelimiter = formatToken(recordTypeDesc.bodyEndDelimiter(), env.trailingWS, env.trailingNL);
 
         return recordTypeDesc.modify()
@@ -662,7 +662,7 @@ public class FormattingTreeModifier extends TreeModifier {
         Token openBrace = formatToken(serviceDeclarationNode.openBraceToken(), 0, 1);
         indent(); // increase the indentation of the following statements.
         NodeList<Node> members = formatNodeList(serviceDeclarationNode.members(), 0, 1, 0, 1);
-        unindent(); // reset the indentation.
+        unIndent(); // reset the indentation.
         Token closeBrace = formatToken(serviceDeclarationNode.closeBraceToken(), env.trailingWS, env.trailingNL);
 
         return serviceDeclarationNode.modify()
@@ -875,13 +875,13 @@ public class FormattingTreeModifier extends TreeModifier {
         Node varRef = formatNode(assignmentStatementNode.varRef(), 1, 0);
         Token equalsToken = formatToken(assignmentStatementNode.equalsToken(), 1, 0);
 
-        boolean previousinLineAnnotation = env.inLineAnnotation;
+        boolean previousInLineAnnotation = env.inLineAnnotation;
         setInLineAnnotation(true);
 
         ExpressionNode expression = formatNode(assignmentStatementNode.expression(), 0, 0);
         Token semicolonToken = formatToken(assignmentStatementNode.semicolonToken(), env.trailingWS, env.trailingNL);
 
-        setInLineAnnotation(previousinLineAnnotation);
+        setInLineAnnotation(previousInLineAnnotation);
 
         return assignmentStatementNode.modify()
                 .withVarRef(varRef)
@@ -1134,12 +1134,12 @@ public class FormattingTreeModifier extends TreeModifier {
     @Override
     public ParenthesisedTypeDescriptorNode transform(ParenthesisedTypeDescriptorNode parenthesisedTypeDescriptorNode) {
         Token openParenToken = formatToken(parenthesisedTypeDescriptorNode.openParenToken(), 0, 0);
-        TypeDescriptorNode typedesc = formatNode(parenthesisedTypeDescriptorNode.typedesc(), 0, 0);
+        TypeDescriptorNode typeDesc = formatNode(parenthesisedTypeDescriptorNode.typedesc(), 0, 0);
         Token closeParenToken = formatToken(parenthesisedTypeDescriptorNode.closeParenToken(),
                 env.trailingWS, env.trailingNL);
         return parenthesisedTypeDescriptorNode.modify()
                 .withOpenParenToken(openParenToken)
-                .withTypedesc(typedesc)
+                .withTypedesc(typeDesc)
                 .withCloseParenToken(closeParenToken)
                 .apply();
     }
@@ -1192,7 +1192,7 @@ public class FormattingTreeModifier extends TreeModifier {
         indent();
         SeparatedNodeList<MappingFieldNode> fields = formatSeparatedNodeList(
                 mappingConstructorExpressionNode.fields(), 0, 0, fieldTrailingWS, fieldTrailingNL, 0, fieldTrailingNL);
-        unindent();
+        unIndent();
         Token closeBrace = formatToken(mappingConstructorExpressionNode.closeBrace(), env.trailingWS, env.trailingNL);
 
         return mappingConstructorExpressionNode.modify()
@@ -1244,7 +1244,7 @@ public class FormattingTreeModifier extends TreeModifier {
         indent();
         SeparatedNodeList<Node> expressions = formatSeparatedNodeList(listConstructorExpressionNode.expressions(),
                 0, 0, fieldTrailingWS, fieldTrailingNL, 0, fieldTrailingNL);
-        unindent();
+        unIndent();
         Token closeBracket = formatToken(listConstructorExpressionNode.closeBracket(),
                 env.trailingWS, env.trailingNL);
 
@@ -1494,7 +1494,7 @@ public class FormattingTreeModifier extends TreeModifier {
         Token openBrace = formatToken(matchStatementNode.openBrace(), 0, 1);
         indent();
         NodeList<MatchClauseNode> matchClauses = formatNodeList(matchStatementNode.matchClauses(), 0, 1, 0, 1);
-        unindent();
+        unIndent();
         Token closeBrace;
 
         if (hasOnFailClause) {
@@ -1599,7 +1599,7 @@ public class FormattingTreeModifier extends TreeModifier {
         indent();
         SeparatedNodeList<Node> enumMemberList = formatSeparatedNodeList(enumDeclarationNode.enumMemberList(),
                 0, 0, 0, 1, 0, 1);
-        unindent();
+        unIndent();
         Token closeBraceToken = formatToken(enumDeclarationNode.closeBraceToken(), env.trailingWS, env.trailingNL);
 
         return enumDeclarationNode.modify()
@@ -2216,7 +2216,7 @@ public class FormattingTreeModifier extends TreeModifier {
         indent();
         NodeList<NamedWorkerDeclarationNode> namedWorkerDeclarations =
                 formatNodeList(forkStatementNode.namedWorkerDeclarations(), 0, 1, 0, 1);
-        unindent();
+        unIndent();
         Token closeBraceToken = formatToken(forkStatementNode.closeBraceToken(), env.trailingWS, env.trailingNL);
 
         return forkStatementNode.modify()
@@ -2345,7 +2345,7 @@ public class FormattingTreeModifier extends TreeModifier {
         indent();
         NodeList<Node> members = formatNodeList(objectTypeDescriptorNode.members(), fieldTrailingWS, fieldTrailingNL,
                 0, fieldTrailingNL);
-        unindent();
+        unIndent();
         Token closeBrace = formatToken(objectTypeDescriptorNode.closeBrace(), env.trailingWS, env.trailingNL);
 
         return objectTypeDescriptorNode.modify()
@@ -2379,7 +2379,7 @@ public class FormattingTreeModifier extends TreeModifier {
         indent();
         NodeList<Node> members = formatNodeList(objectConstructorExpressionNode.members(),
                 fieldTrailingWS, fieldTrailingNL, 0, fieldTrailingNL);
-        unindent();
+        unIndent();
         Token closeBraceToken = formatToken(objectConstructorExpressionNode.closeBraceToken(),
                 env.trailingWS, env.trailingNL);
 
@@ -2508,10 +2508,10 @@ public class FormattingTreeModifier extends TreeModifier {
         SeparatedNodeList<Node> mappingConstructors =
                 formatSeparatedNodeList(tableConstructorExpressionNode.rows(), 0, 0, rowTrailingWS, rowTrailingNL, 0,
                         rowTrailingNL);
-        unindent();
+        unIndent();
         Token closeBracket =
                 formatToken(tableConstructorExpressionNode.closeBracket(), env.trailingWS, env.trailingNL);
-        unindent();
+        unIndent();
 
         return tableConstructorExpressionNode.modify()
                 .withTableKeyword(tableKeyword)
@@ -2582,7 +2582,7 @@ public class FormattingTreeModifier extends TreeModifier {
                 formatSeparatedNodeList(letExpressionNode.letVarDeclarations(), 0, 0, 0, 1);
         Token inKeyword = formatToken(letExpressionNode.inKeyword(), 1, 0);
         ExpressionNode expression = formatNode(letExpressionNode.expression(), env.trailingWS, env.trailingNL);
-        unindent();
+        unIndent();
 
         return letExpressionNode.modify()
                 .withLetKeyword(letKeyword)
@@ -2762,7 +2762,7 @@ public class FormattingTreeModifier extends TreeModifier {
         OnConflictClauseNode onConflictClause = formatNode(queryExpressionNode.onConflictClause().orElse(null),
                 env.trailingWS, env.trailingNL);
         if (lineLength != 0) {
-            unindent();
+            unIndent();
         }
 
         return queryExpressionNode.modify()
@@ -2921,7 +2921,7 @@ public class FormattingTreeModifier extends TreeModifier {
         SeparatedNodeList<NameReferenceNode> receiveFields = formatSeparatedNodeList(receiveFieldsNode.receiveFields(),
                 0, 1, 0, 1);
         Token closeBrace = formatToken(receiveFieldsNode.closeBrace(), 0, 1);
-        unindent();
+        unIndent();
         return receiveFieldsNode.modify()
                 .withOpenBrace(openBrace)
                 .withReceiveFields(receiveFields)
@@ -3022,7 +3022,7 @@ public class FormattingTreeModifier extends TreeModifier {
                 env.trailingWS, env.trailingNL);
         if (lineLength != 0) {
             // Revert the indentation for statements starting with query expression nodes.
-            unindent();
+            unIndent();
         }
 
         return queryActionNode.modify()
@@ -3339,7 +3339,7 @@ public class FormattingTreeModifier extends TreeModifier {
 
         indent();
         NodeList<Node> members = formatNodeList(classDefinitionNode.members(), 0, 1, 0, 1);
-        unindent();
+        unIndent();
         Token closeBrace = formatToken(classDefinitionNode.closeBrace(), env.trailingWS, env.trailingNL);
 
         return classDefinitionNode.modify()
@@ -3658,7 +3658,7 @@ public class FormattingTreeModifier extends TreeModifier {
             env.leadingNL = trailingNL > 0 ? trailingNL - 1 : 0;
 
             // If this node has a trailing new line, then the next immediate token
-            // will become the first token the the next line
+            // will become the first token the next line
             env.hasNewline = trailingNL > 0 || hasTrailingNL(token);
             env.trailingNL = prevTrailingNL;
             env.trailingWS = prevTrailingWS;
@@ -3861,7 +3861,7 @@ public class FormattingTreeModifier extends TreeModifier {
                     separatorTrailingWS++;
                 }
             }
-            Token newSeparator = formatToken(oldSeparator, separatorTrailingWS, separatorTrailingNL);;
+            Token newSeparator = formatToken(oldSeparator, separatorTrailingWS, separatorTrailingNL);
             newNodes[(2 * index) + 1] = newSeparator;
 
             if (oldSeparator != newSeparator) {
@@ -3885,12 +3885,11 @@ public class FormattingTreeModifier extends TreeModifier {
      * @param itemTrailingWS Number of single-length spaces to be added after each item in the list
      * @param itemTrailingNL Number of newlines to be added after each item in the list
      * @param separatorTrailingWS Number of single-length spaces to be added after each separator in the list
-     * @param separatorTrailingNL Number of newlines to be added after each each separator in the list
+     * @param separatorTrailingNL Number of newlines to be added after each separator in the list
      * @param listTrailingWS Number of single-length spaces to be added after the last item in the list
      * @param listTrailingNL Number of newlines to be added after the last item in the list
      * @return Formatted node list
      */
-    @SuppressWarnings("unchecked")
     protected <T extends Node> SeparatedNodeList<T> formatSeparatedNodeList(SeparatedNodeList<T> nodeList,
                                                                             int itemTrailingWS,
                                                                             int itemTrailingNL,
@@ -3984,7 +3983,7 @@ public class FormattingTreeModifier extends TreeModifier {
                 return true;
 
             // Template literals are multi line tokens, and newline are
-            // part of the content. Hence we cannot wrap those.
+            // part of the content. Hence, we cannot wrap those.
             case XML_TEMPLATE_EXPRESSION:
             case STRING_TEMPLATE_EXPRESSION:
             case TEMPLATE_STRING:
@@ -4046,7 +4045,7 @@ public class FormattingTreeModifier extends TreeModifier {
         Minutiae prevMinutiae = null;
         if (env.hasNewline) {
             // 'hasNewlines == true' means a newline has already been added.
-            // Therefore increase the 'consecutiveNewlines' count
+            // Therefore, increase the 'consecutiveNewlines' count
             consecutiveNewlines++;
 
             for (int i = 0; i < env.leadingNL; i++) {
@@ -4080,7 +4079,7 @@ public class FormattingTreeModifier extends TreeModifier {
                     break;
                 case COMMENT_MINUTIAE:
                     if (consecutiveNewlines == 0) {
-                        // A comment without a leading newline is only possible if there is a explicit newline added
+                        // A comment without a leading newline is only possible if there is an explicit newline added
                         // by the user. So, it is being honored here.
                         leadingMinutiae.add(getNewline());
                     }
@@ -4242,8 +4241,8 @@ public class FormattingTreeModifier extends TreeModifier {
     /**
      * Undo the indentation of the code by the number of white-spaces defined by tab-size.
      */
-    private void unindent() {
-        unindent(1);
+    private void unIndent() {
+        unIndent(1);
     }
 
     /**
@@ -4251,7 +4250,7 @@ public class FormattingTreeModifier extends TreeModifier {
      *
      * @param step Number of tabs.
      */
-    private void unindent(int step) {
+    private void unIndent(int step) {
         if (env.currentIndentation < (options.getTabSize() * step)) {
             env.currentIndentation = 0;
             return;
@@ -4335,7 +4334,7 @@ public class FormattingTreeModifier extends TreeModifier {
     }
 
     /**
-     * Check whether a object type descriptor needs to be expanded in to multiple lines.
+     * Check whether an object type descriptor needs to be expanded in to multiple lines.
      *
      * @param objectTypeDesc Object type descriptor
      * @return <code>true</code> If the object type descriptor needs to be expanded in to multiple lines.

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
@@ -354,7 +354,7 @@ public class FormattingTreeModifier extends TreeModifier {
         indent(2);
         SeparatedNodeList<ParameterNode> parameters =
                 formatSeparatedNodeList(functionSignatureNode.parameters(), 0, 0, 0, 0, 0, 0, true);
-        unIndent(2);
+        unindent(2);
 
         Token closePara;
         ReturnTypeDescriptorNode returnTypeDesc = null;
@@ -427,7 +427,7 @@ public class FormattingTreeModifier extends TreeModifier {
         NamedWorkerDeclarator namedWorkerDeclarator =
                 formatNode(functionBodyBlockNode.namedWorkerDeclarator().orElse(null), 0, 1);
 
-        unIndent(); // reset the indentation
+        unindent(); // reset the indentation
         Token closeBrace = formatToken(functionBodyBlockNode.closeBraceToken(), env.trailingWS, env.trailingNL);
 
         return functionBodyBlockNode.modify()
@@ -529,7 +529,7 @@ public class FormattingTreeModifier extends TreeModifier {
         Token openBrace = formatToken(blockStatementNode.openBraceToken(), 0, 1);
         indent(); // start an indentation
         NodeList<StatementNode> statements = formatNodeList(blockStatementNode.statements(), 0, 1, 0, 1);
-        unIndent(); // end the indentation
+        unindent(); // end the indentation
         Token closeBrace = formatToken(blockStatementNode.closeBraceToken(), env.trailingWS, env.trailingNL);
 
         return blockStatementNode.modify()
@@ -557,7 +557,7 @@ public class FormattingTreeModifier extends TreeModifier {
                 0, fieldTrailingNL);
         RecordRestDescriptorNode recordRestDescriptor =
                 formatNode(recordTypeDesc.recordRestDescriptor().orElse(null), fieldTrailingWS, fieldTrailingNL);
-        unIndent(); // Revert indentation for record fields
+        unindent(); // Revert indentation for record fields
         Token bodyEndDelimiter = formatToken(recordTypeDesc.bodyEndDelimiter(), env.trailingWS, env.trailingNL);
 
         return recordTypeDesc.modify()
@@ -662,7 +662,7 @@ public class FormattingTreeModifier extends TreeModifier {
         Token openBrace = formatToken(serviceDeclarationNode.openBraceToken(), 0, 1);
         indent(); // increase the indentation of the following statements.
         NodeList<Node> members = formatNodeList(serviceDeclarationNode.members(), 0, 1, 0, 1);
-        unIndent(); // reset the indentation.
+        unindent(); // reset the indentation.
         Token closeBrace = formatToken(serviceDeclarationNode.closeBraceToken(), env.trailingWS, env.trailingNL);
 
         return serviceDeclarationNode.modify()
@@ -1192,7 +1192,7 @@ public class FormattingTreeModifier extends TreeModifier {
         indent();
         SeparatedNodeList<MappingFieldNode> fields = formatSeparatedNodeList(
                 mappingConstructorExpressionNode.fields(), 0, 0, fieldTrailingWS, fieldTrailingNL, 0, fieldTrailingNL);
-        unIndent();
+        unindent();
         Token closeBrace = formatToken(mappingConstructorExpressionNode.closeBrace(), env.trailingWS, env.trailingNL);
 
         return mappingConstructorExpressionNode.modify()
@@ -1244,7 +1244,7 @@ public class FormattingTreeModifier extends TreeModifier {
         indent();
         SeparatedNodeList<Node> expressions = formatSeparatedNodeList(listConstructorExpressionNode.expressions(),
                 0, 0, fieldTrailingWS, fieldTrailingNL, 0, fieldTrailingNL);
-        unIndent();
+        unindent();
         Token closeBracket = formatToken(listConstructorExpressionNode.closeBracket(),
                 env.trailingWS, env.trailingNL);
 
@@ -1494,7 +1494,7 @@ public class FormattingTreeModifier extends TreeModifier {
         Token openBrace = formatToken(matchStatementNode.openBrace(), 0, 1);
         indent();
         NodeList<MatchClauseNode> matchClauses = formatNodeList(matchStatementNode.matchClauses(), 0, 1, 0, 1);
-        unIndent();
+        unindent();
         Token closeBrace;
 
         if (hasOnFailClause) {
@@ -1599,7 +1599,7 @@ public class FormattingTreeModifier extends TreeModifier {
         indent();
         SeparatedNodeList<Node> enumMemberList = formatSeparatedNodeList(enumDeclarationNode.enumMemberList(),
                 0, 0, 0, 1, 0, 1);
-        unIndent();
+        unindent();
         Token closeBraceToken = formatToken(enumDeclarationNode.closeBraceToken(), env.trailingWS, env.trailingNL);
 
         return enumDeclarationNode.modify()
@@ -2216,7 +2216,7 @@ public class FormattingTreeModifier extends TreeModifier {
         indent();
         NodeList<NamedWorkerDeclarationNode> namedWorkerDeclarations =
                 formatNodeList(forkStatementNode.namedWorkerDeclarations(), 0, 1, 0, 1);
-        unIndent();
+        unindent();
         Token closeBraceToken = formatToken(forkStatementNode.closeBraceToken(), env.trailingWS, env.trailingNL);
 
         return forkStatementNode.modify()
@@ -2345,7 +2345,7 @@ public class FormattingTreeModifier extends TreeModifier {
         indent();
         NodeList<Node> members = formatNodeList(objectTypeDescriptorNode.members(), fieldTrailingWS, fieldTrailingNL,
                 0, fieldTrailingNL);
-        unIndent();
+        unindent();
         Token closeBrace = formatToken(objectTypeDescriptorNode.closeBrace(), env.trailingWS, env.trailingNL);
 
         return objectTypeDescriptorNode.modify()
@@ -2379,7 +2379,7 @@ public class FormattingTreeModifier extends TreeModifier {
         indent();
         NodeList<Node> members = formatNodeList(objectConstructorExpressionNode.members(),
                 fieldTrailingWS, fieldTrailingNL, 0, fieldTrailingNL);
-        unIndent();
+        unindent();
         Token closeBraceToken = formatToken(objectConstructorExpressionNode.closeBraceToken(),
                 env.trailingWS, env.trailingNL);
 
@@ -2508,10 +2508,10 @@ public class FormattingTreeModifier extends TreeModifier {
         SeparatedNodeList<Node> mappingConstructors =
                 formatSeparatedNodeList(tableConstructorExpressionNode.rows(), 0, 0, rowTrailingWS, rowTrailingNL, 0,
                         rowTrailingNL);
-        unIndent();
+        unindent();
         Token closeBracket =
                 formatToken(tableConstructorExpressionNode.closeBracket(), env.trailingWS, env.trailingNL);
-        unIndent();
+        unindent();
 
         return tableConstructorExpressionNode.modify()
                 .withTableKeyword(tableKeyword)
@@ -2582,7 +2582,7 @@ public class FormattingTreeModifier extends TreeModifier {
                 formatSeparatedNodeList(letExpressionNode.letVarDeclarations(), 0, 0, 0, 1);
         Token inKeyword = formatToken(letExpressionNode.inKeyword(), 1, 0);
         ExpressionNode expression = formatNode(letExpressionNode.expression(), env.trailingWS, env.trailingNL);
-        unIndent();
+        unindent();
 
         return letExpressionNode.modify()
                 .withLetKeyword(letKeyword)
@@ -2762,7 +2762,7 @@ public class FormattingTreeModifier extends TreeModifier {
         OnConflictClauseNode onConflictClause = formatNode(queryExpressionNode.onConflictClause().orElse(null),
                 env.trailingWS, env.trailingNL);
         if (lineLength != 0) {
-            unIndent();
+            unindent();
         }
 
         return queryExpressionNode.modify()
@@ -2921,7 +2921,7 @@ public class FormattingTreeModifier extends TreeModifier {
         SeparatedNodeList<NameReferenceNode> receiveFields = formatSeparatedNodeList(receiveFieldsNode.receiveFields(),
                 0, 1, 0, 1);
         Token closeBrace = formatToken(receiveFieldsNode.closeBrace(), 0, 1);
-        unIndent();
+        unindent();
         return receiveFieldsNode.modify()
                 .withOpenBrace(openBrace)
                 .withReceiveFields(receiveFields)
@@ -3022,7 +3022,7 @@ public class FormattingTreeModifier extends TreeModifier {
                 env.trailingWS, env.trailingNL);
         if (lineLength != 0) {
             // Revert the indentation for statements starting with query expression nodes.
-            unIndent();
+            unindent();
         }
 
         return queryActionNode.modify()
@@ -3339,7 +3339,7 @@ public class FormattingTreeModifier extends TreeModifier {
 
         indent();
         NodeList<Node> members = formatNodeList(classDefinitionNode.members(), 0, 1, 0, 1);
-        unIndent();
+        unindent();
         Token closeBrace = formatToken(classDefinitionNode.closeBrace(), env.trailingWS, env.trailingNL);
 
         return classDefinitionNode.modify()
@@ -3823,13 +3823,13 @@ public class FormattingTreeModifier extends TreeModifier {
      * @return Formatted node list
      */
     protected <T extends Node> SeparatedNodeList<T> formatSeparatedNodeList(SeparatedNodeList<T> nodeList,
-                                                                                int itemTrailingWS,
-                                                                                int itemTrailingNL,
-                                                                                int separatorTrailingWS,
-                                                                                int separatorTrailingNL,
-                                                                                int listTrailingWS,
-                                                                                int listTrailingNL,
-                                                                                boolean allowInAndMultiLine) {
+                                                                            int itemTrailingWS,
+                                                                            int itemTrailingNL,
+                                                                            int separatorTrailingWS,
+                                                                            int separatorTrailingNL,
+                                                                            int listTrailingWS,
+                                                                            int listTrailingNL,
+                                                                            boolean allowInAndMultiLine) {
         if (nodeList.isEmpty()) {
             return nodeList;
         }
@@ -4241,8 +4241,8 @@ public class FormattingTreeModifier extends TreeModifier {
     /**
      * Undo the indentation of the code by the number of white-spaces defined by tab-size.
      */
-    private void unIndent() {
-        unIndent(1);
+    private void unindent() {
+        unindent(1);
     }
 
     /**
@@ -4250,7 +4250,7 @@ public class FormattingTreeModifier extends TreeModifier {
      *
      * @param step Number of tabs.
      */
-    private void unIndent(int step) {
+    private void unindent(int step) {
         if (env.currentIndentation < (options.getTabSize() * step)) {
             env.currentIndentation = 0;
             return;

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
@@ -247,7 +247,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.ballerinalang.formatter.core.FormatterUtils.isInLineRange;
+import static org.ballerinalang.formatter.core.FormatterUtils.isInlineRange;
 
 /**
  * A formatter implementation that updates the minutiae of a given tree according to the ballerina formatting
@@ -447,10 +447,10 @@ public class FormattingTreeModifier extends TreeModifier {
         typedBindingPatternNode = formatNode(variableDeclarationNode.typedBindingPattern(), hasInit ? 1 : 0, 0);
         Token equalToken = formatToken(variableDeclarationNode.equalsToken().orElse(null), 1, 0);
 
-        boolean previousInLineAnnotation = env.inLineAnnotation;
-        setInLineAnnotation(true);
+        boolean previousInlineAnnotation = env.inlineAnnotation;
+        setInlineAnnotation(true);
         ExpressionNode initializer = formatNode(variableDeclarationNode.initializer().orElse(null), 0, 0);
-        setInLineAnnotation(previousInLineAnnotation);
+        setInlineAnnotation(previousInlineAnnotation);
 
         Token semicolonToken = formatToken(variableDeclarationNode.semicolonToken(),
                 env.trailingWS, env.trailingNL);
@@ -875,13 +875,13 @@ public class FormattingTreeModifier extends TreeModifier {
         Node varRef = formatNode(assignmentStatementNode.varRef(), 1, 0);
         Token equalsToken = formatToken(assignmentStatementNode.equalsToken(), 1, 0);
 
-        boolean previousInLineAnnotation = env.inLineAnnotation;
-        setInLineAnnotation(true);
+        boolean previousInlineAnnotation = env.inlineAnnotation;
+        setInlineAnnotation(true);
 
         ExpressionNode expression = formatNode(assignmentStatementNode.expression(), 0, 0);
         Token semicolonToken = formatToken(assignmentStatementNode.semicolonToken(), env.trailingWS, env.trailingNL);
 
-        setInLineAnnotation(previousInLineAnnotation);
+        setInlineAnnotation(previousInlineAnnotation);
 
         return assignmentStatementNode.modify()
                 .withVarRef(varRef)
@@ -1309,10 +1309,10 @@ public class FormattingTreeModifier extends TreeModifier {
                         moduleVariableDeclarationNode.equalsToken().isPresent() ? 1 : 0, 0);
         Token equalsToken = formatToken(moduleVariableDeclarationNode.equalsToken().orElse(null), 1, 0);
 
-        boolean prevInLineAnnotation = env.inLineAnnotation;
-        setInLineAnnotation(true);
+        boolean prevInlineAnnotation = env.inlineAnnotation;
+        setInlineAnnotation(true);
         ExpressionNode initializer = formatNode(moduleVariableDeclarationNode.initializer().orElse(null), 0, 0);
-        setInLineAnnotation(prevInLineAnnotation);
+        setInlineAnnotation(prevInlineAnnotation);
 
         Token semicolonToken = formatToken(moduleVariableDeclarationNode.semicolonToken(),
                 env.trailingWS, env.trailingNL);
@@ -2133,7 +2133,7 @@ public class FormattingTreeModifier extends TreeModifier {
     @Override
     public StartActionNode transform(StartActionNode startActionNode) {
         NodeList<AnnotationNode> annotations;
-        if (env.inLineAnnotation) {
+        if (env.inlineAnnotation) {
             annotations = formatNodeList(startActionNode.annotations(), 1, 0, 1, 0);
         } else {
             annotations = formatNodeList(startActionNode.annotations(), 0, 1, 0, 1);
@@ -3592,7 +3592,7 @@ public class FormattingTreeModifier extends TreeModifier {
                 return node;
             }
 
-            if (!isInLineRange(node, lineRange)) {
+            if (!isInlineRange(node, lineRange)) {
                 checkForNewline(node);
                 return node;
             }
@@ -3640,7 +3640,7 @@ public class FormattingTreeModifier extends TreeModifier {
                 return token;
             }
 
-            if (!isInLineRange(token, lineRange)) {
+            if (!isInlineRange(token, lineRange)) {
                 checkForNewline(token);
                 return token;
             }
@@ -3819,6 +3819,36 @@ public class FormattingTreeModifier extends TreeModifier {
      * @param separatorTrailingNL Number of newlines to be added after each separator in the list
      * @param listTrailingWS Number of single-length spaces to be added after the last item in the list
      * @param listTrailingNL Number of newlines to be added after the last item in the list
+     * @return Formatted node list
+     */
+    protected <T extends Node> SeparatedNodeList<T> formatSeparatedNodeList(SeparatedNodeList<T> nodeList,
+                                                                            int itemTrailingWS,
+                                                                            int itemTrailingNL,
+                                                                            int separatorTrailingWS,
+                                                                            int separatorTrailingNL,
+                                                                            int listTrailingWS,
+                                                                            int listTrailingNL) {
+        return formatSeparatedNodeList(nodeList,
+                itemTrailingWS,
+                itemTrailingNL,
+                separatorTrailingWS,
+                separatorTrailingNL,
+                listTrailingWS,
+                listTrailingNL,
+                false);
+    }
+
+    /**
+     * Format a delimited list of nodes.
+     *
+     * @param <T> Type of the list item
+     * @param nodeList Node list to be formatted
+     * @param itemTrailingWS Number of single-length spaces to be added after each item in the list
+     * @param itemTrailingNL Number of newlines to be added after each item in the list
+     * @param separatorTrailingWS Number of single-length spaces to be added after each separator in the list
+     * @param separatorTrailingNL Number of newlines to be added after each separator in the list
+     * @param listTrailingWS Number of single-length spaces to be added after the last item in the list
+     * @param listTrailingNL Number of newlines to be added after the last item in the list
      * @param allowInAndMultiLine Allow both inline and multiline formatting at the same time
      * @return Formatted node list
      */
@@ -3875,36 +3905,6 @@ public class FormattingTreeModifier extends TreeModifier {
         }
 
         return NodeFactory.createSeparatedNodeList(newNodes);
-    }
-
-    /**
-     * Format a delimited list of nodes.
-     *
-     * @param <T> Type of the list item
-     * @param nodeList Node list to be formatted
-     * @param itemTrailingWS Number of single-length spaces to be added after each item in the list
-     * @param itemTrailingNL Number of newlines to be added after each item in the list
-     * @param separatorTrailingWS Number of single-length spaces to be added after each separator in the list
-     * @param separatorTrailingNL Number of newlines to be added after each separator in the list
-     * @param listTrailingWS Number of single-length spaces to be added after the last item in the list
-     * @param listTrailingNL Number of newlines to be added after the last item in the list
-     * @return Formatted node list
-     */
-    protected <T extends Node> SeparatedNodeList<T> formatSeparatedNodeList(SeparatedNodeList<T> nodeList,
-                                                                            int itemTrailingWS,
-                                                                            int itemTrailingNL,
-                                                                            int separatorTrailingWS,
-                                                                            int separatorTrailingNL,
-                                                                            int listTrailingWS,
-                                                                            int listTrailingNL) {
-        return formatSeparatedNodeList(nodeList,
-                itemTrailingWS,
-                itemTrailingNL,
-                separatorTrailingWS,
-                separatorTrailingNL,
-                listTrailingWS,
-                listTrailingNL,
-                false);
     }
 
     /**
@@ -4306,8 +4306,8 @@ public class FormattingTreeModifier extends TreeModifier {
      *
      * @param value boolean true for setting inline annotations.
      */
-    private void setInLineAnnotation(boolean value) {
-        env.inLineAnnotation = value;
+    private void setInlineAnnotation(boolean value) {
+        env.inlineAnnotation = value;
     }
 
     private String getWSContent(int count) {

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/ParserTestFormatter.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/ParserTestFormatter.java
@@ -73,6 +73,9 @@ public class ParserTestFormatter extends FormatterTest {
                 "qualified_identifier_assert_08.bal",
                 "conditional_expr_source_28.bal",
                 "resiliency_source_04.bal",
+                "record_type_def_source_14.bal",
+                "object_type_def_source_12.bal",
+                "anon_func_source_01.bal",
 
                 // the following tests need to be enabled in the future
                 "annotations_source_04.bal", // could be considered an invalid scenario

--- a/misc/formatter/modules/formatter-core/src/test/resources/declarations/class-definition/assert/class_definition_declaration_5.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/declarations/class-definition/assert/class_definition_declaration_5.bal
@@ -4,15 +4,16 @@ class Foo {
     } parent;
 
     function init(object {
-                      public int x;
-                      public function foo() returns int;
+                public int x;
+                public function foo() returns int;
 
-                      public object {
-                          public int x;
-                          public function foo() returns int;
-                      } b;
-                      public int y;
-                  } a) {
+                public object {
+                    public int x;
+                    public function foo() returns int;
+                } b;
+                public int y;
+            } a,
+            int b) {
         self.parent = a;
     }
 }

--- a/misc/formatter/modules/formatter-core/src/test/resources/declarations/class-definition/source/class_definition_declaration_5.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/declarations/class-definition/source/class_definition_declaration_5.bal
@@ -10,7 +10,8 @@ function    init  (   object{
                                                                    public int x;
                                                                    public function foo() returns int;
                                                                } b;
-                                     public int y;}   a  )   {
+                                     public int y;}   a  ,
+                    int b)   {
      self  .  parent   =   a  ;
       }
 }

--- a/misc/formatter/modules/formatter-core/src/test/resources/misc/linewrapping/assert/line_wrapping_1.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/misc/linewrapping/assert/line_wrapping_1.bal
@@ -1,5 +1,5 @@
 function foo(int count, int count, int count, int count, int count, int count, int count, int count, 
-             int count = 999999999) {
+        int count = 999999999) {
 }
 
 public type Client client object {


### PR DESCRIPTION
## Purpose
> Since, there is no style guidelines defined for function signatures, when the function signature has parameters of type like type-descriptor or object-constructor the formatting behaves unexpectedly as mentioned in the issue https://github.com/ballerina-platform/ballerina-lang/issues/34961
> This PR contains the changes to fix the function signature not properly formatting.

Fixes #37098, #34961

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
