### PR TITLE
[2201.2.x] Fix NPE for field access expression on record json field

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -9446,15 +9446,17 @@ public class Desugar extends BLangNodeVisitor {
         }
 
         /*
-         * If the field access is a safe navigation, create a match expression.
-         * Then chain the current expression as the success-pattern of the parent
-         * match expr, if available.
+         * If the field access is a safe navigation, create a temp var definition for current expr and a var ref.
+         * Then use that to create a match expression. Then chain the current expression as the success-pattern of
+         * the parent match expr, if available.
          * eg:
          * x but {              <--- parent match expr
          *   error e => e,
-         *   T t => t.y but {   <--- current expr
+         *   $varDef$ = t;
+         *   T $varDef$ => $varDef$.y but {   <--- current expr
          *      error e => e,
-         *      R r => r.z
+         *      $varDef$ = r;
+         *      R $varDef$ => $varDef$.z
          *   }
          * }
          */

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/access/FieldAccessTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/access/FieldAccessTest.java
@@ -272,4 +272,9 @@ public class FieldAccessTest {
     public void testAccessOptionalFieldWithFieldAccess2() {
         Object returns = BRunUtil.invoke(result, "testAccessOptionalFieldWithFieldAccess2");
     }
+
+    @Test
+    public void testFieldAccessOnRecordContainsJsonField() {
+        BRunUtil.invoke(result, "testFieldAccessOnRecordContainsJsonField");
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/access/FieldAccessTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/access/FieldAccessTest.java
@@ -274,7 +274,12 @@ public class FieldAccessTest {
     }
 
     @Test
-    public void testFieldAccessOnRecordContainsJsonField() {
-        BRunUtil.invoke(result, "testFieldAccessOnRecordContainsJsonField");
+    public void testFieldAccessOnJsonTypedRecordFields() {
+        BRunUtil.invoke(result, "testFieldAccessOnJsonTypedRecordFields");
+    }
+
+    @Test
+    public void testFieldAccessOnJsonTypedRecordFieldsResultsPanic() {
+        BRunUtil.invoke(result, "testFieldAccessOnJsonTypedRecordFieldsResultsPanic");
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bir/bir-dump/mapInits
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bir/bir-dump/mapInits
@@ -12,27 +12,29 @@ mapInits function() -> (string|(), int|()) {
     %13(TEMP) Employee;
     %19(SYNTHETIC) string|();
     %20(SYNTHETIC) Employee|();
-    %24(SYNTHETIC) boolean;
-    %25(SYNTHETIC) boolean;
-    %26(SYNTHETIC) any|error;
-    %27(TEMP) boolean;
-    %39(SYNTHETIC) boolean;
-    %40(SYNTHETIC) boolean;
-    %41(SYNTHETIC) any|error;
-    %57(SYNTHETIC) boolean;
-    %58(SYNTHETIC) boolean;
-    %68(TEMP) ();
-    %70(SYNTHETIC) int|();
-    %71(SYNTHETIC) Employee|();
-    %75(SYNTHETIC) boolean;
-    %76(SYNTHETIC) boolean;
-    %77(SYNTHETIC) any|error;
-    %90(SYNTHETIC) boolean;
-    %91(SYNTHETIC) boolean;
-    %92(SYNTHETIC) any|error;
-    %104(TEMP) int;
-    %108(SYNTHETIC) boolean;
-    %109(SYNTHETIC) boolean;
+    %24(SYNTHETIC) Employee|();
+    %26(SYNTHETIC) boolean;
+    %27(SYNTHETIC) boolean;
+    %28(SYNTHETIC) any|error;
+    %29(TEMP) boolean;
+    %41(SYNTHETIC) boolean;
+    %42(SYNTHETIC) boolean;
+    %43(SYNTHETIC) any|error;
+    %59(SYNTHETIC) boolean;
+    %60(SYNTHETIC) boolean;
+    %70(TEMP) ();
+    %72(SYNTHETIC) int|();
+    %73(SYNTHETIC) Employee|();
+    %77(SYNTHETIC) Employee|();
+    %79(SYNTHETIC) boolean;
+    %80(SYNTHETIC) boolean;
+    %81(SYNTHETIC) any|error;
+    %94(SYNTHETIC) boolean;
+    %95(SYNTHETIC) boolean;
+    %96(SYNTHETIC) any|error;
+    %108(TEMP) int;
+    %112(SYNTHETIC) boolean;
+    %113(SYNTHETIC) boolean;
 
     bb0 {
         %2 = newType map<Employee>;
@@ -51,197 +53,199 @@ mapInits function() -> (string|(), int|()) {
         %10 = ConstLoad 2;
         %8 = ConstLoad jack;
         %20 = %1[%8];
-        %27 = ConstLoad true;
-        %27? bb1 : bb2;
+        %24 = %20;
+        %29 = ConstLoad true;
+        %29? bb1 : bb2;
     }
     bb1 {
-        %25 = ConstLoad true;
-        %26 = <any|error> %20;
+        %27 = ConstLoad true;
+        %28 = <any|error> %24;
         GOTO bb3;
     }
     bb2 {
-        %25 = ConstLoad false;
+        %27 = ConstLoad false;
         GOTO bb3;
     }
     bb3 {
-        %25? bb4 : bb5;
+        %27? bb4 : bb5;
     }
     bb4 {
-        %24 = %26 is ();
+        %26 = %28 is ();
         GOTO bb6;
     }
     bb5 {
-        %24 = ConstLoad false;
+        %26 = ConstLoad false;
         GOTO bb6;
     }
     bb6 {
-        %24? bb7 : bb8;
+        %26? bb7 : bb8;
     }
     bb7 {
-        %19 = <string|()> %26;
+        %19 = <string|()> %28;
         GOTO bb24;
     }
     bb8 {
-        %27 = ConstLoad true;
-        %27? bb9 : bb10;
+        %29 = ConstLoad true;
+        %29? bb9 : bb10;
     }
     bb9 {
-        %40 = ConstLoad true;
-        %41 = <any|error> %20;
+        %42 = ConstLoad true;
+        %43 = <any|error> %24;
         GOTO bb11;
     }
     bb10 {
-        %40 = ConstLoad false;
+        %42 = ConstLoad false;
         GOTO bb11;
     }
     bb11 {
-        %40? bb12 : bb13;
+        %42? bb12 : bb13;
     }
     bb12 {
-        %39 = %41 is Employee;
+        %41 = %43 is Employee;
         GOTO bb14;
     }
     bb13 {
-        %39 = ConstLoad false;
+        %41 = ConstLoad false;
         GOTO bb14;
     }
     bb14 {
-        %39? bb15 : bb16;
+        %41? bb15 : bb16;
     }
     bb15 {
-        %13 = <Employee> %41;
+        %13 = <Employee> %43;
         %9 = ConstLoad name;
         %11 = %13[%9];
         %19 = <string|()> %11;
         GOTO bb24;
     }
     bb16 {
-        %27 = ConstLoad true;
-        %27? bb17 : bb18;
+        %29 = ConstLoad true;
+        %29? bb17 : bb18;
     }
     bb17 {
-        %58 = ConstLoad true;
+        %60 = ConstLoad true;
         GOTO bb19;
     }
     bb18 {
-        %58 = %20 is any;
+        %60 = %24 is any;
         GOTO bb19;
     }
     bb19 {
-        %58? bb20 : bb21;
+        %60? bb20 : bb21;
     }
     bb20 {
-        %57 = ConstLoad true;
+        %59 = ConstLoad true;
         GOTO bb22;
     }
     bb21 {
-        %57 = ConstLoad false;
+        %59 = ConstLoad false;
         GOTO bb22;
     }
     bb22 {
-        %57? bb23 : bb24;
+        %59? bb23 : bb24;
     }
     bb23 {
-        %68 = ConstLoad 0;
-        %19 = <string|()> %68;
+        %70 = ConstLoad 0;
+        %19 = <string|()> %70;
         GOTO bb24;
     }
     bb24 {
         %12 = ConstLoad jack;
-        %71 = %1[%12];
-        %27 = ConstLoad true;
-        %27? bb25 : bb26;
+        %73 = %1[%12];
+        %77 = %73;
+        %29 = ConstLoad true;
+        %29? bb25 : bb26;
     }
     bb25 {
-        %76 = ConstLoad true;
-        %77 = <any|error> %71;
+        %80 = ConstLoad true;
+        %81 = <any|error> %77;
         GOTO bb27;
     }
     bb26 {
-        %76 = ConstLoad false;
+        %80 = ConstLoad false;
         GOTO bb27;
     }
     bb27 {
-        %76? bb28 : bb29;
+        %80? bb28 : bb29;
     }
     bb28 {
-        %75 = %77 is ();
+        %79 = %81 is ();
         GOTO bb30;
     }
     bb29 {
-        %75 = ConstLoad false;
+        %79 = ConstLoad false;
         GOTO bb30;
     }
     bb30 {
-        %75? bb31 : bb32;
+        %79? bb31 : bb32;
     }
     bb31 {
-        %70 = <int|()> %77;
+        %72 = <int|()> %81;
         GOTO bb48;
     }
     bb32 {
-        %27 = ConstLoad true;
-        %27? bb33 : bb34;
+        %29 = ConstLoad true;
+        %29? bb33 : bb34;
     }
     bb33 {
-        %91 = ConstLoad true;
-        %92 = <any|error> %71;
+        %95 = ConstLoad true;
+        %96 = <any|error> %77;
         GOTO bb35;
     }
     bb34 {
-        %91 = ConstLoad false;
+        %95 = ConstLoad false;
         GOTO bb35;
     }
     bb35 {
-        %91? bb36 : bb37;
+        %95? bb36 : bb37;
     }
     bb36 {
-        %90 = %92 is Employee;
+        %94 = %96 is Employee;
         GOTO bb38;
     }
     bb37 {
-        %90 = ConstLoad false;
+        %94 = ConstLoad false;
         GOTO bb38;
     }
     bb38 {
-        %90? bb39 : bb40;
+        %94? bb39 : bb40;
     }
     bb39 {
-        %13 = <Employee> %92;
+        %13 = <Employee> %96;
         %7 = ConstLoad age;
-        %104 = %13[%7];
-        %70 = <int|()> %104;
+        %108 = %13[%7];
+        %72 = <int|()> %108;
         GOTO bb48;
     }
     bb40 {
-        %27 = ConstLoad true;
-        %27? bb41 : bb42;
+        %29 = ConstLoad true;
+        %29? bb41 : bb42;
     }
     bb41 {
-        %109 = ConstLoad true;
+        %113 = ConstLoad true;
         GOTO bb43;
     }
     bb42 {
-        %109 = %71 is any;
+        %113 = %77 is any;
         GOTO bb43;
     }
     bb43 {
-        %109? bb44 : bb45;
+        %113? bb44 : bb45;
     }
     bb44 {
-        %108 = ConstLoad true;
+        %112 = ConstLoad true;
         GOTO bb46;
     }
     bb45 {
-        %108 = ConstLoad false;
+        %112 = ConstLoad false;
         GOTO bb46;
     }
     bb46 {
-        %108? bb47 : bb48;
+        %112? bb47 : bb48;
     }
     bb47 {
-        %68 = ConstLoad 0;
-        %70 = <int|()> %68;
+        %70 = ConstLoad 0;
+        %72 = <int|()> %70;
         GOTO bb48;
     }
     bb48 {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/access/field_access.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/access/field_access.bal
@@ -352,10 +352,56 @@ function testFieldAccessOnMapConstruct() returns boolean {
     return "Sanjiva" == name;
 }
 
+type FooRec1 record {
+    json j;
+};
+
+type FooRec2 record {
+    json j;
+    BarRec1 barRec;
+};
+
+type BarRec1 record {
+    json barFiled;
+};
+
+function testFieldAccessOnRecordContainsJsonField() returns error? {
+    FooRec1 rec1 = {j: "1"};
+    string val = check rec1.j;
+    assertEqual(val, "1");
+
+    rec1 = {j: {k: "2"}};
+    val = check rec1.j.k;
+    assertEqual(val, "2");
+
+    rec1 = {j: {k: {l: "1", m: "3"}}};
+    val = check rec1.j.k.m;
+    assertEqual(val, "3");
+
+    FooRec2 rec2 = {j: "1", barRec: {barFiled: "2"}};
+    val = check rec2.j;
+    assertEqual(val, "1");
+    val = check rec2.barRec.barFiled;
+    assertEqual(val, "2");
+
+    rec2 = {j: "1", barRec: {barFiled: {k: "3", l: {m: "4"}}}};
+    val = check  rec2.barRec.barFiled.k;
+    assertEqual(val, "3");
+    val = check  rec2.barRec.barFiled.l.m;
+    assertEqual(val, "4");
+}
+
 isolated function isEqual(anydata|error val1, anydata|error val2) returns boolean {
     if (val1 is anydata && val2 is anydata) {
         return (val1 == val2);
     } else {
         return (val1 === val2);
     }
+}
+
+function assertEqual(anydata actual, anydata expected) {
+    if expected == actual {
+        return;
+    }
+    panic error(string `expected '${expected.toString()}', found '${actual.toString()}'`);
 }


### PR DESCRIPTION
## Purpose

Fixes #38328
Fixes #37988

## Approach
This works properly in update 3 and master. So, cherry picked the changes from the master.

## Samples
```
type FooRec1 record {
    json j;
};

public function main() returns error? {
    FooRec1 rec1 = {j: "1"};
    rec1 = {j: {k: {l: "1"}}};
    json|error val = rec1.j.k.l.p;
}
```
This gave NPE in 2201.2.2. Now it is fixed

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
