### PR TITLE
Fix compiler crash when function pointer invocation used within type narrowing expression

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -4802,6 +4802,11 @@ public class SymbolEnter extends BLangNodeVisitor {
             varSymbol = new BInvokableSymbol(SymTag.VARIABLE, flags, varName, env.enclPkg.symbol.pkgID, type,
                                              env.scope.owner, location, isInternal ? VIRTUAL : getOrigin(varName));
             varSymbol.kind = SymbolKind.FUNCTION;
+            BInvokableTypeSymbol invokableTypeSymbol = (BInvokableTypeSymbol) varType.tsymbol;
+            BInvokableSymbol invokableSymbol = (BInvokableSymbol) varSymbol;
+            invokableSymbol.params = invokableTypeSymbol.params;
+            invokableSymbol.restParam = invokableTypeSymbol.restParam;
+            invokableSymbol.retType = invokableTypeSymbol.returnType;
             if (varName.value.startsWith(WORKER_LAMBDA_VAR_PREFIX)) {
                 varSymbol.flags |= Flags.WORKER;
             }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/FunctionPointersTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/FunctionPointersTest.java
@@ -67,6 +67,11 @@ public class FunctionPointersTest {
     }
 
     @Test
+    public void testFuncInvocationWithinTypeNarrowingExpr() {
+        BRunUtil.invoke(fpProgram, "testFuncInvocationWithinTypeNarrowingExpr");
+    }
+
+    @Test
     public void testLambdaAsReturnParameter() {
         Object returns = BRunUtil.invoke(fpProgram, "test4");
         Assert.assertNotNull(returns);

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/lambda/function-pointers.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/lambda/function-pointers.bal
@@ -1,3 +1,7 @@
+type Groups string|int;
+type ReplacerFunction function (Groups groups) returns string;
+type Replacement ReplacerFunction|string;
+
 function test1() returns (int){
     function (int, int) returns (int) addFunction = func1;
     return addFunction(1, 2);
@@ -301,6 +305,25 @@ public function testMemberTakenAsAFieldWithRestArgs() {
     _ = f(10, 100);
     assertEquality(112, g());
 }
+
+
+function funcInvocationWithinTypeNarrowingExpr(Replacement replacement) returns string {
+    Groups k = "chiran";
+    if (replacement is ReplacerFunction) {
+        return replacement(k);
+    } else {
+        return "";
+    }
+}
+
+function testFuncInvocationWithinTypeNarrowingExpr() {
+    assertEquality("chiran", funcInvocationWithinTypeNarrowingExpr(mat));
+}
+
+function mat(Groups x) returns string {
+    return "chiran";
+}
+
 
 function assertEquality(any|error expected, any|error  actual) {
     if expected is anydata && actual is anydata && expected == actual {


### PR DESCRIPTION
## Purpose
> $title.

Fixes #37971 

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
