### PR TITLE
Fix typo in ExtensionDevelopmentBestPractices.md

### DIFF
--- a/docs/language-server/ExtensionDevelopmentBestPractices.md
+++ b/docs/language-server/ExtensionDevelopmentBestPractices.md
@@ -116,7 +116,7 @@ When to Use
 **3. How to get the children of a Syntax node**  
 **Answer:** _Use the APIs provided in each of the node. For example the `FunctionDefinition` contains an API
 called `qualifierList` to get the qualifiers in the function. Try to avoid the usage of `children` API since it is too
-generic and includes whitesapces as well_
+generic and includes white spaces as well_
 
 **4. How to access the position details**  
 **Answer:** _Use either the offset or line-column approach. In either case, stick to one usage without mixing them both.


### PR DESCRIPTION

## Purpose
Fixed typo.
```
whitesapces -> white spaces
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
