### PR TITLE
Add unit tests to extract a numeric literal in a unary expr to a constant

### DIFF
--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ExtractToConstantTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ExtractToConstantTest.java
@@ -58,9 +58,9 @@ public class ExtractToConstantTest extends AbstractCodeActionTest {
                 {"extractUnaryNumericExprToConstant.json"},
                 {"extractUnaryNumericExprToConstant2.json"},
                 {"extractUnaryLogicalExprToConstant.json"},
-                {"extractBooleanLiteralInUnaryExprToConstant.json"}
-//                {"extractNumericLiteralInUnaryExprToConstant.json"}, #37525
-//                {"extractNumericLiteralInUnaryExprToConstant2.json"} #37525
+                {"extractBooleanLiteralInUnaryExprToConstant.json"},
+                {"extractNumericLiteralInUnaryExprToConstant.json"},
+                {"extractNumericLiteralInUnaryExprToConstant2.json"}
         };
     }
 


### PR DESCRIPTION
## Purpose
This PR uncomments the test cases to extract a numeric literal in a unary expr to a constant since #37525 is now fixed.

Fixes #37525

## Samples

https://user-images.githubusercontent.com/27485094/197466702-773585dd-2488-4178-aba3-fd533a02d335.mov

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
