### PR TITLE
Fix crashing when a worker uses variable outside resource function

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureDesugar.java
@@ -1664,7 +1664,7 @@ public class ClosureDesugar extends BLangNodeVisitor {
             }
 
             // If the node is not a function, then get its enclosing env and continue.
-            if (symbolEnv.node.getKind() != NodeKind.FUNCTION) {
+            if (symbolEnv.node.getKind() != NodeKind.FUNCTION && symbolEnv.node.getKind() != NodeKind.RESOURCE_FUNC) {
                 symbolEnv = symbolEnv.enclEnv;
                 continue;
             }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
@@ -396,7 +396,6 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
         SymbolEnv funcEnv = SymbolEnv.createFunctionEnv(funcNode, funcNode.symbol.scope, env);
 
         Map<BSymbol, Location> prevUnusedLocalVariables = this.unusedLocalVariables;
-        this.unusedLocalVariables = new HashMap<>();
         this.currDependentSymbolDeque.push(funcNode.symbol);
 
         funcNode.annAttachments.forEach(bLangAnnotationAttachment -> analyzeNode(bLangAnnotationAttachment.expr, env));

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
@@ -396,6 +396,8 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
         SymbolEnv funcEnv = SymbolEnv.createFunctionEnv(funcNode, funcNode.symbol.scope, env);
 
         Map<BSymbol, Location> prevUnusedLocalVariables = this.unusedLocalVariables;
+        this.unusedLocalVariables = new HashMap<>();
+        this.unusedLocalVariables.putAll(prevUnusedLocalVariables);
         this.currDependentSymbolDeque.push(funcNode.symbol);
 
         funcNode.annAttachments.forEach(bLangAnnotationAttachment -> analyzeNode(bLangAnnotationAttachment.expr, env));
@@ -409,6 +411,9 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
         }
 
         this.currDependentSymbolDeque.pop();
+
+        prevUnusedLocalVariables.keySet().removeIf(bSymbol -> !this.unusedLocalVariables.containsKey(bSymbol));
+        this.unusedLocalVariables.keySet().removeAll(prevUnusedLocalVariables.keySet());
 
         emitUnusedVariableWarnings(this.unusedLocalVariables);
         this.unusedLocalVariables = prevUnusedLocalVariables;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/services/service_decl.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/services/service_decl.bal
@@ -224,6 +224,24 @@ function testWithLocalVar() {
             }
         }
     };
+
+    string a = "1";
+    var _ = client object {
+        resource function get name() {
+            worker A {
+                string _ = a;
+            }
+        }
+    };
+
+    int[] c = [10];
+    var d = client object {
+        resource function get name() {
+            worker A {
+                int[] e = c;
+            }
+        }
+    };
 }
 
 function assertEquality(any|error actual, any|error expected) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/services/service_decl.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/services/service_decl.bal
@@ -211,8 +211,19 @@ function testServiceDecl() {
         (checkpanic(wait callMethod(<service object {}> getService(), "$get$foo")));
     string str = <string> (checkpanic (wait callMethod(inner, "$get$foo")));
     assertEquality(str, "foo/foo");
-
+    testWithLocalVar();
     reset();
+}
+
+function testWithLocalVar() {
+    int[] t = [];
+    var _ = service object {
+        resource function get name() {
+            worker A {
+                int[] _ = t;
+            }
+        }
+    };
 }
 
 function assertEquality(any|error actual, any|error expected) {


### PR DESCRIPTION
## Purpose
> Fix compiler crashes when a worker in a resource function refers to a variable outside the function.

Fixes #37679

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
