### PR TITLE
[2201.3.0]Infer type-binding in outer join as nillable

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
@@ -782,7 +782,9 @@ public enum DiagnosticErrorCode implements DiagnosticCode {
     INVALID_QUANTIFIER_MINIMUM("BCE4036", "invalid.quantifier.minimum"),
     DUPLICATE_FLAGS("BCE4037", "duplicate.flags"),
     CANNOT_IMPORT_MODULE_GENERATED_FOR_CLIENT_DECL(
-            "BCE4045", "cannot.import.module.generated.for.a.client.decl")
+            "BCE4045", "cannot.import.module.generated.for.a.client.decl"),
+    OUTER_JOIN_MUST_BE_DECLARED_WITH_VAR(
+            "BCE4046", "outer.join.must.be.declared.with.var")
     ;
 
     private String diagnosticId;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -6465,6 +6465,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
             if (!joinClause.isDeclaredWithVar) {
                 this.dlog.error(joinClause.variableDefinitionNode.getPosition(),
                         DiagnosticErrorCode.OUTER_JOIN_MUST_BE_DECLARED_WITH_VAR);
+                return;
             }
             joinClause.varType = types.addNilForNillableAccessType(joinClause.varType);
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -6461,6 +6461,9 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         checkExpr(joinClause.collection, data.commonAnalyzerData.queryEnvs.peek(), data);
         // Set the type of the foreach node's type node.
         types.setInputClauseTypedBindingPatternType(joinClause);
