### PR TITLE
[Master] Allow underscore as valid XML element name

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeBuilder.java
@@ -3553,7 +3553,8 @@ public class BLangNodeBuilder extends NodeTransformer<BLangNode> {
     @Override
     public BLangNode transform(XMLSimpleNameNode xmlSimpleNameNode) {
         BLangXMLQName xmlName = (BLangXMLQName) TreeBuilder.createXMLQNameNode();
-        xmlName.localname = createIdentifier(xmlSimpleNameNode.name());
+        Token xmlSimpleName = xmlSimpleNameNode.name();
+        xmlName.localname = createIdentifier(getPosition(xmlSimpleName), xmlSimpleName, true);
         xmlName.prefix = createIdentifier(null, "");
         xmlName.pos = getPosition(xmlSimpleNameNode);
         return xmlName;
@@ -5431,6 +5432,10 @@ public class BLangNodeBuilder extends NodeTransformer<BLangNode> {
     }
 
     private BLangIdentifier createIdentifier(Location pos, Token token) {
+        return createIdentifier(pos, token, false);
+    }
+
+    private BLangIdentifier createIdentifier(Location pos, Token token, boolean isXML) {
         if (token == null) {
             return createIdentifier(pos, (String) null);
         }
@@ -5438,7 +5443,7 @@ public class BLangNodeBuilder extends NodeTransformer<BLangNode> {
         String identifierName = token.text();
         if (token.isMissing() || identifierName.equals(IDENTIFIER_LITERAL_PREFIX)) {
             identifierName = missingNodesHelper.getNextMissingNodeName(packageID);
-        } else if (identifierName.equals("_") || identifierName.equals(IDENTIFIER_LITERAL_PREFIX + "_")) {
+        } else if (!isXML && (identifierName.equals("_") || identifierName.equals(IDENTIFIER_LITERAL_PREFIX + "_"))) {
             dlog.error(pos, DiagnosticErrorCode.UNDERSCORE_NOT_ALLOWED_AS_IDENTIFIER);
             identifierName = missingNodesHelper.getNextMissingNodeName(packageID);
         }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-literals.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-literals.bal
@@ -32,11 +32,17 @@ function testXMLSequence() {
     test:assertEquals(x5.toString(), "<!--comment-->text1");
     xml x6 = xml `<!--comment-->`;
     test:assertEquals(x6.toString(), "<!--comment-->");
+    xml x27 = xml `<_>element</_>`;
+    test:assertEquals(x27.toString(), "<_>element</_>");
+    xml x28 = xml `<_/>`;
+    test:assertEquals(x28.toString(), "<_></_>");
 
     xml<'xml:Element> x23 = xml `<foo>Anne</foo><fuu>Peter</fuu>`;
     test:assertEquals(x23.toString(), "<foo>Anne</foo><fuu>Peter</fuu>");
     xml<xml<'xml:Element>> x24 = xml `<foo>Anne</foo><fuu>Peter</fuu>`;
     test:assertEquals(x24.toString(), "<foo>Anne</foo><fuu>Peter</fuu>");
+    xml<'xml:Element> x29 = xml `<_>element</_>`;
+    test:assertEquals(x29.toString(), "<_>element</_>");
 
     xml<'xml:ProcessingInstruction> x17 = xml `<?foo?><?faa?>`;
     test:assertEquals(x17.toString(), "<?foo ?><?faa ?>");


### PR DESCRIPTION
## Purpose

Fixes #36163

## Approach
`_` (underscore) is disallowed for identifier because it is a reserved keyword but it is valid for XML element name. This PR will allow it for XML. 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
