### PR TITLE
Disable change parameter type code action on field accesses of a record type parameter

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/ChangeParameterTypeCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/ChangeParameterTypeCodeAction.java
@@ -90,9 +90,9 @@ public class ChangeParameterTypeCodeAction implements DiagnosticBasedCodeActionP
             return Collections.emptyList();
         }
 
-        // Skip, variable declarations with non-initializers
+        // Skip, variable declarations with non-initializers and field access initializers
         Optional<ExpressionNode> initializer = localVarNode.initializer();
-        if (initializer.isEmpty()) {
+        if (initializer.isEmpty()  || initializer.get().kind() == SyntaxKind.FIELD_ACCESS) {
             return Collections.emptyList();
         }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ChangeParamTypeTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ChangeParamTypeTest.java
@@ -53,4 +53,17 @@ public class ChangeParamTypeTest extends AbstractCodeActionTest {
                 {"changeParamTypeRestParam.json"}
         };
     }
+    
+    @Override
+    @Test(dataProvider = "negative-test-data-provider")
+    public void negativeTest(String config) throws IOException, WorkspaceDocumentException {
+        super.negativeTest(config);
+    }
+
+    @DataProvider(name = "negative-test-data-provider")
+    public Object[][] negativeDataProvider() {
+        return new Object[][]{
+                {"changeParamTypeInFieldAccess.json"}
+        };
+    }
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-param-type/config/changeParamTypeInFieldAccess.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-param-type/config/changeParamTypeInFieldAccess.json
@@ -1,0 +1,12 @@
+{
+  "position": {
+    "line": 5,
+    "character": 30
+  },
+  "source": "changeParamTypeInFieldAccess.bal",
+  "expected": [
+    {
+      "title": "Change parameter 'dataRec' type to 'string'"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/change-param-type/source/changeParamTypeInFieldAccess.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/change-param-type/source/changeParamTypeInFieldAccess.bal
@@ -1,0 +1,7 @@
+type Data record {|
+    string? name;
+|};
+
+public function convert(Data dataRec) {
+    string strVal = dataRec.name;
+}


### PR DESCRIPTION
## Purpose
This PR disables the change parameter type code action on field accesses of a record type parameter.

Fixes #38271

## Samples
<img width="621" alt="Screenshot 2022-11-08 at 13 46 06" src="https://user-images.githubusercontent.com/27485094/200510838-2111ba92-56dd-42a0-9d06-5b5c82901ba7.png">

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
