### PR TITLE
[Master] Fix Compiler crashes with CCE for int[] [...a] = [1, 2];

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -2567,10 +2567,14 @@ public class SymbolEnter extends BLangNodeVisitor {
                 case TypeTags.ARRAY:
                     List<BType> tupleTypes = new ArrayList<>();
                     BArrayType arrayType = (BArrayType) referredType;
-                    for (int i = 0; i < arrayType.size; i++) {
-                        tupleTypes.add(arrayType.eType);
-                    }
                     tupleTypeNode = new BTupleType(tupleTypes);
+                    BType eType = arrayType.eType;
+                    for (int i = 0; i < arrayType.size; i++) {
+                        tupleTypes.add(eType);
+                    }
+                    if (varNode.restVariable != null) {
+                        tupleTypeNode.restType = eType;
+                    }
                     break;
                 default:
                     dlog.error(varNode.pos, DiagnosticErrorCode.INVALID_LIST_BINDING_PATTERN_DECL, bType);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/tuples/TupleRestDescriptorTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/tuples/TupleRestDescriptorTest.java
@@ -111,6 +111,11 @@ public class TupleRestDescriptorTest {
         BRunUtil.invoke(result, "testSubTypingWithRestDescriptorNegative");
     }
 
+    @Test
+    public void testRestVariablesWithArray() {
+        BRunUtil.invoke(result, "testRestVariablesWithArray");
+    }
+
     @Test(description = "Test out of bound indexed based access on tuples with rest descriptor",
             expectedExceptions = {BLangRuntimeException.class},
             expectedExceptionsMessageRegExp =

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/varref/tuple-variable-reference.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/varref/tuple-variable-reference.bal
@@ -374,7 +374,7 @@ function testRestVarRefType7() {
     var [h1, h2, ...h3] = t6;
     assertEqual("typedesc 10", (typeof h1).toString());
     assertEqual("typedesc 20", (typeof h2).toString());
-    assertEqual("typedesc [int,int,int]", (typeof h3).toString());
+    assertEqual("typedesc [int,int,int,int...]", (typeof h3).toString());
     assertEqual(10, h1);
     assertEqual(20, h2);
     assertEqual(3, h3.length());
@@ -386,7 +386,7 @@ function testRestVarRefType7() {
 function testRestVarRefType8() {
     (int|Bar)[5] t7 = [10, 20, {id: 34, flag: true}, 40, {id: 35, flag: false}];
     var [h1, h2, ...h3] = t7;
-    assertEqual("typedesc [(int|Bar),(int|Bar),(int|Bar)]", (typeof h3).toString());
+    assertEqual("typedesc [(int|Bar),(int|Bar),(int|Bar),(int|Bar)...]", (typeof h3).toString());
     assertEqual(10, h1);
     assertEqual(20, h2);
     assertEqual(3, h3.length());

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/vardeclr/module_tuple_var_decl.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/vardeclr/module_tuple_var_decl.bal
@@ -202,7 +202,7 @@ var [h1, h2, ...h3] = t3;
 function testModuleLevelTupleRest3() {
     assertEquality("typedesc 10", (typeof h1).toString());
     assertEquality("typedesc 20", (typeof h2).toString());
-    assertEquality("typedesc [int,int,int]", (typeof h3).toString());
+    assertEquality("typedesc [int,int,int,int...]", (typeof h3).toString());
     assertEquality(10, h1);
     assertEquality(20, h2);
     assertEquality(3, h3.length());

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/tuples/tuple_rest_descriptor_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/tuples/tuple_rest_descriptor_test.bal
@@ -178,6 +178,30 @@ function testSubTypingWithRestDescriptorNegative() {
     assertFalse(v2 is [string, string, string, string]);
 }
 
+function testRestVariablesWithArray() {
+    int[] [...a] = [1, 2];
+    int[] _ = a;
+    assertEquality(a, <int[]>[1, 2]);
+
+    [int...] [...a2] = [1, 2];
+    int[] _ = a2;
+    assertEquality(a2, <[int...]>[1, 2]);
+
+    int[2] [...a3] = [1, 2];
+    assertEquality(a3, <int[2]>[1, 2]);
+
+    string[] [...s] = ["string 1", "string 2"];
+    string[] _ = s;
+    assertEquality(s, <string[]>["string 1", "string 2"]);
+
+    [string...] [...s2] = ["string 1", "string 2"];
+    string[] _ = s2;
+    assertEquality(s2, <[string...]>["string 1", "string 2"]);
+
+    string[2] [...s3] = ["string 1", "string 2"];
+    assertEquality(s3, <string[2]>["string 1", "string 2"]);
+}
+
 function assertTrue(any|error actual) {
     assertEquality(true, actual);
 }


### PR DESCRIPTION
## Purpose
> Fix Compiler crashes with CCE for int[] [...a] = [1, 2];

Fixes #37408

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
