### PR TITLE
Fix rename popup in create variable and check error code action

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/CreateVariableCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/CreateVariableCodeAction.java
@@ -206,15 +206,21 @@ public class CreateVariableCodeAction implements DiagnosticBasedCodeActionProvid
         2. If any text edits are applied before the variable creation edit, the length of those edits is added to the
            "sum". In the above example, the length of "error?" will be added.
         3. renameOffset gives the length of the variable type and the white space between the variable type and the
-           variable. In the example the renameOffset will be the length of "int ".
+           variable. In the example, the renameOffset will be the length of "int ".
         */
 
         int startPos = CommonUtil.getTextEdit(syntaxTree.get(), variableEdit).range().startOffset();
         int sum = 0;
         for (TextEdit textEdit : textEdits) {
             io.ballerina.tools.text.TextEdit edits = CommonUtil.getTextEdit(syntaxTree.get(), textEdit);
-            if (edits.range().startOffset() < startPos) {
+            int startOffset = edits.range().startOffset();
+            int endOffset = edits.range().endOffset();
+            if (startOffset < startPos) {
                 sum = sum + edits.text().length();
+                if (startOffset < endOffset) {
+                    int returnTypeLength = endOffset - startOffset;
+                    sum = sum - returnTypeLength;
+                }
             }
         }
 


### PR DESCRIPTION
## Purpose
This PR adds the missing rename popup to create variable and check error code action when there's a return type.

Fixes #37609

## Samples

https://user-images.githubusercontent.com/61020198/188876325-616593ff-7afb-4fa5-bfab-298a690669f8.mov

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
