### PR TITLE
Fix failing LS testcases after replacing contextTypeResolver with expectedType API

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/InvocationNodeContextProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/InvocationNodeContextProvider.java
@@ -88,16 +88,14 @@ public class InvocationNodeContextProvider<T extends Node> extends AbstractCompl
                     LinePosition.from(context.getCursorPosition().getLine(),
                             context.getCursorPosition().getCharacter()));
         }
-
-        if (parameterSymbol.isEmpty()) {
-            super.sort(context, node, completionItems);
-            return;
-        }
+        
         for (LSCompletionItem completionItem : completionItems) {
             if (completionItem.getType() == LSCompletionItem.CompletionItemType.NAMED_ARG) {
                 String sortText = SortingUtil.genSortText(1) +
                         SortingUtil.genSortText(SortingUtil.toRank(context, completionItem));
                 completionItem.getCompletionItem().setSortText(sortText);
+            } else if (parameterSymbol.isEmpty()) {
+                super.sort(context, node, completionItems);
             } else {
                 completionItem.getCompletionItem().setSortText(
                         SortingUtil.genSortTextByAssignability(context, completionItem, parameterSymbol.get()));

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/InvocationNodeContextProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/InvocationNodeContextProvider.java
@@ -95,7 +95,8 @@ public class InvocationNodeContextProvider<T extends Node> extends AbstractCompl
                         SortingUtil.genSortText(SortingUtil.toRank(context, completionItem));
                 completionItem.getCompletionItem().setSortText(sortText);
             } else if (parameterSymbol.isEmpty()) {
-                super.sort(context, node, completionItems);
+                completionItem.getCompletionItem().setSortText(SortingUtil.genSortText(
+                        SortingUtil.toRank(context, completionItem)));
             } else {
                 completionItem.getCompletionItem().setSortText(
                         SortingUtil.genSortTextByAssignability(context, completionItem, parameterSymbol.get()));

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MappingContextProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MappingContextProvider.java
@@ -16,6 +16,7 @@
 package org.ballerinalang.langserver.completions.providers.context;
 
 import io.ballerina.compiler.api.symbols.FunctionTypeSymbol;
+import io.ballerina.compiler.api.symbols.MapTypeSymbol;
 import io.ballerina.compiler.api.symbols.RecordFieldSymbol;
 import io.ballerina.compiler.api.symbols.RecordTypeSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
@@ -214,15 +215,16 @@ public abstract class MappingContextProvider<T extends Node> extends AbstractCom
         LinePosition linePosition = node.location().lineRange().endLine();
         Optional<TypeSymbol> resolvedType = context.currentSemanticModel().get()
                 .expectedType(context.currentDocument().get(), linePosition);
-        if (resolvedType.isEmpty() || resolvedType.get().typeKind() != TypeDescKind.MAP) {
+        if (resolvedType.isEmpty() ) {
             return Collections.emptyList();
         }
-        Predicate<Symbol> symbolFilter = this.getVariableFilter().or(symbol -> (symbol.kind() == FUNCTION));
+        Predicate<Symbol> symbolFilter = this.getVariableFilter();
         List<Symbol> visibleSymbols = context.visibleSymbols(context.getCursorPosition()).stream()
                 .filter(symbolFilter.and(symbol -> {
                     Optional<TypeSymbol> typeDescriptor = SymbolUtil.getTypeDescriptor(symbol);
-                    return typeDescriptor.isPresent() && typeDescriptor.get().subtypeOf(resolvedType.get())
-                            && (CommonUtil.getRawType(typeDescriptor.get()).typeKind() == TypeDescKind.MAP
+                    return typeDescriptor.isPresent() 
+                            && (CommonUtil.getRawType(typeDescriptor.get()).typeKind() == TypeDescKind.MAP 
+                            && ((MapTypeSymbol) typeDescriptor.get()).typeParam().subtypeOf(resolvedType.get())
                             || CommonUtil.getRawType(typeDescriptor.get()).typeKind() != TypeDescKind.RECORD);
                 })).collect(Collectors.toList());
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MappingContextProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MappingContextProvider.java
@@ -215,7 +215,7 @@ public abstract class MappingContextProvider<T extends Node> extends AbstractCom
         LinePosition linePosition = node.location().lineRange().endLine();
         Optional<TypeSymbol> resolvedType = context.currentSemanticModel().get()
                 .expectedType(context.currentDocument().get(), linePosition);
-        if (resolvedType.isEmpty() ) {
+        if (resolvedType.isEmpty()) {
             return Collections.emptyList();
         }
         Predicate<Symbol> symbolFilter = this.getVariableFilter();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MappingContextProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MappingContextProvider.java
@@ -225,7 +225,7 @@ public abstract class MappingContextProvider<T extends Node> extends AbstractCom
                     return typeDescriptor.isPresent() 
                             && (CommonUtil.getRawType(typeDescriptor.get()).typeKind() == TypeDescKind.MAP 
                             && ((MapTypeSymbol) typeDescriptor.get()).typeParam().subtypeOf(resolvedType.get())
-                            || CommonUtil.getRawType(typeDescriptor.get()).typeKind() != TypeDescKind.RECORD);
+                            );
                 })).collect(Collectors.toList());
 
         return getSpreadFieldCompletionItemList(visibleSymbols, context);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/WaitActionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/WaitActionNodeContext.java
@@ -140,12 +140,14 @@ public class WaitActionNodeContext extends AbstractCompletionProvider<WaitAction
                 if (symbol.kind() == WORKER) {
                     rank = 1;
                 } else if (symbol.kind() == VARIABLE
-                        && ((VariableSymbol) symbol).typeDescriptor().typeKind() == TypeDescKind.FUTURE) {
-                    Optional<TypeSymbol> typeSymbol 
+                        && ((VariableSymbol) symbol).typeDescriptor().typeKind() == TypeDescKind.FUTURE 
+                        && contextType.isPresent() && contextType.get().typeKind() == TypeDescKind.FUTURE) {
+                    Optional<TypeSymbol> completionItemTypeSymbol 
                             = ((FutureTypeSymbol) ((VariableSymbol) symbol).typeDescriptor()).typeParameter();
-                    if (typeSymbol.isPresent() && contextType.isPresent() 
-                            && typeSymbol.get().subtypeOf(contextType.get())) {
-                        rank = 1;
+                    Optional<TypeSymbol> contextTypeSymbol = ((FutureTypeSymbol) contextType.get()).typeParameter();
+                    if (completionItemTypeSymbol.isPresent() && contextTypeSymbol.isPresent() 
+                            && completionItemTypeSymbol.get().subtypeOf(contextTypeSymbol.get())) {
+                            rank = 1;
                     } else {
                         rank = 2;
                     }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/ExpressionContextTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/ExpressionContextTest.java
@@ -58,40 +58,7 @@ public class ExpressionContextTest extends CompletionTest {
                 "conditional_expr_ctx_config12.json", //#34145
                 
                 // TODO ContextTypeResolver's context type for method call expressions should be revisited
-                "method_call_expression_ctx_config9.json",
-
-                // expectedType cases
-                "mapping_expr_ctx_config41.json",
-                "mapping_expr_ctx_config22.json",
-                "mapping_expr_ctx_config64.json",
-                "mapping_expr_ctx_config7.json",
-                "mapping_expr_ctx_config51.json",
-                "mapping_expr_ctx_config11.json",
-                "mapping_expr_ctx_config38_negative.json",
-                "mapping_expr_ctx_config54.json",
-                "mapping_expr_ctx_config69.json",
-                "xml_attribute_access_expr_ctx_config5.json",
-                "xml_attribute_access_expr_ctx_config1.json",
-                "xml_attribute_access_expr_ctx_config6.json",
-                "xml_attribute_access_expr_ctx_config2.json",
-                "table_constructor_expr_ctx_config9.json",
-                "function_call_expression_ctx_config22.json",
-
-                "function_call_expression_ctx_config19.json",
-                "anon_func_expr_ctx_config1a.json",
-                "new_expr_ctx_config12.json",
-                "new_expr_ctx_config14.json",
-                "new_expr_ctx_config15.json",
-                "new_expr_ctx_config11.json",
-                "new_expr_ctx_config16.json",
-                "new_expr_ctx_config26.json",
-                "new_expr_ctx_config13.json",
-                "new_expr_ctx_config24.json",
-                "function_call_expression_ctx_config15.json",
-                "function_call_expression_ctx_config13.json",
-                "mapping_expr_ctx_config32c.json",
-                "mapping_constructor_expr_ctx_config3.json"
-
+                "method_call_expression_ctx_config9.json"
                 );
     }
 }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/ExpressionContextTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/ExpressionContextTest.java
@@ -61,8 +61,6 @@ public class ExpressionContextTest extends CompletionTest {
                 "method_call_expression_ctx_config9.json",
 
                 // expectedType cases
-                "function_call_expression_ctx_config15.json", 
-                "function_call_expression_ctx_config19.json",
                 "mapping_constructor_expr_ctx_config3.json",
                 "new_expr_ctx_config15.json",
                 "new_expr_ctx_config11.json",

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/ExpressionContextTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/ExpressionContextTest.java
@@ -58,7 +58,19 @@ public class ExpressionContextTest extends CompletionTest {
                 "conditional_expr_ctx_config12.json", //#34145
                 
                 // TODO ContextTypeResolver's context type for method call expressions should be revisited
-                "method_call_expression_ctx_config9.json"
-                );
+                "method_call_expression_ctx_config9.json",
+
+                // expectedType cases
+                "function_call_expression_ctx_config15.json", 
+                "function_call_expression_ctx_config19.json",
+                "mapping_constructor_expr_ctx_config3.json",
+                "new_expr_ctx_config15.json",
+                "new_expr_ctx_config11.json",
+                "new_expr_ctx_config16.json",
+                "new_expr_ctx_config26.json",
+                "new_expr_ctx_config14.json",
+                "mapping_expr_ctx_config38_negative.json",
+                "anon_func_expr_ctx_config1a.json"
+        );
     }
 }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/FieldAccessExpressionContextTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/FieldAccessExpressionContextTest.java
