### PR TITLE
Provide temporary API to identify generated modules

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/DependencyUtils.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/DependencyUtils.java
@@ -19,8 +19,12 @@ package io.ballerina.projects.util;
 
 import io.ballerina.projects.CompilationOptions;
 import io.ballerina.projects.IDLClientGeneratorResult;
+import io.ballerina.projects.Module;
 import io.ballerina.projects.Project;
+import io.ballerina.projects.ProjectKind;
 import io.ballerina.projects.environment.ResolutionOptions;
+
+import java.nio.file.Files;
 
 /**
  * Project dependencies related util methods.
@@ -54,5 +58,23 @@ public class DependencyUtils {
         CompilationOptions.CompilationOptionsBuilder compilationOptionsBuilder = CompilationOptions.builder();
         compilationOptionsBuilder.setOffline(false);
         return project.currentPackage().runIDLGeneratorPlugins(ResolutionOptions.builder().setOffline(false).build());
+    }
+
+    /**
+     * Check if the module is a generated module.
+     * This is temporary API gievn till the public API is finalized.
+     *
+     * @param module module instance
+     * @return whether the module is a generated one or not
+     */
+    public static boolean isGeneratedModule(Module module) {
+        if (!module.project().kind().equals(ProjectKind.BUILD_PROJECT)) {
+            return false;
+        }
+        if (module.isDefaultModule()) {
+            return false;
+        }
+        return Files.exists(module.project().sourceRoot().resolve(ProjectConstants.GENERATED_MODULES_ROOT)
+                .resolve(module.moduleName().moduleNamePart()));
     }
 }


### PR DESCRIPTION
## Purpose
> Provide temporary API to identify generated modules
Fixes part of https://github.com/ballerina-platform/ballerina-lang/issues/38423

## Approach
Introduces DependencyUtils#isGeneratedModule to be used by the LS

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
