### PR TITLE
[2201.3.0-stage] Remove re from reserved words

### DIFF
--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/AbstractLexer.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/AbstractLexer.java
@@ -306,4 +306,8 @@ public abstract class AbstractLexer {
 
         this.reader.advance();
     }
+
+    protected static boolean isWhitespace(int ch) {
+        return (ch == 0x0020 || ch == 0x0009 || ch == 0x000A || ch == 0x000D);
+    }
 }

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/AbstractLexer.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/AbstractLexer.java
@@ -306,8 +306,4 @@ public abstract class AbstractLexer {
 
         this.reader.advance();
     }
-
-    protected static boolean isWhitespace(int ch) {
-        return (ch == 0x0020 || ch == 0x0009 || ch == 0x000A || ch == 0x000D);
-    }
 }

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/BallerinaLexer.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/BallerinaLexer.java
@@ -1041,6 +1041,7 @@ public class BallerinaLexer extends AbstractLexer {
                 if (getNextNonWSOrNonCommentChar() == LexerTerminals.BACKTICK) {
                     return getSyntaxToken(SyntaxKind.RE_KEYWORD);
                 }
+                return getIdentifierToken();
             default:
 //                if (this.keywordModes.contains(KeywordMode.QUERY)) {
 //                    return getQueryCtxKeywordOrIdentifier(tokenText);
@@ -1059,7 +1060,7 @@ public class BallerinaLexer extends AbstractLexer {
                 case LexerTerminals.FORM_FEED:
                 case LexerTerminals.CARRIAGE_RETURN:
                 case LexerTerminals.NEWLINE:
-                    lookaheadCount ++;
+                    lookaheadCount++;
                     break;
                 case LexerTerminals.SLASH:
                     if (reader.peek(lookaheadCount + 1) == LexerTerminals.SLASH) {
@@ -1067,6 +1068,7 @@ public class BallerinaLexer extends AbstractLexer {
                         lookaheadCount = skipComment(lookaheadCount);
                         break;
                     }
+                    return reader.peek(lookaheadCount);
                 default:
                     return reader.peek(lookaheadCount);
             }
@@ -1082,7 +1084,7 @@ public class BallerinaLexer extends AbstractLexer {
                 case LexerTerminals.CARRIAGE_RETURN:
                     break;
                 default:
-                    count += 1;
+                    count++;
                     nextToken = reader.peek(count);
                     continue;
             }

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/BallerinaLexer.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/BallerinaLexer.java
@@ -34,6 +34,8 @@ import java.util.List;
  */
 public class BallerinaLexer extends AbstractLexer {
 
+    private static final char BACK_TICK = '`';
+
     public BallerinaLexer(CharReader charReader) {
         super(charReader, ParserMode.DEFAULT);
     }
@@ -1038,13 +1040,25 @@ public class BallerinaLexer extends AbstractLexer {
             case LexerTerminals.JOIN:
                 return getSyntaxToken(SyntaxKind.JOIN_KEYWORD);
             case LexerTerminals.RE:
-                return getSyntaxToken(SyntaxKind.RE_KEYWORD);
+                if (isNextTokenBacktick()) {
+                    return getSyntaxToken(SyntaxKind.RE_KEYWORD);
+                }
             default:
 //                if (this.keywordModes.contains(KeywordMode.QUERY)) {
 //                    return getQueryCtxKeywordOrIdentifier(tokenText);
 //                }
                 return getIdentifierToken();
         }
+    }
+    
+    private boolean isNextTokenBacktick() {
+        int lookaheadCount = 0;
+        char lookaheadChar = reader.peek(lookaheadCount);
+        while (isWhitespace(lookaheadChar)) {
+            lookaheadCount += 1;
+            lookaheadChar = reader.peek(lookaheadCount);
+        }
+        return lookaheadChar == BACK_TICK;
     }
 
 //    private STToken getQueryCtxKeywordOrIdentifier(String tokenText) {

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/BallerinaLexer.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/BallerinaLexer.java
@@ -1052,9 +1052,9 @@ public class BallerinaLexer extends AbstractLexer {
 
     private int getNextNonWSOrNonCommentChar() {
         int lookaheadCount = 0;
-        char nextToken = reader.peek(lookaheadCount);
-        while (nextToken != Character.MAX_VALUE) {
-            switch (nextToken) {
+        char nextChar = reader.peek(lookaheadCount);
+        while (nextChar != Character.MAX_VALUE) {
+            switch (nextChar) {
                 case LexerTerminals.SPACE:
                 case LexerTerminals.TAB:
                 case LexerTerminals.FORM_FEED:
@@ -1068,25 +1068,25 @@ public class BallerinaLexer extends AbstractLexer {
                         lookaheadCount = skipComment(lookaheadCount);
                         break;
                     }
-                    return nextToken;
+                    return nextChar;
                 default:
-                    return nextToken;
+                    return nextChar;
             }
-            nextToken = reader.peek(lookaheadCount);
+            nextChar = reader.peek(lookaheadCount);
         }
-        return nextToken;
+        return nextChar;
     }
 
     private int skipComment(int lookaheadCount) {
-        int nextToken = reader.peek(lookaheadCount);
-        while (nextToken != Character.MAX_VALUE) {
-            switch (nextToken) {
+        int nextChar = reader.peek(lookaheadCount);
+        while (nextChar != Character.MAX_VALUE) {
+            switch (nextChar) {
                 case LexerTerminals.NEWLINE:
                 case LexerTerminals.CARRIAGE_RETURN:
                     break;
                 default:
                     lookaheadCount++;
-                    nextToken = reader.peek(lookaheadCount);
+                    nextChar = reader.peek(lookaheadCount);
                     continue;
             }
             break;

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/BallerinaLexer.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/BallerinaLexer.java
@@ -1052,7 +1052,7 @@ public class BallerinaLexer extends AbstractLexer {
 
     private int getNextNonWSOrNonCommentChar() {
         int lookaheadCount = 0;
-        while (!reader.isEOF()) {
+        while (!(reader.peek(lookaheadCount) == Character.MAX_VALUE)) {
             char c = reader.peek(lookaheadCount);
             switch (c) {
                 case LexerTerminals.SPACE:
@@ -1076,21 +1076,21 @@ public class BallerinaLexer extends AbstractLexer {
         return reader.peek(lookaheadCount);
     }
 
-    private int skipComment(int count) {
-        int nextToken = reader.peek(count);
-        while (!reader.isEOF()) {
+    private int skipComment(int lookaheadCount) {
+        int nextToken = reader.peek(lookaheadCount);
+        while (!(reader.peek(lookaheadCount) == Character.MAX_VALUE)) {
             switch (nextToken) {
                 case LexerTerminals.NEWLINE:
                 case LexerTerminals.CARRIAGE_RETURN:
                     break;
                 default:
-                    count++;
-                    nextToken = reader.peek(count);
+                    lookaheadCount++;
+                    nextToken = reader.peek(lookaheadCount);
                     continue;
             }
             break;
         }
-        return count;
+        return lookaheadCount;
     }
 
 //    private STToken getQueryCtxKeywordOrIdentifier(String tokenText) {

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/BallerinaLexer.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/BallerinaLexer.java
@@ -1052,9 +1052,9 @@ public class BallerinaLexer extends AbstractLexer {
 
     private int getNextNonWSOrNonCommentChar() {
         int lookaheadCount = 0;
-        while (!(reader.peek(lookaheadCount) == Character.MAX_VALUE)) {
-            char c = reader.peek(lookaheadCount);
-            switch (c) {
+        char nextToken = reader.peek(lookaheadCount);
+        while (nextToken != Character.MAX_VALUE) {
+            switch (nextToken) {
                 case LexerTerminals.SPACE:
                 case LexerTerminals.TAB:
                 case LexerTerminals.FORM_FEED:
@@ -1068,17 +1068,18 @@ public class BallerinaLexer extends AbstractLexer {
                         lookaheadCount = skipComment(lookaheadCount);
                         break;
                     }
-                    return reader.peek(lookaheadCount);
+                    return nextToken;
                 default:
-                    return reader.peek(lookaheadCount);
+                    return nextToken;
             }
+            nextToken = reader.peek(lookaheadCount);
         }
-        return reader.peek(lookaheadCount);
+        return nextToken;
     }
 
     private int skipComment(int lookaheadCount) {
         int nextToken = reader.peek(lookaheadCount);
-        while (!(reader.peek(lookaheadCount) == Character.MAX_VALUE)) {
+        while (nextToken != Character.MAX_VALUE) {
             switch (nextToken) {
                 case LexerTerminals.NEWLINE:
                 case LexerTerminals.CARRIAGE_RETURN:

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/BallerinaLexer.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/BallerinaLexer.java
@@ -1062,8 +1062,8 @@ public class BallerinaLexer extends AbstractLexer {
                     lookaheadCount ++;
                     break;
                 case LexerTerminals.SLASH:
-                    if (reader.peek(lookaheadCount ++) == LexerTerminals.SLASH) {
-                        lookaheadCount ++;
+                    if (reader.peek(lookaheadCount + 1) == LexerTerminals.SLASH) {
+                        lookaheadCount += 2;
                         lookaheadCount = skipComment(lookaheadCount);
                         break;
                     }

--- a/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/syntax/declarations/FunctionDefinitionTest.java
+++ b/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/syntax/declarations/FunctionDefinitionTest.java
@@ -203,4 +203,9 @@ public class FunctionDefinitionTest extends AbstractDeclarationTest {
     public void testOptionalSemicolonRecovery() {
         testFile("func-definition/func_def_source_35.bal", "func-definition/func_def_assert_35.json");
     }
+
+    @Test
+    public void testReKeywordAsFuncNameAndParamName() {
+        testFile("func-definition/func_def_source_36.bal", "func-definition/func_def_assert_36.json");
+    }
 }

--- a/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/syntax/expressions/RegExpConstructorExprTest.java
+++ b/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/syntax/expressions/RegExpConstructorExprTest.java
@@ -262,4 +262,10 @@ public class RegExpConstructorExprTest extends AbstractExpressionsTest {
         testFile("regexp-constructor-expr/regexp_constructor_source_39.bal",
                 "regexp-constructor-expr/regexp_constructor_assert_39.json");
     }
+
+    @Test
+    public void testRegExpWithContextuallyExpectedType() {
+        testFile("regexp-constructor-expr/regexp_constructor_source_40.bal",
+                "regexp-constructor-expr/regexp_constructor_assert_40.json");
+    }
 }

--- a/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/syntax/expressions/RegExpConstructorExprTest.java
+++ b/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/syntax/expressions/RegExpConstructorExprTest.java
@@ -268,4 +268,22 @@ public class RegExpConstructorExprTest extends AbstractExpressionsTest {
         testFile("regexp-constructor-expr/regexp_constructor_source_40.bal",
                 "regexp-constructor-expr/regexp_constructor_assert_40.json");
     }
+
+    @Test
+    public void testRegExpWithComment() {
+        testFile("regexp-constructor-expr/regexp_constructor_source_41.bal",
+                "regexp-constructor-expr/regexp_constructor_assert_41.json");
+    }
+
+    @Test
+    public void testRegExpWithWhiteSpace() {
+        testFile("regexp-constructor-expr/regexp_constructor_source_42.bal",
+                "regexp-constructor-expr/regexp_constructor_assert_42.json");
+    }
+
+    @Test
+    public void testInvalidRegExpWithSlash() {
+        testFile("regexp-constructor-expr/regexp_constructor_source_43.bal",
+                "regexp-constructor-expr/regexp_constructor_assert_43.json");
+    }
 }

--- a/compiler/ballerina-parser/src/test/resources/declarations/func-definition/func_def_assert_36.json
+++ b/compiler/ballerina-parser/src/test/resources/declarations/func-definition/func_def_assert_36.json
@@ -1,0 +1,196 @@
+{
+  "kind": "MODULE_PART",
+  "children": [
+    {
+      "kind": "LIST",
+      "children": []
+    },
+    {
+      "kind": "LIST",
+      "children": [
+        {
+          "kind": "FUNCTION_DEFINITION",
+          "children": [
+            {
+              "kind": "LIST",
+              "children": []
+            },
+            {
+              "kind": "FUNCTION_KEYWORD",
+              "trailingMinutiae": [
+                {
+                  "kind": "WHITESPACE_MINUTIAE",
+                  "value": " "
+                }
+              ]
+            },
+            {
+              "kind": "IDENTIFIER_TOKEN",
+              "value": "re"
+            },
+            {
+              "kind": "LIST",
+              "children": []
+            },
+            {
+              "kind": "FUNCTION_SIGNATURE",
+              "children": [
+                {
+                  "kind": "OPEN_PAREN_TOKEN"
+                },
+                {
+                  "kind": "LIST",
+                  "children": [
+                    {
+                      "kind": "REQUIRED_PARAM",
+                      "children": [
+                        {
+                          "kind": "LIST",
+                          "children": []
+                        },
+                        {
+                          "kind": "INT_TYPE_DESC",
+                          "children": [
+                            {
+                              "kind": "INT_KEYWORD",
+                              "trailingMinutiae": [
+                                {
+                                  "kind": "WHITESPACE_MINUTIAE",
+                                  "value": " "
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "IDENTIFIER_TOKEN",
+                          "value": "re"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "CLOSE_PAREN_TOKEN",
+                  "trailingMinutiae": [
+                    {
+                      "kind": "WHITESPACE_MINUTIAE",
+                      "value": " "
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "FUNCTION_BODY_BLOCK",
+              "children": [
+                {
+                  "kind": "OPEN_BRACE_TOKEN",
+                  "trailingMinutiae": [
+                    {
+                      "kind": "END_OF_LINE_MINUTIAE",
+                      "value": "\n"
+                    }
+                  ]
+                },
+                {
+                  "kind": "LIST",
+                  "children": [
+                    {
+                      "kind": "LOCAL_VAR_DECL",
+                      "children": [
+                        {
+                          "kind": "LIST",
+                          "children": []
+                        },
+                        {
+                          "kind": "TYPED_BINDING_PATTERN",
+                          "children": [
+                            {
+                              "kind": "INT_TYPE_DESC",
+                              "children": [
+                                {
+                                  "kind": "INT_KEYWORD",
+                                  "leadingMinutiae": [
+                                    {
+                                      "kind": "WHITESPACE_MINUTIAE",
+                                      "value": "    "
+                                    }
+                                  ],
+                                  "trailingMinutiae": [
+                                    {
+                                      "kind": "WHITESPACE_MINUTIAE",
+                                      "value": " "
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "CAPTURE_BINDING_PATTERN",
+                              "children": [
+                                {
+                                  "kind": "IDENTIFIER_TOKEN",
+                                  "value": "b",
+                                  "trailingMinutiae": [
+                                    {
+                                      "kind": "WHITESPACE_MINUTIAE",
+                                      "value": " "
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "EQUAL_TOKEN",
+                          "trailingMinutiae": [
+                            {
+                              "kind": "WHITESPACE_MINUTIAE",
+                              "value": " "
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "SIMPLE_NAME_REFERENCE",
+                          "children": [
+                            {
+                              "kind": "IDENTIFIER_TOKEN",
+                              "value": "re"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "SEMICOLON_TOKEN",
+                          "trailingMinutiae": [
+                            {
+                              "kind": "END_OF_LINE_MINUTIAE",
+                              "value": "\n"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "CLOSE_BRACE_TOKEN",
+                  "trailingMinutiae": [
+                    {
+                      "kind": "END_OF_LINE_MINUTIAE",
+                      "value": "\n"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "EOF_TOKEN"
+    }
+  ]
+}

--- a/compiler/ballerina-parser/src/test/resources/declarations/func-definition/func_def_source_36.bal
+++ b/compiler/ballerina-parser/src/test/resources/declarations/func-definition/func_def_source_36.bal
@@ -1,0 +1,3 @@
+function re(int re) {
+    int b = re;
+}

--- a/compiler/ballerina-parser/src/test/resources/expressions/regexp-constructor-expr/regexp_constructor_assert_26.json
+++ b/compiler/ballerina-parser/src/test/resources/expressions/regexp-constructor-expr/regexp_constructor_assert_26.json
@@ -106,32 +106,17 @@
                   ]
                 },
                 {
-                  "kind": "REGEX_TEMPLATE_EXPRESSION",
-                  "hasDiagnostics": true,
-                  "diagnostics": [
-                    "ERROR_MISSING_BACKTICK_STRING"
-                  ],
+                  "kind": "SIMPLE_NAME_REFERENCE",
                   "children": [
                     {
-                      "kind": "RE_KEYWORD",
+                      "kind": "IDENTIFIER_TOKEN",
+                      "value": "re",
                       "trailingMinutiae": [
                         {
                           "kind": "WHITESPACE_MINUTIAE",
                           "value": " "
                         }
                       ]
-                    },
-                    {
-                      "kind": "BACKTICK_TOKEN",
-                      "isMissing": true
-                    },
-                    {
-                      "kind": "LIST",
-                      "children": []
-                    },
-                    {
-                      "kind": "BACKTICK_TOKEN",
-                      "isMissing": true
                     }
                   ]
                 },

--- a/compiler/ballerina-parser/src/test/resources/expressions/regexp-constructor-expr/regexp_constructor_assert_40.json
+++ b/compiler/ballerina-parser/src/test/resources/expressions/regexp-constructor-expr/regexp_constructor_assert_40.json
@@ -1,0 +1,146 @@
+{
+  "kind": "MODULE_VAR_DECL",
+  "children": [
+    {
+      "kind": "LIST",
+      "children": []
+    },
+    {
+      "kind": "TYPED_BINDING_PATTERN",
+      "children": [
+        {
+          "kind": "QUALIFIED_NAME_REFERENCE",
+          "children": [
+            {
+              "kind": "IDENTIFIER_TOKEN",
+              "value": "string"
+            },
+            {
+              "kind": "COLON_TOKEN"
+            },
+            {
+              "kind": "IDENTIFIER_TOKEN",
+              "value": "RegExp",
+              "trailingMinutiae": [
+                {
+                  "kind": "WHITESPACE_MINUTIAE",
+                  "value": " "
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "CAPTURE_BINDING_PATTERN",
+          "children": [
+            {
+              "kind": "IDENTIFIER_TOKEN",
+              "value": "re",
+              "trailingMinutiae": [
+                {
+                  "kind": "WHITESPACE_MINUTIAE",
+                  "value": " "
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "EQUAL_TOKEN",
+      "trailingMinutiae": [
+        {
+          "kind": "WHITESPACE_MINUTIAE",
+          "value": " "
+        }
+      ]
+    },
+    {
+      "kind": "REGEX_TEMPLATE_EXPRESSION",
+      "children": [
+        {
+          "kind": "RE_KEYWORD",
+          "trailingMinutiae": [
+            {
+              "kind": "WHITESPACE_MINUTIAE",
+              "value": " "
+            }
+          ]
+        },
+        {
+          "kind": "BACKTICK_TOKEN"
+        },
+        {
+          "kind": "LIST",
+          "children": [
+            {
+              "kind": "RE_SEQUENCE",
+              "children": [
+                {
+                  "kind": "LIST",
+                  "children": [
+                    {
+                      "kind": "RE_ATOM_QUANTIFIER",
+                      "children": [
+                        {
+                          "kind": "RE_CHAR_ESCAPE",
+                          "children": [
+                            {
+                              "kind": "RE_CHAR",
+                              "value": "a"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "RE_ATOM_QUANTIFIER",
+                      "children": [
+                        {
+                          "kind": "RE_CHAR_ESCAPE",
+                          "children": [
+                            {
+                              "kind": "RE_CHAR",
+                              "value": "b"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "RE_ATOM_QUANTIFIER",
+                      "children": [
+                        {
+                          "kind": "RE_CHAR_ESCAPE",
+                          "children": [
+                            {
+                              "kind": "RE_CHAR",
+                              "value": "c"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "BACKTICK_TOKEN"
+        }
+      ]
+    },
+    {
+      "kind": "SEMICOLON_TOKEN",
+      "trailingMinutiae": [
+        {
+          "kind": "END_OF_LINE_MINUTIAE",
+          "value": "\n"
+        }
+      ]
+    }
+  ]
+}

--- a/compiler/ballerina-parser/src/test/resources/expressions/regexp-constructor-expr/regexp_constructor_assert_41.json
+++ b/compiler/ballerina-parser/src/test/resources/expressions/regexp-constructor-expr/regexp_constructor_assert_41.json
@@ -1,0 +1,188 @@
+{
+  "kind": "FUNCTION_DEFINITION",
+  "children": [
+    {
+      "kind": "LIST",
+      "children": []
+    },
+    {
+      "kind": "FUNCTION_KEYWORD",
+      "trailingMinutiae": [
+        {
+          "kind": "WHITESPACE_MINUTIAE",
+          "value": " "
+        }
+      ]
+    },
+    {
+      "kind": "IDENTIFIER_TOKEN",
+      "value": "foo"
+    },
+    {
+      "kind": "LIST",
+      "children": []
+    },
+    {
+      "kind": "FUNCTION_SIGNATURE",
+      "children": [
+        {
+          "kind": "OPEN_PAREN_TOKEN"
+        },
+        {
+          "kind": "LIST",
+          "children": []
+        },
+        {
+          "kind": "CLOSE_PAREN_TOKEN",
+          "trailingMinutiae": [
+            {
+              "kind": "WHITESPACE_MINUTIAE",
+              "value": " "
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "FUNCTION_BODY_BLOCK",
+      "children": [
+        {
+          "kind": "OPEN_BRACE_TOKEN",
+          "trailingMinutiae": [
+            {
+              "kind": "END_OF_LINE_MINUTIAE",
+              "value": "\n"
+            }
+          ]
+        },
+        {
+          "kind": "LIST",
+          "children": [
+            {
+              "kind": "LOCAL_VAR_DECL",
+              "children": [
+                {
+                  "kind": "LIST",
+                  "children": []
+                },
+                {
+                  "kind": "TYPED_BINDING_PATTERN",
+                  "children": [
+                    {
+                      "kind": "QUALIFIED_NAME_REFERENCE",
+                      "children": [
+                        {
+                          "kind": "IDENTIFIER_TOKEN",
+                          "value": "string",
+                          "leadingMinutiae": [
+                            {
+                              "kind": "WHITESPACE_MINUTIAE",
+                              "value": "    "
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "COLON_TOKEN"
+                        },
+                        {
+                          "kind": "IDENTIFIER_TOKEN",
+                          "value": "RegExp",
+                          "trailingMinutiae": [
+                            {
+                              "kind": "WHITESPACE_MINUTIAE",
+                              "value": " "
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "CAPTURE_BINDING_PATTERN",
+                      "children": [
+                        {
+                          "kind": "IDENTIFIER_TOKEN",
+                          "value": "b",
+                          "trailingMinutiae": [
+                            {
+                              "kind": "WHITESPACE_MINUTIAE",
+                              "value": " "
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "EQUAL_TOKEN",
+                  "trailingMinutiae": [
+                    {
+                      "kind": "WHITESPACE_MINUTIAE",
+                      "value": " "
+                    }
+                  ]
+                },
+                {
+                  "kind": "REGEX_TEMPLATE_EXPRESSION",
+                  "children": [
+                    {
+                      "kind": "RE_KEYWORD",
+                      "trailingMinutiae": [
+                        {
+                          "kind": "WHITESPACE_MINUTIAE",
+                          "value": " "
+                        },
+                        {
+                          "kind": "COMMENT_MINUTIAE",
+                          "value": "// some ------------- comment -----------------  string"
+                        },
+                        {
+                          "kind": "END_OF_LINE_MINUTIAE",
+                          "value": "\n"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "BACKTICK_TOKEN",
+                      "leadingMinutiae": [
+                        {
+                          "kind": "WHITESPACE_MINUTIAE",
+                          "value": "    "
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "LIST",
+                      "children": []
+                    },
+                    {
+                      "kind": "BACKTICK_TOKEN"
+                    }
+                  ]
+                },
+                {
+                  "kind": "SEMICOLON_TOKEN",
+                  "trailingMinutiae": [
+                    {
+                      "kind": "END_OF_LINE_MINUTIAE",
+                      "value": "\n"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "CLOSE_BRACE_TOKEN",
+          "trailingMinutiae": [
+            {
+              "kind": "END_OF_LINE_MINUTIAE",
+              "value": "\n"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/compiler/ballerina-parser/src/test/resources/expressions/regexp-constructor-expr/regexp_constructor_assert_41.json
+++ b/compiler/ballerina-parser/src/test/resources/expressions/regexp-constructor-expr/regexp_constructor_assert_41.json
@@ -130,7 +130,7 @@
                       "trailingMinutiae": [
                         {
                           "kind": "WHITESPACE_MINUTIAE",
-                          "value": " "
+                          "value": "  "
                         },
                         {
                           "kind": "COMMENT_MINUTIAE",

--- a/compiler/ballerina-parser/src/test/resources/expressions/regexp-constructor-expr/regexp_constructor_assert_42.json
+++ b/compiler/ballerina-parser/src/test/resources/expressions/regexp-constructor-expr/regexp_constructor_assert_42.json
@@ -1,0 +1,227 @@
+{
+  "kind": "FUNCTION_DEFINITION",
+  "children": [
+    {
+      "kind": "LIST",
+      "children": []
+    },
+    {
+      "kind": "FUNCTION_KEYWORD",
+      "trailingMinutiae": [
+        {
+          "kind": "WHITESPACE_MINUTIAE",
+          "value": " "
+        }
+      ]
+    },
+    {
+      "kind": "IDENTIFIER_TOKEN",
+      "value": "foo"
+    },
+    {
+      "kind": "LIST",
+      "children": []
+    },
+    {
+      "kind": "FUNCTION_SIGNATURE",
+      "children": [
+        {
+          "kind": "OPEN_PAREN_TOKEN"
+        },
+        {
+          "kind": "LIST",
+          "children": []
+        },
+        {
+          "kind": "CLOSE_PAREN_TOKEN",
+          "trailingMinutiae": [
+            {
+              "kind": "WHITESPACE_MINUTIAE",
+              "value": " "
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "FUNCTION_BODY_BLOCK",
+      "children": [
+        {
+          "kind": "OPEN_BRACE_TOKEN",
+          "trailingMinutiae": [
+            {
+              "kind": "END_OF_LINE_MINUTIAE",
+              "value": "\n"
+            }
+          ]
+        },
+        {
+          "kind": "LIST",
+          "children": [
+            {
+              "kind": "LOCAL_VAR_DECL",
+              "children": [
+                {
+                  "kind": "LIST",
+                  "children": []
+                },
+                {
+                  "kind": "TYPED_BINDING_PATTERN",
+                  "children": [
+                    {
+                      "kind": "QUALIFIED_NAME_REFERENCE",
+                      "children": [
+                        {
+                          "kind": "IDENTIFIER_TOKEN",
+                          "value": "string",
+                          "leadingMinutiae": [
+                            {
+                              "kind": "WHITESPACE_MINUTIAE",
+                              "value": "    "
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "COLON_TOKEN"
+                        },
+                        {
+                          "kind": "IDENTIFIER_TOKEN",
+                          "value": "RegExp",
+                          "trailingMinutiae": [
+                            {
+                              "kind": "WHITESPACE_MINUTIAE",
+                              "value": " "
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "CAPTURE_BINDING_PATTERN",
+                      "children": [
+                        {
+                          "kind": "IDENTIFIER_TOKEN",
+                          "value": "b",
+                          "trailingMinutiae": [
+                            {
+                              "kind": "WHITESPACE_MINUTIAE",
+                              "value": " "
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "EQUAL_TOKEN",
+                  "trailingMinutiae": [
+                    {
+                      "kind": "WHITESPACE_MINUTIAE",
+                      "value": " "
+                    }
+                  ]
+                },
+                {
+                  "kind": "REGEX_TEMPLATE_EXPRESSION",
+                  "children": [
+                    {
+                      "kind": "RE_KEYWORD",
+                      "trailingMinutiae": [
+                        {
+                          "kind": "WHITESPACE_MINUTIAE",
+                          "value": "                                       "
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "BACKTICK_TOKEN"
+                    },
+                    {
+                      "kind": "LIST",
+                      "children": [
+                        {
+                          "kind": "RE_SEQUENCE",
+                          "children": [
+                            {
+                              "kind": "LIST",
+                              "children": [
+                                {
+                                  "kind": "RE_ATOM_QUANTIFIER",
+                                  "children": [
+                                    {
+                                      "kind": "RE_CHAR_ESCAPE",
+                                      "children": [
+                                        {
+                                          "kind": "RE_CHAR",
+                                          "value": "a"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "RE_ATOM_QUANTIFIER",
+                                  "children": [
+                                    {
+                                      "kind": "RE_CHAR_ESCAPE",
+                                      "children": [
+                                        {
+                                          "kind": "RE_CHAR",
+                                          "value": "b"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "RE_ATOM_QUANTIFIER",
+                                  "children": [
+                                    {
+                                      "kind": "RE_CHAR_ESCAPE",
+                                      "children": [
+                                        {
+                                          "kind": "RE_CHAR",
+                                          "value": "c"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "BACKTICK_TOKEN"
+                    }
+                  ]
+                },
+                {
+                  "kind": "SEMICOLON_TOKEN",
+                  "trailingMinutiae": [
+                    {
+                      "kind": "END_OF_LINE_MINUTIAE",
+                      "value": "\n"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "CLOSE_BRACE_TOKEN",
+          "trailingMinutiae": [
+            {
+              "kind": "END_OF_LINE_MINUTIAE",
+              "value": "\n"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/compiler/ballerina-parser/src/test/resources/expressions/regexp-constructor-expr/regexp_constructor_assert_42.json
+++ b/compiler/ballerina-parser/src/test/resources/expressions/regexp-constructor-expr/regexp_constructor_assert_42.json
@@ -129,13 +129,19 @@
                       "kind": "RE_KEYWORD",
                       "trailingMinutiae": [
                         {
-                          "kind": "WHITESPACE_MINUTIAE",
-                          "value": "                                       "
+                          "kind": "END_OF_LINE_MINUTIAE",
+                          "value": "\n"
                         }
                       ]
                     },
                     {
-                      "kind": "BACKTICK_TOKEN"
+                      "kind": "BACKTICK_TOKEN",
+                      "leadingMinutiae": [
+                        {
+                          "kind": "WHITESPACE_MINUTIAE",
+                          "value": "    "
+                        }
+                      ]
                     },
                     {
                       "kind": "LIST",

--- a/compiler/ballerina-parser/src/test/resources/expressions/regexp-constructor-expr/regexp_constructor_assert_43.json
+++ b/compiler/ballerina-parser/src/test/resources/expressions/regexp-constructor-expr/regexp_constructor_assert_43.json
@@ -1,0 +1,188 @@
+{
+  "kind": "FUNCTION_DEFINITION",
+  "children": [
+    {
+      "kind": "LIST",
+      "children": []
+    },
+    {
+      "kind": "FUNCTION_KEYWORD",
+      "trailingMinutiae": [
+        {
+          "kind": "WHITESPACE_MINUTIAE",
+          "value": " "
+        }
+      ]
+    },
+    {
+      "kind": "IDENTIFIER_TOKEN",
+      "value": "foo"
+    },
+    {
+      "kind": "LIST",
+      "children": []
+    },
+    {
+      "kind": "FUNCTION_SIGNATURE",
+      "children": [
+        {
+          "kind": "OPEN_PAREN_TOKEN"
+        },
+        {
+          "kind": "LIST",
+          "children": []
+        },
+        {
+          "kind": "CLOSE_PAREN_TOKEN",
+          "trailingMinutiae": [
+            {
+              "kind": "WHITESPACE_MINUTIAE",
+              "value": " "
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "FUNCTION_BODY_BLOCK",
+      "children": [
+        {
+          "kind": "OPEN_BRACE_TOKEN",
+          "trailingMinutiae": [
+            {
+              "kind": "END_OF_LINE_MINUTIAE",
+              "value": "\n"
+            }
+          ]
+        },
+        {
+          "kind": "LIST",
+          "children": [
+            {
+              "kind": "LOCAL_VAR_DECL",
+              "children": [
+                {
+                  "kind": "LIST",
+                  "children": []
+                },
+                {
+                  "kind": "TYPED_BINDING_PATTERN",
+                  "children": [
+                    {
+                      "kind": "QUALIFIED_NAME_REFERENCE",
+                      "children": [
+                        {
+                          "kind": "IDENTIFIER_TOKEN",
+                          "value": "string",
+                          "leadingMinutiae": [
+                            {
+                              "kind": "WHITESPACE_MINUTIAE",
+                              "value": "    "
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "COLON_TOKEN"
+                        },
+                        {
+                          "kind": "IDENTIFIER_TOKEN",
+                          "value": "RegExp",
+                          "trailingMinutiae": [
+                            {
+                              "kind": "WHITESPACE_MINUTIAE",
+                              "value": " "
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "CAPTURE_BINDING_PATTERN",
+                      "children": [
+                        {
+                          "kind": "IDENTIFIER_TOKEN",
+                          "value": "b",
+                          "trailingMinutiae": [
+                            {
+                              "kind": "WHITESPACE_MINUTIAE",
+                              "value": " "
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "EQUAL_TOKEN",
+                  "trailingMinutiae": [
+                    {
+                      "kind": "WHITESPACE_MINUTIAE",
+                      "value": " "
+                    }
+                  ]
+                },
+                {
+                  "kind": "BINARY_EXPRESSION",
+                  "children": [
+                    {
+                      "kind": "SIMPLE_NAME_REFERENCE",
+                      "children": [
+                        {
+                          "kind": "IDENTIFIER_TOKEN",
+                          "value": "re",
+                          "trailingMinutiae": [
+                            {
+                              "kind": "WHITESPACE_MINUTIAE",
+                              "value": " "
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "SLASH_TOKEN"
+                    },
+                    {
+                      "kind": "RAW_TEMPLATE_EXPRESSION",
+                      "children": [
+                        {
+                          "kind": "BACKTICK_TOKEN"
+                        },
+                        {
+                          "kind": "LIST",
+                          "children": []
+                        },
+                        {
+                          "kind": "BACKTICK_TOKEN"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "SEMICOLON_TOKEN",
+                  "trailingMinutiae": [
+                    {
+                      "kind": "END_OF_LINE_MINUTIAE",
+                      "value": "\n"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "CLOSE_BRACE_TOKEN",
+          "trailingMinutiae": [
+            {
+              "kind": "END_OF_LINE_MINUTIAE",
+              "value": "\n"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/compiler/ballerina-parser/src/test/resources/expressions/regexp-constructor-expr/regexp_constructor_assert_43.json
+++ b/compiler/ballerina-parser/src/test/resources/expressions/regexp-constructor-expr/regexp_constructor_assert_43.json
@@ -141,7 +141,13 @@
                       ]
                     },
                     {
-                      "kind": "SLASH_TOKEN"
+                      "kind": "SLASH_TOKEN",
+                      "trailingMinutiae": [
+                        {
+                          "kind": "WHITESPACE_MINUTIAE",
+                          "value": " "
+                        }
+                      ]
                     },
                     {
                       "kind": "RAW_TEMPLATE_EXPRESSION",

--- a/compiler/ballerina-parser/src/test/resources/expressions/regexp-constructor-expr/regexp_constructor_source_40.bal
+++ b/compiler/ballerina-parser/src/test/resources/expressions/regexp-constructor-expr/regexp_constructor_source_40.bal
@@ -1,0 +1,1 @@
+string:RegExp re = re `abc`;

--- a/compiler/ballerina-parser/src/test/resources/expressions/regexp-constructor-expr/regexp_constructor_source_41.bal
+++ b/compiler/ballerina-parser/src/test/resources/expressions/regexp-constructor-expr/regexp_constructor_source_41.bal
@@ -1,0 +1,4 @@
+function foo() {
+    string:RegExp b = re // some ------------- comment -----------------  string
+    ``;
+}

--- a/compiler/ballerina-parser/src/test/resources/expressions/regexp-constructor-expr/regexp_constructor_source_41.bal
+++ b/compiler/ballerina-parser/src/test/resources/expressions/regexp-constructor-expr/regexp_constructor_source_41.bal
@@ -1,4 +1,4 @@
 function foo() {
-    string:RegExp b = re // some ------------- comment -----------------  string
+    string:RegExp b = re  // some ------------- comment -----------------  string
     ``;
 }

--- a/compiler/ballerina-parser/src/test/resources/expressions/regexp-constructor-expr/regexp_constructor_source_42.bal
+++ b/compiler/ballerina-parser/src/test/resources/expressions/regexp-constructor-expr/regexp_constructor_source_42.bal
@@ -1,3 +1,4 @@
 function foo() {
-    string:RegExp b = re                                       `abc`;
+    string:RegExp b = re
+    `abc`;
 }

--- a/compiler/ballerina-parser/src/test/resources/expressions/regexp-constructor-expr/regexp_constructor_source_42.bal
+++ b/compiler/ballerina-parser/src/test/resources/expressions/regexp-constructor-expr/regexp_constructor_source_42.bal
@@ -1,0 +1,3 @@
+function foo() {
+    string:RegExp b = re                                       `abc`;
+}

--- a/compiler/ballerina-parser/src/test/resources/expressions/regexp-constructor-expr/regexp_constructor_source_43.bal
+++ b/compiler/ballerina-parser/src/test/resources/expressions/regexp-constructor-expr/regexp_constructor_source_43.bal
@@ -1,0 +1,3 @@
+function foo() {
+    string:RegExp b = re /``;
+}

--- a/compiler/ballerina-parser/src/test/resources/expressions/regexp-constructor-expr/regexp_constructor_source_43.bal
+++ b/compiler/ballerina-parser/src/test/resources/expressions/regexp-constructor-expr/regexp_constructor_source_43.bal
@@ -1,3 +1,3 @@
 function foo() {
-    string:RegExp b = re /``;
+    string:RegExp b = re / ``;
 }

--- a/langlib/lang.regexp/src/main/ballerina/regexp.bal
+++ b/langlib/lang.regexp/src/main/ballerina/regexp.bal
@@ -38,8 +38,8 @@ type GroupsAsSpanArrayType SpanAsTupleType[];
 type GroupsArrayType GroupsAsSpanArrayType[];
 
 # Returns the span of the first match that starts at or after startIndex.
-public isolated function find(RegExp 're, string str, int startIndex = 0) returns Span? {
-    SpanAsTupleType? resultArr = findImpl('re, str, startIndex);
+public isolated function find(RegExp re, string str, int startIndex = 0) returns Span? {
+    SpanAsTupleType? resultArr = findImpl(re, str, startIndex);
     if (resultArr is SpanAsTupleType) {
         Span spanObj = new java:SpanImpl(resultArr[0], resultArr[1], resultArr[2]);
         return spanObj;
@@ -51,8 +51,8 @@ isolated function findImpl(RegExp reExp, string str, int startIndex = 0) returns
     name: "find"
 } external;
 
-public isolated function findGroups(RegExp 're, string str, int startIndex = 0) returns Groups? {
-    GroupsAsSpanArrayType? resultArr = findGroupsImpl('re, str, startIndex);
+public isolated function findGroups(RegExp re, string str, int startIndex = 0) returns Groups? {
+    GroupsAsSpanArrayType? resultArr = findGroupsImpl(re, str, startIndex);
     if (resultArr is GroupsAsSpanArrayType) {
         SpanAsTupleType firstMatch = resultArr[0];
         Span firstMatchSpan = new java:SpanImpl(firstMatch[0], firstMatch[1], firstMatch[2]);
@@ -72,9 +72,9 @@ isolated function findGroupsImpl(RegExp reExp, string str, int startIndex = 0) r
 } external;
 
 # Return all non-overlapping matches.
-public isolated function findAll(RegExp 're, string str, int startIndex = 0) returns Span[] {
+public isolated function findAll(RegExp re, string str, int startIndex = 0) returns Span[] {
     Span[] spanArr = [];
-    GroupsAsSpanArrayType? resultArr = findGroupsImpl('re, str, startIndex);
+    GroupsAsSpanArrayType? resultArr = findGroupsImpl(re, str, startIndex);
     if (resultArr is GroupsAsSpanArrayType) {
         foreach SpanAsTupleType tpl in resultArr {
             spanArr.push(new java:SpanImpl(tpl[0], tpl[1], tpl[2]));
@@ -84,8 +84,8 @@ public isolated function findAll(RegExp 're, string str, int startIndex = 0) ret
 }
 
 # Return all non-overlapping matches.
-public isolated function findAllGroups(RegExp 're, string str, int startIndex = 0) returns Groups[] {
-    GroupsArrayType? resultArr = findAllGroupsImpl('re, str, startIndex);
+public isolated function findAllGroups(RegExp re, string str, int startIndex = 0) returns Groups[] {
+    GroupsArrayType? resultArr = findAllGroupsImpl(re, str, startIndex);
     if (resultArr is GroupsArrayType) {
         Groups[] groupArrRes = [];
         foreach GroupsAsSpanArrayType groupArr in resultArr {
@@ -111,8 +111,8 @@ isolated function findAllGroupsImpl(RegExp reExp, string str, int startIndex = 0
     name: "findAllGroups"
 } external;
 
-public isolated function matchAt(RegExp 're, string str, int startIndex = 0) returns Span? {
-    SpanAsTupleType? resultArr = matchAtImpl('re, str, startIndex);
+public isolated function matchAt(RegExp re, string str, int startIndex = 0) returns Span? {
+    SpanAsTupleType? resultArr = matchAtImpl(re, str, startIndex);
     if (resultArr is SpanAsTupleType) {
         Span spanObj = new java:SpanImpl(resultArr[0], resultArr[1], resultArr[2]);
         return spanObj;
@@ -124,8 +124,8 @@ isolated function matchAtImpl(RegExp reExp, string str, int startIndex = 0) retu
     name: "matchAt"
 } external;
 
-public isolated function matchGroupsAt(RegExp 're, string str, int startIndex = 0) returns Groups? {
-    GroupsAsSpanArrayType? resultArr = matchGroupsAtImpl('re, str, startIndex);
+public isolated function matchGroupsAt(RegExp re, string str, int startIndex = 0) returns Groups? {
+    GroupsAsSpanArrayType? resultArr = matchGroupsAtImpl(re, str, startIndex);
     if (resultArr is GroupsAsSpanArrayType) {
         SpanAsTupleType firstMatch = resultArr[0];
         Span firstMatchSpan = new java:SpanImpl(firstMatch[0], firstMatch[1], firstMatch[2]);
@@ -145,8 +145,8 @@ isolated function matchGroupsAtImpl(RegExp reExp, string str, int startIndex = 0
 } external;
 
 # Says whether there is a match of the RegExp that starts at the beginning of the string and ends at the end of the string.
-public isolated function isFullMatch(RegExp 're, string str) returns boolean {
-    return isFullMatchImpl('re, str);
+public isolated function isFullMatch(RegExp re, string str) returns boolean {
+    return isFullMatchImpl(re, str);
 }
 
 isolated function isFullMatchImpl(RegExp reExp, string str) returns boolean = @java:Method {
@@ -155,8 +155,8 @@ isolated function isFullMatchImpl(RegExp reExp, string str) returns boolean = @j
 } external;
 
 # Says whether there is a match of the RegExp that starts at the beginning of the string and ends at the end of the string.
-public isolated function fullMatchGroups(RegExp 're, string str) returns Groups? {
-    return matchGroupsAt('re, str);
+public isolated function fullMatchGroups(RegExp re, string str) returns Groups? {
+    return matchGroupsAt(re, str);
 }
 
 public type ReplacerFunction function (Groups groups) returns string;
@@ -164,9 +164,9 @@ public type ReplacerFunction function (Groups groups) returns string;
 public type Replacement ReplacerFunction|string;
 
 # Replaces the first occurrence of a regular expression.
-public isolated function replace(RegExp 're, string str, Replacement replacement, int startIndex = 0) returns string {
+public isolated function replace(RegExp re, string str, Replacement replacement, int startIndex = 0) returns string {
     string replacementStr = "";
-    Groups? findResult = findGroups('re, str, startIndex);
+    Groups? findResult = findGroups(re, str, startIndex);
     if findResult is () {
         return str;
     }
@@ -175,7 +175,7 @@ public isolated function replace(RegExp 're, string str, Replacement replacement
     } else {
         replacementStr = replacement;
     }
-    return replaceFromString('re, str, replacementStr, startIndex);
+    return replaceFromString(re, str, replacementStr, startIndex);
 }
 
 isolated function replaceFromString(RegExp reExp, string str, string replacementStr, int startIndex) returns string = @java:Method {
@@ -184,13 +184,13 @@ isolated function replaceFromString(RegExp reExp, string str, string replacement
 } external;
 
 # Replaces all occurrences of a regular expression.
-public isolated function replaceAll(RegExp 're, string str, Replacement replacement, int startIndex = 0) returns string {
-    Groups? findResult = findGroups('re, str, startIndex);
+public isolated function replaceAll(RegExp re, string str, Replacement replacement, int startIndex = 0) returns string {
+    Groups? findResult = findGroups(re, str, startIndex);
     if findResult is () {
         return str;
     }
     string replacementStr = replacement is ReplacerFunction ? replacement(findResult) : replacement;
-    return replaceAllFromString('re, str, replacementStr, startIndex);
+    return replaceAllFromString(re, str, replacementStr, startIndex);
 }
 
 isolated function replaceAllFromString(RegExp reExp, string str, string replacementStr, int startIndex) returns string = @java:Method {

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibRegexpTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibRegexpTest.java
@@ -64,7 +64,8 @@ public class LangLibRegexpTest {
                 "testReplace",
                 "testFindAllGroups",
                 "testFromString",
-                "testFromStringNegative"
+                "testFromStringNegative",
+                "testLangLibFuncWithNamedArgExpr"
         };
     }
 }

--- a/langlib/langlib-test/src/test/resources/test-src/regexp_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/regexp_test.bal
@@ -929,6 +929,70 @@ function testFromStringNegative() {
     }
 }
 
+function testLangLibFuncWithNamedArgExpr() {
+    regexp:Span? res1 = regexp:find(re = re `World`, str = "HelloWorld");
+    assertTrue(res1 is regexp:Span);
+    regexp:Span resultSpan1 = <regexp:Span>res1;
+    assertEquality(5, resultSpan1.startIndex);
+    assertEquality(10, resultSpan1.endIndex);
+    assertEquality("World", resultSpan1.substring());
+
+    regexp:Groups? res2 = regexp:findGroups(re = re `World`, str = "HelloWorld");
+    assertTrue(res2 is regexp:Groups);
+    regexp:Groups resultGroups1 = <regexp:Groups>res2;
+    assertEquality(1, resultGroups1.length());
+    resultSpan1 = <regexp:Span>resultGroups1[0];
+    assertEquality(5, resultSpan1.startIndex);
+    assertEquality(10, resultSpan1.endIndex);
+    assertEquality("World", resultSpan1.substring());
+
+    regexp:Span[]? res3 = regexp:findAll(re = re `GFG`, str = "GFGFGFGFGFGFGFGFGFG");
+    assertTrue(res3 is regexp:Span[]);
+    regexp:Span[] resultSpanArr1 = <regexp:Span[]>res3;
+    assertEquality(5, resultSpanArr1.length());
+
+    regexp:Span? res4 = regexp:matchAt(re = re `World`, str = "HelloWorld");
+    assertTrue(res4 is ());
+
+    regexp:Groups? res5 = regexp:matchGroupsAt(
+        re = re `([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])(?:\\.([0-9]{1,3}))?`,
+        str = "time: 14:35:59", startIndex = 6);
+    assertTrue(res5 is regexp:Groups);
+    regexp:Groups resultGroups2 = <regexp:Groups>res5;
+    regexp:Span resultSpan2_1 = <regexp:Span>resultGroups2[0];
+    assertEquality(6, resultSpan2_1.startIndex);
+    assertEquality(8, resultSpan2_1.endIndex);
+    assertEquality("14", resultSpan2_1.substring());
+
+    boolean isFullMatch1 = regexp:isFullMatch(re = re `(?i:[a-z]+)`, str = "ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+    assertTrue(isFullMatch1);
+
+    regexp:Groups? res6 = regexp:fullMatchGroups(re = re `([0-9]+)×([0-9]+)`, str = "1440×900");
+    assertTrue(res6 is regexp:Groups);
+    regexp:Groups resultGroups3 = <regexp:Groups>res6;
+    regexp:Span resultSpan3_1 = <regexp:Span>resultGroups3[0];
+    assertEquality(0, resultSpan3_1.startIndex);
+    assertEquality(4, resultSpan3_1.endIndex);
+    assertEquality("1440", resultSpan3_1.substring());
+
+    string result1 = regexp:replaceAll(re = re `T.*G`, str = "ReplaceTTTGGGThis", replacement = " ");
+    assertEquality("Replace This", result1);
+
+    string result2 = regexp:replace(re = re `This`, str = "ReplaceThisThisTextThis", replacement = " ");
+    assertEquality("Replace ThisTextThis", result2);
+
+    regexp:Groups[]? res7 = regexp:findAllGroups(re = re `(GFG)(FGF)`, str = "GFGFGFGFGFGFGFGFGF");
+    assertTrue(res7 is regexp:Groups[]);
+    regexp:Groups[] groupsArr1 = <regexp:Groups[]>res7;
+    assertEquality(3, groupsArr1.length());
+
+    string:RegExp|error x1 = regexp:fromString(str = "AB+C*D{1,4}");
+    assertTrue(x1 is string:RegExp);
+    if (x1 is string:RegExp) {
+       assertTrue(re `AB+C*D{1,4}` == x1);
+    }
+}
+
 function assertEquality(any|error expected, any|error actual) {
     if expected is anydata && actual is anydata && expected == actual {
         return;


### PR DESCRIPTION
## Purpose

Fixes #38492

## Approach
Check for back tick after `re` keyword and then create syntax token for `re` keyword, instead of consider `re` as reserved keyword.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
