### PR TITLE
Update the label of annotation keyword snippet

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/SnippetGenerator.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/SnippetGenerator.java
@@ -668,7 +668,7 @@ public class SnippetGenerator {
      * @return {@link SnippetBlock}     Generated Snippet Block
      */
     public static SnippetBlock getAnnotationKeywordSnippet() {
-        return new SnippetBlock(ItemResolverConstants.ANNOTATION_TYPE, ItemResolverConstants.ANNOTATION_TYPE,
+        return new SnippetBlock(ItemResolverConstants.ANNOTATION, ItemResolverConstants.ANNOTATION,
                 "annotation ", ItemResolverConstants.KEYWORD_TYPE, Kind.KEYWORD);
     }
 

--- a/language-server/modules/langserver-core/src/test/resources/completion/annotation_decl/config/config10.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/annotation_decl/config/config10.json
@@ -105,11 +105,11 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "Annotation",
+      "label": "annotation",
       "kind": "Keyword",
       "detail": "Keyword",
       "sortText": "Q",
-      "filterText": "Annotation",
+      "filterText": "annotation",
       "insertText": "annotation ",
       "insertTextFormat": "Snippet"
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/annotation_decl/config/config19.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/annotation_decl/config/config19.json
@@ -105,11 +105,11 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "Annotation",
+      "label": "annotation",
       "kind": "Keyword",
       "detail": "Keyword",
       "sortText": "Q",
-      "filterText": "Annotation",
+      "filterText": "annotation",
       "insertText": "annotation ",
       "insertTextFormat": "Snippet"
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/module_const_context/config/config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/module_const_context/config/config1.json
@@ -507,11 +507,11 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "Annotation",
+      "label": "annotation",
       "kind": "Keyword",
       "detail": "Keyword",
       "sortText": "Z",
-      "filterText": "Annotation",
+      "filterText": "annotation",
       "insertText": "annotation ",
       "insertTextFormat": "Snippet"
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/module_const_context/config/config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/module_const_context/config/config2.json
@@ -515,11 +515,11 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "Annotation",
+      "label": "annotation",
       "kind": "Keyword",
       "detail": "Keyword",
       "sortText": "Z",
-      "filterText": "Annotation",
+      "filterText": "annotation",
       "insertText": "annotation ",
       "insertTextFormat": "Snippet"
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/module_const_context/config/config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/module_const_context/config/config4.json
@@ -515,11 +515,11 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "Annotation",
+      "label": "annotation",
       "kind": "Keyword",
       "detail": "Keyword",
       "sortText": "Z",
-      "filterText": "Annotation",
+      "filterText": "annotation",
       "insertText": "annotation ",
       "insertTextFormat": "Snippet"
     },


### PR DESCRIPTION
## Purpose
This PR modifies the label of annotation keyword snippet to be `annotation` instead of `Annotation`.

Fixes #36672 

## Approach
Changed the snippet's label and filter text to `ItemResolverConstants.ANNOTATION` from `ItemResolverConstants.ANNOTATION_TYPE`.

## Samples
<img width="785" alt="Screenshot 2022-08-29 at 13 51 23" src="https://user-images.githubusercontent.com/27485094/187157194-f0b53c67-8513-4175-85a6-53a3e55caec3.png">

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
