### PR TITLE
[2201.2.x] Fix passing outdated compilation to code modifiers

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/CodeModifierManager.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/CodeModifierManager.java
@@ -37,7 +37,7 @@ import java.util.Objects;
 
 class CodeModifierManager {
     private Package currentPackage;
-    private final PackageCompilation compilation;
+    private PackageCompilation compilation;
     private final CodeModifierTasks codeModifierTasks;
 
     private CodeModifierManager(PackageCompilation compilation, CodeModifierTasks codeModifierTasks) {
@@ -129,6 +129,7 @@ class CodeModifierManager {
 
             if (codeModifyTaskResult.containsSourceFile() || codeModifyTaskResult.containsTestSourceFile()) {
                 currentPackage = new PackageModifier().modifyPackage(currentPackage, codeModifyTaskResult);
+                compilation = currentPackage.getCompilation();
             }
         }
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Package.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Package.java
@@ -265,6 +265,7 @@ public class Package {
         }
 
         if (compilerPluginManager.engagedCodeModifierCount() > 0) {
+            compilerPluginManager = pkg.getCompilation(compOptions).compilerPluginManager();
             CodeModifierManager codeModifierManager = compilerPluginManager.getCodeModifierManager();
             CodeModifierResult codeModifierResult = codeModifierManager.runCodeModifiers(pkg);
             diagnostics.addAll(codeModifierResult.reportedDiagnostics().allDiagnostics);


### PR DESCRIPTION
## Purpose
> Fix passing outdated compilation to code modifiers
Fixes https://github.com/ballerina-platform/ballerina-lang/issues/38449

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
