### PR TITLE
[2201.3.x] Add rename popup for extract to const and local var

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToConstantCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToConstantCodeAction.java
@@ -143,11 +143,6 @@ public class ExtractToConstantCodeAction implements RangeBasedCodeActionProvider
 
     private void addRenamePopup(CodeActionContext context, CodeAction codeAction,
                                 int constDeclStrLength, int nodeStartOffset) {
-        Optional<SyntaxTree> syntaxTree = context.currentSyntaxTree();
-        if (syntaxTree.isEmpty()) {
-            return;
-        }
-
         int startPos = constDeclStrLength + nodeStartOffset;
         LSClientCapabilities lsClientCapabilities = context.languageServercontext().get(LSClientCapabilities.class);
         if (lsClientCapabilities.getInitializationOptions().isRefactorRenameSupported()) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToConstantCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToConstantCodeAction.java
@@ -73,8 +73,8 @@ public class ExtractToConstantCodeAction implements RangeBasedCodeActionProvider
     public boolean validate(CodeActionContext context, RangeBasedPositionDetails positionDetails) {
         Node node = positionDetails.matchedCodeActionNode();
         SyntaxKind parentKind = node.parent().kind();
-        return  context.currentSyntaxTree().isPresent() && context.currentSemanticModel().isPresent() 
-                && parentKind != SyntaxKind.CONST_DECLARATION 
+        return context.currentSyntaxTree().isPresent() && context.currentSemanticModel().isPresent()
+                && parentKind != SyntaxKind.CONST_DECLARATION
                 && parentKind != SyntaxKind.INVALID_EXPRESSION_STATEMENT
                 && parentKind != SyntaxKind.MODULE_CLIENT_DECLARATION
                 && CodeActionNodeValidator.validate(context.nodeAtRange());
@@ -152,7 +152,7 @@ public class ExtractToConstantCodeAction implements RangeBasedCodeActionProvider
         int startPos = constDeclStrLength + nodeStartOffset;
         LSClientCapabilities lsClientCapabilities = context.languageServercontext().get(LSClientCapabilities.class);
         if (lsClientCapabilities.getInitializationOptions().isRefactorRenameSupported()) {
-            codeAction.setCommand(new Command(RENAME_COMMAND, "ballerina.action.rename",
+            codeAction.setCommand(new Command(RENAME_COMMAND, CommandConstants.BALLERINA_RENAME_ACTION,
                     List.of(context.fileUri(), startPos)));
         }
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToConstantCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToConstantCodeAction.java
@@ -146,7 +146,7 @@ public class ExtractToConstantCodeAction implements RangeBasedCodeActionProvider
         LSClientCapabilities lsClientCapabilities = context.languageServercontext().get(LSClientCapabilities.class);
         if (lsClientCapabilities.getInitializationOptions().isRefactorRenameSupported()) {
             codeAction.setCommand(new Command(
-                    CommandConstants.RENAME_COMMAND_TITLE_FOR_CONSTANT, CommandConstants.BALLERINA_RENAME_ACTION,
+                    CommandConstants.RENAME_COMMAND_TITLE_FOR_CONSTANT, CommandConstants.RENAME_COMMAND,
                     List.of(context.fileUri(), startPos)));
         }
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToConstantCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToConstantCodeAction.java
@@ -62,7 +62,6 @@ public class ExtractToConstantCodeAction implements RangeBasedCodeActionProvider
 
     public static final String NAME = "Extract To Constant";
     private static final String CONSTANT_NAME_PREFIX = "CONST";
-    private static final String RENAME_COMMAND = "Rename Constant";
 
     public List<SyntaxKind> getSyntaxKinds() {
         return List.of(SyntaxKind.BOOLEAN_LITERAL, SyntaxKind.NUMERIC_LITERAL,
@@ -152,7 +151,8 @@ public class ExtractToConstantCodeAction implements RangeBasedCodeActionProvider
         int startPos = constDeclStrLength + nodeStartOffset;
         LSClientCapabilities lsClientCapabilities = context.languageServercontext().get(LSClientCapabilities.class);
         if (lsClientCapabilities.getInitializationOptions().isRefactorRenameSupported()) {
-            codeAction.setCommand(new Command(RENAME_COMMAND, CommandConstants.BALLERINA_RENAME_ACTION,
+            codeAction.setCommand(new Command(
+                    CommandConstants.RENAME_COMMAND_TITLE_FOR_CONSTANT, CommandConstants.BALLERINA_RENAME_ACTION,
                     List.of(context.fileUri(), startPos)));
         }
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToConstantCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToConstantCodeAction.java
@@ -26,7 +26,6 @@ import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.compiler.syntax.tree.NodeList;
 import io.ballerina.compiler.syntax.tree.NodeVisitor;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
-import io.ballerina.compiler.syntax.tree.SyntaxTree;
 import io.ballerina.compiler.syntax.tree.UnaryExpressionNode;
 import io.ballerina.tools.text.LineRange;
 import org.ballerinalang.annotation.JavaSPIService;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToConstantCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToConstantCodeAction.java
@@ -108,7 +108,7 @@ public class ExtractToConstantCodeAction implements RangeBasedCodeActionProvider
 
         CodeAction codeAction = CodeActionUtil.createCodeAction(CommandConstants.EXTRACT_TO_CONSTANT,
                 List.of(constDeclEdit, replaceEdit), context.fileUri(), CodeActionKind.RefactorExtract);
-        addRenamePopup(context, codeAction, constDeclStr.length(), node.textRange().startOffset());
+        addRenamePopup(context, codeAction, replaceEdit.getRange().getStart());
 
         return Collections.singletonList(codeAction);
     }
@@ -140,14 +140,12 @@ public class ExtractToConstantCodeAction implements RangeBasedCodeActionProvider
         return new Position(lastImport.lineRange().endLine().line() + 2, 0);
     }
 
-    private void addRenamePopup(CodeActionContext context, CodeAction codeAction,
-                                int constDeclStrLength, int nodeStartOffset) {
-        int startPos = constDeclStrLength + nodeStartOffset;
+    private void addRenamePopup(CodeActionContext context, CodeAction codeAction, Position position) {
         LSClientCapabilities lsClientCapabilities = context.languageServercontext().get(LSClientCapabilities.class);
         if (lsClientCapabilities.getInitializationOptions().isRefactorRenameSupported()) {
             codeAction.setCommand(new Command(
                     CommandConstants.RENAME_COMMAND_TITLE_FOR_CONSTANT, CommandConstants.RENAME_COMMAND,
-                    List.of(context.fileUri(), startPos)));
+                    List.of(context.fileUri(), new Position(position.getLine() + 1, position.getCharacter()))));
         }
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToLocalVarCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToLocalVarCodeAction.java
@@ -25,7 +25,6 @@ import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.compiler.syntax.tree.ObjectFieldNode;
 import io.ballerina.compiler.syntax.tree.StatementNode;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
-import io.ballerina.compiler.syntax.tree.SyntaxTree;
 import io.ballerina.tools.text.LineRange;
 import org.apache.commons.lang3.StringUtils;
 import org.ballerinalang.annotation.JavaSPIService;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToLocalVarCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToLocalVarCodeAction.java
@@ -25,6 +25,7 @@ import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.compiler.syntax.tree.ObjectFieldNode;
 import io.ballerina.compiler.syntax.tree.StatementNode;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
+import io.ballerina.compiler.syntax.tree.SyntaxTree;
 import io.ballerina.tools.text.LineRange;
 import org.apache.commons.lang3.StringUtils;
 import org.ballerinalang.annotation.JavaSPIService;
@@ -35,10 +36,12 @@ import org.ballerinalang.langserver.common.utils.FunctionGenerator;
 import org.ballerinalang.langserver.common.utils.NameUtil;
 import org.ballerinalang.langserver.common.utils.PositionUtil;
 import org.ballerinalang.langserver.commons.CodeActionContext;
+import org.ballerinalang.langserver.commons.capability.LSClientCapabilities;
 import org.ballerinalang.langserver.commons.codeaction.spi.RangeBasedCodeActionProvider;
 import org.ballerinalang.langserver.commons.codeaction.spi.RangeBasedPositionDetails;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionKind;
+import org.eclipse.lsp4j.Command;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextEdit;
@@ -59,6 +62,8 @@ public class ExtractToLocalVarCodeAction implements RangeBasedCodeActionProvider
 
     public static final String NAME = "Extract To Local Variable";
     private static final String VARIABLE_NAME_PREFIX = "var";
+    
+    private static final String RENAME_COMMAND = "Rename variable";
 
     public List<SyntaxKind> getSyntaxKinds() {
         return List.of(SyntaxKind.BOOLEAN_LITERAL, SyntaxKind.NUMERIC_LITERAL, SyntaxKind.STRING_LITERAL,
@@ -136,8 +141,11 @@ public class ExtractToLocalVarCodeAction implements RangeBasedCodeActionProvider
         TextEdit replaceEdit = new TextEdit(new Range(PositionUtil.toPosition(replaceRange.startLine()),
                 PositionUtil.toPosition(replaceRange.endLine())),  varName);
 
-        return Collections.singletonList(CodeActionUtil.createCodeAction(CommandConstants.EXTRACT_TO_VARIABLE, 
-                List.of(varDeclEdit, replaceEdit), context.fileUri(), CodeActionKind.RefactorExtract));
+        CodeAction codeAction = CodeActionUtil.createCodeAction(CommandConstants.EXTRACT_TO_VARIABLE,
+                List.of(varDeclEdit, replaceEdit), context.fileUri(), CodeActionKind.RefactorExtract);
+        addRenamePopup(context, codeAction, varDeclStr.length(), node.textRange().startOffset());
+        
+        return Collections.singletonList(codeAction);
     }
 
     @Override
@@ -163,6 +171,21 @@ public class ExtractToLocalVarCodeAction implements RangeBasedCodeActionProvider
                 .collect(Collectors.toSet());
         
         return NameUtil.generateTypeName(VARIABLE_NAME_PREFIX, allNames);
+    }
+
+    private void addRenamePopup(CodeActionContext context, CodeAction codeAction,
+                                int varDeclStrLength, int nodeStartOffset) {
+        Optional<SyntaxTree> syntaxTree = context.currentSyntaxTree();
+        if (syntaxTree.isEmpty()) {
+            return;
+        }
+
+        int startPos = varDeclStrLength + nodeStartOffset;
+        LSClientCapabilities lsClientCapabilities = context.languageServercontext().get(LSClientCapabilities.class);
+        if (lsClientCapabilities.getInitializationOptions().isRefactorRenameSupported()) {
+            codeAction.setCommand(new Command(RENAME_COMMAND, "ballerina.action.rename",
+                    List.of(context.fileUri(), startPos)));
+        }
     }
 
     // If the variables within the selected range have been initialized in the closest statement node (and outside

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToLocalVarCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToLocalVarCodeAction.java
@@ -173,11 +173,6 @@ public class ExtractToLocalVarCodeAction implements RangeBasedCodeActionProvider
 
     private void addRenamePopup(CodeActionContext context, CodeAction codeAction,
                                 int varDeclStrLength, int nodeStartOffset) {
-        Optional<SyntaxTree> syntaxTree = context.currentSyntaxTree();
-        if (syntaxTree.isEmpty()) {
-            return;
-        }
-
         int startPos = varDeclStrLength + nodeStartOffset;
         LSClientCapabilities lsClientCapabilities = context.languageServercontext().get(LSClientCapabilities.class);
         if (lsClientCapabilities.getInitializationOptions().isRefactorRenameSupported()) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToLocalVarCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToLocalVarCodeAction.java
@@ -176,7 +176,7 @@ public class ExtractToLocalVarCodeAction implements RangeBasedCodeActionProvider
         LSClientCapabilities lsClientCapabilities = context.languageServercontext().get(LSClientCapabilities.class);
         if (lsClientCapabilities.getInitializationOptions().isRefactorRenameSupported()) {
             codeAction.setCommand(new Command(
-                    CommandConstants.RENAME_COMMAND_TITLE_FOR_VARIABLE, CommandConstants.BALLERINA_RENAME_ACTION,
+                    CommandConstants.RENAME_COMMAND_TITLE_FOR_VARIABLE, CommandConstants.RENAME_COMMAND,
                     List.of(context.fileUri(), startPos)));
         }
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToLocalVarCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToLocalVarCodeAction.java
@@ -183,7 +183,7 @@ public class ExtractToLocalVarCodeAction implements RangeBasedCodeActionProvider
         int startPos = varDeclStrLength + nodeStartOffset;
         LSClientCapabilities lsClientCapabilities = context.languageServercontext().get(LSClientCapabilities.class);
         if (lsClientCapabilities.getInitializationOptions().isRefactorRenameSupported()) {
-            codeAction.setCommand(new Command(RENAME_COMMAND, "ballerina.action.rename",
+            codeAction.setCommand(new Command(RENAME_COMMAND, CommandConstants.BALLERINA_RENAME_ACTION,
                     List.of(context.fileUri(), startPos)));
         }
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToLocalVarCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToLocalVarCodeAction.java
@@ -63,8 +63,6 @@ public class ExtractToLocalVarCodeAction implements RangeBasedCodeActionProvider
     public static final String NAME = "Extract To Local Variable";
     private static final String VARIABLE_NAME_PREFIX = "var";
     
-    private static final String RENAME_COMMAND = "Rename variable";
-
     public List<SyntaxKind> getSyntaxKinds() {
         return List.of(SyntaxKind.BOOLEAN_LITERAL, SyntaxKind.NUMERIC_LITERAL, SyntaxKind.STRING_LITERAL,
                 SyntaxKind.BINARY_EXPRESSION, SyntaxKind.BRACED_EXPRESSION, SyntaxKind.XML_TEMPLATE_EXPRESSION,
@@ -183,7 +181,8 @@ public class ExtractToLocalVarCodeAction implements RangeBasedCodeActionProvider
         int startPos = varDeclStrLength + nodeStartOffset;
         LSClientCapabilities lsClientCapabilities = context.languageServercontext().get(LSClientCapabilities.class);
         if (lsClientCapabilities.getInitializationOptions().isRefactorRenameSupported()) {
-            codeAction.setCommand(new Command(RENAME_COMMAND, CommandConstants.BALLERINA_RENAME_ACTION,
+            codeAction.setCommand(new Command(
+                    CommandConstants.RENAME_COMMAND_TITLE_FOR_VARIABLE, CommandConstants.BALLERINA_RENAME_ACTION,
                     List.of(context.fileUri(), startPos)));
         }
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/CreateVariableCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/CreateVariableCodeAction.java
@@ -227,7 +227,7 @@ public class CreateVariableCodeAction implements DiagnosticBasedCodeActionProvid
         startPos = startPos + sum + renameOffset;
         LSClientCapabilities lsClientCapabilities = context.languageServercontext().get(LSClientCapabilities.class);
         if (lsClientCapabilities.getInitializationOptions().isRefactorRenameSupported()) {
-            codeAction.setCommand(new Command(RENAME_COMMAND, "ballerina.action.rename",
+            codeAction.setCommand(new Command(RENAME_COMMAND, CommandConstants.BALLERINA_RENAME_ACTION,
                     List.of(context.fileUri(), startPos)));
         }
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/CreateVariableCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/CreateVariableCodeAction.java
@@ -227,7 +227,7 @@ public class CreateVariableCodeAction implements DiagnosticBasedCodeActionProvid
         LSClientCapabilities lsClientCapabilities = context.languageServercontext().get(LSClientCapabilities.class);
         if (lsClientCapabilities.getInitializationOptions().isRefactorRenameSupported()) {
             codeAction.setCommand(new Command(
-                    CommandConstants.RENAME_COMMAND_TITLE_FOR_VARIABLE, CommandConstants.BALLERINA_RENAME_ACTION,
+                    CommandConstants.RENAME_COMMAND_TITLE_FOR_VARIABLE, CommandConstants.RENAME_COMMAND,
                     List.of(context.fileUri(), startPos)));
         }
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/CreateVariableCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/CreateVariableCodeAction.java
@@ -57,7 +57,6 @@ import java.util.stream.Collectors;
 public class CreateVariableCodeAction implements DiagnosticBasedCodeActionProvider {
 
     public static final String NAME = "Create Variable";
-    private static final String RENAME_COMMAND = "Rename Variable";
 
     /**
      * {@inheritDoc}
@@ -227,7 +226,8 @@ public class CreateVariableCodeAction implements DiagnosticBasedCodeActionProvid
         startPos = startPos + sum + renameOffset;
         LSClientCapabilities lsClientCapabilities = context.languageServercontext().get(LSClientCapabilities.class);
         if (lsClientCapabilities.getInitializationOptions().isRefactorRenameSupported()) {
-            codeAction.setCommand(new Command(RENAME_COMMAND, CommandConstants.BALLERINA_RENAME_ACTION,
+            codeAction.setCommand(new Command(
+                    CommandConstants.RENAME_COMMAND_TITLE_FOR_VARIABLE, CommandConstants.BALLERINA_RENAME_ACTION,
                     List.of(context.fileUri(), startPos)));
         }
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/CreateVariableCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/CreateVariableCodeAction.java
@@ -179,7 +179,8 @@ public class CreateVariableCodeAction implements DiagnosticBasedCodeActionProvid
         List<TextEdit> imports;
         List<Position> renamePositions;
 
-        public CreateVariableOut(String name, List<String> types, List<TextEdit> edits, List<TextEdit> imports, List<Position> renamePositions) {
+        public CreateVariableOut(String name, List<String> types, List<TextEdit> edits, List<TextEdit> imports, 
+                                 List<Position> renamePositions) {
             this.name = name;
             this.types = types;
             this.edits = edits;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/ErrorHandleInsideCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/ErrorHandleInsideCodeAction.java
@@ -83,15 +83,16 @@ public class ErrorHandleInsideCodeAction extends CreateVariableCodeAction {
         // Add type guard code action
         String commandTitle = CommandConstants.CREATE_VAR_TYPE_GUARD_TITLE;
         List<TextEdit> edits = new ArrayList<>();
-        edits.add(createVarTextEdits.edits.get(0));
+        TextEdit variableEdit = createVarTextEdits.edits.get(0);
+        edits.add(variableEdit);
         edits.addAll(CodeActionUtil.getTypeGuardCodeActionEdits(createVarTextEdits.name, range, unionType, context));
 
         // Add all the import text edits excluding duplicates
         createVarTextEdits.imports.stream().filter(edit -> !edits.contains(edit)).forEach(edits::add);
 
         CodeAction codeAction = CodeActionUtil.createCodeAction(commandTitle, edits, uri, CodeActionKind.QuickFix);
-        addRenamePopup(context, edits, createVarTextEdits.edits.get(0), codeAction,
-                createVarTextEdits.renamePositions.get(0));
+        addRenamePopup(context, codeAction, createVarTextEdits.renamePositions.get(0),
+                createVarTextEdits.imports.size());
         return Collections.singletonList(codeAction);
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/ErrorHandleOutsideCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/ErrorHandleOutsideCodeAction.java
@@ -30,6 +30,7 @@ import org.ballerinalang.langserver.commons.CodeActionContext;
 import org.ballerinalang.langserver.commons.codeaction.spi.DiagBasedPositionDetails;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionKind;
+import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextEdit;
 
@@ -101,7 +102,8 @@ public class ErrorHandleOutsideCodeAction extends CreateVariableCodeAction {
 
         CodeAction codeAction = CodeActionUtil.createCodeAction(
                 CommandConstants.CREATE_VAR_ADD_CHECK_TITLE, edits, uri, CodeActionKind.QuickFix);
-        addRenamePopup(context, codeAction, modifiedTextEdits.renamePositions.get(0), importEdits.size());
+        addRenamePopup(context, codeAction, modifiedTextEdits.renamePositions.get(0), 
+                importEdits.size() + modifiedTextEdits.imports.size());
         return Collections.singletonList(codeAction);
     }
 
@@ -125,6 +127,10 @@ public class ErrorHandleOutsideCodeAction extends CreateVariableCodeAction {
         // Change and add type text edit
         String typeWithError = createVarTextEdits.types.get(0);
         String typeWithoutError = getTypeWithoutError(unionTypeDesc, context, importsAcceptor);
+        
+        Position renamePosition = createVarTextEdits.renamePositions.get(0);
+        renamePosition.setCharacter(
+                renamePosition.getCharacter() - (typeWithError.length() - typeWithoutError.length()));
 
         TextEdit textEdit = createVarTextEdits.edits.get(0);
         textEdit.setNewText(typeWithoutError + textEdit.getNewText().substring(typeWithError.length()));

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/ErrorHandleOutsideCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/ErrorHandleOutsideCodeAction.java
@@ -89,6 +89,7 @@ public class ErrorHandleOutsideCodeAction extends CreateVariableCodeAction {
             return Collections.emptyList();
         }
         ImportsAcceptor importsAcceptor = new ImportsAcceptor(context);
+        List<TextEdit> importEdits = importsAcceptor.getNewImportTextEdits();
         List<TextEdit> edits = new ArrayList<>();
         CreateVariableOut modifiedTextEdits = getModifiedCreateVarTextEdits(diagnostic, unionTypeDesc, positionDetails,
                 typeSymbol.get(), context, importsAcceptor);
@@ -96,12 +97,11 @@ public class ErrorHandleOutsideCodeAction extends CreateVariableCodeAction {
         edits.addAll(CodeActionUtil.getAddCheckTextEdits(
                 PositionUtil.toRange(diagnostic.location().lineRange()).getStart(),
                 positionDetails.matchedNode(), context));
+        edits.addAll(importEdits);
 
-        String commandTitle = CommandConstants.CREATE_VAR_ADD_CHECK_TITLE;
-        int renamePosition = modifiedTextEdits.renamePositions.get(0) - UNION_ERROR_CHAR_OFFSET;
-        edits.addAll(importsAcceptor.getNewImportTextEdits());
-        CodeAction codeAction = CodeActionUtil.createCodeAction(commandTitle, edits, uri, CodeActionKind.QuickFix);
-        addRenamePopup(context, edits, modifiedTextEdits.edits.get(0), codeAction, renamePosition);
+        CodeAction codeAction = CodeActionUtil.createCodeAction(
+                CommandConstants.CREATE_VAR_ADD_CHECK_TITLE, edits, uri, CodeActionKind.QuickFix);
+        addRenamePopup(context, codeAction, modifiedTextEdits.renamePositions.get(0), importEdits.size());
         return Collections.singletonList(codeAction);
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/constants/CommandConstants.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/constants/CommandConstants.java
@@ -181,9 +181,9 @@ public class CommandConstants {
     
     public static final String BALLERINA_RENAME_ACTION = "ballerina.action.rename";
     
-    public static final String RENAME_COMMAND_TITLE_FOR_VARIABLE = "Rename variable";
+    public static final String RENAME_COMMAND_TITLE_FOR_VARIABLE = "Rename Variable";
     
-    public static final String RENAME_COMMAND_TITLE_FOR_CONSTANT = "Rename constant";
+    public static final String RENAME_COMMAND_TITLE_FOR_CONSTANT = "Rename Constant";
 
     public static final String GENERATE_MODULE_FOR_CLIENT_DECLARATION_TITLE = "Generate module for client declaration";
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/constants/CommandConstants.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/constants/CommandConstants.java
@@ -179,7 +179,7 @@ public class CommandConstants {
 
     public static final String EXTRACT_TO_VARIABLE = "Extract to local variable";
     
-    public static final String BALLERINA_RENAME_ACTION = "ballerina.action.rename";
+    public static final String RENAME_COMMAND = "ballerina.action.rename";
     
     public static final String RENAME_COMMAND_TITLE_FOR_VARIABLE = "Rename Variable";
     

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/constants/CommandConstants.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/constants/CommandConstants.java
@@ -180,6 +180,10 @@ public class CommandConstants {
     public static final String EXTRACT_TO_VARIABLE = "Extract to local variable";
     
     public static final String BALLERINA_RENAME_ACTION = "ballerina.action.rename";
+    
+    public static final String RENAME_COMMAND_TITLE_FOR_VARIABLE = "Rename variable";
+    
+    public static final String RENAME_COMMAND_TITLE_FOR_CONSTANT = "Rename constant";
 
     public static final String GENERATE_MODULE_FOR_CLIENT_DECLARATION_TITLE = "Generate module for client declaration";
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/constants/CommandConstants.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/constants/CommandConstants.java
@@ -23,6 +23,7 @@ import java.util.regex.Pattern;
  * @since v0.964.0
  */
 public class CommandConstants {
+
     public static final String UNDEFINED_MODULE = "undefined module";
     public static final String UNDEFINED_FUNCTION = "undefined function";
     public static final String VAR_ASSIGNMENT_REQUIRED = "variable assignment is required";
@@ -78,7 +79,7 @@ public class CommandConstants {
 
     // Command Titles
     public static final String IMPORT_MODULE_TITLE = "Import module '%s'";
-    
+
     public static final String CHANGE_MODULE_PREFIX_TITLE = "Change module prefix to '%s'";
 
     public static final String CREATE_VARIABLE_TITLE = "Create variable";
@@ -110,7 +111,7 @@ public class CommandConstants {
     public static final String ADD_TYPE_CAST_TO_NUMERIC_OPERAND_TITLE = "Add type cast to '%s'";
 
     public static final String CHANGE_VAR_TYPE_TITLE = "Change variable '%s' type to '%s'";
-    
+
     public static final String CHANGE_CONST_TYPE_TITLE = "Change constant '%s' type to '%s'";
 
     public static final String CHANGE_PARAM_TYPE_TITLE = "Change parameter '%s' type to '%s'";
@@ -134,7 +135,7 @@ public class CommandConstants {
     public static final String IMPLEMENT_FUNCS_TITLE = "Implement method '%s'";
 
     public static final String OPTIMIZE_IMPORTS_TITLE = "Optimize all imports";
-    
+
     public static final String REMOVE_ALL_UNUSED_IMPORTS = "Remove all unused imports";
 
     public static final String REMOVE_UNUSED_IMPORT = "Remove unused import '%s'";
@@ -142,18 +143,18 @@ public class CommandConstants {
     public static final String REMOVE_REDECLARED_IMPORT = "Remove re-declared import '%s'";
 
     public static final String REPORT_USAGE_STATISTICS_COMMAND_TITLE = "Report usage statistics";
-    
+
     public static final String CONVERT_FUNCTION_TO_PUBLIC = "Convert to public function";
-    
+
     public static final String CREATE_ON_FAIL_CLAUSE = "Create on fail clause";
 
     public static final String SURROUND_WITH_DO_ON_FAIL = "Surround with do/on-fail";
 
-    public static final String CONVERT_MODULE_VAR_TO_LISTENER_DECLARATION = 
+    public static final String CONVERT_MODULE_VAR_TO_LISTENER_DECLARATION =
             "Convert module variable '%s' to listener declaration";
 
     public static final String CONVERT_TO_READONLY_CLONE = "Convert to Readonly Clone";
-    
+
     public static final String ADD_EXPLICIT_RETURN_STATEMENT = "Add Explicit Return Statement";
 
     public static final String REMOVE_UNREACHABLE_CODE_TITLE = "Remove unreachable code";
@@ -177,6 +178,8 @@ public class CommandConstants {
     public static final String EXTRACT_TO_CONSTANT = "Extract to constant";
 
     public static final String EXTRACT_TO_VARIABLE = "Extract to local variable";
+    
+    public static final String BALLERINA_RENAME_ACTION = "ballerina.action.rename";
 
     public static final String GENERATE_MODULE_FOR_CLIENT_DECLARATION_TITLE = "Generate module for client declaration";
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/AbstractCodeActionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/AbstractCodeActionTest.java
@@ -70,6 +70,7 @@ import java.util.stream.Collectors;
  */
 public abstract class AbstractCodeActionTest extends AbstractLSTest {
 
+    private static final String BALLERINA_ACTION_RENAME = "ballerina.action.rename";
     private final Gson gson = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
     private final Path sourcesPath = new File(getClass().getClassLoader().getResource("codeaction").getFile()).toPath();
 
@@ -396,7 +397,7 @@ public abstract class AbstractCodeActionTest extends AbstractLSTest {
                                                  Path sourceRoot,
                                                  Path sourcePath) {
         //Validate the args of rename command
-        if ("ballerina.action.rename".equals(actualCommand.get("command").getAsString())) {
+        if (BALLERINA_ACTION_RENAME.equals(actualCommand.get("command").getAsString())) {
             if (actualArgs.size() == 2) {
                 Optional<String> actualFilePath =
                         PathUtil.getPathFromURI(actualArgs.get(0).getAsString())

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/AbstractCodeActionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/AbstractCodeActionTest.java
@@ -404,16 +404,16 @@ public abstract class AbstractCodeActionTest extends AbstractLSTest {
                                 .map(path -> path.toUri().toString()
                                         .replace("\\", "/")
                                         .replace(sourceRoot.toUri().toString(), ""));
-                int actualRenamePosition = actualArgs.get(1).getAsInt();
+                JsonObject actualRenamePosition = actualArgs.get(1).getAsJsonObject();
                 String expectedFilePath = expArgs.get(0).getAsString();
-                int expectedRenamePosition = expArgs.get(1).getAsInt();
+                JsonObject expectedRenamePosition = expArgs.get(1).getAsJsonObject();
                 if (actualFilePath.isPresent()) {
                     String actualPath = actualFilePath.get();
                     if (actualFilePath.get().startsWith("/") || actualFilePath.get().startsWith("\\")) {
                         actualPath = actualFilePath.get().substring(1);
                     }
                     if (sourceRoot.resolve(actualPath).equals(sourceRoot.resolve(expectedFilePath))
-                            && actualRenamePosition == expectedRenamePosition) {
+                            && actualRenamePosition.equals(expectedRenamePosition)) {
                         return true;
                     }
                     JsonArray newArgs = new JsonArray();

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/AbstractCodeActionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/AbstractCodeActionTest.java
@@ -401,7 +401,7 @@ public abstract class AbstractCodeActionTest extends AbstractLSTest {
                 Optional<String> actualFilePath =
                         PathUtil.getPathFromURI(actualArgs.get(0).getAsString())
                                 .map(path -> path.toString().replace(sourceRoot.toString(), ""));
-                int actualRenamePosition = expArgs.get(1).getAsInt();
+                int actualRenamePosition = actualArgs.get(1).getAsInt();
                 String expectedFilePath = expArgs.get(0).getAsString();
                 int expectedRenamePosition = expArgs.get(1).getAsInt();
                 if (actualFilePath.isPresent()) {

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/AbstractCodeActionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/AbstractCodeActionTest.java
@@ -401,7 +401,9 @@ public abstract class AbstractCodeActionTest extends AbstractLSTest {
             if (actualArgs.size() == 2) {
                 Optional<String> actualFilePath =
                         PathUtil.getPathFromURI(actualArgs.get(0).getAsString())
-                                .map(path -> path.toString().replace(sourceRoot.toString(), ""));
+                                .map(path -> path.toUri().toString()
+                                        .replace("\\", "/")
+                                        .replace(sourceRoot.toUri().toString(), ""));
                 int actualRenamePosition = actualArgs.get(1).getAsInt();
                 String expectedFilePath = expArgs.get(0).getAsString();
                 int expectedRenamePosition = expArgs.get(1).getAsInt();

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVarInSendAction1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVarInSendAction1.json
@@ -41,7 +41,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVarInSendAction1.bal",
-          128
+          {
+            "line": 9,
+            "character": 15
+          }
         ]
       },
       "resolvable": false
@@ -69,7 +72,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVarInSendAction1.bal",
-          128
+          {
+            "line": 9,
+            "character": 15
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableForOptionalFieldAccess1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableForOptionalFieldAccess1.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariableForOptionalFieldAccess1.bal",
-          81
+          {
+            "line": 6,
+            "character": 9
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableForOptionalFieldAccess2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableForOptionalFieldAccess2.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariableForOptionalFieldAccess2.bal",
-          89
+          {
+            "line": 8,
+            "character": 6
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableInClassMethod.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableInClassMethod.json
@@ -41,7 +41,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariableInClassMethod.bal",
-          133
+          {
+            "line": 7,
+            "character": 18
+          }
         ]
       },
       "resolvable": false
@@ -95,7 +98,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariableInClassMethod.bal",
-          142
+          {
+            "line": 7,
+            "character": 12
+          }
         ]
       },
       "resolvable": false
@@ -123,7 +129,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariableInClassMethod.bal",
-          133
+          {
+            "line": 7,
+            "character": 18
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableInServiceMethod.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableInServiceMethod.json
@@ -41,7 +41,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariableInServiceMethod.bal",
-          240
+          {
+            "line": 10,
+            "character": 18
+          }
         ]
       },
       "resolvable": false
@@ -95,7 +98,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariableInServiceMethod.bal",
-          249
+          {
+            "line": 10,
+            "character": 12
+          }
         ]
       },
       "resolvable": false
@@ -123,7 +129,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariableInServiceMethod.bal",
-          240
+          {
+            "line": 10,
+            "character": 18
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableInServiceRemoteMethod.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableInServiceRemoteMethod.json
@@ -41,7 +41,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariableInServiceMethod.bal",
-          325
+          {
+            "line": 14,
+            "character": 18
+          }
         ]
       },
       "resolvable": false
@@ -95,7 +98,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariableInServiceMethod.bal",
-          334
+          {
+            "line": 14,
+            "character": 12
+          }
         ]
       },
       "resolvable": false
@@ -123,7 +129,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariableInServiceMethod.bal",
-          325
+          {
+            "line": 14,
+            "character": 18
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithCheck1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithCheck1.json
@@ -54,7 +54,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariableWithCheck.bal",
-          144
+          {
+            "line": 5,
+            "character": 8
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithCheck2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithCheck2.json
@@ -4,6 +4,7 @@
     "character": 4
   },
   "source": "createVariableWithCheck.bal",
+  "description": "Parent function has union return type with no error member",
   "expected": [
     {
       "title": "Create variable and check error",
@@ -54,11 +55,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariableWithCheck.bal",
-          274
+          256
         ]
       },
       "resolvable": false
     }
-  ],
-  "description": "Parent function has union return type with no error member"
+  ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithCheck2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithCheck2.json
@@ -55,7 +55,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariableWithCheck.bal",
-          256
+          {
+            "line": 9,
+            "character": 8
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithCheck3.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithCheck3.json
@@ -41,7 +41,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariableWithCheck.bal",
-          369
+          {
+            "line": 13,
+            "character": 8
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithCheck4.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithCheck4.json
@@ -41,7 +41,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariableWithCheck.bal",
-          472
+          {
+            "line": 17,
+            "character": 8
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithCheck5.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithCheck5.json
@@ -4,6 +4,7 @@
     "character": 4
   },
   "source": "createVariableWithCheck.bal",
+  "description": "Parent function has return type other than error",
   "expected": [
     {
       "title": "Create variable and check error",
@@ -54,11 +55,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariableWithCheck.bal",
-          598
+          584
         ]
       },
       "resolvable": false
     }
-  ],
-  "description": "Parent function has return type other than error"
+  ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithCheck5.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithCheck5.json
@@ -55,7 +55,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariableWithCheck.bal",
-          584
+          {
+            "line": 21,
+            "character": 8
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithCheck6.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithCheck6.json
@@ -55,7 +55,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariableWithCheck.bal",
-          783
+          {
+            "line": 29,
+            "character": 8
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithFunctionCall1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithFunctionCall1.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariableWithFunctionCall1.bal",
-          136
+          {
+            "line": 9,
+            "character": 14
+          }
         ]
       },
       "resolvable": false
@@ -56,7 +59,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariableWithFunctionCall1.bal",
-          135
+          {
+            "line": 9,
+            "character": 13
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithFunctionCall2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithFunctionCall2.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariableWithFunctionCall2.bal",
-          172
+          {
+            "line": 11,
+            "character": 22
+          }
         ]
       },
       "resolvable": false
@@ -56,7 +59,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariableWithFunctionCall2.bal",
-          159
+          {
+            "line": 11,
+            "character": 9
+          }
         ]
       },
       "resolvable": false
@@ -84,7 +90,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariableWithFunctionCall2.bal",
-          163
+          {
+            "line": 11,
+            "character": 13
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithFunctionType1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithFunctionType1.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariableWithFunctionType1.bal",
-          58
+          {
+            "line": 2,
+            "character": 32
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithFunctionType2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithFunctionType2.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariableWithFunctionType1.bal",
-          70
+          {
+            "line": 4,
+            "character": 31
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithIntersectionType.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithIntersectionType.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariableWithIntersectionType.bal",
-          229
+          {
+            "line": 7,
+            "character": 47
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithIntersectionType2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithIntersectionType2.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariableWithIntersectionType.bal",
-          230
+          {
+            "line": 9,
+            "character": 19
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithRemoteMethodInvocation.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithRemoteMethodInvocation.json
@@ -54,7 +54,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable9.bal",
-          389
+          {
+            "line": 22,
+            "character": 18
+          }
         ]
       },
       "resolvable": false
@@ -108,7 +111,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable9.bal",
-          398
+          {
+            "line": 22,
+            "character": 15
+          }
         ]
       },
       "resolvable": false
@@ -136,7 +142,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable9.bal",
-          389
+          {
+            "line": 22,
+            "character": 18
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithTuple1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithTuple1.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariableWithTuple1.bal",
-          52
+          {
+            "line": 1,
+            "character": 27
+          }
         ]
       },
       "resolvable": false
@@ -69,7 +72,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariableWithTuple1.bal",
-          52
+          {
+            "line": 1,
+            "character": 27
+          }
         ]
       },
       "resolvable": false
@@ -123,7 +129,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariableWithTuple1.bal",
-          61
+          {
+            "line": 1,
+            "character": 21
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithTypeDesc.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithTypeDesc.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariableWithTypeDesc.bal",
-          113
+          {
+            "line": 5,
+            "character": 33
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithUnionType.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithUnionType.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariableWithUnionType.bal",
-          97
+          {
+            "line": 5,
+            "character": 14
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/projectVariableAssignmentRequiredCodeAction1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/projectVariableAssignmentRequiredCodeAction1.json
@@ -41,7 +41,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "testproject/main.bal",
-          111
+          {
+            "line": 4,
+            "character": 20
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/projectVariableAssignmentRequiredCodeAction2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/projectVariableAssignmentRequiredCodeAction2.json
@@ -54,7 +54,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "testproject/main.bal",
-          180
+          {
+            "line": 8,
+            "character": 26
+          }
         ]
       },
       "resolvable": false
@@ -101,19 +104,6 @@
             }
           },
           "newText": " returns error?"
-        },
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import testproject.module2;\n"
         }
       ],
       "command": {
@@ -121,7 +111,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "testproject/main.bal",
-          189
+          {
+            "line": 8,
+            "character": 20
+          }
         ]
       },
       "resolvable": false
@@ -162,7 +155,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "testproject/main.bal",
-          180
+          {
+            "line": 8,
+            "character": 26
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/projectVariableAssignmentRequiredCodeAction3.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/projectVariableAssignmentRequiredCodeAction3.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "testproject/modules/module1/module1.bal",
-          272
+          {
+            "line": 11,
+            "character": 20
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction1.json
@@ -28,7 +28,7 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable.bal",
-          371
+          369
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction1.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable.bal",
-          369
+          {
+            "line": 20,
+            "character": 7
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction10.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction10.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable3.bal",
-          51
+          {
+            "line": 3,
+            "character": 12
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction11.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction11.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable3.bal",
-          65
+          {
+            "line": 4,
+            "character": 16
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction12.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction12.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable3.bal",
-          77
+          {
+            "line": 5,
+            "character": 9
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction13.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction13.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable3.bal",
-          84
+          {
+            "line": 5,
+            "character": 16
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction14.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction14.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable3.bal",
-          103
+          {
+            "line": 5,
+            "character": 35
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction15.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction15.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable3.bal",
-          97
+          {
+            "line": 6,
+            "character": 9
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction16.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction16.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable3.bal",
-          120
+          {
+            "line": 6,
+            "character": 32
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction17.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction17.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable3.bal",
-          101
+          {
+            "line": 6,
+            "character": 13
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction18.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction18.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable3.bal",
-          165
+          {
+            "line": 7,
+            "character": 58
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction19.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction19.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable3.bal",
-          174
+          {
+            "line": 9,
+            "character": 11
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction2.json
@@ -28,7 +28,7 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable.bal",
-          429
+          427
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction2.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable.bal",
-          427
+          {
+            "line": 22,
+            "character": 10
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction20.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction20.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable4.bal",
-          91
+          {
+            "line": 6,
+            "character": 11
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction21.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction21.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable4.bal",
-          155
+          {
+            "line": 7,
+            "character": 56
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction22.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction22.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable4.bal",
-          111
+          {
+            "line": 7,
+            "character": 12
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction23.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction23.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable4.bal",
-          166
+          {
+            "line": 8,
+            "character": 25
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction24.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction24.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable4.bal",
-          206
+          {
+            "line": 8,
+            "character": 65
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction25.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction25.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable4.bal",
-          228
+          {
+            "line": 9,
+            "character": 43
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction26.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction26.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable4.bal",
-          234
+          {
+            "line": 10,
+            "character": 18
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction27.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction27.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable4.bal",
-          239
+          {
+            "line": 11,
+            "character": 10
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction28.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction28.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable4.bal",
-          249
+          {
+            "line": 11,
+            "character": 20
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction29.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction29.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable5.bal",
-          616
+          {
+            "line": 39,
+            "character": 42
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction3.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction3.json
@@ -28,7 +28,7 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable.bal",
-          444
+          442
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction3.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction3.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable.bal",
-          442
+          {
+            "line": 23,
+            "character": 9
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction30.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction30.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable5.bal",
-          721
+          {
+            "line": 41,
+            "character": 16
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction31.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction31.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable5.bal",
-          736
+          {
+            "line": 42,
+            "character": 8
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction32.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction32.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable5.bal",
-          929
+          {
+            "line": 44,
+            "character": 124
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction33.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction33.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable5.bal",
-          1436
+          {
+            "line": 68,
+            "character": 11
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction34.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction34.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable5.bal",
-          1505
+          {
+            "line": 68,
+            "character": 80
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction35.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction35.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable5.bal",
-          1440
+          {
+            "line": 68,
+            "character": 15
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction36.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction36.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable5.bal",
-          1438
+          {
+            "line": 68,
+            "character": 13
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction37.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction37.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable5.bal",
-          1926
+          {
+            "line": 82,
+            "character": 24
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction38.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction38.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable5.bal",
-          2077
+          {
+            "line": 85,
+            "character": 131
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction39.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction39.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable5.bal",
-          2091
+          {
+            "line": 86,
+            "character": 131
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction4.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction4.json
@@ -28,7 +28,7 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable.bal",
-          461
+          459
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction4.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction4.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable.bal",
-          459
+          {
+            "line": 24,
+            "character": 10
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction40.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction40.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable5.bal",
-          1992
+          {
+            "line": 88,
+            "character": 16
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction41.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction41.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable6.bal",
-          271
+          {
+            "line": 14,
+            "character": 15
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction42.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction42.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable7.bal",
-          127
+          {
+            "line": 2,
+            "character": 77
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction43.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction43.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable7.bal",
-          95
+          {
+            "line": 3,
+            "character": 27
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction44.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction44.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable8.bal",
-          36
+          {
+            "line": 1,
+            "character": 11
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction45.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction45.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable8.bal",
-          73
+          {
+            "line": 2,
+            "character": 11
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction46.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction46.json
@@ -29,7 +29,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "testProject2/main.bal",
-          120
+          {
+            "line": 3,
+            "character": 18
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction5.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction5.json
@@ -28,7 +28,7 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable2.bal",
-          574
+          572
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction5.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction5.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable2.bal",
-          572
+          {
+            "line": 29,
+            "character": 11
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction6.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction6.json
@@ -28,7 +28,7 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable2.bal",
-          437
+          435
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction6.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction6.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable2.bal",
-          435
+          {
+            "line": 24,
+            "character": 8
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction7.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction7.json
@@ -28,7 +28,7 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable2.bal",
-          494
+          492
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction7.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction7.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable2.bal",
-          492
+          {
+            "line": 25,
+            "character": 11
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction8.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction8.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable3.bal",
-          32
+          {
+            "line": 1,
+            "character": 8
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction9.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction9.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable3.bal",
-          42
+          {
+            "line": 2,
+            "character": 11
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractBooleanLiteralInUnaryExprToConstant.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractBooleanLiteralInUnaryExprToConstant.json
@@ -20,7 +20,7 @@
               "character": 0
             }
           },
-          "newText": "const boolean CONST \u003d true;\n"
+          "newText": "const boolean CONST = true;\n"
         },
         {
           "range": {
@@ -35,7 +35,16 @@
           },
           "newText": "CONST"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename Constant",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToConstant.bal",
+          533
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractBooleanLiteralInUnaryExprToConstant.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractBooleanLiteralInUnaryExprToConstant.json
@@ -41,7 +41,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToConstant.bal",
-          533
+          {
+            "line": 25,
+            "character": 28
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractBooleanToConstant.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractBooleanToConstant.json
@@ -20,7 +20,7 @@
               "character": 0
             }
           },
-          "newText": "const boolean CONST \u003d true;\n"
+          "newText": "const boolean CONST = true;\n"
         },
         {
           "range": {
@@ -35,7 +35,16 @@
           },
           "newText": "CONST"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename Constant",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToConstant.bal",
+          220
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractBooleanToConstant.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractBooleanToConstant.json
@@ -41,7 +41,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToConstant.bal",
-          220
+          {
+            "line": 6,
+            "character": 29
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractClassDefToConstant.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractClassDefToConstant.json
@@ -20,7 +20,7 @@
               "character": 0
             }
           },
-          "newText": "const float CONST \u003d 3.14;\n"
+          "newText": "const float CONST = 3.14;\n"
         },
         {
           "range": {
@@ -35,7 +35,16 @@
           },
           "newText": "CONST"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename Constant",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToConstant.bal",
+          407
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractClassDefToConstant.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractClassDefToConstant.json
@@ -41,7 +41,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToConstant.bal",
-          407
+          {
+            "line": 17,
+            "character": 18
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractConstDeclToConstant1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractConstDeclToConstant1.json
@@ -35,7 +35,16 @@
           },
           "newText": "CONST"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename Constant",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToConstant.bal",
+          460
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractConstDeclToConstant1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractConstDeclToConstant1.json
@@ -41,7 +41,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToConstant.bal",
-          460
+          {
+            "line": 22,
+            "character": 19
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractExpressionToConstant.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractExpressionToConstant.json
@@ -26,7 +26,7 @@
               "character": 0
             }
           },
-          "newText": "const int CONST \u003d 10 + 20;\n"
+          "newText": "const int CONST = 10 + 20;\n"
         },
         {
           "range": {
@@ -41,7 +41,16 @@
           },
           "newText": "CONST"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename Constant",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToConstant.bal",
+          277
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractExpressionToConstant.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractExpressionToConstant.json
@@ -47,7 +47,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToConstant.bal",
-          277
+          {
+            "line": 8,
+            "character": 18
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractFloatingPointToConstant.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractFloatingPointToConstant.json
@@ -20,7 +20,7 @@
               "character": 0
             }
           },
-          "newText": "const float CONST \u003d 3.14;\n"
+          "newText": "const float CONST = 3.14;\n"
         },
         {
           "range": {
@@ -35,7 +35,16 @@
           },
           "newText": "CONST"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename Constant",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToConstant.bal",
+          140
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractFloatingPointToConstant.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractFloatingPointToConstant.json
@@ -41,7 +41,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToConstant.bal",
-          140
+          {
+            "line": 4,
+            "character": 33
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractHexFloatingPointToConstant.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractHexFloatingPointToConstant.json
@@ -20,7 +20,7 @@
               "character": 0
             }
           },
-          "newText": "const float CONST \u003d 0xAp1;\n"
+          "newText": "const float CONST = 0xAp1;\n"
         },
         {
           "range": {
@@ -35,7 +35,16 @@
           },
           "newText": "CONST"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename Constant",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToConstant.bal",
+          183
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractHexFloatingPointToConstant.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractHexFloatingPointToConstant.json
@@ -41,7 +41,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToConstant.bal",
-          183
+          {
+            "line": 5,
+            "character": 36
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractHexIntToConstant.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractHexIntToConstant.json
@@ -20,7 +20,7 @@
               "character": 0
             }
           },
-          "newText": "const int CONST \u003d 0x12;\n"
+          "newText": "const int CONST = 0x12;\n"
         },
         {
           "range": {
@@ -35,7 +35,16 @@
           },
           "newText": "CONST"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename Constant",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToConstant.bal",
+          99
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractHexIntToConstant.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractHexIntToConstant.json
@@ -41,7 +41,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToConstant.bal",
-          99
+          {
+            "line": 3,
+            "character": 24
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractIntRangeToConstant.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractIntRangeToConstant.json
@@ -26,7 +26,7 @@
               "character": 0
             }
           },
-          "newText": "const int CONST \u003d 10;\n"
+          "newText": "const int CONST = 10;\n"
         },
         {
           "range": {
@@ -41,7 +41,16 @@
           },
           "newText": "CONST"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename Constant",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToConstant.bal",
+          69
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractIntRangeToConstant.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractIntRangeToConstant.json
@@ -47,7 +47,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToConstant.bal",
-          69
+          {
+            "line": 2,
+            "character": 21
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractIntToConstant.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractIntToConstant.json
@@ -20,7 +20,7 @@
               "character": 0
             }
           },
-          "newText": "const int CONST \u003d 10;\n"
+          "newText": "const int CONST = 10;\n"
         },
         {
           "range": {
@@ -35,7 +35,16 @@
           },
           "newText": "CONST"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename Constant",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToConstant.bal",
+          69
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractIntToConstant.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractIntToConstant.json
@@ -41,7 +41,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToConstant.bal",
-          69
+          {
+            "line": 2,
+            "character": 21
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractNumericLiteralInUnaryExprToConstant.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractNumericLiteralInUnaryExprToConstant.json
@@ -35,7 +35,16 @@
           },
           "newText": "CONST"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename Constant",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToConstant.bal",
+          495
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractNumericLiteralInUnaryExprToConstant.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractNumericLiteralInUnaryExprToConstant.json
@@ -41,7 +41,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToConstant.bal",
-          495
+          {
+            "line": 24,
+            "character": 24
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractNumericLiteralInUnaryExprToConstant2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractNumericLiteralInUnaryExprToConstant2.json
@@ -41,7 +41,16 @@
           },
           "newText": "CONST"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename Constant",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToConstant.bal",
+          495
+        ]
+    },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractNumericLiteralInUnaryExprToConstant2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractNumericLiteralInUnaryExprToConstant2.json
@@ -47,7 +47,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToConstant.bal",
-          495
+          {
+            "line": 24,
+            "character": 24
+          }
         ]
     },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractStringToConstant.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractStringToConstant.json
@@ -20,7 +20,7 @@
               "character": 0
             }
           },
-          "newText": "const string CONST \u003d \"abc\";\n"
+          "newText": "const string CONST = \"abc\";\n"
         },
         {
           "range": {
@@ -35,7 +35,16 @@
           },
           "newText": "CONST"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename Constant",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToConstant.bal",
+          253
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractStringToConstant.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractStringToConstant.json
@@ -41,7 +41,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToConstant.bal",
-          253
+          {
+            "line": 7,
+            "character": 27
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractToConstantWithImports.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractToConstantWithImports.json
@@ -20,7 +20,7 @@
               "character": 0
             }
           },
-          "newText": "const string CONST \u003d \"Hello World\";\n"
+          "newText": "const string CONST = \"Hello World\";\n"
         },
         {
           "range": {
@@ -35,7 +35,16 @@
           },
           "newText": "CONST"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename Constant",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToConstantWithImports.bal",
+          139
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractToConstantWithImports.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractToConstantWithImports.json
@@ -41,7 +41,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToConstantWithImports.bal",
-          139
+          {
+            "line": 5,
+            "character": 22
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractUnaryLogicalExprToConstant.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractUnaryLogicalExprToConstant.json
@@ -20,7 +20,7 @@
               "character": 0
             }
           },
-          "newText": "const boolean CONST \u003d !true;\n"
+          "newText": "const boolean CONST = !true;\n"
         },
         {
           "range": {
@@ -35,7 +35,16 @@
           },
           "newText": "CONST"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename Constant",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToConstant.bal",
+          533
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractUnaryLogicalExprToConstant.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractUnaryLogicalExprToConstant.json
@@ -41,7 +41,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToConstant.bal",
-          533
+          {
+            "line": 25,
+            "character": 27
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractUnaryNumericExprToConstant.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractUnaryNumericExprToConstant.json
@@ -20,7 +20,7 @@
               "character": 0
             }
           },
-          "newText": "const int CONST \u003d -100;\n"
+          "newText": "const int CONST = -100;\n"
         },
         {
           "range": {
@@ -35,7 +35,16 @@
           },
           "newText": "CONST"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename Constant",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToConstant.bal",
+          495
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractUnaryNumericExprToConstant.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractUnaryNumericExprToConstant.json
@@ -41,7 +41,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToConstant.bal",
-          495
+          {
+            "line": 24,
+            "character": 23
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractUnaryNumericExprToConstant2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractUnaryNumericExprToConstant2.json
@@ -26,7 +26,7 @@
               "character": 0
             }
           },
-          "newText": "const int CONST \u003d -100;\n"
+          "newText": "const int CONST = -100;\n"
         },
         {
           "range": {
@@ -41,7 +41,16 @@
           },
           "newText": "CONST"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename Constant",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToConstant.bal",
+          495
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractUnaryNumericExprToConstant2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractUnaryNumericExprToConstant2.json
@@ -47,7 +47,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToConstant.bal",
-          495
+          {
+            "line": 24,
+            "character": 23
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInBinaryExpression.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInBinaryExpression.json
@@ -26,7 +26,7 @@
               "character": 4
             }
           },
-          "newText": "int var1 \u003d length * width;\n    "
+          "newText": "int var1 = length * width;\n    "
         },
         {
           "range": {
@@ -41,7 +41,16 @@
           },
           "newText": "var1"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename variable",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToVariableInBinaryExpression.bal",
+          93
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInBinaryExpression.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInBinaryExpression.json
@@ -47,7 +47,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInBinaryExpression.bal",
-          93
+          {
+            "line": 2,
+            "character": 15
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInBinaryExpression.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInBinaryExpression.json
@@ -43,7 +43,7 @@
         }
       ],
       "command": {
-        "title": "Rename variable",
+        "title": "Rename Variable",
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInBinaryExpression.bal",

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInBinaryExpression2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInBinaryExpression2.json
@@ -26,7 +26,7 @@
               "character": 0
             }
           },
-          "newText": "int var4 \u003d var1 * var2;\n"
+          "newText": "int var4 = var1 * var2;\n"
         },
         {
           "range": {
@@ -41,7 +41,16 @@
           },
           "newText": "var4"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename variable",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToVariableInBinaryExpression2.bal",
+          66
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInBinaryExpression2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInBinaryExpression2.json
@@ -47,7 +47,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInBinaryExpression2.bal",
-          66
+          {
+            "line": 4,
+            "character": 11
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInBinaryExpression2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInBinaryExpression2.json
@@ -43,7 +43,7 @@
         }
       ],
       "command": {
-        "title": "Rename variable",
+        "title": "Rename Variable",
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInBinaryExpression2.bal",

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInBracedExpression.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInBracedExpression.json
@@ -26,7 +26,7 @@
               "character": 4
             }
           },
-          "newText": "boolean var1 \u003d (area \u003d\u003d 5);\n    "
+          "newText": "boolean var1 = (area == 5);\n    "
         },
         {
           "range": {
@@ -41,7 +41,16 @@
           },
           "newText": "var1"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename variable",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToVariableInBracedExpression.bal",
+          117
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInBracedExpression.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInBracedExpression.json
@@ -43,7 +43,7 @@
         }
       ],
       "command": {
-        "title": "Rename variable",
+        "title": "Rename Variable",
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInBracedExpression.bal",

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInBracedExpression.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInBracedExpression.json
@@ -47,7 +47,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInBracedExpression.bal",
-          117
+          {
+            "line": 3,
+            "character": 7
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInCheckExpression.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInCheckExpression.json
@@ -26,7 +26,7 @@
               "character": 4
             }
           },
-          "newText": "string var1 \u003d check getString();\n    "
+          "newText": "string var1 = check getString();\n    "
         },
         {
           "range": {
@@ -41,7 +41,16 @@
           },
           "newText": "var1"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename variable",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToVariableInCheckExpression.bal",
+          80
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInCheckExpression.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInCheckExpression.json
@@ -47,7 +47,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInCheckExpression.bal",
-          80
+          {
+            "line": 2,
+            "character": 17
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInCheckExpression.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInCheckExpression.json
@@ -43,7 +43,7 @@
         }
       ],
       "command": {
-        "title": "Rename variable",
+        "title": "Rename Variable",
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInCheckExpression.bal",

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInErrorConstructor.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInErrorConstructor.json
@@ -26,7 +26,7 @@
               "character": 0
             }
           },
-          "newText": "XErr var1 \u003d error XErr(\"Whoops!\");\n"
+          "newText": "XErr var1 = error XErr(\"Whoops!\");\n"
         },
         {
           "range": {
@@ -41,7 +41,16 @@
           },
           "newText": "var1"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename variable",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToVariableInErrorConstructor.bal",
+          118
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInErrorConstructor.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInErrorConstructor.json
@@ -43,7 +43,7 @@
         }
       ],
       "command": {
-        "title": "Rename variable",
+        "title": "Rename Variable",
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInErrorConstructor.bal",

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInErrorConstructor.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInErrorConstructor.json
@@ -47,7 +47,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInErrorConstructor.bal",
-          118
+          {
+            "line": 5,
+            "character": 10
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInExplicitNewExpression.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInExplicitNewExpression.json
@@ -26,7 +26,7 @@
               "character": 4
             }
           },
-          "newText": "Person var1 \u003d new Person(\"Anne\", 25);\n    "
+          "newText": "Person var1 = new Person(\"Anne\", 25);\n    "
         },
         {
           "range": {
@@ -41,7 +41,16 @@
           },
           "newText": "var1"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename variable",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToVariableInExplicitNewExpression.bal",
+          228
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInExplicitNewExpression.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInExplicitNewExpression.json
@@ -47,7 +47,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInExplicitNewExpression.bal",
-          228
+          {
+            "line": 12,
+            "character": 20
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInExplicitNewExpression.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInExplicitNewExpression.json
@@ -43,7 +43,7 @@
         }
       ],
       "command": {
-        "title": "Rename variable",
+        "title": "Rename Variable",
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInExplicitNewExpression.bal",

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInFieldAccess.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInFieldAccess.json
@@ -26,7 +26,7 @@
               "character": 4
             }
           },
-          "newText": "string var1 \u003d p1.name;\n    "
+          "newText": "string var1 = p1.name;\n    "
         },
         {
           "range": {
@@ -41,7 +41,16 @@
           },
           "newText": "var1"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename variable",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToVariableInFieldAccess.bal",
+          167
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInFieldAccess.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInFieldAccess.json
@@ -43,7 +43,7 @@
         }
       ],
       "command": {
-        "title": "Rename variable",
+        "title": "Rename Variable",
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInFieldAccess.bal",

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInFieldAccess.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInFieldAccess.json
@@ -47,7 +47,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInFieldAccess.bal",
-          167
+          {
+            "line": 8,
+            "character": 18
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInFieldAccessInAssignmentStmt.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInFieldAccessInAssignmentStmt.json
@@ -26,7 +26,7 @@
               "character": 8
             }
           },
-          "newText": "int var1 \u003d self.age;\n        "
+          "newText": "int var1 = self.age;\n        "
         },
         {
           "range": {
@@ -41,7 +41,16 @@
           },
           "newText": "var1"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename variable",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToVariableInFieldAccess.bal",
+          487
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInFieldAccessInAssignmentStmt.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInFieldAccessInAssignmentStmt.json
@@ -47,7 +47,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInFieldAccess.bal",
-          487
+          {
+            "line": 25,
+            "character": 16
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInFieldAccessInAssignmentStmt.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInFieldAccessInAssignmentStmt.json
@@ -43,7 +43,7 @@
         }
       ],
       "command": {
-        "title": "Rename variable",
+        "title": "Rename Variable",
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInFieldAccess.bal",

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInFieldAccessInReturnStmt.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInFieldAccessInReturnStmt.json
@@ -26,7 +26,7 @@
               "character": 8
             }
           },
-          "newText": "int var1 \u003d self.age;\n        "
+          "newText": "int var1 = self.age;\n        "
         },
         {
           "range": {
@@ -41,7 +41,16 @@
           },
           "newText": "var1"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename variable",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToVariableInFieldAccess.bal",
+          318
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInFieldAccessInReturnStmt.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInFieldAccessInReturnStmt.json
@@ -47,7 +47,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInFieldAccess.bal",
-          318
+          {
+            "line": 16,
+            "character": 15
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInFieldAccessInReturnStmt.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInFieldAccessInReturnStmt.json
@@ -43,7 +43,7 @@
         }
       ],
       "command": {
-        "title": "Rename variable",
+        "title": "Rename Variable",
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInFieldAccess.bal",

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInImplicitNewExpression.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInImplicitNewExpression.json
@@ -26,7 +26,7 @@
               "character": 4
             }
           },
-          "newText": "Person var1 \u003d new (\"Anne\", 25);\n    "
+          "newText": "Person var1 = new (\"Anne\", 25);\n    "
         },
         {
           "range": {
@@ -41,7 +41,16 @@
           },
           "newText": "var1"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename variable",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToVariableInImplicitNewExpression.bal",
+          222
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInImplicitNewExpression.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInImplicitNewExpression.json
@@ -47,7 +47,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInImplicitNewExpression.bal",
-          222
+          {
+            "line": 12,
+            "character": 20
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInImplicitNewExpression.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInImplicitNewExpression.json
@@ -43,7 +43,7 @@
         }
       ],
       "command": {
-        "title": "Rename variable",
+        "title": "Rename Variable",
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInImplicitNewExpression.bal",

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInIndexedExpression.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInIndexedExpression.json
@@ -26,7 +26,7 @@
               "character": 4
             }
           },
-          "newText": "int var1 \u003d intArr[0];\n    "
+          "newText": "int var1 = intArr[0];\n    "
         },
         {
           "range": {
@@ -41,7 +41,16 @@
           },
           "newText": "var1"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename variable",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToVariableInIndexedExpression.bal",
+          104
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInIndexedExpression.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInIndexedExpression.json
@@ -43,7 +43,7 @@
         }
       ],
       "command": {
-        "title": "Rename variable",
+        "title": "Rename Variable",
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInIndexedExpression.bal",

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInIndexedExpression.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInIndexedExpression.json
@@ -47,7 +47,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInIndexedExpression.bal",
-          104
+          {
+            "line": 3,
+            "character": 22
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInLetExpression.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInLetExpression.json
@@ -26,7 +26,7 @@
               "character": 4
             }
           },
-          "newText": "int var1 \u003d let int letVar1 \u003d 1, int letVar2 \u003d letVar1 + 1 + intVal in letVar1;\n    "
+          "newText": "int var1 = let int letVar1 = 1, int letVar2 = letVar1 + 1 + intVal in letVar1;\n    "
         },
         {
           "range": {
@@ -41,7 +41,16 @@
           },
           "newText": "var1"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename variable",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToVariableInLetExpression.bal",
+          148
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInLetExpression.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInLetExpression.json
@@ -43,7 +43,7 @@
         }
       ],
       "command": {
-        "title": "Rename variable",
+        "title": "Rename Variable",
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInLetExpression.bal",

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInLetExpression.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInLetExpression.json
@@ -47,7 +47,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInLetExpression.bal",
-          148
+          {
+            "line": 3,
+            "character": 19
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInListConstructor.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInListConstructor.json
@@ -26,7 +26,7 @@
               "character": 4
             }
           },
-          "newText": "int[] var1 \u003d [1,2,3,4];\n    "
+          "newText": "int[] var1 = [1,2,3,4];\n    "
         },
         {
           "range": {
@@ -41,7 +41,16 @@
           },
           "newText": "var1"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename variable",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToVariableInListConstructor.bal",
+          73
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInListConstructor.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInListConstructor.json
@@ -43,7 +43,7 @@
         }
       ],
       "command": {
-        "title": "Rename variable",
+        "title": "Rename Variable",
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInListConstructor.bal",

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInListConstructor.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInListConstructor.json
@@ -47,7 +47,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInListConstructor.bal",
-          73
+          {
+            "line": 2,
+            "character": 19
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInMappingConstructor.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInMappingConstructor.json
@@ -26,7 +26,7 @@
               "character": 4
             }
           },
-          "newText": "Person var1 \u003d {name: \"Anne\", age: 10};\n    "
+          "newText": "Person var1 = {name: \"Anne\", age: 10};\n    "
         },
         {
           "range": {
@@ -41,7 +41,16 @@
           },
           "newText": "var1"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename variable",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToVariableInMappingConstructor.bal",
+          140
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInMappingConstructor.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInMappingConstructor.json
@@ -47,7 +47,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInMappingConstructor.bal",
-          140
+          {
+            "line": 7,
+            "character": 16
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInMappingConstructor.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInMappingConstructor.json
@@ -43,7 +43,7 @@
         }
       ],
       "command": {
-        "title": "Rename variable",
+        "title": "Rename Variable",
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInMappingConstructor.bal",

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInMappingConstructor2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInMappingConstructor2.json
@@ -26,7 +26,7 @@
               "character": 4
             }
           },
-          "newText": "record {|string field1;|} var1 \u003d {field1: \"\"};\n    "
+          "newText": "record {|string field1;|} var1 = {field1: \"\"};\n    "
         },
         {
           "range": {
@@ -41,7 +41,16 @@
           },
           "newText": "var1"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename variable",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToVariableInMappingConstructor.bal",
+          196
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInMappingConstructor2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInMappingConstructor2.json
@@ -43,7 +43,7 @@
         }
       ],
       "command": {
-        "title": "Rename variable",
+        "title": "Rename Variable",
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInMappingConstructor.bal",

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInMappingConstructor2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInMappingConstructor2.json
@@ -47,7 +47,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInMappingConstructor.bal",
-          196
+          {
+            "line": 9,
+            "character": 18
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInMappingConstructor3.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInMappingConstructor3.json
@@ -26,7 +26,7 @@
               "character": 0
             }
           },
-          "newText": "record {|string field2;|} var1 \u003d {field2: \"\"};\n"
+          "newText": "record {|string field2;|} var1 = {field2: \"\"};\n"
         },
         {
           "range": {
@@ -41,7 +41,16 @@
           },
           "newText": "var1"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename variable",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToVariableInMappingConstructor.bal",
+          224
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInMappingConstructor3.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInMappingConstructor3.json
@@ -43,7 +43,7 @@
         }
       ],
       "command": {
-        "title": "Rename variable",
+        "title": "Rename Variable",
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInMappingConstructor.bal",

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInMappingConstructor3.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInMappingConstructor3.json
@@ -47,7 +47,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInMappingConstructor.bal",
-          224
+          {
+            "line": 12,
+            "character": 15
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInMappingConstructor4.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInMappingConstructor4.json
@@ -42,6 +42,14 @@
           "newText": "var1"
         }
       ],
+      "command": {
+        "title": "Rename Variable",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToVariableInMappingConstructor2.bal",
+          148
+        ]
+      },
       "resolvable": false
     }
   ]

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInMappingConstructor4.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInMappingConstructor4.json
@@ -47,7 +47,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInMappingConstructor2.bal",
-          148
+          {
+            "line": 4,
+            "character": 30
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInMethodCall.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInMethodCall.json
@@ -26,7 +26,7 @@
               "character": 4
             }
           },
-          "newText": "int var1 \u003d sq.getArea(5);\n    "
+          "newText": "int var1 = sq.getArea(5);\n    "
         },
         {
           "range": {
@@ -41,7 +41,16 @@
           },
           "newText": "var1"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename variable",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToVariableInMethodCall.bal",
+          180
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInMethodCall.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInMethodCall.json
@@ -43,7 +43,7 @@
         }
       ],
       "command": {
-        "title": "Rename variable",
+        "title": "Rename Variable",
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInMethodCall.bal",

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInMethodCall.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInMethodCall.json
@@ -47,7 +47,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInMethodCall.bal",
-          180
+          {
+            "line": 9,
+            "character": 15
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInMethodCall2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInMethodCall2.json
@@ -26,7 +26,7 @@
               "character": 4
             }
           },
-          "newText": "string var1 \u003d 2.toString();\n    "
+          "newText": "string var1 = 2.toString();\n    "
         },
         {
           "range": {
@@ -41,7 +41,16 @@
           },
           "newText": "var1"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename variable",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToVariableInMethodCall.bal",
+          213
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInMethodCall2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInMethodCall2.json
@@ -43,7 +43,7 @@
         }
       ],
       "command": {
-        "title": "Rename variable",
+        "title": "Rename Variable",
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInMethodCall.bal",

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInMethodCall2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInMethodCall2.json
@@ -47,7 +47,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInMethodCall.bal",
-          213
+          {
+            "line": 11,
+            "character": 15
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInObjectField.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInObjectField.json
@@ -26,7 +26,7 @@
               "character": 4
             }
           },
-          "newText": "int var1 \u003d 40;\n    "
+          "newText": "int var1 = 40;\n    "
         },
         {
           "range": {
@@ -41,7 +41,16 @@
           },
           "newText": "var1"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename variable",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToVariableInFieldAccess.bal",
+          210
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInObjectField.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInObjectField.json
@@ -43,7 +43,7 @@
         }
       ],
       "command": {
-        "title": "Rename variable",
+        "title": "Rename Variable",
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInFieldAccess.bal",

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInObjectField.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInObjectField.json
@@ -47,7 +47,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInFieldAccess.bal",
-          210
+          {
+            "line": 12,
+            "character": 22
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInQNameRef.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInQNameRef.json
@@ -26,7 +26,7 @@
               "character": 4
             }
           },
