### PR TITLE
Set the parallel builds to continue on fail

### DIFF
--- a/.github/workflows/nightly_publish_timestamped_release.yml
+++ b/.github/workflows/nightly_publish_timestamped_release.yml
@@ -9,6 +9,7 @@ jobs:
     name: Build and Publish Ballerina Lang
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       max-parallel: 4
       matrix:
         branch: ['master', '2201.0.x', '2201.1.x', '2201.2.x']


### PR DESCRIPTION
## Purpose
Avoid cancelling parallel builds when a single build fails.


