### PR TITLE
Add missing code actions to object fields

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionContextTypeResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionContextTypeResolver.java
@@ -20,11 +20,14 @@ import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.VariableSymbol;
 import io.ballerina.compiler.syntax.tree.AssignmentStatementNode;
+import io.ballerina.compiler.syntax.tree.BuiltinSimpleNameReferenceNode;
 import io.ballerina.compiler.syntax.tree.LetVariableDeclarationNode;
 import io.ballerina.compiler.syntax.tree.ModuleVariableDeclarationNode;
 import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.compiler.syntax.tree.NodeTransformer;
+import io.ballerina.compiler.syntax.tree.ObjectFieldNode;
 import io.ballerina.compiler.syntax.tree.VariableDeclarationNode;
+import org.ballerinalang.langserver.common.utils.SymbolUtil;
 import org.ballerinalang.langserver.commons.CodeActionContext;
 
 import java.util.ArrayList;
@@ -77,6 +80,18 @@ public class CodeActionContextTypeResolver extends NodeTransformer<Optional<Type
     @Override
     public Optional<TypeSymbol> transform(LetVariableDeclarationNode letVariableDeclarationNode) {
         return getTypeDescriptorOfVariable(letVariableDeclarationNode);
+    }
+
+    @Override
+    public Optional<TypeSymbol> transform(ObjectFieldNode objectFieldNode) {
+        return objectFieldNode.typeName().apply(this);
+    }
+
+    @Override
+    public Optional<TypeSymbol> transform(BuiltinSimpleNameReferenceNode builtinSimpleNameReferenceNode) {
+        Optional<Symbol> symbol = context.currentSemanticModel()
+                .flatMap(semanticModel -> semanticModel.symbol(builtinSimpleNameReferenceNode));
+        return SymbolUtil.getTypeDescriptor(symbol.orElse(null));
     }
 
     private Optional<TypeSymbol> getTypeDescriptorOfVariable(Node node) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/MatchedExpressionNodeResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/MatchedExpressionNodeResolver.java
@@ -16,6 +16,7 @@
 package org.ballerinalang.langserver.codeaction;
 
 import io.ballerina.compiler.syntax.tree.AssignmentStatementNode;
+import io.ballerina.compiler.syntax.tree.BasicLiteralNode;
 import io.ballerina.compiler.syntax.tree.BinaryExpressionNode;
 import io.ballerina.compiler.syntax.tree.BracedExpressionNode;
 import io.ballerina.compiler.syntax.tree.ExplicitNewExpressionNode;
@@ -61,7 +62,7 @@ public class MatchedExpressionNodeResolver extends NodeTransformer<Optional<Expr
      */
     public Optional<ExpressionNode> findExpression(Node node) {
         if (node == null) {
-            return Optional.empty();
+            return Optional.empty();    
         }
 
         Optional<ExpressionNode> exprNode = node.apply(this);
@@ -139,6 +140,11 @@ public class MatchedExpressionNodeResolver extends NodeTransformer<Optional<Expr
             return Optional.of((ExpressionNode) expressionNode.get());
         }
         return Optional.empty();
