### PR TITLE
Add method to parse a query intermediateClause in the NodeParser

### DIFF
--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/syntax/tree/NodeParser.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/syntax/tree/NodeParser.java
@@ -147,4 +147,16 @@ public class NodeParser {
         BallerinaParser parser = ParserFactory.getParser(text);
         return parser.parse().createUnlinkedFacade();
     }
+
+    /**
+     * Parses the input as an intermediate clause.
+     *
+     * @param text the input
+     * @param allowActions Allow actions
+     * @return a {@code IntermediateClauseNode}
+     */
+    public static IntermediateClauseNode parseIntermediateClause(String text, boolean allowActions) {
+        BallerinaParser parser = ParserFactory.getParser(text);
+        return parser.parseAsIntermediateClause(allowActions).createUnlinkedFacade();
+    }
 }

--- a/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/tree/nodeparser/NodeParserLineRangeTest.java
+++ b/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/tree/nodeparser/NodeParserLineRangeTest.java
@@ -22,6 +22,7 @@ import io.ballerina.compiler.syntax.tree.BlockStatementNode;
 import io.ballerina.compiler.syntax.tree.ExpressionNode;
 import io.ballerina.compiler.syntax.tree.FunctionBodyBlockNode;
 import io.ballerina.compiler.syntax.tree.ImportDeclarationNode;
+import io.ballerina.compiler.syntax.tree.IntermediateClauseNode;
 import io.ballerina.compiler.syntax.tree.ModuleMemberDeclarationNode;
 import io.ballerina.compiler.syntax.tree.NodeParser;
 import io.ballerina.compiler.syntax.tree.StatementNode;
@@ -216,5 +217,90 @@ public class NodeParserLineRangeTest {
         LinePosition expectedEndPos = LinePosition.from(3, 2);
         LineRange expectedLineRange = LineRange.from(null, expectedStartPos, expectedEndPos);
         Assert.assertEquals(recordTypeDescriptor.lineRange(), expectedLineRange);
+    }
+
+    @Test
+    public void testParseIntermediateFromClause() {
+        String intermediateClauseText = "from int i in [1, 2, 3]";
+
+        IntermediateClauseNode intermediateClause = NodeParser.parseIntermediateClause(intermediateClauseText, true);
+        Assert.assertEquals(intermediateClause.kind(), SyntaxKind.FROM_CLAUSE);
+        Assert.assertFalse(intermediateClause.hasDiagnostics());
+
+        LinePosition expectedStartPos = LinePosition.from(0, 0);
+        LinePosition expectedEndPos = LinePosition.from(0, 23);
+        LineRange expectedLineRange = LineRange.from(null, expectedStartPos, expectedEndPos);
+        Assert.assertEquals(intermediateClause.lineRange(), expectedLineRange);
+    }
+
+    @Test
+    public void testParseIntermediateWhereClause() {
+        String intermediateClauseText = "where i == 1";
+
+        IntermediateClauseNode intermediateClause = NodeParser.parseIntermediateClause(intermediateClauseText, false);
+        Assert.assertEquals(intermediateClause.kind(), SyntaxKind.WHERE_CLAUSE);
+        Assert.assertFalse(intermediateClause.hasDiagnostics());
+
+        LinePosition expectedStartPos = LinePosition.from(0, 0);
+        LinePosition expectedEndPos = LinePosition.from(0, 12);
+        LineRange expectedLineRange = LineRange.from(null, expectedStartPos, expectedEndPos);
+        Assert.assertEquals(intermediateClause.lineRange(), expectedLineRange);
+    }
+
+    @Test
+    public void testParseIntermediateLetClause() {
+        String intermediateClauseText = "let int a = 3, string b = \"\"";
+
+        IntermediateClauseNode intermediateClause = NodeParser.parseIntermediateClause(intermediateClauseText, true);
+        Assert.assertEquals(intermediateClause.kind(), SyntaxKind.LET_CLAUSE);
+        Assert.assertFalse(intermediateClause.hasDiagnostics());
+
+        LinePosition expectedStartPos = LinePosition.from(0, 0);
+        LinePosition expectedEndPos = LinePosition.from(0, 28);
+        LineRange expectedLineRange = LineRange.from(null, expectedStartPos, expectedEndPos);
+        Assert.assertEquals(intermediateClause.lineRange(), expectedLineRange);
+    }
+
+    @Test
+    public void testParseIntermediateJoinClause() {
+        String intermediateClauseText = "join var user in table [{id: 1234, " +
+                "name: \"Keith\"}, {id: 6789, name: \"Anne\"}] on login.userId equals user.id";
+
+        IntermediateClauseNode intermediateClause = NodeParser.parseIntermediateClause(intermediateClauseText, false);
+        Assert.assertEquals(intermediateClause.kind(), SyntaxKind.JOIN_CLAUSE);
+        Assert.assertFalse(intermediateClause.hasDiagnostics());
+
+        LinePosition expectedStartPos = LinePosition.from(0, 0);
+        LinePosition expectedEndPos = LinePosition.from(0, 107);
+        LineRange expectedLineRange = LineRange.from(null, expectedStartPos, expectedEndPos);
+        Assert.assertEquals(intermediateClause.lineRange(), expectedLineRange);
+    }
+
+    @Test
+    public void testParseIntermediateOrderClause() {
+        String intermediateClauseText = "order by name";
+
+        IntermediateClauseNode intermediateClause = NodeParser.parseIntermediateClause(intermediateClauseText, true);
+        Assert.assertEquals(intermediateClause.kind(), SyntaxKind.ORDER_BY_CLAUSE);
+        Assert.assertFalse(intermediateClause.hasDiagnostics());
+
+        LinePosition expectedStartPos = LinePosition.from(0, 0);
+        LinePosition expectedEndPos = LinePosition.from(0, 13);
+        LineRange expectedLineRange = LineRange.from(null, expectedStartPos, expectedEndPos);
+        Assert.assertEquals(intermediateClause.lineRange(), expectedLineRange);
+    }
+
+    @Test
+    public void testParseIntermediateLimitClause() {
+        String intermediateClauseText = "limit getIntValue()";
+
+        IntermediateClauseNode intermediateClause = NodeParser.parseIntermediateClause(intermediateClauseText, false);
+        Assert.assertEquals(intermediateClause.kind(), SyntaxKind.LIMIT_CLAUSE);
+        Assert.assertFalse(intermediateClause.hasDiagnostics());
+
+        LinePosition expectedStartPos = LinePosition.from(0, 0);
+        LinePosition expectedEndPos = LinePosition.from(0, 19);
+        LineRange expectedLineRange = LineRange.from(null, expectedStartPos, expectedEndPos);
+        Assert.assertEquals(intermediateClause.lineRange(), expectedLineRange);
     }
 }

