### PR TITLE
Fix FP value `===` expression for functions with parameters

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/types/Parameter.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/types/Parameter.java
@@ -18,8 +18,6 @@
 
 package io.ballerina.runtime.api.types;
 
-import java.util.Objects;
-
 /**
  * {@code {@link Parameter } represents the parameter of a function in ballerina.
  *
@@ -48,11 +46,6 @@ public class Parameter {
 
         Parameter that = (Parameter) o;
         return this.name.equals(that.name) && this.type.equals(that.type) && this.isDefault == that.isDefault;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(name, type, isDefault);
     }
 
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/types/Parameter.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/types/Parameter.java
@@ -18,6 +18,8 @@
 
 package io.ballerina.runtime.api.types;
 
+import java.util.Objects;
+
 /**
  * {@code {@link Parameter } represents the parameter of a function in ballerina.
  *
@@ -33,4 +35,24 @@ public class Parameter {
         this.isDefault = isDefault;
         this.type = type;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!(o instanceof Parameter)) {
+            return false;
+        }
+
+        Parameter that = (Parameter) o;
+        return this.name.equals(that.name) && this.type.equals(that.type) && this.isDefault == that.isDefault;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, type, isDefault);
+    }
+
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/ref_equal_and_not_equal_operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/ref_equal_and_not_equal_operation.bal
@@ -619,6 +619,27 @@ function func1 = func;
 function func2 = funcClone;
 function func3 = function() => ();
 
+function func_with_param(string param) {
+}
+
+function func_with_return() returns error? {
+}
+
+function func_with_rest_param(string... params) {
+}
+
+function func_with_default_param(string param = "test") {
+}
+
+function func_with_all(string param1, string param2 = "test", string... param3) returns error? {
+}
+
+function funcParam = func_with_param;
+function funcDefaultParam = func_with_default_param;
+function funcRestParam = func_with_rest_param;
+function funcReturn = func_with_return;
+function funcWithAll = func_with_all;
+
 function testFPValueEquality() {
     function func4 = function() => ();
 
@@ -629,9 +650,21 @@ function testFPValueEquality() {
     test:assertTrue(func4 === func4);
     test:assertTrue(func3 === func3);
 
+    test:assertTrue(funcParam === funcParam);
+    test:assertTrue(funcDefaultParam === funcDefaultParam);
+    test:assertTrue(funcRestParam === funcRestParam);
+    test:assertTrue(funcReturn === funcReturn);
+    test:assertTrue(funcWithAll === funcWithAll);
+
     test:assertFalse(func === funcClone);
     test:assertFalse(func1 === func2);
     test:assertFalse(func3 === func4);
+
+    test:assertFalse(funcParam === funcDefaultParam);
+    test:assertFalse(funcDefaultParam === funcRestParam);
+    test:assertFalse(funcRestParam === funcReturn);
+    test:assertFalse(funcReturn === funcWithAll);
+    test:assertFalse(funcWithAll === funcParam);
 }
 
 function assert(anydata actual, anydata expected) {


### PR DESCRIPTION
## Purpose
$subject

Fixes #37379 

## Approach
The issue happens due to an internal call to the `equals` method for `Parameter` instances which returns false.
Overriding the `equals()` resolves the error

## Samples
```ballerina
import ballerina/io;

function func_with_param(string param) {
}

function funcParam = func_with_param;

public function main() {
    io:println(funcParam === funcParam); // returns false - should be true
}
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