+    }
+    
+    @Override
+    public Optional<ExpressionNode> transform(BasicLiteralNode basicLiteralNode) {
+        return Optional.of(basicLiteralNode);
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/MatchedExpressionNodeResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/MatchedExpressionNodeResolver.java
@@ -62,7 +62,7 @@ public class MatchedExpressionNodeResolver extends NodeTransformer<Optional<Expr
      */
     public Optional<ExpressionNode> findExpression(Node node) {
         if (node == null) {
-            return Optional.empty();    
+            return Optional.empty();
         }
 
         Optional<ExpressionNode> exprNode = node.apply(this);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/ChangeVariableTypeCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/ChangeVariableTypeCodeAction.java
@@ -26,10 +26,10 @@ import io.ballerina.compiler.syntax.tree.BindingPatternNode;
 import io.ballerina.compiler.syntax.tree.BuiltinSimpleNameReferenceNode;
 import io.ballerina.compiler.syntax.tree.CaptureBindingPatternNode;
 import io.ballerina.compiler.syntax.tree.ConstantDeclarationNode;
-import io.ballerina.compiler.syntax.tree.ExpressionNode;
 import io.ballerina.compiler.syntax.tree.ModuleVariableDeclarationNode;
 import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.compiler.syntax.tree.NonTerminalNode;
+import io.ballerina.compiler.syntax.tree.ObjectFieldNode;
 import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
 import io.ballerina.compiler.syntax.tree.SimpleNameReferenceNode;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
@@ -95,12 +95,12 @@ public class ChangeVariableTypeCodeAction extends TypeCastCodeAction {
         }
 
         // Skip, non-local var declarations
-        Optional<NonTerminalNode> variableNode = getVariableNode(positionDetails.matchedNode());
+        Optional<NonTerminalNode> variableNode = getVariableOrObjectFieldNode(positionDetails.matchedNode());
         if (variableNode.isEmpty()) {
             return Collections.emptyList();
         }
 
-        Optional<ExpressionNode> typeNode = getTypeNode(variableNode.get(), context);
+        Optional<Node> typeNode = getTypeNode(variableNode.get(), context);
         Optional<String> variableName = getVariableName(variableNode.get());
         if (typeNode.isEmpty() || variableName.isEmpty()) {
             return Collections.emptyList();
@@ -140,11 +140,11 @@ public class ChangeVariableTypeCodeAction extends TypeCastCodeAction {
         return NAME;
     }
 
-    private Optional<NonTerminalNode> getVariableNode(NonTerminalNode sNode) {
+    private Optional<NonTerminalNode> getVariableOrObjectFieldNode(NonTerminalNode sNode) {
         // Find var node
-        if (isVariableNode(sNode)) {
+        if (isVariableNode(sNode) || sNode.kind() == SyntaxKind.OBJECT_FIELD) {
             return Optional.of(sNode);
-        } else if (isVariableNode(sNode.parent())) {
+        } else if (isVariableNode(sNode.parent()) || sNode.parent().kind() == SyntaxKind.OBJECT_FIELD) {
             return Optional.of(sNode.parent());
         }
 
@@ -162,28 +162,28 @@ public class ChangeVariableTypeCodeAction extends TypeCastCodeAction {
                 || sNode.kind() == SyntaxKind.CONST_DECLARATION;
     }
 
-    private Optional<String> getTypeNodeStr(ExpressionNode expressionNode) {
-        if (expressionNode.kind() == SyntaxKind.SIMPLE_NAME_REFERENCE) {
-            SimpleNameReferenceNode sRefNode = (SimpleNameReferenceNode) expressionNode;
+    private Optional<String> getTypeNodeStr(Node node) {
+        if (node.kind() == SyntaxKind.SIMPLE_NAME_REFERENCE) {
+            SimpleNameReferenceNode sRefNode = (SimpleNameReferenceNode) node;
             return Optional.of(sRefNode.name().text());
-        } else if (expressionNode.kind() == SyntaxKind.QUALIFIED_NAME_REFERENCE) {
-            QualifiedNameReferenceNode qnRefNode = (QualifiedNameReferenceNode) expressionNode;
+        } else if (node.kind() == SyntaxKind.QUALIFIED_NAME_REFERENCE) {
+            QualifiedNameReferenceNode qnRefNode = (QualifiedNameReferenceNode) node;
             return Optional.of(qnRefNode.modulePrefix().text() + ":" + qnRefNode.identifier().text());
-        } else if (expressionNode instanceof BuiltinSimpleNameReferenceNode) {
+        } else if (node instanceof BuiltinSimpleNameReferenceNode) {
             // This case occurs with constant declarations with types
-            return Optional.of(((BuiltinSimpleNameReferenceNode) expressionNode).name().text());
+            return Optional.of(((BuiltinSimpleNameReferenceNode) node).name().text());
         }
         return Optional.empty();
     }
 
-    private Optional<ExpressionNode> getTypeNode(Node matchedNode, CodeActionContext context) {
+    private Optional<Node> getTypeNode(Node matchedNode, CodeActionContext context) {
         switch (matchedNode.kind()) {
             case LOCAL_VAR_DECL:
                 return Optional.of(
                         ((VariableDeclarationNode) matchedNode).typedBindingPattern().typeDescriptor());
             case MODULE_VAR_DECL:
-                 return Optional.of(
-                         ((ModuleVariableDeclarationNode) matchedNode).typedBindingPattern().typeDescriptor());
+                return Optional.of(
+                        ((ModuleVariableDeclarationNode) matchedNode).typedBindingPattern().typeDescriptor());
 
             case ASSIGNMENT_STATEMENT:
                 Optional<VariableSymbol> optVariableSymbol = getVariableSymbol(context, matchedNode);
@@ -200,6 +200,8 @@ public class ChangeVariableTypeCodeAction extends TypeCastCodeAction {
             case CONST_DECLARATION:
                 ConstantDeclarationNode constDecl = (ConstantDeclarationNode) matchedNode;
                 return Optional.ofNullable(constDecl.typeDescriptor().orElse(null));
+            case OBJECT_FIELD:
+                return Optional.of(((ObjectFieldNode) matchedNode).typeName());
             default:
                 return Optional.empty();
         }
@@ -234,6 +236,9 @@ public class ChangeVariableTypeCodeAction extends TypeCastCodeAction {
             case CONST_DECLARATION:
                 ConstantDeclarationNode constantDecl = (ConstantDeclarationNode) matchedNode;
                 return Optional.of(constantDecl.variableName().text());
+            case OBJECT_FIELD:
+                ObjectFieldNode objectFieldNode = (ObjectFieldNode) matchedNode;
+                return Optional.of(objectFieldNode.fieldName().text());
             default:
                 return Optional.empty();
         }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ChangeVariableTypeCodeActionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ChangeVariableTypeCodeActionTest.java
@@ -57,7 +57,10 @@ public class ChangeVariableTypeCodeActionTest extends AbstractCodeActionTest {
                 {"changeVarType4.json"},
                 {"changeVarType3.json"},
                 {"changeVarType_int_to_float.json"},
-                {"changeVarType_int_to_float_in_constant.json"}
+                {"changeVarType_int_to_float_in_constant.json"},
+                {"changeVarTypeInObjectFields1.json"},
+                {"changeVarTypeInObjectFields2.json"},
+                {"changeVarTypeInObjectFields3.json"},
         };
     }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/TypeCastTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/TypeCastTest.java
@@ -78,7 +78,10 @@ public class TypeCastTest extends AbstractCodeActionTest {
                 {"type_cast_in_binary_operation6.json"},
                 {"type_cast_in_binary_operation7.json"},
                 {"type_cast_in_binary_operation8.json"},
-                {"type_cast_in_binary_operation9.json"}
+                {"type_cast_in_binary_operation9.json"},
+
+                {"type_cast_in_obj_field_config1.json"},
+                {"type_cast_in_obj_field_config2.json"}
 
         };
     }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/config/changeVarTypeInObjectFields1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/config/changeVarTypeInObjectFields1.json
@@ -1,0 +1,29 @@
+{
+  "position": {
+    "line": 2,
+    "character": 16
+  },
+  "source": "change_var_type_in_object_fields.bal",
+  "expected": [
+    {
+      "title": "Change variable 'f1' type to 'float'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 2,
+              "character": 4
+            },
+            "end": {
+              "line": 2,
+              "character": 10
+            }
+          },
+          "newText": "float"
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/config/changeVarTypeInObjectFields2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/config/changeVarTypeInObjectFields2.json
@@ -1,0 +1,29 @@
+{
+  "position": {
+    "line": 4,
+    "character": 13
+  },
+  "source": "change_var_type_in_object_fields.bal",
+  "expected": [
+    {
+      "title": "Change variable 'a' type to 'string'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 4,
+              "character": 4
+            },
+            "end": {
+              "line": 4,
+              "character": 7
+            }
+          },
+          "newText": "string"
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/config/changeVarTypeInObjectFields2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/config/changeVarTypeInObjectFields2.json
@@ -1,7 +1,7 @@
 {
   "position": {
     "line": 4,
-    "character": 13
+    "character": 20
   },
   "source": "change_var_type_in_object_fields.bal",
   "expected": [
@@ -13,11 +13,11 @@
           "range": {
             "start": {
               "line": 4,
-              "character": 4
+              "character": 12
             },
             "end": {
               "line": 4,
-              "character": 7
+              "character": 15
             }
           },
           "newText": "string"

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/config/changeVarTypeInObjectFields3.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/config/changeVarTypeInObjectFields3.json
@@ -1,0 +1,49 @@
+{
+  "position": {
+    "line": 6,
+    "character": 18
+  },
+  "source": "change_var_type_in_object_fields.bal",
+  "expected": [
+    {
+      "title": "Change variable 'arr' type to 'string[]'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 6,
+              "character": 4
+            },
+            "end": {
+              "line": 6,
+              "character": 10
+            }
+          },
+          "newText": "string[]"
+        }
+      ],
+      "resolvable": false
+    },
+    {
+      "title": "Change variable 'arr' type to '[string, string]'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 6,
+              "character": 4
+            },
+            "end": {
+              "line": 6,
+              "character": 10
+            }
+          },
+          "newText": "[string, string]"
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/source/change_var_type_in_object_fields.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/source/change_var_type_in_object_fields.bal
@@ -2,7 +2,7 @@ class TestClass {
         
     string f1 = 12.2;
     
-    int a = "string";
+    private int a = "string";
     
     string arr = ["a", "b"];
 

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/source/change_var_type_in_object_fields.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-var-type/source/change_var_type_in_object_fields.bal
@@ -1,0 +1,9 @@
+class TestClass {
+        
+    string f1 = 12.2;
+    
+    int a = "string";
+    
+    string arr = ["a", "b"];
+
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithCheck6.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithCheck6.json
@@ -4,6 +4,7 @@
     "character": 4
   },
   "source": "createVariableWithCheck.bal",
+  "description": "Parent function has undefined return type",
   "expected": [
     {
       "title": "Create variable and check error",
@@ -20,7 +21,7 @@
               "character": 4
             }
           },
-          "newText": "int intWithError \u003d "
+          "newText": "int intWithError = "
         },
         {
           "range": {
@@ -59,6 +60,5 @@
       },
       "resolvable": false
     }
-  ],
-  "description": "Parent function has undefined return type"
+  ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/type-cast/config/type_cast_in_obj_field_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/type-cast/config/type_cast_in_obj_field_config1.json
@@ -1,0 +1,49 @@
+{
+  "position": {
+    "line": 2,
+    "character": 12
+  },
+  "source": "type_cast_in_obj_fields.bal",
+  "expected": [
+    {
+      "title": "Add type cast",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 2,
+              "character": 12
+            },
+            "end": {
+              "line": 2,
+              "character": 12
+            }
+          },
+          "newText": "<int>"
+        }
+      ],
+      "resolvable": false
+    },
+    {
+      "title": "Change variable 'a' type to 'float'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 2,
+              "character": 4
+            },
+            "end": {
+              "line": 2,
+              "character": 7
+            }
+          },
+          "newText": "float"
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/type-cast/config/type_cast_in_obj_field_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/type-cast/config/type_cast_in_obj_field_config2.json
@@ -1,0 +1,29 @@
+{
+  "position": {
+    "line": 7,
+    "character": 15
+  },
+  "source": "type_cast_in_obj_fields.bal",
+  "expected": [
+    {
+      "title": "Add type cast to 'd1'",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 7,
+              "character": 20
+            },
+            "end": {
+              "line": 7,
+              "character": 20
+            }
+          },
+          "newText": "<float>"
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/type-cast/source/type_cast_in_obj_fields.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/type-cast/source/type_cast_in_obj_fields.bal
@@ -1,0 +1,10 @@
+class TypeCastSuggestion {
+    
+    int a = 10.1;
+    
+    float f1 = 10.2;
+    decimal d1 = 10.2;
+
+    float f2 = f1 / d1;
+
+}


### PR DESCRIPTION
## Purpose
In the object fields numeric typecast code action and change variable code action were missing. This pr will add these missing code actions to object fields.

Fixes #37614

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
