### PR TITLE
Handle bad sad error for test command with --native flag when GraalVM is not installed

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunNativeImageTestTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunNativeImageTestTask.java
@@ -258,7 +258,6 @@ public class RunNativeImageTestTask implements Task {
             throw createLauncherException(e.getMessage());
         }
 
-
         if (coverage) {
             // Generate the exec in a separate process
             List<String> execArgs = new ArrayList<>();

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunNativeImageTestTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunNativeImageTestTask.java
@@ -241,18 +241,23 @@ public class RunNativeImageTestTask implements Task {
         String jacocoAgentJarPath = "";
         String nativeImageCommand = System.getenv("GRAALVM_HOME");
 
-        if (nativeImageCommand == null) {
-            throw new ProjectException("GraalVM installation directory not found. Set GRAALVM_HOME as an " +
-                    "environment variable");
-        }
-        nativeImageCommand += File.separator + BIN_DIR_NAME + File.separator
-                + (OS.contains("win") ? "native-image.cmd" : "native-image");
+        try {
+            if (nativeImageCommand == null) {
+                throw new ProjectException("GraalVM installation directory not found. Set GRAALVM_HOME as an " +
+                        "environment variable");
+            }
+            nativeImageCommand += File.separator + BIN_DIR_NAME + File.separator
+                    + (OS.contains("win") ? "native-image.cmd" : "native-image");
 
-        File commandExecutable = Paths.get(nativeImageCommand).toFile();
-        if (!commandExecutable.exists()) {
-            throw new ProjectException("Cannot find '" + commandExecutable.getName() + "' in the GRAALVM_HOME. " +
-                    "Install it using: gu install native-image");
+            File commandExecutable = Paths.get(nativeImageCommand).toFile();
+            if (!commandExecutable.exists()) {
+                throw new ProjectException("Cannot find '" + commandExecutable.getName() + "' in the GRAALVM_HOME. " +
+                        "Install it using: gu install native-image");
+            }
+        } catch (ProjectException e) {
+            throw createLauncherException(e.getMessage());
         }
+
 
         if (coverage) {
             // Generate the exec in a separate process


### PR DESCRIPTION
## Purpose
> $Subject

Fixes #38795

## Approach
> Throw a Project exception instead of a bad sad error. 

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
