### PR TITLE
Fix __execute__ calling the same test multiple times

### DIFF
--- a/misc/testerina/modules/testerina-compiler-plugin/src/main/java/org/ballerinalang/testerina/compiler/TesterinaCompilerPluginUtils.java
+++ b/misc/testerina/modules/testerina-compiler-plugin/src/main/java/org/ballerinalang/testerina/compiler/TesterinaCompilerPluginUtils.java
@@ -247,7 +247,7 @@ public class TesterinaCompilerPluginUtils {
                 populateTestRegistrarStatements(group, registrarStatements, functionsList, statements);
                 testIndex.set(0);
                 group.incrementAndGet();
-                registrarStatements = new ArrayList<>();
+                registrarStatements.clear();
             }
         }
     }


### PR DESCRIPTION
## Purpose
Fix the bug of generated code calling the same test function multiple times.


## Approach
Instead of re initialising the registratStatements arraylist, clearing it. That way the same object is altered instead of assigning a new object to registratStatements.
