### PR TITLE
[master] Handle var-decl initializer not present case in `ConvertToQueryExpressionCodeAction`

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ConvertToQueryExpressionCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ConvertToQueryExpressionCodeAction.java
@@ -175,11 +175,13 @@ public class ConvertToQueryExpressionCodeAction implements RangeBasedCodeActionP
         SemanticModel semanticModel = context.currentSemanticModel().get();
         if (matchedNode.kind() == SyntaxKind.LOCAL_VAR_DECL) {
             VariableDeclarationNode node = (VariableDeclarationNode) matchedNode;
-            rhsNode = node.initializer().get();
-            rhsSymbol = semanticModel.symbol(rhsNode);
-            lhsNode = node.typedBindingPattern();
-            lhsSymbol = semanticModel.symbol(lhsNode)
-                    .filter(symbol -> symbol.kind() == SymbolKind.VARIABLE);
+            if (node.initializer().isPresent()) {
+                rhsNode = node.initializer().get();
+                rhsSymbol = semanticModel.symbol(rhsNode);
+                lhsNode = node.typedBindingPattern();
+                lhsSymbol = semanticModel.symbol(lhsNode)
+                        .filter(symbol -> symbol.kind() == SymbolKind.VARIABLE);
+            }
         } else if (matchedNode.kind() == SyntaxKind.ASSIGNMENT_STATEMENT) {
             // There can be 2 types here: Variable assignments and field access expressions.
             // 1. list = otherList;


### PR DESCRIPTION
## Purpose
$subject

Fixes #38248

## Approach
Checked if initializer is not present of the variable declaration node. A variable declaration node without an initializer is valid syntactically.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
