### PR TITLE
Simplify the return type descriptor for verbose module IDs in refactor extract code actions

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToFunctionCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToFunctionCodeAction.java
@@ -372,7 +372,7 @@ public class ExtractToFunctionCodeAction implements RangeBasedCodeActionProvider
         List<String> argsForReplaceFunctionCall = argLists.get().replaceFunctionCallArgs;
 
         String functionName = getFunctionName(context, matchedCodeActionNode);
-        String function = getFunction(matchedCodeActionNode, newLineAtEnd, typeSymbol.get(), functionName,
+        String function = getFunction(context, matchedCodeActionNode, newLineAtEnd, typeSymbol.get(), functionName,
                 argsForExtractFunction);
 
         String replaceFunctionCall = getReplaceFunctionCall(argsForReplaceFunctionCall, functionName, true);
@@ -414,9 +414,10 @@ public class ExtractToFunctionCodeAction implements RangeBasedCodeActionProvider
         return isExpr ? funcCall : funcCall + CommonKeys.SEMI_COLON_SYMBOL_KEY;
     }
 
-    private String getFunction(NonTerminalNode matchedNode, boolean newLineEnd, TypeSymbol typeSymbol,
-                               String functionName, List<String> args) {
-        String returnsClause = String.format("returns %s", typeSymbol.signature());
+    private String getFunction(CodeActionContext context, NonTerminalNode matchedNode, boolean newLineEnd, 
+                               TypeSymbol typeSymbol, String functionName, List<String> args) {
+        String returnsClause = 
+                String.format("returns %s", FunctionGenerator.getReturnTypeAsString(context, typeSymbol.signature()));
         String returnStatement;
 
         if (matchedNode.kind() == SyntaxKind.BRACED_EXPRESSION) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToLocalVarCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToLocalVarCodeAction.java
@@ -31,6 +31,7 @@ import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.codeaction.CodeActionNodeValidator;
 import org.ballerinalang.langserver.codeaction.CodeActionUtil;
 import org.ballerinalang.langserver.common.constants.CommandConstants;
+import org.ballerinalang.langserver.common.utils.FunctionGenerator;
 import org.ballerinalang.langserver.common.utils.NameUtil;
 import org.ballerinalang.langserver.common.utils.PositionUtil;
 import org.ballerinalang.langserver.commons.CodeActionContext;
@@ -128,7 +129,8 @@ public class ExtractToLocalVarCodeAction implements RangeBasedCodeActionProvider
             return Collections.emptyList();
         }
         String paddingStr = StringUtils.repeat(" ", statementNode.lineRange().startLine().offset());
-        String varDeclStr = String.format("%s %s = %s;%n%s", typeSymbol.get().signature(), varName, value, paddingStr);
+        String typeDescriptor = FunctionGenerator.getReturnTypeAsString(context, typeSymbol.get().signature());
+        String varDeclStr = String.format("%s %s = %s;%n%s", typeDescriptor, varName, value, paddingStr);
         Position varDeclPos = new Position(statementNode.lineRange().startLine().line(), 
                 statementNode.lineRange().startLine().offset());
         TextEdit varDeclEdit = new TextEdit(new Range(varDeclPos, varDeclPos), varDeclStr);

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ExtractToFunctionCodeActionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ExtractToFunctionCodeActionTest.java
@@ -117,6 +117,7 @@ public class ExtractToFunctionCodeActionTest extends AbstractCodeActionTest {
                 {"extract_to_function_exprs_method_call.json"},
                 {"extract_to_function_exprs_mapping_constructor_module.json"},
                 {"extract_to_function_exprs_mapping_constructor_local.json"},
+                {"extract_to_function_exprs_mapping_constructor_imported_module.json"},
                 {"extract_to_function_exprs_computed_name_field.json"},
                 {"extract_to_function_exprs_field_name_expr.json"},
                 {"extract_to_function_exprs_typeof_expr.json"},

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ExtractToLocalVarTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ExtractToLocalVarTest.java
@@ -56,6 +56,7 @@ public class ExtractToLocalVarTest extends AbstractCodeActionTest {
                 {"extractToVariableInMappingConstructor.json"},
                 {"extractToVariableInMappingConstructor2.json"},
                 {"extractToVariableInMappingConstructor3.json"},
+                {"extractToVariableInMappingConstructor4.json"},
                 {"extractToVariableInTypeofExpression.json"},
                 {"extractToVariableInUnaryExpression.json"},
                 {"extractToVariableInTypeTestExpression.json"},

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-function/config/extract_to_function_exprs_mapping_constructor_imported_module.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-function/config/extract_to_function_exprs_mapping_constructor_imported_module.json
@@ -1,0 +1,49 @@
+{
+  "range": {
+    "start": {
+      "line": 3,
+      "character": 30
+    },
+    "end": {
+      "line": 3,
+      "character": 62
+    }
+  },
+  "source": "extract_to_function_exprs_mapping_constructor_imported_module.bal",
+  "description": "Extract to function for expressions, mapping constructor of type which is imported from a module, inside function block",
+  "expected": [
+    {
+      "title": "Extract to function",
+      "kind": "refactor.extract",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 4,
+              "character": 1
+            },
+            "end": {
+              "line": 4,
+              "character": 1
+            }
+          },
+          "newText": "\n\nfunction extracted() returns module1:TestRecord2 {\n    return {rec2Field1: 10, rec3Field2: \"\"};\n}"
+        },
+        {
+          "range": {
+            "start": {
+              "line": 3,
+              "character": 30
+            },
+            "end": {
+              "line": 3,
+              "character": 62
+            }
+          },
+          "newText": "extracted()"
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-function/source/extract_to_function_exprs_mapping_constructor_imported_module.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-function/source/extract_to_function_exprs_mapping_constructor_imported_module.bal
@@ -1,0 +1,5 @@
+import ballerina/module1;
+
+function testFunction() {
+    module1:TestRecord2 rec = {rec2Field1: 10, rec3Field2: ""};
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInMappingConstructor4.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInMappingConstructor4.json
@@ -1,0 +1,48 @@
+{
+  "range": {
+    "start": {
+      "line": 3,
+      "character": 30
+    },
+    "end": {
+      "line": 3,
+      "character": 62
+    }
+  },
+  "source": "extractToVariableInMappingConstructor2.bal",
+  "expected": [
+    {
+      "title": "Extract to local variable",
+      "kind": "refactor.extract",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 3,
+              "character": 4
+            },
+            "end": {
+              "line": 3,
+              "character": 4
+            }
+          },
+          "newText": "module1:TestRecord2 var1 = {rec2Field1: 10, rec3Field2: \"\"};\n    "
+        },
+        {
+          "range": {
+            "start": {
+              "line": 3,
+              "character": 30
+            },
+            "end": {
+              "line": 3,
+              "character": 62
+            }
+          },
+          "newText": "var1"
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/source/extractToVariableInMappingConstructor2.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/source/extractToVariableInMappingConstructor2.bal
@@ -1,0 +1,5 @@
+import ballerina/module1;
+
+function testFunction() {
+    module1:TestRecord2 rec = {rec2Field1: 10, rec3Field2: ""};
+}


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues.

Fixes #38056

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
