### PR TITLE
Fix create variable and check error code action to not return $CompilationError$

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionNodeValidator.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionNodeValidator.java
@@ -292,8 +292,7 @@ public class CodeActionNodeValidator extends NodeTransformer<Boolean> {
                 && !node.closeParenToken().isMissing()
                 && node.leadingInvalidTokens().isEmpty()
                 && node.trailingInvalidTokens().isEmpty()
-                && (node.returnTypeDesc().isEmpty()
-                || node.returnTypeDesc().get().apply(this))
+                && (node.returnTypeDesc().isEmpty() || node.returnTypeDesc().get().apply(this))
                 && node.parameters().stream().allMatch(parameterNode -> parameterNode.apply(this));
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionNodeValidator.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionNodeValidator.java
@@ -40,6 +40,7 @@ import io.ballerina.compiler.syntax.tree.PositionalArgumentNode;
 import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
 import io.ballerina.compiler.syntax.tree.RequiredParameterNode;
 import io.ballerina.compiler.syntax.tree.RestArgumentNode;
+import io.ballerina.compiler.syntax.tree.ReturnTypeDescriptorNode;
 import io.ballerina.compiler.syntax.tree.SimpleNameReferenceNode;
 import io.ballerina.compiler.syntax.tree.SpecificFieldNode;
 import io.ballerina.compiler.syntax.tree.SpreadFieldNode;
@@ -291,6 +292,8 @@ public class CodeActionNodeValidator extends NodeTransformer<Boolean> {
                 && !node.closeParenToken().isMissing()
                 && node.leadingInvalidTokens().isEmpty()
                 && node.trailingInvalidTokens().isEmpty()
+                && (node.returnTypeDesc().isEmpty()
+                || node.returnTypeDesc().get().apply(this))
                 && node.parameters().stream().allMatch(parameterNode -> parameterNode.apply(this));
     }
 
@@ -300,7 +303,14 @@ public class CodeActionNodeValidator extends NodeTransformer<Boolean> {
                 && !node.openBraceToken().isMissing()
                 && !node.closeBraceToken().isMissing()
                 && node.leadingInvalidTokens().isEmpty()
-                && node.trailingInvalidTokens().isEmpty();
+                && node.trailingInvalidTokens().isEmpty()
+                && node.parent().apply(this);
+    }
+
+    @Override
+    public Boolean transform(ReturnTypeDescriptorNode node) {
+        return isVisited(node) || !node.returnsKeyword().isMissing()
+                && node.type().apply(this);
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionUtil.java
@@ -488,6 +488,10 @@ public class CodeActionUtil {
                             returnText = "returns " + typeName + "|error";
                             returnRange = PositionUtil.toRange(enclosedRetTypeDescNode.lineRange());
                         }
+                    } else if (enclosedRetTypeDesc.typeKind() == TypeDescKind.COMPILATION_ERROR) {
+                        String returnType = enclosedRetTypeDescNode.type().toString().replaceAll("\\s+", "");
+                        returnText = "returns " + returnType + "|error";
+                        returnRange = PositionUtil.toRange(enclosedRetTypeDescNode.lineRange());
                     } else {
                         // Parent function already has another return-type
                         if (enclosedRetTypeDesc.typeKind() != TypeDescKind.ERROR) {

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/CreateVariableTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/CreateVariableTest.java
@@ -138,7 +138,8 @@ public class CreateVariableTest extends AbstractCodeActionTest {
         return new Object[][]{
                 {"createVariableNegative1.json"},
                 {"createVariableNegative2.json"},
-                {"createVariableNegative3.json"}
+                {"createVariableNegative3.json"},
+                {"createVariableNegative4.json"}
         };
     }
 }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/CreateVariableTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/CreateVariableTest.java
@@ -129,7 +129,8 @@ public class CreateVariableTest extends AbstractCodeActionTest {
                 {"createVariableWithCheck2.json"},
                 {"createVariableWithCheck3.json"},
                 {"createVariableWithCheck4.json"},
-                {"createVariableWithCheck5.json"}
+                {"createVariableWithCheck5.json"},
+                {"createVariableWithCheck6.json"}
         };
     }
 

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableNegative4.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableNegative4.json
@@ -1,0 +1,12 @@
+{
+  "position": {
+    "line": 25,
+    "character": 4
+  },
+  "source": "createVariableWithCheck.bal",
+  "expected": [
+    {
+      "title": "Create variable"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithCheck6.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithCheck6.json
@@ -1,0 +1,55 @@
+{
+  "position": {
+    "line": 29,
+    "character": 4
+  },
+  "source": "createVariableWithCheck.bal",
+  "expected": [
+    {
+      "title": "Create variable and check error",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 29,
+              "character": 4
+            },
+            "end": {
+              "line": 29,
+              "character": 4
+            }
+          },
+          "newText": "int intWithError \u003d "
+        },
+        {
+          "range": {
+            "start": {
+              "line": 29,
+              "character": 4
+            },
+            "end": {
+              "line": 29,
+              "character": 4
+            }
+          },
+          "newText": "check "
+        },
+        {
+          "range": {
+            "start": {
+              "line": 28,
+              "character": 62
+            },
+            "end": {
+              "line": 28,
+              "character": 73
+            }
+          },
+          "newText": "returns abc|error"
+        }
+      ]
+    }
+  ],
+  "description": "Parent function has undefined return type"
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/source/createVariable.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/source/createVariable.bal
@@ -3,7 +3,7 @@
 # + color - color of the apple
 public class Apple {
     public string color = "red";
-};
+}
 
 # A Grapes Description
 public class Grapes {
@@ -13,7 +13,7 @@ public class Grapes {
      public function init(string color) {
         self.color = color;
      }
-};
+}
 
 public function main (string... args) {
    int a = 12;

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/source/createVariable2.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/source/createVariable2.bal
@@ -8,7 +8,7 @@ public class Lorry {
     public function get_color(int a) returns Color{
         return new Color();
     }
-};
+}
 
 # A Car
 public class Color {
@@ -18,7 +18,7 @@ public class Color {
     public function print(string b) returns string{
         return "red";
     }
-};
+}
 
 public function foo(string... args) {
     Lorry lorry = new Lorry();

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/source/createVariableWithCheck.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/source/createVariableWithCheck.bal
@@ -22,6 +22,10 @@ function testCreateVarWithCheckParentHasAnotherReturnType() returns string {
     createIntWithError();
 }
 
-function testCreateVarWithCheckParentHasAnotherReturnType() returns {
+function testCreateVarWithCheckParentHasNoReturnType() returns {
+    createIntWithError();
+}
+
+function testCreateVarWithCheckParentHasUndefinedReturnType() returns abc {
     createIntWithError();
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/source/createVariableWithCheck.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/source/createVariableWithCheck.bal
@@ -21,3 +21,7 @@ function testCreateVarWithCheckParentHasErrorReturnType() returns error {
 function testCreateVarWithCheckParentHasAnotherReturnType() returns string {
     createIntWithError();
 }
+
+function testCreateVarWithCheckParentHasAnotherReturnType() returns {
+    createIntWithError();
+}


### PR DESCRIPTION
## Purpose
This PR fixes the create variable and check error code action to not return `$CompilationError$` when we only have `returns` without the return type.

Fixes #37252

## Samples

https://user-images.githubusercontent.com/61020198/188059583-845829de-6c26-49db-8c38-70ee10797ff1.mov


## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
