### PR TITLE
Update passing str with name in unknown type er lg

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -1536,7 +1536,8 @@ public class SymbolEnter extends BLangNodeVisitor {
                         currentTypeNodeName, currentTypeOrClassNode.pos.lineRange().startLine().line(),
                         currentTypeOrClassNode.pos.lineRange().startLine().offset());
                 if (unknownTypeRefs.add(locationData)) {
-                    dlog.error(currentTypeOrClassNode.pos, DiagnosticErrorCode.UNKNOWN_TYPE, currentTypeNodeName);
+                    dlog.error(currentTypeOrClassNode.pos, DiagnosticErrorCode.UNKNOWN_TYPE, 
+                            new Name(currentTypeNodeName));
                 }
             } else {
                 for (BLangNode typeDefinition : typeDefinitions) {


### PR DESCRIPTION
## Purpose
There are two places  where we log `UNKOWN_TYPE` errors. One in the `Symbol Enter` class and other in the `Symbol Resolver` class. When logging the errors as argument in the `Symbol Resolver` we pass a `Name` object while in the `Symbol Enter` we pass a `String` object. This leads to create two different diagnostic properties `BStringProperty` and `NonCatProperty`. Passing the same type of arguments mitigate this issue. 

Furthermore this has been lead to an error in the LS `CreateTypeCodeAction`.

Fixes #37104

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