-          "newText": "int var1 \u003d int:MAX_VALUE;\n    "
+          "newText": "int var1 = int:MAX_VALUE;\n    "
         },
         {
           "range": {
@@ -41,7 +41,16 @@
           },
           "newText": "var1"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename variable",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToVariableInQNameRef.bal",
+          73
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInQNameRef.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInQNameRef.json
@@ -47,7 +47,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInQNameRef.bal",
-          73
+          {
+            "line": 2,
+            "character": 17
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInQNameRef.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInQNameRef.json
@@ -43,7 +43,7 @@
         }
       ],
       "command": {
-        "title": "Rename variable",
+        "title": "Rename Variable",
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInQNameRef.bal",

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInQueryExpression.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInQueryExpression.json
@@ -26,7 +26,7 @@
               "character": 4
             }
           },
-          "newText": "int[] var1 \u003d from var i in nums\n                        select i * 10;\n    "
+          "newText": "int[] var1 = from var i in nums\n                        select i * 10;\n    "
         },
         {
           "range": {
@@ -41,7 +41,16 @@
           },
           "newText": "var1"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename variable",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToVariableInQueryExpression.bal",
+          156
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInQueryExpression.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInQueryExpression.json
@@ -43,7 +43,7 @@
         }
       ],
       "command": {
-        "title": "Rename variable",
+        "title": "Rename Variable",
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInQueryExpression.bal",

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInQueryExpression.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInQueryExpression.json
@@ -47,7 +47,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInQueryExpression.bal",
-          156
+          {
+            "line": 3,
+            "character": 24
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInTableConstructor.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInTableConstructor.json
@@ -26,7 +26,7 @@
               "character": 0
             }
           },
