### PR TITLE
[2201.3.0] Fix compiler crash when using resource access actions in query expressions/actions

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
@@ -2249,6 +2249,12 @@ public class QueryDesugar extends BLangNodeVisitor {
         this.acceptNode(workerReceiveNode.sendExpression);
     }
 
+    @Override
+    public void visit(BLangInvocation.BLangResourceAccessInvocation resourceAccessInvocation) {
+        resourceAccessInvocation.argExprs.forEach(this::acceptNode);
+        this.acceptNode(resourceAccessInvocation.expr);
+    }
+
     private void acceptNode(BLangNode node) {
         if (node == null) {
             return;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryActionOrExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryActionOrExprTest.java
@@ -69,7 +69,10 @@ public class QueryActionOrExprTest {
                 "testQueryActionOrExprWithAllQueryClauses",
                 "testQueryActionOrExprWithNestedQueryActionOrExpr",
                 "testQueryActionOrExprWithQueryConstructingTable",
-                "testQueryActionOrExprWithQueryConstructingStream"
+                "testQueryActionOrExprWithQueryConstructingStream",
+                "testQueryActionOrExprWithClientResourceAccessAction",
+                "testQueryActionOrExprWithGroupedClientResourceAccessAction",
+                "testNestedQueryActionOrExprWithClientResourceAccessAction"
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryActionWithActionOrExpr.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryActionWithActionOrExpr.java
@@ -64,7 +64,10 @@ public class QueryActionWithActionOrExpr {
                 "testQueryActionWithParenthesizedQueryActionOrExpr",
                 "testPrecedenceOfActionsWhenUsingActionOrExprWithQueryAction",
                 "testQueryActionWithAllQueryClauses",
-                "testQueryActionWithNestedQueryActionOrExpr"
+                "testQueryActionWithNestedQueryActionOrExpr",
+                "testQueryActionWithClientResourceAccessAction",
+                "testQueryActionWithGroupedClientResourceAccessAction",
+                "testNestedQueryActionWithClientResourceAccessAction"
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/query_action_or_expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/query_action_or_expr.bal
@@ -694,6 +694,106 @@ function getTokenValue((record {| Token value; |}|error?)|(record {| Token value
     }
 }
 
+type Book record {|
+    readonly int id;
+    string name;
+|};
+
+const PATH = "someLongPathSegment";
+
+client class MyClient {
+    resource function get .() returns string {
+        return "book1";
+    }
+
+    resource function get books/names() returns string[2] {
+        return ["book1", "book2"];
+    }
+
+    resource function get books/[int id]() returns string {
+        return "book" + id.toString();
+    }
+
+    resource function bookDetails .(int no, string bookName) returns Book {
+            Book b = {id: no, name: bookName};
+            return b;
+    }
+
+    resource function put books/[PATH](int a) returns string {
+        return "book1";
+    }
+
+    resource function someOtherMethod books/[PATH...](string a) returns string[] {
+        return [a, "book4"];
+    }
+}
+
+function testQueryActionOrExprWithClientResourceAccessAction() {
+    MyClient myClient = new;
+
+    string[] res = from var i in myClient->/books/names
+            let string book = myClient->/.get
+            where i == book
+            select myClient->/books/[1];
+    assertEquality(["book1"], res);
+
+    table<Book> key(id) res2 = table key(id) from var b in myClient->/books/names
+            let string book = myClient->/.get
+            where b == book
+            select myClient->/.bookDetails(1, b);
+    table<Book> key(id) tbl = table [{id: 1, name: "book1"}];
+    assertEquality(tbl, res2);
+
+    "someLongPathSegment" path = "someLongPathSegment";
+    var res3 = from var b in myClient->/books/names
+            let string book = myClient->/books/someLongPathSegment.put(1)
+            where b == book
+            select myClient->/.bookDetails(1, b);
+    assertEquality([{id: 1, name: "book1"}], res3);
+}
+
+function testQueryActionOrExprWithGroupedClientResourceAccessAction() {
+    MyClient myClient = new;
+
+    string[] res = from var i in (myClient->/books/names)
+            let string book = (myClient->/.get)
+            where i == book
+            select (myClient->/books/[1]);
+    assertEquality(["book1"], res);
+
+    table<Book> key(id) res2 = table key(id) from var b in (myClient->/books/names)
+            let string book = myClient->/.get
+            where b == book
+            select (myClient->/.bookDetails(1, b));
+    table<Book> key(id) tbl = table [{id: 1, name: "book1"}];
+    assertEquality(tbl, res2);
+
+    "someLongPathSegment" path = "someLongPathSegment";
+    var res3 = from var b in myClient->/books/names
+            let string book = (myClient->/books/someLongPathSegment.put(1))
+            where b == book
+            select (myClient->/.bookDetails(1, b));
+    assertEquality([{id: 1, name: "book1"}], res3);
+}
+
+function testNestedQueryActionOrExprWithClientResourceAccessAction() {
+    MyClient myClient = new;
+
+    Book[] res = from var i in (from string k in myClient->/books/names
+                         let string book = myClient->/.get
+                         where k == book
+                         select myClient->/books/[1])
+            select myClient->/.bookDetails(1, i);
+    assertEquality([{id: 1, name: "book1"}], res);
+
+    "someLongPathSegment" path = "someLongPathSegment";
+    var res2 = from var b in myClient->/books/names
+            from string c in myClient->/books/someLongPathSegment.someOtherMethod("book2")
+            where b == c
+            select myClient->/.bookDetails(1, b);
+    assertEquality([{id: 1, name: "book2"}], res2);
+}
+
 const ASSERTION_ERROR_REASON = "AssertionError";
 
 function assertEquality(anydata expected, anydata actual) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/query_action_with_action_or_expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/query_action_with_action_or_expr.bal
@@ -629,6 +629,133 @@ function testQueryActionWithNestedQueryActionOrExpr() {
     assertEquality(152, sum);
 }
 
+type Book record {|
+    int id;
+    string name;
+|};
+
+const PATH = "someLongPathSegment";
+
+client class MyClient {
+    resource function get .() returns string {
+        return "book1";
+    }
+
+    resource function get books/names() returns string[2] {
+        return ["book1", "book2"];
+    }
+
+    resource function get books/[int id]() returns string {
+        return "book" + id.toString();
+    }
+
+    resource function bookDetails .(int no, string bookName) returns Book {
+            Book b = {id: no, name: bookName};
+            return b;
+    }
+
+    resource function put books/[PATH](int a) returns string {
+        return "book1";
+    }
+
+    resource function someOtherMethod books/[PATH...](string a) returns string[] {
+        return [a, "book4"];
+    }
+}
+
+function testQueryActionWithClientResourceAccessAction() {
+    MyClient myClient = new;
+    string[] arr = [];
+    error? res = from var i in myClient->/books/names
+            let string book = myClient->/.get
+            where i == book
+            do {
+                string s = myClient->/books/[1];
+                arr.push(s);
+            };
+    assertEquality(true, res is ());
+    assertEquality(["book1"], arr);
+
+    error? res2 = from var b in myClient->/books/names
+            let Book book = myClient->/.bookDetails(1, b)
+            where b == book.name
+            do {
+                arr.push(book.name);
+            };
+    assertEquality(true, res2 is ());
+    assertEquality(["book1", "book1", "book2"], arr);
+
+    "someLongPathSegment" path = "someLongPathSegment";
+    var res3 = from var b in myClient->/books/names
+            let string book = myClient->/books/someLongPathSegment.put(1)
+            where b == book
+            do {
+                arr.push(book);
+            };
+    assertEquality(true, res3 is ());
+    assertEquality(["book1", "book1", "book2", "book1"], arr);
+}
+
+function testQueryActionWithGroupedClientResourceAccessAction() {
+    MyClient myClient = new;
+    string[] arr = [];
+    error? res = from var i in (myClient->/books/names)
+            let string book = (myClient->/.get)
+            where i == book
+            do {
+                string s = myClient->/books/[1];
+                arr.push(s);
+            };
+    assertEquality(true, res is ());
+    assertEquality(["book1"], arr);
+
+    error? res2 = from var b in (myClient->/books/names)
+            let Book book = (myClient->/.bookDetails(1, b))
+            where b == book.name
+            do {
+                arr.push(book.name);
+            };
+    assertEquality(true, res2 is ());
+    assertEquality(["book1", "book1", "book2"], arr);
+
+    "someLongPathSegment" path = "someLongPathSegment";
+    var res3 = from var b in (myClient->/books/names)
+            let string book = (myClient->/books/someLongPathSegment.put(1))
+            where b == book
+            do {
+                arr.push(book);
+            };
+    assertEquality(true, res3 is ());
+    assertEquality(["book1", "book1", "book2", "book1"], arr);
+}
+
+function testNestedQueryActionWithClientResourceAccessAction() {
+    MyClient myClient = new;
+    anydata[] arr = [];
+
+    error? res = from var i in (from string k in myClient->/books/names
+                         let string book = myClient->/.get
+                         where k == book
+                         select myClient->/books/[1])
+            do {
+                Book bk = myClient->/.bookDetails(1, i);
+                arr.push(bk);
+            };
+    assertEquality(true, res is ());
+    assertEquality([{id: 1, name: "book1"}], arr);
+
+    "someLongPathSegment" path = "someLongPathSegment";
+    var res2 = from var b in myClient->/books/names
+            from string c in myClient->/books/someLongPathSegment.someOtherMethod("book2")
+            where b == c
+            do {
+                Book bk = myClient->/.bookDetails(1, b);
+                arr.push(bk);
+            };
+    assertEquality(true, res2 is ());
+    assertEquality([{id: 1, name: "book1"}, {id: 1, name: "book2"}], arr);
+}
+
 const ASSERTION_ERROR_REASON = "AssertionError";
 
 function assertEquality(anydata expected, anydata actual) {


### PR DESCRIPTION
## Purpose
> $subject

Fixes #38757

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
