### PR TITLE
Fix `.signature()` of classes with quoted identifiers

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeReferenceTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeReferenceTypeSymbol.java
@@ -33,6 +33,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BParameterizedType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BTypeReferenceType;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
+import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.Names;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 
@@ -106,7 +107,12 @@ public class BallerinaTypeReferenceTypeSymbol extends AbstractTypeSymbol impleme
             this.definition = symbolFactory.getBCompiledSymbol(referredType.tsymbol,
                     referredType.tsymbol.getName().getValue());
         } else {
-            Scope.ScopeEntry scopeEntry = tSymbol.owner.scope.lookup(Names.fromString(this.name()));
+            Name name = Names.fromString(this.name());
+            Scope.ScopeEntry scopeEntry = tSymbol.owner.scope.lookup(name);
+            if (scopeEntry.symbol == null) {
+                scopeEntry = tSymbol.owner.scope.lookup(tSymbol.getName());
+            }
+
             this.definition = symbolFactory.getBCompiledSymbol(scopeEntry.symbol, this.name());
         }
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
@@ -1131,8 +1131,8 @@ public class TypedescriptorTest {
         };
     }
 
-    @Test(dataProvider = "ClassObjectTypePosProvider")
-    public void testClassObjectType(int line, int column, String expectedSignature, TypeDescKind expTypeKind) {
+    @Test(dataProvider = "ClassAndObjectTypePosProvider")
+    public void testClassAndObjectType(int line, int column, String expectedSignature, TypeDescKind expTypeKind) {
         Symbol varSymbol = getSymbol(line, column);
         assertEquals(varSymbol.kind(), VARIABLE);
         TypeSymbol typeSymbol = ((VariableSymbol) varSymbol).typeDescriptor();
@@ -1141,8 +1141,8 @@ public class TypedescriptorTest {
         assertEquals(((TypeReferenceTypeSymbol) typeSymbol).typeDescriptor().typeKind(), expTypeKind);
     }
 
-    @DataProvider(name = "ClassObjectTypePosProvider")
-    private Object[][] getClassObjectTypePos() {
+    @DataProvider(name = "ClassAndObjectTypePosProvider")
+    private Object[][] getClassAndObjectTypePos() {
         return new Object[][] {
                 {371, 12, "'client", OBJECT},
                 {372, 11, "'class", OBJECT},

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
@@ -89,6 +89,7 @@ import static io.ballerina.compiler.api.symbols.ParameterKind.REST;
 import static io.ballerina.compiler.api.symbols.SymbolKind.CONSTANT;
 import static io.ballerina.compiler.api.symbols.SymbolKind.TYPE;
 import static io.ballerina.compiler.api.symbols.SymbolKind.TYPE_DEFINITION;
+import static io.ballerina.compiler.api.symbols.SymbolKind.VARIABLE;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.ANY;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.ANYDATA;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.ARRAY;
@@ -1127,6 +1128,24 @@ public class TypedescriptorTest {
                 {359, 14, FLOAT, "0xB2.8Fp1"},
                 {360, 8, STRING, "\"a\""},
                 {361, 8, STRING, "\"RED\""},
+        };
+    }
+
+    @Test(dataProvider = "ClassObjectTypePosProvider")
+    public void testClassObjectType(int line, int column, String expectedSignature, TypeDescKind expTypeKind) {
+        Symbol varSymbol = getSymbol(line, column);
+        assertEquals(varSymbol.kind(), VARIABLE);
+        TypeSymbol typeSymbol = ((VariableSymbol) varSymbol).typeDescriptor();
+        assertEquals(typeSymbol.signature(), expectedSignature);
+        assertEquals(typeSymbol.typeKind(), TYPE_REFERENCE);
+        assertEquals(((TypeReferenceTypeSymbol) typeSymbol).typeDescriptor().typeKind(), expTypeKind);
+    }
+
+    @DataProvider(name = "ClassObjectTypePosProvider")
+    private Object[][] getClassObjectTypePos() {
+        return new Object[][] {
+                {371, 12, "'client", OBJECT},
+                {372, 11, "'class", OBJECT},
         };
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/typedesc_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/typedesc_test.bal
@@ -361,3 +361,14 @@ function testSingletonTypes() {
     "a" j;
     RED k;
 }
+
+public isolated client class 'client {
+}
+
+class 'class {
+}
+
+function testQuotedClientClass() {
+    'client c;
+    'class cls;
+}


### PR DESCRIPTION
## Purpose
> $title

Fixes #37511

## Approach

## Samples

## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