-          "newText": "table\u003cEmployee\u003e key(name) var1 \u003d table [\n    { name: \"John\", salary: 100 },\n    { name: \"Jane\", salary: 200 }\n];\n"
+          "newText": "table<Employee> key(name) var1 = table [\n    { name: \"John\", salary: 100 },\n    { name: \"Jane\", salary: 200 }\n];\n"
         },
         {
           "range": {
@@ -41,7 +41,16 @@
           },
           "newText": "var1"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename variable",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToVariableInTableConstructor.bal",
+          212
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInTableConstructor.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInTableConstructor.json
@@ -47,7 +47,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInTableConstructor.bal",
-          212
+          {
+            "line": 6,
+            "character": 30
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInTableConstructor.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInTableConstructor.json
@@ -43,7 +43,7 @@
         }
       ],
       "command": {
-        "title": "Rename variable",
+        "title": "Rename Variable",
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInTableConstructor.bal",

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInTableConstructor2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInTableConstructor2.json
@@ -26,7 +26,7 @@
               "character": 0
             }
           },
-          "newText": "table\u003cEmployee\u003e key(name) var1 \u003d table key(name) [\n        {name: \"Cena\", salary: 0},\n        {name: \"Edward\", salary: 600}\n    ];\n"
+          "newText": "table<Employee> key(name) var1 = table key(name) [\n        {name: \"Cena\", salary: 0},\n        {name: \"Edward\", salary: 600}\n    ];\n"
         },
         {
           "range": {
@@ -41,7 +41,16 @@
           },
           "newText": "var1"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename variable",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToVariableInTableConstructor.bal",
+          379
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInTableConstructor2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInTableConstructor2.json
@@ -47,7 +47,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInTableConstructor.bal",
-          379
+          {
+            "line": 13,
+            "character": 21
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInTableConstructor2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInTableConstructor2.json
@@ -43,7 +43,7 @@
         }
       ],
       "command": {
-        "title": "Rename variable",
+        "title": "Rename Variable",
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInTableConstructor.bal",

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInTrapExpression.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInTrapExpression.json
@@ -26,7 +26,7 @@
               "character": 5
             }
           },
