### PR TITLE
Update LSPackageLoader to consider the modules of the current package [2201.2.x]

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/imports/ImportModuleCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/imports/ImportModuleCodeAction.java
@@ -88,7 +88,7 @@ public class ImportModuleCodeAction implements DiagnosticBasedCodeActionProvider
 
         String modulePrefix = qNameReferenceNode.get().modulePrefix().text();
 
-        List<LSPackageLoader.PackageInfo> packagesList = LSPackageLoader
+        List<LSPackageLoader.ModuleInfo> packagesList = LSPackageLoader
                 .getInstance(context.languageServercontext()).getAllVisiblePackages(context);
 
         // Check if we already have packages imported with the given module prefix but with different aliases
@@ -131,9 +131,11 @@ public class ImportModuleCodeAction implements DiagnosticBasedCodeActionProvider
                     String pkgName = pkgEntry.packageName().value();
                     String moduleName = ModuleUtil.escapeModuleName(pkgName);
                     Position insertPos = getImportPosition(context);
-                    String importText = ItemResolverConstants.IMPORT + " " + orgName + "/"
+                    String importText = orgName.isEmpty() ? ItemResolverConstants.IMPORT + " " + moduleName + ";" +
+                            CommonUtil.LINE_SEPARATOR : ItemResolverConstants.IMPORT + " " + orgName + "/"
                             + moduleName + ";" + CommonUtil.LINE_SEPARATOR;
-                    String commandTitle = String.format(CommandConstants.IMPORT_MODULE_TITLE,
+                    String commandTitle = orgName.isEmpty() ? String.format(CommandConstants.IMPORT_MODULE_TITLE,
+                            moduleName) : String.format(CommandConstants.IMPORT_MODULE_TITLE,
                             orgName + "/" + moduleName);
                     List<TextEdit> edits = Collections.singletonList(
                             new TextEdit(new Range(insertPos, insertPos), importText));

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -307,9 +307,10 @@ public class CommonUtil {
      * @param pkg {@link Package} package info to evaluate
      * @return {@link String} label computed
      */
-    public static String getPackageLabel(LSPackageLoader.PackageInfo pkg) {
+    public static String getPackageLabel(LSPackageLoader.ModuleInfo pkg) {
         String orgName = "";
-        if (pkg.packageOrg().value() != null && !pkg.packageOrg().value().equals(Names.ANON_ORG.getValue())) {
+        if (!pkg.packageOrg().value().isEmpty() && pkg.packageOrg().value() != null
+                && !pkg.packageOrg().value().equals(Names.ANON_ORG.getValue())) {
             orgName = pkg.packageOrg().value() + "/";
         }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/ModuleUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/ModuleUtil.java
@@ -223,7 +223,7 @@ public class ModuleUtil {
      * @return {@link Optional}
      */
     public static Optional<ImportDeclarationNode> matchingImportedModule(CompletionContext context,
-                                                                         LSPackageLoader.PackageInfo pkg) {
+                                                                         LSPackageLoader.ModuleInfo pkg) {
         String name = pkg.packageName().value();
         String orgName = pkg.packageOrg().value();
         Map<ImportDeclarationNode, ModuleSymbol> currentDocImports = context.currentDocImportsMap();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/AbstractCompletionProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/AbstractCompletionProvider.java
@@ -373,13 +373,15 @@ public abstract class AbstractCompletionProvider<T extends Node> implements Ball
                         .map(ModuleUtil::escapeModuleName)
                         .map(CommonUtil::escapeReservedKeyword)
                         .collect(Collectors.toList());
+                String label = (pkgNameComps.size() > 1 && !orgName.equals("ballerina")) ?
+                        String.join(".", pkgNameComps) : CommonUtil.getPackageLabel(pkg);
                 String aliasComponent = pkgNameComps.get(pkgNameComps.size() - 1);
                 // TODO: 2021-04-23 This has to be revamped with completion/resolve request for faster responses 
                 String insertText = CommonUtil.escapeReservedKeyword(NameUtil.getValidatedSymbolName(ctx,
                         aliasComponent));
                 String alias = !insertText.equals(aliasComponent) ? insertText : "";
-                List<TextEdit> txtEdits = CommonUtil.getAutoImportTextEdits(orgName, name, alias, ctx);
-                CompletionItem item = getModuleCompletionItem(CommonUtil.getPackageLabel(pkg), insertText, txtEdits,
+                List<TextEdit> txtEdits = CommonUtil.getAutoImportTextEdits("", label, alias, ctx);
+                CompletionItem item = getModuleCompletionItem(label, insertText, txtEdits,
                         aliasComponent);
                 completionItems.add(new StaticCompletionItem(ctx, item, StaticCompletionItem.Kind.MODULE));
             }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/AbstractCompletionProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/AbstractCompletionProvider.java
@@ -373,8 +373,8 @@ public abstract class AbstractCompletionProvider<T extends Node> implements Ball
                         .map(ModuleUtil::escapeModuleName)
                         .map(CommonUtil::escapeReservedKeyword)
                         .collect(Collectors.toList());
-                String label = (pkgNameComps.size() > 1 && !orgName.equals("ballerina")) ?
-                        String.join(".", pkgNameComps) : CommonUtil.getPackageLabel(pkg);
+                String label = pkg.packageOrg().value().isEmpty() ? String.join(".", pkgNameComps)
+                        : CommonUtil.getPackageLabel(pkg);
                 String aliasComponent = pkgNameComps.get(pkgNameComps.size() - 1);
                 // TODO: 2021-04-23 This has to be revamped with completion/resolve request for faster responses 
                 String insertText = CommonUtil.escapeReservedKeyword(NameUtil.getValidatedSymbolName(ctx,

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ImportDeclarationNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ImportDeclarationNodeContext.java
@@ -200,8 +200,8 @@ public class ImportDeclarationNodeContext extends AbstractCompletionProvider<Imp
                     .map(ModuleUtil::escapeModuleName)
                     .map(CommonUtil::escapeReservedKeyword)
                     .collect(Collectors.toList());
-            String label = (pkgNameComps.size() > 1 && !orgName.equals("ballerina")) ?
-                    String.join(".", pkgNameComps) : CommonUtil.getPackageLabel(pkg);
+            String label = pkg.packageOrg().value().isEmpty() ? String.join(".", pkgNameComps)
+                    : CommonUtil.getPackageLabel(pkg);
             String insertText = orgName.isEmpty() ? "" : orgName + Names.ORG_NAME_SEPARATOR.getValue();
 
             if (orgName.equals(Names.BALLERINA_ORG.value)

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ImportOrgNameNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ImportOrgNameNodeContext.java
@@ -55,7 +55,7 @@ public class ImportOrgNameNodeContext extends AbstractCompletionProvider<ImportO
             throw new AssertionError("ModuleName cannot be empty");
         }
 
-        List<LSPackageLoader.PackageInfo> packagesList =
+        List<LSPackageLoader.ModuleInfo> packagesList =
                 new ArrayList<>(LSPackageLoader.getInstance(ctx.languageServercontext()).getDistributionRepoPackages());
         ArrayList<LSCompletionItem> completionItems = moduleNameContextCompletions(ctx, orgName, packagesList);
         this.sort(ctx, node, completionItems);
@@ -64,7 +64,7 @@ public class ImportOrgNameNodeContext extends AbstractCompletionProvider<ImportO
     }
 
     private ArrayList<LSCompletionItem> moduleNameContextCompletions(BallerinaCompletionContext context, String orgName,
-                                                                     List<LSPackageLoader.PackageInfo> packagesList) {
+                                                                     List<LSPackageLoader.ModuleInfo> packagesList) {
         ArrayList<LSCompletionItem> completionItems = new ArrayList<>();
         List<String> pkgNameLabels = new ArrayList<>();
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/util/ServiceTemplateGenerator.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/util/ServiceTemplateGenerator.java
@@ -175,7 +175,7 @@ public class ServiceTemplateGenerator {
             //Load distribution repo packages
             LSClientLogger clientLogger = LSClientLogger.getInstance(context);
             clientLogger.logTrace("Loading packages from the distribution");
-            List<LSPackageLoader.PackageInfo> packages = LSPackageLoader.getInstance(context)
+            List<LSPackageLoader.ModuleInfo> packages = LSPackageLoader.getInstance(context)
                     .getDistributionRepoPackages();
             loadListenersFromPackages(packages, context);
             this.isInitialized = true;
@@ -196,7 +196,7 @@ public class ServiceTemplateGenerator {
             //Load packages from BallerinaUserHome
             LSClientLogger clientLogger = LSClientLogger.getInstance(lsContext);
             clientLogger.logTrace("Loading modules from the BallerinaUserHome");
-            List<LSPackageLoader.PackageInfo> packages = LSPackageLoader.getInstance(lsContext)
+            List<LSPackageLoader.ModuleInfo> packages = LSPackageLoader.getInstance(lsContext)
                     .getPackagesFromBallerinaUserHome(context);
             loadListenersFromPackages(packages, lsContext);
             clientLogger.logTrace("Finished loading listener symbols from the  BallerinaUserHome");
@@ -208,7 +208,7 @@ public class ServiceTemplateGenerator {
      *
      * @param packages List of package info.
      */
-    private void loadListenersFromPackages(List<LSPackageLoader.PackageInfo> packages, LanguageServerContext context) {
+    private void loadListenersFromPackages(List<LSPackageLoader.ModuleInfo> packages, LanguageServerContext context) {
         packages.forEach(distPackage -> {
             String orgName = ModuleUtil.escapeModuleName(distPackage.packageOrg().value());
             Project project = ProjectLoader.loadProject(distPackage.sourceRoot());
@@ -241,7 +241,7 @@ public class ServiceTemplateGenerator {
      * @param newPackages packages list
      * @param context     language server context
      */
-    public void updateListenerMetaDataMap(List<LSPackageLoader.PackageInfo> newPackages,
+    public void updateListenerMetaDataMap(List<LSPackageLoader.ModuleInfo> newPackages,
                                           LanguageServerContext context) {
         this.loadListenersFromPackages(newPackages, context);
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/eventsync/subscribers/PullModuleSubscriber.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/eventsync/subscribers/PullModuleSubscriber.java
@@ -46,10 +46,10 @@ public class PullModuleSubscriber implements EventSubscriber {
     @Override
     public void onEvent(ExtendedLanguageClient client, DocumentServiceContext context,
                         LanguageServerContext languageServerContext) {
-        List<LSPackageLoader.PackageInfo> packageInfos =
+        List<LSPackageLoader.ModuleInfo> moduleInfos =
                 LSPackageLoader.getInstance(languageServerContext).updatePackageMap(context);
         ServiceTemplateGenerator.getInstance(context.languageServercontext())
-                .updateListenerMetaDataMap(packageInfos, context.languageServercontext());
+                .updateListenerMetaDataMap(moduleInfos, context.languageServercontext());
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/AbstractLSTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/AbstractLSTest.java
@@ -48,8 +48,8 @@ public abstract class AbstractLSTest {
     private static final Map<String, String> REMOTE_PROJECTS = Map.of("project1", "main.bal", "project2", "main.bal");
     private static final Map<String, String> LOCAL_PROJECTS =
             Map.of("local_project1", "main.bal", "local_project2", "main.bal");
-    private static final List<LSPackageLoader.PackageInfo> REMOTE_PACKAGES = new ArrayList<>();
-    private static final List<LSPackageLoader.PackageInfo> LOCAL_PACKAGES = new ArrayList<>();
+    private static final List<LSPackageLoader.ModuleInfo> REMOTE_PACKAGES = new ArrayList<>();
+    private static final List<LSPackageLoader.ModuleInfo> LOCAL_PACKAGES = new ArrayList<>();
 
     private Endpoint serviceEndpoint;
 
@@ -63,10 +63,10 @@ public abstract class AbstractLSTest {
         Endpoint endpoint = TestUtil.initializeLanguageSever(languageServer);
         try {
             REMOTE_PACKAGES.addAll(getPackages(REMOTE_PROJECTS,
-                    languageServer.getWorkspaceManager(), context).stream().map(LSPackageLoader.PackageInfo::new)
+                    languageServer.getWorkspaceManager(), context).stream().map(LSPackageLoader.ModuleInfo::new)
                     .collect(Collectors.toList()));
             LOCAL_PACKAGES.addAll(getPackages(LOCAL_PROJECTS,
-                    languageServer.getWorkspaceManager(), context).stream().map(LSPackageLoader.PackageInfo::new)
+                    languageServer.getWorkspaceManager(), context).stream().map(LSPackageLoader.ModuleInfo::new)
                     .collect(Collectors.toList()));
         } catch (Exception e) {
             //ignore
@@ -142,11 +142,11 @@ public abstract class AbstractLSTest {
         return this.lsPackageLoader;
     }
 
-    public static List<LSPackageLoader.PackageInfo> getLocalPackages() {
+    public static List<LSPackageLoader.ModuleInfo> getLocalPackages() {
         return LOCAL_PACKAGES;
     }
 
-    public static List<LSPackageLoader.PackageInfo> getRemotePackages() {
+    public static List<LSPackageLoader.ModuleInfo> getRemotePackages() {
         return REMOTE_PACKAGES;
     }
 }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/lspackageloader/LSPackageLoaderTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/lspackageloader/LSPackageLoaderTest.java
@@ -56,7 +56,7 @@ public class LSPackageLoaderTest extends AbstractLSTest {
 
     private final Path testRoot = FileUtils.RES_DIR.resolve("lspackageloader");
     private static final Map<String, String> REMOTE_PROJECTS = Map.of("project3", "main.bal");
-    private List<LSPackageLoader.PackageInfo> remoteRepoPackages = new ArrayList<>(getRemotePackages());
+    private List<LSPackageLoader.ModuleInfo> remoteRepoPackages = new ArrayList<>(getRemotePackages());
 
     @Test(dataProvider = "data-provider")
     public void test(String source) throws IOException, EventSyncException, WorkspaceDocumentException {
@@ -72,7 +72,7 @@ public class LSPackageLoaderTest extends AbstractLSTest {
                 ContextBuilder.buildDocumentServiceContext(sourcePath.toUri().toString(),
                         languageServer.getWorkspaceManager(), LSContextOperation.WS_EXEC_CMD,
                         languageServer.getServerContext());
-        //PackageInfo count before adding a new package
+        //ModuleInfo count before adding a new package
         int packageCount = getLoadedPackagesFromLoader(documentServiceContext).size();
 
         //Publish a mock event using pull module publisher.
@@ -100,18 +100,18 @@ public class LSPackageLoaderTest extends AbstractLSTest {
             Object[] arguments = invocation.getArguments();
             if (arguments != null && arguments.length == 1 && arguments[0] != null) {
                 DocumentServiceContext context = (DocumentServiceContext) arguments[0];
-                LSPackageLoader.PackageInfo packageInfo = getPackages(REMOTE_PROJECTS,
+                LSPackageLoader.ModuleInfo moduleInfo = getPackages(REMOTE_PROJECTS,
                         context.workspace(), context.languageServercontext()).stream()
-                        .map(LSPackageLoader.PackageInfo::new)
+                        .map(LSPackageLoader.ModuleInfo::new)
                         .collect(Collectors.toList()).get(0);
-                this.remoteRepoPackages.add(packageInfo);
-                return List.of(packageInfo);
+                this.remoteRepoPackages.add(moduleInfo);
+                return List.of(moduleInfo);
             }
             return null;
         }).when(lsPackageLoader).updatePackageMap(Mockito.any());
     }
 
-    private List<LSPackageLoader.PackageInfo> getLoadedPackagesFromLoader(DocumentServiceContext context) {
+    private List<LSPackageLoader.ModuleInfo> getLoadedPackagesFromLoader(DocumentServiceContext context) {
         Optional<Project> project = context.workspace().project(context.filePath());
         if (project.isEmpty()) {
             return Collections.emptyList();
@@ -134,7 +134,7 @@ public class LSPackageLoaderTest extends AbstractLSTest {
         return true;
     }
 
-    public List<LSPackageLoader.PackageInfo> getRemoteRepoPackages() {
+    public List<LSPackageLoader.ModuleInfo> getRemoteRepoPackages() {
         return remoteRepoPackages;
     }
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/enum_decl_ctx/config/config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/enum_decl_ctx/config/config3.json
@@ -280,7 +280,7 @@
       "kind": "Module",
       "detail": "Module",
       "sortText": "R",
-      "filterText": "",
+      "filterText": "constants",
       "insertText": "constants",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/type_test_expression_ctx_config9.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/type_test_expression_ctx_config9.json
@@ -415,7 +415,7 @@
       "kind": "Module",
       "detail": "Module",
       "sortText": "BCG",
-      "filterText": "",
+      "filterText": "mod4",
       "insertText": "mod4",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -439,7 +439,7 @@
       "kind": "Module",
       "detail": "Module",
       "sortText": "BCG",
-      "filterText": "",
+      "filterText": "lsmod2",
       "insertText": "lsmod2",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -463,7 +463,7 @@
       "kind": "Module",
       "detail": "Module",
       "sortText": "BCG",
-      "filterText": "",
+      "filterText": "lsmod1",
       "insertText": "lsmod1",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -610,6 +610,30 @@
       "sortText": "BG",
       "insertText": "function",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "projectls.lsmod3",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "BCG",
+      "filterText": "lsmod3",
+      "insertText": "lsmod3",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 0
+            },
+            "end": {
+              "line": 1,
+              "character": 0
+            }
+          },
+          "newText": "import projectls.lsmod3;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/function_def/config/config23.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function_def/config/config23.json
@@ -302,7 +302,7 @@
       "kind": "Module",
       "detail": "Module",
       "sortText": "R",
-      "filterText": "",
+      "filterText": "mod1",
       "insertText": "mod1",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -326,7 +326,7 @@
       "kind": "Module",
       "detail": "Module",
       "sortText": "R",
-      "filterText": "",
+      "filterText": "mod2",
       "insertText": "mod2",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -555,7 +555,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _chiran/projectls:0.1.0_  \n  \n  \n**Params**  \n- `string` a  \n- `int` b(Defaultable)  \n  \n**Return** `string`   \n  \n"
+          "value": "**Package:** _mindula/projectls:0.1.0_  \n  \n  \n**Params**  \n- `string` a  \n- `int` b(Defaultable)  \n  \n**Return** `string`   \n  \n"
         }
       },
       "sortText": "G",
@@ -585,7 +585,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _chiran/projectls:0.1.0_  \n  \n  \n  \n  \n**Return** `int`   \n  \n"
+          "value": "**Package:** _mindula/projectls:0.1.0_  \n  \n  \n  \n  \n**Return** `int`   \n  \n"
         }
       },
       "sortText": "AC",

--- a/language-server/modules/langserver-core/src/test/resources/completion/import_decl/config/config11.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/import_decl/config/config11.json
@@ -529,7 +529,7 @@
       "kind": "Module",
       "detail": "Module",
       "sortText": "R",
-      "filterText": "",
+      "filterText": "module4",
       "insertText": "module4",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -553,7 +553,7 @@
       "kind": "Module",
       "detail": "Module",
       "sortText": "R",
-      "filterText": "",
+      "filterText": "module2",
       "insertText": "module2",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -852,7 +852,7 @@
       ]
     },
     {
-      "label": "ballerina/module1",
+      "label": "lsproject.module1",
       "kind": "Module",
       "detail": "Module",
       "sortText": "R",
@@ -871,7 +871,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/module1 as module11;\n"
+          "newText": "import lsproject.module1 as module11;\n"
         }
       ]
     },
@@ -963,6 +963,30 @@
       "sortText": "R",
       "insertText": "function",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/module1",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "module1",
+      "insertText": "module11",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/module1 as module11;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/import_decl/config/config12.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/import_decl/config/config12.json
@@ -529,7 +529,7 @@
       "kind": "Module",
       "detail": "Module",
       "sortText": "R",
-      "filterText": "",
+      "filterText": "module4",
       "insertText": "module4",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -553,7 +553,7 @@
       "kind": "Module",
       "detail": "Module",
       "sortText": "R",
-      "filterText": "",
+      "filterText": "module2",
       "insertText": "module2",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -852,7 +852,7 @@
       ]
     },
     {
-      "label": "ballerina/module1",
+      "label": "lsproject.module1",
       "kind": "Module",
       "detail": "Module",
       "sortText": "R",
@@ -871,7 +871,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/module1 as module11;\n"
+          "newText": "import lsproject.module1 as module11;\n"
         }
       ]
     },
@@ -963,6 +963,30 @@
       "sortText": "R",
       "insertText": "function",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/module1",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "module1",
+      "insertText": "module11",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/module1 as module11;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/import_decl/config/config13.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/import_decl/config/config13.json
@@ -6,14 +6,6 @@
   "source": "import_decl/source/lsproject/modules/module3/main4.bal",
   "items": [
     {
-      "label": "lsproject",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "A",
-      "insertText": "lsproject.",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "lsproject.module2",
       "kind": "Module",
       "detail": "Module",
@@ -243,6 +235,14 @@
       "detail": "Module",
       "sortText": "C",
       "insertText": "ballerina/lang.'function;",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "lsproject.module1",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "A",
+      "insertText": "lsproject.module1",
       "insertTextFormat": "Snippet"
     }
   ]

--- a/language-server/modules/langserver-core/src/test/resources/completion/import_decl/config/config14.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/import_decl/config/config14.json
@@ -6,14 +6,6 @@
   "source": "import_decl/source/lsproject/modules/module3/main5.bal",
   "items": [
     {
-      "label": "lsproject",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "A",
-      "insertText": "lsproject.",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "lsproject.module2",
       "kind": "Module",
       "detail": "Module",
@@ -243,6 +235,14 @@
       "detail": "Module",
       "sortText": "C",
       "insertText": "ballerina/lang.'function;",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "lsproject.module1",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "A",
+      "insertText": "lsproject.module1",
       "insertTextFormat": "Snippet"
     }
   ]

--- a/language-server/modules/langserver-core/src/test/resources/completion/import_decl/config/config21.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/import_decl/config/config21.json
@@ -529,7 +529,7 @@
       "kind": "Module",
       "detail": "Module",
       "sortText": "R",
-      "filterText": "",
+      "filterText": "module4",
       "insertText": "module4",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -553,7 +553,7 @@
       "kind": "Module",
       "detail": "Module",
       "sortText": "R",
-      "filterText": "",
+      "filterText": "module2",
       "insertText": "module2",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -577,7 +577,7 @@
       "kind": "Module",
       "detail": "Module",
       "sortText": "R",
-      "filterText": "module11",
+      "filterText": "module1",
       "insertText": "module11",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [

--- a/language-server/modules/langserver-core/src/test/resources/completion/import_decl/config/config24.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/import_decl/config/config24.json
@@ -6,14 +6,6 @@
   "source": "import_decl/source/lsproject2/modules/module3/main.bal",
   "items": [
     {
-      "label": "'service",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "A",
-      "insertText": "'service.",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "'service.'transaction.'join",
       "kind": "Module",
       "detail": "Module",

--- a/language-server/modules/langserver-core/src/test/resources/completion/import_decl/config/config26.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/import_decl/config/config26.json
@@ -520,7 +520,7 @@
       "kind": "Module",
       "detail": "Module",
       "sortText": "R",
-      "filterText": "",
+      "filterText": "'join",
       "insertText": "'join",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -544,7 +544,7 @@
       "kind": "Module",
       "detail": "Module",
       "sortText": "R",
-      "filterText": "",
+      "filterText": "'client",
       "insertText": "'client",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [

--- a/language-server/modules/langserver-core/src/test/resources/completion/import_decl/config/config8.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/import_decl/config/config8.json
@@ -6,14 +6,6 @@
   "source": "import_decl/source/lsproject/modules/module1/source1.bal",
   "items": [
     {
-      "label": "lsproject",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "A",
-      "insertText": "lsproject.",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "lsproject.module2",
       "kind": "Module",
       "detail": "Module",

--- a/language-server/modules/langserver-core/src/test/resources/completion/module_part_context/config/config14.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/module_part_context/config/config14.json
@@ -676,7 +676,7 @@
       "kind": "Module",
       "detail": "Module",
       "sortText": "C",
-      "filterText": "",
+      "filterText": "module3",
       "insertText": "module3",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -909,6 +909,54 @@
       "sortText": "E",
       "insertText": "function",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "lsproject.module2",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "filterText": "module2",
+      "insertText": "module21",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 2,
+              "character": 0
+            },
+            "end": {
+              "line": 2,
+              "character": 0
+            }
+          },
+          "newText": "import lsproject.module2 as module21;\n"
+        }
+      ]
+    },
+    {
+      "label": "lsproject.module1",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "filterText": "module1",
+      "insertText": "module11",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 2,
+              "character": 0
+            },
+            "end": {
+              "line": 2,
+              "character": 0
+            }
+          },
+          "newText": "import lsproject.module1 as module11;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/module_part_context/config/config16.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/module_part_context/config/config16.json
@@ -658,7 +658,7 @@
       "kind": "Module",
       "detail": "Module",
       "sortText": "C",
-      "filterText": "",
+      "filterText": "module3",
       "insertText": "module3",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -716,7 +716,7 @@
       "kind": "Module",
       "detail": "Module",
       "sortText": "C",
-      "filterText": "module11",
+      "filterText": "module1",
       "insertText": "module11",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [

--- a/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/project_var_def_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/project_var_def_ctx_config1.json
@@ -766,6 +766,30 @@
       "sortText": "R",
       "insertText": "function",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "lsproject.models",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "models",
+      "insertText": "models1",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import lsproject.models as models1;\n"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/project_var_def_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/project_var_def_ctx_config2.json
@@ -774,6 +774,30 @@
       "sortText": "R",
       "insertText": "function",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "lsproject.models",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "models",
+      "insertText": "models1",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import lsproject.models as models1;\n"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Purpose
This PR improves the LSPackageLoader class to consider the modules of the current package.

Fixes #37169 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
