### PR TITLE
Introduce several validations for client declarations

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
@@ -785,7 +785,9 @@ public enum DiagnosticErrorCode implements DiagnosticCode {
     NO_MODULE_GENERATED_FOR_CLIENT_DECL("BCE4037", "no.module.generated.for.client.decl"),
     UNUSED_CLIENT_DECL_PREFIX("BCE4038", "unused.client.decl.prefix"),
     UNSUPPORTED_EXPOSURE_OF_CONSTRUCT_FROM_MODULE_GENERATED_FOR_CLIENT_DECL(
-            "BCE4039", "unsupported.exposure.of.construct.from.module.generated.for.client.decl")
+            "BCE4039", "unsupported.exposure.of.construct.from.module.generated.for.client.decl"),
+    MODULE_GENERATED_FOR_CLIENT_DECL_MUST_HAVE_A_CLIENT_OBJECT_TYPE(
+            "BCE4040", "module.generated.for.client.decl.must.have.a.client.object.type")
     ;
 
     private String diagnosticId;

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
@@ -787,7 +787,9 @@ public enum DiagnosticErrorCode implements DiagnosticCode {
     UNSUPPORTED_EXPOSURE_OF_CONSTRUCT_FROM_MODULE_GENERATED_FOR_CLIENT_DECL(
             "BCE4039", "unsupported.exposure.of.construct.from.module.generated.for.client.decl"),
     MODULE_GENERATED_FOR_CLIENT_DECL_MUST_HAVE_A_CLIENT_OBJECT_TYPE(
-            "BCE4040", "module.generated.for.client.decl.must.have.a.client.object.type")
+            "BCE4040", "module.generated.for.client.decl.must.have.a.client.object.type"),
+    MODULE_GENERATED_FOR_CLIENT_DECL_CANNOT_HAVE_MUTABLE_STATE(
+            "BCE4041", "module.generated.for.client.decl.cannot.have.mutable.state")
     ;
 
     private String diagnosticId;

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
@@ -783,7 +783,9 @@ public enum DiagnosticErrorCode implements DiagnosticCode {
             "BCE4035", "invalid.usage.of.the.client.keyword.as.an.unquoted.identifier"),
     INVALID_NON_ANYDATA_CLIENT_DECL_ANNOTATION("BCE4036", "invalid.non.anydata.client.decl.annotation"),
     NO_MODULE_GENERATED_FOR_CLIENT_DECL("BCE4037", "no.module.generated.for.client.decl"),
