### PR TITLE
Support accepting non-abstract TypeSymbols as type parameters in Type Builders

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/type/builders/BallerinaArrayTypeBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/type/builders/BallerinaArrayTypeBuilder.java
@@ -20,8 +20,12 @@ package io.ballerina.compiler.api.impl.type.builders;
 
 import io.ballerina.compiler.api.TypeBuilder;
 import io.ballerina.compiler.api.impl.symbols.AbstractTypeSymbol;
+import io.ballerina.compiler.api.impl.symbols.BallerinaSymbol;
 import io.ballerina.compiler.api.impl.symbols.TypesFactory;
 import io.ballerina.compiler.api.symbols.ArrayTypeSymbol;
+import io.ballerina.compiler.api.symbols.ClassSymbol;
+import io.ballerina.compiler.api.symbols.ConstantSymbol;
+import io.ballerina.compiler.api.symbols.EnumSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BTypeSymbol;
@@ -103,6 +107,11 @@ public class BallerinaArrayTypeBuilder implements TypeBuilder.ARRAY {
 
         if (type instanceof AbstractTypeSymbol) {
             return ((AbstractTypeSymbol) type).getBType();
+        }
+
+        if ((type instanceof ClassSymbol || type instanceof ConstantSymbol || type instanceof EnumSymbol)
+                && type instanceof BallerinaSymbol) {
+            return ((BallerinaSymbol) type).getInternalSymbol().getType();
         }
 
         throw new IllegalArgumentException("Invalid array member type descriptor provided");

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypeBuildersTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypeBuildersTest.java
@@ -90,14 +90,14 @@ public class TypeBuildersTest {
     private static final String ORG = "$anon";
     private static final String MODULE = ".";
     private static final String VERSION = "0.0.0";
-    private TypeSymbol CLASS_TYPE;
-    private TypeSymbol CUS_RECORD_TYPE;
-    private TypeSymbol CONST_TYPE;
-    private TypeSymbol RED_TYPE;
-    private TypeSymbol GREEN_TYPE;
-    private TypeSymbol SINGLETON_TYPE;
-    private TypeSymbol TABLE_TYPE;
-    private TypeSymbol ENUM_TYPE;
+    private TypeSymbol classType;
+    private TypeSymbol cusRecordType;
+    private TypeSymbol constType;
+    private TypeSymbol redType;
+    private TypeSymbol greenType;
+    private TypeSymbol singletonType;
+    private TypeSymbol tableType;
+    private TypeSymbol enumType;
 
     @BeforeClass
     public void setup() {
@@ -112,14 +112,14 @@ public class TypeBuildersTest {
             xmlSubTypes.add(((XMLTypeSymbol) ((TypeReferenceTypeSymbol) xmlSubTypeMember).typeDescriptor()));
         }
 
-        CLASS_TYPE = getReferredTypeSymbol(157, 10);
-        CUS_RECORD_TYPE = getReferredTypeSymbol(158, 8);
-        CONST_TYPE = getReferredTypeSymbol(159, 12);
-        RED_TYPE = getReferredTypeSymbol(160, 8);
-        GREEN_TYPE = getReferredTypeSymbol(161, 10);
-        SINGLETON_TYPE = getReferredTypeSymbol(162, 6);
-        TABLE_TYPE = getReferredTypeSymbol(163, 13);
-        ENUM_TYPE = getReferredTypeSymbol(164, 11);
+        classType = getReferredTypeSymbol(157, 10);
+        cusRecordType = getReferredTypeSymbol(158, 8);
+        constType = getReferredTypeSymbol(159, 12);
+        redType = getReferredTypeSymbol(160, 8);
+        greenType = getReferredTypeSymbol(161, 10);
+        singletonType = getReferredTypeSymbol(162, 6);
+        tableType = getReferredTypeSymbol(163, 13);
+        enumType = getReferredTypeSymbol(164, 11);
     }
 
     @Test(dataProvider = "xmlTypeBuilderProvider")
@@ -312,10 +312,10 @@ public class TypeBuildersTest {
                 {types.INT, null, "int[]"},
                 {types.BYTE, 24, "byte[24]"},
                 {types.FLOAT, -1, "float[*]"},
-                {CONST_TYPE, 4, "\"389\"[4]"},
-                {ENUM_TYPE, 2, "myEnum[2]"},
-                {SINGLETON_TYPE, 5, "5[5]"},
-                {CLASS_TYPE, -1, "MyCls[*]"},
+                {constType, 4, "\"389\"[4]"},
+                {enumType, 2, "myEnum[2]"},
+                {singletonType, 5, "5[5]"},
+                {classType, -1, "MyCls[*]"},
         };
     }
 
@@ -578,11 +578,11 @@ public class TypeBuildersTest {
     private Object[][] getUnionTypes() {
         return new Object[][] {
                 {List.of(types.INT, types.STRING), "int|string"},
-                {List.of(types.FLOAT, CLASS_TYPE, types.BOOLEAN), "float|MyCls|boolean"},
-                {List.of(CONST_TYPE, CUS_RECORD_TYPE), "\"389\"|Cus"},
-                {List.of(RED_TYPE, TABLE_TYPE, GREEN_TYPE), "\"DER\"|table<Student>|\"GREEN\""},
-                {List.of(types.BYTE, SINGLETON_TYPE), "byte|5"},
-                {List.of(types.DECIMAL, ENUM_TYPE, CONST_TYPE), "decimal|myEnum|\"389\""},
+                {List.of(types.FLOAT, classType, types.BOOLEAN), "float|MyCls|boolean"},
+                {List.of(constType, cusRecordType), "\"389\"|Cus"},
+                {List.of(redType, tableType, greenType), "\"DER\"|table<Student>|\"GREEN\""},
+                {List.of(types.BYTE, singletonType), "byte|5"},
+                {List.of(types.DECIMAL, enumType, constType), "decimal|myEnum|\"389\""},
         };
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypeBuildersTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypeBuildersTest.java
@@ -90,6 +90,14 @@ public class TypeBuildersTest {
     private static final String ORG = "$anon";
     private static final String MODULE = ".";
     private static final String VERSION = "0.0.0";
+    private TypeSymbol CLASS_TYPE;
+    private TypeSymbol CUS_RECORD_TYPE;
+    private TypeSymbol CONST_TYPE;
+    private TypeSymbol RED_TYPE;
+    private TypeSymbol GREEN_TYPE;
+    private TypeSymbol SINGLETON_TYPE;
+    private TypeSymbol TABLE_TYPE;
+    private TypeSymbol ENUM_TYPE;
 
     @BeforeClass
     public void setup() {
@@ -103,6 +111,15 @@ public class TypeBuildersTest {
         for (TypeSymbol xmlSubTypeMember : xmlSubTypeMembers) {
             xmlSubTypes.add(((XMLTypeSymbol) ((TypeReferenceTypeSymbol) xmlSubTypeMember).typeDescriptor()));
         }
+
+        CLASS_TYPE = getReferredTypeSymbol(157, 10);
+        CUS_RECORD_TYPE = getReferredTypeSymbol(158, 8);
+        CONST_TYPE = getReferredTypeSymbol(159, 12);
+        RED_TYPE = getReferredTypeSymbol(160, 8);
+        GREEN_TYPE = getReferredTypeSymbol(161, 10);
+        SINGLETON_TYPE = getReferredTypeSymbol(162, 6);
+        TABLE_TYPE = getReferredTypeSymbol(163, 13);
+        ENUM_TYPE = getReferredTypeSymbol(164, 11);
     }
 
     @Test(dataProvider = "xmlTypeBuilderProvider")
@@ -295,6 +312,10 @@ public class TypeBuildersTest {
                 {types.INT, null, "int[]"},
                 {types.BYTE, 24, "byte[24]"},
                 {types.FLOAT, -1, "float[*]"},
+                {CONST_TYPE, 4, "\"389\"[4]"},
+                {ENUM_TYPE, 2, "myEnum[2]"},
+                {SINGLETON_TYPE, 5, "5[5]"},
+                {CLASS_TYPE, -1, "MyCls[*]"},
         };
     }
 
@@ -557,12 +578,21 @@ public class TypeBuildersTest {
     private Object[][] getUnionTypes() {
         return new Object[][] {
                 {List.of(types.INT, types.STRING), "int|string"},
-                {List.of(types.FLOAT, getSymbolTypeDef(140, 6), types.BOOLEAN), "float|MyCls|boolean"},
-                {List.of(getSymbolTypeDef(133, 6), getSymbolTypeDef(135, 5)), "\"389\"|Cus"},
+                {List.of(types.FLOAT, CLASS_TYPE, types.BOOLEAN), "float|MyCls|boolean"},
+                {List.of(CONST_TYPE, CUS_RECORD_TYPE), "\"389\"|Cus"},
+                {List.of(RED_TYPE, TABLE_TYPE, GREEN_TYPE), "\"DER\"|table<Student>|\"GREEN\""},
+                {List.of(types.BYTE, SINGLETON_TYPE), "byte|5"},
+                {List.of(types.DECIMAL, ENUM_TYPE, CONST_TYPE), "decimal|myEnum|\"389\""},
         };
     }
 
     // utils
+
+    private TypeSymbol getReferredTypeSymbol(int line, int column) {
+        TypeSymbol typeSymbol = getSymbolTypeDef(line, column);
+        return typeSymbol.typeKind() == TYPE_REFERENCE ? ((TypeReferenceTypeSymbol) typeSymbol).typeDescriptor() :
+                typeSymbol;
+    }
 
     private TypeSymbol getSymbolTypeDef(int line, int column) {
         Project project = BCompileUtil.loadProject("test-src/typedefs_for_type_builders.bal");

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/typedefs_for_type_builders.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/typedefs_for_type_builders.bal
@@ -153,3 +153,14 @@ class MyCls {
         self.x = x;
     }
 }
+
+function miscTypes() {
+    MyCls a;
+    Cus b;
+    MYCONST c;
+    RED d;
+    GREEN e;
+    5 f;
+    StuTable g;
+    myEnum h;
+}


### PR DESCRIPTION
## Purpose
> $title

Fixes #37189

## Approach
> 

## Samples
> 

## Remarks
> 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
