### PR TITLE
Define formatting options with FormattingOptionsBuilder

### DIFF
--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/ForceFormattingOptions.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/ForceFormattingOptions.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.formatter.core;
+
+/**
+ * A model for formatting options that can be forced by the API user, that could be passed onto the formatter.
+ */
+public class ForceFormattingOptions {
+    boolean forceFormatRecordTypeDesc;
+
+    ForceFormattingOptions(boolean forceFormatRecordTypeDesc) {
+        this.forceFormatRecordTypeDesc = forceFormatRecordTypeDesc;
+    }
+
+    public boolean getForceFormatRecordTypeDesc() {
+        return forceFormatRecordTypeDesc;
+    }
+
+    public static ForceFormattingOptionsBuilder builder() {
+        return new ForceFormattingOptionsBuilder();
+    }
+
+    /**
+     * A builder for the {@code ForceFormattingOptions}.
+     *
+     * @since 2.0.0
+     */
+    public static class ForceFormattingOptionsBuilder {
+        private boolean forceFormatRecordTypeDesc = false;
+
+        public ForceFormattingOptionsBuilder setForceFormatRecordTypeDesc(boolean value) {
+            forceFormatRecordTypeDesc = value;
+            return this;
+        }
+
+        public ForceFormattingOptions build() {
+            return new ForceFormattingOptions(forceFormatRecordTypeDesc);
+        }
+    }
+}

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/ForceFormattingOptions.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/ForceFormattingOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ * Copyright (c) 2022, WSO2 LLC. (http://wso2.com) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,16 +17,18 @@ package org.ballerinalang.formatter.core;
 
 /**
  * A model for formatting options that can be forced by the API user, that could be passed onto the formatter.
+ *
+ * @since 2201.2.2
  */
 public class ForceFormattingOptions {
-    boolean forceFormatRecordTypeDesc;
+    private boolean forceFormatRecordFields;
 
-    ForceFormattingOptions(boolean forceFormatRecordTypeDesc) {
-        this.forceFormatRecordTypeDesc = forceFormatRecordTypeDesc;
+    private ForceFormattingOptions(boolean forceFormatRecordFields) {
+        this.forceFormatRecordFields = forceFormatRecordFields;
     }
 
     public boolean getForceFormatRecordTypeDesc() {
-        return forceFormatRecordTypeDesc;
+        return forceFormatRecordFields;
     }
 
     public static ForceFormattingOptionsBuilder builder() {
@@ -35,19 +37,17 @@ public class ForceFormattingOptions {
 
     /**
      * A builder for the {@code ForceFormattingOptions}.
-     *
-     * @since 2.0.0
      */
     public static class ForceFormattingOptionsBuilder {
-        private boolean forceFormatRecordTypeDesc = false;
+        private boolean forceFormatRecordFields = false;
 
-        public ForceFormattingOptionsBuilder setForceFormatRecordTypeDesc(boolean value) {
-            forceFormatRecordTypeDesc = value;
+        public ForceFormattingOptionsBuilder setForceFormatRecordFields(boolean forceFormatRecordFields) {
+            this.forceFormatRecordFields = forceFormatRecordFields;
             return this;
         }
 
         public ForceFormattingOptions build() {
-            return new ForceFormattingOptions(forceFormatRecordTypeDesc);
+            return new ForceFormattingOptions(forceFormatRecordFields);
         }
     }
 }

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/ForceFormattingOptions.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/ForceFormattingOptions.java
@@ -18,7 +18,7 @@ package org.ballerinalang.formatter.core;
 /**
  * A model for formatting options that can be forced by the API user, that could be passed onto the formatter.
  *
- * @since 2201.2.2
+ * @since 2201.3.0
  */
 public class ForceFormattingOptions {
     private boolean forceFormatRecordFields;
@@ -27,7 +27,7 @@ public class ForceFormattingOptions {
         this.forceFormatRecordFields = forceFormatRecordFields;
     }
 
-    public boolean getForceFormatRecordTypeDesc() {
+    public boolean getForceFormatRecordFields() {
         return forceFormatRecordFields;
     }
 

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/Formatter.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/Formatter.java
@@ -34,7 +34,7 @@ public class Formatter {
      * @throws FormatterException Exception caught while formatting
      */
     public static String format(String source) throws FormatterException {
-        return format(source, new FormattingOptions());
+        return format(source, FormattingOptions.builder().build());
     }
 
     /**
@@ -47,7 +47,7 @@ public class Formatter {
      * @throws FormatterException Exception caught while formatting
      */
     public static SyntaxTree format(SyntaxTree syntaxTree, LineRange range) throws FormatterException {
-        return format(syntaxTree, range, new FormattingOptions());
+        return format(syntaxTree, range, FormattingOptions.builder().build());
     }
 
     /**
@@ -58,7 +58,7 @@ public class Formatter {
      * @throws FormatterException Exception caught while formatting
      */
     public static SyntaxTree format(SyntaxTree syntaxTree) throws FormatterException {
-        return format(syntaxTree, new FormattingOptions());
+        return format(syntaxTree, FormattingOptions.builder().build());
     }
 
     /**

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingOptions.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingOptions.java
@@ -30,13 +30,23 @@ public class FormattingOptions {
 
     private boolean lineWrapping;
 
-    FormattingOptions() {
-        this.tabSize = 4;
-        this.wsCharacter = " ";
-        this.columnLimit = 120;
-        this.lineWrapping = false;
+    private ForceFormattingOptions forceFormattingOptions;
+
+    FormattingOptions(int tabSize, String wsCharacter, int columnLimit, boolean lineWrapping,
+                      ForceFormattingOptions forceFormattingOptions) {
+        this.tabSize = tabSize;
+        this.wsCharacter = wsCharacter;
+        this.columnLimit = columnLimit;
+        this.lineWrapping = lineWrapping;
+        this.forceFormattingOptions = forceFormattingOptions;
     }
 
+    /**
+     * @deprecated
+     * This constructor is no longer acceptable to instantiate Formatting Options.
+     * <p> Use {@link FormattingOptions#builder()} instead.
+     */
+    @Deprecated
     public FormattingOptions(int tabSize, String wsCharacter) {
         this.tabSize = tabSize;
         this.wsCharacter = wsCharacter;
@@ -44,6 +54,12 @@ public class FormattingOptions {
         this.lineWrapping = false;
     }
 
+    /**
+     * @deprecated
+     * This constructor is no longer acceptable to instantiate Formatting Options.
+     * <p> Use {@link FormattingOptions#builder()} instead.
+     */
+    @Deprecated
     public FormattingOptions(boolean lineWrapping, int columnLimit) {
         this.tabSize = 4;
         this.wsCharacter = " ";
@@ -51,6 +67,12 @@ public class FormattingOptions {
         this.lineWrapping = lineWrapping;
     }
 
+    /**
+     * @deprecated
+     * This constructor is no longer acceptable to instantiate Formatting Options.
+     * <p> Use {@link FormattingOptions#builder()} instead.
+     */
+    @Deprecated
     public FormattingOptions(int tabSize, String wsCharacter, boolean lineWrapping, int columnLimit) {
         this.tabSize = tabSize;
         this.wsCharacter = wsCharacter;
@@ -62,6 +84,12 @@ public class FormattingOptions {
         return tabSize;
     }
 
+    /**
+     * @deprecated
+     * This setter method is no longer acceptable to set Formatting Options.
+     * <p> Use {@link FormattingOptions#builder()} instead.
+     */
+    @Deprecated
     public void setTabSize(int tabSize) {
         this.tabSize = tabSize;
     }
@@ -70,23 +98,88 @@ public class FormattingOptions {
         return wsCharacter;
     }
 
+    /**
+     * @deprecated
+     * This setter method is no longer acceptable to set Formatting Options.
+     * <p> Use {@link FormattingOptions#builder()} instead.
+     */
     public void setWSCharacter(String wsCharacter) {
         this.wsCharacter = wsCharacter;
-    }
-
-    public void setColumnLimit(int columnLimit) {
-        this.columnLimit = columnLimit;
     }
 
     public int getColumnLimit() {
         return this.columnLimit;
     }
 
+    /**
+     * @deprecated
+     * This setter method is no longer acceptable to set Formatting Options.
+     * <p> Use {@link FormattingOptions#builder()} instead.
+     */
+    public void setColumnLimit(int columnLimit) {
+        this.columnLimit = columnLimit;
+    }
+
     public boolean getLineWrapping() {
         return lineWrapping;
     }
 
+    /**
+     * @deprecated
+     * This setter method is no longer acceptable to set Formatting Options.
+     * <p> Use {@link FormattingOptions#builder()} instead.
+     */
     public void setLineWrapping(boolean lineWrapping) {
         this.lineWrapping = lineWrapping;
+    }
+
+    public ForceFormattingOptions getForceFormattingOptions() {
+        return forceFormattingOptions;
+    }
+
+    public static FormattingOptionsBuilder builder() {
+        return new FormattingOptionsBuilder();
+    }
+
+    /**
+     * A builder for the {@code FormattingOptions}.
+     *
+     * @since 2.0.0
+     */
+    public static class FormattingOptionsBuilder {
+        private int tabSize = 4;
+        private String wsCharacter = " ";
+        private int columnLimit = 120;
+        private boolean lineWrapping = false;
+        private ForceFormattingOptions forceFormattingOptions = ForceFormattingOptions.builder().build();
+
+        public FormattingOptions.FormattingOptionsBuilder setTabSize(int value) {
+            tabSize = value;
+            return this;
+        }
+
+        public FormattingOptions.FormattingOptionsBuilder setWSCharacter(String value) {
+            wsCharacter = value;
+            return this;
+        }
+
+        public FormattingOptions.FormattingOptionsBuilder setColumnLimit(int value) {
+            columnLimit = value;
+            return this;
+        }
+
+        public FormattingOptions.FormattingOptionsBuilder setLineWrapping(boolean value) {
+            lineWrapping = value;
+            return this;
+        }
+
+        public FormattingOptions.FormattingOptionsBuilder setForceFormattingOptions(ForceFormattingOptions value) {
+            forceFormattingOptions = value;
+            return this;
+        }
+
+        public FormattingOptions build() {
+            return new FormattingOptions(tabSize, wsCharacter, columnLimit, lineWrapping, forceFormattingOptions);
+        }
     }
 }

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingOptions.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingOptions.java
@@ -103,6 +103,7 @@ public class FormattingOptions {
      * This setter method is no longer acceptable to set Formatting Options.
      * <p> Use {@link FormattingOptions#builder()} instead.
      */
+    @Deprecated
     public void setWSCharacter(String wsCharacter) {
         this.wsCharacter = wsCharacter;
     }
@@ -116,6 +117,7 @@ public class FormattingOptions {
      * This setter method is no longer acceptable to set Formatting Options.
      * <p> Use {@link FormattingOptions#builder()} instead.
      */
+    @Deprecated
     public void setColumnLimit(int columnLimit) {
         this.columnLimit = columnLimit;
     }
@@ -129,6 +131,7 @@ public class FormattingOptions {
      * This setter method is no longer acceptable to set Formatting Options.
      * <p> Use {@link FormattingOptions#builder()} instead.
      */
+    @Deprecated
     public void setLineWrapping(boolean lineWrapping) {
         this.lineWrapping = lineWrapping;
     }

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingOptions.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingOptions.java
@@ -147,7 +147,7 @@ public class FormattingOptions {
     /**
      * A builder for the {@code FormattingOptions}.
      *
-     * @since 2.0.0
+     * @since 2201.2.2
      */
     public static class FormattingOptionsBuilder {
         private int tabSize = 4;
@@ -156,28 +156,29 @@ public class FormattingOptions {
         private boolean lineWrapping = false;
         private ForceFormattingOptions forceFormattingOptions = ForceFormattingOptions.builder().build();
 
-        public FormattingOptions.FormattingOptionsBuilder setTabSize(int value) {
-            tabSize = value;
+        public FormattingOptions.FormattingOptionsBuilder setTabSize(int tabSize) {
+            this.tabSize = tabSize;
             return this;
         }
 
-        public FormattingOptions.FormattingOptionsBuilder setWSCharacter(String value) {
-            wsCharacter = value;
+        public FormattingOptions.FormattingOptionsBuilder setWSCharacter(String wsCharacter) {
+            this.wsCharacter = wsCharacter;
             return this;
         }
 
-        public FormattingOptions.FormattingOptionsBuilder setColumnLimit(int value) {
-            columnLimit = value;
+        public FormattingOptions.FormattingOptionsBuilder setColumnLimit(int columnLimit) {
+            this.columnLimit = columnLimit;
             return this;
         }
 
-        public FormattingOptions.FormattingOptionsBuilder setLineWrapping(boolean value) {
-            lineWrapping = value;
+        public FormattingOptions.FormattingOptionsBuilder setLineWrapping(boolean lineWrapping) {
+            this.lineWrapping = lineWrapping;
             return this;
         }
 
-        public FormattingOptions.FormattingOptionsBuilder setForceFormattingOptions(ForceFormattingOptions value) {
-            forceFormattingOptions = value;
+        public FormattingOptions.FormattingOptionsBuilder setForceFormattingOptions(
+                ForceFormattingOptions forceFormattingOptions) {
+            this.forceFormattingOptions = forceFormattingOptions;
             return this;
         }
 

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingOptions.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingOptions.java
@@ -147,7 +147,7 @@ public class FormattingOptions {
     /**
      * A builder for the {@code FormattingOptions}.
      *
-     * @since 2201.2.2
+     * @since 2201.3.0
      */
     public static class FormattingOptionsBuilder {
         private int tabSize = 4;

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
@@ -4389,11 +4389,11 @@ public class FormattingTreeModifier extends TreeModifier {
                 NodeList<Node> objectConstructorMembers = objectConstructor.members();
                 return shouldExpandObjectMembers(objectConstructorMembers);
             case RECORD_TYPE_DESC:
-                RecordTypeDescriptorNode recordTypeDesc = (RecordTypeDescriptorNode) node;
                 if (options.getForceFormattingOptions().getForceFormatRecordTypeDesc()) {
                     return true;
                 }
 
+                RecordTypeDescriptorNode recordTypeDesc = (RecordTypeDescriptorNode) node;
                 if (recordTypeDesc.parent().kind() == SyntaxKind.TYPE_DEFINITION) {
                     return true;
                 }

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
@@ -4358,52 +4358,79 @@ public class FormattingTreeModifier extends TreeModifier {
     }
 
     /**
-     * Check whether a node list needs to be expanded into multiple lines.
+     * Check whether the node needs to be expanded in to multiple lines.
      *
-     * @param node node to be expanded
-     * @return <code>true</code> If the node list needs to be expanded into multiple lines.
+     * @param node Node
+     * @return <code>true</code> If the node needs to be expanded in to multiple lines.
      *         <code>false</code> otherwise
      */
     private boolean shouldExpand(Node node) {
-        return node.toSourceCode().trim().contains(System.lineSeparator());
-    }
+        switch (node.kind()) {
+            case OBJECT_TYPE_DESC:
+                ObjectTypeDescriptorNode objectTypeDesc = (ObjectTypeDescriptorNode) node;
+                if (objectTypeDesc.parent().kind() == SyntaxKind.TYPE_DEFINITION) {
+                    return true;
+                }
 
-    /**
-     * Check whether an object type descriptor needs to be expanded in to multiple lines.
-     *
-     * @param objectTypeDesc Object type descriptor
-     * @return <code>true</code> If the object type descriptor needs to be expanded in to multiple lines.
-     *         <code>false</code> otherwise
-     */
-    private boolean shouldExpand(ObjectTypeDescriptorNode objectTypeDesc) {
-        if (objectTypeDesc.parent().kind() == SyntaxKind.TYPE_DEFINITION) {
-            return true;
+                if (hasNonWSMinutiae(objectTypeDesc.openBrace().trailingMinutiae())
+                        || hasNonWSMinutiae(objectTypeDesc.closeBrace().leadingMinutiae())) {
+                    return true;
+                }
+
+                NodeList<Node> objectTypeDescMembers = objectTypeDesc.members();
+                return shouldExpandObjectMembers(objectTypeDescMembers);
+            case OBJECT_CONSTRUCTOR:
+                ObjectConstructorExpressionNode objectConstructor = (ObjectConstructorExpressionNode) node;
+                if (hasNonWSMinutiae(objectConstructor.openBraceToken().trailingMinutiae())
+                        || hasNonWSMinutiae(objectConstructor.closeBraceToken().leadingMinutiae())) {
+                    return true;
+                }
+
+                NodeList<Node> objectConstructorMembers = objectConstructor.members();
+                return shouldExpandObjectMembers(objectConstructorMembers);
+            case RECORD_TYPE_DESC:
+                RecordTypeDescriptorNode recordTypeDesc = (RecordTypeDescriptorNode) node;
+                if (options.getForceFormattingOptions().getForceFormatRecordTypeDesc()) {
+                    return true;
+                }
+
+                if (recordTypeDesc.parent().kind() == SyntaxKind.TYPE_DEFINITION) {
+                    return true;
+                }
+
+                if (hasNonWSMinutiae(recordTypeDesc.bodyStartDelimiter().trailingMinutiae())
+                        || hasNonWSMinutiae(recordTypeDesc.bodyEndDelimiter().leadingMinutiae())) {
+                    return true;
+                }
+
+                for (Node field : recordTypeDesc.fields()) {
+                    if (hasNonWSMinutiae(field.leadingMinutiae()) || hasNonWSMinutiae(field.trailingMinutiae())
+                            || field.toSourceCode().contains(System.lineSeparator())) {
+                        return true;
+                    }
+                }
+                return false;
+            case LET_EXPRESSION:
+                LetExpressionNode letExpressionNode = (LetExpressionNode) node;
+                SeparatedNodeList<LetVariableDeclarationNode> letVarDeclarations = letExpressionNode.letVarDeclarations();
+                LetVariableDeclarationNode lastLetVarDeclarationNode = letVarDeclarations.get(letVarDeclarations.size() - 1);
+
+                return hasNonWSMinutiae(lastLetVarDeclarationNode.trailingMinutiae())
+                        || lastLetVarDeclarationNode.toSourceCode().contains(System.lineSeparator());
+            case ENUM_DECLARATION:
+                EnumDeclarationNode enumDeclarationNode = (EnumDeclarationNode) node;
+                SeparatedNodeList<Node> enumMemberList = enumDeclarationNode.enumMemberList();
+                for (int index = 0; index < enumMemberList.size() - 1; index++) {
+                    Token separator = enumMemberList.getSeparator(index);
+                    if (hasNonWSMinutiae(separator.leadingMinutiae()) || hasNonWSMinutiae(separator.trailingMinutiae())
+                            || separator.toSourceCode().contains(System.lineSeparator())) {
+                        return true;
+                    }
+                }
+                return false;
+            default:
+                return node.toSourceCode().trim().contains(System.lineSeparator());
         }
-
-        if (hasNonWSMinutiae(objectTypeDesc.openBrace().trailingMinutiae())
-                || hasNonWSMinutiae(objectTypeDesc.closeBrace().leadingMinutiae())) {
-            return true;
-        }
-
-        NodeList<Node> members = objectTypeDesc.members();
-        return shouldExpandObjectMembers(members);
-    }
-
-    /**
-     * Check whether an object constructor expression node needs to be expanded in to multiple lines.
-     *
-     * @param objectConstructor Object constructor expression node
-     * @return <code>true</code> If the object constructor expression node needs to be expanded in to multiple lines.
-     *         <code>false</code> otherwise
-     */
-    private boolean shouldExpand(ObjectConstructorExpressionNode objectConstructor) {
-        if (hasNonWSMinutiae(objectConstructor.openBraceToken().trailingMinutiae())
-                || hasNonWSMinutiae(objectConstructor.closeBraceToken().leadingMinutiae())) {
-            return true;
-        }
-
-        NodeList<Node> members = objectConstructor.members();
-        return shouldExpandObjectMembers(members);
     }
 
     private boolean shouldExpandObjectMembers(NodeList<Node> members) {
@@ -4412,66 +4439,6 @@ public class FormattingTreeModifier extends TreeModifier {
                     || hasNonWSMinutiae(member.leadingMinutiae())
                     || hasNonWSMinutiae(member.trailingMinutiae())
                     || member.toSourceCode().contains(System.lineSeparator())) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Check whether a record type descriptor needs to be expanded in to multiple lines.
-     *
-     * @param recordTypeDesc Record type descriptor
-     * @return <code>true</code> If the record type descriptor needs to be expanded in to multiple lines.
-     *         <code>false</code> otherwise
-     */
-    private boolean shouldExpand(RecordTypeDescriptorNode recordTypeDesc) {
-        if (recordTypeDesc.parent().kind() == SyntaxKind.TYPE_DEFINITION) {
-            return true;
-        }
-
-        if (hasNonWSMinutiae(recordTypeDesc.bodyStartDelimiter().trailingMinutiae())
-                || hasNonWSMinutiae(recordTypeDesc.bodyEndDelimiter().leadingMinutiae())) {
-            return true;
-        }
-
-        for (Node field : recordTypeDesc.fields()) {
-            if (hasNonWSMinutiae(field.leadingMinutiae()) || hasNonWSMinutiae(field.trailingMinutiae())
-                    || field.toSourceCode().contains(System.lineSeparator())) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Check whether a let expression needs to be expanded in to multiple lines.
-     *
-     * @param letExpressionNode Let Expression
-     * @return <code>true</code> If the let expression needs to be expanded in to multiple lines.
-     *         <code>false</code> otherwise
-     */
-    private boolean shouldExpand(LetExpressionNode letExpressionNode) {
-        SeparatedNodeList<LetVariableDeclarationNode> letVarDeclarations = letExpressionNode.letVarDeclarations();
-        LetVariableDeclarationNode lastLetVarDeclarationNode = letVarDeclarations.get(letVarDeclarations.size() - 1);
-
-        return hasNonWSMinutiae(lastLetVarDeclarationNode.trailingMinutiae())
-                || lastLetVarDeclarationNode.toSourceCode().contains(System.lineSeparator());
-    }
-
-    /**
-     * Check whether an enum declaration needs to be expanded in to multiple lines.
-     *
-     * @param enumDeclarationNode Enum declaration
-     * @return <code>true</code> If the enum declaration needs to be expanded in to multiple lines.
-     *         <code>false</code> otherwise
-     */
-    private boolean shouldExpand(EnumDeclarationNode enumDeclarationNode) {
-        SeparatedNodeList<Node> enumMemberList = enumDeclarationNode.enumMemberList();
-        for (int index = 0; index < enumMemberList.size() - 1; index++) {
-            Token separator = enumMemberList.getSeparator(index);
-            if (hasNonWSMinutiae(separator.leadingMinutiae()) || hasNonWSMinutiae(separator.trailingMinutiae())
-                    || separator.toSourceCode().contains(System.lineSeparator())) {
                 return true;
             }
         }

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
@@ -4412,8 +4412,10 @@ public class FormattingTreeModifier extends TreeModifier {
                 return false;
             case LET_EXPRESSION:
                 LetExpressionNode letExpressionNode = (LetExpressionNode) node;
-                SeparatedNodeList<LetVariableDeclarationNode> letVarDeclarations = letExpressionNode.letVarDeclarations();
-                LetVariableDeclarationNode lastLetVarDeclarationNode = letVarDeclarations.get(letVarDeclarations.size() - 1);
+                SeparatedNodeList<LetVariableDeclarationNode> letVarDeclarations =
+                        letExpressionNode.letVarDeclarations();
+                LetVariableDeclarationNode lastLetVarDeclarationNode =
+                        letVarDeclarations.get(letVarDeclarations.size() - 1);
 
                 return hasNonWSMinutiae(lastLetVarDeclarationNode.trailingMinutiae())
                         || lastLetVarDeclarationNode.toSourceCode().contains(System.lineSeparator());

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
@@ -4389,7 +4389,7 @@ public class FormattingTreeModifier extends TreeModifier {
                 NodeList<Node> objectConstructorMembers = objectConstructor.members();
                 return shouldExpandObjectMembers(objectConstructorMembers);
             case RECORD_TYPE_DESC:
-                if (options.getForceFormattingOptions().getForceFormatRecordTypeDesc()) {
+                if (options.getForceFormattingOptions().getForceFormatRecordFields()) {
                     return true;
                 }
 
@@ -4430,8 +4430,15 @@ public class FormattingTreeModifier extends TreeModifier {
                     }
                 }
                 return false;
+            case MAPPING_CONSTRUCTOR:
+                MappingConstructorExpressionNode mappingConstructorExpressionNode =
+                        (MappingConstructorExpressionNode) node;
+                return mappingConstructorExpressionNode.toSourceCode().trim().contains(System.lineSeparator());
+            case LIST_CONSTRUCTOR:
+                ListConstructorExpressionNode listConstructorExpressionNode = (ListConstructorExpressionNode) node;
+                return listConstructorExpressionNode.toSourceCode().trim().contains(System.lineSeparator());
             default:
-                return node.toSourceCode().trim().contains(System.lineSeparator());
+                return false;
         }
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/FormatterTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/FormatterTest.java
@@ -73,7 +73,8 @@ public abstract class FormatterTest {
         String content = getSourceText(sourceFilePath);
         TextDocument textDocument = TextDocuments.from(content);
         SyntaxTree syntaxTree = SyntaxTree.from(textDocument);
-        FormattingOptions formattingOptions = new FormattingOptions(true, 120);
+        FormattingOptions formattingOptions =
+                FormattingOptions.builder().setLineWrapping(true).setColumnLimit(120).build();
         try {
             SyntaxTree newSyntaxTree = Formatter.format(syntaxTree, formattingOptions);
             Assert.assertEquals(newSyntaxTree.toSourceCode(), getSourceText(assertFilePath));


### PR DESCRIPTION
## Purpose
> This PR has refactored the way how FormattingOptions are defined earlier. Now FormattingOptions for the Formatter can be defined with FormattingOptionsBuilder. This improvement is a part of the issue #37881.

Fixes #37881

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [x] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