-          "newText": "int|error var1 \u003d trap foo();\n     "
+          "newText": "int|error var1 = trap foo();\n     "
         },
         {
           "range": {
@@ -41,7 +41,16 @@
           },
           "newText": "var1"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename variable",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToVariableInTrapExpression.bal",
+          84
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInTrapExpression.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInTrapExpression.json
@@ -47,7 +47,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInTrapExpression.bal",
-          84
+          {
+            "line": 2,
+            "character": 24
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInTrapExpression.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInTrapExpression.json
@@ -43,7 +43,7 @@
         }
       ],
       "command": {
-        "title": "Rename variable",
+        "title": "Rename Variable",
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInTrapExpression.bal",

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInTrapExpression2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInTrapExpression2.json
@@ -20,7 +20,7 @@
               "character": 5
             }
           },
-          "newText": "int var1 \u003d foo();\n     "
+          "newText": "int var1 = foo();\n     "
         },
         {
           "range": {
@@ -35,7 +35,16 @@
           },
           "newText": "var1"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename variable",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToVariableInTrapExpression.bal",
+          78
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInTrapExpression2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInTrapExpression2.json
@@ -41,7 +41,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInTrapExpression.bal",
-          78
+          {
+            "line": 2,
+            "character": 29
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInTrapExpression2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInTrapExpression2.json
@@ -37,7 +37,7 @@
         }
       ],
       "command": {
-        "title": "Rename variable",
+        "title": "Rename Variable",
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInTrapExpression.bal",

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInTypeCastExpression.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInTypeCastExpression.json
@@ -26,7 +26,7 @@
               "character": 4
             }
           },
