### PR TITLE
[2201.2.x] Fix reference equals for function pointer values

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -507,9 +507,12 @@ public class TypeChecker {
                     return false;
                 }
                 return isHandleValueRefEqual(lhsValue, rhsValue);
+            case TypeTags.FUNCTION_POINTER_TAG:
+                return lhsType.getPackage().equals(rhsType.getPackage()) &&
+                        lhsType.getName().equals(rhsType.getName()) && rhsType.equals(lhsType);
+            default:
+                return false;
         }
-
-        return false;
     }
 
     private static boolean isXMLValueRefEqual(XmlValue lhsValue, XmlValue rhsValue) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BFunctionType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BFunctionType.java
@@ -18,6 +18,7 @@
 package io.ballerina.runtime.internal.types;
 
 import io.ballerina.identifier.Utils;
+import io.ballerina.runtime.api.Module;
 import io.ballerina.runtime.api.PredefinedTypes;
 import io.ballerina.runtime.api.TypeTags;
 import io.ballerina.runtime.api.flags.SymbolFlags;
@@ -61,8 +62,8 @@ public class BFunctionType extends BAnnotatableType implements FunctionType {
         this.flags = flags;
     }
 
-    public BFunctionType(Parameter[] parameters, Type restType, Type retType, long flags) {
-        super("function ()", null, Object.class);
+    public BFunctionType(Parameter[] parameters, Type restType, Type retType, long flags, String name, Module pkg) {
+        super(name, pkg, Object.class);
         this.parameters = parameters;
         this.restType = restType;
         this.retType = retType;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -1818,7 +1818,7 @@ public class BIRGen extends BLangNodeVisitor {
             this.env.enclFunc.localVars.add(tempVarDcl);
             BIROperand tempVarRef = new BIROperand(tempVarDcl);
 
-            BIRVariableDcl varDecl = this.env.symbolVarMap.get(varSymbol);;
+            BIRVariableDcl varDecl = this.env.symbolVarMap.get(varSymbol);
 
             BIROperand fromVarRef = new BIROperand(varDecl);
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
@@ -1710,10 +1710,8 @@ public class JvmInstructionGen {
         String name = inst.funcName.value;
 
         String funcKey = inst.pkgId.toString() + ":" + name;
-        String lambdaName;
-        if (functions.containsKey(funcKey)) {
-            lambdaName = functions.get(funcKey);
-        } else {
+        String lambdaName = functions.get(funcKey);
+        if (lambdaName == null) {
             lambdaName = Utils.encodeFunctionIdentifier(inst.funcName.value) + "$lambda" +
                     asyncDataCollector.getLambdaIndex() + "$";
             functions.put(funcKey, lambdaName);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
@@ -51,7 +51,9 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BTypeReferenceType;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.util.Flags;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.objectweb.asm.Opcodes.AASTORE;
 import static org.objectweb.asm.Opcodes.ACONST_NULL;
@@ -248,6 +250,8 @@ public class JvmInstructionGen {
     private final SymbolTable symbolTable;
     private final AsyncDataCollector asyncDataCollector;
     private final JvmTypeTestGen typeTestGen;
+    private final Map<String, String> functions;
+
 
     public JvmInstructionGen(MethodVisitor mv, BIRVarToJVMIndexMap indexMap, PackageID currentPackage,
                              JvmPackageGen jvmPackageGen, JvmTypeGen jvmTypeGen, JvmCastGen jvmCastGen,
@@ -262,6 +266,7 @@ public class JvmInstructionGen {
         this.jvmCastGen = jvmCastGen;
         this.jvmConstantsGen = jvmConstantsGen;
         typeTestGen = new JvmTypeTestGen(this, types, mv, jvmTypeGen);
+        this.functions = new HashMap<>();
     }
 
     static void addJUnboxInsn(MethodVisitor mv, JType jType) {
@@ -1712,8 +1717,12 @@ public class JvmInstructionGen {
         this.mv.visitInsn(DUP);
 
         String name = inst.funcName.value;
-        String lambdaName = Utils.encodeFunctionIdentifier(name) + "$lambda" +
-                asyncDataCollector.getLambdaIndex() + "$";
+
+        String funcKey = inst.pkgId.toString() + ":" + name;
+        String lambdaName = functions.containsKey(funcKey) ? functions.get(funcKey) :
+                Utils.encodeFunctionIdentifier(inst.funcName.value) + "$lambda" + asyncDataCollector.getLambdaIndex() +
+                        "$";
+
         asyncDataCollector.incrementLambdaIndex();
 
         BType type = JvmCodeGenUtil.getReferredType(inst.type);
@@ -1760,6 +1769,7 @@ public class JvmInstructionGen {
 
         this.storeToVar(inst.lhsOp.variableDcl);
         asyncDataCollector.add(lambdaName, inst);
+        functions.put(funcKey, lambdaName);
     }
 
     void generateNewXMLElementIns(BIRNonTerminator.NewXMLElement newXMLElement) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmSignatures.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmSignatures.java
@@ -272,7 +272,7 @@ public class JvmSignatures {
     public static final String INIT_FINITE_TYPE_IMPL = "(L" + STRING_VALUE + ";L" + SET + ";I)V";
     public static final String INIT_FUCNTION_PARAM = "(L" + STRING_VALUE + ";L" + BOOLEAN_VALUE + ";L" + TYPE + ";)V";
     public static final String INIT_FUNCTION_TYPE_IMPL = "([L" + FUNCTION_PARAMETER + ";L" + TYPE + ";L" + TYPE + ";" +
-            "J)V";
+            "JL" + STRING_VALUE + ";L" + MODULE + ";)V";
     public static final String INIT_INTERSECTION_TYPE_WITH_REFERENCE_TYPE =
             "(L" + MODULE + ";[L" + TYPE + ";L" + INTERSECTABLE_REFERENCE_TYPE + ";IZ)V";
     public static final String INIT_INTERSECTION_TYPE_WITH_TYPE = "(L" + MODULE + ";[L" + TYPE + ";L" + TYPE + ";IZ)V";

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTypeGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTypeGen.java
@@ -913,7 +913,8 @@ public class JvmTypeGen {
             mv.visitInsn(ACONST_NULL);
         } else {
             String moduleVarName = jvmConstantsGen.getModuleConstantVar(bType.tsymbol.pkgID);
-            mv.visitFieldInsn(GETSTATIC, jvmConstantsGen.getModuleConstantClass(), moduleVarName, JvmSignatures.GET_MODULE);
+            mv.visitFieldInsn(GETSTATIC, jvmConstantsGen.getModuleConstantClass(), moduleVarName,
+                    JvmSignatures.GET_MODULE);
         }
         // initialize the function type using the param types array and the return type
         mv.visitMethodInsn(INVOKESPECIAL, FUNCTION_TYPE_IMPL, JVM_INIT_METHOD, INIT_FUNCTION_TYPE_IMPL, false);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTypeGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTypeGen.java
@@ -908,7 +908,13 @@ public class JvmTypeGen {
         loadType(mv, bType.retType);
 
         mv.visitLdcInsn(bType.flags);
-
+        mv.visitLdcInsn(bType.name.getValue());
+        if (bType.tsymbol == null) {
+            mv.visitInsn(ACONST_NULL);
+        } else {
+            String moduleVarName = jvmConstantsGen.getModuleConstantVar(bType.tsymbol.pkgID);
+            mv.visitFieldInsn(GETSTATIC, jvmConstantsGen.getModuleConstantClass(), moduleVarName, JvmSignatures.GET_MODULE);
+        }
         // initialize the function type using the param types array and the return type
         mv.visitMethodInsn(INVOKESPECIAL, FUNCTION_TYPE_IMPL, JVM_INIT_METHOD, INIT_FUNCTION_TYPE_IMPL, false);
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/emit/TypeEmitter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/emit/TypeEmitter.java
@@ -250,15 +250,17 @@ class TypeEmitter {
     private static String emitBInvokableType(BInvokableType bType, int tabs) {
 
         StringBuilder invString = new StringBuilder("function(");
-        int pLength = bType.paramTypes.size();
         int i = 0;
-        for (BType pType : bType.paramTypes) {
-            if (pType != null) {
-                invString.append(emitTypeRef(pType, tabs));
-                i += 1;
-                if (i < pLength) {
-                    invString.append(",");
-                    invString.append(emitSpaces(1));
+        if (bType.paramTypes != null) {
+            int pLength = bType.paramTypes.size();
+            for (BType pType : bType.paramTypes) {
+                if (pType != null) {
+                    invString.append(emitTypeRef(pType, tabs));
+                    i += 1;
+                    if (i < pLength) {
+                        invString.append(",");
+                        invString.append(emitSpaces(1));
+                    }
                 }
             }
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRNonTerminator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRNonTerminator.java
@@ -747,6 +747,7 @@ public abstract class BIRNonTerminator extends BIRAbstractInstruction implements
             this.params = params;
             this.closureMaps = closureMaps;
             this.type = type;
+            this.type.name = funcName;
         }
 
         public FPLoad(Location location, PackageID pkgId, PackageID boundMethodPkgId, Name funcName, BIROperand lhsOp,
@@ -754,6 +755,7 @@ public abstract class BIRNonTerminator extends BIRAbstractInstruction implements
                       SchedulerPolicy schedulerPolicy) {
             this(location, pkgId, funcName, lhsOp, params, closureMaps, type, strandName, schedulerPolicy);
             this.boundMethodPkgId = boundMethodPkgId;
+            this.type.name = funcName;
         }
 
         @Override

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/RefEqualAndNotEqualOperationsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/RefEqualAndNotEqualOperationsTest.java
@@ -328,14 +328,18 @@ public class RefEqualAndNotEqualOperationsTest {
                            "Expected values to be identified as not reference equal");
     }
 
-    @Test
-    public void testTupleJSONRefEquality() {
-        BRunUtil.invoke(result, "testTupleJSONRefEquality");
+    @Test(dataProvider = "function-provider")
+    public void testRefEqualsFunctions(String funcName) {
+        BRunUtil.invoke(result, funcName);
     }
 
-    @Test
-    public void testIntersectingUnionRefEquality() {
-        BRunUtil.invoke(result, "testIntersectingUnionRefEquality");
+    @DataProvider(name = "function-provider")
+    public Object[] getRefEqualsFunctions() {
+        return new String[] {
+                "testTupleJSONRefEquality",
+                "testIntersectingUnionRefEquality",
+                "testFPValueEquality"
+        };
     }
 
     @Test(dataProvider = "functionsWithXmlExactEqualityChecks")

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/ref_equal_and_not_equal_operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/ref_equal_and_not_equal_operation.bal
@@ -609,6 +609,31 @@ function testIntersectingUnionRefEquality() {
     assert(c !== a, true);
 }
 
+function func() {
+}
+
+function funcClone() {
+}
+
+function func1 = func;
+function func2 = funcClone;
+function func3 = function() => ();
+
+function testFPValueEquality() {
+    function func4 = function() => ();
+
+    test:assertTrue(func === func);
+    test:assertTrue(funcClone === funcClone);
+    test:assertTrue(func1 === func1);
+    test:assertTrue(func2 === func2);
+    test:assertTrue(func4 === func4);
+    test:assertTrue(func3 === func3);
+
+    test:assertFalse(func === funcClone);
+    test:assertFalse(func1 === func2);
+    test:assertFalse(func3 === func4);
+}
+
 function assert(anydata actual, anydata expected) {
     if (expected == actual) {
         return;


### PR DESCRIPTION
## Purpose
$subject

Fixes #37379
Duplicate of PR https://github.com/ballerina-platform/ballerina-lang/pull/37431

## Approach
- Removed creating multiple lambda functions when creating multiple `FPValue` values that point to the same function. 
- Modified `refEquals()` logic to support function pointers pointing same function.

## Samples
```ballerina
import ballerina/io;
function func() {}

public function main() {
    io:println(func === func);
}
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
