### PR TITLE
Handle error.message() exception in getErrorMessage

### DIFF
--- a/misc/testerina/modules/testerina-core/src/main/ballerina/execute.bal
+++ b/misc/testerina/modules/testerina-core/src/main/ballerina/execute.bal
@@ -356,7 +356,16 @@ function executeFunction(TestFunction|function testFunction) returns ExecutionEr
 
 function getErrorMessage(error err) returns string {
     string|error message = err.detail()["message"].ensureType();
-    return message is error ? err.message() : message;
+    if message is error {
+        message = trap err.message();
+        if message is error {
+            return "No content";
+        } else {
+            return message;
+        }
+    } else {
+        return message;
+    }
 }
 
 function orderTests() returns error? {


### PR DESCRIPTION
## Purpose

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/38609

https://github.com/ballerina-platform/ballerina-lang/issues/38609#issuecomment-1311312774

## Approach

Trap the error coming from error:message() and return a string "No content" as the error message.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