-          "newText": "int var1 \u003d \u003cint\u003efloatVal;\n    "
+          "newText": "int var1 = <int>floatVal;\n    "
         },
         {
           "range": {
@@ -41,7 +41,16 @@
           },
           "newText": "var1"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename variable",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToVariableInTypeCastExpression.bal",
+          99
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInTypeCastExpression.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInTypeCastExpression.json
@@ -47,7 +47,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInTypeCastExpression.bal",
-          99
+          {
+            "line": 3,
+            "character": 17
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInTypeCastExpression.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInTypeCastExpression.json
@@ -43,7 +43,7 @@
         }
       ],
       "command": {
-        "title": "Rename variable",
+        "title": "Rename Variable",
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInTypeCastExpression.bal",

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInTypeTestExpression.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInTypeTestExpression.json
@@ -26,7 +26,7 @@
               "character": 4
             }
           },
-          "newText": "boolean var1 \u003d val is int;\n    "
+          "newText": "boolean var1 = val is int;\n    "
         },
         {
           "range": {
@@ -41,7 +41,16 @@
           },
           "newText": "var1"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename variable",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToVariableInTypeTestExpression.bal",
+          91
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInTypeTestExpression.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInTypeTestExpression.json
@@ -43,7 +43,7 @@
         }
       ],
       "command": {
-        "title": "Rename variable",
+        "title": "Rename Variable",
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInTypeTestExpression.bal",

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInTypeTestExpression.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInTypeTestExpression.json
@@ -47,7 +47,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInTypeTestExpression.bal",
-          91
+          {
+            "line": 2,
+            "character": 20
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInTypeofExpression.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInTypeofExpression.json
@@ -26,7 +26,7 @@
               "character": 4
             }
           },
