### PR TITLE
Fix incorrect results with type-test of type-reference errors

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTypeTestGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTypeTestGen.java
@@ -155,7 +155,7 @@ public class JvmTypeTestGen {
         BType otherType = null;
         int foundError = 0;
         for (BType bType : ((BUnionType) sourceType).getMemberTypes()) {
-            if (bType.tag == TypeTags.ERROR) {
+            if (JvmCodeGenUtil.getReferredType(bType).tag == TypeTags.ERROR) {
                 foundError++;
             } else {
                 otherType = bType;
@@ -195,7 +195,7 @@ public class JvmTypeTestGen {
     private void handleErrorUnionType(BIRNonTerminator.TypeTest typeTestIns) {
         jvmInstructionGen.loadVar(typeTestIns.rhsOp.variableDcl);
         mv.visitTypeInsn(INSTANCEOF, BERROR);
-        if (typeTestIns.type.tag != TypeTags.ERROR) {
+        if (JvmCodeGenUtil.getReferredType(typeTestIns.type).tag != TypeTags.ERROR) {
             generateNegateBoolean();
         }
         jvmInstructionGen.storeToVar(typeTestIns.lhsOp.variableDcl);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/typechecker/ErrorOptimizationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/typechecker/ErrorOptimizationTest.java
@@ -54,6 +54,7 @@ public class ErrorOptimizationTest {
                 "testWithMultipleErrors",
                 "testWithMultipleErrorsAndError",
                 "testWithRecordAndError",
+                "testMultipleErrorUnionWithError"
         };
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/typechecker/error_optimizations.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/typechecker/error_optimizations.bal
@@ -19,6 +19,9 @@ import ballerina/test;
 public type MyError error<record { int code; string message?; error cause?; }>;
 public type YourError error<record { int value; string message?; error cause?; }>;
 
+type FooError error;
+type BarError error;
+
 function testWithValue() {
     string|MyError someValue = "some";
     test:assertTrue(someValue is string);
@@ -90,4 +93,18 @@ function testWithMultipleErrorsAndError() {
     test:assertTrue(someValue is error);
     test:assertFalse(someValue is int);
     test:assertFalse(someValue is YourError);
+}
+
+function testMultipleErrorUnionWithError() {
+    FooError|error foo = error("");
+    test:assertTrue(foo is FooError);
+    test:assertTrue(foo is BarError);
+    test:assertTrue(foo is error);
+
+    MyError|error errorValue = error("");
+    test:assertTrue(errorValue is error);
+    test:assertFalse(errorValue is MyError);
+    test:assertFalse(errorValue is YourError);
+    test:assertTrue(errorValue is FooError);
+    test:assertTrue(errorValue is FooError|BarError);
 }


### PR DESCRIPTION
## Purpose
> $title

Fixes #38723 

## Approach
## Samples
>```ballerina
>type Err1 error;
>type Err2 error;
>type Foo error<record { int value; string message?; error cause?; }>;
>type Bar error<record { int value; string message?; error cause?; }>;
>
>public function main() {
>    Bar|error bar = error("");
>    io:println(bar is Foo);  // false
>    io:println(bar is Bar);  // false
>
>    Err1|error e = error("");
>    io:println(e is Err1);   // true
>    io:println(e is Err2);   // true
>}
>```

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
