### PR TITLE
[2201.3.x] Fix typeOf() giving incorrect typeSymbol for basic literal type

### DIFF
--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typeof/TypeOfRegressionTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typeof/TypeOfRegressionTest.java
@@ -63,4 +63,15 @@ public class TypeOfRegressionTest {
         assertEquals(clazz.typeKind(), TypeDescKind.OBJECT);
         assertEquals(clazz.getName().get(), "Listener");
     }
+
+    @Test
+    public void testLiteralType() {
+        Optional<TypeSymbol> type = model.typeOf(
+                LineRange.from("typeof_listener_test.bal",
+                        LinePosition.from(45, 32), LinePosition.from(45, 36)));
+
+        assertTrue(type.isPresent());
+        assertEquals(type.get().kind(), SymbolKind.TYPE);
+        assertEquals(type.get().typeKind(), TypeDescKind.INT);
+    }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typeof/TypeOfRegressionTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typeof/TypeOfRegressionTest.java
@@ -66,9 +66,8 @@ public class TypeOfRegressionTest {
 
     @Test
     public void testLiteralType() {
-        Optional<TypeSymbol> type = model.typeOf(
-                LineRange.from("typeof_listener_test.bal",
-                        LinePosition.from(45, 32), LinePosition.from(45, 36)));
+        Optional<TypeSymbol> type = model.typeOf(LineRange.from("typeof_listener_test.bal",
+                                LinePosition.from(45, 32), LinePosition.from(45, 36)));
 
         assertTrue(type.isPresent());
         assertEquals(type.get().kind(), SymbolKind.TYPE);

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/regression-tests/typeof_listener_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/regression-tests/typeof_listener_test.bal
@@ -42,3 +42,8 @@ public class Listener {
 
     public function immediateStop() returns error? {}
 }
+
+service on new module1:Listener(9090) {
+
+}
+

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/regression-tests/typeof_listener_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/regression-tests/typeof_listener_test.bal
@@ -44,6 +44,5 @@ public class Listener {
 }
 
 service on new module1:Listener(9090) {
-
 }
 


### PR DESCRIPTION

Fixes #37613 

This is already fixed in the branch, hence adding a testcase to validate the behavior.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
