### PR TITLE
Fix incorrect indentation on Conditional-expr formatting when written over mutiple lines

### DIFF
--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
@@ -3075,12 +3075,33 @@ public class FormattingTreeModifier extends TreeModifier {
 
     @Override
     public ConditionalExpressionNode transform(ConditionalExpressionNode conditionalExpressionNode) {
+        boolean isContinuing = isContinuing(conditionalExpressionNode.questionMarkToken());
+        boolean prevPreserveIndent = env.preserveIndentation;
         ExpressionNode lhsExpression = formatNode(conditionalExpressionNode.lhsExpression(), 1, 0);
         Token questionMarkToken = formatToken(conditionalExpressionNode.questionMarkToken(), 1, 0);
+        if (isContinuing) {
+            indent();
+            preserveIndentation(false);
+        }
         ExpressionNode middleExpression = formatNode(conditionalExpressionNode.middleExpression(), 1, 0);
+        if (isContinuing) {
+            unindent();
+            preserveIndentation(prevPreserveIndent);
+        }
+
+        isContinuing = isContinuing(conditionalExpressionNode.colonToken());
+        prevPreserveIndent = env.preserveIndentation;
         Token colonToken = formatToken(conditionalExpressionNode.colonToken(), 1, 0);
+        if (isContinuing) {
+            indent();
+            preserveIndentation(false);
+        }
         ExpressionNode endExpression = formatNode(conditionalExpressionNode.endExpression(),
                 env.trailingWS, env.trailingNL);
+        if (isContinuing) {
+            unindent();
+            preserveIndentation(prevPreserveIndent);
+        }
 
         return conditionalExpressionNode.modify()
                 .withLhsExpression(lhsExpression)
@@ -4355,6 +4376,17 @@ public class FormattingTreeModifier extends TreeModifier {
         }
 
         return sb.toString();
+    }
+
+    /**
+     * Check whether a node in a statement continues to the next lines.
+     *
+     * @param node node to be checked for continuity
+     * @return <code>true</code> If the statement continues to the next line.
+     *         <code>false</code> otherwise
+     */
+    private boolean isContinuing(Node node) {
+        return node.toSourceCode().contains(System.lineSeparator());
     }
 
     /**

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
@@ -3075,33 +3075,15 @@ public class FormattingTreeModifier extends TreeModifier {
 
     @Override
     public ConditionalExpressionNode transform(ConditionalExpressionNode conditionalExpressionNode) {
-        boolean isContinuing = isContinuing(conditionalExpressionNode.questionMarkToken());
-        boolean prevPreserveIndent = env.preserveIndentation;
-        ExpressionNode lhsExpression = formatNode(conditionalExpressionNode.lhsExpression(), 1, 0);
-        Token questionMarkToken = formatToken(conditionalExpressionNode.questionMarkToken(), 1, 0);
-        if (isContinuing) {
-            indent();
-            preserveIndentation(false);
-        }
-        ExpressionNode middleExpression = formatNode(conditionalExpressionNode.middleExpression(), 1, 0);
-        if (isContinuing) {
-            unindent();
-            preserveIndentation(prevPreserveIndent);
-        }
-
-        isContinuing = isContinuing(conditionalExpressionNode.colonToken());
-        prevPreserveIndent = env.preserveIndentation;
-        Token colonToken = formatToken(conditionalExpressionNode.colonToken(), 1, 0);
-        if (isContinuing) {
-            indent();
-            preserveIndentation(false);
-        }
+        indent();
+        ExpressionNode lhsExpression = formatNode(conditionalExpressionNode.lhsExpression(), 1, 0, !env.hasNewline);
+        Token questionMarkToken = formatToken(conditionalExpressionNode.questionMarkToken(), 1, 0, !env.hasNewline);
+        ExpressionNode middleExpression = formatNode(conditionalExpressionNode.middleExpression(),
+                1, 0, !env.hasNewline);
+        Token colonToken = formatToken(conditionalExpressionNode.colonToken(), 1, 0, !env.hasNewline);
         ExpressionNode endExpression = formatNode(conditionalExpressionNode.endExpression(),
-                env.trailingWS, env.trailingNL);
-        if (isContinuing) {
-            unindent();
-            preserveIndentation(prevPreserveIndent);
-        }
+                env.trailingWS, env.trailingNL, !env.hasNewline);
+        unindent();
 
         return conditionalExpressionNode.modify()
                 .withLhsExpression(lhsExpression)
@@ -3631,10 +3613,11 @@ public class FormattingTreeModifier extends TreeModifier {
      * @param node Node to be formatted
      * @param trailingWS Number of single-length spaces to be added after the node
      * @param trailingNL Number of newlines to be added after the node
+     * @param preserveIndentation Preserve user-defined indentation
      * @return Formatted node
      */
     @SuppressWarnings("unchecked")
-    private <T extends Node> T formatNode(T node, int trailingWS, int trailingNL) {
+    private <T extends Node> T formatNode(T node, int trailingWS, int trailingNL, Boolean preserveIndentation) {
         try {
             if (node == null) {
                 return node;
@@ -3649,6 +3632,9 @@ public class FormattingTreeModifier extends TreeModifier {
             int prevTrailingWS = env.trailingWS;
             env.trailingNL = trailingNL;
             env.trailingWS = trailingWS;
+            if (preserveIndentation != null) {
+                env.preserveIndentation = preserveIndentation;
+            }
 
             // Cache the current node and parent before format.
             // Because reference to the nodes will change after modifying.
@@ -3674,15 +3660,30 @@ public class FormattingTreeModifier extends TreeModifier {
     }
 
     /**
+     * Format a node.
+     *
+     * @param <T> Type of the node
+     * @param node Node to be formatted
+     * @param trailingWS Number of single-length spaces to be added after the node
+     * @param trailingNL Number of newlines to be added after the node
+     * @return Formatted node
+     */
+    @SuppressWarnings("unchecked")
+    private <T extends Node> T formatNode(T node, int trailingWS, int trailingNL) {
+        return formatNode(node, trailingWS, trailingNL, null);
+    }
+
+    /**
      * Format a token.
      *
      * @param <T> Type of the token
      * @param token Token to be formatted
      * @param trailingWS Number of single-length spaces to be added after the token
      * @param trailingNL Number of newlines to be added after the token
+     * @param preserveIndentation Preserve user-defined indentation
      * @return Formatted token
      */
-    private <T extends Token> T formatToken(T token, int trailingWS, int trailingNL) {
+    private <T extends Token> T formatToken(T token, int trailingWS, int trailingNL, Boolean preserveIndentation) {
         try {
             if (token == null) {
                 return token;
@@ -3699,6 +3700,9 @@ public class FormattingTreeModifier extends TreeModifier {
             // Trailing newlines can be at-most 1. Rest will go as newlines for the next token
             env.trailingNL = trailingNL > 0 ? 1 : 0;
             env.trailingWS = trailingWS;
+            if (preserveIndentation != null) {
+                env.preserveIndentation = preserveIndentation;
+            }
 
             token = formatTokenInternal(token);
 
@@ -3719,6 +3723,19 @@ public class FormattingTreeModifier extends TreeModifier {
         }
 
         return token;
+    }
+
+    /**
+     * Format a token.
+     *
+     * @param <T> Type of the token
+     * @param token Token to be formatted
+     * @param trailingWS Number of single-length spaces to be added after the token
+     * @param trailingNL Number of newlines to be added after the token
+     * @return Formatted token
+     */
+    private <T extends Token> T formatToken(T token, int trailingWS, int trailingNL) {
+        return formatToken(token, trailingWS, trailingNL, null);
     }
 
     protected <T extends Node> NodeList<T> formatModuleMembers(NodeList<T> members) {
@@ -4154,6 +4171,7 @@ public class FormattingTreeModifier extends TreeModifier {
             prevMinutiae = minutiae;
         }
 
+        // token.isMission() issue has to be discussed.
         if (consecutiveNewlines > 0 && !env.preserveIndentation) {
             addWhitespace(env.currentIndentation, leadingMinutiae);
         }

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
@@ -4397,17 +4397,6 @@ public class FormattingTreeModifier extends TreeModifier {
     }
 
     /**
-     * Check whether a node in a statement continues to the next lines.
-     *
-     * @param node node to be checked for continuity
-     * @return <code>true</code> If the statement continues to the next line.
-     *         <code>false</code> otherwise
-     */
-    private boolean isContinuing(Node node) {
-        return node.toSourceCode().contains(System.lineSeparator());
-    }
-
-    /**
      * Check whether a node list needs to be expanded into multiple lines.
      *
      * @param node node to be expanded

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/ParserTestFormatter.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/ParserTestFormatter.java
@@ -76,6 +76,7 @@ public class ParserTestFormatter extends FormatterTest {
                 "record_type_def_source_14.bal",
                 "object_type_def_source_12.bal",
                 "anon_func_source_01.bal",
+                "conditional_expr_source_27.bal",
 
                 // the following tests need to be enabled in the future
                 "annotations_source_04.bal", // could be considered an invalid scenario

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/ParserTestFormatter.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/ParserTestFormatter.java
@@ -74,6 +74,7 @@ public class ParserTestFormatter extends FormatterTest {
                 "conditional_expr_source_28.bal",
                 "resiliency_source_04.bal",
                 "record_type_def_source_14.bal",
+                "record_type_def_source_29.bal",
                 "object_type_def_source_12.bal",
                 "anon_func_source_01.bal",
                 "conditional_expr_source_27.bal",

--- a/misc/formatter/modules/formatter-core/src/test/resources/expressions/conditional/assert/conditional_expression_1.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/expressions/conditional/assert/conditional_expression_1.bal
@@ -5,4 +5,14 @@ function getValue(int v) returns int|() {
 public function foo() {
     int t = true ? 7 : 0;
     int u = getValue(6) ?: 8;
+
+    string var1 = true ?
+        "hello" : "hi";
+
+    string var2 = true ? "hello" :
+        "hi";
+
+    string var3 = true ?
+        "hello" :
+        "hi";
 }

--- a/misc/formatter/modules/formatter-core/src/test/resources/expressions/conditional/assert/conditional_expression_1.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/expressions/conditional/assert/conditional_expression_1.bal
@@ -15,4 +15,11 @@ public function foo() {
     string var3 = true ?
         "hello" :
         "hi";
+
+    string var4 = true
+        ? "hello" :
+        "hi";
+
+    string var5 = true ? "hello"
+        : "hi";
 }

--- a/misc/formatter/modules/formatter-core/src/test/resources/expressions/conditional/source/conditional_expression_1.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/expressions/conditional/source/conditional_expression_1.bal
@@ -15,4 +15,11 @@ public function foo() {
                   string var3 = true ?
          "hello" :
                                     "hi";
+
+string var4 =            true
+?                     "hello"               :
+                                 "hi";
+
+                                 string var5 = true      ?      "hello"
+                 :          "hi";
 }

--- a/misc/formatter/modules/formatter-core/src/test/resources/expressions/conditional/source/conditional_expression_1.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/expressions/conditional/source/conditional_expression_1.bal
@@ -5,4 +5,14 @@ function getValue(int v) returns int|() {
 public function foo() {
    int t = true   ?    7    :    0  ;
    int u = getValue(6)   ?:   8  ;
+
+   string var1 =          true ?
+    "hello"    :      "hi";
+
+   string var2 = true ?      "hello" :
+                  "hi";
+
+                  string var3 = true ?
+         "hello" :
+                                    "hi";
 }


### PR DESCRIPTION
## Purpose
> This PR is to fix the formatting conditional expressions when the expression is broken into multiple lines.

Fixes #35163

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [x] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
