### PR TITLE
Disable `gson` Unicode escaping certain characters

### DIFF
--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/AbstractCodeActionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/AbstractCodeActionTest.java
@@ -66,7 +66,7 @@ import java.util.stream.Collectors;
  */
 public abstract class AbstractCodeActionTest extends AbstractLSTest {
 
-    private final Gson gson = new GsonBuilder().setPrettyPrinting().create();
+    private final Gson gson = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
     private final Path sourcesPath = new File(getClass().getClassLoader().getResource("codeaction").getFile()).toPath();
 
     private  WorkspaceManager workspaceManager;

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/command/AbstractCommandExecutionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/command/AbstractCommandExecutionTest.java
@@ -46,7 +46,7 @@ public abstract class AbstractCommandExecutionTest {
 
     private Endpoint serviceEndpoint;
 
-    private final Gson gson = new GsonBuilder().setPrettyPrinting().create();
+    private final Gson gson = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
 
     private final JsonParser parser = new JsonParser();
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/CompletionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/CompletionTest.java
@@ -55,7 +55,7 @@ public abstract class CompletionTest extends AbstractLSTest {
 
     private final String configDir = "config";
 
-    private final Gson gson = new GsonBuilder().setPrettyPrinting().create();
+    private final Gson gson = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
 
     @Test(dataProvider = "completion-data-provider")
     public void test(String config, String configPath) throws WorkspaceDocumentException, IOException {


### PR DESCRIPTION
## Purpose
$title

Fixes #37355

## Approach
Add configuration to disable HTML escaping (https://www.javadoc.io/doc/com.google.code.gson/gson/2.7/com/google/gson/GsonBuilder.html#disableHtmlEscaping)

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
