### PR TITLE
[2201.2.x] Fix type cast code action for numeric optional types

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/MatchedExpressionNodeResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/MatchedExpressionNodeResolver.java
@@ -18,6 +18,7 @@ package org.ballerinalang.langserver.codeaction;
 import io.ballerina.compiler.syntax.tree.AssignmentStatementNode;
 import io.ballerina.compiler.syntax.tree.BinaryExpressionNode;
 import io.ballerina.compiler.syntax.tree.BracedExpressionNode;
+import io.ballerina.compiler.syntax.tree.ConditionalExpressionNode;
 import io.ballerina.compiler.syntax.tree.ExplicitNewExpressionNode;
 import io.ballerina.compiler.syntax.tree.ExpressionNode;
 import io.ballerina.compiler.syntax.tree.FromClauseNode;
@@ -33,6 +34,7 @@ import io.ballerina.compiler.syntax.tree.PositionalArgumentNode;
 import io.ballerina.compiler.syntax.tree.ReturnStatementNode;
 import io.ballerina.compiler.syntax.tree.SpecificFieldNode;
 import io.ballerina.compiler.syntax.tree.VariableDeclarationNode;
+import io.ballerina.tools.text.LineRange;
 import org.ballerinalang.langserver.common.utils.PositionUtil;
 
 import java.util.Optional;
@@ -151,7 +153,7 @@ public class MatchedExpressionNodeResolver extends NodeTransformer<Optional<Expr
         if (PositionUtil.isWithinLineRange(matchedNode.lineRange(), node.containerExpression().lineRange())) {
             return Optional.of(node.containerExpression());
         }
-        
+
         if (!node.keyExpression().isEmpty()) {
             for (ExpressionNode expressionNode : node.keyExpression()) {
                 if (PositionUtil.isWithinLineRange(matchedNode.lineRange(), expressionNode.lineRange())) {
@@ -159,8 +161,27 @@ public class MatchedExpressionNodeResolver extends NodeTransformer<Optional<Expr
                 }
             }
         }
-        
+
         return Optional.of(node);
