### PR TITLE
Remove superfluous `flagSet` attribute

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/types/BLangObjectTypeNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/types/BLangObjectTypeNode.java
@@ -17,7 +17,6 @@
 */
 package org.wso2.ballerinalang.compiler.tree.types;
 
-import org.ballerinalang.model.elements.Flag;
 import org.ballerinalang.model.tree.FunctionNode;
 import org.ballerinalang.model.tree.NodeKind;
 import org.ballerinalang.model.tree.types.ObjectTypeNode;
@@ -28,9 +27,7 @@ import org.wso2.ballerinalang.compiler.tree.BLangNodeVisitor;
 import org.wso2.ballerinalang.compiler.tree.BLangSimpleVariable;
 
 import java.util.ArrayList;
-import java.util.EnumSet;
 import java.util.List;
-import java.util.Set;
 
 /**
  * {@code BLangObjectTypeNode} represents a object type node in Ballerina.

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/types/BLangObjectTypeNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/types/BLangObjectTypeNode.java
@@ -44,12 +44,8 @@ public class BLangObjectTypeNode extends BLangStructureTypeNode implements Objec
     // BLangNodes
     public List<BLangFunction> functions;
 
-    // Parser Flags and Data
-    public Set<Flag> flagSet;
-
     public BLangObjectTypeNode() {
         this.functions = new ArrayList<>();
-        this.flagSet = EnumSet.noneOf(Flag.class);
     }
 
     // This ctor is used in node cloner. Fields being set in node cloner are not initialized here

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
@@ -1269,8 +1269,8 @@ public class TypedescriptorTest {
 
     private void assertQualifiers(List<Qualifier> qualifiers, List<Qualifier> expectedQualifiers) {
         assertEquals(qualifiers.size(), expectedQualifiers.size());
-        for (Qualifier qualifier : qualifiers) {
-            assertTrue(expectedQualifiers.contains(qualifier));
+        for (Qualifier expectedQualifier : expectedQualifiers) {
+            assertTrue(qualifiers.contains(expectedQualifier));
         }
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
@@ -807,7 +807,7 @@ public class TypedescriptorTest {
     private Object[][] getDistinctObjectTypes() {
         return new Object[][] {
                 {174, 12, List.of(Qualifier.PUBLIC), List.of(Qualifier.DISTINCT)},
-                {364, 12, List.of(Qualifier.PUBLIC), List.of(Qualifier.DISTINCT, Qualifier.SERVICE)},
+                {375, 12, List.of(Qualifier.PUBLIC), List.of(Qualifier.DISTINCT, Qualifier.SERVICE)},
         };
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
@@ -792,15 +792,23 @@ public class TypedescriptorTest {
         assertEquals(members.get(1).typeKind(), READONLY);
     }
 
-    @Test
-    public void testDistinctObjects() {
-        Symbol symbol = getSymbol(174, 12);
-        TypeSymbol type = ((TypeDefinitionSymbol) symbol).typeDescriptor();
+    @Test(dataProvider = "DistinctObjectTypeProvider")
+    public void testDistinctObjects(int line, int column, List<Qualifier> typeDefQuals, List<Qualifier> objectQuals) {
+        Symbol symbol = getSymbol(line, column);
+        assertEquals(symbol.kind(), TYPE_DEFINITION);
+        TypeDefinitionSymbol typeDefinitionSymbol = (TypeDefinitionSymbol) symbol;
+        TypeSymbol typeSymbol = (typeDefinitionSymbol).typeDescriptor();
+        assertEquals(typeSymbol.typeKind(), OBJECT);
+        assertQualifiers(typeDefinitionSymbol.qualifiers(), typeDefQuals);
+        assertQualifiers(((ObjectTypeSymbol) typeSymbol).qualifiers(), objectQuals);
+    }
 
-        assertTrue(((TypeDefinitionSymbol) symbol).qualifiers().contains(Qualifier.PUBLIC));
-        assertEquals(type.typeKind(), OBJECT);
-        // disabled due to https://github.com/ballerina-platform/ballerina-lang/issues/27279
-//        assertTrue(((ObjectTypeSymbol) type).qualifiers().contains(Qualifier.DISTINCT));
+    @DataProvider(name = "DistinctObjectTypeProvider")
+    private Object[][] getDistinctObjectTypes() {
+        return new Object[][] {
+                {174, 12, List.of(Qualifier.PUBLIC), List.of(Qualifier.DISTINCT)},
+                {364, 12, List.of(Qualifier.PUBLIC), List.of(Qualifier.DISTINCT, Qualifier.SERVICE)},
+        };
     }
 
     @Test
@@ -1259,8 +1267,17 @@ public class TypedescriptorTest {
         }
     }
 
+    private void assertQualifiers(List<Qualifier> qualifiers, List<Qualifier> expectedQualifiers) {
+        assertEquals(qualifiers.size(), expectedQualifiers.size());
+        for (Qualifier qualifier : qualifiers) {
+            assertTrue(expectedQualifiers.contains(qualifier));
+        }
+    }
+
     private Symbol getSymbol(int line, int column) {
-        return model.symbol(srcFile, from(line, column)).get();
+        Optional<Symbol> symbol = model.symbol(srcFile, from(line, column));
+        assertTrue(symbol.isPresent());
+        return symbol.get();
     }
 
     private void validateParam(ParameterSymbol param, String name, ParameterKind kind, TypeDescKind typeKind) {

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/typedesc_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/typedesc_test.bal
@@ -372,3 +372,6 @@ function testQuotedClientClass() {
     'client c;
     'class cls;
 }
+
+public type PersonType distinct service object {
+};


### PR DESCRIPTION
## Purpose
> Removes the redundant flagSet attribute in the `BLangObjectTypeNode`, which is also available in one of its parent classes: `BLangType`

Fixes #37560

## Approach

## Samples

## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
