### PR TITLE
Save and use stdout in testerina println

### DIFF
--- a/misc/testerina/modules/testerina-core/src/main/ballerina/external.bal
+++ b/misc/testerina/modules/testerina-core/src/main/ballerina/external.bal
@@ -16,14 +16,15 @@
 
 import ballerina/jballerina.java;
 
+handle outStreamObj = outStream();
+
 isolated function print(handle printStream, any|error obj) = @java:Method {
     name: "print",
     'class: "java.io.PrintStream",
     paramTypes: ["java.lang.Object"]
 } external;
 
-isolated function println(any|error... objs) {
-    handle outStreamObj = outStream();
+function println(any|error... objs) {
     foreach var obj in objs {
         print(outStreamObj, obj);
     }


### PR DESCRIPTION
## Purpose
The tests of the io module failed with no proper logs. 

The reason was that within a beforeeach method, io tests set the system.out to a newly created printstream. The testerina ballerina code uses a custom `println` method that uses the `java.lang.System.out`. Therefore the testerina logs also are printed to that stream.

## Approach
Save the original System.out into a variable once, and use it for all `println` function calls in testerina.
