### PR TITLE
Pull dependencies during bal pull

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PullCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PullCommand.java
@@ -49,6 +49,7 @@ import java.util.List;
 
 import static io.ballerina.cli.cmd.Constants.PULL_COMMAND;
 import static io.ballerina.cli.launcher.LauncherUtils.createLauncherException;
+import static io.ballerina.projects.util.ProjectUtils.deleteDirectory;
 import static io.ballerina.projects.util.ProjectUtils.getAccessTokenOfCLI;
 import static io.ballerina.projects.util.ProjectUtils.initializeProxy;
 import static io.ballerina.projects.util.ProjectUtils.validateOrgName;
@@ -251,9 +252,9 @@ public class PullCommand implements BLauncherCmd {
         BalaProject balaProject = BalaProject.loadProject(defaultBuilder, balaPath);
 
         // Delete package cache if available
-        File packageCacheDir = cacheDir.resolve(orgName).resolve(packageName).resolve(version).toFile();
-        if (packageCacheDir.exists()) {
-            packageCacheDir.delete();
+        Path packageCacheDir = cacheDir.resolve(orgName).resolve(packageName).resolve(version);
+        if (packageCacheDir.toFile().exists()) {
+            deleteDirectory(packageCacheDir);
         }
 
         // getResolution pulls all dependencies of the pulled package

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PullCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PullCommand.java
@@ -40,7 +40,6 @@ import org.wso2.ballerinalang.compiler.util.Names;
 import org.wso2.ballerinalang.util.RepoUtils;
 import picocli.CommandLine;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.file.Path;


### PR DESCRIPTION
## Purpose
The current implementation of PullCommand->execute() pulls the specified package, but does not pull its dependencies. This PR improves this to pull the dependencies of the package pulled.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/37201

## Approach
load the pulled package as a Project and use package resolution to pull the dependencies.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
Spec Issue -  https://github.com/wso2-enterprise/internal-support-ballerina/issues/163

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
