### PR TITLE
[master] Allow unary expressions in const annotation attachments

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -4273,6 +4273,9 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
             case LITERAL:
             case NUMERIC_LITERAL:
                 break;
+            case UNARY_EXPR:
+                checkAnnotConstantExpression(((BLangUnaryExpr) expression).expr);
+                break;
             case SIMPLE_VARIABLE_REF:
                 BSymbol symbol = ((BLangSimpleVarRef) expression).symbol;
                 // Symbol can be null in some invalid scenarios. Eg - const string m = { name: "Ballerina" };

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/annotations/AnnotationAttachmentNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/annotations/AnnotationAttachmentNegativeTest.java
@@ -507,4 +507,10 @@ public class AnnotationAttachmentNegativeTest {
         validateError(compileResult, index++, "annotation 'v23' is not allowed on type", line += 7, 1);
         validateError(compileResult, index, "annotation 'v22' is not allowed on const", line + 2, 5);
     }
+
+    // https://github.com/ballerina-platform/ballerina-lang/issues/38746
+    @Test(enabled = false)
+    public void testInvalidNonConstUnaryExprInConstAnnotAttachment() {
+        validateError(compileResult, 272, "expression is not a constant expression", 943, 17);
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/annotations/AnnotationAttachmentSymbolsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/annotations/AnnotationAttachmentSymbolsTest.java
@@ -332,6 +332,15 @@ public class AnnotationAttachmentSymbolsTest {
         Assert.assertEquals(f2.get(1).value, "test");
     }
 
+    @Test
+    public void testConstAnnotWithUnaryExpr() {
+        List<? extends AnnotationAttachmentSymbol> attachments =
+                ((BTypeDefinitionSymbol) getTypeDefinition(compileResult.getAST().getTypeDefinitions(), "Qux").symbol)
+                        .getAnnotations();
+        Assert.assertEquals(attachments.size(), 1);
+        assertAttachmentSymbol(attachments.get(0), "v29", true, "increment", -1L);
+    }
+
     private BLangTypeDefinition getTypeDefinition(List<? extends TypeDefinition> typeDefinitions, String name) {
         for (TypeDefinition typeDefinition : typeDefinitions) {
             BLangTypeDefinition bLangTypeDefinition = (BLangTypeDefinition) typeDefinition;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/annotations/annot_attachments.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/annotations/annot_attachments.bal
@@ -294,3 +294,13 @@ public enum Color2 {
     RED,
     BLUE
 }
+
+public const annotation record {| int increment = 1; |} v29 on source type;
+
+@v29 {
+    increment: -1
+}
+type Qux record {|
+    int x;
+|};
+

--- a/tests/jballerina-unit-test/src/test/resources/test-src/annotations/annot_attachments_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/annotations/annot_attachments_negative.bal
@@ -934,3 +934,14 @@ public enum Color5 {
     ORANGE,
     GREEN
 }
+
+// public const annotation record {| int increment = 1; |} v25 on source type;
+
+// int x = 1;
+
+// @v25 {
+//     increment: -x
+// }
+// type Qux record {|
+//     int x;
+// |};


### PR DESCRIPTION
## Purpose
$title.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/38743

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
