### PR TITLE
Fix stackoverflow of tuples with self referencing

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TupleValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TupleValueImpl.java
@@ -88,11 +88,6 @@ public class TupleValueImpl extends AbstractArrayValue {
                 Arrays.equals(refValues, that.refValues);
     }
 
-    @Override
-    public int hashCode() {
-        return System.identityHashCode(this);
-    }
-
     public TupleValueImpl(Object[] values, TupleType type) {
         this.refValues = values;
         this.tupleType = type;

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TupleValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/TupleValueImpl.java
@@ -42,7 +42,6 @@ import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.StringJoiner;
 import java.util.stream.IntStream;
 
@@ -91,9 +90,7 @@ public class TupleValueImpl extends AbstractArrayValue {
 
     @Override
     public int hashCode() {
-        int result = Objects.hash(tupleType, minSize, hasRestElement);
-        result = 31 * result + Arrays.hashCode(refValues);
-        return result;
+        return System.identityHashCode(this);
     }
 
     public TupleValueImpl(Object[] values, TupleType type) {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/typedefs/CyclicTypeDefinitionsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/typedefs/CyclicTypeDefinitionsTest.java
@@ -64,7 +64,8 @@ public class CyclicTypeDefinitionsTest {
                 {"testCastingToImmutableCyclicTuple"},
                 {"recursiveTupleArrayCloneTest"},
                 {"testRecursiveTupleWithRestType"},
-                {"testUnionWithCyclicTuplesHashCode"}
+                {"testUnionWithCyclicTuplesHashCode"},
+                {"testCloneOnRecursiveTuples"}
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/typedefs/tuple-type-definitions-cyclic.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/typedefs/tuple-type-definitions-cyclic.bal
@@ -14,6 +14,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/test;
+
 type A [int, A[]];
 public function testCycleTypeArray() {
     A a = [1];
@@ -325,6 +327,20 @@ function testUnionWithCyclicTuplesHashCode() {
     SubtypeRelation p = {subtype: subtype, superType: superType};
     assert(p.toJsonString(), "{\"subtype\":[\"|\", \"int\", [\"tuple\", \"never\", \"int\"]], " +
     "\"superType\":[\"|\", [\"|\", \"int\", \"float\"], [\"tuple\", \"never\", [\"|\", \"int\", \"string\"]]]}"); 
+}
+
+type List [List?];
+
+function testCloneOnRecursiveTuples() {
+    List list = [()];
+    list[0] = list;
+    List list_cloned = list.clone();
+    test:assertTrue(list_cloned == list);
+    test:assertFalse(list_cloned === list);
+
+    List list_readonly = list.cloneReadOnly();
+    test:assertTrue(list_readonly == list);
+    test:assertFalse(list_readonly === list);
 }
 
 function assertTrue(anydata actual) {


### PR DESCRIPTION
## Purpose
> Fix issues with hash code of recursive tuples, which causes stackoverflow. 

Fixes #38302

## Approach
> Remove the overridden hashCode() method in `TupleValueImpl.java`. 

## Samples
> ```ballerina
> type List [List?];
> 
> public function main() {
>     List list = [()];
>     list[0] = list;
>     _ = list.clone(); 
> }
> ```

## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