+        if (joinClause.isOuterJoin) {
+            joinClause.varType = types.addNilForNillableAccessType(joinClause.varType);
+        }
         handleInputClauseVariables(joinClause, data.commonAnalyzerData.queryEnvs.peek());
         if (joinClause.onClause != null) {
             ((BLangOnClause) joinClause.onClause).accept(this, data);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -6462,6 +6462,10 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         // Set the type of the foreach node's type node.
         types.setInputClauseTypedBindingPatternType(joinClause);
         if (joinClause.isOuterJoin) {
+            if (!joinClause.isDeclaredWithVar) {
+                this.dlog.error(joinClause.variableDefinitionNode.getPosition(),
+                        DiagnosticErrorCode.OUTER_JOIN_MUST_BE_DECLARED_WITH_VAR);
+            }
             joinClause.varType = types.addNilForNillableAccessType(joinClause.varType);
         }
         handleInputClauseVariables(joinClause, data.commonAnalyzerData.queryEnvs.peek());

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1931,3 +1931,6 @@ error.duplicate.flags=\
 
 error.cannot.import.module.generated.for.a.client.decl=\
   a module generated for a client declaration cannot be imported
+
+error.outer.join.must.be.declared.with.var=\
+  outer join must be declared with var

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1934,3 +1934,4 @@ error.cannot.import.module.generated.for.a.client.decl=\
 
 error.outer.join.must.be.declared.with.var=\
   outer join must be declared with var
+  

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1933,5 +1933,5 @@ error.cannot.import.module.generated.for.a.client.decl=\
   a module generated for a client declaration cannot be imported
 
 error.outer.join.must.be.declared.with.var=\
-  outer join must be declared with var
+  outer join must be declared with ''var''
   

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/JoinClauseTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/JoinClauseTest.java
@@ -122,7 +122,7 @@ public class JoinClauseTest {
 
     @Test(description = "Test negative scenarios for query expr with join clause")
     public void testNegativeScenarios() {
-        Assert.assertEquals(negativeResult.getErrorCount(), 32);
+        Assert.assertEquals(negativeResult.getErrorCount(), 38);
         int i = 0;
         validateError(negativeResult, i++, "incompatible types: expected 'Department', found 'Person'", 46, 13);
         validateError(negativeResult, i++, "undeclared field 'name' in record 'Person'", 51, 19);
@@ -155,7 +155,9 @@ public class JoinClauseTest {
         validateError(negativeResult, i++, "missing on keyword", 309, 1);
         validateError(negativeResult, i++, "undefined symbol 'dept'", 329, 24);
         validateError(negativeResult, i++, "missing equals keyword", 330, 1);
-        validateError(negativeResult, i, "missing identifier", 330, 1);
+        validateError(negativeResult, i++, "missing identifier", 330, 1);
+        validateError(negativeResult, i++, "incompatible types: expected 'Department?', found 'Department'", 353, 19);
+        validateError(negativeResult, i++, "outer join must be declared with var", 353, 19);
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/JoinClauseTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/JoinClauseTest.java
@@ -115,6 +115,11 @@ public class JoinClauseTest {
         Assert.assertTrue((Boolean) values);
     }
 
+    @Test(description = "Test outer join with null results")
+    public void testOuterJoinWithNullResults() {
+        BRunUtil.invoke(result, "testOuterJoin");
+    }
+
     @Test(description = "Test negative scenarios for query expr with join clause")
     public void testNegativeScenarios() {
         Assert.assertEquals(negativeResult.getErrorCount(), 32);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/JoinClauseTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/JoinClauseTest.java
@@ -122,7 +122,7 @@ public class JoinClauseTest {
 
     @Test(description = "Test negative scenarios for query expr with join clause")
     public void testNegativeScenarios() {
-        Assert.assertEquals(negativeResult.getErrorCount(), 38);
+        Assert.assertEquals(negativeResult.getErrorCount(), 40);
         int i = 0;
         validateError(negativeResult, i++, "incompatible types: expected 'Department', found 'Person'", 46, 13);
         validateError(negativeResult, i++, "undeclared field 'name' in record 'Person'", 51, 19);
@@ -156,12 +156,14 @@ public class JoinClauseTest {
         validateError(negativeResult, i++, "undefined symbol 'dept'", 329, 24);
         validateError(negativeResult, i++, "missing equals keyword", 330, 1);
         validateError(negativeResult, i++, "missing identifier", 330, 1);
-        validateError(negativeResult, i++, "incompatible types: expected 'Department?', found 'Department'", 353, 19);
         validateError(negativeResult, i++, "outer join must be declared with var", 353, 19);
-        validateError(negativeResult, i++, "missing equals keyword", 354, 1);
-        validateError(negativeResult, i++, "missing identifier", 354, 1);
-        validateError(negativeResult, i++, "missing identifier", 354, 1);
-        validateError(negativeResult, i, "missing on keyword", 354, 1);
+        validateError(negativeResult, i++, "undefined symbol 'dept'", 357, 19);
+        validateError(negativeResult, i++, "invalid operation: type 'Person?' does not support field access", 374, 16);
+        validateError(negativeResult, i++, "incompatible types: expected 'int', found 'other'", 389, 59);
+        validateError(negativeResult, i++, "invalid operation: type 'Person?' does not support field access", 389, 59);
+        validateError(negativeResult, i++, "invalid operation: type 'Person?' does not support field access", 395, 22);
+        validateError(negativeResult, i++, "order by not supported for complex type fields, order key should belong to a basic type", 395, 22);
+        validateError(negativeResult, i++, "invalid operation: type 'Person?' does not support field access", 397, 36);
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/JoinClauseTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/JoinClauseTest.java
@@ -156,7 +156,7 @@ public class JoinClauseTest {
         validateError(negativeResult, i++, "undefined symbol 'dept'", 329, 24);
         validateError(negativeResult, i++, "missing equals keyword", 330, 1);
         validateError(negativeResult, i++, "missing identifier", 330, 1);
-        validateError(negativeResult, i++, "outer join must be declared with var", 353, 19);
+        validateError(negativeResult, i++, "outer join must be declared with 'var'", 353, 19);
         validateError(negativeResult, i++, "undefined symbol 'dept'", 357, 19);
         validateError(negativeResult, i++, "invalid operation: type 'Person?' does not support field access", 374, 16);
         validateError(negativeResult, i++, "incompatible types: expected 'int', found 'other'", 389, 59);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/JoinClauseTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/JoinClauseTest.java
@@ -162,7 +162,8 @@ public class JoinClauseTest {
         validateError(negativeResult, i++, "incompatible types: expected 'int', found 'other'", 389, 59);
         validateError(negativeResult, i++, "invalid operation: type 'Person?' does not support field access", 389, 59);
         validateError(negativeResult, i++, "invalid operation: type 'Person?' does not support field access", 395, 22);
-        validateError(negativeResult, i++, "order by not supported for complex type fields, order key should belong to a basic type", 395, 22);
+        validateError(negativeResult, i++, "order by not supported for complex type fields, order key should belong" +
+                " to a basic type", 395, 22);
         validateError(negativeResult, i++, "invalid operation: type 'Person?' does not support field access", 397, 36);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/JoinClauseTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/JoinClauseTest.java
@@ -158,6 +158,10 @@ public class JoinClauseTest {
         validateError(negativeResult, i++, "missing identifier", 330, 1);
         validateError(negativeResult, i++, "incompatible types: expected 'Department?', found 'Department'", 353, 19);
         validateError(negativeResult, i++, "outer join must be declared with var", 353, 19);
+        validateError(negativeResult, i++, "missing equals keyword", 354, 1);
+        validateError(negativeResult, i++, "missing identifier", 354, 1);
+        validateError(negativeResult, i++, "missing identifier", 354, 1);
+        validateError(negativeResult, i, "missing on keyword", 354, 1);
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/join-clause-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/join-clause-negative.bal
@@ -17,7 +17,7 @@
 type DeptPerson record {|
    string fname;
    string lname;
-   string dept;
+   string? dept;
 |};
 
 type Department record {|
@@ -284,12 +284,12 @@ function testOuterJoinWithOnClauseWithFunction() returns boolean {
 
     DeptPerson[] deptPersonList =
        from var person in personList
-       outer join Department dept in deptList
+       outer join var dept in deptList
        on condition(person.fname)
        select {
            fname : person.fname,
            lname : person.lname,
-           dept : dept.name
+           dept : dept?.name
        };
 }
 
@@ -305,11 +305,11 @@ function testOuterJoinWithOutOnClause() returns boolean {
 
     DeptPerson[] deptPersonList =
        from var person in personList
-       outer join Department dept in deptList
+       outer join var dept in deptList
        select {
            fname : person.fname,
            lname : person.lname,
-           dept : dept.name
+           dept : dept?.name
        };
 }
 
@@ -325,15 +325,35 @@ function testOnClauseWithoutEquals() returns boolean {
 
     DeptPerson[] deptPersonList =
        from var person in personList
-       outer join Department dept in deptList
+       outer join var dept in deptList
        on person.id == dept.id
        select {
            fname : person.fname,
            lname : person.lname,
-           dept : dept.name
+           dept : dept?.name
        };
 }
 
 function condition(string name) returns boolean{
     return name == "Alex";
+}
+
+function testOuterJoinWithoutVar() returns boolean {
+    Person p1 = {id: 1, fname: "Alex", lname: "George"};
+    Person p2 = {id: 2, fname: "Ranjan", lname: "Fonseka"};
+
+    Department d1 = {id: 1, name:"HR"};
+    Department d2 = {id: 2, name:"Operations"};
+
+    Person[] personList = [p1, p2];
+    Department[] deptList = [d1, d2];
+
+    DeptPerson[] deptPersonList =
+       from Person person in personList
+       outer join Department dept in deptList
+       select {
+           fname : person.fname,
+           lname : person.lname,
+           dept : dept?.name
+       };
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/join-clause-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/join-clause-negative.bal
@@ -183,7 +183,7 @@ function testOuterJoinWithInvalidEqualsClause2() returns DeptPerson[]{
     DeptPerson[] deptPersonList =
        from var person in personList
        outer join var {id,name} in deptList
-       on id equals person.id
+       on id equals person?.id
        select {
            fname : person.fname,
            lname : person.lname,
@@ -350,10 +350,50 @@ function testOuterJoinWithoutVar() returns boolean {
 
     DeptPerson[] deptPersonList =
        from Person person in personList
-       outer join Department dept in deptList
+       outer join Department dept in deptList on dept.id equals person?.id
        select {
            fname : person.fname,
            lname : person.lname,
            dept : dept?.name
        };
+}
+
+function testOuterJoinWithoutOptionalAccess1() returns boolean {
+    Person[] people = [
+        {id: 1, fname: "Alex", lname: "George"},
+        {id: 2, fname: "Ranjan", lname: "Fonseka"}
+    ];
+
+    Department[] departments = [
+        {id: 1, name:"HR"},
+        {id: 2, name:"Operations"}
+    ];
+
+    string?[] _ = from Department dept in departments
+        outer join var person in people on dept.id equals person?.id
+        select person.fname;
+}
+
+function testOuterJoinWithoutOptionalAccess2() returns boolean {
+    Person[] people = [
+        {id: 1, fname: "Alex", lname: "George"},
+        {id: 2, fname: "Ranjan", lname: "Fonseka"}
+    ];
+
+    Department[] departments = [
+        {id: 1, name:"HR"},
+        {id: 2, name:"Operations"}
+    ];
+
+    string?[] _ = from Department dept in departments
+        outer join var person in people on dept.id equals person.id
+        select person?.fname;
+
+    string[] ordered_names = [];
+    error? e = from Department dept in departments
+            outer join var person in people on dept.id equals person?.id
+            order by person.id
+            do {
+                ordered_names.push(person.lname);
+            };
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/join-clause.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/join-clause.bal
@@ -482,7 +482,9 @@ public function testOuterJoin() {
         outer join var user in users on login.userId equals user?.id
         select (user?.name);
 
-    assertEquality(["Anne", "Keith", null], selected);
+    assertEquality("Anne", selected[0]);
+    assertEquality("Keith", selected[1]);
+    assertEquality(null, selected[2]);
 }
 
 const ASSERTION_ERROR_REASON = "AssertionError";

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/join-clause.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/join-clause.bal
@@ -482,9 +482,20 @@ public function testOuterJoin() {
         outer join var user in users on login.userId equals user?.id
         select (user?.name);
 
+    int?[] ids = [];
+
+    error? e = from Login login in logins
+                outer join var user in users on login.userId equals user?.id
+                do {
+                    ids.push(user?.id);
+                };
+
     assertEquality("Anne", selected[0]);
     assertEquality("Keith", selected[1]);
     assertEquality(null, selected[2]);
+    assertEquality(6789, ids[0]);
+    assertEquality(1234, ids[1]);
+    assertEquality(null, ids[2]);
 }
 
 const ASSERTION_ERROR_REASON = "AssertionError";

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/join-clause.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/join-clause.bal
@@ -490,12 +490,23 @@ public function testOuterJoin() {
                     ids.push(user?.id);
                 };
 
+    string?[] ordered_names = [];
+    error? e2 = from Login login in logins
+            outer join var user in users on login.userId equals user?.id
+            order by user?.id
+            do {
+                ordered_names.push(user?.name);
+            };
+
     assertEquality("Anne", selected[0]);
     assertEquality("Keith", selected[1]);
     assertEquality(null, selected[2]);
     assertEquality(6789, ids[0]);
     assertEquality(1234, ids[1]);
     assertEquality(null, ids[2]);
+    assertEquality("Keith", ordered_names[0]);
+    assertEquality("Anne", ordered_names[1]);
+    assertEquality(null, ordered_names[2]);
 }
 
 const ASSERTION_ERROR_REASON = "AssertionError";

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/query_expr_with_errors.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/query_expr_with_errors.bal
@@ -354,7 +354,7 @@ function testCatchingErrorAtOnFail() {
     error? res14 = ();
     do {
         _ = from int i in 1 ... 3
-            outer join int j in (from int jj in 1 ... 3
+            outer join var j in (from int jj in 1 ... 3
                 select check verifyCheck(jj))
             on i equals j
             select i;
@@ -460,7 +460,7 @@ function checkErrorAtOnEqualRHS() returns error? {
 
 function checkErrorAtOuterJoin() returns error? {
     _ = from int i in 1 ... 3
-        outer join int j in (from int jj in 1 ... 3
+        outer join var j in (from int jj in 1 ... 3
             select check verifyCheck(jj))
         on i equals j
         select i;
@@ -468,14 +468,14 @@ function checkErrorAtOuterJoin() returns error? {
 
 function checkErrorAtOuterJoinOnEqualLHS() returns error? {
     _ = from int i in 1 ... 3
-        outer join int j in 1 ... 3
+        outer join var j in 1 ... 3
         on check verifyCheck(i) equals j
         select i;
 }
 
 function checkErrorAtOuterJoinOnEqualRHS() returns error? {
     _ = from int i in 1 ... 3
-        outer join int j in 1 ... 3
+        outer join var j in 1 ... 3
         on i equals check verifyCheck(j)
         select i;
 }
@@ -492,7 +492,7 @@ function checkErrorAtOrderBy() returns error? {
 
 // Utils ---------------------------------------------------------------------------------------------------------
 
-public function verifyCheck(int i) returns int|error {
+public function verifyCheck(int? i) returns int|error {
     return error("Verify Check.");
 }
 


### PR DESCRIPTION
## Purpose
>Infer type-binding in outer join as nillable and enforce inferable type descriptor is var

Fixes #https://github.com/ballerina-platform/ballerina-lang/issues/34897 & https://github.com/ballerina-platform/ballerina-lang/issues/38223

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> Porting #38232

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