-          "newText": "typedesc\u003cT1\u003e var1 \u003d typeof a;\n    "
+          "newText": "typedesc<T1> var1 = typeof a;\n    "
         },
         {
           "range": {
@@ -41,7 +41,16 @@
           },
           "newText": "var1"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename variable",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToVariableInTypeofExpression.bal",
+          153
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInTypeofExpression.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInTypeofExpression.json
@@ -43,7 +43,7 @@
         }
       ],
       "command": {
-        "title": "Rename variable",
+        "title": "Rename Variable",
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInTypeofExpression.bal",

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInTypeofExpression.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInTypeofExpression.json
@@ -47,7 +47,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInTypeofExpression.bal",
-          153
+          {
+            "line": 8,
+            "character": 22
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInUnaryExpression.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInUnaryExpression.json
@@ -26,7 +26,7 @@
               "character": 4
             }
           },
-          "newText": "int var1 \u003d ~10;\n    "
+          "newText": "int var1 = ~10;\n    "
         },
         {
           "range": {
@@ -41,7 +41,16 @@
           },
           "newText": "var1"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename variable",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToVariableInUnaryExpression.bal",
+          63
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInUnaryExpression.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInUnaryExpression.json
@@ -47,7 +47,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInUnaryExpression.bal",
-          63
+          {
+            "line": 2,
+            "character": 17
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInUnaryExpression.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInUnaryExpression.json
@@ -43,7 +43,7 @@
         }
       ],
       "command": {
-        "title": "Rename variable",
+        "title": "Rename Variable",
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInUnaryExpression.bal",

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInXmlnsDecl.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInXmlnsDecl.json
@@ -26,7 +26,7 @@
               "character": 4
             }
           },
