### PR TITLE
Fix ConcurrentModificationException due to the usage of TreeMap#computeIfAbsent 

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/constants/JvmArrayTypeConstantsGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/constants/JvmArrayTypeConstantsGen.java
@@ -85,7 +85,10 @@ public class JvmArrayTypeConstantsGen {
     }
 
     public String add(BArrayType arrayType) {
-        return arrayTypeVarMap.computeIfAbsent(arrayType, str -> generateBArrayInits(arrayType));
+        if (!arrayTypeVarMap.containsKey(arrayType)) {
+            arrayTypeVarMap.put(arrayType, generateBArrayInits(arrayType));
+        }
+        return arrayTypeVarMap.get(arrayType);
     }
 
     private String generateBArrayInits(BArrayType arrayType) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/constants/JvmArrayTypeConstantsGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/constants/JvmArrayTypeConstantsGen.java
@@ -85,10 +85,12 @@ public class JvmArrayTypeConstantsGen {
     }
 
     public String add(BArrayType arrayType) {
-        if (!arrayTypeVarMap.containsKey(arrayType)) {
-            arrayTypeVarMap.put(arrayType, generateBArrayInits(arrayType));
+        String varName = arrayTypeVarMap.get(arrayType);
+        if (varName == null) {
+            varName = generateBArrayInits(arrayType);
+            arrayTypeVarMap.put(arrayType, varName);
         }
-        return arrayTypeVarMap.get(arrayType);
+        return varName;
     }
 
     private String generateBArrayInits(BArrayType arrayType) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/constants/JvmRefTypeConstantsGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/constants/JvmRefTypeConstantsGen.java
@@ -77,10 +77,12 @@ public class JvmRefTypeConstantsGen {
     }
 
     public String add(BTypeReferenceType type) {
-        if (!typeRefVarMap.containsKey(type)) {
-            typeRefVarMap.put(type, generateTypeRefInits(type));
+        String varName = typeRefVarMap.get(type);
+        if (varName == null) {
+            varName = generateTypeRefInits(type);
+            typeRefVarMap.put(type, varName);
         }
-        return typeRefVarMap.get(type);
+        return varName;
     }
 
     private void visitTypeRefTypeInitMethod() {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/constants/JvmRefTypeConstantsGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/constants/JvmRefTypeConstantsGen.java
@@ -77,7 +77,10 @@ public class JvmRefTypeConstantsGen {
     }
 
     public String add(BTypeReferenceType type) {
-        return typeRefVarMap.computeIfAbsent(type, str -> generateTypeRefInits(type));
+        if (!typeRefVarMap.containsKey(type)) {
+            typeRefVarMap.put(type, generateTypeRefInits(type));
+        }
+        return typeRefVarMap.get(type);
     }
 
     private void visitTypeRefTypeInitMethod() {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/constants/JvmTupleTypeConstantsGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/constants/JvmTupleTypeConstantsGen.java
@@ -83,7 +83,10 @@ public class JvmTupleTypeConstantsGen {
     }
 
     public String add(BTupleType type, SymbolTable symbolTable) {
-        return tupleTypeVarMap.computeIfAbsent(type, str -> generateBTupleInits(type, symbolTable));
+        if (!tupleTypeVarMap.containsKey(type)) {
+            tupleTypeVarMap.put(type, generateBTupleInits(type, symbolTable));
+        }
+        return tupleTypeVarMap.get(type);
     }
 
     private void visitTupleTypeInitMethod() {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/constants/JvmTupleTypeConstantsGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/constants/JvmTupleTypeConstantsGen.java
@@ -83,10 +83,12 @@ public class JvmTupleTypeConstantsGen {
     }
 
     public String add(BTupleType type, SymbolTable symbolTable) {
-        if (!tupleTypeVarMap.containsKey(type)) {
-            tupleTypeVarMap.put(type, generateBTupleInits(type, symbolTable));
+        String varName = tupleTypeVarMap.get(type);
+        if (varName == null) {
+            varName = generateBTupleInits(type, symbolTable);
+            tupleTypeVarMap.put(type, varName);
         }
-        return tupleTypeVarMap.get(type);
+        return varName;
     }
 
     private void visitTupleTypeInitMethod() {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/constants/JvmUnionTypeConstantsGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/constants/JvmUnionTypeConstantsGen.java
@@ -86,7 +86,10 @@ public class JvmUnionTypeConstantsGen {
     }
 
     public String add(BUnionType type, SymbolTable symbolTable) {
-        return unionTypeVarMap.computeIfAbsent(type, str -> generateBUnionInits(type, symbolTable));
+        if (!unionTypeVarMap.containsKey(type)) {
+            unionTypeVarMap.put(type, generateBUnionInits(type, symbolTable));
+        }
+        return unionTypeVarMap.get(type);
     }
 
     private void visitUnionTypeInitMethod() {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/constants/JvmUnionTypeConstantsGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/constants/JvmUnionTypeConstantsGen.java
@@ -86,10 +86,12 @@ public class JvmUnionTypeConstantsGen {
     }
 
     public String add(BUnionType type, SymbolTable symbolTable) {
-        if (!unionTypeVarMap.containsKey(type)) {
-            unionTypeVarMap.put(type, generateBUnionInits(type, symbolTable));
+        String varName = unionTypeVarMap.get(type);
+        if (varName == null) {
+            varName = generateBUnionInits(type, symbolTable);
+            unionTypeVarMap.put(type, varName);
         }
-        return unionTypeVarMap.get(type);
+        return varName;
     }
 
     private void visitUnionTypeInitMethod() {


### PR DESCRIPTION
## Purpose
> $title

Fixes #37236

## Approach
We can avoid CME by using `ConcurrentSkipListMap` instead of `TreeMap`, but the code generation happen sequentially we actually do not need a concurrent approach to solve this problem and using `ConcurrentSkipListMap` may bring some performance issues. 

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
