### PR TITLE
Add quick pick support to infer sub expressions in extract to constant code action

### DIFF
--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/capability/InitializationOptions.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/capability/InitializationOptions.java
@@ -38,6 +38,11 @@ public interface InitializationOptions {
     String KEY_RENAME_SUPPORT = "supportRenamePopup";
 
     /**
+     * Whether the client supports the quick pick.
+     */
+    String KEY_QUICKPICK_SUPPORT = "supportQuickPick";
+
+    /**
      * Return if the client support bala URI scheme.
      *
      * @return True if bala URi scheme is supported.
@@ -57,4 +62,11 @@ public interface InitializationOptions {
      * @return True if supported, false otherwise
      */
     boolean isRefactorRenameSupported();
+
+    /**
+     * Returns if the client supports the quick pick.
+     *
+     * @return True if supported, false otherwise
+     */
+    boolean isQuickPickSupported();
 }

--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/capability/InitializationOptions.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/capability/InitializationOptions.java
@@ -38,7 +38,7 @@ public interface InitializationOptions {
     String KEY_RENAME_SUPPORT = "supportRenamePopup";
 
     /**
-     * Whether the client supports the quick pick.
+     * Whether the client supports quick picks.
      */
     String KEY_QUICKPICK_SUPPORT = "supportQuickPick";
 
@@ -64,7 +64,7 @@ public interface InitializationOptions {
     boolean isRefactorRenameSupported();
 
     /**
-     * Returns if the client supports the quick pick.
+     * Returns if the client supports quick picks.
      *
      * @return True if supported, false otherwise
      */

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSClientCapabilitiesImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSClientCapabilitiesImpl.java
@@ -146,6 +146,11 @@ public class LSClientCapabilitiesImpl implements LSClientCapabilities {
                 Boolean.parseBoolean(String.valueOf(renameSupport));
         initializationOptions.setSupportRenamePopup(enableRenameSupport);
 
+        Object quickPickSupport = initOptions.get(InitializationOptions.KEY_QUICKPICK_SUPPORT);
+        boolean enableQuickPickSupport = quickPickSupport != null &&
+                Boolean.parseBoolean(String.valueOf(quickPickSupport));
+        initializationOptions.setSupportQuickPick(enableQuickPickSupport);
+
         return initializationOptions;
     }
 
@@ -192,6 +197,7 @@ public class LSClientCapabilitiesImpl implements LSClientCapabilities {
         private boolean supportBalaScheme = false;
         private boolean enableSemanticTokens = false;
         private boolean supportRenamePopup = false;
+        private boolean supportQuickPick = false;
         
         @Override
         public boolean isBalaSchemeSupported() {
@@ -218,5 +224,10 @@ public class LSClientCapabilitiesImpl implements LSClientCapabilities {
         public void setSupportRenamePopup(boolean supportRenamePopup) {
             this.supportRenamePopup = supportRenamePopup;
         }
+
+        @Override
+        public boolean isQuickPickSupported() { return supportQuickPick; }
+
+        public void setSupportQuickPick(boolean supportQuickPick) { this.supportQuickPick = supportQuickPick; }
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSClientCapabilitiesImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSClientCapabilitiesImpl.java
@@ -226,8 +226,12 @@ public class LSClientCapabilitiesImpl implements LSClientCapabilities {
         }
 
         @Override
-        public boolean isQuickPickSupported() { return supportQuickPick; }
+        public boolean isQuickPickSupported() {
+            return supportQuickPick;
+        }
 
-        public void setSupportQuickPick(boolean supportQuickPick) { this.supportQuickPick = supportQuickPick; }
+        public void setSupportQuickPick(boolean supportQuickPick) {
+            this.supportQuickPick = supportQuickPick;
+        }
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToConstantCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToConstantCodeAction.java
@@ -130,7 +130,8 @@ public class ExtractToConstantCodeAction implements RangeBasedCodeActionProvider
     private List<Node> getPossibleExpressionNodes(Node node, BasicLiteralNodeValidator nodeValidator) {
         // Identify the sub-expressions to be extracted
         List<Node> nodeList = new ArrayList<>();
-        while (node != null && !isExpressionNode(node) && node.kind() != SyntaxKind.OBJECT_FIELD && !nodeValidator.getInvalidNode()) {
+        while (node != null && !isExpressionNode(node) && node.kind() != SyntaxKind.OBJECT_FIELD 
+                && !nodeValidator.getInvalidNode()) {
             nodeList.add(node);
             node = node.parent();
             node.accept(nodeValidator);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToLocalVarCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToLocalVarCodeAction.java
@@ -22,7 +22,6 @@ import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.syntax.tree.AssignmentStatementNode;
 import io.ballerina.compiler.syntax.tree.ModuleMemberDeclarationNode;
 import io.ballerina.compiler.syntax.tree.Node;
-import io.ballerina.compiler.syntax.tree.ObjectFieldNode;
 import io.ballerina.compiler.syntax.tree.StatementNode;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.tools.text.LineRange;
@@ -150,7 +149,7 @@ public class ExtractToLocalVarCodeAction implements RangeBasedCodeActionProvider
         Node statementNode = node;
         while (statementNode != null && !(statementNode instanceof StatementNode)
                 && !(statementNode instanceof ModuleMemberDeclarationNode) 
-                && !(statementNode instanceof ObjectFieldNode)) {
+                && statementNode.kind() != SyntaxKind.OBJECT_FIELD) {
             statementNode = statementNode.parent();
         }
         return statementNode;

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/AbstractLSTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/AbstractLSTest.java
@@ -85,7 +85,13 @@ public abstract class AbstractLSTest {
         if (this.loadMockedPackages()) {
             setUp();
         }
-        this.serviceEndpoint = TestUtil.initializeLanguageSever(this.languageServer);
+        TestUtil.LanguageServerBuilder builder = TestUtil.newLanguageServer()
+                .withLanguageServer(languageServer);
+        setupLanguageServer(builder);
+        this.serviceEndpoint = builder.build();
+    }
+    
+    protected void setupLanguageServer(TestUtil.LanguageServerBuilder builder) {
     }
 
     public void setUp() {

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/AbstractCodeActionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/AbstractCodeActionTest.java
@@ -422,6 +422,32 @@ public abstract class AbstractCodeActionTest extends AbstractLSTest {
                 }
             }
             return false;
+        } else if ("ballerina.action.extract".equals(actualCommand.get("command").getAsString())) {
+            if (actualArgs.size() == 3) {
+                String actualName = actualArgs.get(0).getAsString();
+                String expectedName = expArgs.get(0).getAsString();
+
+                String actualFilePath = actualArgs.get(1).getAsString().replace(sourceRoot.toString(),"");
+                if (actualFilePath.startsWith("/") || actualFilePath.startsWith("\\")) {
+                    actualFilePath = actualFilePath.substring(1);
+                }
+                String expectedFilePath = expArgs.get(1).getAsString();
+                
+                JsonObject actualTextEdits = actualArgs.get(2).getAsJsonObject();
+                JsonObject expectedTextEdits = expArgs.get(2).getAsJsonObject();
+
+                if (actualName.equals(expectedName) && actualFilePath.equals(expectedFilePath)
+                        && actualTextEdits.equals(expectedTextEdits)) {
+                    return true;
+                }
+
+                JsonArray newArgs = new JsonArray();
+                newArgs.add(actualName);
+                newArgs.add(actualFilePath);
+                newArgs.add(actualTextEdits);
+                actualCommand.add("arguments", newArgs);
+            }
+            return false;
         }
 
         for (JsonElement actualArg : actualArgs) {

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/AbstractCodeActionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/AbstractCodeActionTest.java
@@ -427,7 +427,7 @@ public abstract class AbstractCodeActionTest extends AbstractLSTest {
                 String actualName = actualArgs.get(0).getAsString();
                 String expectedName = expArgs.get(0).getAsString();
 
-                String actualFilePath = actualArgs.get(1).getAsString().replace(sourceRoot.toString(),"");
+                String actualFilePath = actualArgs.get(1).getAsString().replace(sourceRoot.toString(), "");
                 if (actualFilePath.startsWith("/") || actualFilePath.startsWith("\\")) {
                     actualFilePath = actualFilePath.substring(1);
                 }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ExtractToConstantWithQuickPickTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ExtractToConstantWithQuickPickTest.java
@@ -56,7 +56,8 @@ public class ExtractToConstantWithQuickPickTest extends AbstractCodeActionTest {
                 {"extractExprToConstantWithQuickPick3.json"},
                 {"extractExprToConstantWithQuickPick4.json"},
                 {"extractExprToConstantWithQuickPick5.json"},
-                {"extractExprToConstantWithQuickPick6.json"}
+                {"extractExprToConstantWithQuickPick6.json"},
+                {"extractExprToConstantWithQuickPick7.json"}
         };
     }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ExtractToConstantWithQuickPickTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ExtractToConstantWithQuickPickTest.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * Test cases for Extract to Constant code action with quick pick.
  * 
- * @since 2201.3.0
+ * @since 2201.4.0
  */
 public class ExtractToConstantWithQuickPickTest extends AbstractCodeActionTest {
     
@@ -55,7 +55,8 @@ public class ExtractToConstantWithQuickPickTest extends AbstractCodeActionTest {
                 {"extractExprToConstantWithQuickPick2.json"},
                 {"extractExprToConstantWithQuickPick3.json"},
                 {"extractExprToConstantWithQuickPick4.json"},
-                {"extractExprToConstantWithQuickPick5.json"}
+                {"extractExprToConstantWithQuickPick5.json"},
+                {"extractExprToConstantWithQuickPick6.json"}
         };
     }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ExtractToConstantWithQuickPickTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ExtractToConstantWithQuickPickTest.java
@@ -15,18 +15,25 @@
  */
 package org.ballerinalang.langserver.codeaction;
 
+import org.ballerinalang.langserver.commons.capability.InitializationOptions;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceDocumentException;
+import org.ballerinalang.langserver.util.TestUtil;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
 
 /**
- * Test cases for Extract to Constant code action.
+ * Test cases for Extract to Constant code action with quick pick.
  * 
- * @since 2201.2.0
+ * @since 2201.3.0
  */
-public class ExtractToConstantTest extends AbstractCodeActionTest {
+public class ExtractToConstantWithQuickPickTest extends AbstractCodeActionTest {
+    
+    @Override 
+    protected void setupLanguageServer(TestUtil.LanguageServerBuilder builder) {
+        builder.withInitOption(InitializationOptions.KEY_QUICKPICK_SUPPORT, true);
+    }
 
     @Override
     @Test(dataProvider = "codeaction-data-provider")
@@ -44,38 +51,18 @@ public class ExtractToConstantTest extends AbstractCodeActionTest {
     @Override
     public Object[][] dataProvider() {
         return new Object[][]{
-                {"extractIntToConstant.json"},
-                {"extractHexIntToConstant.json"},
-                {"extractFloatingPointToConstant.json"},
-                {"extractHexFloatingPointToConstant.json"},
-                {"extractBooleanToConstant.json"},
-                {"extractStringToConstant.json"},
-                {"extractClassDefToConstant.json"},
-                {"extractIntRangeToConstant.json"},
-                {"extractExpressionToConstant.json"},
-                {"extractConstDeclToConstant1.json"},
-                {"extractToConstantWithImports.json"},
-                {"extractUnaryNumericExprToConstant.json"},
-                {"extractUnaryNumericExprToConstant2.json"},
-                {"extractUnaryLogicalExprToConstant.json"},
-                {"extractBooleanLiteralInUnaryExprToConstant.json"},
-                {"extractNumericLiteralInUnaryExprToConstant.json"},
-                {"extractNumericLiteralInUnaryExprToConstant2.json"},
-                {"extractExprToConstant1.json"},
-                {"extractExprToConstant2.json"}
+                {"extractExprToConstantWithQuickPick1.json"},
+                {"extractExprToConstantWithQuickPick2.json"},
+                {"extractExprToConstantWithQuickPick3.json"},
+                {"extractExprToConstantWithQuickPick4.json"},
+                {"extractExprToConstantWithQuickPick5.json"}
         };
     }
 
     @DataProvider(name = "negative-test-data-provider")
     public Object[][] negativeDataProvider() {
         return new Object[][]{
-                {"extractConstDeclToConstant.json"},
-                {"extractInvalidExprStmtToConstant.json"},
-                {"extractExpressionToConstant1.json"},
-                {"extractExpressionToConstant2.json"},
-                {"extractExpressionToConstant3.json"},
-                {"extractServiceUriInModuleClientDeclToConstant.json"},
-                {"extractServiceUriInClientDeclarationToConstant.json"}
+                {"extractExprToConstantWithQuickPickNegative1.json"}
         };
     }
 

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractExprToConstant1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractExprToConstant1.json
@@ -1,0 +1,42 @@
+{
+  "position": {
+    "line": 7,
+    "character": 19
+  },
+  "source": "extractToConstant.bal",
+  "expected": [
+    {
+      "title": "Extract to constant",
+      "kind": "refactor.extract",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "const int CONST = 10;\n"
+        },
+        {
+          "range": {
+            "start": {
+              "line": 7,
+              "character": 18
+            },
+            "end": {
+              "line": 7,
+              "character": 20
+            }
+          },
+          "newText": "CONST"
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractExprToConstant2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractExprToConstant2.json
@@ -1,0 +1,42 @@
+{
+  "position": {
+    "line": 16,
+    "character": 24
+  },
+  "source": "extractToConstant.bal",
+  "expected": [
+    {
+      "title": "Extract to constant",
+      "kind": "refactor.extract",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "const float CONST = 3.14 * 3;\n"
+        },
+        {
+          "range": {
+            "start": {
+              "line": 16,
+              "character": 18
+            },
+            "end": {
+              "line": 16,
+              "character": 26
+            }
+          },
+          "newText": "CONST"
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractExprToConstantWithQuickPick1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractExprToConstantWithQuickPick1.json
@@ -9,10 +9,10 @@
       "title": "Extract to constant",
       "kind": "refactor.extract",
       "command": {
-        "title": "Extract To Constant",
+        "title": "extract to constant",
         "command": "ballerina.action.extract",
         "arguments": [
-          "extractConstant",
+          "extract to constant",
           "extractExprToConstantWithQuickPick.bal",
           {
             "10": [

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractExprToConstantWithQuickPick1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractExprToConstantWithQuickPick1.json
@@ -1,0 +1,108 @@
+{
+  "position": {
+    "line": 1,
+    "character": 22
+  },
+  "source": "extractExprToConstantWithQuickPick.bal",
+  "expected": [
+    {
+      "title": "Extract to constant",
+      "kind": "refactor.extract",
+      "command": {
+        "title": "Extract To Constant",
+        "command": "ballerina.action.extract",
+        "arguments": [
+          "extractConstant",
+          "extractExprToConstantWithQuickPick.bal",
+          {
+            "10": [
+              {
+                "range": {
+                  "start": {
+                    "line": 0,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 0,
+                    "character": 0
+                  }
+                },
+                "newText": "const int CONST = 10;\n"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 1,
+                    "character": 21
+                  },
+                  "end": {
+                    "line": 1,
+                    "character": 23
+                  }
+                },
+                "newText": "CONST"
+              }
+            ],
+            "10 * 20": [
+              {
+                "range": {
+                  "start": {
+                    "line": 0,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 0,
+                    "character": 0
+                  }
+                },
+                "newText": "const int CONST = 10 * 20;\n"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 1,
+                    "character": 21
+                  },
+                  "end": {
+                    "line": 1,
+                    "character": 28
+                  }
+                },
+                "newText": "CONST"
+              }
+            ],
+            "10 * 20 + 30": [
+              {
+                "range": {
+                  "start": {
+                    "line": 0,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 0,
+                    "character": 0
+                  }
+                },
+                "newText": "const int CONST = 10 * 20 + 30;\n"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 1,
+                    "character": 21
+                  },
+                  "end": {
+                    "line": 1,
+                    "character": 33
+                  }
+                },
+                "newText": "CONST"
+              }
+            ]
+          }
+        ]
+      },
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractExprToConstantWithQuickPick2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractExprToConstantWithQuickPick2.json
@@ -1,0 +1,80 @@
+{
+  "position": {
+    "line": 1,
+    "character": 32
+  },
+  "source": "extractExprToConstantWithQuickPick.bal",
+  "expected": [
+    {
+      "title": "Extract to constant",
+      "kind": "refactor.extract",
+      "command": {
+        "title": "Extract To Constant",
+        "command": "ballerina.action.extract",
+        "arguments": [
+          "extractConstant",
+          "extractExprToConstantWithQuickPick.bal",
+          {
+            "30": [
+              {
+                "range": {
+                  "start": {
+                    "line": 0,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 0,
+                    "character": 0
+                  }
+                },
+                "newText": "const int CONST = 30;\n"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 1,
+                    "character": 31
+                  },
+                  "end": {
+                    "line": 1,
+                    "character": 33
+                  }
+                },
+                "newText": "CONST"
+              }
+            ],
+            "10 * 20 + 30": [
+              {
+                "range": {
+                  "start": {
+                    "line": 0,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 0,
+                    "character": 0
+                  }
+                },
+                "newText": "const int CONST = 10 * 20 + 30;\n"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 1,
+                    "character": 21
+                  },
+                  "end": {
+                    "line": 1,
+                    "character": 33
+                  }
+                },
+                "newText": "CONST"
+              }
+            ]
+          }
+        ]
+      },
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractExprToConstantWithQuickPick2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractExprToConstantWithQuickPick2.json
@@ -9,10 +9,10 @@
       "title": "Extract to constant",
       "kind": "refactor.extract",
       "command": {
-        "title": "Extract To Constant",
+        "title": "extract to constant",
         "command": "ballerina.action.extract",
         "arguments": [
-          "extractConstant",
+          "extract to constant",
           "extractExprToConstantWithQuickPick.bal",
           {
             "30": [

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractExprToConstantWithQuickPick3.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractExprToConstantWithQuickPick3.json
@@ -1,0 +1,80 @@
+{
+  "position": {
+    "line": 3,
+    "character": 23
+  },
+  "source": "extractExprToConstantWithQuickPick.bal",
+  "expected": [
+    {
+      "title": "Extract to constant",
+      "kind": "refactor.extract",
+      "command": {
+        "title": "Extract To Constant",
+        "command": "ballerina.action.extract",
+        "arguments": [
+          "extractConstant",
+          "extractExprToConstantWithQuickPick.bal",
+          {
+            "40": [
+              {
+                "range": {
+                  "start": {
+                    "line": 0,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 0,
+                    "character": 0
+                  }
+                },
+                "newText": "const int CONST = 40;\n"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 3,
+                    "character": 22
+                  },
+                  "end": {
+                    "line": 3,
+                    "character": 24
+                  }
+                },
+                "newText": "CONST"
+              }
+            ],
+            "40 + 50": [
+              {
+                "range": {
+                  "start": {
+                    "line": 0,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 0,
+                    "character": 0
+                  }
+                },
+                "newText": "const int CONST = 40 + 50;\n"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 3,
+                    "character": 22
+                  },
+                  "end": {
+                    "line": 3,
+                    "character": 29
+                  }
+                },
+                "newText": "CONST"
+              }
+            ]
+          }
+        ]
+      },
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractExprToConstantWithQuickPick3.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractExprToConstantWithQuickPick3.json
@@ -9,10 +9,10 @@
       "title": "Extract to constant",
       "kind": "refactor.extract",
       "command": {
-        "title": "Extract To Constant",
+        "title": "extract to constant",
         "command": "ballerina.action.extract",
         "arguments": [
-          "extractConstant",
+          "extract to constant",
           "extractExprToConstantWithQuickPick.bal",
           {
             "40": [

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractExprToConstantWithQuickPick4.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractExprToConstantWithQuickPick4.json
@@ -9,10 +9,10 @@
       "title": "Extract to constant",
       "kind": "refactor.extract",
       "command": {
-        "title": "Extract To Constant",
+        "title": "extract to constant",
         "command": "ballerina.action.extract",
         "arguments": [
-          "extractConstant",
+          "extract to constant",
           "extractExprToConstantWithQuickPick.bal",
           {
             "10": [

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractExprToConstantWithQuickPick4.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractExprToConstantWithQuickPick4.json
@@ -1,0 +1,136 @@
+{
+  "position": {
+    "line": 8,
+    "character": 21
+  },
+  "source": "extractExprToConstantWithQuickPick.bal",
+  "expected": [
+    {
+      "title": "Extract to constant",
+      "kind": "refactor.extract",
+      "command": {
+        "title": "Extract To Constant",
+        "command": "ballerina.action.extract",
+        "arguments": [
+          "extractConstant",
+          "extractExprToConstantWithQuickPick.bal",
+          {
+            "10": [
+              {
+                "range": {
+                  "start": {
+                    "line": 0,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 0,
+                    "character": 0
+                  }
+                },
+                "newText": "const int CONST = 10;\n"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 20
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 22
+                  }
+                },
+                "newText": "CONST"
+              }
+            ],
+            "10 / 2": [
+              {
+                "range": {
+                  "start": {
+                    "line": 0,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 0,
+                    "character": 0
+                  }
+                },
+                "newText": "const int CONST = 10 / 2;\n"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 20
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 26
+                  }
+                },
+                "newText": "CONST"
+              }
+            ],
+            "10 / 2 + 20": [
+              {
+                "range": {
+                  "start": {
+                    "line": 0,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 0,
+                    "character": 0
+                  }
+                },
+                "newText": "const int CONST = 10 / 2 + 20;\n"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 20
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 31
+                  }
+                },
+                "newText": "CONST"
+              }
+            ],
+            "10 / 2 + 20 + 30": [
+              {
+                "range": {
+                  "start": {
+                    "line": 0,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 0,
+                    "character": 0
+                  }
+                },
+                "newText": "const int CONST = 10 / 2 + 20 + 30;\n"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 20
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 36
+                  }
+                },
+                "newText": "CONST"
+              }
+            ]
+          }
+        ]
+      },
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractExprToConstantWithQuickPick5.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractExprToConstantWithQuickPick5.json
@@ -9,10 +9,10 @@
       "title": "Extract to constant",
       "kind": "refactor.extract",
       "command": {
-        "title": "Extract To Constant",
+        "title": "extract to constant",
         "command": "ballerina.action.extract",
         "arguments": [
-          "extractConstant",
+          "extract to constant",
           "extractExprToConstantWithQuickPick.bal",
           {
             "10 / 2 + 20": [

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractExprToConstantWithQuickPick5.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractExprToConstantWithQuickPick5.json
@@ -1,0 +1,80 @@
+{
+  "position": {
+    "line": 8,
+    "character": 28
+  },
+  "source": "extractExprToConstantWithQuickPick.bal",
+  "expected": [
+    {
+      "title": "Extract to constant",
+      "kind": "refactor.extract",
+      "command": {
+        "title": "Extract To Constant",
+        "command": "ballerina.action.extract",
+        "arguments": [
+          "extractConstant",
+          "extractExprToConstantWithQuickPick.bal",
+          {
+            "10 / 2 + 20": [
+              {
+                "range": {
+                  "start": {
+                    "line": 0,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 0,
+                    "character": 0
+                  }
+                },
+                "newText": "const int CONST = 10 / 2 + 20;\n"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 20
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 31
+                  }
+                },
+                "newText": "CONST"
+              }
+            ],
+            "10 / 2 + 20 + 30": [
+              {
+                "range": {
+                  "start": {
+                    "line": 0,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 0,
+                    "character": 0
+                  }
+                },
+                "newText": "const int CONST = 10 / 2 + 20 + 30;\n"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 20
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 36
+                  }
+                },
+                "newText": "CONST"
+              }
+            ]
+          }
+        ]
+      },
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractExprToConstantWithQuickPick6.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractExprToConstantWithQuickPick6.json
@@ -1,0 +1,108 @@
+{
+  "position": {
+    "line": 12,
+    "character": 22
+  },
+  "source": "extractExprToConstantWithQuickPick.bal",
+  "expected": [
+    {
+      "title": "Extract to constant",
+      "kind": "refactor.extract",
+      "command": {
+        "title": "extract to constant",
+        "command": "ballerina.action.extract",
+        "arguments": [
+          "extract to constant",
+          "extractExprToConstantWithQuickPick.bal",
+          {
+            "3.14": [
+              {
+                "range": {
+                  "start": {
+                    "line": 0,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 0,
+                    "character": 0
+                  }
+                },
+                "newText": "const float CONST = 3.14;\n"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 12,
+                    "character": 21
+                  },
+                  "end": {
+                    "line": 12,
+                    "character": 25
+                  }
+                },
+                "newText": "CONST"
+              }
+            ],
+            "3.14 * 3": [
+              {
+                "range": {
+                  "start": {
+                    "line": 0,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 0,
+                    "character": 0
+                  }
+                },
+                "newText": "const float CONST = 3.14 * 3;\n"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 12,
+                    "character": 21
+                  },
+                  "end": {
+                    "line": 12,
+                    "character": 29
+                  }
+                },
+                "newText": "CONST"
+              }
+            ],
+            "3.14 * 3 * 4": [
+              {
+                "range": {
+                  "start": {
+                    "line": 0,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 0,
+                    "character": 0
+                  }
+                },
+                "newText": "const float CONST = 3.14 * 3 * 4;\n"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 12,
+                    "character": 21
+                  },
+                  "end": {
+                    "line": 12,
+                    "character": 33
+                  }
+                },
+                "newText": "CONST"
+              }
+            ]
+          }
+        ]
+      },
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractExprToConstantWithQuickPick7.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractExprToConstantWithQuickPick7.json
@@ -1,7 +1,7 @@
 {
   "position": {
-    "line": 11,
-    "character": 18
+    "line": 14,
+    "character": 22
   },
   "source": "extractExprToConstantWithQuickPick.bal",
   "expected": [
@@ -15,7 +15,7 @@
           "extract to constant",
           "extractExprToConstantWithQuickPick.bal",
           {
-            "4": [
+            "3.14": [
               {
                 "range": {
                   "start": {
@@ -27,23 +27,23 @@
                     "character": 0
                   }
                 },
-                "newText": "const int CONST = 4;\n"
+                "newText": "const float CONST = 3.14;\n"
               },
               {
                 "range": {
                   "start": {
-                    "line": 11,
-                    "character": 17
+                    "line": 14,
+                    "character": 21
                   },
                   "end": {
-                    "line": 11,
-                    "character": 18
+                    "line": 14,
+                    "character": 25
                   }
                 },
                 "newText": "CONST"
               }
             ],
-            "4 * 5": [
+            "3.14 * 3": [
               {
                 "range": {
                   "start": {
@@ -55,17 +55,45 @@
                     "character": 0
                   }
                 },
-                "newText": "const int CONST = 4 * 5;\n"
+                "newText": "const float CONST = 3.14 * 3;\n"
               },
               {
                 "range": {
                   "start": {
-                    "line": 11,
-                    "character": 17
+                    "line": 14,
+                    "character": 21
                   },
                   "end": {
-                    "line": 11,
-                    "character": 22
+                    "line": 14,
+                    "character": 29
+                  }
+                },
+                "newText": "CONST"
+              }
+            ],
+            "3.14 * 3 * 4": [
+              {
+                "range": {
+                  "start": {
+                    "line": 0,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 0,
+                    "character": 0
+                  }
+                },
+                "newText": "const float CONST = 3.14 * 3 * 4;\n"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 14,
+                    "character": 21
+                  },
+                  "end": {
+                    "line": 14,
+                    "character": 33
                   }
                 },
                 "newText": "CONST"

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractExprToConstantWithQuickPickNegative1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractExprToConstantWithQuickPickNegative1.json
@@ -1,0 +1,12 @@
+{
+  "position": {
+    "line": 3,
+    "character": 39
+  },
+  "source": "extractExprToConstantWithQuickPick.bal",
+  "expected": [
+    {
+      "title": "Extract to constant"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/source/extractExprToConstantWithQuickPick.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/source/extractExprToConstantWithQuickPick.bal
@@ -7,3 +7,10 @@ function testFunction() {
 }
 
 int intModLiteral = 10 / 2 + 20 + 30;
+
+class Square {
+	function getArea() returns float {
+        float area = 3.14 * 3 * 4;
+	    return area;
+	}
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/source/extractExprToConstantWithQuickPick.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/source/extractExprToConstantWithQuickPick.bal
@@ -9,6 +9,8 @@ function testFunction() {
 int intModLiteral = 10 / 2 + 20 + 30;
 
 class Square {
+    int length = 4 * 5;
+    
 	function getArea() returns float {
         float area = 3.14 * 3 * 4;
 	    return area;

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/source/extractExprToConstantWithQuickPick.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/source/extractExprToConstantWithQuickPick.bal
@@ -1,0 +1,9 @@
+function testFunction() {
+    int intLiteral = 10 * 20 + 30;
+    int two = 2;
+    if (intLiteral == 40 + 50 + 60 * two) {
+        // do something
+    }
+}
+
+int intModLiteral = 10 / 2 + 20 + 30;


### PR DESCRIPTION
## Purpose
This PR adds support for quick picks in the VSCode plugin to identify the sub expression selected by a user when extracting a complex expression to a constant using the `extract to constant` code action.

PR to the VSCode plugin : https://github.com/wso2-enterprise/ballerina-plugin-vscode/pull/559

Fixes #37480

## Samples

https://user-images.githubusercontent.com/27485094/195769926-b69cacb8-5d9b-467d-b75c-7a65e9f64545.mov

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
