### PR TITLE
Fix Optional#isPresent() sonar cloud bug in TestFunctionVisitor

### DIFF
--- a/misc/testerina/modules/testerina-compiler-plugin/src/main/java/org/ballerinalang/testerina/compiler/TestFunctionVisitor.java
+++ b/misc/testerina/modules/testerina-compiler-plugin/src/main/java/org/ballerinalang/testerina/compiler/TestFunctionVisitor.java
@@ -28,6 +28,7 @@ import io.ballerina.compiler.syntax.tree.SyntaxKind;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Visit the functions with test annotations.
@@ -56,8 +57,9 @@ public class TestFunctionVisitor extends NodeVisitor {
 
     @Override
     public void visit(FunctionDefinitionNode functionDefinitionNode) {
-        if (functionDefinitionNode.metadata().isPresent()) {
-            MetadataNode metadataNode = functionDefinitionNode.metadata().get();
+        Optional<MetadataNode> metadataNodeOptional = functionDefinitionNode.metadata();
+        if (metadataNodeOptional.isPresent()) {
+            MetadataNode metadataNode = metadataNodeOptional.get();
             for (AnnotationNode annotation : metadataNode.annotations()) {
                 if (annotation.annotReference().kind() != SyntaxKind.QUALIFIED_NAME_REFERENCE) {
                     continue;


### PR DESCRIPTION
## Purpose
FIx the [sonarcloud bug](https://sonarcloud.io/project/issues?id=com.sonarqube.examples%3Ajava11-maven-travis-project&open=AXJinqfvUyXgVaNMxd4E&resolved=false&types=BUG) by assigning the Optional value to a variable before getting the value.

Related to https://github.com/ballerina-platform/ballerina-lang/issues/38462

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
