### PR TITLE
Update issue template with stackoverflow and discord links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: General Question
+    url: https://stackoverflow.com/questions/tagged/ballerina
+    about: "If you have a question then please ask on Stack Overflow using the #ballerina tag."
+  - name: Chat
+    url: https://discord.com/invite/wAJYFbMrG2
+    about: "Chat about anything else with the community."


### PR DESCRIPTION
## Purpose

Add SO and Discord links to issue template. This will help new users as it is easy to ask in SO or discord than create issues. 

## Approach
Refer [Configuring issue templates for your repository](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser)

It will look like below.

<img width="1260" alt="image" src="https://user-images.githubusercontent.com/16300038/190511677-2ef79dc0-b490-46d8-be80-5b51404c3f43.png">

