### PR TITLE
Fix escaping special characters method omitting `\` char

### DIFF
--- a/cli/ballerina-cli/build.gradle
+++ b/cli/ballerina-cli/build.gradle
@@ -44,7 +44,6 @@ dependencies {
     implementation project(':maven-resolver')
     implementation project(':ballerina-shell:shell-cli')
     implementation project(':toml-parser')
-    implementation project(':identifier-util')
     testCompile project(':ballerina-test-utils')
 
     testCompile 'org.testng:testng'

--- a/cli/ballerina-cli/src/main/java/module-info.java
+++ b/cli/ballerina-cli/src/main/java/module-info.java
@@ -18,5 +18,4 @@ module io.ballerina.cli {
     requires slf4j.api;
     requires io.ballerina.shell.cli;
     requires io.ballerina.toml;
-    requires io.ballerina.identifier;
 }

--- a/misc/identifier-util/src/main/java/io/ballerina/identifier/Utils.java
+++ b/misc/identifier-util/src/main/java/io/ballerina/identifier/Utils.java
@@ -35,10 +35,8 @@ public class Utils {
 
     private static final String CHAR_PREFIX = "$";
     private static final String ESCAPE_PREFIX = "\\";
-    private static final String JVM_RESERVED_CHAR_SET = "\\.:;[]/<>";
-    private static final String ENCODABLE_CHAR_SET = JVM_RESERVED_CHAR_SET + CHAR_PREFIX;
-    private static final Pattern UNESCAPED_SPECIAL_CHAR_SET =
-            Pattern.compile("(?<!\\\\)(?:\\\\\\\\)*([$&+,:;=\\?@#|/' \\[\\}\\]<\\>.\"^*{}~`()%!-])");
+    private static final Pattern UNESCAPED_SPECIAL_CHAR_SET = Pattern.compile("([$&+,:;=\\?@#\\\\|/'\\ \\[\\}\\]<\\>" +
+            ".\"^*{}~`()%!-])");
     private static final String GENERATED_METHOD_PREFIX = "$gen$";
 
     private Utils() {

--- a/misc/identifier-util/src/main/java/module-info.java
+++ b/misc/identifier-util/src/main/java/module-info.java
@@ -3,6 +3,6 @@ module io.ballerina.identifier {
     requires org.apache.commons.text;
 
     exports io.ballerina.identifier to io.ballerina.lang, io.ballerina.runtime, io.ballerina.shell,
-            io.ballerina.testerina.runtime, io.ballerina.lang.runtime, io.ballerina.lang.error, io.ballerina.cli,
+            io.ballerina.testerina.runtime, io.ballerina.lang.runtime, io.ballerina.lang.error,
             ballerina.debug.adapter.core, io.ballerina.jsonmapper;
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/literals/IdentifierLiteralTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/literals/IdentifierLiteralTest.java
@@ -28,6 +28,7 @@ import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 /**
@@ -41,21 +42,6 @@ public class IdentifierLiteralTest {
     @BeforeClass
     public void setup() {
         result = BCompileUtil.compile("test-src/expressions/literals/identifierliteral/identifier-literal-success.bal");
-    }
-
-    @Test(description = "Test defining final variables with Identifier Literal and refer within a function")
-    public void testILInFinalVariables() {
-        BRunUtil.invoke(result, "testFinalVariableIL");
-    }
-
-    @Test(description = "Test defining global variable with Identifier Literal and refer within a function")
-    public void testILInGlobalVariables() {
-        BRunUtil.invoke(result, "testGlobalVariableIL");
-    }
-
-    @Test(description = "Test defining local variable with Identifier Literal and refer within a function")
-    public void testILInLocalVariables() {
-        BRunUtil.invoke(result, "testLocalVariableIL");
     }
 
     @Test(description = "Test defining local variables with Identifier Literal and get them as return parameters")
@@ -91,42 +77,12 @@ public class IdentifierLiteralTest {
         Assert.assertEquals(returns.toString(), "{\"name\":\"James\",\"age\":30}");
     }
 
-    @Test(description = "Test using identifier literals in arrays and array indexes")
-    public void testUsingIdentifierLiteralAsArrayIndex() {
-        BRunUtil.invoke(result, "useILAsArrayIndex");
-    }
-
-    @Test(description = "Test using identifier literals in function parameters")
-    public void testUsingIdentifierLiteralAsFunctionParams() {
-        BRunUtil.invoke(result, "passILValuesToFunction");
-    }
-
     @Test(description = "Test character range in identifier literal")
     public void testCharacterRangeInIdentifierLiteral() {
         Object returns = BRunUtil.invoke(result, "testCharInIL");
         Assert.assertTrue(returns instanceof BString);
         String actualString = returns.toString();
         Assert.assertEquals(actualString, "sample value");
-    }
-
-    @Test(description = "Test function name with identifier literal")
-    public void testFunctionNameWithInIdentifierLiteral() {
-        BRunUtil.invoke(result, "testFunctionNameWithIL");
-    }
-
-    @Test(description = "Test connector name with identifier literal")
-    public void testConnectorWithIdentifierLiteral() {
-        BRunUtil.invoke(result, "testConnectorNameWithIL");
-    }
-
-    @Test(description = "Test connector action with identifier literal")
-    public void testConnectorActionWithIdentifierLiteral() {
-        BRunUtil.invoke(result, "testConnectorActionWithIL");
-    }
-
-    @Test(description = "Test defining local variables with Identifier Literal")
-    public void testIdentifierLiteralInStructName() {
-        BRunUtil.invoke(result, "useILInStructName");
     }
 
     @Test(description = "Test unicode with identifier literal")
@@ -235,45 +191,18 @@ public class IdentifierLiteralTest {
         Assert.assertEquals(returns.toString(), "I am an integer");
     }
 
-    @Test(description = "Test quoted identifier literals in workers")
-    public void testILInWorkers() {
-        BRunUtil.invoke(result, "useILAsWorkerName");
+    @Test(description = "Test IL with different types", dataProvider = "IL-function-provider")
+    public void testILWithFunctions(String funcName) {
+        BRunUtil.invoke(result, funcName);
     }
 
-    @Test(description = "Test quoted identifier literals in workers")
-    public void testILInWorkerInteraction() {
-        BRunUtil.invoke(result, "testWorkerInteractionWithIL");
-    }
-
-    @Test(description = "Test struct type member access with literal string")
-    public void testMemberAccessWithIL() {
-        Object arr = BRunUtil.invoke(result, "testMemberAccessWithIL");
-        BArray returns = (BArray) arr;
-        Assert.assertEquals(returns.size(), 4);
-        Assert.assertEquals(returns.get(0).toString(), "Jack");
-        Assert.assertEquals(returns.get(1), 50L);
-        Assert.assertEquals(returns.get(2).toString(), "John");
-        Assert.assertEquals(returns.get(3).toString(), "25");
-    }
-
-    @Test(description = "Test struct type to string returning expected value for IL")
-    public void testStructTypeToStringMethod() {
-        BRunUtil.invoke(result, "testToStringWithIL");
-    }
-
-    @Test(description = "Test ToString method returning expected value for struct type field name with IL")
-    public void testStructFieldToStringMethod() {
-        BRunUtil.invoke(result, "testToStringStructFieldsWithIL");
-    }
-
-    @Test(description = "Test IL with immutable type")
-    public void testImmutableTypeIL() {
-        BRunUtil.invoke(result, "testImmutableTypeIL");
-    }
-
-    @Test(description = "Test IL with table type with quoted IL as key")
-    public void testILInTableType() {
-        BRunUtil.invoke(result, "testILInTableType");
+    @DataProvider(name = "IL-function-provider")
+    public Object[] functionProvider() {
+        return new String[]{
+                "testLocalVariableIL", "testGlobalVariableIL", "testFinalVariableIL", "passILValuesToFunction",
+                "useILAsArrayIndex", "useILInStructName", "testConnectorActionWithIL", "testConnectorNameWithIL",
+                "testFunctionNameWithIL", "testILInTableType", "testImmutableTypeIL", "testToStringStructFieldsWithIL",
+                "testToStringWithIL", "testWorkerInteractionWithIL", "useILAsWorkerName", "testMemberAccessWithIL"};
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/literals/identifierliteral/identifier-literal-success.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/literals/identifierliteral/identifier-literal-success.bal
@@ -223,18 +223,33 @@ function testWorkerInteractionWithIL() {
      assertEquality(20, result);
 }
 
-function testMemberAccessWithIL() returns [string?, int?, string?, string?] {
-    'Person_ƮέŞŢ_\ \/\:\@\[\`\{\~\u{2324} person = {'1st_name: "Jack", 'Ȧɢέ_\ \/\:\@\[\`\{\~\u{2324}: 50};
+function testMemberAccessWithIL() {
+    'Person_ƮέŞŢ_\ \/\:\@\[\`\{\~\u{2324} person = {'1st_name: "Jack", 'Ȧɢέ_\ \/\\\:\@\[\`\{\~\u{2324}: 50};
     map<string> personMap = {
-        '\ \/\:\@\[\`\{\~\u{2324}_First_name: "John",
+        '\ \/\\\:\@\[\`\{\~\u{2324}_First_name: "John",
         'Ȧɢέ: "25"
     };
-    return [person["1st_name"], person["Ȧɢέ_ /:@[`{~⌤"], personMap[" /:@[`{~⌤_First_name"], personMap["Ȧɢέ"]];
+
+    string? result1 = person["1st_name"];
+    assertEquality("Jack", result1);
+
+    int? result2 = person["Ȧɢέ_ /\\:@[`{~⌤"];
+    assertEquality(50, result2);
+
+    result1 = personMap[" /\\:@[`{~⌤_First_name"];
+    assertEquality("John", result1);
+    result1 = personMap["Ȧɢέ"];
+    assertEquality("25", result1);
+
+    int[] arr = [person["Ȧɢέ_ /\\:@[`{~⌤"], 22, 44];
+    int 'Ȧɢέ_\ \\\/\:\@\[\`\{\~\u{2324} = 0;
+    result2 = arr['Ȧɢέ_\ \\\/\:\@\[\`\{\~\u{2324}];
+    assertEquality(50, result2);
 }
 
 type 'Person_ƮέŞŢ_\ \/\:\@\[\`\{\~\u{2324} record {
     string '1st_name;
-    int 'Ȧɢέ_\ \/\:\@\[\`\{\~\u{2324};
+    int 'Ȧɢέ_\ \/\\\:\@\[\`\{\~\u{2324};
 };
 
 function testToStringWithIL() {
@@ -245,13 +260,13 @@ function testToStringWithIL() {
 }
 
 function testToStringStructFieldsWithIL() {
-    'Person_ƮέŞŢ_\ \/\:\@\[\`\{\~\u{2324} person = {'1st_name: "Jack", 'Ȧɢέ_\ \/\:\@\[\`\{\~\u{2324}: 50};
+    'Person_ƮέŞŢ_\ \/\:\@\[\`\{\~\u{2324} person = {'1st_name: "Jack", 'Ȧɢέ_\ \/\\\:\@\[\`\{\~\u{2324}: 50};
     map<string> personMap = {
         '\ \/\:\@\[\`\{\~\u{2324}_First_name: "John",
         'Ȧɢέ: "25"
     };
     '\ \/\:\@\[\`\{\~\u{2324}_ƮέŞŢ_Connector testConnector = new("MyParam1", "MyParam2", 5);
-    assertEquality("{\"1st_name\":\"Jack\",\"Ȧɢέ_ /:@[`{~⌤\":50}", person.toString());
+    assertEquality("{\"1st_name\":\"Jack\",\"Ȧɢέ_ /\\:@[`{~⌤\":50}", person.toString());
     assertEquality("{\" /:@[`{~⌤_First_name\":\"John\",\"Ȧɢέ\":\"25\"}", personMap.toString());
     assertEquality("object  /:@[`{~⌤_ƮέŞŢ_Connector", value:toString(testConnector));
 }


### PR DESCRIPTION
## Purpose
$subject 

Fixes #36912 
Fixes #37514 

## Approach
Added `\` to escaping characters set after verifying the current usages.

## Samples
```ballerina
import ballerina/io;
type Person record {
    string 'name\\_\:\@2;
};

public function main() {
    Person person = {'name\\_\:\@2: "Hinduja"};
    string? result = person["name\\_:@2"]; // should pass
    io:println(result.toString());
}
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
