### PR TITLE
Fix how formatter defines new line before in keyword

### DIFF
--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
@@ -2590,10 +2590,17 @@ public class FormattingTreeModifier extends TreeModifier {
     @Override
     public LetExpressionNode transform(LetExpressionNode letExpressionNode) {
         Token letKeyword = formatToken(letExpressionNode.letKeyword(), 1, 0);
+        int listTrailingNL = 0;
+        int listTrailingWS = 0;
+        if (shouldExpand(letExpressionNode)) {
+            listTrailingNL++;
+        } else {
+            listTrailingWS++;
+        }
 
         indent();
         SeparatedNodeList<LetVariableDeclarationNode> letVarDeclarations =
-                formatSeparatedNodeList(letExpressionNode.letVarDeclarations(), 0, 0, 0, 1);
+                formatSeparatedNodeList(letExpressionNode.letVarDeclarations(), 0, 0, listTrailingWS, listTrailingNL);
         Token inKeyword = formatToken(letExpressionNode.inKeyword(), 1, 0);
         ExpressionNode expression = formatNode(letExpressionNode.expression(), env.trailingWS, env.trailingNL);
         unindent();
@@ -4420,6 +4427,21 @@ public class FormattingTreeModifier extends TreeModifier {
             }
         }
         return false;
+    }
+
+    /**
+     * Check whether a let expression needs to be expanded in to multiple lines.
+     *
+     * @param letExpressionNode Let Expression
+     * @return <code>true</code> If the let expression needs to be expanded in to multiple lines.
+     *         <code>false</code> otherwise
+     */
+    private boolean shouldExpand(LetExpressionNode letExpressionNode) {
+        SeparatedNodeList<LetVariableDeclarationNode> letVarDeclarations = letExpressionNode.letVarDeclarations();
+        LetVariableDeclarationNode lastLetVarDeclarationNode = letVarDeclarations.get(letVarDeclarations.size() - 1);
+
+        return hasNonWSMinutiae(lastLetVarDeclarationNode.trailingMinutiae())
+                || lastLetVarDeclarationNode.toSourceCode().contains(System.lineSeparator());
     }
 
     /**

--- a/misc/formatter/modules/formatter-core/src/test/resources/expressions/let/assert/let_expression_1.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/expressions/let/assert/let_expression_1.bal
@@ -5,22 +5,21 @@ type Person record {
 function getPerson() returns Person => {age: 31};
 
 public function foo() {
-    int a = let int b = 1
-        in b * 2;
+    int a = let int b = 1 in b * 2;
 
-    string greeting = let string hello = "Hello ", string ballerina = "Ballerina!"
-        in hello + ballerina;
+    int c = let int d = 1
+        in d * 2;
+
+    string greeting = let string hello = "Hello ", string ballerina = "Ballerina!" in hello + ballerina;
 
     int three = let int one = 1, int two = one + one
         in one + two;
 
-    int length = let var num = 10, var txt = "four"
-        in num + txt.length();
+    int length = let var num = 10, var txt = "four" in num + txt.length();
 
     [int, int] v1 = [10, 20];
     int tupleBindingResult = let [int, int] [d1, d2] = v1, int d3 = d1 + d2
         in d3 * 2;
 
-    int age = let Person {age: personAge} = getPerson()
-        in personAge;
+    int age = let Person {age: personAge} = getPerson() in personAge;
 }

--- a/misc/formatter/modules/formatter-core/src/test/resources/expressions/let/source/let_expression_1.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/expressions/let/source/let_expression_1.bal
@@ -7,6 +7,9 @@ function getPerson() returns Person => {    age: 31   };
 public function foo() {
    int a =    let    int b = 1     in b * 2;
 
+   int c =    let    int d = 1
+in d * 2;
+
    string greeting =let string hello = "Hello ",   string ballerina = "Ballerina!"in hello + ballerina;
 
    int three =    let int one = 1  , int two = one + one


### PR DESCRIPTION
## Purpose
> This is an enhancement which addresses the newly proposed way on formatting newline before the `in` keyword

Fixes #31950

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
