### PR TITLE
Stop sending diagnostics when LS in lightweight mode

### DIFF
--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/capability/InitializationOptions.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/capability/InitializationOptions.java
@@ -43,6 +43,11 @@ public interface InitializationOptions {
     String KEY_QUICKPICK_SUPPORT = "supportQuickPick";
 
     /**
+     * Whether the LS should run in lightweight mode.
+     */
+    String KEY_ENABLE_LIGHTWEIGHT_MODE = "enableLightWeightMode";
+
+    /**
      * Return if the client support bala URI scheme.
      *
      * @return True if bala URi scheme is supported.
@@ -69,4 +74,11 @@ public interface InitializationOptions {
      * @return True if supported, false otherwise
      */
     boolean isQuickPickSupported();
+
+    /**
+     * Returns if the LS enable lightweight mode.
+     *
+     * @return True if enabled, false otherwise
+     */
+    boolean isEnableLightWeightMode();
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaLanguageServer.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaLanguageServer.java
@@ -21,6 +21,7 @@ import io.ballerina.projects.util.ProjectConstants;
 import org.ballerinalang.langserver.command.LSCommandExecutorProvidersHolder;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.commons.LanguageServerContext;
+import org.ballerinalang.langserver.commons.capability.InitializationOptions;
 import org.ballerinalang.langserver.commons.capability.LSClientCapabilities;
 import org.ballerinalang.langserver.commons.client.ExtendedLanguageClient;
 import org.ballerinalang.langserver.commons.client.ExtendedLanguageClientAware;
@@ -89,9 +90,10 @@ public class BallerinaLanguageServer extends AbstractExtendedLanguageServer
     private ExtendedLanguageClient client = null;
     private final TextDocumentService textService;
     private final WorkspaceService workspaceService;
+
+    private LSClientCapabilities capabilities;
     private int shutdown = 1;
 
-    private static final String LS_INIT_MODE_PROPERTY = "enableLightWeightMode";
     private static final String LS_ENABLE_SEMANTIC_HIGHLIGHTING = "enableSemanticHighlighting";
 
     public BallerinaLanguageServer() {
@@ -112,8 +114,27 @@ public class BallerinaLanguageServer extends AbstractExtendedLanguageServer
         final InitializeResult res = new InitializeResult(new ServerCapabilities());
         res.getCapabilities().setTextDocumentSync(TextDocumentSyncKind.Full);
 
+        Map experimentalClientCapabilities = null;
+        if (params.getCapabilities().getExperimental() != null) {
+            experimentalClientCapabilities = new Gson().fromJson(params.getCapabilities().getExperimental().toString(),
+                    HashMap.class);
+        }
+
+        Map initializationOptions = null;
+        if (params.getInitializationOptions() != null) {
+            initializationOptions = new Gson().fromJson(params.getInitializationOptions().toString(), HashMap.class);
+        }
+
+        TextDocumentClientCapabilities textDocClientCapabilities = params.getCapabilities().getTextDocument();
+        WorkspaceClientCapabilities workspaceClientCapabilities = params.getCapabilities().getWorkspace();
+        LSClientCapabilities capabilities = new LSClientCapabilitiesImpl(textDocClientCapabilities,
+                workspaceClientCapabilities,
+                experimentalClientCapabilities,
+                initializationOptions);
+        this.serverContext.put(LSClientCapabilities.class, capabilities);
+
         //Checks for instances in which the LS needs to be initiated in lightweight mode
-        if (isLightWeightMode(params)) {
+        if (capabilities.getInitializationOptions().isEnableLightWeightMode()) {
             return CompletableFuture.supplyAsync(() -> res);
         }
 
@@ -128,7 +149,7 @@ public class BallerinaLanguageServer extends AbstractExtendedLanguageServer
         res.getCapabilities().setFoldingRangeProvider(true);
         res.getCapabilities().setCodeLensProvider(new CodeLensOptions());
 
-        CodeActionOptions codeActionOptions = new CodeActionOptions(List.of(CodeActionKind.Refactor, 
+        CodeActionOptions codeActionOptions = new CodeActionOptions(List.of(CodeActionKind.Refactor,
                 CodeActionKind.QuickFix, CodeActionKind.Source));
         codeActionOptions.setResolveProvider(true);
         res.getCapabilities().setCodeActionProvider(codeActionOptions);
@@ -165,17 +186,6 @@ public class BallerinaLanguageServer extends AbstractExtendedLanguageServer
         ExecuteCommandOptions executeCommandOptions = new ExecuteCommandOptions(commandsList);
         res.getCapabilities().setExecuteCommandProvider(executeCommandOptions);
 
-        Map initializationOptions = null;
-        if (params.getInitializationOptions() != null) {
-            initializationOptions = new Gson().fromJson(params.getInitializationOptions().toString(), HashMap.class);
-        }
-
-        Map experimentalClientCapabilities = null;
-        if (params.getCapabilities().getExperimental() != null) {
-            experimentalClientCapabilities = new Gson().fromJson(params.getCapabilities().getExperimental().toString(),
-                    HashMap.class);
-        }
-
         // Set AST provider and examples provider capabilities
         HashMap<String, Object> experimentalServerCapabilities = new HashMap<>();
         experimentalServerCapabilities.put(AST_PROVIDER.getValue(), true);
@@ -183,13 +193,6 @@ public class BallerinaLanguageServer extends AbstractExtendedLanguageServer
         experimentalServerCapabilities.put(API_EDITOR_PROVIDER.getValue(), true);
         res.getCapabilities().setExperimental(experimentalServerCapabilities);
 
-        TextDocumentClientCapabilities textDocClientCapabilities = params.getCapabilities().getTextDocument();
-        WorkspaceClientCapabilities workspaceClientCapabilities = params.getCapabilities().getWorkspace();
-        LSClientCapabilities capabilities = new LSClientCapabilitiesImpl(textDocClientCapabilities,
-                workspaceClientCapabilities,
-                experimentalClientCapabilities,
-                initializationOptions);
-        this.serverContext.put(LSClientCapabilities.class, capabilities);
         this.serverContext.put(ServerCapabilities.class, res.getCapabilities());
         ((BallerinaTextDocumentService) textService).setClientCapabilities(capabilities);
         ((BallerinaWorkspaceService) workspaceService).setClientCapabilities(capabilities);
@@ -419,8 +422,8 @@ public class BallerinaLanguageServer extends AbstractExtendedLanguageServer
     private Boolean isLightWeightMode(InitializeParams params) {
         if (params.getInitializationOptions() != null) {
             JsonObject initOptions = (JsonObject) params.getInitializationOptions();
-            if (initOptions.has(LS_INIT_MODE_PROPERTY)) {
-                return initOptions.get(LS_INIT_MODE_PROPERTY).getAsBoolean();
+            if (initOptions.has(InitializationOptions.KEY_ENABLE_LIGHTWEIGHT_MODE)) {
+                return initOptions.get(InitializationOptions.KEY_ENABLE_LIGHTWEIGHT_MODE).getAsBoolean();
             }
         }
         return false;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaLanguageServer.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaLanguageServer.java
@@ -21,7 +21,6 @@ import io.ballerina.projects.util.ProjectConstants;
 import org.ballerinalang.langserver.command.LSCommandExecutorProvidersHolder;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.commons.LanguageServerContext;
-import org.ballerinalang.langserver.commons.capability.InitializationOptions;
 import org.ballerinalang.langserver.commons.capability.LSClientCapabilities;
 import org.ballerinalang.langserver.commons.client.ExtendedLanguageClient;
 import org.ballerinalang.langserver.commons.client.ExtendedLanguageClientAware;
@@ -90,8 +89,6 @@ public class BallerinaLanguageServer extends AbstractExtendedLanguageServer
     private ExtendedLanguageClient client = null;
     private final TextDocumentService textService;
     private final WorkspaceService workspaceService;
-
-    private LSClientCapabilities capabilities;
     private int shutdown = 1;
 
     private static final String LS_ENABLE_SEMANTIC_HIGHLIGHTING = "enableSemanticHighlighting";
@@ -417,16 +414,6 @@ public class BallerinaLanguageServer extends AbstractExtendedLanguageServer
         Registration registration = new Registration(UUID.randomUUID().toString(),
                 "workspace/didChangeWatchedFiles", opts);
         languageClient.registerCapability(new RegistrationParams(Collections.singletonList(registration)));
-    }
-
-    private Boolean isLightWeightMode(InitializeParams params) {
-        if (params.getInitializationOptions() != null) {
-            JsonObject initOptions = (JsonObject) params.getInitializationOptions();
-            if (initOptions.has(InitializationOptions.KEY_ENABLE_LIGHTWEIGHT_MODE)) {
-                return initOptions.get(InitializationOptions.KEY_ENABLE_LIGHTWEIGHT_MODE).getAsBoolean();
-            }
-        }
-        return false;
     }
 
     private boolean enableBallerinaSemanticTokens(InitializeParams params) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaWorkspaceService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaWorkspaceService.java
@@ -86,9 +86,10 @@ public class BallerinaWorkspaceService implements WorkspaceService {
     @Override
     public void didChangeWatchedFiles(DidChangeWatchedFilesParams params) {
         try {
+            List<Path> paths = this.workspaceManagerProxy.get().didChangeWatched(params);
             LSClientCapabilities lsClientCapabilities = this.serverContext.get(LSClientCapabilities.class);
+            // Don't publish diagnostics on lightweight mode
             if (!lsClientCapabilities.getInitializationOptions().isEnableLightWeightMode()) {
-                List<Path> paths = this.workspaceManagerProxy.get().didChangeWatched(params);
                 DidChangeWatchedFilesContext context =
                         ContextBuilder.buildDidChangeWatchedFilesContext(
                                 this.workspaceManagerProxy.get(),

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSClientCapabilitiesImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSClientCapabilitiesImpl.java
@@ -35,6 +35,7 @@ import static org.ballerinalang.langserver.Experimental.SHOW_TEXT_DOCUMENT;
  * @since 1.2.0
  */
 public class LSClientCapabilitiesImpl implements LSClientCapabilities {
+
     private final ExperimentalClientCapabilities experimentalCapabilities;
     private final InitializationOptions initializationOptions;
     private final WorkspaceClientCapabilities workspaceCapabilities;
@@ -43,7 +44,7 @@ public class LSClientCapabilitiesImpl implements LSClientCapabilities {
 
     LSClientCapabilitiesImpl(TextDocumentClientCapabilities textDocCapabilities,
                              WorkspaceClientCapabilities workspaceCapabilities,
-                             Map experimentalClientCapabilities, 
+                             Map experimentalClientCapabilities,
                              Map initializationOptionsMap) {
         this.textDocCapabilities = (textDocCapabilities != null) ?
                 textDocCapabilities : new TextDocumentClientCapabilities();
@@ -56,7 +57,7 @@ public class LSClientCapabilitiesImpl implements LSClientCapabilities {
 
         this.initializationOptions = initializationOptionsMap != null ?
                 parseInitializationOptions(initializationOptionsMap) : new InitializationOptionsImpl();
-        
+
         this.ballerinaClientCapabilities = new ArrayList<>();
     }
 
@@ -69,7 +70,7 @@ public class LSClientCapabilitiesImpl implements LSClientCapabilities {
     public ExperimentalClientCapabilities getExperimentalCapabilities() {
         return experimentalCapabilities;
     }
-    
+
     @Override
     public InitializationOptions getInitializationOptions() {
         return initializationOptions;
@@ -151,6 +152,11 @@ public class LSClientCapabilitiesImpl implements LSClientCapabilities {
                 Boolean.parseBoolean(String.valueOf(quickPickSupport));
         initializationOptions.setSupportQuickPick(enableQuickPickSupport);
 
+        Object lsLightWeightMode = initOptions.get(InitializationOptions.KEY_ENABLE_LIGHTWEIGHT_MODE);
+        boolean enableLSLightWeightMode = lsLightWeightMode != null &&
+                Boolean.parseBoolean(String.valueOf(lsLightWeightMode));
+        initializationOptions.setEnableLSLightWeightMode(enableLSLightWeightMode);
+
         return initializationOptions;
     }
 
@@ -158,6 +164,7 @@ public class LSClientCapabilitiesImpl implements LSClientCapabilities {
      * Represents Extended LSP capabilities.
      */
     public static class ExperimentalClientCapabilitiesImpl implements ExperimentalClientCapabilities {
+
         private boolean introspectionEnabled = false;
         private boolean showTextDocumentEnabled = false;
 
@@ -194,11 +201,13 @@ public class LSClientCapabilitiesImpl implements LSClientCapabilities {
      * Represents the initialization options the LS client will be sending.
      */
     public static class InitializationOptionsImpl implements InitializationOptions {
+
         private boolean supportBalaScheme = false;
         private boolean enableSemanticTokens = false;
         private boolean supportRenamePopup = false;
         private boolean supportQuickPick = false;
-        
+        private boolean enableLSLightWeightMode = false;
+
         @Override
         public boolean isBalaSchemeSupported() {
             return supportBalaScheme;
@@ -230,8 +239,18 @@ public class LSClientCapabilitiesImpl implements LSClientCapabilities {
             return supportQuickPick;
         }
 
+        public void setEnableLSLightWeightMode(boolean enableLSLightWeightMode) {
+            this.enableLSLightWeightMode = enableLSLightWeightMode;
+        }
+
+        @Override
+        public boolean isEnableLightWeightMode() {
+            return enableLSLightWeightMode;
+        }
+
         public void setSupportQuickPick(boolean supportQuickPick) {
             this.supportQuickPick = supportQuickPick;
         }
+
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/eventsync/subscribers/PublishDiagnosticSubscriber.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/eventsync/subscribers/PublishDiagnosticSubscriber.java
@@ -20,6 +20,7 @@ package org.ballerinalang.langserver.eventsync.subscribers;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.commons.DocumentServiceContext;
 import org.ballerinalang.langserver.commons.LanguageServerContext;
+import org.ballerinalang.langserver.commons.capability.LSClientCapabilities;
 import org.ballerinalang.langserver.commons.client.ExtendedLanguageClient;
 import org.ballerinalang.langserver.commons.eventsync.EventKind;
 import org.ballerinalang.langserver.commons.eventsync.spi.EventSubscriber;
@@ -32,18 +33,22 @@ import org.ballerinalang.langserver.diagnostic.DiagnosticsHelper;
  */
 @JavaSPIService("org.ballerinalang.langserver.commons.eventsync.spi.EventSubscriber")
 public class PublishDiagnosticSubscriber implements EventSubscriber {
+
     public static final String NAME = "Publish diagnostic subscriber";
 
     @Override
     public EventKind eventKind() {
         return EventKind.PROJECT_UPDATE;
     }
-    
+
     @Override
     public void onEvent(ExtendedLanguageClient client, DocumentServiceContext context,
                         LanguageServerContext languageServerContext) {
-        DiagnosticsHelper diagnosticsHelper = DiagnosticsHelper.getInstance(languageServerContext);
-        diagnosticsHelper.compileAndSendDiagnostics(client, context);
+        LSClientCapabilities lsClientCapabilities = context.languageServercontext().get(LSClientCapabilities.class);
+        if (!lsClientCapabilities.getInitializationOptions().isEnableLightWeightMode()) {
+            DiagnosticsHelper diagnosticsHelper = DiagnosticsHelper.getInstance(languageServerContext);
+            diagnosticsHelper.compileAndSendDiagnostics(client, context);
+        }
     }
 
     @Override


### PR DESCRIPTION
## Purpose
Currently we are not checking weather the LS is in lightweight mode when we are publishing diagnostics. Ballerina compiler toolkit connects to a lightweight language server and it will publish diagnostic messages. Because of this when a user have both plugin and compiler toolkit it shows same diagnostic twice.  

With this PR this incorrect behavior is go away.

Fixes #38431

## Samples
-  how it looks like before the fix.
<img width="587" alt="Screenshot 2022-11-16 at 12 12 16" src="https://user-images.githubusercontent.com/46857198/202105843-fec5e6f9-22e1-43f8-a707-2285416e72d0.png">


- how it looks like after the fix.
<img width="533" alt="Screenshot 2022-11-16 at 12 10 36" src="https://user-images.githubusercontent.com/46857198/202105950-191454c4-2bd7-43d8-938f-6ea0e00140f4.png">


## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
