### PR TITLE
Add validation for decimal values at runtime

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/constants/RuntimeConstants.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/constants/RuntimeConstants.java
@@ -23,6 +23,7 @@ import io.ballerina.runtime.api.values.BString;
 
 import java.math.BigDecimal;
 import java.math.MathContext;
+import java.math.RoundingMode;
 
 /**
  * This file contains a list of constant values used by Ballerina Runtime.
@@ -106,7 +107,7 @@ public class RuntimeConstants {
     public static final double BINT_MIN_VALUE_DOUBLE_RANGE_MIN = -9223372036854775807.6;
     public static final BigDecimal BINT_MAX_VALUE_BIG_DECIMAL_RANGE_MAX = new BigDecimal("9223372036854775807.5",
                                                                                          MathContext.DECIMAL128);
-    public static final BigDecimal BINT_MIN_VALUE_BIG_DECIMAL_RANGE_MIN = new BigDecimal("-9223372036854775807.6",
+    public static final BigDecimal BINT_MIN_VALUE_BIG_DECIMAL_RANGE_MIN = new BigDecimal("-9223372036854775808.5",
                                                                                          MathContext.DECIMAL128);
     // runtime related error message constant values
     public static final String INTERNAL_ERROR_MESSAGE =

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/constants/RuntimeConstants.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/constants/RuntimeConstants.java
@@ -23,7 +23,6 @@ import io.ballerina.runtime.api.values.BString;
 
 import java.math.BigDecimal;
 import java.math.MathContext;
-import java.math.RoundingMode;
 
 /**
  * This file contains a list of constant values used by Ballerina Runtime.

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/util/exceptions/RuntimeErrors.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/util/exceptions/RuntimeErrors.java
@@ -126,7 +126,8 @@ public enum RuntimeErrors implements DiagnosticCode {
     CONFIG_SIZE_MISMATCH("config.size.mismatch", "RUNTIME_0098"),
     INVALID_FRACTION_DIGITS("invalid.fraction.digits", "RUNTIME_0099"),
     INVALID_UTF_8_BYTE_ARRAY_VALUE("invalid.utf8.byte.array.value", "RUNTIME_0100"),
-    INCOMPATIBLE_ARGUMENTS("incompatible.arguments", "RUNTIME_0101");
+    INCOMPATIBLE_ARGUMENTS("incompatible.arguments", "RUNTIME_0101"),
+    DECIMAL_VALUE_OUT_OF_RANGE("decimal.value.out.of.range", "RUNTIME_0102");
 
     private String errorMsgKey;
     private String errorCode;

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/DecimalValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/DecimalValue.java
@@ -33,6 +33,7 @@ import io.ballerina.runtime.internal.util.exceptions.RuntimeErrors;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.MathContext;
+import java.math.RoundingMode;
 import java.util.Map;
 
 /**
@@ -50,6 +51,15 @@ public class DecimalValue implements SimpleValue, BDecimal {
     private static final String NEG_INF_STRING = "-" + INF_STRING;
     private static final String NAN = "NaN";
 
+    private static final BigDecimal DECIMAL_MAX =
+            new BigDecimal("9.999999999999999999999999999999999e6144", MathContext.DECIMAL128);
+
+    private static final BigDecimal DECIMAL_MIN =
+            new BigDecimal("-9.999999999999999999999999999999999e6144", MathContext.DECIMAL128);
+
+    private static final BigDecimal SMALLEST_DECIMAL_MAGNITUDE =
+            new BigDecimal("1.000000e-6143", MathContext.DECIMAL128);
+
     // Variable used to track the kind of a decimal value.
     @Deprecated
     public DecimalValueKind valueKind = DecimalValueKind.OTHER;
@@ -57,7 +67,7 @@ public class DecimalValue implements SimpleValue, BDecimal {
     private final BigDecimal value;
 
     public DecimalValue(BigDecimal value) {
-        this.value = value;
+        this.value = getValidDecimalValue(value);
         if (!this.booleanValue()) {
             this.valueKind = DecimalValueKind.ZERO;
         }
@@ -65,11 +75,12 @@ public class DecimalValue implements SimpleValue, BDecimal {
 
     public DecimalValue(String value) {
         // Check whether the number provided is a hexadecimal value.
+        BigDecimal bd;
         if (isHexValueString(value)) {
-            this.value = hexToDecimalFloatingPointNumber(value);
+            bd = hexToDecimalFloatingPointNumber(value);
         } else {
             try {
-                this.value = new BigDecimal(value, MathContext.DECIMAL128);
+                bd = new BigDecimal(value, MathContext.DECIMAL128);
             } catch (NumberFormatException exception) {
                 String message = exception.getMessage();
                 if ((message != null) && (message.equals("Too many nonzero exponent digits.") ||
@@ -80,6 +91,8 @@ public class DecimalValue implements SimpleValue, BDecimal {
                 throw exception;
             }
         }
+        this.value = getValidDecimalValue(bd);
+
         if (!this.booleanValue()) {
             this.valueKind = DecimalValueKind.ZERO;
         }
@@ -88,6 +101,16 @@ public class DecimalValue implements SimpleValue, BDecimal {
     public DecimalValue(String value, DecimalValueKind valueKind) {
         this(value);
         this.valueKind = valueKind;
+    }
+
+    private static BigDecimal getValidDecimalValue(BigDecimal bd) {
+        if (bd.compareTo(DECIMAL_MAX) > 0 || bd.compareTo(DECIMAL_MIN) < 0) {
+            throw ErrorCreator.createError(BallerinaErrorReasons.NUMBER_OVERFLOW,
+                    BLangExceptionHelper.getErrorDetails(RuntimeErrors.DECIMAL_VALUE_OUT_OF_RANGE));
+        } else if (bd.abs(MathContext.DECIMAL128).compareTo(SMALLEST_DECIMAL_MAGNITUDE) < 0) {
+            return BigDecimal.ZERO;
+        }
+        return bd;
     }
 
     private static boolean isHexValueString(String value) {
@@ -166,7 +189,7 @@ public class DecimalValue implements SimpleValue, BDecimal {
             throw ErrorUtils.createNumericConversionError(this.stringValue(null), PredefinedTypes.TYPE_DECIMAL,
                                                           PredefinedTypes.TYPE_INT);
         }
-        return (long) Math.rint(value.doubleValue());
+        return (long) Math.rint(value.longValue());
     }
 
     /**
@@ -438,7 +461,7 @@ public class DecimalValue implements SimpleValue, BDecimal {
      * @return decimal value
      */
     public static DecimalValue valueOf(int value) {
-        return new DecimalValue(new BigDecimal(value, MathContext.DECIMAL128).setScale(1, BigDecimal.ROUND_HALF_EVEN));
+        return new DecimalValue(new BigDecimal(value, MathContext.DECIMAL128).setScale(1, RoundingMode.HALF_EVEN));
     }
 
     /**
@@ -447,7 +470,7 @@ public class DecimalValue implements SimpleValue, BDecimal {
      * @return decimal value
      */
     public static DecimalValue valueOf(long value) {
-        return new DecimalValue(new BigDecimal(value, MathContext.DECIMAL128).setScale(1, BigDecimal.ROUND_HALF_EVEN));
+        return new DecimalValue(new BigDecimal(value, MathContext.DECIMAL128).setScale(1, RoundingMode.HALF_EVEN));
     }
 
     /**

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/DecimalValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/DecimalValue.java
@@ -189,7 +189,7 @@ public class DecimalValue implements SimpleValue, BDecimal {
             throw ErrorUtils.createNumericConversionError(this.stringValue(null), PredefinedTypes.TYPE_DECIMAL,
                                                           PredefinedTypes.TYPE_INT);
         }
-        return (long) Math.rint(value.longValue());
+        return (long) Math.rint(value.doubleValue());
     }
 
     /**

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/DecimalValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/DecimalValue.java
@@ -57,8 +57,6 @@ public class DecimalValue implements SimpleValue, BDecimal {
     private static final BigDecimal DECIMAL_MIN =
             new BigDecimal("-9.999999999999999999999999999999999e6144", MathContext.DECIMAL128);
 
-    private static final BigDecimal SMALLEST_DECIMAL_MAGNITUDE =
-            new BigDecimal("1.000000e-6143", MathContext.DECIMAL128);
 
     // Variable used to track the kind of a decimal value.
     @Deprecated
@@ -107,8 +105,6 @@ public class DecimalValue implements SimpleValue, BDecimal {
         if (bd.compareTo(DECIMAL_MAX) > 0 || bd.compareTo(DECIMAL_MIN) < 0) {
             throw ErrorCreator.createError(BallerinaErrorReasons.NUMBER_OVERFLOW,
                     BLangExceptionHelper.getErrorDetails(RuntimeErrors.DECIMAL_VALUE_OUT_OF_RANGE));
-        } else if (bd.abs(MathContext.DECIMAL128).compareTo(SMALLEST_DECIMAL_MAGNITUDE) < 0) {
-            return BigDecimal.ZERO;
         }
         return bd;
     }
@@ -189,7 +185,7 @@ public class DecimalValue implements SimpleValue, BDecimal {
             throw ErrorUtils.createNumericConversionError(this.stringValue(null), PredefinedTypes.TYPE_DECIMAL,
                                                           PredefinedTypes.TYPE_INT);
         }
-        return (long) Math.rint(value.doubleValue());
+        return value.setScale(0, RoundingMode.HALF_EVEN).longValue();
     }
 
     /**

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/DecimalValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/DecimalValue.java
@@ -50,13 +50,10 @@ public class DecimalValue implements SimpleValue, BDecimal {
     private static final String INF_STRING = "Infinity";
     private static final String NEG_INF_STRING = "-" + INF_STRING;
     private static final String NAN = "NaN";
-
     private static final BigDecimal DECIMAL_MAX =
             new BigDecimal("9.999999999999999999999999999999999e6144", MathContext.DECIMAL128);
-
     private static final BigDecimal DECIMAL_MIN =
             new BigDecimal("-9.999999999999999999999999999999999e6144", MathContext.DECIMAL128);
-
 
     // Variable used to track the kind of a decimal value.
     @Deprecated

--- a/bvm/ballerina-runtime/src/main/resources/MessagesBundle.properties
+++ b/bvm/ballerina-runtime/src/main/resources/MessagesBundle.properties
@@ -238,6 +238,7 @@ config.cli.args.ambiguity = configurable value for variable ''{0}'' clashes with
 config.cli.unused.args = [{0}] unused command line argument
 large.number.of.exponents.in.decimal = too many exponents found in decimal value ''{0}''
 unsupported.decimal.value = decimal operation resulting in unsupported decimal value ''{0}''
+decimal.value.out.of.range = decimal range overflow
 config.size.mismatch = [{0}] the size for configurable variable ''{1}'' is expected to be ''{2}'', \
   but found ''{3}''
 invalid.utf8.byte.array.value = array contains invalid UTF-8 byte value

--- a/bvm/ballerina-runtime/src/test/java/io/ballerina/runtime/test/cli/OperandTest.java
+++ b/bvm/ballerina-runtime/src/test/java/io/ballerina/runtime/test/cli/OperandTest.java
@@ -63,7 +63,7 @@ public class OperandTest {
     @Test
     public void testDecimal() {
         Operand[] operands = {new Operand(false, "opDecimal", PredefinedTypes.TYPE_DECIMAL)};
-        String val = "1e10111";
+        String val = "9.999999999999999999999999999999999e6144";
         Object[] args = new CliSpec(null, operands, val).getMainArgs();
         Assert.assertTrue(args[1] instanceof BDecimal);
         Assert.assertEquals(((BDecimal) args[1]).value(), new BigDecimal(val));

--- a/langlib/langlib-test/src/test/resources/test-src/decimallib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/decimallib_test.bal
@@ -397,9 +397,9 @@ function testFromStringFunctionWithInvalidValues() {
         assertEquality("'string' value '' cannot be converted to 'decimal'", <string> checkpanic a1.detail()["message"]);
     }
 
-    a1 = decimal:fromString("1e-6144");
+    a1 = decimal:fromString("1e-6143");
     assertEquality(false, a1 is error);
-    assertEquality(0d, checkpanic a1);
+    assertEquality(1e-6143d, checkpanic a1);
 
     a1 = trap decimal:fromString("9.999999999999999999999999999999999E6145");
     assertEquality(true, a1 is error);
@@ -563,11 +563,11 @@ function testQuantizeFunctionWithInvalidOutput() {
     assertEquality(true, a1 is error);
     assertEquality("{ballerina/lang.decimal}QuantizeError", (<error> a1).message());
     
-    a1 = trap decimal:quantize(0.000000000000000000000000000000000E6-6143, 1E-6143);
+    a1 = trap decimal:quantize(0.000000000000000000000000000000000E6-6176, 1E-6176);
     assertEquality(true, a1 is error);
     assertEquality("{ballerina/lang.decimal}QuantizeError", (<error> a1).message());
 
-    a1 = trap decimal:quantize(0.000000000000000000000000000000000E6-6143, 1E-6142);
+    a1 = trap decimal:quantize(0.000000000000000000000000000000000E6-6176, 1E-6175);
     assertEquality(true, a1 is error);
     assertEquality("{ballerina/lang.decimal}QuantizeError", (<error> a1).message());
 }

--- a/langlib/langlib-test/src/test/resources/test-src/decimallib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/decimallib_test.bal
@@ -396,6 +396,24 @@ function testFromStringFunctionWithInvalidValues() {
         assertEquality("{ballerina/lang.decimal}NumberParsingError", a1.message());
         assertEquality("'string' value '' cannot be converted to 'decimal'", <string> checkpanic a1.detail()["message"]);
     }
+
+    a1 = decimal:fromString("1e-6144");
+    assertEquality(false, a1 is error);
+    assertEquality(0d, checkpanic a1);
+
+    a1 = trap decimal:fromString("9.999999999999999999999999999999999E6145");
+    assertEquality(true, a1 is error);
+    if (a1 is error) {
+        assertEquality("{ballerina}NumberOverflow", a1.message());
+        assertEquality("decimal range overflow", <string> checkpanic a1.detail()["message"]);
+    }
+
+    a1 = trap decimal:fromString("10E6145");
+    assertEquality(true, a1 is error);
+    if (a1 is error) {
+        assertEquality("{ballerina}NumberOverflow", a1.message());
+        assertEquality("decimal range overflow", <string> checkpanic a1.detail()["message"]);
+    }
 }
 
 function testQuantize() {
@@ -506,9 +524,9 @@ function testQuantize() {
     assertEquality(decimal:quantize(-0.26E-2, 10E-2), -0.00d);
     assertEquality(decimal:quantize(-0.26E-2, 10E-1), 0d);
     assertEquality(decimal:quantize(-0.26E-2, 10E0), 0d);
-    assertEquality(decimal:quantize(9.999999999999999999999999999999999E6144, 1E6144), 1.0E+6145d);
-    assertEquality(decimal:quantize(9.999999999999999999999999999999999E6144, 1E6145), 1.0E+6145d);
-    assertEquality(decimal:quantize(9.999999999999999999999999999999999E6144, 1E6145), 1.0E+6145d);
+    assertEquality(decimal:quantize(9.999999999999999999999999999999999E6143, 1E6143), 1.0E+6144d);
+    assertEquality(decimal:quantize(9.999999999999999999999999999999999E6143, 1E6144), 1.0E+6144d);
+    assertEquality(decimal:quantize(9.999999999999999999999999999999999E6143, 1E6144), 1.0E+6144d);
     assertEquality(decimal:quantize(1E-6142, 1E0), 0d);
     assertEquality(decimal:quantize(1E-6142, 1E10), 0d);
     assertEquality(decimal:quantize(1E-6142, 1E-6142), 1E-6142d);
@@ -545,11 +563,11 @@ function testQuantizeFunctionWithInvalidOutput() {
     assertEquality(true, a1 is error);
     assertEquality("{ballerina/lang.decimal}QuantizeError", (<error> a1).message());
     
-    a1 = trap decimal:quantize(0.000000000000000000000000000000000E6-6176, 1E-6176);
+    a1 = trap decimal:quantize(0.000000000000000000000000000000000E6-6143, 1E-6143);
     assertEquality(true, a1 is error);
     assertEquality("{ballerina/lang.decimal}QuantizeError", (<error> a1).message());
 
-    a1 = trap decimal:quantize(0.000000000000000000000000000000000E6-6176, 1E-6175);
+    a1 = trap decimal:quantize(0.000000000000000000000000000000000E6-6143, 1E-6142);
     assertEquality(true, a1 is error);
     assertEquality("{ballerina/lang.decimal}QuantizeError", (<error> a1).message());
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExprTest.java
@@ -642,9 +642,9 @@ public class TypeCastExprTest {
         Assert.assertEquals(returns.toString(), "{\"name\":\"Pubudu\"}");
     }
 
-    @Test
-    public void testDecimalToIntCasting() {
-        BRunUtil.invoke(result, "testDecimalToIntCasting");
+    @Test(dataProvider = "typeCastExprTestFunctions")
+    public void testSimpleValueCasting(String function) {
+        BRunUtil.invoke(result, function);
     }
 
     @Test(dataProvider = "typesTestExpressionTestFunctions")
@@ -655,6 +655,15 @@ public class TypeCastExprTest {
     @Test(dataProvider = "immutableArrayTypesTestFunctions")
     public void testCastOfImmutableArrayTypes(String function) {
         BRunUtil.invoke(result, function);
+    }
+
+    @DataProvider(name = "typeCastExprTestFunctions")
+    public Object[] typeCastExprTestFunctions() {
+        return new Object[] {
+                "testDecimalToIntCasting",
+                "testFloatToDecimalCasting",
+                "testDecimalToFloatCasting"
+        };
     }
 
     @DataProvider(name = "typesTestExpressionTestFunctions")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExprTest.java
@@ -642,6 +642,11 @@ public class TypeCastExprTest {
         Assert.assertEquals(returns.toString(), "{\"name\":\"Pubudu\"}");
     }
 
+    @Test
+    public void testDecimalToIntCasting() {
+        BRunUtil.invoke(result, "testDecimalToIntCasting");
+    }
+
     @Test(dataProvider = "typesTestExpressionTestFunctions")
     public void testTypeTestsExpression(String function) {
         BRunUtil.invoke(result, function);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/decimaltype/BDecimalValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/decimaltype/BDecimalValueTest.java
@@ -291,6 +291,11 @@ public class BDecimalValueTest {
         BRunUtil.invoke(result, "testDecimalZeroOperations");
     }
 
+    @Test
+    public void testDecimalValueOverflow() {
+        BRunUtil.invoke(result, "testDecimalValueOverflow");
+    }
+
     @Test()
     public void testDecimalValUsingIntLiterals() {
         BRunUtil.invoke(result, "testDecimalValUsingIntLiterals");

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typecast/type-casting.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typecast/type-casting.bal
@@ -28,6 +28,25 @@ function stringtoint(string value) returns int|error {
     return result;
 }
 
+function testDecimalToIntCasting() {
+    decimal d1 = -9223372036854775807d;
+    int i1 = -9223372036854775807;
+    int res = <int> d1;
+    assertEquality(i1, res);
+
+    decimal d2 = 9223372036854775807d;
+    res = <int> d2;
+    assertEquality(9223372036854775807, res);
+
+    decimal d3 = -9223372036854775808.9d;
+    int|error result = trap <int> d3;
+    assertEquality(true, result is error);
+    error err = <error> result;
+    assertEquality("{ballerina}NumberConversionError", err.message());
+    assertEquality("'decimal' value '-9223372036854775808.9' cannot be converted to 'int'",
+                    checkpanic <string|error> err.detail()["message"]);
+}
+
 function testIntSubtypeArrayCasting() {
 
     byte[] byteArray = [1, 128, 255];

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typecast/type-casting.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typecast/type-casting.bal
@@ -47,6 +47,26 @@ function testDecimalToIntCasting() {
                     checkpanic <string|error> err.detail()["message"]);
 }
 
+function testDecimalToFloatCasting() {
+    decimal d = 0.0000000000000009e+308;
+    float f = <float> d;
+    assertEquality(9E+292, f);
+
+    d = 9.999999999999999999999999999999999E6001d;
+    f = <float> d;
+    assertEquality(float:Infinity, f);
+}
+
+function testFloatToDecimalCasting() {
+    float f = 0.0000000000000009e+308;
+    decimal d = <decimal> f;
+    assertEquality(9E+292d, d);
+
+    f = -1.999999999e-200;
+    d = <decimal> f;
+    assertEquality(-1.999999999E-200d, d);
+}
+
 function testIntSubtypeArrayCasting() {
 
     byte[] byteArray = [1, 128, 255];

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typecast/type-casting.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typecast/type-casting.bal
@@ -29,21 +29,36 @@ function stringtoint(string value) returns int|error {
 }
 
 function testDecimalToIntCasting() {
-    decimal d1 = -9223372036854775807d;
-    int i1 = -9223372036854775807;
-    int res = <int> d1;
-    assertEquality(i1, res);
+    decimal d = -9223372036854775807d;
+    int res = <int> d;
+    assertEquality(-9223372036854775807, res);
 
-    decimal d2 = 9223372036854775807d;
-    res = <int> d2;
+    d = 9223372036854775807d;
+    res = <int> d;
     assertEquality(9223372036854775807, res);
 
-    decimal d3 = -9223372036854775808.9d;
-    int|error result = trap <int> d3;
+    d = 9223372036854775806.5d;
+    res = <int> d;
+    assertEquality(9223372036854775806, res);
+
+    d = -9223372036854775805.5d;
+    res = <int> d;
+    assertEquality(-9223372036854775806, res);
+
+    d = -9223372036854775808.9d;
+    int|error result = trap <int> d;
     assertEquality(true, result is error);
     error err = <error> result;
     assertEquality("{ballerina}NumberConversionError", err.message());
     assertEquality("'decimal' value '-9223372036854775808.9' cannot be converted to 'int'",
+                    checkpanic <string|error> err.detail()["message"]);
+
+    d = 9223372036854775807.5d;
+    result = trap <int> d;
+    assertEquality(true, result is error);
+    err = <error> result;
+    assertEquality("{ballerina}NumberConversionError", err.message());
+    assertEquality("'decimal' value '9223372036854775807.5' cannot be converted to 'int'",
                     checkpanic <string|error> err.detail()["message"]);
 }
 
@@ -52,9 +67,21 @@ function testDecimalToFloatCasting() {
     float f = <float> d;
     assertEquality(9E+292, f);
 
+    d = -0.0000000000000009e+308;
+    f = <float> d;
+    assertEquality(-9E+292, f);
+
+    d = -0.0000000000000005e-308;
+    f = <float> d;
+    assertEquality(-5E-324, f);
+
     d = 9.999999999999999999999999999999999E6001d;
     f = <float> d;
     assertEquality(float:Infinity, f);
+
+    d = -9.999999999999999999999999999999999E6001d;
+    f = <float> d;
+    assertEquality(-float:Infinity, f);
 }
 
 function testFloatToDecimalCasting() {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/decimal/decimal_value.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/decimal/decimal_value.bal
@@ -291,6 +291,38 @@ function testDecimalTypeRef() {
     assertEquality(sec2 is decimal, true);
 }
 
+function testDecimalValueOverflow() {
+    decimal|error d = trap 9.999999999999999999999999999999999E6001d * 1E145d;
+    assertEquality(true, d is error);
+    error err = <error> d;
+    assertEquality("{ballerina}NumberOverflow", err.message());
+    assertEquality("decimal range overflow", checkpanic <string|error> err.detail()["message"]);
+
+    d = trap -9.999999999999999999999999999999999E6141d * 1E5d;
+    assertEquality(true, d is error);
+    err = <error> d;
+    assertEquality("{ballerina}NumberOverflow", err.message());
+    assertEquality("decimal range overflow", checkpanic <string|error> err.detail()["message"]);
+
+    d = trap 9.999999999999999999999999999999999E6144d + 1E6143d;
+    assertEquality(true, d is error);
+    err = <error> d;
+    assertEquality("{ballerina}NumberOverflow", err.message());
+    assertEquality("decimal range overflow", checkpanic <string|error> err.detail()["message"]);
+
+    d = trap -1E6144d - 9.999999999999999999999999999999999E6144d;
+    assertEquality(true, d is error);
+    err = <error> d;
+    assertEquality("{ballerina}NumberOverflow", err.message());
+    assertEquality("decimal range overflow", checkpanic <string|error> err.detail()["message"]);
+
+    d = trap 1E614d / 2E-5800d;
+    assertEquality(true, d is error);
+    err = <error> d;
+    assertEquality("{ballerina}NumberOverflow", err.message());
+    assertEquality("decimal range overflow", checkpanic <string|error> err.detail()["message"]);
+}
+
 type AssertionError distinct error;
 
 const ASSERTION_ERROR_REASON = "AssertionError";


### PR DESCRIPTION
## Purpose
> $title

Fixes #33805

## Approach
> Determine MIN and MAX values for Ballerina decimal values per IEEE 754 Decimal encoding spec.

## Samples

## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
