### PR TITLE
[2201.2.x] Add an UUID as the serviceId for unannotated services

### DIFF
--- a/misc/ls-extensions/modules/project-design-service/src/main/java/io/ballerina/projectdesign/generators/GeneratorUtils.java
+++ b/misc/ls-extensions/modules/project-design-service/src/main/java/io/ballerina/projectdesign/generators/GeneratorUtils.java
@@ -29,6 +29,8 @@ import io.ballerina.projectdesign.model.ElementLocation;
 import io.ballerina.projectdesign.model.service.ServiceAnnotation;
 import io.ballerina.tools.text.LineRange;
 
+import java.util.UUID;
+
 import static io.ballerina.projectdesign.ProjectDesignConstants.DISPLAY_ANNOTATION;
 import static io.ballerina.projectdesign.ProjectDesignConstants.ID;
 import static io.ballerina.projectdesign.ProjectDesignConstants.LABEL;
@@ -53,7 +55,7 @@ public class GeneratorUtils {
 
     public static ServiceAnnotation getServiceAnnotation(NodeList<AnnotationNode> annotationNodes, String filePath) {
 
-        String id = "";
+        String id = UUID.randomUUID().toString();
         String label = "";
         ElementLocation elementLocation = null;
         for (AnnotationNode annotationNode : annotationNodes) {

--- a/misc/ls-extensions/modules/project-design-service/src/main/java/io/ballerina/projectdesign/generators/service/nodevisitors/ServiceDeclarationNodeVisitor.java
+++ b/misc/ls-extensions/modules/project-design-service/src/main/java/io/ballerina/projectdesign/generators/service/nodevisitors/ServiceDeclarationNodeVisitor.java
@@ -51,6 +51,7 @@ import java.nio.file.Path;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import static io.ballerina.projectdesign.ProjectDesignConstants.FORWARD_SLASH;
 import static io.ballerina.projectdesign.ProjectDesignConstants.LISTENER;
@@ -85,7 +86,7 @@ public class ServiceDeclarationNodeVisitor extends NodeVisitor {
     public void visit(ServiceDeclarationNode serviceDeclarationNode) {
 
         StringBuilder serviceNameBuilder = new StringBuilder();
-        ServiceAnnotation serviceAnnotation = new ServiceAnnotation();
+        ServiceAnnotation serviceAnnotation;
         NodeList<Node> serviceNameNodes = serviceDeclarationNode.absoluteResourcePath();
         for (Node serviceNameNode : serviceNameNodes) {
             serviceNameBuilder.append(serviceNameNode.toString().replace("\"", ""));
@@ -95,6 +96,8 @@ public class ServiceDeclarationNodeVisitor extends NodeVisitor {
         if (metadataNode.isPresent()) {
             NodeList<AnnotationNode> annotationNodes = metadataNode.get().annotations();
             serviceAnnotation = GeneratorUtils.getServiceAnnotation(annotationNodes, this.filePath.toString());
+        } else {
+            serviceAnnotation = new ServiceAnnotation(UUID.randomUUID().toString(), "", null);
         }
 
         String serviceName = serviceNameBuilder.toString().startsWith(FORWARD_SLASH) ?


### PR DESCRIPTION
## Purpose
> $subject

Fixes [#38777](https://github.com/ballerina-platform/ballerina-lang/issues/38777) in 2201.2.x

An UUID will be added as the serviceId in below two scenarios

1. When display annotation is not given for a service
2. When display annotation is given, but `id` is mssing. 

Generated component

```json
"services": {
    "84a04fdc-bc9f-4947-9c75-294ed3f14fc5": {
      "path": "reservations/my",
      "serviceId": "84a04fdc-bc9f-4947-9c75-294ed3f14fc5",
      "serviceType": "ballerina/http:2.4.4",
      "resources": [
        ...
      ],
      "annotation": {
        "id": "84a04fdc-bc9f-4947-9c75-294ed3f14fc5",
        "label": "",
        "elementLocation": null
      },
      "remoteFunctions": [],
      "elementLocation": {
        ...
      }
    }
}
```
## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
