### PR TITLE
[2201.3.0] Fix freeze exception thrown for `RegExpValue`

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/RegExpValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/RegExpValue.java
@@ -37,13 +37,13 @@ import static io.ballerina.runtime.internal.ValueUtils.getTypedescValue;
  * @since 2201.3.0
  */
 public class RegExpValue implements BRegexpValue, RefValue {
-    private RegExpDisjunction regExpDisjunction;
-    private BTypedesc typedesc;
-    private final Type type = PredefinedTypes.TYPE_READONLY_ANYDATA;
+    private final RegExpDisjunction regExpDisjunction;
+    private final BTypedesc typedesc;
+    private static final Type type = PredefinedTypes.TYPE_READONLY_ANYDATA;
 
     public RegExpValue(RegExpDisjunction regExpDisjunction) {
         this.regExpDisjunction = regExpDisjunction;
-        setTypedescValue(this.type);
+        this.typedesc = getTypedescValue(type, this);
     }
 
     public RegExpDisjunction getRegExpDisjunction() {
@@ -67,11 +67,7 @@ public class RegExpValue implements BRegexpValue, RefValue {
 
     @Override
     public Type getType() {
-        return this.type;
-    }
-
-    protected void setTypedescValue(Type type) {
-        this.typedesc = getTypedescValue(type, this);
+        return type;
     }
 
     @Override
@@ -97,5 +93,10 @@ public class RegExpValue implements BRegexpValue, RefValue {
     @Override
     public Object frozenCopy(Map<Object, Object> refs) {
         return this;
+    }
+
+    @Override
+    public void freezeDirect() {
+        // RegExpValue is always readonly
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/regexp/RegExpValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/regexp/RegExpValueTest.java
@@ -66,7 +66,8 @@ public class RegExpValueTest {
                 "testComplexRegExpValue2",
                 "testEqualityWithRegExp",
                 "testExactEqualityWithRegExp",
-                "testInvalidInsertionsInRegExp"
+                "testInvalidInsertionsInRegExp",
+                "testFreezeDirectWithRegExp"
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/regexp/regexp_value_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/regexp/regexp_value_test.bal
@@ -527,10 +527,23 @@ function testExactEqualityWithRegExp() {
     assertEquality(true, re `a\td-*ab[^c-f]+(?m:xj(?i:x|y))` === x4);
 }
 
+public type Constraint record {|
+    string:RegExp pattern?;
+|};
+
+public annotation Constraint String on type;
+
+@String {
+    pattern: re `[^0-9]*`
+}
+type Number string;
+
 function testFreezeDirectWithRegExp() {
-    string:RegExp regExp = re `[^0-9]*`;
-    any result = regExp.cloneReadOnly();
-    assertEquality(true, result is readonly);
+    typedesc<any> numTd = Number;
+    assertEquality(true, numTd.@String is Constraint);
+    Constraint constraint = <Constraint>numTd.@String;
+    assertEquality(false, constraint.pattern is ());
+    assertEquality(true, constraint.pattern == re `[^0-9]*`);
 }
 
 const ASSERTION_ERROR_REASON = "AssertionError";

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/regexp/regexp_value_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/regexp/regexp_value_test.bal
@@ -527,6 +527,12 @@ function testExactEqualityWithRegExp() {
     assertEquality(true, re `a\td-*ab[^c-f]+(?m:xj(?i:x|y))` === x4);
 }
 
+function testFreezeDirectWithRegExp() {
+    string:RegExp regExp = re `[^0-9]*`;
+    any result = regExp.cloneReadOnly();
+    assertEquality(true, result is readonly);
+}
+
 const ASSERTION_ERROR_REASON = "AssertionError";
 
 function assertEquality(any|error expected, any|error actual) {


### PR DESCRIPTION
## Purpose
$subject

Fixes #38336

## Approach
This happens as the `RegExpValue` does not contain an implementation for `freezeDirect()` which by default throws a `BLangFreezeException`.

## Samples
```ballerina
public type Constraint record {|
    string:RegExp pattern?;
|};

public annotation Constraint String on type;

@String {
    pattern: re `[^0-9]*`
}
type Number string;
```
## CheckList 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
