### PR TITLE
[2201.2.x] Align finding logic with improved resource-access-action location information

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/ReferenceFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/ReferenceFinder.java
@@ -1298,7 +1298,7 @@ public class ReferenceFinder extends BaseVisitor {
         if (!resourceAccessInvocation.pkgAlias.value.isEmpty()) {
             addIfSameSymbol(resourceAccessInvocation.symbol.owner, resourceAccessInvocation.pkgAlias.pos);
         }
-        addIfSameSymbol(resourceAccessInvocation.symbol, resourceAccessInvocation.pos);
+        addIfSameSymbol(resourceAccessInvocation.symbol, resourceAccessInvocation.resourceAccessPathSegments.pos);
     }
 
     // Private methods

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
@@ -1591,14 +1591,20 @@ class SymbolFinder extends BaseVisitor {
 
     @Override
     public void visit(BLangInvocation.BLangResourceAccessInvocation resourceAccessInvocation) {
-        if (setEnclosingNode(resourceAccessInvocation.symbol, resourceAccessInvocation.pos)) {
-            return;
-        }
         lookupNodes(resourceAccessInvocation.annAttachments);
-        lookupNode(resourceAccessInvocation.resourceAccessPathSegments);
+        lookupNode(resourceAccessInvocation.resourceAccessPathSegments); //TODO: Need symbols for path segments (#37604)
         lookupNodes(resourceAccessInvocation.requiredArgs);
         lookupNodes(resourceAccessInvocation.restArgs);
         lookupNode(resourceAccessInvocation.expr);
+
+        // The assumption is that if it's moduled-qualified, it must be a public symbol.
+        // Hence, the owner would be a package symbol.
+        if (resourceAccessInvocation.symbol != null &&
+                setEnclosingNode(resourceAccessInvocation.symbol.owner, resourceAccessInvocation.pkgAlias.pos)) {
+            return;
+        }
+
+        setEnclosingNode(resourceAccessInvocation.symbol, resourceAccessInvocation.resourceAccessPathSegments.pos);
     }
 
     private boolean setEnclosingNode(BSymbol symbol, Location pos) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SyntaxNodeToLocationMapper.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SyntaxNodeToLocationMapper.java
@@ -185,7 +185,7 @@ public class SyntaxNodeToLocationMapper extends NodeTransformer<Optional<Locatio
 
     @Override
     public Optional<Location> transform(ClientResourceAccessActionNode clientResourceAccessActionNode) {
-        return Optional.of(clientResourceAccessActionNode.location());
+        return Optional.of(clientResourceAccessActionNode.slashToken().location());
     }
 
     @Override

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/actions/SymbolsInResourceAccessActionTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/actions/SymbolsInResourceAccessActionTest.java
@@ -20,12 +20,14 @@ import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.impl.symbols.resourcepath.BallerinaPathSegmentList;
 import io.ballerina.compiler.api.symbols.FunctionTypeSymbol;
 import io.ballerina.compiler.api.symbols.ResourceMethodSymbol;
+import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.resourcepath.ResourcePath;
 import io.ballerina.compiler.api.symbols.resourcepath.util.PathSegment;
 import io.ballerina.projects.Document;
 import io.ballerina.projects.Project;
+import io.ballerina.tools.text.LinePosition;
 import org.ballerinalang.test.BCompileUtil;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
@@ -33,6 +35,7 @@ import org.testng.annotations.Test;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.assertBasicsAndGetSymbol;
 import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDefaultModulesSemanticModel;
@@ -56,7 +59,7 @@ public class SymbolsInResourceAccessActionTest {
         srcFile = getDocumentForSingleSource(project);
     }
 
-    @Test(dataProvider = "SymbolPosInResourceAccessAction")
+    @Test(dataProvider = "ResourceAccessActionPosition")
     public void testResourceAccessAction(int line, int col, String name, Map<String, PathSegment.Kind> pathSegments) {
         ResourceMethodSymbol sym = (ResourceMethodSymbol)
                 assertBasicsAndGetSymbol(model, srcFile, line, col, name, SymbolKind.RESOURCE_METHOD);
@@ -66,19 +69,43 @@ public class SymbolsInResourceAccessActionTest {
         assertEquals(functionTypeSymbol.typeKind(), TypeDescKind.FUNCTION);
     }
 
-    @DataProvider(name = "SymbolPosInResourceAccessAction")
-    public Object[][] getPathSegmentInfo() {
+    @DataProvider(name = "ResourceAccessActionPosition")
+    public Object[][] getResourceAccessActionPosAndPathSegments() {
         return new Object[][]{
-                {40, 23, "get", Map.of(
+                {40, 34, "get", Map.of(
                         "foo", PathSegment.Kind.NAMED_SEGMENT,
                         "bar", PathSegment.Kind.NAMED_SEGMENT,
                         "[string id]", PathSegment.Kind.PATH_PARAMETER)},
-                {41, 14, "get", Map.of(
+                {41, 25, "get", Map.of(
                         "foo", PathSegment.Kind.NAMED_SEGMENT,
                         "[string id]", PathSegment.Kind.PATH_PARAMETER)},
-                {42, 17, "post", Map.of(
+                {42, 28, "post", Map.of(
                         "bar", PathSegment.Kind.NAMED_SEGMENT,
                         "[string... ids]", PathSegment.Kind.PATH_REST_PARAMETER)},
+        };
+    }
+
+    @Test(dataProvider = "SymbolPosInResourceAccessAction")
+    public void testSymbolsInResourceAccessAction(int line, int col, String name, SymbolKind symbolKind) {
+        Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, col));
+        if (name == null) {
+            assertTrue(symbol.isEmpty());
+            return;
+        }
+        assertTrue(symbol.isPresent());
+        assertEquals(symbol.get().kind(), symbolKind);
+        assertTrue(symbol.get().getName().isPresent());
+        assertEquals(symbol.get().getName().get(), name);
+    }
+
+    @DataProvider(name = "SymbolPosInResourceAccessAction")
+    public Object[][] getSymbolPosInResourceAccessAction() {
+        return new Object[][]{
+                {40, 23, "fooClient", SymbolKind.VARIABLE}, // <c>fooClient->/foo
+                {40, 32, null, null},   // -><c>/foo
+                {40, 34, "get", SymbolKind.RESOURCE_METHOD},    // <c>->
+//                {40, 35, "foo", <undefined>}, // ->/<c>foo    //TODO: Enable this after fixing #37604
+                {40, 49, "x", SymbolKind.CONSTANT}  // ["3"](<c>x, 2);
         };
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsInResourceAccessActionTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsInResourceAccessActionTest.java
@@ -34,18 +34,27 @@ public class FindRefsInResourceAccessActionTest extends FindAllReferencesTest {
     @DataProvider(name = "PositionProvider")
     public Object[][] getLookupPositions() {
         return new Object[][]{
-                {40, 23, location(22, 21, 24),
+                {40, 23, location(39, 7, 16),
+                        List.of(location(39, 7, 16),
+                                location(40, 23, 32),
+                                location(41, 14, 23),
+                                location(42, 17, 26))
+                },
+
+                // Resource function invocation
+                // Note: The symbol location of the resource-function is set to function-name's location
+                {40, 34, location(22, 21, 24),
                         List.of(location(22, 21, 24),
-                                location(40, 23, 54),
-                                location(46, 16, 50))
+                                location(40, 34, 48),
+                                location(46, 27, 42))
                 },
-                {41, 14, location(29, 21, 24),
+                {41, 25, location(29, 21, 24),
                         List.of(location(29, 21, 24),
-                                location(41, 14, 41))
+                                location(41, 25, 35))
                 },
-                {42, 17, location(33, 21, 25),
+                {42, 28, location(33, 21, 25),
                         List.of(location(33, 21, 25),
-                                location(42, 17, 53))
+                                location(42, 28, 38))
                 }
         };
     }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByClientResourceAccessActionTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByClientResourceAccessActionTest.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static io.ballerina.compiler.api.symbols.SymbolKind.RESOURCE_METHOD;
+import static io.ballerina.compiler.api.symbols.SymbolKind.VARIABLE;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -60,7 +61,11 @@ public class SymbolByClientResourceAccessActionTest extends SymbolByNodeTest {
                 ResourceMethodSymbol symbol =
                         (ResourceMethodSymbol) assertSymbol(clientResourceAccessActionNode, model, RESOURCE_METHOD,
                                                                 "post");
-                symbol.resourcePath();
+
+                // expression
+                assertSymbol(clientResourceAccessActionNode.expression(), model, VARIABLE, "cl");
+
+                // Resource-path
                 assertEquals(symbol.resourcePath().kind(), ResourcePath.Kind.PATH_SEGMENT_LIST);
 
                 PathSegmentList pathSegmentList = (PathSegmentList) symbol.resourcePath();
@@ -90,7 +95,7 @@ public class SymbolByClientResourceAccessActionTest extends SymbolByNodeTest {
 
     @Override
     void verifyAssertCount() {
-        assertEquals(getAssertCount(), 2);
+        assertEquals(getAssertCount(), 3);
     }
 
     private Symbol assertSymbol(Node node, SemanticModel model, SymbolKind kind, String name) {

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/actions/resource_access_action.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/actions/resource_access_action.bal
@@ -38,7 +38,9 @@ client class Foo {
 
 public function main() {
    Foo fooClient = new();
-   Person|error wVal = fooClient->/foo/bar/["3"](1, 2);
+   Person|error wVal = fooClient->/foo/bar/["3"](x, 2);
    int xVal = fooClient->/foo/["3"](1, 2);
    string yVal = fooClient->/bar/["3"].post("myname");
 }
+
+const x = 1;


### PR DESCRIPTION
## Purpose
$title

Fixes #38055

## Approach
Use the location of the resource-path-list to distinguish the resource-access-action and expression

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [x] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