--- a/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/tree/nodeparser/ParseIntermediateClauseTest.java
+++ b/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/tree/nodeparser/ParseIntermediateClauseTest.java
@@ -1,0 +1,353 @@
+/*
+ *  Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package io.ballerinalang.compiler.parser.test.tree.nodeparser;
+
+import io.ballerina.compiler.syntax.tree.IntermediateClauseNode;
+import io.ballerina.compiler.syntax.tree.NodeParser;
+import io.ballerina.compiler.syntax.tree.SyntaxKind;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Test {@code parseIntermediateClause} method.
+ */
+public class ParseIntermediateClauseTest {
+
+    // Valid syntax tests
+
+    @Test
+    public void testValidFromClause() {
+        IntermediateClauseNode intermediateNode = NodeParser.parseIntermediateClause(
+                "from int i in [1, 2, 3]", true);
+        Assert.assertEquals(intermediateNode.kind(), SyntaxKind.FROM_CLAUSE);
+        Assert.assertFalse(intermediateNode.hasDiagnostics());
+    }
+
+    @Test
+    public void testValidFromClause2() {
+        IntermediateClauseNode intermediateNode = NodeParser.parseIntermediateClause(
+                "from int i in intList", false);
+        Assert.assertEquals(intermediateNode.kind(), SyntaxKind.FROM_CLAUSE);
+        Assert.assertFalse(intermediateNode.hasDiagnostics());
+    }
+
+    @Test
+    public void testValidFromClause3() {
+        IntermediateClauseNode intermediateNode = NodeParser.parseIntermediateClause(
+                "from var _ in [1, 2, 3]", true);
+        Assert.assertEquals(intermediateNode.kind(), SyntaxKind.FROM_CLAUSE);
+        Assert.assertFalse(intermediateNode.hasDiagnostics());
+    }
+
+    @Test
+    public void testValidFromClause4() {
+        IntermediateClauseNode intermediateNode = NodeParser.parseIntermediateClause(
+                "from int _ in [1, 2, 3]", false);
+        Assert.assertEquals(intermediateNode.kind(), SyntaxKind.FROM_CLAUSE);
+        Assert.assertFalse(intermediateNode.hasDiagnostics());
+    }
+
+    @Test
+    public void testValidFromClause5() {
+        IntermediateClauseNode intermediateNode = NodeParser.parseIntermediateClause(
+                "from var i in a -> w2", true);
+        Assert.assertEquals(intermediateNode.kind(), SyntaxKind.FROM_CLAUSE);
+        Assert.assertFalse(intermediateNode.hasDiagnostics());
+    }
+
+    @Test
+    public void testValidWhereClause() {
+        IntermediateClauseNode intermediateNode = NodeParser.parseIntermediateClause(
+                "where true", true);
+        Assert.assertEquals(intermediateNode.kind(), SyntaxKind.WHERE_CLAUSE);
+        Assert.assertFalse(intermediateNode.hasDiagnostics());
+    }
+
+    @Test
+    public void testValidWhereClause2() {
+        IntermediateClauseNode intermediateNode = NodeParser.parseIntermediateClause(
+                "where i == 1", false);
+        Assert.assertEquals(intermediateNode.kind(), SyntaxKind.WHERE_CLAUSE);
+        Assert.assertFalse(intermediateNode.hasDiagnostics());
+    }
+
+    @Test
+    public void testValidWhereClause3() {
+        IntermediateClauseNode intermediateNode = NodeParser.parseIntermediateClause(
+                "where evaluateTrue()", true);
+        Assert.assertEquals(intermediateNode.kind(), SyntaxKind.WHERE_CLAUSE);
+        Assert.assertFalse(intermediateNode.hasDiagnostics());
+    }
+
+    @Test
+    public void testValidWhereClause4() {
+        IntermediateClauseNode intermediateNode = NodeParser.parseIntermediateClause(
+                "where 1 != 1", false);
+        Assert.assertEquals(intermediateNode.kind(), SyntaxKind.WHERE_CLAUSE);
+        Assert.assertFalse(intermediateNode.hasDiagnostics());
+    }
+
+    @Test
+    public void testValidWhereClause5() {
+        IntermediateClauseNode intermediateNode = NodeParser.parseIntermediateClause(
+                "where !evaluateTrue()", true);
+        Assert.assertEquals(intermediateNode.kind(), SyntaxKind.WHERE_CLAUSE);
+        Assert.assertFalse(intermediateNode.hasDiagnostics());
+    }
+
+    @Test
+    public void testValidLetClause() {
+        IntermediateClauseNode intermediateNode = NodeParser.parseIntermediateClause(
+                "let int a = 1", false);
+        Assert.assertEquals(intermediateNode.kind(), SyntaxKind.LET_CLAUSE);
+        Assert.assertFalse(intermediateNode.hasDiagnostics());
+    }
+
+    @Test
+    public void testValidLetClause2() {
+        IntermediateClauseNode intermediateNode = NodeParser.parseIntermediateClause(
+                "let int _ = 1", true);
+        Assert.assertEquals(intermediateNode.kind(), SyntaxKind.LET_CLAUSE);
+        Assert.assertFalse(intermediateNode.hasDiagnostics());
+    }
+
+    @Test
+    public void testValidLetClause3() {
+        IntermediateClauseNode intermediateNode = NodeParser.parseIntermediateClause("let record" +
+                " { int id; } a = {id: 1}", false);
+        Assert.assertEquals(intermediateNode.kind(), SyntaxKind.LET_CLAUSE);
+        Assert.assertFalse(intermediateNode.hasDiagnostics());
+    }
+
+    @Test
+    public void testValidLetClause4() {
+        IntermediateClauseNode intermediateNode = NodeParser.parseIntermediateClause(
+                "let int a = 1, int b = 7", true);
+        Assert.assertEquals(intermediateNode.kind(), SyntaxKind.LET_CLAUSE);
+        Assert.assertFalse(intermediateNode.hasDiagnostics());
+    }
+
+    @Test
+    public void testValidLetClause5() {
+        IntermediateClauseNode intermediateNode = NodeParser
+                .parseIntermediateClause("let int a = 1 + 2, int b = 7 - 2, int c = getInt()", false);
+        Assert.assertEquals(intermediateNode.kind(), SyntaxKind.LET_CLAUSE);
+        Assert.assertFalse(intermediateNode.hasDiagnostics());
+    }
+
+    @Test
+    public void testValidJoinClause() {
+        IntermediateClauseNode intermediateNode = NodeParser.parseIntermediateClause("join var user in " +
+                "table [{id: 1234, name: \"Keith\"}, {id: 6789, name: \"Anne\"}] " +
+                "on login.userId equals user.id", true);
+        Assert.assertEquals(intermediateNode.kind(), SyntaxKind.JOIN_CLAUSE);
+        Assert.assertFalse(intermediateNode.hasDiagnostics());
+    }
+
+    @Test
+    public void testValidJoinClause2() {
+        IntermediateClauseNode intermediateNode = NodeParser.parseIntermediateClause("outer join var " +
+                "user in table [{id: 1234, name: \"Keith\"}, {id: 6789, name: \"Anne\"}] " +
+                "on login.userId equals user.id", false);
+        Assert.assertEquals(intermediateNode.kind(), SyntaxKind.JOIN_CLAUSE);
+        Assert.assertFalse(intermediateNode.hasDiagnostics());
+    }
+
+    @Test
+    public void testValidJoinClause3() {
+        IntermediateClauseNode intermediateNode = NodeParser.parseIntermediateClause("outer join var " +
+                "user in getTable() on login.userId equals user.id", true);
+        Assert.assertEquals(intermediateNode.kind(), SyntaxKind.JOIN_CLAUSE);
+        Assert.assertFalse(intermediateNode.hasDiagnostics());
+    }
+
+    @Test
+    public void testValidJoinClause4() {
+        IntermediateClauseNode intermediateNode = NodeParser.parseIntermediateClause("outer join var " +
+                "user in table[] on loginUserId equals userId", false);
+        Assert.assertEquals(intermediateNode.kind(), SyntaxKind.JOIN_CLAUSE);
+        Assert.assertFalse(intermediateNode.hasDiagnostics());
+    }
+
+    @Test
+    public void testValidJoinClause5() {
+        IntermediateClauseNode intermediateNode = NodeParser
+                .parseIntermediateClause("join var user in getTable() on loginUserId equals userId", true);
+        Assert.assertEquals(intermediateNode.kind(), SyntaxKind.JOIN_CLAUSE);
+        Assert.assertFalse(intermediateNode.hasDiagnostics());
+    }
+
+    @Test
+    public void testValidOrderClause() {
+        IntermediateClauseNode intermediateNode = NodeParser.parseIntermediateClause("order by name", false);
+        Assert.assertEquals(intermediateNode.kind(), SyntaxKind.ORDER_BY_CLAUSE);
+        Assert.assertFalse(intermediateNode.hasDiagnostics());
+    }
+
+    @Test
+    public void testValidOrderClause2() {
+        IntermediateClauseNode intermediateNode = NodeParser.parseIntermediateClause("order by employee.name", true);
+        Assert.assertEquals(intermediateNode.kind(), SyntaxKind.ORDER_BY_CLAUSE);
+        Assert.assertFalse(intermediateNode.hasDiagnostics());
+    }
+
+    @Test
+    public void testValidOrderClause3() {
+        IntermediateClauseNode intermediateNode = NodeParser.parseIntermediateClause("order by " +
+                "getEmployee().id", false);
+        Assert.assertEquals(intermediateNode.kind(), SyntaxKind.ORDER_BY_CLAUSE);
+        Assert.assertFalse(intermediateNode.hasDiagnostics());
+    }
+
+    @Test
+    public void testValidOrderClause4() {
+        IntermediateClauseNode intermediateNode = NodeParser.parseIntermediateClause("order by name " +
+                "ascending, emp.id ascending", false);
+        Assert.assertEquals(intermediateNode.kind(), SyntaxKind.ORDER_BY_CLAUSE);
+        Assert.assertFalse(intermediateNode.hasDiagnostics());
+    }
+
+    @Test
+    public void testValidOrderClause5() {
+        IntermediateClauseNode intermediateNode = NodeParser.parseIntermediateClause("order by name" +
+                " ascending, emp.id descending", true);
+        Assert.assertEquals(intermediateNode.kind(), SyntaxKind.ORDER_BY_CLAUSE);
+        Assert.assertFalse(intermediateNode.hasDiagnostics());
+    }
+
+    @Test
+    public void testValidLimitClause() {
+        IntermediateClauseNode intermediateNode = NodeParser.parseIntermediateClause("limit 1", false);
+        Assert.assertEquals(intermediateNode.kind(), SyntaxKind.LIMIT_CLAUSE);
+        Assert.assertFalse(intermediateNode.hasDiagnostics());
+    }
+
+    @Test
+    public void testValidLimitClause2() {
+        IntermediateClauseNode intermediateNode = NodeParser.parseIntermediateClause("limit getName()", true);
+        Assert.assertEquals(intermediateNode.kind(), SyntaxKind.LIMIT_CLAUSE);
+        Assert.assertFalse(intermediateNode.hasDiagnostics());
+    }
+
+    @Test
+    public void testValidLimitClause3() {
+        IntermediateClauseNode intermediateNode = NodeParser.parseIntermediateClause("limit emp.id", true);
+        Assert.assertEquals(intermediateNode.kind(), SyntaxKind.LIMIT_CLAUSE);
+        Assert.assertFalse(intermediateNode.hasDiagnostics());
+    }
+
+    // Invalid syntax tests
+
+    @Test
+    public void testEmptyString() {
+        IntermediateClauseNode intermediateNode = NodeParser.parseIntermediateClause("", false);
+        Assert.assertEquals(intermediateNode.kind(), SyntaxKind.WHERE_CLAUSE);
+        Assert.assertTrue(intermediateNode.hasDiagnostics());
+        Assert.assertEquals(intermediateNode.leadingInvalidTokens().size(), 0);
+        Assert.assertEquals(intermediateNode.trailingInvalidTokens().size(), 0);
+        Assert.assertEquals(intermediateNode.toString(), " MISSING[where] MISSING[]");
+    }
+
+    @Test
+    public void testWithIntermediateClauseRecovery1() {
+        IntermediateClauseNode intermediateNode = NodeParser.parseIntermediateClause("from", true);
+        Assert.assertEquals(intermediateNode.kind(), SyntaxKind.FROM_CLAUSE);
+        Assert.assertTrue(intermediateNode.hasDiagnostics());
+        Assert.assertEquals(intermediateNode.leadingInvalidTokens().size(), 0);
+        Assert.assertEquals(intermediateNode.trailingInvalidTokens().size(), 0);
+        Assert.assertEquals(intermediateNode.toString(), "from MISSING[] MISSING[] MISSING[in] MISSING[]");
+    }
+
+    @Test
+    public void testWithIntermediateClauseRecovery2() {
+        IntermediateClauseNode intermediateNode = NodeParser.parseIntermediateClause("from int", false);
+        Assert.assertEquals(intermediateNode.kind(), SyntaxKind.FROM_CLAUSE);
+        Assert.assertTrue(intermediateNode.hasDiagnostics());
+        Assert.assertEquals(intermediateNode.leadingInvalidTokens().size(), 0);
+        Assert.assertEquals(intermediateNode.trailingInvalidTokens().size(), 0);
+        Assert.assertEquals(intermediateNode.toString(), "from int MISSING[] MISSING[in] MISSING[]");
+    }
+
+    @Test
+    public void testWithInvalidTokens() {
+        IntermediateClauseNode intermediateNode = NodeParser.parseIntermediateClause("% isolated function " +
+                "from int i in [1, 2, 3] +", false);
+        Assert.assertEquals(intermediateNode.kind(), SyntaxKind.WHERE_CLAUSE);
+        Assert.assertTrue(intermediateNode.hasDiagnostics());
+        Assert.assertEquals(intermediateNode.leadingInvalidTokens().size(), 0);
+        Assert.assertEquals(intermediateNode.trailingInvalidTokens().size(), 15);
+        Assert.assertEquals(intermediateNode.toString(), " MISSING[where] MISSING[ INVALID[%]  " +
+                "INVALID[isolated]  INVALID[function]  INVALID[from]  INVALID[int]  INVALID[i] " +
+                " INVALID[in]  INVALID[[] INVALID[1] INVALID[,]  INVALID[2] INVALID[,]" +
+                "  INVALID[3] INVALID[]]  INVALID[+]]");
+    }
+
+    @Test
+    public void testWithInvalidTokens2() {
+        IntermediateClauseNode intermediateNode = NodeParser.parseIntermediateClause("invalid!", false);
+        Assert.assertEquals(intermediateNode.kind(), SyntaxKind.WHERE_CLAUSE);
+        Assert.assertTrue(intermediateNode.hasDiagnostics());
+        Assert.assertEquals(intermediateNode.leadingInvalidTokens().size(), 0);
+        Assert.assertEquals(intermediateNode.trailingInvalidTokens().size(), 2);
+        Assert.assertEquals(intermediateNode.toString(), " MISSING[where] MISSING[ INVALID[invalid] INVALID[!]]");
+    }
+
+    @Test
+    public void testWithInvalidTokens3() {
+        IntermediateClauseNode intermediateNode = NodeParser.parseIntermediateClause(
+                "from var i in a -> w2", false);
+        Assert.assertEquals(intermediateNode.kind(), SyntaxKind.FROM_CLAUSE);
+        Assert.assertTrue(intermediateNode.hasDiagnostics());
+        Assert.assertEquals(intermediateNode.leadingInvalidTokens().size(), 0);
+        Assert.assertEquals(intermediateNode.trailingInvalidTokens().size(), 3);
+        Assert.assertEquals(intermediateNode.toString(), "from var i in  MISSING[ INVALID[a] " +
+                " INVALID[->]  INVALID[w2]]");
+    }
+
+    @Test
+    public void testWithAStmt() {
+        IntermediateClauseNode intermediateNode = NodeParser.parseIntermediateClause("int num = 3", false);
+        Assert.assertEquals(intermediateNode.kind(), SyntaxKind.LET_CLAUSE);
+        Assert.assertTrue(intermediateNode.hasDiagnostics());
+        Assert.assertEquals(intermediateNode.leadingInvalidTokens().size(), 0);
+        Assert.assertEquals(intermediateNode.trailingInvalidTokens().size(), 0);
+        Assert.assertEquals(intermediateNode.toString(), " MISSING[let]int num = 3");
+    }
+
+    @Test
+    public void testWithAStmt2() {
+        IntermediateClauseNode intermediateNode = NodeParser.parseIntermediateClause("a += 4", false);
+        Assert.assertEquals(intermediateNode.kind(), SyntaxKind.WHERE_CLAUSE);
+        Assert.assertTrue(intermediateNode.hasDiagnostics());
+        Assert.assertEquals(intermediateNode.leadingInvalidTokens().size(), 0);
+        Assert.assertEquals(intermediateNode.trailingInvalidTokens().size(), 4);
+        Assert.assertEquals(intermediateNode.toString(), " MISSING[where] MISSING[ INVALID[a]" +
+                "  INVALID[+] INVALID[=]  INVALID[4]]");
+    }
+
+    @Test
+    public void testWithAExpression() {
+        IntermediateClauseNode intermediateNode = NodeParser.parseIntermediateClause("func()", false);
+        Assert.assertEquals(intermediateNode.kind(), SyntaxKind.WHERE_CLAUSE);
+        Assert.assertTrue(intermediateNode.hasDiagnostics());
+        Assert.assertEquals(intermediateNode.leadingInvalidTokens().size(), 0);
+        Assert.assertEquals(intermediateNode.trailingInvalidTokens().size(), 3);
+        Assert.assertEquals(intermediateNode.toString(), " MISSING[where] MISSING[ INVALID[func] " +
+                "INVALID[(] INVALID[)]]");
+    }
+}


### PR DESCRIPTION
## Purpose
> Add method to parse a query intermediateClause in the NodeParse.

Fixes #37749
Fixes https://github.com/wso2-enterprise/internal-support-ballerina/issues/176


## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
