### PR TITLE
Fix showing failure message on diagnostics in IDL client gen command executor

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/GenerateModuleForClientDeclExecutor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/GenerateModuleForClientDeclExecutor.java
@@ -32,7 +32,6 @@ import org.ballerinalang.langserver.commons.command.spi.LSCommandExecutor;
 import org.ballerinalang.langserver.contexts.ContextBuilder;
 import org.ballerinalang.langserver.diagnostic.DiagnosticsHelper;
 import org.ballerinalang.langserver.exception.UserErrorException;
-import org.ballerinalang.util.diagnostic.DiagnosticErrorCode;
 import org.eclipse.lsp4j.MessageType;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.ProgressParams;
@@ -43,7 +42,6 @@ import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
 import java.nio.file.Path;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
@@ -56,9 +54,6 @@ import java.util.concurrent.CompletableFuture;
 public class GenerateModuleForClientDeclExecutor implements LSCommandExecutor {
 
     public static final String COMMAND = "GENERATE_MODULE_FOR_CLIENT_DECL";
-
-    public static final Set<String> DIAGNOSTIC_CODES = Set.of(
-            DiagnosticErrorCode.NO_MODULE_GENERATED_FOR_CLIENT_DECL.diagnosticId(), "BCE5303");
 
     @Override
     public Object execute(ExecuteCommandContext context) throws LSCommandExecutorException {
@@ -103,13 +98,8 @@ public class GenerateModuleForClientDeclExecutor implements LSCommandExecutor {
                 .thenRunAsync(() -> {
                     Optional<IDLClientGeneratorResult> idlClientGeneratorResult =
                             context.workspace().waitAndRunIDLGeneratorPlugins(filePath, project);
-                    boolean diagnosticNotResolved = true;
-                    if (idlClientGeneratorResult.isPresent()) {
-                        diagnosticNotResolved = idlClientGeneratorResult.get().reportedDiagnostics().diagnostics()
-                                .stream().anyMatch(diagnostic ->
-                                        DIAGNOSTIC_CODES.contains(diagnostic.diagnosticInfo().code()));
-                    }
-                    if (diagnosticNotResolved) {
+                    if (idlClientGeneratorResult.isEmpty() 
+                            || idlClientGeneratorResult.get().reportedDiagnostics().diagnostics().size() > 0) {
                         throw new UserErrorException("Failed to generate modules for client declarations");
                     }
                 })


### PR DESCRIPTION
## Purpose
$subject to fail if there is any diagnostics in the IDLClientGenration result. 

Fixes #38451

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
