### PR TITLE
Increase the test limit in the Testerina migration

### DIFF
--- a/misc/testerina/modules/testerina-compiler-plugin/src/main/java/org/ballerinalang/testerina/compiler/TesterinaCompilerPluginConstants.java
+++ b/misc/testerina/modules/testerina-compiler-plugin/src/main/java/org/ballerinalang/testerina/compiler/TesterinaCompilerPluginConstants.java
@@ -32,6 +32,8 @@ public class TesterinaCompilerPluginConstants {
     public static final String TEST_MODULE_NAME = "test";
     public static final String TEST_EXEC_FUNCTION = "__execute__";
     public static final String TEST_EXEC_FILENAME = "test_execute";
+    public static final String TEST_REGISTRAR_EXEC_FUNCTION = "executeTestRegistrar";
+    public static final int REGISTERS_PER_FUNCTION = 150;
 
     public static final String TARGET_PATH_PARAMETER = "targetPath";
     public static final String PACKAGE_NAME_PARAMETER = "packageName";

--- a/misc/testerina/modules/testerina-compiler-plugin/src/main/java/org/ballerinalang/testerina/compiler/TesterinaCompilerPluginUtils.java
+++ b/misc/testerina/modules/testerina-compiler-plugin/src/main/java/org/ballerinalang/testerina/compiler/TesterinaCompilerPluginUtils.java
@@ -68,6 +68,17 @@ public class TesterinaCompilerPluginUtils {
                 NodeFactory.createSeparatedNodeList(new ArrayList<>()))));
     }
 
+    public static void addTestRegistrarCall(List<StatementNode> statements, int group) {
+        // Add the statement, 'executeTestRegistrarX();'
+        statements.add(getFunctionCallStatement(NodeFactory.createFunctionCallExpressionNode(
+                NodeFactory.createSimpleNameReferenceNode(NodeFactory.createIdentifierToken(
+                        TesterinaCompilerPluginConstants.TEST_REGISTRAR_EXEC_FUNCTION + group)),
+                NodeFactory.createToken(SyntaxKind.OPEN_PAREN_TOKEN),
+                NodeFactory.createSeparatedNodeList(new ArrayList<>()),
+                NodeFactory.createToken(SyntaxKind.CLOSE_PAREN_TOKEN))
+        ));
+    }
+
     public static FunctionDefinitionNode createTestExecutionFunction(List<StatementNode> statements) {
         // Construct the test execution function
         FunctionBodyBlockNode functionBodyNode = NodeFactory.createFunctionBodyBlockNode(
@@ -78,7 +89,7 @@ public class TesterinaCompilerPluginUtils {
                 null,
                 NodeFactory.createNodeList(statements.toArray(new StatementNode[0])),
                 NodeFactory.createToken(SyntaxKind.CLOSE_BRACE_TOKEN));
-        FunctionDefinitionNode functionDefinition = NodeFactory.createFunctionDefinitionNode(
+        return NodeFactory.createFunctionDefinitionNode(
                 SyntaxKind.FUNCTION_DEFINITION,
                 null,
                 NodeFactory.createNodeList(NodeFactory.createToken(
@@ -95,7 +106,35 @@ public class TesterinaCompilerPluginUtils {
                 NodeFactory.createEmptyNodeList(),
                 getFunctionSignature(),
                 functionBodyNode);
-        return functionDefinition;
+    }
+
+    public static FunctionDefinitionNode createTestRegistrarFunction(List<StatementNode> statements, int group) {
+        FunctionBodyBlockNode functionBodyNode = NodeFactory.createFunctionBodyBlockNode(
+                NodeFactory.createToken(
+                        SyntaxKind.OPEN_BRACE_TOKEN,
+                        NodeFactory.createEmptyMinutiaeList(),
+                        NodeFactory.createMinutiaeList(NodeFactory.createWhitespaceMinutiae("\n"))),
+                null,
+                NodeFactory.createNodeList(statements.toArray(new StatementNode[0])),
+                NodeFactory.createToken(SyntaxKind.CLOSE_BRACE_TOKEN));
+        FunctionSignatureNode functionSignatureNode = NodeFactory.createFunctionSignatureNode(
+                NodeFactory.createToken(SyntaxKind.OPEN_PAREN_TOKEN),
+                NodeFactory.createSeparatedNodeList(),
+                NodeFactory.createToken(SyntaxKind.CLOSE_PAREN_TOKEN), null);
+        return NodeFactory.createFunctionDefinitionNode(
+                SyntaxKind.FUNCTION_DEFINITION,
+                null,
+                NodeFactory.createEmptyNodeList(),
+                NodeFactory.createToken(
+                        SyntaxKind.FUNCTION_KEYWORD,
+                        NodeFactory.createEmptyMinutiaeList(),
+                        NodeFactory.createMinutiaeList(NodeFactory.createWhitespaceMinutiae(" "))),
+                NodeFactory.createIdentifierToken(TesterinaCompilerPluginConstants.TEST_REGISTRAR_EXEC_FUNCTION + group,
+                        NodeFactory.createEmptyMinutiaeList(),
+                        NodeFactory.createMinutiaeList()),
+                NodeFactory.createEmptyNodeList(),
+                functionSignatureNode,
+                functionBodyNode);
     }
 
     public static StatementNode invokeRegisterFunction(String testNameVal, String testFuncVal) {


### PR DESCRIPTION
## Purpose
Since there is a limit on the number of lines per function in Ballerina, it will generate an error when the number of test cases exceeds the limits.

## Approach
Registering a test function is delegated to a new function, and it has a configurable limit on the number of registrations. For now, the value is set to 150. Once the limit is reached, there will be a new function that has the same responsibility for a different set of test functions.

## Samples
The compiler plugin now generates the following file for the test execution if the limit is 3.
```ballerina
import ballerina/test;

function executeTestRegistrar0() {
    test:registerTest("beforeSuiteFunc", beforeSuiteFunc);
    test:registerTest("testFunction", testFunction);
    test:registerTest("negativeTestFunction", negativeTestFunction);
}

function executeTestRegistrar1() {
    test:registerTest("afterSuiteFunc", afterSuiteFunc);
    test:registerTest("testFalse", testFalse);
}

public function __execute__(string targetPath, string packageName, string moduleName, string report, string coverage, string groups, string disableGroups, string tests, string rerunFailed, string listGroups) returns error? {
    test:setTestOptions(targetPath, packageName, moduleName, report, coverage, groups, disableGroups, tests, rerunFailed, listGroups);
    executeTestRegistrar0();
    executeTestRegistrar1();
    test:startSuite();
}
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
