### PR TITLE
[2201.2.x] Improve obj field mapping constructor completions 

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/ContextTypeResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/ContextTypeResolver.java
@@ -22,6 +22,7 @@ import io.ballerina.compiler.api.TypeBuilder;
 import io.ballerina.compiler.api.Types;
 import io.ballerina.compiler.api.symbols.AnnotationSymbol;
 import io.ballerina.compiler.api.symbols.ArrayTypeSymbol;
+import io.ballerina.compiler.api.symbols.ClassFieldSymbol;
 import io.ballerina.compiler.api.symbols.ClassSymbol;
 import io.ballerina.compiler.api.symbols.ErrorTypeSymbol;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
@@ -232,11 +233,12 @@ public class ContextTypeResolver extends NodeTransformer<Optional<TypeSymbol>> {
     @Override
     public Optional<TypeSymbol> transform(ObjectFieldNode node) {
         Optional<Symbol> symbol =
-                this.context.currentSemanticModel().flatMap(semanticModel -> semanticModel.symbol(node.typeName()));
-        if (symbol.isEmpty() || symbol.get().kind() != SymbolKind.TYPE) {
+                this.context.currentSemanticModel().flatMap(semanticModel -> semanticModel.symbol(node));
+        if (symbol.isEmpty() || symbol.get().kind() != SymbolKind.CLASS_FIELD) {
             return Optional.empty();
         }
-        return Optional.of(this.getRawContextType((TypeSymbol) symbol.get()));
+        ClassFieldSymbol classFieldSymbol = (ClassFieldSymbol) symbol.get();
+        return Optional.of(this.getRawContextType(classFieldSymbol.typeDescriptor()));
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_constructor_expr_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_constructor_expr_ctx_config1.json
@@ -1,0 +1,43 @@
+{
+  "position": {
+    "line": 1,
+    "character": 34
+  },
+  "source": "expression_context/source/mapping_constructor_expr_ctx_source1.bal",
+  "items": [
+    {
+      "label": "readonly",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "readonly",
+      "insertText": "readonly ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "x",
+      "kind": "Field",
+      "detail": "(record {|int x; int y; anydata...;|}).x",
+      "sortText": "K",
+      "insertText": "x: ${1:0}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "y",
+      "kind": "Field",
+      "detail": "(record {|int x; int y; anydata...;|}).y",
+      "sortText": "K",
+      "insertText": "y: ${1:0}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Fill record {|int x; int y; anydata...;|} Required Fields",
+      "kind": "Property",
+      "detail": "record {|int x; int y; anydata...;|}",
+      "sortText": "R",
+      "filterText": "fill",
+      "insertText": "x: ${1:0},\ny: ${2:0}",
+      "insertTextFormat": "Snippet"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_constructor_expr_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_constructor_expr_ctx_config1.json
@@ -4,6 +4,7 @@
     "character": 34
   },
   "source": "expression_context/source/mapping_constructor_expr_ctx_source1.bal",
+  "description": "completions for anonymous object field record mapping constructor expression",
   "items": [
     {
       "label": "readonly",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_constructor_expr_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_constructor_expr_ctx_config2.json
@@ -1,0 +1,35 @@
+{
+  "position": {
+    "line": 1,
+    "character": 40
+  },
+  "source": "expression_context/source/mapping_constructor_expr_ctx_source2.bal",
+  "items": [
+    {
+      "label": "readonly",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "readonly",
+      "insertText": "readonly ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "y",
+      "kind": "Field",
+      "detail": "(record {|int x; int y; anydata...;|}).y",
+      "sortText": "K",
+      "insertText": "y: ${1:0}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Fill record {|int x; int y; anydata...;|} Required Fields",
+      "kind": "Property",
+      "detail": "record {|int x; int y; anydata...;|}",
+      "sortText": "R",
+      "filterText": "fill",
+      "insertText": "y: ${1:0}",
+      "insertTextFormat": "Snippet"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_constructor_expr_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_constructor_expr_ctx_config2.json
@@ -4,6 +4,7 @@
     "character": 40
   },
   "source": "expression_context/source/mapping_constructor_expr_ctx_source2.bal",
+  "description": "completions for anonymous object field record mapping constructor expression",
   "items": [
     {
       "label": "readonly",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_constructor_expr_ctx_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_constructor_expr_ctx_config3.json
@@ -4,6 +4,7 @@
     "character": 51
   },
   "source": "expression_context/source/mapping_constructor_expr_ctx_source3.bal",
+  "description": "completions for mapping constructor in a row list of a table constructor",
   "items": [
     {
       "label": "readonly",

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_constructor_expr_ctx_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_constructor_expr_ctx_config3.json
@@ -1,0 +1,43 @@
+{
+  "position": {
+    "line": 6,
+    "character": 51
+  },
+  "source": "expression_context/source/mapping_constructor_expr_ctx_source3.bal",
+  "items": [
+    {
+      "label": "readonly",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "readonly",
+      "insertText": "readonly ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "empId",
+      "kind": "Field",
+      "detail": "(record {|readonly int empId; string name;|}).empId",
+      "sortText": "K",
+      "insertText": "empId: ${1:0}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "name",
+      "kind": "Field",
+      "detail": "(record {|readonly int empId; string name;|}).name",
+      "sortText": "K",
+      "insertText": "name: ${1:\"\"}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Fill record {|readonly int empId; string name;|} Required Fields",
+      "kind": "Property",
+      "detail": "record {|readonly int empId; string name;|}",
+      "sortText": "R",
+      "filterText": "fill",
+      "insertText": "empId: ${1:0},\nname: ${2:\"\"}",
+      "insertTextFormat": "Snippet"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_constructor_expr_ctx_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_constructor_expr_ctx_config4.json
@@ -1,0 +1,35 @@
+{
+  "position": {
+    "line": 5,
+    "character": 37
+  },
+  "source": "expression_context/source/mapping_constructor_expr_ctx_source4.bal",
+  "items": [
+    {
+      "label": "readonly",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "readonly",
+      "insertText": "readonly ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "y",
+      "kind": "Field",
+      "detail": "(record {|int y; int x; anydata...;|}).y",
+      "sortText": "K",
+      "insertText": "y: ${1:0}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Fill record {|int y; int x; anydata...;|} Required Fields",
+      "kind": "Property",
+      "detail": "record {|int y; int x; anydata...;|}",
+      "sortText": "R",
+      "filterText": "fill",
+      "insertText": "y: ${1:0}",
+      "insertTextFormat": "Snippet"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_constructor_expr_ctx_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_constructor_expr_ctx_config5.json
@@ -1,0 +1,640 @@
+{
+  "position": {
+    "line": 5,
+    "character": 39
+  },
+  "source": "expression_context/source/mapping_constructor_expr_ctx_source5.bal",
+  "items": [
+    {
+      "label": "test/project2",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "project2",
+      "insertText": "project2",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import test/project2;\n"
+        }
+      ]
+    },
+    {
+      "label": "test/project1",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "project1",
+      "insertText": "project1",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import test/project1;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.runtime",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "runtime",
+      "insertText": "runtime",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.runtime;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/module1",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "module1",
+      "insertText": "module1",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/module1;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.test",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "test",
+      "insertText": "test",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.test;\n"
+        }
+      ]
+    },
+    {
+      "label": "test/local_project2",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "local_project2",
+      "insertText": "local_project2",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import test/local_project2;\n"
+        }
+      ]
+    },
+    {
+      "label": "test/local_project1",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "local_project1",
+      "insertText": "local_project1",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import test/local_project1;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "value",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/jballerina.java",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "java",
+      "insertText": "java",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/jballerina.java;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.array",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "array",
+      "insertText": "array",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.array;\n"
+        }
+      ]
+    },
+    {
+      "label": "boolean",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "boolean",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "decimal",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "decimal",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "error",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "error",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "float",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "float",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "function",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "function",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "future",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "future",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "int",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "int",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "map",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "map",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "object",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "object",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "stream",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "stream",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "string",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "table",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "table",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "transaction",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "transaction",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "typedesc",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "typedesc",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "xml",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "service",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "service",
+      "insertText": "service",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "new",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "new",
+      "insertText": "new ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "isolated",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "isolated",
+      "insertText": "isolated ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "transactional",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "transactional",
+      "insertText": "transactional",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "function",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "function",
+      "insertText": "function ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "let",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "let",
+      "insertText": "let",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "typeof",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "typeof",
+      "insertText": "typeof ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "trap",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "trap",
+      "insertText": "trap",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "client",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "client",
+      "insertText": "client ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "true",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "true",
+      "insertText": "true",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "false",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "false",
+      "insertText": "false",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "null",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "null",
+      "insertText": "null",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "check",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "check",
+      "insertText": "check ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "checkpanic",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "checkpanic",
+      "insertText": "checkpanic ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "is",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "is",
+      "insertText": "is",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "error",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "object constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "object",
+      "insertText": "object {${1}}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "base16",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "base16",
+      "insertText": "base16 `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "base64",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "base64",
+      "insertText": "base64 `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "from",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "from",
+      "insertText": "from ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "MyClass",
+      "kind": "Interface",
+      "detail": "Class",
+      "sortText": "O",
+      "insertText": "MyClass",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "moduleVar",
+      "kind": "Variable",
+      "detail": "int",
+      "sortText": "AB",
+      "insertText": "moduleVar",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Thread",
+      "kind": "TypeParameter",
+      "detail": "Union",
+      "sortText": "R",
+      "insertText": "Thread",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "StrandData",
+      "kind": "Struct",
+      "detail": "Record",
+      "documentation": {
+        "left": "Describes Strand execution details for the runtime.\n"
+      },
+      "sortText": "Q",
+      "insertText": "StrandData",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "readonly",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "readonly",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "handle",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "handle",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "never",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "never",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "json",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "json",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "anydata",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "anydata",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "any",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "any",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "byte",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "byte",
+      "insertTextFormat": "Snippet"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/mapping_constructor_expr_ctx_source1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/mapping_constructor_expr_ctx_source1.bal
@@ -1,0 +1,3 @@
+class TestClass {
+    record {int x; int y;} rec = {};
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/mapping_constructor_expr_ctx_source2.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/mapping_constructor_expr_ctx_source2.bal
@@ -1,0 +1,3 @@
+class TestClass {
+    record {int x; int y;} rec = {x: 0, };
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/mapping_constructor_expr_ctx_source3.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/mapping_constructor_expr_ctx_source3.bal
@@ -1,0 +1,8 @@
+type Employee record {|
+    readonly int empId;
+    string name;
+|}; 
+
+class TestClass {
+    table<Employee> key(empId) employees = table [{}];
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/mapping_constructor_expr_ctx_source4.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/mapping_constructor_expr_ctx_source4.bal
@@ -1,0 +1,7 @@
+int moduleVar = 20;
+
+class MyClass {
+    int x = 10;
+    int y = 20;
+    record {int y; int x;} rec = {x, };
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/mapping_constructor_expr_ctx_source5.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/mapping_constructor_expr_ctx_source5.bal
@@ -1,0 +1,7 @@
+int moduleVar = 20;
+
+class MyClass {
+    int x = 10;
+    int y = 20;
+    record {int y; int x;} rec = {x, y:};
+}


### PR DESCRIPTION
## Purpose
$subject

Fixes #37625

Related PRs - #38367 (2201.3.x), #38370 (master)

## Samples
<img width="719" alt="Screenshot 2022-09-15 at 09 49 16" src="https://user-images.githubusercontent.com/46857198/190313611-84449eae-1ca9-4741-94c7-fc7d7de0228b.png">

<img width="802" alt="Screenshot 2022-09-15 at 09 49 51" src="https://user-images.githubusercontent.com/46857198/190313618-2f3e963b-bc31-4962-92b7-bf2301da9763.png">


## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