-    UNUSED_CLIENT_DECL_PREFIX("BCE4038", "unused.client.decl.prefix")
+    UNUSED_CLIENT_DECL_PREFIX("BCE4038", "unused.client.decl.prefix"),
+    UNSUPPORTED_EXPOSURE_OF_CONSTRUCT_FROM_MODULE_GENERATED_FOR_CLIENT_DECL(
+            "BCE4039", "unsupported.exposure.of.construct.from.module.generated.for.client.decl")
     ;
 
     private String diagnosticId;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -10081,7 +10081,7 @@ public class Desugar extends BLangNodeVisitor {
         importDcl.pkgNameComps = List.of(ASTBuilderUtil.createIdentifier(pos, packageID.name.value));
         importDcl.orgName = ASTBuilderUtil.createIdentifier(pos, packageID.orgName.value);
         importDcl.version = ASTBuilderUtil.createIdentifier(pos, packageID.version.value);
-        BPackageSymbol moduleSymbol = symResolver.getModuleForClientDecl(packageID);
+        BPackageSymbol moduleSymbol = symResolver.getModuleForPackageId(packageID);
         importDcl.symbol = moduleSymbol;
         enclPkg.imports.add(importDcl);
         enclPkg.symbol.imports.add(moduleSymbol);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
@@ -735,7 +735,7 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
     public void visit(BLangClientDeclaration clientDeclaration) {
         BLangIdentifier prefix = clientDeclaration.prefix;
         Location location = prefix.pos;
-        BPackageSymbol symbol = symResolver.getModuleForClientDecl(
+        BPackageSymbol symbol = symResolver.getModuleForPackageId(
                 symTable.clientDeclarations.get(location.lineRange()));
         checkUnusedImportOrClientDeclPrefix(symbol, prefix.value, location,
                                             DiagnosticErrorCode.UNUSED_CLIENT_DECL_PREFIX);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -5198,7 +5198,7 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
 
         @Override
         public void visit(BUnionType bUnionType) {
-            for (BType memType : bUnionType.getMemberTypes()) {
+            for (BType memType : bUnionType.getOriginalMemberTypes()) {
                 visitType(memType);
             }
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -5061,14 +5061,14 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
         List<BType> exposedTypes;
         PackageID currentPkgId;
 
-        public BClientDeclConstructExposureDisallowingTypeVisitor(SymbolResolver symResolver, SymbolTable symTable) {
+        private BClientDeclConstructExposureDisallowingTypeVisitor(SymbolResolver symResolver, SymbolTable symTable) {
             this.symResolver = symResolver;
             this.symTable = symTable;
             this.unresolvedTypes = Collections.emptySet();
             this.exposedTypes = Collections.emptyList();
         }
 
-        public void visitType(BType type, List<BType> exposedTypes, PackageID currentPkgId) {
+        private void visitType(BType type, List<BType> exposedTypes, PackageID currentPkgId) {
             this.unresolvedTypes = new HashSet<>();
             this.exposedTypes = exposedTypes;
             this.currentPkgId = currentPkgId;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -38,6 +38,7 @@ import org.wso2.ballerinalang.compiler.diagnostic.BLangDiagnosticLog;
 import org.wso2.ballerinalang.compiler.parser.BLangAnonymousModelHelper;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolEnv;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
+import org.wso2.ballerinalang.compiler.semantics.model.TypeVisitor;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BAnnotationAttachmentSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BAnnotationSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BAttachedFunction;
@@ -56,25 +57,43 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.BTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BVarSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.SymTag;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BAnnotationType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BAnyType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BAnydataType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BArrayType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BBuiltInRefType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BErrorType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BField;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BFiniteType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BFutureType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BHandleType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BIntersectionType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BInvokableType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BJSONType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BMapType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BNeverType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BNilType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BNoType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BObjectType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BPackageType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BParameterizedType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BRecordType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BStreamType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BStructureType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BTableType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BTupleType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BTypeIdSet;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BTypeReferenceType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BTypedescType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BUnionType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BXMLType;
 import org.wso2.ballerinalang.compiler.tree.BLangAnnotation;
 import org.wso2.ballerinalang.compiler.tree.BLangAnnotationAttachment;
 import org.wso2.ballerinalang.compiler.tree.BLangBlockFunctionBody;
 import org.wso2.ballerinalang.compiler.tree.BLangClassDefinition;
 import org.wso2.ballerinalang.compiler.tree.BLangClientDeclaration;
+import org.wso2.ballerinalang.compiler.tree.BLangCompilationUnit;
 import org.wso2.ballerinalang.compiler.tree.BLangErrorVariable;
 import org.wso2.ballerinalang.compiler.tree.BLangExprFunctionBody;
 import org.wso2.ballerinalang.compiler.tree.BLangExternalFunctionBody;
@@ -355,6 +374,7 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
             data.env = lambdaFunction.capturedClosureEnv;
             analyzeDef(lambdaFunction.function, data);
         }
+        validateClientDeclarations(pkgNode, data);
 
         pkgNode.getTestablePkgs().forEach(testablePackage -> visit((BLangPackage) testablePackage, data));
         pkgNode.completedPhases.add(CompilerPhase.TYPE_CHECK);
@@ -4921,6 +4941,321 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
         }
 
         return locations;
+    }
+
+    private void validateClientDeclarations(BLangPackage bLangPackage, AnalyzerData data) {
+        if (this.symTable.clientDeclarations.containsValue(bLangPackage.packageID)) {
+            checkForClientObjectTypeOrClass(bLangPackage);
+            checkForMutableState(bLangPackage, data);
+        }
+
+        checkForPubliclyExposedConstructsFromClientDeclModules(bLangPackage);
+    }
+
+    private void checkForClientObjectTypeOrClass(BLangPackage bLangPackage) {
+        for (BLangClassDefinition classDefinition : bLangPackage.classDefinitions) {
+            if (classDefinition.name.value.equals(Names.CLIENT.value) &&
+                    classDefinition.flagSet.contains(Flag.CLIENT)) {
+                return;
+            }
+        }
+
+        for (BLangTypeDefinition typeDefinition : bLangPackage.typeDefinitions) {
+            BType bType = typeDefinition.typeNode.getBType();
+            if (bType.tag != TypeTags.OBJECT) {
+                continue;
+            }
+
+            if (Names.CLIENT.value.equals(bType.tsymbol.name.value) &&
+                    Symbols.isFlagOn(bType.tsymbol.flags, Flags.CLIENT)) {
+                return;
+            }
+        }
+
+        List<BLangCompilationUnit> compUnits = bLangPackage.compUnits;
+        dlog.error(compUnits.isEmpty() ? bLangPackage.symbol.pos : compUnits.get(0).pos,
+                   DiagnosticErrorCode.MODULE_GENERATED_FOR_CLIENT_DECL_MUST_HAVE_A_CLIENT_OBJECT_TYPE);
+    }
+
+    private void checkForMutableState(BLangPackage bLangPackage, AnalyzerData data) {
+        for (BLangVariable moduleLevelVar : bLangPackage.globalVars) {
+            if (!moduleLevelVar.flagSet.contains(Flag.FINAL) ||
+                    !types.isSubTypeOfReadOnly(moduleLevelVar.getBType(), data.env)) {
+                dlog.error(moduleLevelVar.pos,
+                           DiagnosticErrorCode.MODULE_GENERATED_FOR_CLIENT_DECL_CANNOT_HAVE_MUTABLE_STATE);
+            }
+        }
+    }
+
+    private void checkForPubliclyExposedConstructsFromClientDeclModules(BLangPackage bLangPackage) {
+        BClientDeclConstructExposureDisallowingTypeVisitor collector =
+                new BClientDeclConstructExposureDisallowingTypeVisitor(this.symResolver, this.symTable);
+        PackageID packageID = bLangPackage.packageID;
+
+        List<BLangVariable> moduleVarsAndConstants = new ArrayList<>() {{
+            addAll(bLangPackage.globalVars);
+            addAll(bLangPackage.constants);
+        }};
+
+        for (BLangVariable construct : moduleVarsAndConstants) {
+            if (!construct.flagSet.contains(Flag.PUBLIC)) {
+                continue;
+            }
+
+            BLangType typeNode = construct.typeNode;
+
+            if (typeNode == null) {
+                continue;
+            }
+
+            logErrorForUnsupportedConstructExposureFromClientDeclModule(packageID, collector, construct.pos,
+                                                                        typeNode.getBType());
+        }
+
+        for (BLangTypeDefinition typeDefinition : bLangPackage.typeDefinitions) {
+            Set<Flag> flagSet = typeDefinition.flagSet;
+            if (!flagSet.contains(Flag.PUBLIC) || flagSet.contains(Flag.ANONYMOUS)) {
+                continue;
+            }
+
+            logErrorForUnsupportedConstructExposureFromClientDeclModule(packageID, collector, typeDefinition.pos,
+                                                                        typeDefinition.typeNode.getBType());
+        }
+
+        for (BLangClassDefinition classDefinition : bLangPackage.classDefinitions) {
+            Set<Flag> flagSet = classDefinition.flagSet;
+            if (!flagSet.contains(Flag.PUBLIC) || classDefinition.isServiceDecl || flagSet.contains(Flag.OBJECT_CTOR)) {
+                continue;
+            }
+
+            logErrorForUnsupportedConstructExposureFromClientDeclModule(packageID, collector, classDefinition.pos,
+                                                                        classDefinition.getBType());
+        }
+
+        for (BLangFunction function : bLangPackage.functions) {
+            if (!function.flagSet.contains(Flag.PUBLIC) &&
+                    (!function.attachedFunction || !function.receiver.flagSet.contains(Flag.PUBLIC))) {
+                continue;
+            }
+
+            logErrorForUnsupportedConstructExposureFromClientDeclModule(packageID, collector, function.pos,
+                                                                        function.getBType());
+        }
+    }
+
+    private void logErrorForUnsupportedConstructExposureFromClientDeclModule(PackageID currentPkgId,
+                         BClientDeclConstructExposureDisallowingTypeVisitor collector, Location location, BType type) {
+        List<BType> exposedTypes = new ArrayList<>(1);
+        collector.visitType(type, exposedTypes, currentPkgId);
+        if (!exposedTypes.isEmpty()) {
+            dlog.error(location,
+                       DiagnosticErrorCode.UNSUPPORTED_EXPOSURE_OF_CONSTRUCT_FROM_MODULE_GENERATED_FOR_CLIENT_DECL);
+        }
+    }
+
+    private static class BClientDeclConstructExposureDisallowingTypeVisitor implements TypeVisitor {
+
+        Set<BType> unresolvedTypes;
+        SymbolResolver symResolver;
+        SymbolTable symTable;
+        List<BType> exposedTypes;
+        PackageID currentPkgId;
+
+        public BClientDeclConstructExposureDisallowingTypeVisitor(SymbolResolver symResolver, SymbolTable symTable) {
+            this.symResolver = symResolver;
+            this.symTable = symTable;
+            this.unresolvedTypes = Collections.emptySet();
+            this.exposedTypes = Collections.emptyList();
+        }
+
+        public void visitType(BType type, List<BType> exposedTypes, PackageID currentPkgId) {
+            this.unresolvedTypes = new HashSet<>();
+            this.exposedTypes = exposedTypes;
+            this.currentPkgId = currentPkgId;
+            this.visitType(type);
+        }
+
+        private void visitType(BType type) {
+            if (type == null) {
+                return;
+            }
+
+            if (!unresolvedTypes.add(type)) {
+                return;
+            }
+
+            BTypeSymbol tsymbol = type.tsymbol;
+            if (tsymbol != null &&
+                    !this.currentPkgId.equals(tsymbol.pkgID) &&
+                    this.symTable.clientDeclarations.containsValue(tsymbol.pkgID)) {
+                this.exposedTypes.add(type);
+                return;
+            }
+
+            type.accept(this);
+        }
+
+        @Override
+        public void visit(BAnnotationType bAnnotationType) {
+        }
+
+        @Override
+        public void visit(BArrayType bArrayType) {
+            visitType(bArrayType.eType);
+        }
+
+        @Override
+        public void visit(BBuiltInRefType bBuiltInRefType) {
+        }
+
+        @Override
+        public void visit(BAnyType bAnyType) {
+        }
+
+        @Override
+        public void visit(BAnydataType bAnydataType) {
+        }
+
+        @Override
+        public void visit(BErrorType bErrorType) {
+            visitType(bErrorType.detailType);
+        }
+
+        @Override
+        public void visit(BFiniteType bFiniteType) {
+        }
+
+        @Override
+        public void visit(BInvokableType bInvokableType) {
+            if (Symbols.isFlagOn(bInvokableType.flags, Flags.ANY_FUNCTION)) {
+                return;
+            }
+
+            for (BType paramType : bInvokableType.paramTypes) {
+                visitType(paramType);
+            }
+            visitType(bInvokableType.restType);
+            visitType(bInvokableType.retType);
+        }
+
+        @Override
+        public void visit(BJSONType bjsonType) {
+        }
+
+        @Override
+        public void visit(BMapType bMapType) {
+            visitType(bMapType.constraint);
+        }
+
+        @Override
+        public void visit(BStreamType bStreamType) {
+            visitType(bStreamType.constraint);
+            visitType(bStreamType.completionType);
+        }
+
+        @Override
+        public void visit(BTypedescType bTypedescType) {
+            visitType(bTypedescType.constraint);
+        }
+
+        @Override
+        public void visit(BTypeReferenceType bTypeReferenceType) {
+            visitType(bTypeReferenceType.referredType);
+        }
+
+        @Override
+        public void visit(BParameterizedType bTypedescType) {
+        }
+
+        @Override
+        public void visit(BNeverType bNeverType) {
+        }
+
+        @Override
+        public void visit(BNilType bNilType) {
+        }
+
+        @Override
+        public void visit(BNoType bNoType) {
+        }
+
+        @Override
+        public void visit(BPackageType bPackageType) {
+        }
+
+        @Override
+        public void visit(BStructureType bStructureType) {
+        }
+
+        @Override
+        public void visit(BTupleType bTupleType) {
+            for (BType memType : bTupleType.tupleTypes) {
+                visitType(memType);
+            }
+
+            visitType(bTupleType.restType);
+        }
+
+        @Override
+        public void visit(BUnionType bUnionType) {
+            for (BType memType : bUnionType.getMemberTypes()) {
+                visitType(memType);
+            }
+        }
+
+        @Override
+        public void visit(BIntersectionType bIntersectionType) {
+            for (BType constituentType : bIntersectionType.getConstituentTypes()) {
+                visitType(constituentType);
+            }
+            visitType(bIntersectionType.effectiveType);
+        }
+
+        @Override
+        public void visit(BXMLType bXmlType) {
+            visitType(bXmlType.constraint);
+        }
+
+        @Override
+        public void visit(BTableType bTableType) {
+            visitType(bTableType.constraint);
+            visitType(bTableType.keyTypeConstraint);
+        }
+
+        @Override
+        public void visit(BRecordType bRecordType) {
+            for (BField field : bRecordType.fields.values()) {
+                visitType(field.type);
+            }
+
+            if (!bRecordType.sealed) {
+                visitType(bRecordType.restFieldType);
+            }
+        }
+
+        @Override
+        public void visit(BObjectType bObjectType) {
+            for (BField field : bObjectType.fields.values()) {
+                visitType(field.type);
+            }
+
+            for (BAttachedFunction attachedFunc : ((BObjectTypeSymbol) bObjectType.tsymbol).attachedFuncs) {
+                visitType(attachedFunc.type);
+            }
+        }
+
+        @Override
+        public void visit(BType bType) {
+        }
+
+        @Override
+        public void visit(BFutureType bFutureType) {
+            visitType(bFutureType.constraint);
+        }
+
+        @Override
+        public void visit(BHandleType bHandleType) {
+        }
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -47,6 +47,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.Scope;
 import org.wso2.ballerinalang.compiler.semantics.model.Scope.ScopeEntry;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolEnv;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
+import org.wso2.ballerinalang.compiler.semantics.model.TypeVisitor;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BAnnotationSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BAttachedFunction;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BClassSymbol;
@@ -72,23 +73,36 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.BXMLNSSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.SymTag;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BAnnotationType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BAnyType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BAnydataType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BArrayType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BBuiltInRefType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BErrorType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BField;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BFiniteType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BFutureType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BHandleType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BIntersectionType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BInvokableType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BJSONType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BMapType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BNeverType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BNilType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BNoType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BObjectType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BPackageType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BParameterizedType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BRecordType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BStreamType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BStructureType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BTableType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BTupleType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BTypeIdSet;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BTypeReferenceType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BTypedescType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BUnionType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BXMLType;
 import org.wso2.ballerinalang.compiler.tree.BLangAnnotation;
 import org.wso2.ballerinalang.compiler.tree.BLangAnnotationAttachment;
 import org.wso2.ballerinalang.compiler.tree.BLangClassDefinition;
@@ -351,6 +365,7 @@ public class SymbolEnter extends BLangNodeVisitor {
 
         defineConstructs(pkgNode, pkgEnv);
         pkgNode.getTestablePkgs().forEach(testablePackage -> defineTestablePackage(testablePackage, pkgEnv));
+        validateClientDeclarations(pkgNode);
         pkgNode.completedPhases.add(CompilerPhase.DEFINE);
 
         // cleanup to avoid caching on compile context
@@ -5441,6 +5456,282 @@ public class SymbolEnter extends BLangNodeVisitor {
         @Override
         public int hashCode() {
             return Objects.hash(name, row, column);
+        }
+    }
+
+    private void validateClientDeclarations(BLangPackage bLangPackage) {
+        // TODO: 2022-09-05 Validate presence of client objects and absence of mutable state for generated modules.
+        disallowExposingConstructsFromClientDeclModules(bLangPackage);
+    }
+
+    private void disallowExposingConstructsFromClientDeclModules(BLangPackage bLangPackage) {
+        BClientDeclConstructExposureDisallowingTypeVisitor collector =
+                new BClientDeclConstructExposureDisallowingTypeVisitor(this.symResolver, this.symTable);
+        PackageID packageID = bLangPackage.packageID;
+
+        List<BLangVariable> moduleVarsAndConstants = new ArrayList<>() {{
+            addAll(bLangPackage.globalVars);
+            addAll(bLangPackage.constants);
+        }};
+
+        for (BLangVariable construct : moduleVarsAndConstants) {
+            if (!construct.flagSet.contains(Flag.PUBLIC)) {
+                continue;
+            }
+
+            BLangType typeNode = construct.typeNode;
+
+            if (typeNode == null) {
+                continue;
+            }
+
+            logErrorForUnsupportedConstructExposureFromClientDeclModule(packageID, collector, construct.pos,
+                                                                        typeNode.getBType());
+        }
+
+        for (BLangTypeDefinition typeDefinition : bLangPackage.typeDefinitions) {
+            Set<Flag> flagSet = typeDefinition.flagSet;
+            if (!flagSet.contains(Flag.PUBLIC) || flagSet.contains(Flag.ANONYMOUS)) {
+                continue;
+            }
+
+            logErrorForUnsupportedConstructExposureFromClientDeclModule(packageID, collector, typeDefinition.pos,
+                                                                        typeDefinition.typeNode.getBType());
+        }
+
+        for (BLangClassDefinition classDefinition : bLangPackage.classDefinitions) {
+            Set<Flag> flagSet = classDefinition.flagSet;
+            if (!flagSet.contains(Flag.PUBLIC) || classDefinition.isServiceDecl || flagSet.contains(Flag.OBJECT_CTOR)) {
+                continue;
+            }
+
+            logErrorForUnsupportedConstructExposureFromClientDeclModule(packageID, collector, classDefinition.pos,
+                                                                        classDefinition.getBType());
+        }
+
+        for (BLangFunction function : bLangPackage.functions) {
+            if (!function.flagSet.contains(Flag.PUBLIC) &&
+                    (!function.attachedFunction || !function.receiver.flagSet.contains(Flag.PUBLIC))) {
+                continue;
+            }
+
+            logErrorForUnsupportedConstructExposureFromClientDeclModule(packageID, collector, function.pos,
+                                                                        function.getBType());
+        }
+    }
+
+    private void logErrorForUnsupportedConstructExposureFromClientDeclModule(PackageID currentPkgId,
+            BClientDeclConstructExposureDisallowingTypeVisitor collector, Location location, BType type) {
+        List<BType> exposedTypes = new ArrayList<>(1);
+        collector.visitType(type, exposedTypes, currentPkgId);
+        if (!exposedTypes.isEmpty()) {
+            dlog.error(location,
+                       DiagnosticErrorCode.UNSUPPORTED_EXPOSURE_OF_CONSTRUCT_FROM_MODULE_GENERATED_FOR_CLIENT_DECL);
+        }
+    }
+
+    private static class BClientDeclConstructExposureDisallowingTypeVisitor implements TypeVisitor {
+
+        Set<BType> unresolvedTypes;
+        SymbolResolver symResolver;
+        SymbolTable symTable;
+        List<BType> exposedTypes;
+        PackageID currentPkgId;
+
+        public BClientDeclConstructExposureDisallowingTypeVisitor(SymbolResolver symResolver, SymbolTable symTable) {
+            this.symResolver = symResolver;
+            this.symTable = symTable;
+            this.unresolvedTypes = Collections.emptySet();
+            this.exposedTypes = Collections.emptyList();
+        }
+
+        public void visitType(BType type, List<BType> exposedTypes, PackageID currentPkgId) {
+            this.unresolvedTypes = new HashSet<>();
+            this.exposedTypes = exposedTypes;
+            this.currentPkgId = currentPkgId;
+            this.visitType(type);
+        }
+
+        private void visitType(BType type) {
+            if (type == null) {
+                return;
+            }
+
+            if (!unresolvedTypes.add(type)) {
+                return;
+            }
+
+            BTypeSymbol tsymbol = type.tsymbol;
+            if (tsymbol != null &&
+                    !this.currentPkgId.equals(tsymbol.pkgID) &&
+                    this.symTable.clientDeclarations.containsValue(tsymbol.pkgID)) {
+                this.exposedTypes.add(type);
+                return;
+            }
+
+            type.accept(this);
+        }
+
+        @Override
+        public void visit(BAnnotationType bAnnotationType) {
+        }
+
+        @Override
+        public void visit(BArrayType bArrayType) {
+            visitType(bArrayType.eType);
+        }
+
+        @Override
+        public void visit(BBuiltInRefType bBuiltInRefType) {
+        }
+
+        @Override
+        public void visit(BAnyType bAnyType) {
+        }
+
+        @Override
+        public void visit(BAnydataType bAnydataType) {
+        }
+
+        @Override
+        public void visit(BErrorType bErrorType) {
+            visitType(bErrorType.detailType);
+        }
+
+        @Override
+        public void visit(BFiniteType bFiniteType) {
+        }
+
+        @Override
+        public void visit(BInvokableType bInvokableType) {
+            if (Symbols.isFlagOn(bInvokableType.flags, Flags.ANY_FUNCTION)) {
+                return;
+            }
+
+            for (BType paramType : bInvokableType.paramTypes) {
+                visitType(paramType);
+            }
+            visitType(bInvokableType.restType);
+            visitType(bInvokableType.retType);
+        }
+
+        @Override
+        public void visit(BJSONType bjsonType) {
+        }
+
+        @Override
+        public void visit(BMapType bMapType) {
+            visitType(bMapType.constraint);
+        }
+
+        @Override
+        public void visit(BStreamType bStreamType) {
+            visitType(bStreamType.constraint);
+            visitType(bStreamType.completionType);
+        }
+
+        @Override
+        public void visit(BTypedescType bTypedescType) {
+            visitType(bTypedescType.constraint);
+        }
+
+        @Override
+        public void visit(BTypeReferenceType bTypeReferenceType) {
+            visitType(bTypeReferenceType.referredType);
+        }
+
+        @Override
+        public void visit(BParameterizedType bTypedescType) {
+        }
+
+        @Override
+        public void visit(BNeverType bNeverType) {
+        }
+
+        @Override
+        public void visit(BNilType bNilType) {
+        }
+
+        @Override
+        public void visit(BNoType bNoType) {
+        }
+
+        @Override
+        public void visit(BPackageType bPackageType) {
+        }
+
+        @Override
+        public void visit(BStructureType bStructureType) {
+        }
+
+        @Override
+        public void visit(BTupleType bTupleType) {
+            for (BType memType : bTupleType.tupleTypes) {
+                visitType(memType);
+            }
+
+            visitType(bTupleType.restType);
+        }
+
+        @Override
+        public void visit(BUnionType bUnionType) {
+            for (BType memType : bUnionType.getMemberTypes()) {
+                visitType(memType);
+            }
+        }
+
+        @Override
+        public void visit(BIntersectionType bIntersectionType) {
+            for (BType constituentType : bIntersectionType.getConstituentTypes()) {
+                visitType(constituentType);
+            }
+            visitType(bIntersectionType.effectiveType);
+        }
+
+        @Override
+        public void visit(BXMLType bXmlType) {
+            visitType(bXmlType.constraint);
+        }
+
+        @Override
+        public void visit(BTableType bTableType) {
+            visitType(bTableType.constraint);
+            visitType(bTableType.keyTypeConstraint);
+        }
+
+        @Override
+        public void visit(BRecordType bRecordType) {
+            for (BField field : bRecordType.fields.values()) {
+                visitType(field.type);
+            }
+
+            if (!bRecordType.sealed) {
+                visitType(bRecordType.restFieldType);
+            }
+        }
+
+        @Override
+        public void visit(BObjectType bObjectType) {
+            for (BField field : bObjectType.fields.values()) {
+                visitType(field.type);
+            }
+
+            for (BAttachedFunction attachedFunc : ((BObjectTypeSymbol) bObjectType.tsymbol).attachedFuncs) {
+                visitType(attachedFunc.type);
+            }
+        }
+
+        @Override
+        public void visit(BType bType) {
+        }
+
+        @Override
+        public void visit(BFutureType bFutureType) {
+            visitType(bFutureType.constraint);
+        }
+
+        @Override
+        public void visit(BHandleType bHandleType) {
         }
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -2619,7 +2619,7 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
                 symTable.pkgEnvMap.get(symTable.rootPkgSymbol), names.fromString("strand"));
     }
 
-    public BPackageSymbol getModuleForClientDecl(PackageID packageID) {
+    public BPackageSymbol getModuleForPackageId(PackageID packageID) {
         return symTable.pkgEnvMap.keySet().stream()
                 .filter(moduleSymbol -> packageID.equals(moduleSymbol.pkgID))
                 .findFirst()
@@ -2648,7 +2648,7 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
             return symTable.notFoundSymbol;
         }
 
-        BPackageSymbol moduleSymbol = getModuleForClientDecl(clientDeclarations.get(lineRange));
+        BPackageSymbol moduleSymbol = getModuleForPackageId(clientDeclarations.get(lineRange));
         moduleSymbol.isUsed = true;
         return moduleSymbol;
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BNeverType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BNeverType.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.ballerinalang.compiler.semantics.model.types;
 
+import org.wso2.ballerinalang.compiler.semantics.model.TypeVisitor;
 import org.wso2.ballerinalang.compiler.util.Names;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.util.Flags;
@@ -42,5 +43,10 @@ public class BNeverType extends BType {
     @Override
     public String toString() {
         return Names.NEVER.value;
+    }
+
+    @Override
+    public void accept(TypeVisitor visitor) {
+        visitor.visit(this);
     }
 }

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1938,3 +1938,6 @@ error.unsupported.exposure.of.construct.from.module.generated.for.client.decl=\
 
 error.module.generated.for.client.decl.must.have.a.client.object.type=\
   a module generated for a client declaration must have an object type or class named ''client''
+
+error.module.generated.for.client.decl.cannot.have.mutable.state=\
+  a module generated for a client declaration cannot have mutable state

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1935,3 +1935,6 @@ error.unused.client.decl.prefix=\
 
 error.unsupported.exposure.of.construct.from.module.generated.for.client.decl=\
   exposing a construct from a module generated for a client declaration is not yet supported
+
+error.module.generated.for.client.decl.must.have.a.client.object.type=\
+  a module generated for a client declaration must have an object type or class named ''client''

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1932,3 +1932,6 @@ error.no.module.generated.for.client.decl=\
 
 error.unused.client.decl.prefix=\
   unused client declaration prefix ''{0}''
+
+error.unsupported.exposure.of.construct.from.module.generated.for.client.decl=\
+  exposing a construct from a module generated for a client declaration is not yet supported

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/plugins/IDLClientCompilerTests.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/plugins/IDLClientCompilerTests.java
@@ -177,6 +177,7 @@ public class IDLClientCompilerTests {
         validateError(diagnostics, index++, UNSUPPORTED_EXPOSURE_OF_PUBLIC_CONSTRUCT_ERROR, 138, 1);
         validateError(diagnostics, index++, UNSUPPORTED_EXPOSURE_OF_PUBLIC_CONSTRUCT_ERROR, 141, 1);
         validateError(diagnostics, index++, UNSUPPORTED_EXPOSURE_OF_PUBLIC_CONSTRUCT_ERROR, 143, 1);
+        validateError(diagnostics, index++, UNSUPPORTED_EXPOSURE_OF_PUBLIC_CONSTRUCT_ERROR, 148, 1);
         Assert.assertEquals(diagnostics.length, index);
     }
 

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/plugins/IDLClientCompilerTests.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/plugins/IDLClientCompilerTests.java
@@ -63,6 +63,9 @@ public class IDLClientCompilerTests {
     private static final String CARRIAGE_RETURN_CHAR = "\\r";
     private static final String EMPTY_STRING = "";
 
+    private static final String UNSUPPORTED_EXPOSURE_OF_PUBLIC_CONSTRUCT_ERROR =
+            "exposing a construct from a module generated for a client declaration is not yet supported";
+
     private CompileResult result;
 
     @BeforeSuite
@@ -131,6 +134,42 @@ public class IDLClientCompilerTests {
         validateError(diagnostics, index++, "unused client declaration prefix 'foo'", 17, 46);
         validateError(diagnostics, index++, "unused client declaration prefix 'bar'", 20, 50);
         validateError(diagnostics, index++, "unused client declaration prefix 'baz'", 23, 56);
+        Assert.assertEquals(diagnostics.length, index);
+    }
+
+    @Test
+    public void testExposingConstructFromGeneratedModuleNegative() {
+        Project project = loadPackage("simpleclientnegativetestthree");
+        IDLClientGeneratorResult idlClientGeneratorResult = project.currentPackage().runIDLGeneratorPlugins();
+        Assert.assertTrue(idlClientGeneratorResult.reportedDiagnostics().diagnostics().isEmpty());
+        PackageCompilation compilation = project.currentPackage().getCompilation();
+
+        Diagnostic[] diagnostics = compilation.diagnosticResult().diagnostics().toArray(new Diagnostic[0]);
+        int index = 0;
+        validateError(diagnostics, index++, UNSUPPORTED_EXPOSURE_OF_PUBLIC_CONSTRUCT_ERROR, 20, 1);
+        validateError(diagnostics, index++, UNSUPPORTED_EXPOSURE_OF_PUBLIC_CONSTRUCT_ERROR, 23, 1);
+        validateError(diagnostics, index++, UNSUPPORTED_EXPOSURE_OF_PUBLIC_CONSTRUCT_ERROR, 37, 1);
+        validateError(diagnostics, index++, UNSUPPORTED_EXPOSURE_OF_PUBLIC_CONSTRUCT_ERROR, 45, 1);
+        validateError(diagnostics, index++, UNSUPPORTED_EXPOSURE_OF_PUBLIC_CONSTRUCT_ERROR, 51, 1);
+        validateError(diagnostics, index++, UNSUPPORTED_EXPOSURE_OF_PUBLIC_CONSTRUCT_ERROR, 54, 1);
+        validateError(diagnostics, index++, UNSUPPORTED_EXPOSURE_OF_PUBLIC_CONSTRUCT_ERROR, 57, 1);
+        validateError(diagnostics, index++, UNSUPPORTED_EXPOSURE_OF_PUBLIC_CONSTRUCT_ERROR, 63, 1);
+        validateError(diagnostics, index++, UNSUPPORTED_EXPOSURE_OF_PUBLIC_CONSTRUCT_ERROR, 72, 1);
+        validateError(diagnostics, index++, UNSUPPORTED_EXPOSURE_OF_PUBLIC_CONSTRUCT_ERROR, 78, 1);
+        validateError(diagnostics, index++, UNSUPPORTED_EXPOSURE_OF_PUBLIC_CONSTRUCT_ERROR, 81, 1);
+        validateError(diagnostics, index++, UNSUPPORTED_EXPOSURE_OF_PUBLIC_CONSTRUCT_ERROR, 84, 1);
+        validateError(diagnostics, index++, UNSUPPORTED_EXPOSURE_OF_PUBLIC_CONSTRUCT_ERROR, 87, 1);
+        validateError(diagnostics, index++, UNSUPPORTED_EXPOSURE_OF_PUBLIC_CONSTRUCT_ERROR, 90, 1);
+        validateError(diagnostics, index++, UNSUPPORTED_EXPOSURE_OF_PUBLIC_CONSTRUCT_ERROR, 93, 1);
+        validateError(diagnostics, index++, UNSUPPORTED_EXPOSURE_OF_PUBLIC_CONSTRUCT_ERROR, 96, 1);
+        validateError(diagnostics, index++, UNSUPPORTED_EXPOSURE_OF_PUBLIC_CONSTRUCT_ERROR, 99, 1);
+        validateError(diagnostics, index++, UNSUPPORTED_EXPOSURE_OF_PUBLIC_CONSTRUCT_ERROR, 102, 1);
+        validateError(diagnostics, index++, UNSUPPORTED_EXPOSURE_OF_PUBLIC_CONSTRUCT_ERROR, 105, 1);
+        validateError(diagnostics, index++, UNSUPPORTED_EXPOSURE_OF_PUBLIC_CONSTRUCT_ERROR, 108, 1);
+        validateError(diagnostics, index++, UNSUPPORTED_EXPOSURE_OF_PUBLIC_CONSTRUCT_ERROR, 114, 1);
+        validateError(diagnostics, index++, UNSUPPORTED_EXPOSURE_OF_PUBLIC_CONSTRUCT_ERROR, 123, 1);
+        validateError(diagnostics, index++, UNSUPPORTED_EXPOSURE_OF_PUBLIC_CONSTRUCT_ERROR, 127, 1);
+        validateError(diagnostics, index++, UNSUPPORTED_EXPOSURE_OF_PUBLIC_CONSTRUCT_ERROR, 138, 1);
         Assert.assertEquals(diagnostics.length, index);
     }
 

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/plugins/IDLClientCompilerTests.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/plugins/IDLClientCompilerTests.java
@@ -65,6 +65,8 @@ public class IDLClientCompilerTests {
 
     private static final String UNSUPPORTED_EXPOSURE_OF_PUBLIC_CONSTRUCT_ERROR =
             "exposing a construct from a module generated for a client declaration is not yet supported";
+    private static final String NO_CLIENT_OBJECT_NAMED_CLIENT_IN_GENERATED_MODULE_ERROR =
+            "a module generated for a client declaration must have an object type or class named 'client'";
 
     private CompileResult result;
 
@@ -96,7 +98,8 @@ public class IDLClientCompilerTests {
         return new Object[] {
             "testModuleClientDecl",
             "testClientDeclStmt",
-            "testClientDeclScoping1"
+            "testClientDeclScoping1",
+            "testClientDeclModuleWithClientObjectType"
         };
     }
 
@@ -170,6 +173,21 @@ public class IDLClientCompilerTests {
         validateError(diagnostics, index++, UNSUPPORTED_EXPOSURE_OF_PUBLIC_CONSTRUCT_ERROR, 123, 1);
         validateError(diagnostics, index++, UNSUPPORTED_EXPOSURE_OF_PUBLIC_CONSTRUCT_ERROR, 127, 1);
         validateError(diagnostics, index++, UNSUPPORTED_EXPOSURE_OF_PUBLIC_CONSTRUCT_ERROR, 138, 1);
+        Assert.assertEquals(diagnostics.length, index);
+    }
+
+    @Test
+    public void testInvalidGeneratedModuleNegative() {
+        Project project = loadPackage("simpleclientnegativetestfour");
+        IDLClientGeneratorResult idlClientGeneratorResult = project.currentPackage().runIDLGeneratorPlugins();
+        Assert.assertTrue(idlClientGeneratorResult.reportedDiagnostics().diagnostics().isEmpty());
+        PackageCompilation compilation = project.currentPackage().getCompilation();
+
+        Diagnostic[] diagnostics = compilation.diagnosticResult().diagnostics().toArray(new Diagnostic[0]);
+        int index = 0;
+        validateError(diagnostics, index++, NO_CLIENT_OBJECT_NAMED_CLIENT_IN_GENERATED_MODULE_ERROR, 1, 1);
+        validateError(diagnostics, index++, NO_CLIENT_OBJECT_NAMED_CLIENT_IN_GENERATED_MODULE_ERROR, 1, 1);
+        validateError(diagnostics, index++, NO_CLIENT_OBJECT_NAMED_CLIENT_IN_GENERATED_MODULE_ERROR, 1, 1);
         Assert.assertEquals(diagnostics.length, index);
     }
 

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/plugins/IDLClientCompilerTests.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/plugins/IDLClientCompilerTests.java
@@ -67,6 +67,8 @@ public class IDLClientCompilerTests {
             "exposing a construct from a module generated for a client declaration is not yet supported";
     private static final String NO_CLIENT_OBJECT_NAMED_CLIENT_IN_GENERATED_MODULE_ERROR =
             "a module generated for a client declaration must have an object type or class named 'client'";
+    private static final String MUTABLE_STATE_IN_GENERATED_MODULE_ERROR =
+            "a module generated for a client declaration cannot have mutable state";
 
     private CompileResult result;
 
@@ -173,6 +175,8 @@ public class IDLClientCompilerTests {
         validateError(diagnostics, index++, UNSUPPORTED_EXPOSURE_OF_PUBLIC_CONSTRUCT_ERROR, 123, 1);
         validateError(diagnostics, index++, UNSUPPORTED_EXPOSURE_OF_PUBLIC_CONSTRUCT_ERROR, 127, 1);
         validateError(diagnostics, index++, UNSUPPORTED_EXPOSURE_OF_PUBLIC_CONSTRUCT_ERROR, 138, 1);
+        validateError(diagnostics, index++, UNSUPPORTED_EXPOSURE_OF_PUBLIC_CONSTRUCT_ERROR, 141, 1);
+        validateError(diagnostics, index++, UNSUPPORTED_EXPOSURE_OF_PUBLIC_CONSTRUCT_ERROR, 143, 1);
         Assert.assertEquals(diagnostics.length, index);
     }
 
@@ -188,6 +192,11 @@ public class IDLClientCompilerTests {
         validateError(diagnostics, index++, NO_CLIENT_OBJECT_NAMED_CLIENT_IN_GENERATED_MODULE_ERROR, 1, 1);
         validateError(diagnostics, index++, NO_CLIENT_OBJECT_NAMED_CLIENT_IN_GENERATED_MODULE_ERROR, 1, 1);
         validateError(diagnostics, index++, NO_CLIENT_OBJECT_NAMED_CLIENT_IN_GENERATED_MODULE_ERROR, 1, 1);
+        validateError(diagnostics, index++, MUTABLE_STATE_IN_GENERATED_MODULE_ERROR, 9, 1);
+        validateError(diagnostics, index++, MUTABLE_STATE_IN_GENERATED_MODULE_ERROR, 11, 1);
+        validateError(diagnostics, index++, MUTABLE_STATE_IN_GENERATED_MODULE_ERROR, 13, 1);
+        validateError(diagnostics, index++, MUTABLE_STATE_IN_GENERATED_MODULE_ERROR, 15, 1);
+        validateError(diagnostics, index++, MUTABLE_STATE_IN_GENERATED_MODULE_ERROR, 19, 1);
         Assert.assertEquals(diagnostics.length, index);
     }
 

--- a/project-api/project-api-test/src/test/resources/idl_client_compiler_tests/simpleclientnegativetestfour/Ballerina.toml
+++ b/project-api/project-api-test/src/test/resources/idl_client_compiler_tests/simpleclientnegativetestfour/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "idl_clients"
+name = "simpleclientnegativefour"
+version = "0.1.0"

--- a/project-api/project-api-test/src/test/resources/idl_client_compiler_tests/simpleclientnegativetestfour/main.bal
+++ b/project-api/project-api-test/src/test/resources/idl_client_compiler_tests/simpleclientnegativetestfour/main.bal
@@ -23,4 +23,7 @@ bar:'client b = new;
 function fn() {
     client "http://example.com/invalidgeneratedcode/three.yaml" as baz;
     baz:'client? _ = ();
+
+    client "http://example.com/invalidgeneratedcode/four.yaml" as qux;
+    qux:client _ = new;
 }

--- a/project-api/project-api-test/src/test/resources/idl_client_compiler_tests/simpleclientnegativetestfour/main.bal
+++ b/project-api/project-api-test/src/test/resources/idl_client_compiler_tests/simpleclientnegativetestfour/main.bal
@@ -1,0 +1,26 @@
+// Copyright (c) 2022 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+client "http://example.com/invalidgeneratedcode/one.yaml" as foo;
+foo:MyClientClass a = new;
+
+client "http://example.com/invalidgeneratedcode/two.yaml" as bar;
+bar:'client b = new;
+
+function fn() {
+    client "http://example.com/invalidgeneratedcode/three.yaml" as baz;
+    baz:'client? _ = ();
+}

--- a/project-api/project-api-test/src/test/resources/idl_client_compiler_tests/simpleclientnegativetestthree/Ballerina.toml
+++ b/project-api/project-api-test/src/test/resources/idl_client_compiler_tests/simpleclientnegativetestthree/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "idl_clients"
+name = "simpleclientnegativethree"
+version = "0.1.0"

--- a/project-api/project-api-test/src/test/resources/idl_client_compiler_tests/simpleclientnegativetestthree/main.bal
+++ b/project-api/project-api-test/src/test/resources/idl_client_compiler_tests/simpleclientnegativetestthree/main.bal
@@ -1,0 +1,138 @@
+// Copyright (c) 2022 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+client "http://example.com/apis/one.yaml" as foo;
+
+const foo:IntMap C1 = {a: 1}; // OK
+public const foo:IntMap C2 = {a: 1}; // error
+
+foo:IntMap v1 = {a: 1}; // OK
+public foo:IntMap v2 = {a: 1}; // error
+
+public function main() {
+    foo:ClientConfiguration x; // OK
+}
+
+class Class1 { // OK
+    foo:IntMap a;
+
+    function init(foo:IntMap a) {
+        self.a = a;
+    }
+}
+
+public class Class2 { // error
+    foo:IntMap a;
+
+    function init(foo:IntMap a) {
+        self.a = a;
+    }
+}
+
+public class Class3 { // error
+    public function fn() returns foo:ClientConfiguration => {'limit: 5}; // error
+}
+
+function fn(foo:ClientConfiguration x, foo:ClientConfiguration y = {'limit: 5}, foo:ClientConfiguration... z) returns foo:ClientConfiguration => x; // OK
+
+public function fn2(foo:ClientConfiguration x, foo:ClientConfiguration y = {'limit: 5}, foo:ClientConfiguration... z) returns foo:ClientConfiguration => x; // errors
+
+foo:IntMap[] v3 = []; // OK
+public foo:IntMap[] v4 = []; // error
+
+error<foo:IntMap> v5 = error("e1"); // OK
+public error<foo:IntMap> v6 = error("e2"); // error
+
+function (foo:IntMap) v7 = function (foo:IntMap a) { // OK
+
+};
+
+public function (foo:IntMap) v8 = function (foo:IntMap a) { // error
+
+};
+
+function (foo:IntMap a, foo:IntMap b = {}, foo:IntMap... c) returns foo:IntMap v9 =  // OK
+function (foo:IntMap a, foo:IntMap b = {}, foo:IntMap... c) returns foo:IntMap {
+    return a;
+};
+
+public function (foo:IntMap a, foo:IntMap b = {}, foo:IntMap... c) returns foo:IntMap v10 =  // error
+function (foo:IntMap a, foo:IntMap b = {}, foo:IntMap... c) returns foo:IntMap {
+    return a;
+};
+
+map<foo:IntMap> v11 = {}; // OK
+public map<foo:IntMap> v12 = {}; // error
+
+stream<foo:IntMap> v31 = new; // OK
+public stream<foo:IntMap> v32 = new; // error
+
+stream<foo:IntMap, error<foo:IntMap>?> v13 = new; // OK
+public stream<int, error<foo:IntMap>?> v14 = new; // error
+
+typedesc<foo:IntMap> v15 = foo:IntMap; // OK
+public typedesc<foo:IntMap> v16 = foo:IntMap; // error
+
+type T1 foo:IntMap; // OK
+public type T2 foo:IntMap; // error
+
+[foo:IntMap] v17 = [{}]; // OK
+public [foo:IntMap] v18 = [{}]; // error
+
+[foo:IntMap, foo:IntMap...] v19 = [{}]; // OK
+public [foo:IntMap, foo:IntMap...] v20 = [{}]; // error
+
+foo:IntMap|int v21 = 1; // OK
+public foo:IntMap|int v22 = 1; // error
+
+foo:IntMap & readonly v23 = {}; // OK
+public foo:IntMap & readonly v24 = {}; // error
+
+xml<foo:XmlElement> v25 = xml `<foo/>`; // OK
+public xml<foo:XmlElement> v26 = xml `<foo/>`; // error
+
+table<foo:IntMap> v27 = table []; // OK
+public table<foo:IntMap> v28 = table []; // error
+
+type T3 record {| // OK
+    foo:IntMap a;
+|};
+
+public type T4 record {| // error
+    foo:IntMap a;
+    int b;
+|};
+
+type T5 object { // OK
+    foo:IntMap a;
+};
+
+public type T6 object { // error
+    foo:IntMap a;
+};
+
+public type T7 object { // error
+    public function fn() returns foo:ClientConfiguration;
+};
+
+function testFn() returns future<foo:IntMap> {
+    function () returns foo:IntMap f = () => {};
+    future<foo:IntMap> ft = start f();
+    return ft;
+}
+
+future<foo:IntMap> v29 = testFn(); // OK
+public future<foo:IntMap> v30 = testFn(); // error

--- a/project-api/project-api-test/src/test/resources/idl_client_compiler_tests/simpleclientnegativetestthree/main.bal
+++ b/project-api/project-api-test/src/test/resources/idl_client_compiler_tests/simpleclientnegativetestthree/main.bal
@@ -136,3 +136,10 @@ function testFn() returns future<foo:IntMap> {
 
 future<foo:IntMap> v29 = testFn(); // OK
 public future<foo:IntMap> v30 = testFn(); // error
+
+type T8 foo:IntMap|map<T8>; // OK
+public type T9 foo:IntMap|map<T8>; // error
+
+public function testFn2() returns T8 { // error
+    return {a: 1};
+}

--- a/project-api/project-api-test/src/test/resources/idl_client_compiler_tests/simpleclientnegativetestthree/main.bal
+++ b/project-api/project-api-test/src/test/resources/idl_client_compiler_tests/simpleclientnegativetestthree/main.bal
@@ -143,3 +143,6 @@ public type T9 foo:IntMap|map<T8>; // error
 public function testFn2() returns T8 { // error
     return {a: 1};
 }
+
+never|foo:IntMap v33 = {}; // OK
+public never|foo:IntMap v34 = {}; // error

--- a/project-api/project-api-test/src/test/resources/idl_client_compiler_tests/simpleclienttest/main.bal
+++ b/project-api/project-api-test/src/test/resources/idl_client_compiler_tests/simpleclienttest/main.bal
@@ -90,6 +90,13 @@ function testClientDeclScoping2(boolean b) { // no assertion, validates absence 
     bar:ClientConfiguration _ = {'limit: 5};
 }
 
+function testClientDeclModuleWithClientObjectType() {
+    client "http://example.com/apis/clientobjecttype.yaml" as foo2; // OK, shadows the module-level prefix
+    foo2:client cl = foo2:fn();
+    int index = cl->getIndex();
+    assertEquals(10, index);
+}
+
 function assertEquals(anydata expected, anydata actual) {
     if expected == actual {
         return;

--- a/project-api/test-artifacts/idl-import-simple-compiler-plugin/src/main/java/io/idl/plugins/simpleclient/SimpleClientGeneratorPlugin.java
+++ b/project-api/test-artifacts/idl-import-simple-compiler-plugin/src/main/java/io/idl/plugins/simpleclient/SimpleClientGeneratorPlugin.java
@@ -96,6 +96,10 @@ public class SimpleClientGeneratorPlugin extends IDLGeneratorPlugin {
                 return DocumentConfig.from(
                         documentId, "public const DEFAULT_URL = \"http://www.example.com\";\n" +
                                 "\n" +
+                                "public type IntMap map<int>;\n" +
+                                "\n" +
+                                "public type XmlElement xml:Element;\n" +
+                                "\n" +
                                 "public type ClientConfiguration record {\n" +
                                 "    string url?;\n" +
                                 "    int 'limit;\n" +

--- a/project-api/test-artifacts/idl-import-simple-compiler-plugin/src/main/java/io/idl/plugins/simpleclient/SimpleClientGeneratorPlugin.java
+++ b/project-api/test-artifacts/idl-import-simple-compiler-plugin/src/main/java/io/idl/plugins/simpleclient/SimpleClientGeneratorPlugin.java
@@ -92,6 +92,10 @@ public class SimpleClientGeneratorPlugin extends IDLGeneratorPlugin {
         }
 
         private DocumentConfig getClientCode(DocumentId documentId, String uri) {
+            if (uri.startsWith("http://example.com/invalidgeneratedcode")) {
+                return getInvalidCode(documentId, uri);
+            }
+
             if ("http://example.com/apis/one.yaml".equals(uri)) {
                 return DocumentConfig.from(
                         documentId, "public const DEFAULT_URL = \"http://www.example.com\";\n" +
@@ -128,6 +132,23 @@ public class SimpleClientGeneratorPlugin extends IDLGeneratorPlugin {
                                 "}", "simple_client.bal");
             }
 
+            if ("http://example.com/apis/clientobjecttype.yaml".equals(uri)) {
+                return DocumentConfig.from(
+                        documentId, "public type 'client client object {\n" +
+                                "    int index;\n" +
+                                "\n" +
+                                "    remote function getIndex() returns int;\n" +
+                                "};\n" +
+                                "\n" +
+                                "public function fn() returns 'client {\n" +
+                                "    return client object {\n" +
+                                "        int index = 10;\n" +
+                                "\n" +
+                                "        remote function getIndex() returns int => self.index;\n" +
+                                "    };\n" +
+                                "}", "simple_client.bal");
+            }
+
             return DocumentConfig.from(
                     documentId, "public type Config record {\n" +
                             "    string url;\n" +
@@ -146,6 +167,35 @@ public class SimpleClientGeneratorPlugin extends IDLGeneratorPlugin {
                             "        }\n" +
                             "    }\n" +
                             "}", "simple_client.bal");
+        }
+
+        private DocumentConfig getInvalidCode(DocumentId documentId, String uri) {
+            if (uri.equals("http://example.com/invalidgeneratedcode/one.yaml")) {
+                return DocumentConfig.from(
+                        documentId, "public client class MyClientClass {\n" +
+                                "    remote function fn() {\n" +
+                                "\n" +
+                                "    }\n" +
+                                "}\n" +
+                                "\n" +
+                                "public type Client client object {\n" +
+                                "    remote function getId();\n" +
+                                "};", "simple_client.bal");
+            }
+
+            if (uri.equals("http://example.com/invalidgeneratedcode/two.yaml")) {
+                return DocumentConfig.from(
+                        documentId, "public class 'client { // Not a client class\n" +
+                                "    function fn() {\n" +
+                                "        \n" +
+                                "    }\n" +
+                                "}", "simple_client.bal");
+            }
+
+            return DocumentConfig.from(
+                    documentId, "public type 'client object { // Not a client object\n" +
+                            "    function fn();\n" +
+                            "};", "simple_client.bal");
         }
     }
 }

--- a/project-api/test-artifacts/idl-import-simple-compiler-plugin/src/main/java/io/idl/plugins/simpleclient/SimpleClientGeneratorPlugin.java
+++ b/project-api/test-artifacts/idl-import-simple-compiler-plugin/src/main/java/io/idl/plugins/simpleclient/SimpleClientGeneratorPlugin.java
@@ -192,10 +192,39 @@ public class SimpleClientGeneratorPlugin extends IDLGeneratorPlugin {
                                 "}", "simple_client.bal");
             }
 
+            if (uri.equals("http://example.com/invalidgeneratedcode/three.yaml")) {
+                return DocumentConfig.from(
+                        documentId, "public type 'client object { // Not a client object\n" +
+                                "    function fn();\n" +
+                                "};", "simple_client.bal");
+            }
+
             return DocumentConfig.from(
-                    documentId, "public type 'client object { // Not a client object\n" +
-                            "    function fn();\n" +
-                            "};", "simple_client.bal");
+                    documentId, "const int A = 1; // OK\n" +
+                            "\n" +
+                            "const map<int> B = {a: 1, b: A}; // OK\n" +
+                            "\n" +
+                            "final int c = 2; // OK\n" +
+                            "\n" +
+                            "final int[] & readonly d = [1, 2]; // OK\n" +
+                            "\n" +
+                            "final int[] e = [1, 2]; // error\n" +
+                            "\n" +
+                            "readonly & int[] f = [1, 2]; // error\n" +
+                            "\n" +
+                            "final var g = e; // error\n" +
+                            "\n" +
+                            "var h = f; // error\n" +
+                            "\n" +
+                            "final var i = d; // OK\n" +
+                            "\n" +
+                            "var j = d; // error\n" +
+                            "\n" +
+                            "public client class 'client {\n" +
+                            "    remote function fn() {\n" +
+                            "        \n" +
+                            "    }\n" +
+                            "}\n", "simple_client.bal");
         }
     }
 }


### PR DESCRIPTION
## Purpose
Introduce the following validations.
- Disallow publicly exposing constucts from modules generated for clients at least until we use a type instead of the typedesc with inferring. If not may cause issues with the BIR pointing to generated modules by name.
- Validate that the module generated for a client declaration contains either a class or an object type with the name `client`.
- Disallow mutable module-level variables in a module generated for a client declaration.