@@ -22,8 +22,6 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
 
 /**
  * Field Access Expression Context tests.

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/FieldAccessExpressionContextTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/FieldAccessExpressionContextTest.java
@@ -48,14 +48,4 @@ public class FieldAccessExpressionContextTest extends CompletionTest {
     public String getTestResourceDir() {
         return "field_access_expression_context";
     }
-
-    @Override
-    public List<String> skipList() {
-        return Arrays.asList(
-            "foreach_stmt_ctx_config24.json",
-            "foreach_stmt_ctx_config20.json",
-            "field_access_ctx_config20.json",
-            "field_access_ctx_config4.json"
-        );
-    }
 }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/ModuleConstantContextTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/ModuleConstantContextTest.java
@@ -44,13 +44,6 @@ public class ModuleConstantContextTest extends CompletionTest {
     }
 
     @Override
-    public List<String> skipList() {
-        return List.of(
-                "config7.json"
-        );
-    }
-
-    @Override
     public String getTestResourceDir() {
         return "module_const_context";
     }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/ModuleConstantContextTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/ModuleConstantContextTest.java
@@ -22,7 +22,6 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
-import java.util.List;
 
 /**
  * Module Constant Declaration Context tests.

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/QueryExpressionContextTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/QueryExpressionContextTest.java
@@ -53,11 +53,7 @@ public class QueryExpressionContextTest extends CompletionTest {
                 // Order By [asc/desc]
                 "query_expr_ctx_orderby_clause_config4.json",
                 "query_expr_ctx_config3.json", // issue #31449
-                "query_expr_ctx_config4.json", // issue #31449
-
-                // expected type cases
-                "query_expr_ctx_where_clause_config5.json",
-                "query_expr_ctx_config7.json"
+                "query_expr_ctx_config4.json" // issue #31449
         );
     }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/StatementContextTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/StatementContextTest.java
@@ -55,13 +55,7 @@ public class StatementContextTest extends CompletionTest {
                 "match_stmt_ctx_config11.json",
 
                 // TODO: Strand type is not identified inside mapping constructor
-                "start_action_ctx_config4a.json",
-
-                // expected type cases
-                "wait_action_ctx_config18.json",
-                "wait_action_ctx_config19.json",
-                "wait_action_ctx_config4.json",
-                "assignment_stmt_ctx_config9.json"
+                "start_action_ctx_config4a.json"
         );
     }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/TypeDescContextTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/TypeDescContextTest.java
@@ -22,8 +22,6 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
 
 /**
  * Expression Context tests.

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/TypeDescContextTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/TypeDescContextTest.java
@@ -48,15 +48,4 @@ public class TypeDescContextTest extends CompletionTest {
     public String getTestResourceDir() {
         return "typedesc_context";
     }
-
-    @Override
-    public List<String> skipList() {
-        return Arrays.asList(
-                // expected type cases
-            "function_typedesc15a.json",
-            "function_typedesc15b.json",
-            "function_typedesc15c.json",
-            "function_typedesc15d.json"
-        );
-    }
 }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/VariableDeclarationContextTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/VariableDeclarationContextTest.java
@@ -45,4 +45,12 @@ public class VariableDeclarationContextTest extends CompletionTest {
     public String getTestResourceDir() {
         return "variable-declaration";
     }
+
+    @Override
+    public List<String> skipList() {
+        return Arrays.asList(
+                // expected type cases
+                "var_def_ctx_config16.json"
+        );
+    }
 }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/VariableDeclarationContextTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/VariableDeclarationContextTest.java
@@ -45,15 +45,4 @@ public class VariableDeclarationContextTest extends CompletionTest {
     public String getTestResourceDir() {
         return "variable-declaration";
     }
-
-    @Override
-    public List<String> skipList() {
-        return Arrays.asList(
-                // expected type cases
-            "var_def_ctx_config7.json",
-            "var_def_ctx_config20.json",
-            "var_def_ctx_config16.json",
-            "var_def_in_obj_constructor_config1.json"
-        );
-    }
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/anon_func_expr_ctx_config1a.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/anon_func_expr_ctx_config1a.json
@@ -9,7 +9,7 @@
       "label": "function",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "function",
       "insertText": "function ",
       "insertTextFormat": "Snippet"
@@ -18,7 +18,7 @@
       "label": "service",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "service",
       "insertText": "service",
       "insertTextFormat": "Snippet"
@@ -27,7 +27,7 @@
       "label": "transactional",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "transactional",
       "insertText": "transactional",
       "insertTextFormat": "Snippet"
@@ -36,7 +36,7 @@
       "label": "client",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "client",
       "insertText": "client ",
       "insertTextFormat": "Snippet"
@@ -45,7 +45,7 @@
       "label": "object",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "object",
       "insertText": "object ",
       "insertTextFormat": "Snippet"
@@ -54,7 +54,7 @@
       "label": "object {}",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "T",
+      "sortText": "P",
       "filterText": "object",
       "insertText": "object {${1}}",
       "insertTextFormat": "Snippet"

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config13.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config13.json
@@ -9,7 +9,7 @@
       "label": "start",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "start",
       "insertText": "start ",
       "insertTextFormat": "Snippet"
@@ -18,7 +18,7 @@
       "label": "wait",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "wait",
       "insertText": "wait ",
       "insertTextFormat": "Snippet"
@@ -27,7 +27,7 @@
       "label": "flush",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "flush",
       "insertText": "flush ",
       "insertTextFormat": "Snippet"
@@ -36,7 +36,7 @@
       "label": "from clause",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "T",
+      "sortText": "P",
       "filterText": "from",
       "insertText": "from ${1:var} ${2:item} in ${3}",
       "insertTextFormat": "Snippet"
@@ -301,7 +301,7 @@
       "label": "service",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "service",
       "insertText": "service",
       "insertTextFormat": "Snippet"
@@ -310,7 +310,7 @@
       "label": "new",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "new",
       "insertText": "new ",
       "insertTextFormat": "Snippet"
@@ -319,7 +319,7 @@
       "label": "isolated",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "isolated",
       "insertText": "isolated ",
       "insertTextFormat": "Snippet"
@@ -328,7 +328,7 @@
       "label": "transactional",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "transactional",
       "insertText": "transactional",
       "insertTextFormat": "Snippet"
@@ -337,7 +337,7 @@
       "label": "function",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "function",
       "insertText": "function ",
       "insertTextFormat": "Snippet"
@@ -346,7 +346,7 @@
       "label": "let",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "let",
       "insertText": "let",
       "insertTextFormat": "Snippet"
@@ -355,7 +355,7 @@
       "label": "typeof",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "typeof",
       "insertText": "typeof ",
       "insertTextFormat": "Snippet"
@@ -364,7 +364,7 @@
       "label": "trap",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "trap",
       "insertText": "trap",
       "insertTextFormat": "Snippet"
@@ -373,7 +373,7 @@
       "label": "client",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "client",
       "insertText": "client ",
       "insertTextFormat": "Snippet"
@@ -382,7 +382,7 @@
       "label": "true",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "true",
       "insertText": "true",
       "insertTextFormat": "Snippet"
@@ -391,7 +391,7 @@
       "label": "false",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "false",
       "insertText": "false",
       "insertTextFormat": "Snippet"
@@ -400,7 +400,7 @@
       "label": "check",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "check",
       "insertText": "check ",
       "insertTextFormat": "Snippet"
@@ -409,7 +409,7 @@
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "checkpanic",
       "insertText": "checkpanic ",
       "insertTextFormat": "Snippet"
@@ -418,7 +418,7 @@
       "label": "is",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "is",
       "insertText": "is",
       "insertTextFormat": "Snippet"
@@ -427,7 +427,7 @@
       "label": "error constructor",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "T",
+      "sortText": "P",
       "filterText": "error",
       "insertText": "error(\"${1}\")",
       "insertTextFormat": "Snippet"
@@ -436,7 +436,7 @@
       "label": "object constructor",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "T",
+      "sortText": "P",
       "filterText": "object",
       "insertText": "object {${1}}",
       "insertTextFormat": "Snippet"
@@ -445,7 +445,7 @@
       "label": "base16",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "T",
+      "sortText": "P",
       "filterText": "base16",
       "insertText": "base16 `${1}`",
       "insertTextFormat": "Snippet"
@@ -454,7 +454,7 @@
       "label": "base64",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "T",
+      "sortText": "P",
       "filterText": "base64",
       "insertText": "base64 `${1}`",
       "insertTextFormat": "Snippet"
@@ -463,7 +463,7 @@
       "label": "from",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "from",
       "insertText": "from ",
       "insertTextFormat": "Snippet"
@@ -472,7 +472,7 @@
       "label": "myInt",
       "kind": "Variable",
       "detail": "int",
-      "sortText": "F",
+      "sortText": "B",
       "insertText": "myInt",
       "insertTextFormat": "Snippet"
     },
@@ -486,7 +486,7 @@
           "value": "**Package:** _._  \n  \n  \n"
         }
       },
-      "sortText": "G",
+      "sortText": "C",
       "filterText": "myFunction",
       "insertText": "myFunction()",
       "insertTextFormat": "Snippet"
@@ -495,7 +495,7 @@
       "label": "Thread",
       "kind": "TypeParameter",
       "detail": "Union",
-      "sortText": "R",
+      "sortText": "N",
       "insertText": "Thread",
       "insertTextFormat": "Snippet"
     },
@@ -503,7 +503,7 @@
       "label": "myStr",
       "kind": "Variable",
       "detail": "string",
-      "sortText": "AB",
+      "sortText": "B",
       "insertText": "myStr",
       "insertTextFormat": "Snippet"
     },
@@ -514,7 +514,7 @@
       "documentation": {
         "left": "Describes Strand execution details for the runtime.\n"
       },
-      "sortText": "Q",
+      "sortText": "M",
       "insertText": "StrandData",
       "insertTextFormat": "Snippet"
     },
@@ -578,7 +578,7 @@
       "label": "null",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "null",
       "insertText": "null",
       "insertTextFormat": "Snippet"

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config15.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config15.json
@@ -9,7 +9,7 @@
       "label": "start",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "start",
       "insertText": "start ",
       "insertTextFormat": "Snippet"
@@ -18,7 +18,7 @@
       "label": "wait",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "wait",
       "insertText": "wait ",
       "insertTextFormat": "Snippet"
@@ -27,7 +27,7 @@
       "label": "flush",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "flush",
       "insertText": "flush ",
       "insertTextFormat": "Snippet"
@@ -36,10 +36,58 @@
       "label": "from clause",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "T",
+      "sortText": "P",
       "filterText": "from",
       "insertText": "from ${1:var} ${2:item} in ${3}",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "test/project2",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "project2",
+      "insertText": "project2",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import test/project2;\n"
+        }
+      ]
+    },
+    {
+      "label": "test/project1",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "project1",
+      "insertText": "project1",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import test/project1;\n"
+        }
+      ]
     },
     {
       "label": "ballerina/lang.runtime",
@@ -66,12 +114,12 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
+      "label": "ballerina/lang.regexp",
       "kind": "Module",
       "detail": "Module",
       "sortText": "R",
-      "filterText": "value",
-      "insertText": "value",
+      "filterText": "regexp",
+      "insertText": "regexp",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -85,7 +133,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.value;\n"
+          "newText": "import ballerina/lang.regexp;\n"
         }
       ]
     },
@@ -114,12 +162,12 @@
       ]
     },
     {
-      "label": "ballerina/lang.array",
+      "label": "ballerina/lang.test",
       "kind": "Module",
       "detail": "Module",
       "sortText": "R",
-      "filterText": "array",
-      "insertText": "array",
+      "filterText": "test",
+      "insertText": "test",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -133,7 +181,79 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.array;\n"
+          "newText": "import ballerina/lang.test;\n"
+        }
+      ]
+    },
+    {
+      "label": "test/local_project2",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "local_project2",
+      "insertText": "local_project2",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import test/local_project2;\n"
+        }
+      ]
+    },
+    {
+      "label": "test/local_project1",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "local_project1",
+      "insertText": "local_project1",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import test/local_project1;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "value",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
         }
       ]
     },
@@ -162,12 +282,12 @@
       ]
     },
     {
-      "label": "ballerina/lang.test",
+      "label": "ballerina/lang.array",
       "kind": "Module",
       "detail": "Module",
       "sortText": "R",
-      "filterText": "test",
-      "insertText": "test",
+      "filterText": "array",
+      "insertText": "array",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -181,17 +301,9 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.test;\n"
+          "newText": "import ballerina/lang.array;\n"
         }
       ]
-    },
-    {
-      "label": "boolean",
-      "kind": "Unit",
-      "detail": "type",
-      "sortText": "R",
-      "insertText": "boolean",
-      "insertTextFormat": "Snippet"
     },
     {
       "label": "decimal",
@@ -210,11 +322,59 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "float",
+      "label": "object",
       "kind": "Unit",
       "detail": "type",
       "sortText": "R",
-      "insertText": "float",
+      "insertText": "object",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "transaction",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "transaction",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "xml",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "table",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "table",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "map",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "map",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "stream",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "stream",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "boolean",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "boolean",
       "insertTextFormat": "Snippet"
     },
     {
@@ -234,27 +394,19 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map",
+      "label": "float",
       "kind": "Unit",
       "detail": "type",
       "sortText": "R",
-      "insertText": "map",
+      "insertText": "float",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "object",
+      "label": "function",
       "kind": "Unit",
       "detail": "type",
       "sortText": "R",
-      "insertText": "object",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "stream",
-      "kind": "Unit",
-      "detail": "type",
-      "sortText": "R",
-      "insertText": "stream",
+      "insertText": "function",
       "insertTextFormat": "Snippet"
     },
     {
@@ -266,22 +418,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "table",
-      "kind": "Unit",
-      "detail": "type",
-      "sortText": "R",
-      "insertText": "table",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "transaction",
-      "kind": "Unit",
-      "detail": "type",
-      "sortText": "R",
-      "insertText": "transaction",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "typedesc",
       "kind": "Unit",
       "detail": "type",
@@ -290,18 +426,10 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "xml",
-      "kind": "Unit",
-      "detail": "type",
-      "sortText": "R",
-      "insertText": "xml",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "service",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "service",
       "insertText": "service",
       "insertTextFormat": "Snippet"
@@ -310,7 +438,7 @@
       "label": "new",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "new",
       "insertText": "new ",
       "insertTextFormat": "Snippet"
@@ -319,7 +447,7 @@
       "label": "isolated",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "isolated",
       "insertText": "isolated ",
       "insertTextFormat": "Snippet"
@@ -328,7 +456,7 @@
       "label": "transactional",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "transactional",
       "insertText": "transactional",
       "insertTextFormat": "Snippet"
@@ -337,7 +465,7 @@
       "label": "function",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "function",
       "insertText": "function ",
       "insertTextFormat": "Snippet"
@@ -346,7 +474,7 @@
       "label": "let",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "let",
       "insertText": "let",
       "insertTextFormat": "Snippet"
@@ -355,7 +483,7 @@
       "label": "typeof",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "typeof",
       "insertText": "typeof ",
       "insertTextFormat": "Snippet"
@@ -364,7 +492,7 @@
       "label": "trap",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "trap",
       "insertText": "trap",
       "insertTextFormat": "Snippet"
@@ -373,7 +501,7 @@
       "label": "client",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "client",
       "insertText": "client ",
       "insertTextFormat": "Snippet"
@@ -382,7 +510,7 @@
       "label": "true",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "true",
       "insertText": "true",
       "insertTextFormat": "Snippet"
@@ -391,16 +519,25 @@
       "label": "false",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "false",
       "insertText": "false",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "null",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "Q",
+      "filterText": "null",
+      "insertText": "null",
       "insertTextFormat": "Snippet"
     },
     {
       "label": "check",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "check",
       "insertText": "check ",
       "insertTextFormat": "Snippet"
@@ -409,7 +546,7 @@
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "checkpanic",
       "insertText": "checkpanic ",
       "insertTextFormat": "Snippet"
@@ -418,7 +555,7 @@
       "label": "is",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "is",
       "insertText": "is",
       "insertTextFormat": "Snippet"
@@ -427,7 +564,7 @@
       "label": "error constructor",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "T",
+      "sortText": "P",
       "filterText": "error",
       "insertText": "error(\"${1}\")",
       "insertTextFormat": "Snippet"
@@ -436,7 +573,7 @@
       "label": "object constructor",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "T",
+      "sortText": "P",
       "filterText": "object",
       "insertText": "object {${1}}",
       "insertTextFormat": "Snippet"
@@ -445,7 +582,7 @@
       "label": "base16",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "T",
+      "sortText": "P",
       "filterText": "base16",
       "insertText": "base16 `${1}`",
       "insertTextFormat": "Snippet"
@@ -454,7 +591,7 @@
       "label": "base64",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "T",
+      "sortText": "P",
       "filterText": "base64",
       "insertText": "base64 `${1}`",
       "insertTextFormat": "Snippet"
@@ -463,43 +600,17 @@
       "label": "from",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "from",
       "insertText": "from ",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "StrandData",
-      "kind": "Struct",
-      "detail": "Record",
-      "documentation": {
-        "left": "Describes Strand execution details for the runtime.\n"
-      },
-      "sortText": "Q",
-      "insertText": "StrandData",
       "insertTextFormat": "Snippet"
     },
     {
       "label": "Thread",
       "kind": "TypeParameter",
       "detail": "Union",
-      "sortText": "R",
+      "sortText": "N",
       "insertText": "Thread",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "main()",
-      "kind": "Function",
-      "detail": "()",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n"
-        }
-      },
-      "sortText": "ZD",
-      "filterText": "main",
-      "insertText": "main()",
       "insertTextFormat": "Snippet"
     },
     {
@@ -512,7 +623,7 @@
           "value": "**Package:** _._  \n  \n  \n**Params**  \n- `string` arg1  \n- `string` arg2  \n- `int` arg3(Defaultable)"
         }
       },
-      "sortText": "G",
+      "sortText": "C",
       "filterText": "myFunction",
       "insertText": "myFunction(${1})",
       "insertTextFormat": "Snippet",
@@ -520,6 +631,32 @@
         "title": "editor.action.triggerParameterHints",
         "command": "editor.action.triggerParameterHints"
       }
+    },
+    {
+      "label": "main()",
+      "kind": "Function",
+      "detail": "()",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _._  \n  \n  \n"
+        }
+      },
+      "sortText": "Z",
+      "filterText": "main",
+      "insertText": "main()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "StrandData",
+      "kind": "Struct",
+      "detail": "Record",
+      "documentation": {
+        "left": "Describes Strand execution details for the runtime.\n"
+      },
+      "sortText": "M",
+      "insertText": "StrandData",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "readonly",
@@ -585,143 +722,6 @@
       "filterText": "arg2",
       "insertText": "arg2 = ${1:\"\"}",
       "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "null",
-      "kind": "Keyword",
-      "detail": "Keyword",
-      "sortText": "U",
-      "filterText": "null",
-      "insertText": "null",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "test/project2",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "filterText": "project2",
-      "insertText": "project2",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import test/project2;\n"
-        }
-      ]
-    },
-    {
-      "label": "test/project1",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "filterText": "project1",
-      "insertText": "project1",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import test/project1;\n"
-        }
-      ]
-    },
-    {
-      "label": "test/local_project2",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "filterText": "local_project2",
-      "insertText": "local_project2",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import test/local_project2;\n"
-        }
-      ]
-    },
-    {
-      "label": "test/local_project1",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "filterText": "local_project1",
-      "insertText": "local_project1",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import test/local_project1;\n"
-        }
-      ]
-    },
-    {
-      "label": "function",
-      "kind": "Unit",
-      "detail": "type",
-      "sortText": "R",
-      "insertText": "function",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ballerina/lang.regexp",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "filterText": "regexp",
-      "insertText": "regexp",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.regexp;\n"
-        }
-      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config19.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config19.json
@@ -9,7 +9,7 @@
       "label": "start",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "start",
       "insertText": "start ",
       "insertTextFormat": "Snippet"
@@ -18,7 +18,7 @@
       "label": "wait",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "wait",
       "insertText": "wait ",
       "insertTextFormat": "Snippet"
@@ -27,7 +27,7 @@
       "label": "flush",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "flush",
       "insertText": "flush ",
       "insertTextFormat": "Snippet"
@@ -36,10 +36,58 @@
       "label": "from clause",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "T",
+      "sortText": "P",
       "filterText": "from",
       "insertText": "from ${1:var} ${2:item} in ${3}",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "test/project2",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "project2",
+      "insertText": "project2",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import test/project2;\n"
+        }
+      ]
+    },
+    {
+      "label": "test/project1",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "project1",
+      "insertText": "project1",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import test/project1;\n"
+        }
+      ]
     },
     {
       "label": "ballerina/lang.runtime",
@@ -66,12 +114,12 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
+      "label": "ballerina/lang.regexp",
       "kind": "Module",
       "detail": "Module",
       "sortText": "R",
-      "filterText": "value",
-      "insertText": "value",
+      "filterText": "regexp",
+      "insertText": "regexp",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -85,7 +133,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.value;\n"
+          "newText": "import ballerina/lang.regexp;\n"
         }
       ]
     },
@@ -114,12 +162,12 @@
       ]
     },
     {
-      "label": "ballerina/lang.array",
+      "label": "ballerina/lang.test",
       "kind": "Module",
       "detail": "Module",
       "sortText": "R",
-      "filterText": "array",
-      "insertText": "array",
+      "filterText": "test",
+      "insertText": "test",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -133,7 +181,79 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.array;\n"
+          "newText": "import ballerina/lang.test;\n"
+        }
+      ]
+    },
+    {
+      "label": "test/local_project2",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "local_project2",
+      "insertText": "local_project2",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import test/local_project2;\n"
+        }
+      ]
+    },
+    {
+      "label": "test/local_project1",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "local_project1",
+      "insertText": "local_project1",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import test/local_project1;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "value",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
         }
       ]
     },
@@ -162,12 +282,12 @@
       ]
     },
     {
-      "label": "ballerina/lang.test",
+      "label": "ballerina/lang.array",
       "kind": "Module",
       "detail": "Module",
       "sortText": "R",
-      "filterText": "test",
-      "insertText": "test",
+      "filterText": "array",
+      "insertText": "array",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -181,17 +301,9 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.test;\n"
+          "newText": "import ballerina/lang.array;\n"
         }
       ]
-    },
-    {
-      "label": "boolean",
-      "kind": "Unit",
-      "detail": "type",
-      "sortText": "R",
-      "insertText": "boolean",
-      "insertTextFormat": "Snippet"
     },
     {
       "label": "decimal",
@@ -210,11 +322,59 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "float",
+      "label": "object",
       "kind": "Unit",
       "detail": "type",
       "sortText": "R",
-      "insertText": "float",
+      "insertText": "object",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "transaction",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "transaction",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "xml",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "table",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "table",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "map",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "map",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "stream",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "stream",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "boolean",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "boolean",
       "insertTextFormat": "Snippet"
     },
     {
@@ -234,27 +394,19 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map",
+      "label": "float",
       "kind": "Unit",
       "detail": "type",
       "sortText": "R",
-      "insertText": "map",
+      "insertText": "float",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "object",
+      "label": "function",
       "kind": "Unit",
       "detail": "type",
       "sortText": "R",
-      "insertText": "object",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "stream",
-      "kind": "Unit",
-      "detail": "type",
-      "sortText": "R",
-      "insertText": "stream",
+      "insertText": "function",
       "insertTextFormat": "Snippet"
     },
     {
@@ -266,22 +418,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "table",
-      "kind": "Unit",
-      "detail": "type",
-      "sortText": "R",
-      "insertText": "table",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "transaction",
-      "kind": "Unit",
-      "detail": "type",
-      "sortText": "R",
-      "insertText": "transaction",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "typedesc",
       "kind": "Unit",
       "detail": "type",
@@ -290,18 +426,10 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "xml",
-      "kind": "Unit",
-      "detail": "type",
-      "sortText": "R",
-      "insertText": "xml",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "service",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "service",
       "insertText": "service",
       "insertTextFormat": "Snippet"
@@ -310,7 +438,7 @@
       "label": "new",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "new",
       "insertText": "new ",
       "insertTextFormat": "Snippet"
@@ -319,7 +447,7 @@
       "label": "isolated",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "isolated",
       "insertText": "isolated ",
       "insertTextFormat": "Snippet"
@@ -328,7 +456,7 @@
       "label": "transactional",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "transactional",
       "insertText": "transactional",
       "insertTextFormat": "Snippet"
@@ -337,7 +465,7 @@
       "label": "function",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "function",
       "insertText": "function ",
       "insertTextFormat": "Snippet"
@@ -346,7 +474,7 @@
       "label": "let",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "let",
       "insertText": "let",
       "insertTextFormat": "Snippet"
@@ -355,7 +483,7 @@
       "label": "typeof",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "typeof",
       "insertText": "typeof ",
       "insertTextFormat": "Snippet"
@@ -364,7 +492,7 @@
       "label": "trap",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "trap",
       "insertText": "trap",
       "insertTextFormat": "Snippet"
@@ -373,7 +501,7 @@
       "label": "client",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "client",
       "insertText": "client ",
       "insertTextFormat": "Snippet"
@@ -382,7 +510,7 @@
       "label": "true",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "true",
       "insertText": "true",
       "insertTextFormat": "Snippet"
@@ -391,16 +519,25 @@
       "label": "false",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "false",
       "insertText": "false",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "null",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "Q",
+      "filterText": "null",
+      "insertText": "null",
       "insertTextFormat": "Snippet"
     },
     {
       "label": "check",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "check",
       "insertText": "check ",
       "insertTextFormat": "Snippet"
@@ -409,7 +546,7 @@
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "checkpanic",
       "insertText": "checkpanic ",
       "insertTextFormat": "Snippet"
@@ -418,7 +555,7 @@
       "label": "is",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "is",
       "insertText": "is",
       "insertTextFormat": "Snippet"
@@ -427,7 +564,7 @@
       "label": "error constructor",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "T",
+      "sortText": "P",
       "filterText": "error",
       "insertText": "error(\"${1}\")",
       "insertTextFormat": "Snippet"
@@ -436,7 +573,7 @@
       "label": "object constructor",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "T",
+      "sortText": "P",
       "filterText": "object",
       "insertText": "object {${1}}",
       "insertTextFormat": "Snippet"
@@ -445,7 +582,7 @@
       "label": "base16",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "T",
+      "sortText": "P",
       "filterText": "base16",
       "insertText": "base16 `${1}`",
       "insertTextFormat": "Snippet"
@@ -454,7 +591,7 @@
       "label": "base64",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "T",
+      "sortText": "P",
       "filterText": "base64",
       "insertText": "base64 `${1}`",
       "insertTextFormat": "Snippet"
@@ -463,7 +600,7 @@
       "label": "from",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "from",
       "insertText": "from ",
       "insertTextFormat": "Snippet"
@@ -472,34 +609,8 @@
       "label": "Thread",
       "kind": "TypeParameter",
       "detail": "Union",
-      "sortText": "R",
+      "sortText": "N",
       "insertText": "Thread",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "StrandData",
-      "kind": "Struct",
-      "detail": "Record",
-      "documentation": {
-        "left": "Describes Strand execution details for the runtime.\n"
-      },
-      "sortText": "Q",
-      "insertText": "StrandData",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "main()",
-      "kind": "Function",
-      "detail": "()",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n"
-        }
-      },
-      "sortText": "ZD",
-      "filterText": "main",
-      "insertText": "main()",
       "insertTextFormat": "Snippet"
     },
     {
@@ -512,7 +623,7 @@
           "value": "**Package:** _._  \n  \n  \n**Params**  \n- `string` arg1  \n- `string` arg2  \n- `int` arg3(Defaultable)"
         }
       },
-      "sortText": "G",
+      "sortText": "C",
       "filterText": "myFunction",
       "insertText": "myFunction(${1})",
       "insertTextFormat": "Snippet",
@@ -520,6 +631,32 @@
         "title": "editor.action.triggerParameterHints",
         "command": "editor.action.triggerParameterHints"
       }
+    },
+    {
+      "label": "main()",
+      "kind": "Function",
+      "detail": "()",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _._  \n  \n  \n"
+        }
+      },
+      "sortText": "Z",
+      "filterText": "main",
+      "insertText": "main()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "StrandData",
+      "kind": "Struct",
+      "detail": "Record",
+      "documentation": {
+        "left": "Describes Strand execution details for the runtime.\n"
+      },
+      "sortText": "M",
+      "insertText": "StrandData",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "readonly",
@@ -585,143 +722,6 @@
       "filterText": "arg2",
       "insertText": "arg2 = ${1:\"\"}",
       "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "null",
-      "kind": "Keyword",
-      "detail": "Keyword",
-      "sortText": "U",
-      "filterText": "null",
-      "insertText": "null",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "test/project2",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "filterText": "project2",
-      "insertText": "project2",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import test/project2;\n"
-        }
-      ]
-    },
-    {
-      "label": "test/project1",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "filterText": "project1",
-      "insertText": "project1",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import test/project1;\n"
-        }
-      ]
-    },
-    {
-      "label": "test/local_project2",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "filterText": "local_project2",
-      "insertText": "local_project2",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import test/local_project2;\n"
-        }
-      ]
-    },
-    {
-      "label": "test/local_project1",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "filterText": "local_project1",
-      "insertText": "local_project1",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import test/local_project1;\n"
-        }
-      ]
-    },
-    {
-      "label": "function",
-      "kind": "Unit",
-      "detail": "type",
-      "sortText": "R",
-      "insertText": "function",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ballerina/lang.regexp",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "R",
-      "filterText": "regexp",
-      "insertText": "regexp",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.regexp;\n"
-        }
-      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config22.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config22.json
@@ -585,7 +585,7 @@
       "label": "Thread",
       "kind": "TypeParameter",
       "detail": "Union",
-      "sortText": "AP",
+      "sortText": "CP",
       "insertText": "Thread",
       "insertTextFormat": "Snippet"
     },
@@ -601,7 +601,7 @@
       "label": "myJson",
       "kind": "Variable",
       "detail": "json",
-      "sortText": "CD",
+      "sortText": "AD",
       "insertText": "myJson",
       "insertTextFormat": "Snippet"
     },
@@ -615,7 +615,7 @@
           "value": "**Package:** _._  \n  \n  \n"
         }
       },
-      "sortText": "CE",
+      "sortText": "AE",
       "filterText": "testPositionalArgs",
       "insertText": "testPositionalArgs()",
       "insertTextFormat": "Snippet"

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config11.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config11.json
@@ -18,7 +18,7 @@
       "label": "field1",
       "kind": "Field",
       "detail": "TestRecord2.field1",
-      "sortText": "K",
+      "sortText": "AG",
       "insertText": "field1: ${1:0}",
       "insertTextFormat": "Snippet"
     },
@@ -26,7 +26,7 @@
       "label": "field3",
       "kind": "Field",
       "detail": "TestRecord2.field3",
-      "sortText": "K",
+      "sortText": "AG",
       "insertText": "field3: ${1:false}",
       "insertTextFormat": "Snippet"
     },
@@ -34,7 +34,7 @@
       "label": "field2",
       "kind": "Field",
       "detail": "TestRecord2.field2",
-      "sortText": "K",
+      "sortText": "AG",
       "insertText": "field2: ${1:\"\"}",
       "insertTextFormat": "Snippet"
     },
@@ -60,7 +60,7 @@
       "label": "...rec1",
       "kind": "Variable",
       "detail": "TestRecord1",
-      "sortText": "F",
+      "sortText": "AB",
       "filterText": "rec1",
       "insertText": "...rec1",
       "insertTextFormat": "Snippet"

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config22.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config22.json
@@ -18,7 +18,7 @@
       "label": "rec2f1",
       "kind": "Field",
       "detail": "Record2.rec2f1",
-      "sortText": "K",
+      "sortText": "AG",
       "insertText": "rec2f1: ${1:0}",
       "insertTextFormat": "Snippet"
     },
@@ -26,7 +26,7 @@
       "label": "rec2f2",
       "kind": "Field",
       "detail": "Record2.rec2f2",
-      "sortText": "K",
+      "sortText": "AG",
       "insertText": "rec2f2: ${1:0}",
       "insertTextFormat": "Snippet"
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config32c.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config32c.json
@@ -9,7 +9,7 @@
       "label": "readonly",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "U",
+      "sortText": "Q",
       "filterText": "readonly",
       "insertText": "readonly ",
       "insertTextFormat": "Snippet"
@@ -18,7 +18,7 @@
       "label": "employee",
       "kind": "Variable",
       "detail": "Employee",
-      "sortText": "AB",
+      "sortText": "B",
       "insertText": "employee",
       "insertTextFormat": "Snippet"
     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config41.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config41.json
@@ -18,7 +18,7 @@
       "label": "rec3Field2",
       "kind": "Field",
       "detail": "Rec3.rec3Field2",
-      "sortText": "K",
+      "sortText": "AG",
       "insertText": "rec3Field2: ${1:0}",
       "insertTextFormat": "Snippet"
     },
@@ -26,7 +26,7 @@
       "label": "rec3Field2",
       "kind": "Variable",
       "detail": "int",
-      "sortText": "F",
+      "sortText": "AB",
       "insertText": "rec3Field2",
       "insertTextFormat": "Snippet"
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config50.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config50.json
@@ -21,6 +21,15 @@
       "sortText": "F",
       "insertText": "recMap",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "...recMap",
+      "kind": "Variable",
+      "detail": "map<map<RecordName>>",
+      "sortText": "F",
+      "filterText": "recMap",
+      "insertText": "...recMap",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config51.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config51.json
@@ -59,6 +59,15 @@
       "sortText": "AB",
       "insertText": "b",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "...b",
+      "kind": "Variable",
+      "detail": "map<any>",
+      "sortText": "AB",
+      "filterText": "b",
+      "insertText": "...b",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config51.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config51.json
@@ -18,7 +18,7 @@
       "label": "a",
       "kind": "Variable",
       "detail": "int",
-      "sortText": "F",
+      "sortText": "AB",
       "insertText": "a",
       "insertTextFormat": "Snippet"
     },
@@ -32,7 +32,7 @@
           "value": ""
         }
       },
-      "sortText": "F",
+      "sortText": "AB",
       "insertText": "CONST1",
       "insertTextFormat": "Snippet"
     },
@@ -40,7 +40,7 @@
       "label": "param2",
       "kind": "Variable",
       "detail": "int",
-      "sortText": "F",
+      "sortText": "AB",
       "insertText": "param2",
       "insertTextFormat": "Snippet"
     },
@@ -48,7 +48,7 @@
       "label": "param1",
       "kind": "Variable",
       "detail": "int",
-      "sortText": "F",
+      "sortText": "AB",
       "insertText": "param1",
       "insertTextFormat": "Snippet"
     },
@@ -58,15 +58,6 @@
       "detail": "map<any>",
       "sortText": "AB",
       "insertText": "b",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "...b",
-      "kind": "Variable",
-      "detail": "map<any>",
-      "sortText": "AB",
-      "filterText": "b",
-      "insertText": "...b",
       "insertTextFormat": "Snippet"
     }
   ]

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config54.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config54.json
@@ -15,7 +15,7 @@
           "value": ""
         }
       },
-      "sortText": "F",
+      "sortText": "AB",
       "insertText": "CONST1",
       "insertTextFormat": "Snippet"
     },
@@ -39,7 +39,7 @@
       "label": "b",
       "kind": "Variable",
       "detail": "map<any>",
-      "sortText": "F",
+      "sortText": "AB",
       "insertText": "b",
       "insertTextFormat": "Snippet"
     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config64.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config64.json
@@ -18,7 +18,7 @@
       "label": "name",
       "kind": "Field",
       "detail": "Person.name",
-      "sortText": "K",
+      "sortText": "AG",
       "insertText": "name: ${1:\"\"}",
       "insertTextFormat": "Snippet"
     },
@@ -26,7 +26,7 @@
       "label": "age",
       "kind": "Field",
       "detail": "Person.age",
-      "sortText": "K",
+      "sortText": "AG",
       "insertText": "age: ${1:0}",
       "insertTextFormat": "Snippet"
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config69.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config69.json
@@ -18,7 +18,7 @@
       "label": "map1",
       "kind": "Variable",
       "detail": "map<int>",
-      "sortText": "AB",
+      "sortText": "F",
       "insertText": "map1",
       "insertTextFormat": "Snippet"
     },
@@ -26,26 +26,8 @@
       "label": "map2",
       "kind": "Variable",
       "detail": "map<int>",
-      "sortText": "AB",
+      "sortText": "F",
       "insertText": "map2",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "...map2",
-      "kind": "Variable",
-      "detail": "map<int>",
-      "sortText": "AB",
-      "filterText": "map2",
-      "insertText": "...map2",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "...map1",
-      "kind": "Variable",
-      "detail": "map<int>",
-      "sortText": "AB",
-      "filterText": "map1",
-      "insertText": "...map1",
       "insertTextFormat": "Snippet"
     }
   ]

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config69.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config69.json
@@ -29,6 +29,24 @@
       "sortText": "F",
       "insertText": "map2",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "...map2",
+      "kind": "Variable",
+      "detail": "map<int>",
+      "sortText": "F",
+      "filterText": "map2",
+      "insertText": "...map2",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "...map1",
+      "kind": "Variable",
+      "detail": "map<int>",
+      "sortText": "F",
+      "filterText": "map1",
+      "insertText": "...map1",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config7.json
@@ -15,7 +15,7 @@
           "value": "**Package:** _._  \n  \n  \n  \n  \n**Return** `int`   \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "G",
       "filterText": "getInt",
       "insertText": "getInt()",
       "insertTextFormat": "Snippet"
@@ -24,7 +24,7 @@
       "label": "value1",
       "kind": "Variable",
       "detail": "int",
-      "sortText": "B",
+      "sortText": "F",
       "insertText": "value1",
       "insertTextFormat": "Snippet"
     },
@@ -32,7 +32,7 @@
       "label": "value2",
       "kind": "Variable",
       "detail": "int",
-      "sortText": "B",
+      "sortText": "F",
       "insertText": "value2",
       "insertTextFormat": "Snippet"
     },
@@ -46,7 +46,7 @@
           "value": "**Package:** _._  \n  \n  \n  \n  \n**Return** `string`   \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "AC",
       "filterText": "getField",
       "insertText": "getField()",
       "insertTextFormat": "Snippet"
@@ -61,7 +61,7 @@
           "value": "**Package:** _._  \n  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "G",
       "filterText": "testFunction",
       "insertText": "testFunction()",
       "insertTextFormat": "Snippet"
@@ -76,7 +76,7 @@
           "value": "**Package:** _._  \n  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "G",
       "filterText": "doTask",
       "insertText": "doTask()",
       "insertTextFormat": "Snippet"
@@ -85,7 +85,7 @@
       "label": "module1",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "O",
+      "sortText": "S",
       "filterText": "module1",
       "insertText": "module1",
       "insertTextFormat": "Snippet"

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/new_expr_ctx_config24.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/new_expr_ctx_config24.json
@@ -265,7 +265,7 @@
       "label": "service",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "service",
       "insertText": "service",
       "insertTextFormat": "Snippet"
@@ -274,7 +274,7 @@
       "label": "new",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "new",
       "insertText": "new ",
       "insertTextFormat": "Snippet"
@@ -283,7 +283,7 @@
       "label": "isolated",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "isolated",
       "insertText": "isolated ",
       "insertTextFormat": "Snippet"
@@ -292,7 +292,7 @@
       "label": "transactional",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "transactional",
       "insertText": "transactional",
       "insertTextFormat": "Snippet"
@@ -301,7 +301,7 @@
       "label": "function",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "function",
       "insertText": "function ",
       "insertTextFormat": "Snippet"
@@ -310,7 +310,7 @@
       "label": "let",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "let",
       "insertText": "let",
       "insertTextFormat": "Snippet"
@@ -319,7 +319,7 @@
       "label": "typeof",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "typeof",
       "insertText": "typeof ",
       "insertTextFormat": "Snippet"
@@ -328,7 +328,7 @@
       "label": "trap",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "trap",
       "insertText": "trap",
       "insertTextFormat": "Snippet"
@@ -337,7 +337,7 @@
       "label": "client",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "client",
       "insertText": "client ",
       "insertTextFormat": "Snippet"
@@ -346,7 +346,7 @@
       "label": "true",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "true",
       "insertText": "true",
       "insertTextFormat": "Snippet"
@@ -355,7 +355,7 @@
       "label": "false",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "false",
       "insertText": "false",
       "insertTextFormat": "Snippet"
@@ -364,7 +364,7 @@
       "label": "check",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "check",
       "insertText": "check ",
       "insertTextFormat": "Snippet"
@@ -373,7 +373,7 @@
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "checkpanic",
       "insertText": "checkpanic ",
       "insertTextFormat": "Snippet"
@@ -382,7 +382,7 @@
       "label": "is",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "is",
       "insertText": "is",
       "insertTextFormat": "Snippet"
@@ -391,7 +391,7 @@
       "label": "error constructor",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "T",
       "filterText": "error",
       "insertText": "error(\"${1}\")",
       "insertTextFormat": "Snippet"
@@ -400,7 +400,7 @@
       "label": "object constructor",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "T",
       "filterText": "object",
       "insertText": "object {${1}}",
       "insertTextFormat": "Snippet"
@@ -409,7 +409,7 @@
       "label": "base16",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "T",
       "filterText": "base16",
       "insertText": "base16 `${1}`",
       "insertTextFormat": "Snippet"
@@ -418,7 +418,7 @@
       "label": "base64",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "T",
       "filterText": "base64",
       "insertText": "base64 `${1}`",
       "insertTextFormat": "Snippet"
@@ -427,7 +427,7 @@
       "label": "from",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "from",
       "insertText": "from ",
       "insertTextFormat": "Snippet"
@@ -439,7 +439,7 @@
       "documentation": {
         "left": "Describes Strand execution details for the runtime.\n"
       },
-      "sortText": "M",
+      "sortText": "Q",
       "insertText": "StrandData",
       "insertTextFormat": "Snippet"
     },
@@ -447,7 +447,7 @@
       "label": "Thread",
       "kind": "TypeParameter",
       "detail": "Union",
-      "sortText": "N",
+      "sortText": "R",
       "insertText": "Thread",
       "insertTextFormat": "Snippet"
     },
@@ -455,7 +455,7 @@
       "label": "c1",
       "kind": "Variable",
       "detail": "MyClass",
-      "sortText": "B",
+      "sortText": "F",
       "insertText": "c1",
       "insertTextFormat": "Snippet"
     },
@@ -463,7 +463,7 @@
       "label": "MyClass",
       "kind": "Interface",
       "detail": "Class",
-      "sortText": "K",
+      "sortText": "O",
       "insertText": "MyClass",
       "insertTextFormat": "Snippet"
     },
@@ -477,7 +477,7 @@
           "value": "**Package:** _._  \n  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "G",
       "filterText": "myFunc",
       "insertText": "myFunc()",
       "insertTextFormat": "Snippet"
@@ -486,7 +486,7 @@
       "label": "MyType",
       "kind": "Struct",
       "detail": "Record",
-      "sortText": "M",
+      "sortText": "Q",
       "insertText": "MyType",
       "insertTextFormat": "Snippet"
     },
@@ -550,7 +550,7 @@
       "label": "null",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "null",
       "insertText": "null",
       "insertTextFormat": "Snippet"

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/xml_attribute_access_expr_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/xml_attribute_access_expr_ctx_config1.json
@@ -330,7 +330,7 @@
           "value": "**Package:** _ballerina/lang.xml:0.0.0_  \n  \nReturns a string with the character data of an xml value.\n\nThe character data of an xml value is as follows:\n* the character data of a text item is a string with one character for each\ncharacter information item represented by the text item;\n* the character data of an element item is the character data of its children;\n* the character data of a comment item is the empty string;\n* the character data of a processing instruction item is the empty string;\n* the character data of an empty xml sequence is the empty string;\n* the character data of the concatenation of two xml sequences x1 and x2 is the\nconcatenation of the character data of x1 and the character data of x2.\n  \n  \n  \n**Return** `string`   \n- a string consisting of all the character data of parameter `x`  \n  \n"
         }
       },
-      "sortText": "CD",
+      "sortText": "AD",
       "filterText": "data",
       "insertText": "data()",
       "insertTextFormat": "Snippet"
@@ -534,7 +534,7 @@
           "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nConstructs a value with a specified type by cloning another value.\n\nWhen parameter `v` is a structural value, the inherent type of the value to be constructed\ncomes from parameter `t`. When parameter `t` is a union, it must be possible to determine which\nmember of the union to use for the inherent type by following the same rules\nthat are used by list constructor expressions and mapping constructor expressions\nwith the contextually expected type. If not, then an error is returned.\nThe `cloneWithType` operation is recursively applied to each member of parameter `v` using\nthe type descriptor that the inherent type requires for that member.\n\nLike the Clone abstract operation, this does a deep copy, but differs in\nthe following respects:\n- the inherent type of any structural values constructed comes from the specified\ntype descriptor rather than the value being constructed\n- the read-only bit of values and fields comes from the specified type descriptor\n- the graph structure of `v` is not preserved; the result will always be a tree;\nan error will be returned if `v` has cycles\n- immutable structural values are copied rather being returned as is; all\nstructural values in the result will be mutable.\n- numeric values can be converted using the NumericConvert abstract operation\n- if a record type descriptor specifies default values, these will be used\nto supply any missing members\n  \n**Params**  \n- `typedesc<anydata>` t: the type for the cloned to be constructed(Defaultable)  \n  \n**Return** `t|error`   \n- a new value that belongs to parameter `t`, or an error if this cannot be done  \n  \n"
         }
       },
-      "sortText": "CD",
+      "sortText": "BD",
       "filterText": "cloneWithType",
       "insertText": "cloneWithType(${1})",
       "insertTextFormat": "Snippet",
@@ -568,7 +568,7 @@
           "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nConverts a value to a string that describes the value in Ballerina syntax.\n\nIf parameter `v` is anydata and does not have cycles, then the result will\nconform to the grammar for a Ballerina expression and when evaluated\nwill result in a value that is == to parameter `v`.\n\nThe details of the conversion are specified by the ToString abstract operation\ndefined in the Ballerina Language Specification, using the expression style.\n  \n  \n  \n**Return** `string`   \n- a string resulting from the conversion  \n  \n"
         }
       },
-      "sortText": "CD",
+      "sortText": "AD",
       "filterText": "toBalString",
       "insertText": "toBalString()",
       "insertTextFormat": "Snippet"
@@ -628,7 +628,7 @@
           "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nSafely casts a value to a type.\n\nThis casts a value to a type in the same way as a type cast expression,\nbut returns an error if the cast cannot be done, rather than panicking.\n  \n**Params**  \n- `typedesc<any>` t: a typedesc for the type to which to cast it(Defaultable)  \n  \n**Return** `t|error`   \n- `v` cast to the type described by parameter `t`, or an error, if the cast cannot be done  \n  \n"
         }
       },
-      "sortText": "CD",
+      "sortText": "BD",
       "filterText": "ensureType",
       "insertText": "ensureType(${1})",
       "insertTextFormat": "Snippet",
@@ -647,7 +647,7 @@
           "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nPerforms a direct conversion of a value to a string.\n\nThe conversion is direct in the sense that when applied to a value that is already\na string it leaves the value unchanged.\n\nThe details of the conversion are specified by the ToString abstract operation\ndefined in the Ballerina Language Specification, using the direct style.\n  \n  \n  \n**Return** `string`   \n- a string resulting from the conversion  \n  \n"
         }
       },
-      "sortText": "CD",
+      "sortText": "AD",
       "filterText": "toString",
       "insertText": "toString()",
       "insertTextFormat": "Snippet"
@@ -662,7 +662,7 @@
           "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nReturns the string that represents a anydata value in JSON format.\n\nparameter `v` is first converted to `json` as if by the function `toJson`.\n  \n  \n  \n**Return** `string`   \n- string representation of parameter `v` converted to `json`  \n  \n"
         }
       },
-      "sortText": "CD",
+      "sortText": "AD",
       "filterText": "toJsonString",
       "insertText": "toJsonString()",
       "insertTextFormat": "Snippet"

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/xml_attribute_access_expr_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/xml_attribute_access_expr_ctx_config2.json
@@ -330,7 +330,7 @@
           "value": "**Package:** _ballerina/lang.xml:0.0.0_  \n  \nReturns a string with the character data of an xml value.\n\nThe character data of an xml value is as follows:\n* the character data of a text item is a string with one character for each\ncharacter information item represented by the text item;\n* the character data of an element item is the character data of its children;\n* the character data of a comment item is the empty string;\n* the character data of a processing instruction item is the empty string;\n* the character data of an empty xml sequence is the empty string;\n* the character data of the concatenation of two xml sequences x1 and x2 is the\nconcatenation of the character data of x1 and the character data of x2.\n  \n  \n  \n**Return** `string`   \n- a string consisting of all the character data of parameter `x`  \n  \n"
         }
       },
-      "sortText": "CD",
+      "sortText": "AD",
       "filterText": "data",
       "insertText": "data()",
       "insertTextFormat": "Snippet"
@@ -534,7 +534,7 @@
           "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nConstructs a value with a specified type by cloning another value.\n\nWhen parameter `v` is a structural value, the inherent type of the value to be constructed\ncomes from parameter `t`. When parameter `t` is a union, it must be possible to determine which\nmember of the union to use for the inherent type by following the same rules\nthat are used by list constructor expressions and mapping constructor expressions\nwith the contextually expected type. If not, then an error is returned.\nThe `cloneWithType` operation is recursively applied to each member of parameter `v` using\nthe type descriptor that the inherent type requires for that member.\n\nLike the Clone abstract operation, this does a deep copy, but differs in\nthe following respects:\n- the inherent type of any structural values constructed comes from the specified\ntype descriptor rather than the value being constructed\n- the read-only bit of values and fields comes from the specified type descriptor\n- the graph structure of `v` is not preserved; the result will always be a tree;\nan error will be returned if `v` has cycles\n- immutable structural values are copied rather being returned as is; all\nstructural values in the result will be mutable.\n- numeric values can be converted using the NumericConvert abstract operation\n- if a record type descriptor specifies default values, these will be used\nto supply any missing members\n  \n**Params**  \n- `typedesc<anydata>` t: the type for the cloned to be constructed(Defaultable)  \n  \n**Return** `t|error`   \n- a new value that belongs to parameter `t`, or an error if this cannot be done  \n  \n"
         }
       },
-      "sortText": "CD",
+      "sortText": "BD",
       "filterText": "cloneWithType",
       "insertText": "cloneWithType(${1})",
       "insertTextFormat": "Snippet",
@@ -568,7 +568,7 @@
           "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nConverts a value to a string that describes the value in Ballerina syntax.\n\nIf parameter `v` is anydata and does not have cycles, then the result will\nconform to the grammar for a Ballerina expression and when evaluated\nwill result in a value that is == to parameter `v`.\n\nThe details of the conversion are specified by the ToString abstract operation\ndefined in the Ballerina Language Specification, using the expression style.\n  \n  \n  \n**Return** `string`   \n- a string resulting from the conversion  \n  \n"
         }
       },
-      "sortText": "CD",
+      "sortText": "AD",
       "filterText": "toBalString",
       "insertText": "toBalString()",
       "insertTextFormat": "Snippet"
@@ -628,7 +628,7 @@
           "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nSafely casts a value to a type.\n\nThis casts a value to a type in the same way as a type cast expression,\nbut returns an error if the cast cannot be done, rather than panicking.\n  \n**Params**  \n- `typedesc<any>` t: a typedesc for the type to which to cast it(Defaultable)  \n  \n**Return** `t|error`   \n- `v` cast to the type described by parameter `t`, or an error, if the cast cannot be done  \n  \n"
         }
       },
-      "sortText": "CD",
+      "sortText": "BD",
       "filterText": "ensureType",
       "insertText": "ensureType(${1})",
       "insertTextFormat": "Snippet",
@@ -647,7 +647,7 @@
           "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nPerforms a direct conversion of a value to a string.\n\nThe conversion is direct in the sense that when applied to a value that is already\na string it leaves the value unchanged.\n\nThe details of the conversion are specified by the ToString abstract operation\ndefined in the Ballerina Language Specification, using the direct style.\n  \n  \n  \n**Return** `string`   \n- a string resulting from the conversion  \n  \n"
         }
       },
-      "sortText": "CD",
+      "sortText": "AD",
       "filterText": "toString",
       "insertText": "toString()",
       "insertTextFormat": "Snippet"
@@ -662,7 +662,7 @@
           "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nReturns the string that represents a anydata value in JSON format.\n\nparameter `v` is first converted to `json` as if by the function `toJson`.\n  \n  \n  \n**Return** `string`   \n- string representation of parameter `v` converted to `json`  \n  \n"
         }
       },
-      "sortText": "CD",
+      "sortText": "AD",
       "filterText": "toJsonString",
       "insertText": "toJsonString()",
       "insertTextFormat": "Snippet"

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/xml_attribute_access_expr_ctx_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/xml_attribute_access_expr_ctx_config5.json
@@ -15,7 +15,7 @@
           "value": ""
         }
       },
-      "sortText": "CG",
+      "sortText": "AG",
       "insertText": "TEST_STRING_CONST1",
       "insertTextFormat": "Snippet"
     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/xml_attribute_access_expr_ctx_config6.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/xml_attribute_access_expr_ctx_config6.json
@@ -15,7 +15,7 @@
           "value": ""
         }
       },
-      "sortText": "CG",
+      "sortText": "AG",
       "insertText": "TEST_STRING_CONST1",
       "insertTextFormat": "Snippet"
     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config20.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config20.json
@@ -49,7 +49,7 @@
           "value": "**Package:** _ballerina/lang.int:0.0.0_  \n  \nReturns representation of an integer as hexdecimal string.\n\nThere is no `0x` prefix. Lowercase letters a-f are used.\nNegative numbers will have a `-` prefix. No sign for\nnon-negative numbers.\n  \n  \n  \n**Return** `string`   \n- hexadecimal string representation of int value  \n  \n"
         }
       },
-      "sortText": "CA",
+      "sortText": "AA",
       "filterText": "toHexString",
       "insertText": "toHexString()",
       "insertTextFormat": "Snippet"
@@ -136,7 +136,7 @@
           "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nConverts a value to a string that describes the value in Ballerina syntax.\n\nIf parameter `v` is anydata and does not have cycles, then the result will\nconform to the grammar for a Ballerina expression and when evaluated\nwill result in a value that is == to parameter `v`.\n\nThe details of the conversion are specified by the ToString abstract operation\ndefined in the Ballerina Language Specification, using the expression style.\n  \n  \n  \n**Return** `string`   \n- a string resulting from the conversion  \n  \n"
         }
       },
-      "sortText": "CA",
+      "sortText": "AA",
       "filterText": "toBalString",
       "insertText": "toBalString()",
       "insertTextFormat": "Snippet"
@@ -253,7 +253,7 @@
           "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nPerforms a direct conversion of a value to a string.\n\nThe conversion is direct in the sense that when applied to a value that is already\na string it leaves the value unchanged.\n\nThe details of the conversion are specified by the ToString abstract operation\ndefined in the Ballerina Language Specification, using the direct style.\n  \n  \n  \n**Return** `string`   \n- a string resulting from the conversion  \n  \n"
         }
       },
-      "sortText": "CA",
+      "sortText": "AA",
       "filterText": "toString",
       "insertText": "toString()",
       "insertTextFormat": "Snippet"
@@ -268,277 +268,9 @@
           "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nReturns the string that represents a anydata value in JSON format.\n\nparameter `v` is first converted to `json` as if by the function `toJson`.\n  \n  \n  \n**Return** `string`   \n- string representation of parameter `v` converted to `json`  \n  \n"
         }
       },
-      "sortText": "CA",
+      "sortText": "AA",
       "filterText": "toJsonString",
       "insertText": "toJsonString()",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "abs",
-      "kind": "Variable",
-      "detail": "int",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.int:0.0.0_  \n  \nReturns the absolute value of an int value.\n  \n  \n  \n**Return** `int`   \n- absolute value of parameter `n`  \n  \n"
-        }
-      },
-      "sortText": "CD",
-      "filterText": "abs",
-      "insertText": "abs",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "min",
-      "kind": "Variable",
-      "detail": "int",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.int:0.0.0_  \n  \nReturns the minimum of one or more int values.\n  \n**Params**  \n- `int[]` ns: other int values  \n  \n**Return** `int`   \n- minimum value of parameter `n` and all of parameter `ns`  \n  \n"
-        }
-      },
-      "sortText": "CD",
-      "filterText": "min",
-      "insertText": "min",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "toHexString",
-      "kind": "Variable",
-      "detail": "string",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.int:0.0.0_  \n  \nReturns representation of an integer as hexdecimal string.\n\nThere is no `0x` prefix. Lowercase letters a-f are used.\nNegative numbers will have a `-` prefix. No sign for\nnon-negative numbers.\n  \n  \n  \n**Return** `string`   \n- hexadecimal string representation of int value  \n  \n"
-        }
-      },
-      "sortText": "AD",
-      "filterText": "toHexString",
-      "insertText": "toHexString",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "max",
-      "kind": "Variable",
-      "detail": "int",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.int:0.0.0_  \n  \nReturns the maximum of one or more int values.\n  \n**Params**  \n- `int[]` ns: other int values  \n  \n**Return** `int`   \n- maximum value of value of parameter `n` and all of parameter `ns`  \n  \n"
-        }
-      },
-      "sortText": "CD",
-      "filterText": "max",
-      "insertText": "max",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "sum",
-      "kind": "Variable",
-      "detail": "int",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.int:0.0.0_  \n  \nReturns sum of zero or more int values.\n  \n  \n  \n**Return** `int`   \n- sum of all of parameter `ns`; 0 if parameter `ns` is empty  \n  \n"
-        }
-      },
-      "sortText": "CD",
-      "filterText": "sum",
-      "insertText": "sum",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "cloneWithType",
-      "kind": "Variable",
-      "detail": "t|error",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nConstructs a value with a specified type by cloning another value.\n\nWhen parameter `v` is a structural value, the inherent type of the value to be constructed\ncomes from parameter `t`. When parameter `t` is a union, it must be possible to determine which\nmember of the union to use for the inherent type by following the same rules\nthat are used by list constructor expressions and mapping constructor expressions\nwith the contextually expected type. If not, then an error is returned.\nThe `cloneWithType` operation is recursively applied to each member of parameter `v` using\nthe type descriptor that the inherent type requires for that member.\n\nLike the Clone abstract operation, this does a deep copy, but differs in\nthe following respects:\n- the inherent type of any structural values constructed comes from the specified\ntype descriptor rather than the value being constructed\n- the read-only bit of values and fields comes from the specified type descriptor\n- the graph structure of `v` is not preserved; the result will always be a tree;\nan error will be returned if `v` has cycles\n- immutable structural values are copied rather being returned as is; all\nstructural values in the result will be mutable.\n- numeric values can be converted using the NumericConvert abstract operation\n- if a record type descriptor specifies default values, these will be used\nto supply any missing members\n  \n**Params**  \n- `typedesc<anydata>` t: the type for the cloned to be constructed(Defaultable)  \n  \n**Return** `t|error`   \n- a new value that belongs to parameter `t`, or an error if this cannot be done  \n  \n"
-        }
-      },
-      "sortText": "CD",
-      "filterText": "cloneWithType",
-      "insertText": "cloneWithType",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "cloneReadOnly",
-      "kind": "Variable",
-      "detail": "value:CloneableType & readonly",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nReturns a clone of a value that is read-only, i.e., immutable.\n\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Return** `value:CloneableType & readonly`   \n- immutable clone of parameter `v`  \n  \n"
-        }
-      },
-      "sortText": "CD",
-      "filterText": "cloneReadOnly",
-      "insertText": "cloneReadOnly",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "toBalString",
-      "kind": "Variable",
-      "detail": "string",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nConverts a value to a string that describes the value in Ballerina syntax.\n\nIf parameter `v` is anydata and does not have cycles, then the result will\nconform to the grammar for a Ballerina expression and when evaluated\nwill result in a value that is == to parameter `v`.\n\nThe details of the conversion are specified by the ToString abstract operation\ndefined in the Ballerina Language Specification, using the expression style.\n  \n  \n  \n**Return** `string`   \n- a string resulting from the conversion  \n  \n"
-        }
-      },
-      "sortText": "AD",
-      "filterText": "toBalString",
-      "insertText": "toBalString",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "toJson",
-      "kind": "Variable",
-      "detail": "json",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nConverts a value of type `anydata` to `json`.\n\nThis does a deep copy of parameter `v` converting values that do\nnot belong to json into values that do.\nA value of type `xml` is converted into a string as if\nby the `toString` function.\nA value of type `table` is converted into a list of\nmappings one for each row.\nThe inherent type of arrays in the return value will be\n`json[]` and of mappings will be `map<json>`.\nA new copy is made of all structural values, including\nimmutable values.\nThis panics if parameter `v` has cycles.\n  \n  \n  \n**Return** `json`   \n- representation of `v` as value of type json  \n  \n"
-        }
-      },
-      "sortText": "CD",
-      "filterText": "toJson",
-      "insertText": "toJson",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "isReadOnly",
-      "kind": "Variable",
-      "detail": "boolean",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nTests whether a value is read-only, i.e., immutable.\n\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Return** `boolean`   \n- true if read-only, false otherwise  \n  \n"
-        }
-      },
-      "sortText": "CD",
-      "filterText": "isReadOnly",
-      "insertText": "isReadOnly",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "fromJsonWithType",
-      "kind": "Variable",
-      "detail": "t|error",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nConverts a value of type json to a user-specified type.\n\nThis works the same as function `cloneWithType`,\nexcept that it also does the inverse of the conversions done by `toJson`.\n  \n**Params**  \n- `typedesc<anydata>` t: type to convert to(Defaultable)  \n  \n**Return** `t|error`   \n- value belonging to type parameter `t` or error if this cannot be done  \n  \n"
-        }
-      },
-      "sortText": "CD",
-      "filterText": "fromJsonWithType",
-      "insertText": "fromJsonWithType",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "mergeJson",
-      "kind": "Variable",
-      "detail": "json|error",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nMerges two `json` values.\n\nThe merge of parameter `j1` with parameter `j2` is defined as follows:\n- if parameter `j1` is `()`, then the result is parameter `j2`\n- if parameter `j2` is `()`, then the result is parameter `j1`\n- if parameter `j1` is a mapping and parameter `j2` is a mapping, then for each entry [k, j] in parameter `j2`, set `j1[k]` to the merge of `j1[k]` with `j`\n- if `j1[k]` is undefined, then set `j1[k]` to `j`\n- if any merge fails, then the merge of parameter `j1` with parameter `j2` fails\n- otherwise, the result is parameter `j1`.\n- otherwise, the merge fails\nIf the merge fails, then parameter `j1` is unchanged.\n  \n**Params**  \n- `json` j2: json value  \n  \n**Return** `json|error`   \n- the merge of parameter `j1` with parameter `j2` or an error if the merge fails  \n  \n"
-        }
-      },
-      "sortText": "CD",
-      "filterText": "mergeJson",
-      "insertText": "mergeJson",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "clone",
-      "kind": "Variable",
-      "detail": "value:CloneableType",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nReturns a clone of a value.\n\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Return** `value:CloneableType`   \n- clone of parameter `v`  \n  \n"
-        }
-      },
-      "sortText": "CD",
-      "filterText": "clone",
-      "insertText": "clone",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ensureType",
-      "kind": "Variable",
-      "detail": "t|error",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nSafely casts a value to a type.\n\nThis casts a value to a type in the same way as a type cast expression,\nbut returns an error if the cast cannot be done, rather than panicking.\n  \n**Params**  \n- `typedesc<any>` t: a typedesc for the type to which to cast it(Defaultable)  \n  \n**Return** `t|error`   \n- `v` cast to the type described by parameter `t`, or an error, if the cast cannot be done  \n  \n"
-        }
-      },
-      "sortText": "CD",
-      "filterText": "ensureType",
-      "insertText": "ensureType",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "toString",
-      "kind": "Variable",
-      "detail": "string",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nPerforms a direct conversion of a value to a string.\n\nThe conversion is direct in the sense that when applied to a value that is already\na string it leaves the value unchanged.\n\nThe details of the conversion are specified by the ToString abstract operation\ndefined in the Ballerina Language Specification, using the direct style.\n  \n  \n  \n**Return** `string`   \n- a string resulting from the conversion  \n  \n"
-        }
-      },
-      "sortText": "AD",
-      "filterText": "toString",
-      "insertText": "toString",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "toJsonString",
-      "kind": "Variable",
-      "detail": "string",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nReturns the string that represents a anydata value in JSON format.\n\nparameter `v` is first converted to `json` as if by the function `toJson`.\n  \n  \n  \n**Return** `string`   \n- string representation of parameter `v` converted to `json`  \n  \n"
-        }
-      },
-      "sortText": "AD",
-      "filterText": "toJsonString",
-      "insertText": "toJsonString",
       "insertTextFormat": "Snippet"
     }
   ]

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_config4.json
@@ -323,7 +323,7 @@
           "value": "**Package:** _ballerina/lang.xml:0.0.0_  \n  \nReturns a string with the character data of an xml value.\n\nThe character data of an xml value is as follows:\n* the character data of a text item is a string with one character for each\ncharacter information item represented by the text item;\n* the character data of an element item is the character data of its children;\n* the character data of a comment item is the empty string;\n* the character data of a processing instruction item is the empty string;\n* the character data of an empty xml sequence is the empty string;\n* the character data of the concatenation of two xml sequences x1 and x2 is the\nconcatenation of the character data of x1 and the character data of x2.\n  \n  \n  \n**Return** `string`   \n- a string consisting of all the character data of parameter `x`  \n  \n"
         }
       },
-      "sortText": "CD",
+      "sortText": "AD",
       "filterText": "data",
       "insertText": "data()",
       "insertTextFormat": "Snippet"
@@ -527,7 +527,7 @@
           "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nConstructs a value with a specified type by cloning another value.\n\nWhen parameter `v` is a structural value, the inherent type of the value to be constructed\ncomes from parameter `t`. When parameter `t` is a union, it must be possible to determine which\nmember of the union to use for the inherent type by following the same rules\nthat are used by list constructor expressions and mapping constructor expressions\nwith the contextually expected type. If not, then an error is returned.\nThe `cloneWithType` operation is recursively applied to each member of parameter `v` using\nthe type descriptor that the inherent type requires for that member.\n\nLike the Clone abstract operation, this does a deep copy, but differs in\nthe following respects:\n- the inherent type of any structural values constructed comes from the specified\ntype descriptor rather than the value being constructed\n- the read-only bit of values and fields comes from the specified type descriptor\n- the graph structure of `v` is not preserved; the result will always be a tree;\nan error will be returned if `v` has cycles\n- immutable structural values are copied rather being returned as is; all\nstructural values in the result will be mutable.\n- numeric values can be converted using the NumericConvert abstract operation\n- if a record type descriptor specifies default values, these will be used\nto supply any missing members\n  \n**Params**  \n- `typedesc<anydata>` t: the type for the cloned to be constructed(Defaultable)  \n  \n**Return** `t|error`   \n- a new value that belongs to parameter `t`, or an error if this cannot be done  \n  \n"
         }
       },
-      "sortText": "CD",
+      "sortText": "BD",
       "filterText": "cloneWithType",
       "insertText": "cloneWithType(${1})",
       "insertTextFormat": "Snippet",
@@ -561,7 +561,7 @@
           "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nConverts a value to a string that describes the value in Ballerina syntax.\n\nIf parameter `v` is anydata and does not have cycles, then the result will\nconform to the grammar for a Ballerina expression and when evaluated\nwill result in a value that is == to parameter `v`.\n\nThe details of the conversion are specified by the ToString abstract operation\ndefined in the Ballerina Language Specification, using the expression style.\n  \n  \n  \n**Return** `string`   \n- a string resulting from the conversion  \n  \n"
         }
       },
-      "sortText": "CD",
+      "sortText": "AD",
       "filterText": "toBalString",
       "insertText": "toBalString()",
       "insertTextFormat": "Snippet"
@@ -621,7 +621,7 @@
           "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nSafely casts a value to a type.\n\nThis casts a value to a type in the same way as a type cast expression,\nbut returns an error if the cast cannot be done, rather than panicking.\n  \n**Params**  \n- `typedesc<any>` t: a typedesc for the type to which to cast it(Defaultable)  \n  \n**Return** `t|error`   \n- `v` cast to the type described by parameter `t`, or an error, if the cast cannot be done  \n  \n"
         }
       },
-      "sortText": "CD",
+      "sortText": "BD",
       "filterText": "ensureType",
       "insertText": "ensureType(${1})",
       "insertTextFormat": "Snippet",
@@ -640,7 +640,7 @@
           "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nPerforms a direct conversion of a value to a string.\n\nThe conversion is direct in the sense that when applied to a value that is already\na string it leaves the value unchanged.\n\nThe details of the conversion are specified by the ToString abstract operation\ndefined in the Ballerina Language Specification, using the direct style.\n  \n  \n  \n**Return** `string`   \n- a string resulting from the conversion  \n  \n"
         }
       },
-      "sortText": "CD",
+      "sortText": "AD",
       "filterText": "toString",
       "insertText": "toString()",
       "insertTextFormat": "Snippet"
@@ -655,7 +655,7 @@
           "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nReturns the string that represents a anydata value in JSON format.\n\nparameter `v` is first converted to `json` as if by the function `toJson`.\n  \n  \n  \n**Return** `string`   \n- string representation of parameter `v` converted to `json`  \n  \n"
         }
       },
-      "sortText": "CD",
+      "sortText": "AD",
       "filterText": "toJsonString",
       "insertText": "toJsonString()",
       "insertTextFormat": "Snippet"

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/foreach_stmt_ctx_config20.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/foreach_stmt_ctx_config20.json
@@ -323,7 +323,7 @@
           "value": "**Package:** _ballerina/lang.xml:0.0.0_  \n  \nReturns a string with the character data of an xml value.\n\nThe character data of an xml value is as follows:\n* the character data of a text item is a string with one character for each\ncharacter information item represented by the text item;\n* the character data of an element item is the character data of its children;\n* the character data of a comment item is the empty string;\n* the character data of a processing instruction item is the empty string;\n* the character data of an empty xml sequence is the empty string;\n* the character data of the concatenation of two xml sequences x1 and x2 is the\nconcatenation of the character data of x1 and the character data of x2.\n  \n  \n  \n**Return** `string`   \n- a string consisting of all the character data of parameter `x`  \n  \n"
         }
       },
-      "sortText": "CD",
+      "sortText": "AD",
       "filterText": "data",
       "insertText": "data()",
       "insertTextFormat": "Snippet"
@@ -527,7 +527,7 @@
           "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nConstructs a value with a specified type by cloning another value.\n\nWhen parameter `v` is a structural value, the inherent type of the value to be constructed\ncomes from parameter `t`. When parameter `t` is a union, it must be possible to determine which\nmember of the union to use for the inherent type by following the same rules\nthat are used by list constructor expressions and mapping constructor expressions\nwith the contextually expected type. If not, then an error is returned.\nThe `cloneWithType` operation is recursively applied to each member of parameter `v` using\nthe type descriptor that the inherent type requires for that member.\n\nLike the Clone abstract operation, this does a deep copy, but differs in\nthe following respects:\n- the inherent type of any structural values constructed comes from the specified\ntype descriptor rather than the value being constructed\n- the read-only bit of values and fields comes from the specified type descriptor\n- the graph structure of `v` is not preserved; the result will always be a tree;\nan error will be returned if `v` has cycles\n- immutable structural values are copied rather being returned as is; all\nstructural values in the result will be mutable.\n- numeric values can be converted using the NumericConvert abstract operation\n- if a record type descriptor specifies default values, these will be used\nto supply any missing members\n  \n**Params**  \n- `typedesc<anydata>` t: the type for the cloned to be constructed(Defaultable)  \n  \n**Return** `t|error`   \n- a new value that belongs to parameter `t`, or an error if this cannot be done  \n  \n"
         }
       },
-      "sortText": "CD",
+      "sortText": "BD",
       "filterText": "cloneWithType",
       "insertText": "cloneWithType(${1})",
       "insertTextFormat": "Snippet",
@@ -561,7 +561,7 @@
           "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nConverts a value to a string that describes the value in Ballerina syntax.\n\nIf parameter `v` is anydata and does not have cycles, then the result will\nconform to the grammar for a Ballerina expression and when evaluated\nwill result in a value that is == to parameter `v`.\n\nThe details of the conversion are specified by the ToString abstract operation\ndefined in the Ballerina Language Specification, using the expression style.\n  \n  \n  \n**Return** `string`   \n- a string resulting from the conversion  \n  \n"
         }
       },
-      "sortText": "CD",
+      "sortText": "AD",
       "filterText": "toBalString",
       "insertText": "toBalString()",
       "insertTextFormat": "Snippet"
@@ -621,7 +621,7 @@
           "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nSafely casts a value to a type.\n\nThis casts a value to a type in the same way as a type cast expression,\nbut returns an error if the cast cannot be done, rather than panicking.\n  \n**Params**  \n- `typedesc<any>` t: a typedesc for the type to which to cast it(Defaultable)  \n  \n**Return** `t|error`   \n- `v` cast to the type described by parameter `t`, or an error, if the cast cannot be done  \n  \n"
         }
       },
-      "sortText": "CD",
+      "sortText": "BD",
       "filterText": "ensureType",
       "insertText": "ensureType(${1})",
       "insertTextFormat": "Snippet",
@@ -640,7 +640,7 @@
           "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nPerforms a direct conversion of a value to a string.\n\nThe conversion is direct in the sense that when applied to a value that is already\na string it leaves the value unchanged.\n\nThe details of the conversion are specified by the ToString abstract operation\ndefined in the Ballerina Language Specification, using the direct style.\n  \n  \n  \n**Return** `string`   \n- a string resulting from the conversion  \n  \n"
         }
       },
-      "sortText": "CD",
+      "sortText": "AD",
       "filterText": "toString",
       "insertText": "toString()",
       "insertTextFormat": "Snippet"
@@ -655,7 +655,7 @@
           "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nReturns the string that represents a anydata value in JSON format.\n\nparameter `v` is first converted to `json` as if by the function `toJson`.\n  \n  \n  \n**Return** `string`   \n- string representation of parameter `v` converted to `json`  \n  \n"
         }
       },
-      "sortText": "CD",
+      "sortText": "AD",
       "filterText": "toJsonString",
       "insertText": "toJsonString()",
       "insertTextFormat": "Snippet"

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/foreach_stmt_ctx_config24.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/foreach_stmt_ctx_config24.json
@@ -323,7 +323,7 @@
           "value": "**Package:** _ballerina/lang.xml:0.0.0_  \n  \nReturns a string with the character data of an xml value.\n\nThe character data of an xml value is as follows:\n* the character data of a text item is a string with one character for each\ncharacter information item represented by the text item;\n* the character data of an element item is the character data of its children;\n* the character data of a comment item is the empty string;\n* the character data of a processing instruction item is the empty string;\n* the character data of an empty xml sequence is the empty string;\n* the character data of the concatenation of two xml sequences x1 and x2 is the\nconcatenation of the character data of x1 and the character data of x2.\n  \n  \n  \n**Return** `string`   \n- a string consisting of all the character data of parameter `x`  \n  \n"
         }
       },
-      "sortText": "CD",
+      "sortText": "AD",
       "filterText": "data",
       "insertText": "data()",
       "insertTextFormat": "Snippet"
@@ -527,7 +527,7 @@
           "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nConstructs a value with a specified type by cloning another value.\n\nWhen parameter `v` is a structural value, the inherent type of the value to be constructed\ncomes from parameter `t`. When parameter `t` is a union, it must be possible to determine which\nmember of the union to use for the inherent type by following the same rules\nthat are used by list constructor expressions and mapping constructor expressions\nwith the contextually expected type. If not, then an error is returned.\nThe `cloneWithType` operation is recursively applied to each member of parameter `v` using\nthe type descriptor that the inherent type requires for that member.\n\nLike the Clone abstract operation, this does a deep copy, but differs in\nthe following respects:\n- the inherent type of any structural values constructed comes from the specified\ntype descriptor rather than the value being constructed\n- the read-only bit of values and fields comes from the specified type descriptor\n- the graph structure of `v` is not preserved; the result will always be a tree;\nan error will be returned if `v` has cycles\n- immutable structural values are copied rather being returned as is; all\nstructural values in the result will be mutable.\n- numeric values can be converted using the NumericConvert abstract operation\n- if a record type descriptor specifies default values, these will be used\nto supply any missing members\n  \n**Params**  \n- `typedesc<anydata>` t: the type for the cloned to be constructed(Defaultable)  \n  \n**Return** `t|error`   \n- a new value that belongs to parameter `t`, or an error if this cannot be done  \n  \n"
         }
       },
-      "sortText": "CD",
+      "sortText": "BD",
       "filterText": "cloneWithType",
       "insertText": "cloneWithType(${1})",
       "insertTextFormat": "Snippet",
@@ -561,7 +561,7 @@
           "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nConverts a value to a string that describes the value in Ballerina syntax.\n\nIf parameter `v` is anydata and does not have cycles, then the result will\nconform to the grammar for a Ballerina expression and when evaluated\nwill result in a value that is == to parameter `v`.\n\nThe details of the conversion are specified by the ToString abstract operation\ndefined in the Ballerina Language Specification, using the expression style.\n  \n  \n  \n**Return** `string`   \n- a string resulting from the conversion  \n  \n"
         }
       },
-      "sortText": "CD",
+      "sortText": "AD",
       "filterText": "toBalString",
       "insertText": "toBalString()",
       "insertTextFormat": "Snippet"
@@ -621,7 +621,7 @@
           "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nSafely casts a value to a type.\n\nThis casts a value to a type in the same way as a type cast expression,\nbut returns an error if the cast cannot be done, rather than panicking.\n  \n**Params**  \n- `typedesc<any>` t: a typedesc for the type to which to cast it(Defaultable)  \n  \n**Return** `t|error`   \n- `v` cast to the type described by parameter `t`, or an error, if the cast cannot be done  \n  \n"
         }
       },
-      "sortText": "CD",
+      "sortText": "BD",
       "filterText": "ensureType",
       "insertText": "ensureType(${1})",
       "insertTextFormat": "Snippet",
@@ -640,7 +640,7 @@
           "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nPerforms a direct conversion of a value to a string.\n\nThe conversion is direct in the sense that when applied to a value that is already\na string it leaves the value unchanged.\n\nThe details of the conversion are specified by the ToString abstract operation\ndefined in the Ballerina Language Specification, using the direct style.\n  \n  \n  \n**Return** `string`   \n- a string resulting from the conversion  \n  \n"
         }
       },
-      "sortText": "CD",
+      "sortText": "AD",
       "filterText": "toString",
       "insertText": "toString()",
       "insertTextFormat": "Snippet"
@@ -655,7 +655,7 @@
           "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nReturns the string that represents a anydata value in JSON format.\n\nparameter `v` is first converted to `json` as if by the function `toJson`.\n  \n  \n  \n**Return** `string`   \n- string representation of parameter `v` converted to `json`  \n  \n"
         }
       },
-      "sortText": "CD",
+      "sortText": "AD",
       "filterText": "toJsonString",
       "insertText": "toJsonString()",
       "insertTextFormat": "Snippet"

--- a/language-server/modules/langserver-core/src/test/resources/completion/module_const_context/config/config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/module_const_context/config/config7.json
@@ -9,7 +9,7 @@
       "label": "module1",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "O",
+      "sortText": "S",
       "filterText": "module1",
       "insertText": "module1",
       "insertTextFormat": "Snippet"
@@ -256,7 +256,7 @@
           "value": ""
         }
       },
-      "sortText": "B",
+      "sortText": "AB",
       "insertText": "CONST1",
       "insertTextFormat": "Snippet"
     },
@@ -270,7 +270,7 @@
           "value": ""
         }
       },
-      "sortText": "B",
+      "sortText": "AB",
       "insertText": "varName",
       "insertTextFormat": "Snippet"
     },
@@ -278,7 +278,7 @@
       "label": "true",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "true",
       "insertText": "true",
       "insertTextFormat": "Snippet"
@@ -287,7 +287,7 @@
       "label": "false",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "false",
       "insertText": "false",
       "insertTextFormat": "Snippet"

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config7.json
@@ -9,7 +9,7 @@
       "label": "Thread",
       "kind": "TypeParameter",
       "detail": "Union",
-      "sortText": "BN",
+      "sortText": "R",
       "insertText": "Thread",
       "insertTextFormat": "Snippet"
     },
@@ -20,7 +20,7 @@
       "documentation": {
         "left": "Describes Strand execution details for the runtime.\n"
       },
-      "sortText": "BM",
+      "sortText": "Q",
       "insertText": "StrandData",
       "insertTextFormat": "Snippet"
     },
@@ -28,7 +28,7 @@
       "label": "readonly",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "G",
+      "sortText": "R",
       "insertText": "readonly",
       "insertTextFormat": "Snippet"
     },
@@ -36,7 +36,7 @@
       "label": "handle",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "G",
+      "sortText": "R",
       "insertText": "handle",
       "insertTextFormat": "Snippet"
     },
@@ -44,7 +44,7 @@
       "label": "never",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "G",
+      "sortText": "R",
       "insertText": "never",
       "insertTextFormat": "Snippet"
     },
@@ -52,7 +52,7 @@
       "label": "json",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "G",
+      "sortText": "R",
       "insertText": "json",
       "insertTextFormat": "Snippet"
     },
@@ -60,7 +60,7 @@
       "label": "anydata",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "G",
+      "sortText": "R",
       "insertText": "anydata",
       "insertTextFormat": "Snippet"
     },
@@ -68,7 +68,7 @@
       "label": "any",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "G",
+      "sortText": "R",
       "insertText": "any",
       "insertTextFormat": "Snippet"
     },
@@ -76,7 +76,7 @@
       "label": "byte",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "G",
+      "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
     },
@@ -92,7 +92,7 @@
       "label": "record",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Z",
+      "sortText": "U",
       "filterText": "record",
       "insertText": "record ",
       "insertTextFormat": "Snippet"
@@ -101,7 +101,7 @@
       "label": "function",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Z",
+      "sortText": "U",
       "filterText": "function",
       "insertText": "function ",
       "insertTextFormat": "Snippet"
@@ -110,7 +110,7 @@
       "label": "record {}",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "X",
+      "sortText": "T",
       "filterText": "record",
       "insertText": "record {${1}}",
       "insertTextFormat": "Snippet"
@@ -119,7 +119,7 @@
       "label": "record {||}",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "X",
+      "sortText": "T",
       "filterText": "record",
       "insertText": "record {|${1}|}",
       "insertTextFormat": "Snippet"
@@ -128,7 +128,7 @@
       "label": "distinct",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Z",
+      "sortText": "U",
       "filterText": "distinct",
       "insertText": "distinct",
       "insertTextFormat": "Snippet"
@@ -137,7 +137,7 @@
       "label": "object {}",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "X",
+      "sortText": "T",
       "filterText": "object",
       "insertText": "object {${1}}",
       "insertTextFormat": "Snippet"
@@ -146,7 +146,7 @@
       "label": "true",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Z",
+      "sortText": "U",
       "filterText": "true",
       "insertText": "true",
       "insertTextFormat": "Snippet"
@@ -155,7 +155,7 @@
       "label": "false",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Z",
+      "sortText": "U",
       "filterText": "false",
       "insertText": "false",
       "insertTextFormat": "Snippet"
@@ -164,7 +164,7 @@
       "label": "module1",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "BO",
+      "sortText": "S",
       "filterText": "module1",
       "insertText": "module1",
       "insertTextFormat": "Snippet"
@@ -173,7 +173,7 @@
       "label": "ballerina/lang.array",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "CE",
+      "sortText": "R",
       "filterText": "array",
       "insertText": "array",
       "insertTextFormat": "Snippet",
@@ -197,7 +197,7 @@
       "label": "ballerina/lang.runtime",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "CE",
+      "sortText": "R",
       "filterText": "runtime",
       "insertText": "runtime",
       "insertTextFormat": "Snippet",
@@ -221,7 +221,7 @@
       "label": "ballerina/jballerina.java",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "CF",
+      "sortText": "R",
       "filterText": "java",
       "insertText": "java",
       "insertTextFormat": "Snippet",
@@ -245,7 +245,7 @@
       "label": "boolean",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "G",
+      "sortText": "R",
       "insertText": "boolean",
       "insertTextFormat": "Snippet"
     },
@@ -253,7 +253,7 @@
       "label": "decimal",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "G",
+      "sortText": "R",
       "insertText": "decimal",
       "insertTextFormat": "Snippet"
     },
@@ -261,7 +261,7 @@
       "label": "error",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "G",
+      "sortText": "R",
       "insertText": "error",
       "insertTextFormat": "Snippet"
     },
@@ -269,7 +269,7 @@
       "label": "float",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "G",
+      "sortText": "R",
       "insertText": "float",
       "insertTextFormat": "Snippet"
     },
@@ -277,7 +277,7 @@
       "label": "future",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "G",
+      "sortText": "R",
       "insertText": "future",
       "insertTextFormat": "Snippet"
     },
@@ -285,7 +285,7 @@
       "label": "int",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "G",
+      "sortText": "R",
       "insertText": "int",
       "insertTextFormat": "Snippet"
     },
@@ -293,7 +293,7 @@
       "label": "map",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "G",
+      "sortText": "R",
       "insertText": "map",
       "insertTextFormat": "Snippet"
     },
@@ -301,7 +301,7 @@
       "label": "object",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "G",
+      "sortText": "R",
       "insertText": "object",
       "insertTextFormat": "Snippet"
     },
@@ -309,7 +309,7 @@
       "label": "stream",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "G",
+      "sortText": "R",
       "insertText": "stream",
       "insertTextFormat": "Snippet"
     },
@@ -317,7 +317,7 @@
       "label": "string",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "G",
+      "sortText": "R",
       "insertText": "string",
       "insertTextFormat": "Snippet"
     },
@@ -325,7 +325,7 @@
       "label": "table",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "G",
+      "sortText": "R",
       "insertText": "table",
       "insertTextFormat": "Snippet"
     },
@@ -333,7 +333,7 @@
       "label": "transaction",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "G",
+      "sortText": "R",
       "insertText": "transaction",
       "insertTextFormat": "Snippet"
     },
@@ -341,7 +341,7 @@
       "label": "typedesc",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "G",
+      "sortText": "R",
       "insertText": "typedesc",
       "insertTextFormat": "Snippet"
     },
@@ -349,7 +349,7 @@
       "label": "xml",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "G",
+      "sortText": "R",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
     },
@@ -357,7 +357,7 @@
       "label": "var",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Z",
+      "sortText": "U",
       "filterText": "var",
       "insertText": "var ",
       "insertTextFormat": "Snippet"
@@ -366,7 +366,7 @@
       "label": "ballerina/lang.value",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "CE",
+      "sortText": "R",
       "filterText": "value",
       "insertText": "value",
       "insertTextFormat": "Snippet",
@@ -390,7 +390,7 @@
       "label": "test/project2",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "CG",
+      "sortText": "R",
       "filterText": "project2",
       "insertText": "project2",
       "insertTextFormat": "Snippet",
@@ -414,7 +414,7 @@
       "label": "test/project1",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "CG",
+      "sortText": "R",
       "filterText": "project1",
       "insertText": "project1",
       "insertTextFormat": "Snippet",
@@ -438,7 +438,7 @@
       "label": "test/local_project2",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "CG",
+      "sortText": "R",
       "filterText": "local_project2",
       "insertText": "local_project2",
       "insertTextFormat": "Snippet",
@@ -462,7 +462,7 @@
       "label": "test/local_project1",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "CG",
+      "sortText": "R",
       "filterText": "local_project1",
       "insertText": "local_project1",
       "insertTextFormat": "Snippet",
@@ -486,7 +486,7 @@
       "label": "null",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Z",
+      "sortText": "U",
       "filterText": "null",
       "insertText": "null",
       "insertTextFormat": "Snippet"
@@ -495,7 +495,7 @@
       "label": "function",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "G",
+      "sortText": "R",
       "insertText": "function",
       "insertTextFormat": "Snippet"
     },
@@ -503,7 +503,7 @@
       "label": "ballerina/lang.test",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "CE",
+      "sortText": "R",
       "filterText": "test",
       "insertText": "test",
       "insertTextFormat": "Snippet",
@@ -527,7 +527,7 @@
       "label": "ballerina/lang.regexp",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "CE",
+      "sortText": "R",
       "filterText": "regexp",
       "insertText": "regexp",
       "insertTextFormat": "Snippet",

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_where_clause_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_where_clause_config5.json
@@ -748,30 +748,6 @@
       ]
     },
     {
-      "label": "testFunction",
-      "kind": "Variable",
-      "detail": "()",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n"
-        }
-      },
-      "sortText": "BB",
-      "filterText": "testFunction",
-      "insertText": "testFunction",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "function (..) {..}",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "BP",
-      "filterText": "function",
-      "insertText": "function (int[] a) returns int {\n    return 0;\n}",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "function",
       "kind": "Unit",
       "detail": "type",

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/assignment_stmt_ctx_config9.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/assignment_stmt_ctx_config9.json
@@ -569,13 +569,13 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "new(string url)",
+      "label": "new(string proxyHost, int proxyPort)",
       "kind": "Function",
       "detail": "()",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \n  \n**Params**  \n- `string` url"
+          "value": "**Package:** _._  \n  \n  \n**Params**  \n- `string` proxyHost  \n- `int` proxyPort"
         }
       },
       "sortText": "G",

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/wait_action_ctx_config11.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/wait_action_ctx_config11.json
@@ -442,7 +442,7 @@
       "label": "fs",
       "kind": "Variable",
       "detail": "future<string>",
-      "sortText": "B",
+      "sortText": "D",
       "insertText": "fs",
       "insertTextFormat": "Snippet"
     },
@@ -458,7 +458,7 @@
       "label": "fs2",
       "kind": "Variable",
       "detail": "future<string>",
-      "sortText": "B",
+      "sortText": "D",
       "insertText": "fs2",
       "insertTextFormat": "Snippet"
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/wait_action_ctx_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/wait_action_ctx_config4.json
@@ -9,7 +9,7 @@
       "label": "fs",
       "kind": "Variable",
       "detail": "future<string>",
-      "sortText": "B",
+      "sortText": "F",
       "insertText": "fs",
       "insertTextFormat": "Snippet"
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/typedesc_context/config/function_typedesc15a.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/typedesc_context/config/function_typedesc15a.json
@@ -9,7 +9,7 @@
       "label": "start",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "start",
       "insertText": "start ",
       "insertTextFormat": "Snippet"
@@ -18,7 +18,7 @@
       "label": "wait",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "wait",
       "insertText": "wait ",
       "insertTextFormat": "Snippet"
@@ -27,7 +27,7 @@
       "label": "flush",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "flush",
       "insertText": "flush ",
       "insertTextFormat": "Snippet"
@@ -36,7 +36,7 @@
       "label": "from clause",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "T",
       "filterText": "from",
       "insertText": "from ${1:var} ${2:item} in ${3}",
       "insertTextFormat": "Snippet"
@@ -45,7 +45,7 @@
       "label": "module1",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "O",
+      "sortText": "S",
       "filterText": "module1",
       "insertText": "module1",
       "insertTextFormat": "Snippet"
@@ -286,7 +286,7 @@
       "label": "service",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "service",
       "insertText": "service",
       "insertTextFormat": "Snippet"
@@ -295,7 +295,7 @@
       "label": "new",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "new",
       "insertText": "new ",
       "insertTextFormat": "Snippet"
@@ -304,7 +304,7 @@
       "label": "isolated",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "isolated",
       "insertText": "isolated ",
       "insertTextFormat": "Snippet"
@@ -313,7 +313,7 @@
       "label": "transactional",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "transactional",
       "insertText": "transactional",
       "insertTextFormat": "Snippet"
@@ -322,7 +322,7 @@
       "label": "function",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "function",
       "insertText": "function ",
       "insertTextFormat": "Snippet"
@@ -331,7 +331,7 @@
       "label": "let",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "let",
       "insertText": "let",
       "insertTextFormat": "Snippet"
@@ -340,7 +340,7 @@
       "label": "typeof",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "typeof",
       "insertText": "typeof ",
       "insertTextFormat": "Snippet"
@@ -349,7 +349,7 @@
       "label": "trap",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "trap",
       "insertText": "trap",
       "insertTextFormat": "Snippet"
@@ -358,7 +358,7 @@
       "label": "client",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "client",
       "insertText": "client ",
       "insertTextFormat": "Snippet"
@@ -367,7 +367,7 @@
       "label": "true",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "true",
       "insertText": "true",
       "insertTextFormat": "Snippet"
@@ -376,7 +376,7 @@
       "label": "false",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "false",
       "insertText": "false",
       "insertTextFormat": "Snippet"
@@ -385,7 +385,7 @@
       "label": "check",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "check",
       "insertText": "check ",
       "insertTextFormat": "Snippet"
@@ -394,7 +394,7 @@
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "checkpanic",
       "insertText": "checkpanic ",
       "insertTextFormat": "Snippet"
@@ -403,7 +403,7 @@
       "label": "is",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "is",
       "insertText": "is",
       "insertTextFormat": "Snippet"
@@ -412,7 +412,7 @@
       "label": "error constructor",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "T",
       "filterText": "error",
       "insertText": "error(\"${1}\")",
       "insertTextFormat": "Snippet"
@@ -421,7 +421,7 @@
       "label": "object constructor",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "T",
       "filterText": "object",
       "insertText": "object {${1}}",
       "insertTextFormat": "Snippet"
@@ -430,7 +430,7 @@
       "label": "base16",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "T",
       "filterText": "base16",
       "insertText": "base16 `${1}`",
       "insertTextFormat": "Snippet"
@@ -439,7 +439,7 @@
       "label": "base64",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "T",
       "filterText": "base64",
       "insertText": "base64 `${1}`",
       "insertTextFormat": "Snippet"
@@ -448,7 +448,7 @@
       "label": "from",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "from",
       "insertText": "from ",
       "insertTextFormat": "Snippet"
@@ -463,7 +463,7 @@
           "value": "**Package:** _._  \n  \n  \n"
         }
       },
-      "sortText": "Z",
+      "sortText": "ZD",
       "filterText": "main",
       "insertText": "main()",
       "insertTextFormat": "Snippet"
@@ -472,7 +472,7 @@
       "label": "Thread",
       "kind": "TypeParameter",
       "detail": "Union",
-      "sortText": "N",
+      "sortText": "R",
       "insertText": "Thread",
       "insertTextFormat": "Snippet"
     },
@@ -480,7 +480,7 @@
       "label": "TestRecord1",
       "kind": "Struct",
       "detail": "Record",
-      "sortText": "M",
+      "sortText": "Q",
       "insertText": "TestRecord1",
       "insertTextFormat": "Snippet"
     },
@@ -488,7 +488,7 @@
       "label": "TestMap3",
       "kind": "TypeParameter",
       "detail": "Map",
-      "sortText": "N",
+      "sortText": "R",
       "insertText": "TestMap3",
       "insertTextFormat": "Snippet"
     },
@@ -502,7 +502,7 @@
           "value": ""
         }
       },
-      "sortText": "B",
+      "sortText": "AB",
       "insertText": "TEST_CONST",
       "insertTextFormat": "Snippet"
     },
@@ -516,7 +516,7 @@
           "value": "**Package:** _._  \n  \n  \n  \n  \n**Return** `int`   \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "AC",
       "filterText": "getInt",
       "insertText": "getInt()",
       "insertTextFormat": "Snippet"
@@ -525,7 +525,7 @@
       "label": "TestMap1",
       "kind": "TypeParameter",
       "detail": "Map",
-      "sortText": "N",
+      "sortText": "R",
       "insertText": "TestMap1",
       "insertTextFormat": "Snippet"
     },
@@ -536,7 +536,7 @@
       "documentation": {
         "left": "Describes Strand execution details for the runtime.\n"
       },
-      "sortText": "M",
+      "sortText": "Q",
       "insertText": "StrandData",
       "insertTextFormat": "Snippet"
     },
@@ -544,7 +544,7 @@
       "label": "TestMap2",
       "kind": "TypeParameter",
       "detail": "Map",
-      "sortText": "N",
+      "sortText": "R",
       "insertText": "TestMap2",
       "insertTextFormat": "Snippet"
     },
@@ -608,7 +608,7 @@
       "label": "null",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "null",
       "insertText": "null",
       "insertTextFormat": "Snippet"

--- a/language-server/modules/langserver-core/src/test/resources/completion/typedesc_context/config/function_typedesc15b.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/typedesc_context/config/function_typedesc15b.json
@@ -9,7 +9,7 @@
       "label": "start",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "start",
       "insertText": "start ",
       "insertTextFormat": "Snippet"
@@ -18,7 +18,7 @@
       "label": "wait",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "wait",
       "insertText": "wait ",
       "insertTextFormat": "Snippet"
@@ -27,7 +27,7 @@
       "label": "flush",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "flush",
       "insertText": "flush ",
       "insertTextFormat": "Snippet"
@@ -36,7 +36,7 @@
       "label": "from clause",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "T",
       "filterText": "from",
       "insertText": "from ${1:var} ${2:item} in ${3}",
       "insertTextFormat": "Snippet"
@@ -45,7 +45,7 @@
       "label": "module1",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "O",
+      "sortText": "S",
       "filterText": "module1",
       "insertText": "module1",
       "insertTextFormat": "Snippet"
@@ -286,7 +286,7 @@
       "label": "service",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "service",
       "insertText": "service",
       "insertTextFormat": "Snippet"
@@ -295,7 +295,7 @@
       "label": "new",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "new",
       "insertText": "new ",
       "insertTextFormat": "Snippet"
@@ -304,7 +304,7 @@
       "label": "isolated",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "isolated",
       "insertText": "isolated ",
       "insertTextFormat": "Snippet"
@@ -313,7 +313,7 @@
       "label": "transactional",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "transactional",
       "insertText": "transactional",
       "insertTextFormat": "Snippet"
@@ -322,7 +322,7 @@
       "label": "function",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "function",
       "insertText": "function ",
       "insertTextFormat": "Snippet"
@@ -331,7 +331,7 @@
       "label": "let",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "let",
       "insertText": "let",
       "insertTextFormat": "Snippet"
@@ -340,7 +340,7 @@
       "label": "typeof",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "typeof",
       "insertText": "typeof ",
       "insertTextFormat": "Snippet"
@@ -349,7 +349,7 @@
       "label": "trap",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "trap",
       "insertText": "trap",
       "insertTextFormat": "Snippet"
@@ -358,7 +358,7 @@
       "label": "client",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "client",
       "insertText": "client ",
       "insertTextFormat": "Snippet"
@@ -367,7 +367,7 @@
       "label": "true",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "true",
       "insertText": "true",
       "insertTextFormat": "Snippet"
@@ -376,7 +376,7 @@
       "label": "false",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "false",
       "insertText": "false",
       "insertTextFormat": "Snippet"
@@ -385,7 +385,7 @@
       "label": "check",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "check",
       "insertText": "check ",
       "insertTextFormat": "Snippet"
@@ -394,7 +394,7 @@
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "checkpanic",
       "insertText": "checkpanic ",
       "insertTextFormat": "Snippet"
@@ -403,7 +403,7 @@
       "label": "is",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "is",
       "insertText": "is",
       "insertTextFormat": "Snippet"
@@ -412,7 +412,7 @@
       "label": "error constructor",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "T",
       "filterText": "error",
       "insertText": "error(\"${1}\")",
       "insertTextFormat": "Snippet"
@@ -421,7 +421,7 @@
       "label": "object constructor",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "T",
       "filterText": "object",
       "insertText": "object {${1}}",
       "insertTextFormat": "Snippet"
@@ -430,7 +430,7 @@
       "label": "base16",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "T",
       "filterText": "base16",
       "insertText": "base16 `${1}`",
       "insertTextFormat": "Snippet"
@@ -439,7 +439,7 @@
       "label": "base64",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "T",
       "filterText": "base64",
       "insertText": "base64 `${1}`",
       "insertTextFormat": "Snippet"
@@ -448,7 +448,7 @@
       "label": "from",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "from",
       "insertText": "from ",
       "insertTextFormat": "Snippet"
@@ -463,7 +463,7 @@
           "value": "**Package:** _._  \n  \n  \n"
         }
       },
-      "sortText": "Z",
+      "sortText": "ZD",
       "filterText": "main",
       "insertText": "main()",
       "insertTextFormat": "Snippet"
@@ -472,7 +472,7 @@
       "label": "Thread",
       "kind": "TypeParameter",
       "detail": "Union",
-      "sortText": "N",
+      "sortText": "R",
       "insertText": "Thread",
       "insertTextFormat": "Snippet"
     },
@@ -480,7 +480,7 @@
       "label": "TestRecord1",
       "kind": "Struct",
       "detail": "Record",
-      "sortText": "M",
+      "sortText": "Q",
       "insertText": "TestRecord1",
       "insertTextFormat": "Snippet"
     },
@@ -488,7 +488,7 @@
       "label": "TestMap3",
       "kind": "TypeParameter",
       "detail": "Map",
-      "sortText": "N",
+      "sortText": "R",
       "insertText": "TestMap3",
       "insertTextFormat": "Snippet"
     },
@@ -502,7 +502,7 @@
           "value": ""
         }
       },
-      "sortText": "B",
+      "sortText": "AB",
       "insertText": "TEST_CONST",
       "insertTextFormat": "Snippet"
     },
@@ -516,7 +516,7 @@
           "value": "**Package:** _._  \n  \n  \n  \n  \n**Return** `int`   \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "AC",
       "filterText": "getInt",
       "insertText": "getInt()",
       "insertTextFormat": "Snippet"
@@ -525,7 +525,7 @@
       "label": "TestMap1",
       "kind": "TypeParameter",
       "detail": "Map",
-      "sortText": "N",
+      "sortText": "R",
       "insertText": "TestMap1",
       "insertTextFormat": "Snippet"
     },
@@ -536,7 +536,7 @@
       "documentation": {
         "left": "Describes Strand execution details for the runtime.\n"
       },
-      "sortText": "M",
+      "sortText": "Q",
       "insertText": "StrandData",
       "insertTextFormat": "Snippet"
     },
@@ -544,7 +544,7 @@
       "label": "TestMap2",
       "kind": "TypeParameter",
       "detail": "Map",
-      "sortText": "N",
+      "sortText": "R",
       "insertText": "TestMap2",
       "insertTextFormat": "Snippet"
     },
@@ -608,7 +608,7 @@
       "label": "null",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "null",
       "insertText": "null",
       "insertTextFormat": "Snippet"

--- a/language-server/modules/langserver-core/src/test/resources/completion/typedesc_context/config/function_typedesc15c.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/typedesc_context/config/function_typedesc15c.json
@@ -15,7 +15,7 @@
           "value": ""
         }
       },
-      "sortText": "H",
+      "sortText": "L",
       "insertText": "ENUM1_FIELD1",
       "insertTextFormat": "Snippet"
     },
@@ -29,7 +29,7 @@
           "value": ""
         }
       },
-      "sortText": "C",
+      "sortText": "AC",
       "insertText": "TEST_INT_CONST1",
       "insertTextFormat": "Snippet"
     },
@@ -43,7 +43,7 @@
           "value": ""
         }
       },
-      "sortText": "C",
+      "sortText": "G",
       "insertText": "TEST_STRING_CONST1",
       "insertTextFormat": "Snippet"
     },
@@ -51,7 +51,7 @@
       "label": "AnnotationType",
       "kind": "Struct",
       "detail": "Record",
-      "sortText": "M",
+      "sortText": "Q",
       "insertText": "AnnotationType",
       "insertTextFormat": "Snippet"
     },
@@ -62,7 +62,7 @@
       "documentation": {
         "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
       },
-      "sortText": "I",
+      "sortText": "M",
       "insertText": "ResponseMessage",
       "insertTextFormat": "Snippet"
     },
@@ -73,7 +73,7 @@
       "documentation": {
         "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
       },
-      "sortText": "I",
+      "sortText": "M",
       "insertText": "RequestMessage",
       "insertTextFormat": "Snippet"
     },
@@ -81,7 +81,7 @@
       "label": "TestRecord1",
       "kind": "Struct",
       "detail": "Record",
-      "sortText": "M",
+      "sortText": "Q",
       "insertText": "TestRecord1",
       "insertTextFormat": "Snippet"
     },
@@ -89,7 +89,7 @@
       "label": "TestRecord2",
       "kind": "Struct",
       "detail": "Record",
-      "sortText": "M",
+      "sortText": "Q",
       "insertText": "TestRecord2",
       "insertTextFormat": "Snippet"
     },
@@ -97,7 +97,7 @@
       "label": "TestMap2",
       "kind": "TypeParameter",
       "detail": "Map",
-      "sortText": "N",
+      "sortText": "R",
       "insertText": "TestMap2",
       "insertTextFormat": "Snippet"
     },
@@ -105,7 +105,7 @@
       "label": "TestMap3",
       "kind": "TypeParameter",
       "detail": "Map",
-      "sortText": "N",
+      "sortText": "R",
       "insertText": "TestMap3",
       "insertTextFormat": "Snippet"
     },
@@ -113,7 +113,7 @@
       "label": "TestObject1",
       "kind": "Interface",
       "detail": "Object",
-      "sortText": "K",
+      "sortText": "O",
       "insertText": "TestObject1",
       "insertTextFormat": "Snippet"
     },
@@ -121,7 +121,7 @@
       "label": "ErrorOne",
       "kind": "Event",
       "detail": "Error",
-      "sortText": "L",
+      "sortText": "P",
       "insertText": "ErrorOne",
       "insertTextFormat": "Snippet"
     },
@@ -129,7 +129,7 @@
       "label": "ErrorTwo",
       "kind": "Event",
       "detail": "Error",
-      "sortText": "L",
+      "sortText": "P",
       "insertText": "ErrorTwo",
       "insertTextFormat": "Snippet"
     },
@@ -137,7 +137,7 @@
       "label": "Listener",
       "kind": "Interface",
       "detail": "Class",
-      "sortText": "K",
+      "sortText": "O",
       "insertText": "Listener",
       "insertTextFormat": "Snippet"
     },
@@ -148,7 +148,7 @@
       "documentation": {
         "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs."
       },
-      "sortText": "K",
+      "sortText": "O",
       "insertText": "Client",
       "insertTextFormat": "Snippet"
     },
@@ -159,7 +159,7 @@
       "documentation": {
         "left": "Represents a response.\n"
       },
-      "sortText": "K",
+      "sortText": "O",
       "insertText": "Response",
       "insertTextFormat": "Snippet"
     },
@@ -167,7 +167,7 @@
       "label": "TestClass1",
       "kind": "Interface",
       "detail": "Class",
-      "sortText": "K",
+      "sortText": "O",
       "insertText": "TestClass1",
       "insertTextFormat": "Snippet"
     },
@@ -175,7 +175,7 @@
       "label": "listener1",
       "kind": "Variable",
       "detail": "module1:Listener",
-      "sortText": "C",
+      "sortText": "G",
       "insertText": "listener1",
       "insertTextFormat": "Snippet"
     },
@@ -189,7 +189,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \n  \n"
         }
       },
-      "sortText": "A",
+      "sortText": "E",
       "filterText": "function1",
       "insertText": "function1()",
       "insertTextFormat": "Snippet"
@@ -204,7 +204,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function2  \n"
         }
       },
-      "sortText": "A",
+      "sortText": "E",
       "filterText": "function2",
       "insertText": "function2()",
       "insertTextFormat": "Snippet"
@@ -219,7 +219,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function3 with input parameters\n  \n**Params**  \n- `int` param1: param1 Parameter Description   \n- `int` param2: param2 Parameter Description  \n- `float[]` param3: param3 Parameter Description  \n  \n**Return** `int`   \n- Return Value Description  \n  \n"
         }
       },
-      "sortText": "A",
+      "sortText": "AA",
       "filterText": "function3",
       "insertText": "function3(${1})",
       "insertTextFormat": "Snippet",
@@ -238,7 +238,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function4 with input parameters\n  \n**Params**  \n- `int` param1: param1 Parameter Description   \n- `int` param2: param2 Parameter Description  \n- `string` param3: param3 Parameter Description(Defaultable)  \n- `float[]` param4: param4 Parameter Description"
         }
       },
-      "sortText": "A",
+      "sortText": "E",
       "filterText": "function4",
       "insertText": "function4(${1})",
       "insertTextFormat": "Snippet",
@@ -251,7 +251,7 @@
       "label": "TEST_FUTURE_INT",
       "kind": "Variable",
       "detail": "future<int>",
-      "sortText": "C",
+      "sortText": "G",
       "insertText": "TEST_FUTURE_INT",
       "insertTextFormat": "Snippet"
     },
@@ -259,7 +259,7 @@
       "label": "GLOBAL_VAR",
       "kind": "Variable",
       "detail": "int",
-      "sortText": "C",
+      "sortText": "AC",
       "insertText": "GLOBAL_VAR",
       "insertTextFormat": "Snippet"
     },
@@ -270,7 +270,7 @@
       "documentation": {
         "left": "Defines the possible client error types."
       },
-      "sortText": "L",
+      "sortText": "P",
       "insertText": "ClientError",
       "insertTextFormat": "Snippet"
     },
@@ -281,7 +281,7 @@
       "documentation": {
         "left": "The super type of all the types."
       },
-      "sortText": "N",
+      "sortText": "R",
       "insertText": "TargetType2",
       "insertTextFormat": "Snippet"
     },
@@ -292,7 +292,7 @@
       "documentation": {
         "left": "The types of data values that are expected by the `client` to return after the data binding operation."
       },
-      "sortText": "N",
+      "sortText": "R",
       "insertText": "TargetType",
       "insertTextFormat": "Snippet"
     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/typedesc_context/config/function_typedesc15d.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/typedesc_context/config/function_typedesc15d.json
@@ -15,7 +15,7 @@
           "value": ""
         }
       },
-      "sortText": "H",
+      "sortText": "L",
       "insertText": "ENUM1_FIELD1",
       "insertTextFormat": "Snippet"
     },
@@ -29,7 +29,7 @@
           "value": ""
         }
       },
-      "sortText": "C",
+      "sortText": "AC",
       "insertText": "TEST_INT_CONST1",
       "insertTextFormat": "Snippet"
     },
@@ -43,7 +43,7 @@
           "value": ""
         }
       },
-      "sortText": "C",
+      "sortText": "G",
       "insertText": "TEST_STRING_CONST1",
       "insertTextFormat": "Snippet"
     },
@@ -51,7 +51,7 @@
       "label": "AnnotationType",
       "kind": "Struct",
       "detail": "Record",
-      "sortText": "M",
+      "sortText": "Q",
       "insertText": "AnnotationType",
       "insertTextFormat": "Snippet"
     },
@@ -62,7 +62,7 @@
       "documentation": {
         "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
       },
-      "sortText": "I",
+      "sortText": "M",
       "insertText": "ResponseMessage",
       "insertTextFormat": "Snippet"
     },
@@ -73,7 +73,7 @@
       "documentation": {
         "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
       },
-      "sortText": "I",
+      "sortText": "M",
       "insertText": "RequestMessage",
       "insertTextFormat": "Snippet"
     },
@@ -81,7 +81,7 @@
       "label": "TestRecord1",
       "kind": "Struct",
       "detail": "Record",
-      "sortText": "M",
+      "sortText": "Q",
       "insertText": "TestRecord1",
       "insertTextFormat": "Snippet"
     },
@@ -89,7 +89,7 @@
       "label": "TestRecord2",
       "kind": "Struct",
       "detail": "Record",
-      "sortText": "M",
+      "sortText": "Q",
       "insertText": "TestRecord2",
       "insertTextFormat": "Snippet"
     },
@@ -97,7 +97,7 @@
       "label": "TestMap2",
       "kind": "TypeParameter",
       "detail": "Map",
-      "sortText": "N",
+      "sortText": "R",
       "insertText": "TestMap2",
       "insertTextFormat": "Snippet"
     },
@@ -105,7 +105,7 @@
       "label": "TestMap3",
       "kind": "TypeParameter",
       "detail": "Map",
-      "sortText": "N",
+      "sortText": "R",
       "insertText": "TestMap3",
       "insertTextFormat": "Snippet"
     },
@@ -113,7 +113,7 @@
       "label": "TestObject1",
       "kind": "Interface",
       "detail": "Object",
-      "sortText": "K",
+      "sortText": "O",
       "insertText": "TestObject1",
       "insertTextFormat": "Snippet"
     },
@@ -121,7 +121,7 @@
       "label": "ErrorOne",
       "kind": "Event",
       "detail": "Error",
-      "sortText": "L",
+      "sortText": "P",
       "insertText": "ErrorOne",
       "insertTextFormat": "Snippet"
     },
@@ -129,7 +129,7 @@
       "label": "ErrorTwo",
       "kind": "Event",
       "detail": "Error",
-      "sortText": "L",
+      "sortText": "P",
       "insertText": "ErrorTwo",
       "insertTextFormat": "Snippet"
     },
@@ -137,7 +137,7 @@
       "label": "Listener",
       "kind": "Interface",
       "detail": "Class",
-      "sortText": "K",
+      "sortText": "O",
       "insertText": "Listener",
       "insertTextFormat": "Snippet"
     },
@@ -148,7 +148,7 @@
       "documentation": {
         "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs."
       },
-      "sortText": "K",
+      "sortText": "O",
       "insertText": "Client",
       "insertTextFormat": "Snippet"
     },
@@ -159,7 +159,7 @@
       "documentation": {
         "left": "Represents a response.\n"
       },
-      "sortText": "K",
+      "sortText": "O",
       "insertText": "Response",
       "insertTextFormat": "Snippet"
     },
@@ -167,7 +167,7 @@
       "label": "TestClass1",
       "kind": "Interface",
       "detail": "Class",
-      "sortText": "K",
+      "sortText": "O",
       "insertText": "TestClass1",
       "insertTextFormat": "Snippet"
     },
@@ -175,7 +175,7 @@
       "label": "listener1",
       "kind": "Variable",
       "detail": "module1:Listener",
-      "sortText": "C",
+      "sortText": "G",
       "insertText": "listener1",
       "insertTextFormat": "Snippet"
     },
@@ -189,7 +189,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \n  \n"
         }
       },
-      "sortText": "A",
+      "sortText": "E",
       "filterText": "function1",
       "insertText": "function1()",
       "insertTextFormat": "Snippet"
@@ -204,7 +204,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function2  \n"
         }
       },
-      "sortText": "A",
+      "sortText": "E",
       "filterText": "function2",
       "insertText": "function2()",
       "insertTextFormat": "Snippet"
@@ -219,7 +219,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function3 with input parameters\n  \n**Params**  \n- `int` param1: param1 Parameter Description   \n- `int` param2: param2 Parameter Description  \n- `float[]` param3: param3 Parameter Description  \n  \n**Return** `int`   \n- Return Value Description  \n  \n"
         }
       },
-      "sortText": "A",
+      "sortText": "AA",
       "filterText": "function3",
       "insertText": "function3(${1})",
       "insertTextFormat": "Snippet",
@@ -238,7 +238,7 @@
           "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function4 with input parameters\n  \n**Params**  \n- `int` param1: param1 Parameter Description   \n- `int` param2: param2 Parameter Description  \n- `string` param3: param3 Parameter Description(Defaultable)  \n- `float[]` param4: param4 Parameter Description"
         }
       },
-      "sortText": "A",
+      "sortText": "E",
       "filterText": "function4",
       "insertText": "function4(${1})",
       "insertTextFormat": "Snippet",
@@ -251,7 +251,7 @@
       "label": "TEST_FUTURE_INT",
       "kind": "Variable",
       "detail": "future<int>",
-      "sortText": "C",
+      "sortText": "G",
       "insertText": "TEST_FUTURE_INT",
       "insertTextFormat": "Snippet"
     },
@@ -259,7 +259,7 @@
       "label": "GLOBAL_VAR",
       "kind": "Variable",
       "detail": "int",
-      "sortText": "C",
+      "sortText": "AC",
       "insertText": "GLOBAL_VAR",
       "insertTextFormat": "Snippet"
     },
@@ -270,7 +270,7 @@
       "documentation": {
         "left": "Defines the possible client error types."
       },
-      "sortText": "L",
+      "sortText": "P",
       "insertText": "ClientError",
       "insertTextFormat": "Snippet"
     },
@@ -281,7 +281,7 @@
       "documentation": {
         "left": "The super type of all the types."
       },
-      "sortText": "N",
+      "sortText": "R",
       "insertText": "TargetType2",
       "insertTextFormat": "Snippet"
     },
@@ -292,7 +292,7 @@
       "documentation": {
         "left": "The types of data values that are expected by the `client` to return after the data binding operation."
       },
-      "sortText": "N",
+      "sortText": "R",
       "insertText": "TargetType",
       "insertTextFormat": "Snippet"
     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/var_def_ctx_config20.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/var_def_ctx_config20.json
@@ -574,25 +574,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "getStr",
-      "kind": "Variable",
-      "detail": "string",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n**Params**  \n- `int` a  \n  \n**Return** `string`   \n  \n"
-        }
-      },
-      "sortText": "F",
-      "filterText": "getStr",
-      "insertText": "getStr",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
       "label": "getStr(int a)",
       "kind": "Function",
       "detail": "string",
@@ -610,21 +591,6 @@
         "title": "editor.action.triggerParameterHints",
         "command": "editor.action.triggerParameterHints"
       }
-    },
-    {
-      "label": "main",
-      "kind": "Variable",
-      "detail": "error?",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n  \n**Return** `error?`   \n  \n"
-        }
-      },
-      "sortText": "F",
-      "filterText": "main",
-      "insertText": "main",
-      "insertTextFormat": "Snippet"
     },
     {
       "label": "main()",
@@ -669,21 +635,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "getInt",
-      "kind": "Variable",
-      "detail": "int",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n  \n**Return** `int`   \n  \n"
-        }
-      },
-      "sortText": "F",
-      "filterText": "getInt",
-      "insertText": "getInt",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "getInt()",
       "kind": "Function",
       "detail": "int",
@@ -696,21 +647,6 @@
       "sortText": "AC",
       "filterText": "getInt",
       "insertText": "getInt()",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "getStr2",
-      "kind": "Variable",
-      "detail": "string",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n  \n**Return** `string`   \n  \n"
-        }
-      },
-      "sortText": "F",
-      "filterText": "getStr2",
-      "insertText": "getStr2",
       "insertTextFormat": "Snippet"
     },
     {
@@ -782,15 +718,6 @@
       "detail": "type",
       "sortText": "R",
       "insertText": "byte",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "function (..) {..}",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "T",
-      "filterText": "function",
-      "insertText": "function (int i) returns string {\n    return \"\";\n}",
       "insertTextFormat": "Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/var_def_ctx_config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/var_def_ctx_config7.json
@@ -567,24 +567,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "new(int field1, int field2)",
-      "kind": "Function",
-      "detail": "()",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \n  \n**Params**  \n- `int` field1  \n- `int` field2"
-        }
-      },
-      "sortText": "AC",
-      "insertText": "new(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
       "label": "null",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/var_def_in_obj_constructor_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/var_def_in_obj_constructor_config1.json
@@ -623,20 +623,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "new()",
-      "kind": "Function",
-      "detail": "()",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n"
-        }
-      },
-      "sortText": "C",
-      "insertText": "new()",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "test/project2",
       "kind": "Module",
       "detail": "Module",


### PR DESCRIPTION
## Purpose
This PR fixes the failing LS testcases after replacing contextTypeResolver with expectedType API.

Fixes #38546

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
