### PR TITLE
Add `graphql` & `asyncapi` cmd to bal help text

### DIFF
--- a/cli/ballerina-cli/src/main/resources/cli-help/ballerina-help.help
+++ b/cli/ballerina-cli/src/main/resources/cli-help/ballerina-help.help
@@ -40,8 +40,11 @@ COMMANDS
         format          Format Ballerina source files
         grpc            Generate the Ballerina sources for a given Protocol
                         Buffer definition
+        graphql         Generate Ballerina client sources
+                        for a given GraphQL schema(SDL) and GraphQL queries
         openapi         Generate the Ballerina sources for a given OpenAPI
                         definition and vice versa
+        asyncapi        Generate the Ballerina sources for a given AsyncAPI definition
         bindgen         Generate the Ballerina bindings for Java APIs
         shell           Run Ballerina interactive REPL
         version         Print the Ballerina version


### PR DESCRIPTION
## Purpose
> Add `graphql` & `asyncapi` cmd to bal help text

Resolves https://github.com/ballerina-platform/ballerina-lang/issues/37375

## Approach
> Add `graphql` & `asyncapi`  command info in `ballerina-lang/cli/ballerina-cli/src/main/resources/cli-help/ballerina-help.help`

