### PR TITLE
[master] Refactor DocumentServiceContext visibleSymbols() method and completions in import declaration node

### DIFF
--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/DocumentServiceContext.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/DocumentServiceContext.java
@@ -76,6 +76,16 @@ public interface DocumentServiceContext {
      * @return {@link LSOperation}
      */
     LSOperation operation();
+    
+    /**
+     * Get the imports in the current document.
+     * This API is deprecated. Instead, use {@link #currentDocImportsMap}
+     *
+     * @return {@link List} of import nodes
+     * @deprecated Use {@link #currentDocImportsMap()} instead
+     */
+    @Deprecated(forRemoval = true)
+    List<ImportDeclarationNode> currentDocImports();
 
     /**
      * Get the imports in the current document.

--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/DocumentServiceContext.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/DocumentServiceContext.java
@@ -79,16 +79,6 @@ public interface DocumentServiceContext {
 
     /**
      * Get the imports in the current document.
-     * This API is deprecated. Instead, use {@link #currentDocImportsMap}
-     *
-     * @return {@link List} of import nodes
-     * @deprecated Use {@link #currentDocImportsMap()} instead
-     */
-    @Deprecated(forRemoval = true)
-    List<ImportDeclarationNode> currentDocImports();
-
-    /**
-     * Get the imports in the current document.
      *
      * @return {@link Map} of import nodes
      */

--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/HoverContext.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/HoverContext.java
@@ -44,13 +44,6 @@ public interface HoverContext extends PositionedOperationContext {
     Token getTokenAtCursor();
 
     /**
-     * Get the cursor position.
-     *
-     * @return {@link Position}
-     */
-    Position getCursorPosition();
-
-    /**
      * Set the node at cursor.
      *
      * @param node {@link NonTerminalNode} at the cursor position

--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/HoverContext.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/HoverContext.java
@@ -19,7 +19,6 @@ package org.ballerinalang.langserver.commons;
 
 import io.ballerina.compiler.syntax.tree.NonTerminalNode;
 import io.ballerina.compiler.syntax.tree.Token;
-import org.eclipse.lsp4j.Position;
 
 /**
  * Represents the hover operation context.

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ImportDeclarationNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ImportDeclarationNodeContext.java
@@ -272,7 +272,7 @@ public class ImportDeclarationNodeContext extends AbstractCompletionProvider<Imp
     private ArrayList<LSCompletionItem> moduleNameContextCompletions(BallerinaCompletionContext context,
                                                                      ImportDeclarationNode node) {
         String orgName = node.orgName().get().orgName().text();
-        List< TextEdit> additionalEdits = new ArrayList<>();
+        List<TextEdit> additionalEdits = new ArrayList<>();
         // If the module name contains a dot, we should replace what's before the last dot to make sure a part
         // of the module name is not repeated.
         if (node.moduleName().size() > 1) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ImportDeclarationNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ImportDeclarationNodeContext.java
@@ -27,10 +27,12 @@ import io.ballerina.projects.Module;
 import io.ballerina.projects.PackageName;
 import io.ballerina.projects.Project;
 import io.ballerina.projects.ProjectKind;
+import io.ballerina.tools.text.LinePosition;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.LSPackageLoader;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.common.utils.ModuleUtil;
+import org.ballerinalang.langserver.common.utils.PositionUtil;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
 import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
@@ -38,6 +40,8 @@ import org.ballerinalang.langserver.completions.SnippetCompletionItem;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
 import org.ballerinalang.langserver.completions.util.Snippet;
 import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextEdit;
 import org.wso2.ballerinalang.compiler.util.Names;
 
 import java.util.ArrayList;
@@ -79,6 +83,7 @@ public class ImportDeclarationNodeContext extends AbstractCompletionProvider<Imp
             (3) import abc.xy<cursor>
             (4) import org/mod<cursor>
             (5) import org/mod v<cursor>
+            (6) import org/mod.<cursor>
             
             Suggests org names and the module names within the same directory
          */
@@ -103,8 +108,7 @@ public class ImportDeclarationNodeContext extends AbstractCompletionProvider<Imp
             /*
             Covers case (4)
              */
-            String orgName = node.orgName().get().orgName().text();
-            completionItems.addAll(this.moduleNameContextCompletions(ctx, orgName));
+            completionItems.addAll(this.moduleNameContextCompletions(ctx, node));
             contextScope = ContextScope.SCOPE2;
         } else {
             /*
@@ -266,7 +270,27 @@ public class ImportDeclarationNodeContext extends AbstractCompletionProvider<Imp
     }
 
     private ArrayList<LSCompletionItem> moduleNameContextCompletions(BallerinaCompletionContext context,
-                                                                     String orgName) {
+                                                                     ImportDeclarationNode node) {
+        String orgName = node.orgName().get().orgName().text();
+        List< TextEdit> additionalEdits = new ArrayList<>();
+        // If the module name contains a dot, we should replace what's before the last dot to make sure a part
+        // of the module name is not repeated.
+        if (node.moduleName().size() > 1) {
+            // There can be 2 cases:
+            // 1) orgName/mod.xx<cursor>
+            // 2) orgName/mod.<cursor>
+            IdentifierToken lastModeNamePart = node.moduleName().get(node.moduleName().size() - 1);
+            LinePosition startPos = node.orgName().get().lineRange().endLine();
+            LinePosition endPos = lastModeNamePart.lineRange().endLine();
+            if (!lastModeNamePart.isMissing()) {
+                // Case (2) above
+                endPos = lastModeNamePart.lineRange().startLine();
+            }
+            Range editRange = new Range(PositionUtil.toPosition(startPos), PositionUtil.toPosition(endPos));
+            TextEdit removeModNameEdit = new TextEdit(editRange, "");
+            additionalEdits.add(removeModNameEdit);
+        }
+        
         ArrayList<LSCompletionItem> completionItems = new ArrayList<>();
         List<String> addedPkgNames = new ArrayList<>();
         LanguageServerContext serverContext = context.languageServercontext();
@@ -285,7 +309,9 @@ public class ImportDeclarationNodeContext extends AbstractCompletionProvider<Imp
                 }
                 addedPkgNames.add(packageName);
                 // Do not add the semi colon at the end of the insert text since the user might type the as keyword
-                completionItems.add(getImportCompletion(context, packageName, insertText));
+                LSCompletionItem completionItem = getImportCompletion(context, packageName, insertText);
+                completionItem.getCompletionItem().setAdditionalTextEdits(additionalEdits);
+                completionItems.add(completionItem);
             }
         });
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ImportOrgNameNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ImportOrgNameNodeContext.java
@@ -56,7 +56,7 @@ public class ImportOrgNameNodeContext extends AbstractCompletionProvider<ImportO
         }
 
         List<LSPackageLoader.ModuleInfo> moduleList =
-                new ArrayList<>(LSPackageLoader.getInstance(ctx.languageServercontext()).getDistributionRepoPackages());
+                new ArrayList<>(LSPackageLoader.getInstance(ctx.languageServercontext()).getAllVisiblePackages(ctx));
         ArrayList<LSCompletionItem> completionItems = moduleNameContextCompletions(ctx, orgName, moduleList);
         this.sort(ctx, node, completionItems);
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/AbstractDocumentServiceContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/AbstractDocumentServiceContext.java
@@ -60,9 +60,7 @@ public class AbstractDocumentServiceContext implements DocumentServiceContext {
     private final String fileUri;
 
     private final WorkspaceManager workspaceManager;
-
-    private List<Symbol> visibleSymbols;
-
+    
     private List<ImportDeclarationNode> currentDocImports;
 
     private Map<ImportDeclarationNode, ModuleSymbol> currentDocImportsMap;
@@ -132,26 +130,23 @@ public class AbstractDocumentServiceContext implements DocumentServiceContext {
 
     @Override
     public List<Symbol> visibleSymbols(Position position) {
-        if (this.visibleSymbols == null) {
-            Optional<SemanticModel> semanticModel;
-            if (this.cancelChecker == null) {
-                semanticModel = this.workspaceManager.semanticModel(this.filePath);
-            } else {
-                semanticModel = this.workspaceManager.semanticModel(this.filePath, this.cancelChecker);
-            }
-            Optional<Document> srcFile = this.workspaceManager.document(filePath);
+        Optional<SemanticModel> semanticModel;
+        if (this.cancelChecker == null) {
+            semanticModel = this.workspaceManager.semanticModel(this.filePath);
+        } else {
+            semanticModel = this.workspaceManager.semanticModel(this.filePath, this.cancelChecker);
+        }
+        Optional<Document> srcFile = this.workspaceManager.document(filePath);
 
-            if (semanticModel.isEmpty() || srcFile.isEmpty()) {
-                return Collections.emptyList();
-            }
-
-            this.checkCancelled();
-            visibleSymbols = semanticModel.get().visibleSymbols(srcFile.get(),
-                    LinePosition.from(position.getLine(),
-                            position.getCharacter()), DiagnosticState.VALID, DiagnosticState.REDECLARED);
+        if (semanticModel.isEmpty() || srcFile.isEmpty()) {
+            return Collections.emptyList();
         }
 
-        return visibleSymbols;
+        this.checkCancelled();
+
+        return semanticModel.get().visibleSymbols(srcFile.get(),
+                LinePosition.from(position.getLine(),
+                        position.getCharacter()), DiagnosticState.VALID, DiagnosticState.REDECLARED);
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/AbstractDocumentServiceContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/AbstractDocumentServiceContext.java
@@ -42,6 +42,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+
 import javax.annotation.Nonnull;
 
 /**
@@ -58,8 +59,6 @@ public class AbstractDocumentServiceContext implements DocumentServiceContext {
     private final String fileUri;
 
     private final WorkspaceManager workspaceManager;
-    
-    private List<ImportDeclarationNode> currentDocImports;
 
     private Map<ImportDeclarationNode, ModuleSymbol> currentDocImportsMap;
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/AbstractDocumentServiceContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/AbstractDocumentServiceContext.java
@@ -42,6 +42,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 
@@ -149,6 +150,16 @@ public class AbstractDocumentServiceContext implements DocumentServiceContext {
     @Override
     public WorkspaceManager workspace() {
         return this.workspaceManager;
+    }
+
+    @Override
+    public List<ImportDeclarationNode> currentDocImports() {
+        Optional<Document> document = this.workspace().document(this.filePath);
+        if (document.isEmpty()) {
+            throw new RuntimeException("Cannot find a valid document");
+        }
+        return ((ModulePartNode) document.get().syntaxTree().rootNode()).imports().stream()
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/AbstractDocumentServiceContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/AbstractDocumentServiceContext.java
@@ -42,8 +42,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
-
 import javax.annotation.Nonnull;
 
 /**
@@ -152,20 +150,6 @@ public class AbstractDocumentServiceContext implements DocumentServiceContext {
     @Override
     public WorkspaceManager workspace() {
         return this.workspaceManager;
-    }
-
-    @Override
-    public List<ImportDeclarationNode> currentDocImports() {
-        if (this.currentDocImports == null) {
-            Optional<Document> document = this.workspace().document(this.filePath);
-            if (document.isEmpty()) {
-                throw new RuntimeException("Cannot find a valid document");
-            }
-            this.currentDocImports = ((ModulePartNode) document.get().syntaxTree().rootNode()).imports().stream()
-                    .collect(Collectors.toList());
-        }
-
-        return this.currentDocImports;
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/BallerinaDefinitionContextImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/BallerinaDefinitionContextImpl.java
@@ -34,12 +34,10 @@ import java.util.Optional;
  *
  * @since 2.0.0
  */
-public class BallerinaDefinitionContextImpl
-        extends AbstractDocumentServiceContext implements BallerinaDefinitionContext {
+public class BallerinaDefinitionContextImpl 
+        extends PositionedOperationContextImpl implements BallerinaDefinitionContext {
     private boolean capturedEnclosingNode = false;
     private ModuleMemberDeclarationNode enclosingNode = null;
-    private int cursorPosInTree = -1;
-    private final Position cursorPosition;
 
     BallerinaDefinitionContextImpl(LSOperation operation,
                                    String fileUri,
@@ -47,8 +45,7 @@ public class BallerinaDefinitionContextImpl
                                    Position position,
                                    LanguageServerContext serverContext,
                                    CancelChecker cancelChecker) {
-        super(operation, fileUri, wsManager, serverContext, cancelChecker);
-        this.cursorPosition = position;
+        super(operation, fileUri, position, wsManager, serverContext, cancelChecker);
     }
 
     @Override
@@ -65,25 +62,7 @@ public class BallerinaDefinitionContextImpl
 
         return Optional.ofNullable(this.enclosingNode);
     }
-
-    @Override
-    public void setCursorPositionInTree(int offset) {
-        if (this.cursorPosInTree > -1) {
-            throw new RuntimeException("Setting the cursor offset more than once is not allowed");
-        }
-        this.cursorPosInTree = offset;
-    }
-
-    @Override
-    public int getCursorPositionInTree() {
-        return this.cursorPosInTree;
-    }
-
-    @Override
-    public Position getCursorPosition() {
-        return this.cursorPosition;
-    }
-
+    
     /**
      * Represents Language server completion context Builder.
      *

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/CompletionContextImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/CompletionContextImpl.java
@@ -31,11 +31,9 @@ import org.eclipse.lsp4j.jsonrpc.CancelChecker;
  *
  * @since 1.2.0
  */
-public class CompletionContextImpl extends AbstractDocumentServiceContext implements CompletionContext {
+public class CompletionContextImpl extends PositionedOperationContextImpl implements CompletionContext {
 
     private final CompletionCapabilities capabilities;
-    private final Position cursorPosition;
-    private int cursorPosInTree = -1;
 
     CompletionContextImpl(LSOperation operation,
                           String fileUri,
@@ -43,9 +41,7 @@ public class CompletionContextImpl extends AbstractDocumentServiceContext implem
                           CompletionCapabilities capabilities,
                           Position cursorPosition,
                           LanguageServerContext serverContext) {
-        super(operation, fileUri, wsManager, serverContext);
-        this.capabilities = capabilities;
-        this.cursorPosition = cursorPosition;
+        this(operation, fileUri, wsManager, capabilities, cursorPosition, serverContext, null);
     }
 
     CompletionContextImpl(LSOperation operation,
@@ -55,34 +51,15 @@ public class CompletionContextImpl extends AbstractDocumentServiceContext implem
                           Position cursorPosition,
                           LanguageServerContext serverContext,
                           CancelChecker cancelChecker) {
-        super(operation, fileUri, wsManager, serverContext, cancelChecker);
+        super(operation, fileUri, cursorPosition, wsManager, serverContext, cancelChecker);
         this.capabilities = capabilities;
-        this.cursorPosition = cursorPosition;
     }
 
     @Override
     public CompletionCapabilities getCapabilities() {
         return this.capabilities;
     }
-
-    @Override
-    public void setCursorPositionInTree(int offset) {
-        if (this.cursorPosInTree > -1) {
-            throw new RuntimeException("Setting the cursor offset more than once is not allowed");
-        }
-        this.cursorPosInTree = offset;
-    }
-
-    @Override
-    public int getCursorPositionInTree() {
-        return this.cursorPosInTree;
-    }
-
-    @Override
-    public Position getCursorPosition() {
-        return this.cursorPosition;
-    }
-
+    
     /**
      * Represents Language server completion context Builder.
      *

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/HoverContextImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/HoverContextImpl.java
@@ -34,14 +34,10 @@ import javax.annotation.Nonnull;
  *
  * @since 1.2.0
  */
-public class HoverContextImpl extends AbstractDocumentServiceContext implements HoverContext {
+public class HoverContextImpl extends PositionedOperationContextImpl implements HoverContext {
 
     private Token tokenAtCursor;
-
-    private final Position cursorPosition;
-
-    private int cursorPositionInTree = -1;
-
+    
     private NonTerminalNode nodeAtCursor;
 
     HoverContextImpl(LSOperation operation,
@@ -50,8 +46,7 @@ public class HoverContextImpl extends AbstractDocumentServiceContext implements 
                      Position cursorPosition,
                      LanguageServerContext serverContext,
                      CancelChecker cancelChecker) {
-        super(operation, fileUri, wsManager, serverContext, cancelChecker);
-        this.cursorPosition = cursorPosition;
+        super(operation, fileUri, cursorPosition, wsManager, serverContext, cancelChecker);
     }
 
     @Override
@@ -67,25 +62,7 @@ public class HoverContextImpl extends AbstractDocumentServiceContext implements 
 
         return this.tokenAtCursor;
     }
-
-    @Override
-    public void setCursorPositionInTree(int offset) {
-        if (this.cursorPositionInTree > -1) {
-            throw new RuntimeException("Setting the cursor offset more than once is not allowed");
-        }
-        this.cursorPositionInTree = offset;
-    }
-
-    @Override
-    public int getCursorPositionInTree() {
-        return this.cursorPositionInTree;
-    }
-
-    @Override
-    public Position getCursorPosition() {
-        return this.cursorPosition;
-    }
-
+    
     @Override
     public void setNodeAtCursor(NonTerminalNode node) {
         if (this.nodeAtCursor != null) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/PositionedOperationContextImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/PositionedOperationContextImpl.java
@@ -55,7 +55,8 @@ public abstract class PositionedOperationContextImpl extends AbstractDocumentSer
      * {@inheritDoc}
      * <p>
      * Since we know the cursor position here, we can cache the visible symbols for the cursor position. This will be
-     * good for the performance since the chance of accessing the visible symbols of the cursor position repetitively is high.
+     * good for the performance since the chance of accessing the visible symbols of the cursor position repetitively
+     * is high.
      *
      * @param position Position at which visible symbols are needed
      * @return Visible symbols

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/PositionedOperationContextImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/PositionedOperationContextImpl.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.langserver.contexts;
 
+import io.ballerina.compiler.api.symbols.Symbol;
 import org.ballerinalang.langserver.LSContextOperation;
 import org.ballerinalang.langserver.commons.DocumentServiceContext;
 import org.ballerinalang.langserver.commons.LSOperation;
@@ -24,6 +25,8 @@ import org.ballerinalang.langserver.commons.workspace.WorkspaceManager;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 
+import java.util.List;
+
 /**
  * Abstract implementation of the {@link PositionedOperationContext}.
  *
@@ -32,20 +35,59 @@ import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 public abstract class PositionedOperationContextImpl extends AbstractDocumentServiceContext
         implements PositionedOperationContext {
 
-    @Deprecated(forRemoval = true)
-    PositionedOperationContextImpl(LSOperation operation,
-                                   String fileUri,
-                                   WorkspaceManager wsManager,
-                                   LanguageServerContext serverContext) {
-        super(operation, fileUri, wsManager, serverContext);
-    }
+    private final Position cursorPosition;
+
+    private int cursorPositionInTree = -1;
+    
+    private List<Symbol> visibleSymbols;
     
     PositionedOperationContextImpl(LSOperation operation,
                                    String fileUri,
+                                   Position cursorPosition,
                                    WorkspaceManager wsManager,
                                    LanguageServerContext serverContext,
                                    CancelChecker cancelChecker) {
         super(operation, fileUri, wsManager, serverContext, cancelChecker);
+        this.cursorPosition = cursorPosition;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Since we know the cursor position here, we can cache the visible symbols for the cursor position. This will be
+     * good for the performance since the chance of accessing the visible symbols of the cursor position repetitively is high.
+     *
+     * @param position Position at which visible symbols are needed
+     * @return Visible symbols
+     */
+    @Override
+    public List<Symbol> visibleSymbols(Position position) {
+        if (this.cursorPosition.equals(position)) {
+            if (this.visibleSymbols == null) {
+                this.visibleSymbols = super.visibleSymbols(position);
+            }
+            return this.visibleSymbols;
+        } else {
+            return super.visibleSymbols(position);
+        }
+    }
+
+    @Override
+    public void setCursorPositionInTree(int offset) {
+        if (this.cursorPositionInTree > -1) {
+            throw new RuntimeException("Setting the cursor offset more than once is not allowed");
+        }
+        this.cursorPositionInTree = offset;
+    }
+
+    @Override
+    public int getCursorPositionInTree() {
+        return this.cursorPositionInTree;
+    }
+
+    @Override
+    public Position getCursorPosition() {
+        return this.cursorPosition;
     }
 
     /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/ReferencesContextImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/ReferencesContextImpl.java
@@ -32,37 +32,15 @@ import org.eclipse.lsp4j.jsonrpc.CancelChecker;
  */
 public class ReferencesContextImpl extends PositionedOperationContextImpl implements ReferencesContext {
 
-    private final Position cursorPos;
-    private int cursorPosInTree = -1;
-
     ReferencesContextImpl(LSOperation operation,
                           String fileUri,
                           WorkspaceManager wsManager,
                           Position cursorPos,
                           LanguageServerContext serverContext,
                           CancelChecker cancelChecker) {
-        super(operation, fileUri, wsManager, serverContext, cancelChecker);
-        this.cursorPos = cursorPos;
+        super(operation, fileUri, cursorPos, wsManager, serverContext, cancelChecker);
     }
-
-    @Override
-    public Position getCursorPosition() {
-        return this.cursorPos;
-    }
-
-    @Override
-    public void setCursorPositionInTree(int offset) {
-        if (this.cursorPosInTree > -1) {
-            throw new RuntimeException("Setting the cursor offset more than once is not allowed");
-        }
-        this.cursorPosInTree = offset;
-    }
-
-    @Override
-    public int getCursorPositionInTree() {
-        return this.cursorPosInTree;
-    }
-
+    
     /**
      * Represents Language server references context Builder.
      *

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/SignatureContextImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/SignatureContextImpl.java
@@ -34,11 +34,9 @@ import java.util.Optional;
  *
  * @since 1.2.0
  */
-public class SignatureContextImpl extends AbstractDocumentServiceContext implements SignatureContext {
+public class SignatureContextImpl extends PositionedOperationContextImpl implements SignatureContext {
 
     private final SignatureHelpCapabilities capabilities;
-    private final Position cursorPos;
-    private int cursorPosInTree = -1;
     private NonTerminalNode nodeAtCursor;
 
     SignatureContextImpl(LSOperation operation,
@@ -48,32 +46,13 @@ public class SignatureContextImpl extends AbstractDocumentServiceContext impleme
                          Position cursorPos,
                          LanguageServerContext serverContext,
                          CancelChecker cancelChecker) {
-        super(operation, fileUri, wsManager, serverContext, cancelChecker);
+        super(operation, fileUri, cursorPos, wsManager, serverContext, cancelChecker);
         this.capabilities = capabilities;
-        this.cursorPos = cursorPos;
     }
 
     @Override
     public SignatureHelpCapabilities capabilities() {
         return this.capabilities;
-    }
-
-    @Override
-    public Position getCursorPosition() {
-        return this.cursorPos;
-    }
-
-    @Override
-    public void setCursorPositionInTree(int offset) {
-        if (this.cursorPosInTree > -1) {
-            throw new RuntimeException("Setting the cursor offset more than once is not allowed");
-        }
-        this.cursorPosInTree = offset;
-    }
-
-    @Override
-    public int getCursorPositionInTree() {
-        return this.cursorPosInTree;
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/toml/ballerinatoml/completion/BallerinaTomlCompletionContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/toml/ballerinatoml/completion/BallerinaTomlCompletionContext.java
@@ -44,6 +44,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * Ballerina toml completion context.
@@ -91,6 +92,17 @@ public class BallerinaTomlCompletionContext implements TomlCompletionContext {
                             position.getCharacter()));
         }
         return visibleSymbols;
+    }
+
+    @Override
+    public List<ImportDeclarationNode> currentDocImports() {
+        Optional<Document> document = this.workspace().document(this.filePath());
+        if (document.isEmpty()) {
+            throw new RuntimeException("Cannot find a valid document");
+        }
+
+        return ((ModulePartNode) document.get().syntaxTree().rootNode()).imports().stream()
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/toml/ballerinatoml/completion/BallerinaTomlCompletionContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/toml/ballerinatoml/completion/BallerinaTomlCompletionContext.java
@@ -44,7 +44,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Ballerina toml completion context.
@@ -93,20 +92,6 @@ public class BallerinaTomlCompletionContext implements TomlCompletionContext {
                             position.getCharacter()));
         }
         return visibleSymbols;
-    }
-
-    @Override
-    public List<ImportDeclarationNode> currentDocImports() {
-        if (this.currentDocImports == null) {
-            Optional<Document> document = this.workspace().document(this.filePath());
-            if (document.isEmpty()) {
-                throw new RuntimeException("Cannot find a valid document");
-            }
-            this.currentDocImports = ((ModulePartNode) document.get().syntaxTree().rootNode()).imports().stream()
-                    .collect(Collectors.toList());
-        }
-
-        return this.currentDocImports;
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/toml/ballerinatoml/completion/BallerinaTomlCompletionContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/toml/ballerinatoml/completion/BallerinaTomlCompletionContext.java
@@ -51,7 +51,6 @@ import java.util.Optional;
 public class BallerinaTomlCompletionContext implements TomlCompletionContext {
 
     private List<Symbol> visibleSymbols;
-    private List<ImportDeclarationNode> currentDocImports;
     private Map<ImportDeclarationNode, ModuleSymbol> currentDocImportsMap;
     private final LanguageServerContext languageServerContext;
     private final CompletionCapabilities capabilities;

--- a/language-server/modules/langserver-core/src/test/resources/completion/import_decl/config/import_decl_with_no_module_name1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/import_decl/config/import_decl_with_no_module_name1.json
@@ -1,0 +1,38 @@
+{
+  "position": {
+    "line": 0,
+    "character": 12
+  },
+  "source": "import_decl/source/import_decl_with_no_module_name1.bal",
+  "description": "Test completions in import declaration node: import orgName/<cursor>",
+  "items": [
+    {
+      "label": "project2",
+      "kind": "Module",
+      "detail": "Module",
+      "insertText": "project2",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "project1",
+      "kind": "Module",
+      "detail": "Module",
+      "insertText": "project1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "local_project2",
+      "kind": "Module",
+      "detail": "Module",
+      "insertText": "local_project2",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "local_project1",
+      "kind": "Module",
+      "detail": "Module",
+      "insertText": "local_project1",
+      "insertTextFormat": "Snippet"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/import_decl/config/import_decl_with_partial_module_name1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/import_decl/config/import_decl_with_partial_module_name1.json
@@ -1,0 +1,515 @@
+{
+  "position": {
+    "line": 0,
+    "character": 22
+  },
+  "source": "import_decl/source/import_decl_with_partial_module_name1.bal",
+  "items": [
+    {
+      "label": "module1",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "insertText": "module1",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 17
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": "lang.int",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "insertText": "lang.'int;",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 17
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": "lang.boolean",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "insertText": "lang.'boolean;",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 17
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": "lang.decimal",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "insertText": "lang.'decimal;",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 17
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": "lang.runtime",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "insertText": "lang.runtime;",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 17
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": "lang.future",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "insertText": "lang.'future;",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 17
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": "lang.error",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "insertText": "lang.'error;",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 17
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": "lang.regexp",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "insertText": "lang.regexp;",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 17
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": "lang.transaction",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "insertText": "lang.'transaction;",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 17
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": "lang.object",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "insertText": "lang.'object;",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 17
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": "lang.function",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "insertText": "lang.'function;",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 17
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": "lang.typedesc",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "insertText": "lang.'typedesc;",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 17
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": "lang.table",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "insertText": "lang.'table;",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 17
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": "lang.string",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "insertText": "lang.'string;",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 17
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": "lang.test",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "insertText": "lang.test;",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 17
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": "lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "insertText": "lang.value;",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 17
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": "lang.xml",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "insertText": "lang.'xml;",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 17
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": "jballerina.java",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "insertText": "jballerina.java",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 17
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": "lang.stream",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "insertText": "lang.'stream;",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 17
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": "lang.map",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "insertText": "lang.'map;",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 17
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": "lang.array",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "insertText": "lang.array;",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 17
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": "lang.float",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "insertText": "lang.'float;",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 17
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": ""
+        }
+      ]
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/import_decl/config/import_decl_with_partial_module_name2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/import_decl/config/import_decl_with_partial_module_name2.json
@@ -1,0 +1,515 @@
+{
+  "position": {
+    "line": 0,
+    "character": 25
+  },
+  "source": "import_decl/source/import_decl_with_partial_module_name2.bal",
+  "items": [
+    {
+      "label": "module1",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "insertText": "module1",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 17
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": "lang.int",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "insertText": "lang.'int;",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 17
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": "lang.boolean",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "insertText": "lang.'boolean;",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 17
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": "lang.decimal",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "insertText": "lang.'decimal;",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 17
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": "lang.runtime",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "insertText": "lang.runtime;",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 17
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": "lang.future",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "insertText": "lang.'future;",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 17
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": "lang.error",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "insertText": "lang.'error;",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 17
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": "lang.regexp",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "insertText": "lang.regexp;",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 17
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": "lang.transaction",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "insertText": "lang.'transaction;",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 17
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": "lang.object",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "insertText": "lang.'object;",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 17
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": "lang.function",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "insertText": "lang.'function;",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 17
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": "lang.typedesc",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "insertText": "lang.'typedesc;",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 17
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": "lang.table",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "insertText": "lang.'table;",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 17
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": "lang.string",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "insertText": "lang.'string;",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 17
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": "lang.test",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "insertText": "lang.test;",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 17
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": "lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "insertText": "lang.value;",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 17
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": "lang.xml",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "insertText": "lang.'xml;",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 17
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": "jballerina.java",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "insertText": "jballerina.java",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 17
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": "lang.stream",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "insertText": "lang.'stream;",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 17
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": "lang.map",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "insertText": "lang.'map;",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 17
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": "lang.array",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "insertText": "lang.array;",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 17
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": "lang.float",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "C",
+      "insertText": "lang.'float;",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 17
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": ""
+        }
+      ]
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/import_decl/source/import_decl_with_no_module_name1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/import_decl/source/import_decl_with_no_module_name1.bal
@@ -1,0 +1,1 @@
+import test/

--- a/language-server/modules/langserver-core/src/test/resources/completion/import_decl/source/import_decl_with_partial_module_name1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/import_decl/source/import_decl_with_partial_module_name1.bal
@@ -1,0 +1,1 @@
+import ballerina/lang.

--- a/language-server/modules/langserver-core/src/test/resources/completion/import_decl/source/import_decl_with_partial_module_name2.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/import_decl/source/import_decl_with_partial_module_name2.bal
@@ -1,0 +1,1 @@
+import ballerina/lang.arr


### PR DESCRIPTION
## Purpose
$subject

Only the contexts which are subclasses of `PositionedOperationContext` are now caching the visible symbols for the cursor position.

Fixes #37234
Fixes #38085

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
