### PR TITLE
Fix incorrect formatting if-else-stmt when else is written in a newline

### DIFF
--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
@@ -4049,7 +4049,7 @@ public class FormattingTreeModifier extends TreeModifier {
 
                     continue;
                 case WHITESPACE_MINUTIAE:
-                    if (!shouldAddWS(prevMinutiae) && (!env.preserveIndentation)) {
+                    if (!shouldAddWS(prevMinutiae) && !env.preserveIndentation) {
                         // Shouldn't update the prevMinutiae
                         continue;
                     }
@@ -4088,7 +4088,7 @@ public class FormattingTreeModifier extends TreeModifier {
             prevMinutiae = minutiae;
         }
 
-        if (consecutiveNewlines > 0 && (!env.preserveIndentation)) {
+        if (consecutiveNewlines > 0 && !env.preserveIndentation) {
             addWhitespace(env.currentIndentation, leadingMinutiae);
         }
 

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
@@ -289,11 +289,11 @@ public class FormattingTreeModifier extends TreeModifier {
         boolean prevPreservedNewLine = env.hasPreservedNewline;
         MetadataNode metadata = formatNode(functionDefinitionNode.metadata().orElse(null), 0, 1);
         // If metadata is documentation string, set preserved new line to false, so to remove user defined new line
-        env.hasPreservedNewline = metadata == null ? prevPreservedNewLine
-                : metadata.documentationString().isEmpty() && prevPreservedNewLine;
+        preserveNewline(metadata == null ?
+                prevPreservedNewLine : metadata.documentationString().isEmpty() && prevPreservedNewLine);
         NodeList<Token> qualifierList = formatNodeList(functionDefinitionNode.qualifierList(), 1, 0, 1, 0);
         Token functionKeyword = formatToken(functionDefinitionNode.functionKeyword(), 1, 0);
-        env.hasPreservedNewline = prevPreservedNewLine;
+        preserveNewline(prevPreservedNewLine);
 
         IdentifierToken functionName;
         if (functionDefinitionNode.relativeResourcePath().isEmpty()) {
@@ -499,13 +499,16 @@ public class FormattingTreeModifier extends TreeModifier {
 
     @Override
     public IfElseStatementNode transform(IfElseStatementNode ifElseStatementNode) {
+        boolean prevPreservedNewLine = env.hasPreservedNewline;
         Token ifKeyword = formatToken(ifElseStatementNode.ifKeyword(), 1, 0);
         ExpressionNode condition = formatNode(ifElseStatementNode.condition(), 1, 0);
         BlockStatementNode ifBody;
         Node elseBody = null;
         if (ifElseStatementNode.elseBody().isPresent()) {
             ifBody = formatNode(ifElseStatementNode.ifBody(), 1, 0);
+            preserveIndentation(!hasTrailingNL(ifElseStatementNode.ifBody().closeBraceToken()));
             elseBody = formatNode(ifElseStatementNode.elseBody().orElse(null), env.trailingWS, env.trailingNL);
+            preserveIndentation(prevPreservedNewLine);
         } else {
             ifBody = formatNode(ifElseStatementNode.ifBody(), env.trailingWS, env.trailingNL);
         }
@@ -4046,7 +4049,7 @@ public class FormattingTreeModifier extends TreeModifier {
 
                     continue;
                 case WHITESPACE_MINUTIAE:
-                    if (!shouldAddWS(prevMinutiae) && !env.preserveIndentation) {
+                    if (!shouldAddWS(prevMinutiae) && (!env.preserveIndentation)) {
                         // Shouldn't update the prevMinutiae
                         continue;
                     }
@@ -4085,7 +4088,7 @@ public class FormattingTreeModifier extends TreeModifier {
             prevMinutiae = minutiae;
         }
 
-        if (consecutiveNewlines > 0 && !env.preserveIndentation) {
+        if (consecutiveNewlines > 0 && (!env.preserveIndentation)) {
             addWhitespace(env.currentIndentation, leadingMinutiae);
         }
 
@@ -4259,6 +4262,15 @@ public class FormattingTreeModifier extends TreeModifier {
             }
         }
         return position;
+    }
+
+    /**
+     * Set the flag for setting preserve new line for currently formatting token.
+     *
+     * @param value boolean true for setting new line.
+     */
+    private void preserveNewline(boolean value) {
+        env.hasPreservedNewline = value;
     }
 
     /**

--- a/misc/formatter/modules/formatter-core/src/test/resources/statements/if-else/assert/if_else_statement_7.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/statements/if-else/assert/if_else_statement_7.bal
@@ -1,0 +1,16 @@
+public function foo() {
+    if (true) {
+
+    }
+    else {
+        int y = 0;
+        return i;
+    }
+
+    if (true) {
+
+    }
+    else {
+        int y = 0;
+    }
+}

--- a/misc/formatter/modules/formatter-core/src/test/resources/statements/if-else/source/if_else_statement_7.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/statements/if-else/source/if_else_statement_7.bal
@@ -1,0 +1,11 @@
+public function foo() {
+    if   (  true)  {
+
+     }
+else{int y=0;return i;}
+
+if   (  true)  {
+
+     }
+            else{int y=0;}
+}


### PR DESCRIPTION
## Purpose
> This PR is a fix for the issue related to formatting if-else-statement. When else is written in a new line, it doesn't format properly as explained in the issue #34929

Fixes #34929 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
