### PR TITLE
Fix the test report fail message escape character missing issue.

### DIFF
--- a/misc/testerina/modules/testerina-core/src/main/ballerina/report.bal
+++ b/misc/testerina/modules/testerina-core/src/main/ballerina/report.bal
@@ -147,7 +147,7 @@ function moduleStatusReport(ReportData data) {
     data.failedCases().forEach(result => tests.push({
         "name": result.fullName(),
         "status": "FAILURE",
-        "failureMessage": result.message()
+        "failureMessage": replaceDoubleQuotes(result.message())
     }));
     data.skippedCases().forEach(result => tests.push({
         "name": result.fullName(),
@@ -167,4 +167,16 @@ function moduleStatusReport(ReportData data) {
     if err is error {
         println(err.message());
     }
+}
+
+function replaceDoubleQuotes(string originalString) returns string {
+    string updatedString = "";
+    foreach string chr in originalString {
+        if chr == "\"" {
+            updatedString += "\\\"";
+        } else {
+            updatedString += chr;
+        }
+    }
+    return updatedString;
 }


### PR DESCRIPTION
## Purpose
When the fail message contains double quotes, the `module_status.json` forms incorrectly since the double quotes are not escaped properly. 

Fixes #38538

## Approach
Use the `regex:replaceAll` method to replace `"` with `\"`.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