+    }
+
+    @Override
+    public Optional<ExpressionNode> transform(ConditionalExpressionNode conditionalExpressionNode) {
+        ExpressionNode lhsExpr = conditionalExpressionNode.lhsExpression();
+        ExpressionNode middleExpr = conditionalExpressionNode.middleExpression();
+        ExpressionNode endExpr = conditionalExpressionNode.endExpression();
+        LineRange matchedLineRange = matchedNode.lineRange();
+
+        if (PositionUtil.isWithinLineRange(matchedLineRange, lhsExpr.lineRange())) {
+            return Optional.of(lhsExpr);
+        }
+        if (PositionUtil.isWithinLineRange(matchedLineRange, middleExpr.lineRange())) {
+            return Optional.of(middleExpr);
+        }
+        if (PositionUtil.isWithinLineRange(matchedLineRange, endExpr.lineRange())) {
+            return Optional.of(endExpr);
+        }
+        return Optional.of(conditionalExpressionNode);
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/TypeCastCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/TypeCastCodeAction.java
@@ -192,6 +192,10 @@ public class TypeCastCodeAction implements DiagnosticBasedCodeActionProvider {
     }
 
     private boolean isNumeric(TypeSymbol typeSymbol) {
+        //Todo: When the type is a singleton.
+        if (typeSymbol.typeKind() == TypeDescKind.UNION) {
+           return  ((UnionTypeSymbol) typeSymbol).memberTypeDescriptors().stream().allMatch(this::isNumeric);
+        }
         return (typeSymbol.typeKind().isIntegerType()
                 || typeSymbol.typeKind() == TypeDescKind.FLOAT
                 || typeSymbol.typeKind() == TypeDescKind.DECIMAL);

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/TypeCastTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/TypeCastTest.java
@@ -51,36 +51,35 @@ public class TypeCastTest extends AbstractCodeActionTest {
     @Override
     public Object[][] dataProvider() {
         return new Object[][]{
-//                {"typeCast1.json"},
-//                {"typeCast2.json"},
-//                {"typeCast3.json"},
-//                {"typeCast4.json"},
-//                {"typeCast5.json"},
-////                {"typeCast6.json", "typeCast.bal"}, Not supported by the subtype of API.
-//                {"typeCast7.json"},
-//                {"typeCast8.json"},
-//                {"typeCast9.json"},
-//                {"typeCast10.json"},
-//                {"typeCast11.json"},
-//                {"typeCast12.json"},
-//                {"typeCast13.json"},
-//                {"typeCast14.json"},
-//                {"nilTypeCast.json"},
-//                {"type_cast_function_param_config1.json"},
-//                {"typeCast11.json"},
-//                {"typeCastInMemberAccess1.json"},
-//
-//                {"type_cast_in_binary_operation1.json"},
-//                {"type_cast_in_binary_operation2.json"},
-//                {"type_cast_in_binary_operation3.json"},
-//                {"type_cast_in_binary_operation4.json"},
-//                {"type_cast_in_binary_operation5.json"},
-//                {"type_cast_in_binary_operation6.json"},
-//                {"type_cast_in_binary_operation7.json"},
-//                {"type_cast_in_binary_operation8.json"},
-//                {"type_cast_in_binary_operation9.json"},
-                {"type_cast_in_assignment1.json"}
+                {"typeCast1.json"},
+                {"typeCast2.json"},
+                {"typeCast3.json"},
+                {"typeCast4.json"},
+                {"typeCast5.json"},
+//                {"typeCast6.json", "typeCast.bal"}, Not supported by the subtype of API.
+                {"typeCast7.json"},
+                {"typeCast8.json"},
+                {"typeCast9.json"},
+                {"typeCast10.json"},
+                {"typeCast11.json"},
+                {"typeCast12.json"},
+                {"typeCast13.json"},
+                {"typeCast14.json"},
+                {"nilTypeCast.json"},
+                {"type_cast_function_param_config1.json"},
+                {"typeCast11.json"},
+                {"typeCastInMemberAccess1.json"},
 
+                {"type_cast_in_binary_operation1.json"},
+                {"type_cast_in_binary_operation2.json"},
+                {"type_cast_in_binary_operation3.json"},
+                {"type_cast_in_binary_operation4.json"},
+                {"type_cast_in_binary_operation5.json"},
+                {"type_cast_in_binary_operation6.json"},
+                {"type_cast_in_binary_operation7.json"},
+                {"type_cast_in_binary_operation8.json"},
+                {"type_cast_in_binary_operation9.json"},
+                {"type_cast_in_assignment1.json"}
         };
     }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/TypeCastTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/TypeCastTest.java
@@ -79,7 +79,11 @@ public class TypeCastTest extends AbstractCodeActionTest {
                 {"type_cast_in_binary_operation7.json"},
                 {"type_cast_in_binary_operation8.json"},
                 {"type_cast_in_binary_operation9.json"},
-                {"type_cast_in_assignment1.json"}
+                {"type_cast_in_assignment1.json"},
+                {"type_cast_in_conditional_expr1.json"},
+                {"type_cast_in_conditional_expr2.json"},
+                {"type_cast_in_conditional_expr3.json"},
+                {"type_cast_numeric1.json"}
         };
     }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/TypeCastTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/TypeCastTest.java
@@ -51,34 +51,35 @@ public class TypeCastTest extends AbstractCodeActionTest {
     @Override
     public Object[][] dataProvider() {
         return new Object[][]{
-                {"typeCast1.json"},
-                {"typeCast2.json"},
-                {"typeCast3.json"},
-                {"typeCast4.json"},
-                {"typeCast5.json"},
-//                {"typeCast6.json", "typeCast.bal"}, Not supported by the subtype of API.
-                {"typeCast7.json"},
-                {"typeCast8.json"},
-                {"typeCast9.json"},
-                {"typeCast10.json"},
-                {"typeCast11.json"},
-                {"typeCast12.json"},
-                {"typeCast13.json"},
-                {"typeCast14.json"},
-                {"nilTypeCast.json"},
-                {"type_cast_function_param_config1.json"},
-                {"typeCast11.json"},
-                {"typeCastInMemberAccess1.json"},
-
-                {"type_cast_in_binary_operation1.json"},
-                {"type_cast_in_binary_operation2.json"},
-                {"type_cast_in_binary_operation3.json"},
-                {"type_cast_in_binary_operation4.json"},
-                {"type_cast_in_binary_operation5.json"},
-                {"type_cast_in_binary_operation6.json"},
-                {"type_cast_in_binary_operation7.json"},
-                {"type_cast_in_binary_operation8.json"},
-                {"type_cast_in_binary_operation9.json"}
+//                {"typeCast1.json"},
+//                {"typeCast2.json"},
+//                {"typeCast3.json"},
+//                {"typeCast4.json"},
+//                {"typeCast5.json"},
+////                {"typeCast6.json", "typeCast.bal"}, Not supported by the subtype of API.
+//                {"typeCast7.json"},
+//                {"typeCast8.json"},
+//                {"typeCast9.json"},
+//                {"typeCast10.json"},
+//                {"typeCast11.json"},
+//                {"typeCast12.json"},
+//                {"typeCast13.json"},
+//                {"typeCast14.json"},
+//                {"nilTypeCast.json"},
+//                {"type_cast_function_param_config1.json"},
+//                {"typeCast11.json"},
+//                {"typeCastInMemberAccess1.json"},
+//
+//                {"type_cast_in_binary_operation1.json"},
+//                {"type_cast_in_binary_operation2.json"},
+//                {"type_cast_in_binary_operation3.json"},
+//                {"type_cast_in_binary_operation4.json"},
+//                {"type_cast_in_binary_operation5.json"},
+//                {"type_cast_in_binary_operation6.json"},
+//                {"type_cast_in_binary_operation7.json"},
+//                {"type_cast_in_binary_operation8.json"},
+//                {"type_cast_in_binary_operation9.json"},
+                {"type_cast_in_assignment1.json"}
 
         };
     }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/type-cast/config/type_cast_in_assignment1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/type-cast/config/type_cast_in_assignment1.json
@@ -1,0 +1,29 @@
+{
+  "position": {
+    "line": 1,
+    "character": 19
+  },
+  "source": "type_cast_in_assignment1.bal",
+  "description": "Tests the type cast code action when the expected type is an optional numeric type",
+  "expected": [
+    {
+      "title": "Add type cast",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 18
+            },
+            "end": {
+              "line": 1,
+              "character": 18
+            }
+          },
+          "newText": "<float>"
+        }
+      ]
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/type-cast/config/type_cast_in_conditional_expr1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/type-cast/config/type_cast_in_conditional_expr1.json
@@ -1,0 +1,28 @@
+{
+  "position": {
+    "line": 3,
+    "character": 29
+  },
+  "source": "type_cast_in_conditional_expr.bal",
+  "expected": [
+    {
+      "title": "Add type cast",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 3,
+              "character": 27
+            },
+            "end": {
+              "line": 3,
+              "character": 27
+            }
+          },
+          "newText": "<int>"
+        }
+      ]
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/type-cast/config/type_cast_in_conditional_expr2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/type-cast/config/type_cast_in_conditional_expr2.json
@@ -1,0 +1,28 @@
+{
+  "position": {
+    "line": 9,
+    "character": 37
+  },
+  "source": "type_cast_in_conditional_expr.bal",
+  "expected": [
+    {
+      "title": "Add type cast",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 9,
+              "character": 35
+            },
+            "end": {
+              "line": 9,
+              "character": 35
+            }
+          },
+          "newText": "<int>"
+        }
+      ]
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/type-cast/config/type_cast_in_conditional_expr3.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/type-cast/config/type_cast_in_conditional_expr3.json
@@ -1,0 +1,29 @@
+{
+  "position": {
+    "line": 16,
+    "character": 20
+  },
+  "source": "type_cast_in_conditional_expr.bal",
+  "expected": [
+    {
+      "title": "Add type cast",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 16,
+              "character": 16
+            },
+            "end": {
+              "line": 16,
+              "character": 16
+            }
+          },
+          "newText": "<boolean>"
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/type-cast/config/type_cast_numeric1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/type-cast/config/type_cast_numeric1.json
@@ -1,0 +1,29 @@
+{
+  "position": {
+    "line": 1,
+    "character": 24
+  },
+  "source": "type_cast_numeric.bal",
+  "expected": [
+    {
+      "title": "Add type cast",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 22
+            },
+            "end": {
+              "line": 1,
+              "character": 22
+            }
+          },
+          "newText": "<int>"
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/type-cast/source/type_cast_in_assignment1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/type-cast/source/type_cast_in_assignment1.bal
@@ -1,0 +1,3 @@
+function test(int num) {
+    float? num1 = num;
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/type-cast/source/type_cast_in_conditional_expr.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/type-cast/source/type_cast_in_conditional_expr.bal
@@ -1,0 +1,18 @@
+public function testMiddle() {
+        int adult = 20;
+        int age = 30; 
+        int i = age < 18 ? 2.5 : adult;
+}
+
+public function testEnd() {
+        int adult = 20;
+        int age = 30; 
+        int i = age < 18 ? adult : 2.5;
+}
+
+public function testLHS() {
+        int adult = 20;
+        int age = 30; 
+        string | boolean condition = true;
+        int i = condition ? adult : 2.5;
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/type-cast/source/type_cast_numeric.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/type-cast/source/type_cast_numeric.bal
@@ -1,0 +1,3 @@
+function test(float|decimal num) {
+    int|string num2 = num;
+}


### PR DESCRIPTION
## Purpose
$subject to suggest type cast code action as a quick fix  when the expected type is a optional numeric type.

Fixes #37465
Fixes #37678

## Samples
![capture](https://user-images.githubusercontent.com/35211477/186836044-3e72bff2-28aa-44ae-b275-2e005cb19e8d.gif)


## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
