### PR TITLE
Add missing change variable type code actions

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/ChangeVariableTypeCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/ChangeVariableTypeCodeAction.java
@@ -18,6 +18,7 @@ package org.ballerinalang.langserver.codeaction.providers.changetype;
 import io.ballerina.compiler.api.symbols.MapTypeSymbol;
 import io.ballerina.compiler.api.symbols.TableTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeDescTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.VariableSymbol;
 import io.ballerina.compiler.syntax.tree.AssignmentStatementNode;
@@ -63,7 +64,7 @@ import java.util.Set;
 public class ChangeVariableTypeCodeAction extends TypeCastCodeAction {
 
     public static final String NAME = "Change Variable Type";
-    public static final Set<String> DIAGNOSTIC_CODES = Set.of("BCE2066", "BCE2068", "BCE2652");
+    public static final Set<String> DIAGNOSTIC_CODES = Set.of("BCE2066", "BCE2068", "BCE2652", "BCE3931");
 
     @Override
     public boolean validate(Diagnostic diagnostic, DiagBasedPositionDetails positionDetails,
@@ -109,7 +110,12 @@ public class ChangeVariableTypeCodeAction extends TypeCastCodeAction {
         Optional<String> typeNodeStr = getTypeNodeStr(typeNode.get());
         List<CodeAction> actions = new ArrayList<>();
         List<TextEdit> importEdits = new ArrayList<>();
-        List<String> types = CodeActionUtil.getPossibleTypes(foundType.get(), importEdits, context);
+        List<String> types;
+        if ("BCE3931".equals(diagnostic.diagnosticInfo().code())) {
+            types = Collections.singletonList(((TypeDescTypeSymbol) foundType.get()).typeParameter().get().signature());
+        } else {
+            types = CodeActionUtil.getPossibleTypes(foundType.get(), importEdits, context);
+        }
         for (String type : types) {
             if (typeNodeStr.isPresent() && typeNodeStr.get().equals(type)) {
                 // Skip suggesting same type

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/ChangeVariableTypeCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/ChangeVariableTypeCodeAction.java
@@ -63,7 +63,7 @@ import java.util.Set;
 public class ChangeVariableTypeCodeAction extends TypeCastCodeAction {
 
     public static final String NAME = "Change Variable Type";
-    public static final Set<String> DIAGNOSTIC_CODES = Set.of("BCE2066", "BCE2068");
+    public static final Set<String> DIAGNOSTIC_CODES = Set.of("BCE2066", "BCE2068", "BCE2652");
 
     @Override
     public boolean validate(Diagnostic diagnostic, DiagBasedPositionDetails positionDetails,

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ChangeVariableTypeCodeActionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ChangeVariableTypeCodeActionTest.java
@@ -53,6 +53,7 @@ public class ChangeVariableTypeCodeActionTest extends AbstractCodeActionTest {
         return new Object[][]{
                 {"changeVarType1.json"},
                 {"changeVarType2.json"},
+                {"changeVarType3.json"},
                 {"changeVarType_int_to_float.json"},
                 {"changeVarType_int_to_float_in_constant.json"}
         };

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ChangeVariableTypeCodeActionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ChangeVariableTypeCodeActionTest.java
@@ -54,6 +54,8 @@ public class ChangeVariableTypeCodeActionTest extends AbstractCodeActionTest {
                 {"changeVarType1.json"},
                 {"changeVarType2.json"},
                 {"changeVarType3.json"},
+                {"changeVarType4.json"},
+                {"changeVarType3.json"},
                 {"changeVarType_int_to_float.json"},
                 {"changeVarType_int_to_float_in_constant.json"}
         };

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/config/changeVarType3.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/config/changeVarType3.json
@@ -1,0 +1,28 @@
+{
+  "position": {
+    "line": 15,
+    "character": 21
+  },
+  "source": "changeVarType.bal",
+  "expected": [
+    {
+      "title": "Change variable \u0027fVal\u0027 type to \u0027float|error\u0027",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 15,
+              "character": 4
+            },
+            "end": {
+              "line": 15,
+              "character": 9
+            }
+          },
+          "newText": "float|error"
+        }
+      ]
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/config/changeVarType4.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/config/changeVarType4.json
@@ -1,0 +1,28 @@
+{
+  "position": {
+    "line": 17,
+    "character": 27
+  },
+  "source": "changeVarType.bal",
+  "expected": [
+    {
+      "title": "Change variable \u0027inferredVal\u0027 type to \u0027int\u0027",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 17,
+              "character": 4
+            },
+            "end": {
+              "line": 17,
+              "character": 11
+            }
+          },
+          "newText": "int"
+        }
+      ]
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/source/changeVarType.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/source/changeVarType.bal
@@ -14,6 +14,8 @@ public function main(string... args) {
     
     future<float> fut = start foo(); 
     float fVal = wait fut;
+ 
+    boolean inferredVal = bar();
 }
 
 function foo() returns float {
@@ -33,3 +35,6 @@ type Car record {
     string model;
     int year;
 };
+
+public type TargetType typedesc<int>;
+function bar(TargetType t = <>) returns t = external;

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/source/changeVarType.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/source/changeVarType.bal
@@ -11,6 +11,9 @@ public function main(string... args) {
     };
     
     car.year = "2020";
+    
+    future<float> fut = start foo(); 
+    float fVal = wait fut;
 }
 
 function foo() returns float {


### PR DESCRIPTION
## Purpose
This PR adds the missing change variable code action in wait future expressions and functions with inferred typedesc value.

Fixes #37202

## Samples
1. 
<img width="517" alt="Screenshot 2022-08-25 at 11 36 56" src="https://user-images.githubusercontent.com/27485094/186587744-ec707d56-7ce8-4e37-8b64-6b36031755be.png">

2. 
<img width="517" alt="Screenshot 2022-08-25 at 11 38 23" src="https://user-images.githubusercontent.com/27485094/186587933-65266842-7db8-449c-a6fa-34c9de202eb8.png">

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
