### PR TITLE
[Master] Fix query expression looping a stream should not contain () as its result type

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -6071,10 +6071,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
             }
 
             if (completionType != null && completionType.tag != TypeTags.NIL) {
-                if (completionType.tag == TypeTags.UNION) {
-                    ((BUnionType) completionType).getMemberTypes().remove(symTable.nilType);
-                }
-                return BUnionType.create(null, actualType, completionType);
+                return BUnionType.create(null, actualType, types.getSafeType(completionType, true, false));
             } else {
                 return actualType;
             }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -6071,6 +6071,9 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
             }
 
             if (completionType != null && completionType.tag != TypeTags.NIL) {
+                if (completionType.tag == TypeTags.UNION) {
+                    ((BUnionType) completionType).getMemberTypes().remove(symTable.nilType);
+                }
                 return BUnionType.create(null, actualType, completionType);
             } else {
                 return actualType;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/SimpleQueryExpressionWithDefinedTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/SimpleQueryExpressionWithDefinedTypeTest.java
@@ -239,6 +239,11 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         BRunUtil.invoke(result, "testQueryStreamWithError");
     }
 
+    @Test(description = "Query a stream with different completion types")
+    public void testQueryStreamWithDifferentCompletionTypes() {
+        BRunUtil.invoke(result, "testQueryStreamWithDifferentCompletionTypes");
+    }
+
     @Test(description = "Test anonymous record type, record type referencing, optional field, " +
             "changed order of the fields")
     public void testOthersAssociatedWithRecordTypes() {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/simple-query-with-defined-type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/simple-query-with-defined-type.bal
@@ -344,7 +344,7 @@ public function testQueryWithStream() returns boolean {
     NumberGenerator numGen = new;
     var numberStream = new stream<int, error?>(numGen);
 
-    int[]|error? oddNumberList = from int num in numberStream
+    int[]|error oddNumberList = from int num in numberStream
                                  where (num % 2 == 1)
                                  select num;
     if (oddNumberList is error) {
@@ -359,7 +359,7 @@ public function testQueryStreamWithError() {
     NumberGeneratorWithError numGen = new;
     var numberStream = new stream<int, error?>(numGen);
 
-    int[]|error? oddNumberList = from int num in numberStream
+    int[]|error oddNumberList = from int num in numberStream
                                 where (num % 2 == 1)
                                 select num;
     if (oddNumberList is error) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/simple-query-with-defined-type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/simple-query-with-defined-type.bal
@@ -83,7 +83,7 @@ class NumberGenerator {
 class NumberGeneratorWithError {
     int i = 0;
     public isolated function next() returns record {|int value;|}|error? {
-        if (self.i == 3) {
+        if (self.i == 2) {
             return error("Custom error thrown explicitly.");
         }
         self.i += 1;
@@ -94,7 +94,7 @@ class NumberGeneratorWithError {
 class NumberGeneratorWithError2 {
     int i = 0;
     public isolated function next() returns record {|int value;|}|error {
-        if (self.i == 3) {
+        if (self.i == 2) {
             return error("Custom error thrown explicitly.");
         }
         self.i += 1;
@@ -424,6 +424,31 @@ public function testQueryStreamWithDifferentCompletionTypes() {
 
     if !(oddNumberList3 is ErrorR1) {
         panic error("Expeted error, found: " + (typeof oddNumberList3).toString());
+    }
+
+    int[]|error oddNumberList4 = from int num1 in numberStream1
+        from int num2 in [1, 3, 5]
+        where num1 == num2
+        select num1;
+
+    if !(oddNumberList4 is error) {
+        panic error("Expeted error, found: " + (typeof oddNumberList4).toString());
+    }
+
+    stream<int, error?> numberStream5 = new (numGen1);
+
+    var oddNumberList5 = from int num in numberStream5
+        where (num % 2 == 1)
+        select num;
+
+    record {|int value;|}|error? next = oddNumberList5.next();
+    if next !is error {
+        assertEquality(1, next is null ? null : next.value);
+        next = oddNumberList5.next();
+    }
+
+    if !(next is error) {
+        panic error("Expeted error, found: " + (typeof oddNumberList5).toString());
     }
 }
 


### PR DESCRIPTION
## Purpose

Fixes #37121

## Approach
> Removed the `nil-type` from completion type of stream when resolving the type of query.

## Samples
```
class NumberGeneratorWithError {
    int i = 0;
    public isolated function next() returns record {|int value;|}|error? {
        if (self.i == 3) {
            return error("Custom error thrown explicitly.");
        }
        self.i += 1;
        return {value: self.i};
    }
}

public function main() {
    NumberGeneratorWithError numGen = new;
    stream<int, error?> numberStream = new(numGen);

    // Now this is not an error
    int[]|error oddNumberList = from int num in numberStream
                                where (num % 2 == 1)
                                select num;
}
```
type of oddNumberList is `int[]|error` not `int[]|error?`
## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
