### PR TITLE
Set timeout to 2 hrs for full build PR check

### DIFF
--- a/.github/workflows/pull_request_full_build.yml
+++ b/.github/workflows/pull_request_full_build.yml
@@ -9,6 +9,7 @@ jobs:
   build-lang:
     name: Build Ballerina Lang
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     concurrency: 
       group: ${{ github.head_ref }}-full-build-pipeline
       cancel-in-progress: true
@@ -46,6 +47,7 @@ jobs:
     needs: build-lang
     name: Build Stdlib Level
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Purpose
Set timeout to 2 hrs instead of default value (6 hrs) for full build PR check. This will reduce PR checks being queued.

Fixes #38510

