### PR TITLE
Fix suggesting incorrect completions inside match clause

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MatchClauseNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MatchClauseNodeContext.java
@@ -53,6 +53,14 @@ public class MatchClauseNodeContext extends MatchStatementContext<MatchClauseNod
             completionItems.addAll(this.getCompletionItemList(moduleContent, context));
         } else if (onSuggestIfClause(context, node)) {
             completionItems.add(new SnippetCompletionItem(context, Snippet.KW_IF.get()));
+        } else if (onSuggestionsAfterDoubleArrow(context, node)) {
+            /*
+            Handles the following
+            eg: match v {
+                    1 => <cursor>
+                }
+             */
+            return completionItems;
         } else {
             completionItems.addAll(this.getPatternClauseCompletions(context));
         }
@@ -60,11 +68,16 @@ public class MatchClauseNodeContext extends MatchStatementContext<MatchClauseNod
 
         return completionItems;
     }
-    
+
+    private boolean onSuggestionsAfterDoubleArrow(BallerinaCompletionContext context, MatchClauseNode node) {
+        return context.getCursorPositionInTree() >= node.rightDoubleArrow().textRange().endOffset();
+    }
+
     private boolean onSuggestIfClause(BallerinaCompletionContext context, MatchClauseNode node) {
         int cursor = context.getCursorPositionInTree();
         SeparatedNodeList<Node> matchPatterns = node.matchPatterns();
         
-        return !matchPatterns.isEmpty() && cursor > matchPatterns.get(matchPatterns.size() - 1).textRange().endOffset();
+        return !matchPatterns.isEmpty() && cursor > matchPatterns.get(matchPatterns.size() - 1).textRange().endOffset()
+                && cursor <= node.rightDoubleArrow().textRange().startOffset();
     }
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/match_stmt_ctx_config23.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/match_stmt_ctx_config23.json
@@ -1,0 +1,8 @@
+{
+  "position": {
+    "line": 2,
+    "character": 13
+  },
+  "source": "statement_context/source/match_stmt_ctx_source23.bal",
+  "items": []
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/source/match_stmt_ctx_source23.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/source/match_stmt_ctx_source23.bal
@@ -1,0 +1,5 @@
+function testFunction(int param) {
+    match param {
+        1 => 
+    }
+}


### PR DESCRIPTION
## Purpose
This PR refactors the completions inside match clause to avoid suggesting incorrect completions for if clause. 

Fixes #37305

## Samples
<img width="514" alt="Screenshot 2022-08-17 at 16 00 08" src="https://user-images.githubusercontent.com/27485094/185101192-7822edf7-416e-46ff-b6c4-44b59cfca73a.png">

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
