### PR TITLE
[2201.2.x] Fix setting record type flags from cached BIR

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
@@ -1204,15 +1204,9 @@ public class BIRPackageSymbolEnter {
                                                                                 env.pkgSymbol.pkgID, null,
                                                                                 env.pkgSymbol, symTable.builtinPos,
                                                                                 COMPILED_SOURCE);
-                    recordSymbol.flags |= flags;
                     recordSymbol.scope = new Scope(recordSymbol);
-                    BRecordType recordType = new BRecordType(recordSymbol, recordSymbol.flags);
-                    recordType.flags |= flags;
 
-                    if (isImmutable(flags)) {
-                        recordSymbol.flags |= Flags.READONLY;
-                    }
-
+                    BRecordType recordType = new BRecordType(recordSymbol, flags);
                     recordSymbol.type = recordType;
 
                     compositeStack.push(recordType);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/types/PublicAndPrivateTypesTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/types/PublicAndPrivateTypesTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.test.bala.types;
+
+import org.ballerinalang.test.BCompileUtil;
+import org.ballerinalang.test.BRunUtil;
+import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.Test;
+
+/**
+ * Test module public and private types with bala.
+ */
+public class PublicAndPrivateTypesTest {
+
+    @Test
+    public void testModulePublicAndPrivateTypes() {
+        BCompileUtil.compileAndCacheBala("test-src/bala/test_projects/test_project_types");
+        CompileResult compileResult = BCompileUtil.compile(
+                "test-src/bala/test_bala/types/public_and_private_types_test.bal");
+        BRunUtil.invoke(compileResult, "testModulePublicAndPrivateTypes");
+    }
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/types/public_and_private_types_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/types/public_and_private_types_test.bal
@@ -1,0 +1,26 @@
+// Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+import testOrg/public_and_private_types as test_module;
+
+function testModulePublicAndPrivateTypes() {
+    any timeZone = test_module:loadZone();
+    test:assertEquals(timeZone is test_module:Zone, true);
+    if (timeZone is test_module:Zone) {
+        test:assertEquals(timeZone.getInt({year:1, month: 2, day: 3}), 6);
+    }
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/test_project_types/Ballerina.toml
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/test_project_types/Ballerina.toml
@@ -1,0 +1,7 @@
+[package]
+org = "testOrg"
+name = "public_and_private_types"
+version = "0.1.0"
+
+[build-options]
+observabilityIncluded = false

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/test_project_types/module_public_and_private_types.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/test_project_types/module_public_and_private_types.bal
@@ -1,0 +1,41 @@
+// Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+type DateFields record {
+    int year;
+    int month;
+    int day;
+};
+
+public type Civil record {
+    *DateFields;
+};
+
+public type Zone readonly & object {
+    public isolated function getInt(Civil civil) returns int;
+};
+
+public readonly class TimeZone {
+    *Zone;
+
+    public isolated function getInt(Civil civil) returns int {
+        return civil.year + civil.month + civil.day;
+    }
+}
+
+public isolated function loadZone() returns Zone {
+    return new TimeZone();
+}


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues.

$title
Duplicate PR https://github.com/ballerina-platform/ballerina-lang/pull/37992
Fixes #37815

## Approach
> Describe how you are implementing the solutions along with the design details.

The issue happened because the hash code was not correct for some record types, when the cached BIR was used. This was because when reading from the cached BIR, the record type flags was not correctly populated. Record type symbol flags and record type flags are actually different.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