-          "newText": "xml:Element var1 \u003d xml `\u003ceg:doc\u003eHello\u003c/eg:doc\u003e`;\n    "
+          "newText": "xml:Element var1 = xml `<eg:doc>Hello</eg:doc>`;\n    "
         },
         {
           "range": {
@@ -41,7 +41,16 @@
           },
           "newText": "var1"
         }
-      ]
+      ],
+      "command": {
+        "title": "Rename variable",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "extractToVariableInXmlnsDecl.bal",
+          129
+        ]
+      },
+      "resolvable": false
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInXmlnsDecl.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInXmlnsDecl.json
@@ -43,7 +43,7 @@
         }
       ],
       "command": {
-        "title": "Rename variable",
+        "title": "Rename Variable",
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInXmlnsDecl.bal",

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInXmlnsDecl.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInXmlnsDecl.json
@@ -47,7 +47,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "extractToVariableInXmlnsDecl.bal",
-          129
+          {
+            "line": 3,
+            "character": 12
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/type-guard/config/typeGuardCodeAction1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/type-guard/config/typeGuardCodeAction1.json
@@ -28,7 +28,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "typeGuard.bal",
-          62
+          {
+            "line": 3,
+            "character": 21
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/type-guard/config/typeGuardCodeAction2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/type-guard/config/typeGuardCodeAction2.json
@@ -41,7 +41,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "typeGuard.bal",
-          63
+          {
+            "line": 4,
+            "character": 11
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/type-guard/config/typeGuardCodeAction3.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/type-guard/config/typeGuardCodeAction3.json
@@ -41,7 +41,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "typeGuard.bal",
-          80
+          {
+            "line": 5,
+            "character": 14
+          }
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/type-guard/config/typeGuardWithTuple1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/type-guard/config/typeGuardWithTuple1.json
@@ -41,7 +41,10 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "typeGuardWithTuple1.bal",
-          52
+          {
+            "line": 1,
+            "character": 27
+          }
         ]
       },
       "resolvable": false


### PR DESCRIPTION
## Purpose
This PR will add rename popup for the extract to constant and extract to local variable code actions.

Fixes #37479
Related PRS #37891(2201.2.x-closed), #37970(master)

https://user-images.githubusercontent.com/46857198/192220255-a6301a6a-85f5-4af1-be98-9fc67697ff41.mov


## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples