### PR TITLE
Add empty project validation to `run` and `test` commands

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PackCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PackCommand.java
@@ -10,12 +10,11 @@ import io.ballerina.cli.task.ResolveMavenDependenciesTask;
 import io.ballerina.cli.utils.BuildTime;
 import io.ballerina.cli.utils.FileUtils;
 import io.ballerina.projects.BuildOptions;
-import io.ballerina.projects.Module;
-import io.ballerina.projects.ModuleId;
 import io.ballerina.projects.Project;
 import io.ballerina.projects.ProjectException;
 import io.ballerina.projects.directory.BuildProject;
 import io.ballerina.projects.util.ProjectConstants;
+import io.ballerina.projects.util.ProjectUtils;
 import io.ballerina.toml.semantic.TomlType;
 import io.ballerina.toml.semantic.ast.TomlTableNode;
 import org.ballerinalang.toml.exceptions.SettingsTomlException;
@@ -42,8 +41,8 @@ public class PackCommand implements BLauncherCmd {
 
     private final PrintStream outStream;
     private final PrintStream errStream;
-    private boolean exitWhenFinish;
-    private boolean skipCopyLibsFromDist;
+    private final boolean exitWhenFinish;
+    private final boolean skipCopyLibsFromDist;
 
     @CommandLine.Option(names = {"--offline"}, description = "Build/Compile offline without downloading " +
             "dependencies.")
@@ -156,7 +155,7 @@ public class PackCommand implements BLauncherCmd {
         }
 
         // If project is empty
-        if (isProjectEmpty(project) && project.currentPackage().compilerPluginToml().isEmpty()) {
+        if (ProjectUtils.isProjectEmpty(project) && project.currentPackage().compilerPluginToml().isEmpty()) {
             CommandUtil.printError(this.errStream, "package is empty. Please add at least one .bal file.", null,
                         false);
             CommandUtil.exitError(this.exitWhenFinish);
@@ -272,16 +271,6 @@ public class PackCommand implements BLauncherCmd {
         }
 
         return buildOptionsBuilder.build();
-    }
-
-    private boolean isProjectEmpty(Project project) {
-        for (ModuleId moduleId : project.currentPackage().moduleIds()) {
-            Module module = project.currentPackage().module(moduleId);
-            if (!module.documentIds().isEmpty() || !module.testDocumentIds().isEmpty()) {
-                return false;
-            }
-        }
-        return true;
     }
 
     @Override

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/RunCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/RunCommand.java
@@ -31,6 +31,7 @@ import io.ballerina.projects.ProjectException;
 import io.ballerina.projects.directory.BuildProject;
 import io.ballerina.projects.directory.SingleFileProject;
 import io.ballerina.projects.util.ProjectConstants;
+import io.ballerina.projects.util.ProjectUtils;
 import picocli.CommandLine;
 
 import java.io.PrintStream;
@@ -194,6 +195,13 @@ public class RunCommand implements BLauncherCmd {
                 CommandUtil.exitError(this.exitWhenFinish);
                 return;
             }
+        }
+
+        // If project is empty
+        if (ProjectUtils.isProjectEmpty(project)) {
+            CommandUtil.printError(this.errStream, "package is empty. Please add at least one .bal file.", null, false);
+            CommandUtil.exitError(this.exitWhenFinish);
+            return;
         }
 
         // Check package files are modified after last build

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/TestCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/TestCommand.java
@@ -34,6 +34,7 @@ import io.ballerina.projects.ProjectException;
 import io.ballerina.projects.directory.BuildProject;
 import io.ballerina.projects.directory.SingleFileProject;
 import io.ballerina.projects.util.ProjectConstants;
+import io.ballerina.projects.util.ProjectUtils;
 import picocli.CommandLine;
 
 import java.io.PrintStream;
@@ -242,6 +243,13 @@ public class TestCommand implements BLauncherCmd {
                 CommandUtil.exitError(this.exitWhenFinish);
                 return;
             }
+        }
+
+        // If project is empty
+        if (ProjectUtils.isProjectEmpty(project)) {
+            CommandUtil.printError(this.errStream, "package is empty. Please add at least one .bal file.", null, false);
+            CommandUtil.exitError(this.exitWhenFinish);
+            return;
         }
 
         // Sets the debug port as a system property, which will be used when setting up debug args before running tests.

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/RunCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/RunCommandTest.java
@@ -65,7 +65,7 @@ public class RunCommandTest extends BaseCommandTest {
         RunCommand runCommand = new RunCommand(validBalFilePath, printStream, false);
         // name of the file as argument
         new CommandLine(runCommand).setEndOfOptionsDelimiter("").setUnmatchedOptionsArePositionalParams(true)
-                .parse(validBalFilePath.toString(), "--", tempFile.toString());
+                .parseArgs(validBalFilePath.toString(), "--", tempFile.toString());
 
         Assert.assertFalse(tempFile.toFile().exists());
         runCommand.execute();
@@ -84,11 +84,11 @@ public class RunCommandTest extends BaseCommandTest {
         Path validBalFilePath = this.testResources.resolve("valid-run-bal-file").resolve("xyz.bal");
         RunCommand runCommand = new RunCommand(validBalFilePath, printStream, false);
         // non existing bal file
-        new CommandLine(runCommand).parse(validBalFilePath.toString());
+        new CommandLine(runCommand).parseArgs(validBalFilePath.toString());
         runCommand.execute();
         String buildLog = readOutput(true);
         Assert.assertTrue(buildLog.replaceAll("\r", "")
-                .contains("The file does not exist: " + validBalFilePath.toString()));
+                .contains("The file does not exist: " + validBalFilePath));
 
     }
 
@@ -98,7 +98,7 @@ public class RunCommandTest extends BaseCommandTest {
         Path balFilePath = this.testResources.resolve("bal-file-with-syntax-error").resolve("hello_world.bal");
         RunCommand runCommand = new RunCommand(balFilePath, printStream, false);
         // non existing bal file
-        new CommandLine(runCommand).parse(balFilePath.toString());
+        new CommandLine(runCommand).parseArgs(balFilePath.toString());
         try {
             runCommand.execute();
         } catch (BLauncherException e) {
@@ -112,7 +112,7 @@ public class RunCommandTest extends BaseCommandTest {
         Path balFilePath = this.testResources.resolve("bal-project-with-syntax-error");
         RunCommand runCommand = new RunCommand(balFilePath, printStream, false);
         // non existing bal file
-        new CommandLine(runCommand).parse(balFilePath.toString());
+        new CommandLine(runCommand).parseArgs(balFilePath.toString());
         try {
             runCommand.execute();
         } catch (BLauncherException e) {
@@ -129,7 +129,7 @@ public class RunCommandTest extends BaseCommandTest {
         RunCommand runCommand = new RunCommand(projectPath, printStream, false);
         // name of the file as argument
         new CommandLine(runCommand).setEndOfOptionsDelimiter("").setUnmatchedOptionsArePositionalParams(true)
-                .parse(projectPath.toString(), "--", tempFile.toString());
+                .parseArgs(projectPath.toString(), "--", tempFile.toString());
 
         Assert.assertFalse(tempFile.toFile().exists());
         runCommand.execute();
@@ -148,7 +148,7 @@ public class RunCommandTest extends BaseCommandTest {
         RunCommand runCommand = new RunCommand(projectPath, printStream, false);
         // name of the file as argument
         new CommandLine(runCommand).setEndOfOptionsDelimiter("").setUnmatchedOptionsArePositionalParams(true)
-                .parse("--", tempFile.toString());
+                .parseArgs("--", tempFile.toString());
 
         Assert.assertFalse(tempFile.toFile().exists());
         runCommand.execute();
@@ -167,7 +167,7 @@ public class RunCommandTest extends BaseCommandTest {
         RunCommand runCommand = new RunCommand(projectPath, printStream, false);
         // name of the file as argument
         new CommandLine(runCommand).setEndOfOptionsDelimiter("").setUnmatchedOptionsArePositionalParams(true)
-                .parse(projectPath.toString(), tempFile.toString());
+                .parseArgs(projectPath.toString(), tempFile.toString());
         try {
             runCommand.execute();
         } catch (BLauncherException e) {
@@ -181,7 +181,7 @@ public class RunCommandTest extends BaseCommandTest {
         // set valid source root
         RunCommand runCommand = new RunCommand(projectPath, printStream, false);
         // name of the file as argument
-        new CommandLine(runCommand).parse(projectPath.toString());
+        new CommandLine(runCommand).parseArgs(projectPath.toString());
 
         // No assertions required since the command will fail upon expected behavior
         runCommand.execute();
@@ -203,7 +203,7 @@ public class RunCommandTest extends BaseCommandTest {
 
         String args = "--offline";
         new CommandLine(runCommand).setEndOfOptionsDelimiter("").setUnmatchedOptionsArePositionalParams(true)
-                .parse(projectPath.toString(), args, tempFile.toString());
+                .parseArgs(projectPath.toString(), args, tempFile.toString());
 
         try {
             runCommand.execute();
@@ -256,7 +256,7 @@ public class RunCommandTest extends BaseCommandTest {
         System.setProperty("user.dir", String.valueOf(projectPath));
         // set valid source root
         RunCommand runCommand = new RunCommand(projectPath, printStream, false);
-        new CommandLine(runCommand).parse();
+        new CommandLine(runCommand).parseArgs();
         runCommand.execute();
     }
 
@@ -309,5 +309,18 @@ public class RunCommandTest extends BaseCommandTest {
                 .resolve("foo-package_a-0.1.0.jar").toFile().exists());
 
         ProjectUtils.deleteDirectory(projectPath.resolve("target"));
+    }
+
+    @Test(description = "Run an empty package")
+    public void testRunEmptyPackage() throws IOException {
+        Path projectPath = this.testResources.resolve("emptyPackage");
+        System.setProperty("user.dir", projectPath.toString());
+
+        RunCommand runCommand = new RunCommand(projectPath, printStream, false);
+        new CommandLine(runCommand).parseArgs();
+        runCommand.execute();
+
+        String buildLog = readOutput(true);
+        Assert.assertEquals(buildLog.replaceAll("\r", ""), getOutput("build-empty-package.txt"));
     }
 }

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/TestCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/TestCommandTest.java
@@ -91,7 +91,7 @@ public class TestCommandTest extends BaseCommandTest {
         // set valid source root
         TestCommand testCommand = new TestCommand(validBalFilePath, false);
         // name of the file as argument
-        new CommandLine(testCommand).parse(validBalFilePath.toString());
+        new CommandLine(testCommand).parseArgs(validBalFilePath.toString());
         testCommand.execute();
     }
 
@@ -103,7 +103,7 @@ public class TestCommandTest extends BaseCommandTest {
         // set valid source root
         TestCommand testCommand = new TestCommand(validBalFilePath, false);
         // name of the file as argument
-        new CommandLine(testCommand).parse(validBalFilePath.toString());
+        new CommandLine(testCommand).parseArgs(validBalFilePath.toString());
         testCommand.execute();
     }
 
@@ -111,12 +111,12 @@ public class TestCommandTest extends BaseCommandTest {
     public void testNonBalFileTest() throws IOException {
         Path nonBalFilePath = this.testResources.resolve("non-bal-file").resolve("hello_world.txt");
         TestCommand testCommand = new TestCommand(nonBalFilePath, printStream, printStream, false);
-        new CommandLine(testCommand).parse(nonBalFilePath.toString());
+        new CommandLine(testCommand).parseArgs(nonBalFilePath.toString());
         testCommand.execute();
 
         String buildLog = readOutput(true);
         Assert.assertTrue(buildLog.replaceAll("\r", "")
-                .contains("Invalid Ballerina source file(.bal): " + nonBalFilePath.toString()));
+                .contains("Invalid Ballerina source file(.bal): " + nonBalFilePath));
     }
 
     @Test(description = "Test non existing bal file")
@@ -125,11 +125,11 @@ public class TestCommandTest extends BaseCommandTest {
         Path validBalFilePath = this.testResources.resolve("valid-non-bal-file").resolve("xyz.bal");
         TestCommand testCommand = new TestCommand(validBalFilePath, printStream, printStream, false);
         // non existing bal file
-        new CommandLine(testCommand).parse(validBalFilePath.toString());
+        new CommandLine(testCommand).parseArgs(validBalFilePath.toString());
         testCommand.execute();
         String buildLog = readOutput(true);
         Assert.assertTrue(buildLog.replaceAll("\r", "")
-                .contains("The file does not exist: " + validBalFilePath.toString()));
+                .contains("The file does not exist: " + validBalFilePath));
 
     }
 
@@ -139,7 +139,7 @@ public class TestCommandTest extends BaseCommandTest {
         Path balFilePath = this.testResources.resolve("bal-file-with-syntax-error").resolve("sample_tests.bal");
         TestCommand testCommand = new TestCommand(balFilePath, printStream, printStream, false);
         // non existing bal file
-        new CommandLine(testCommand).parse(balFilePath.toString());
+        new CommandLine(testCommand).parseArgs(balFilePath.toString());
         try {
             testCommand.execute();
         } catch (BLauncherException e) {
@@ -153,7 +153,7 @@ public class TestCommandTest extends BaseCommandTest {
         System.setProperty(ProjectConstants.USER_DIR, projectPath.toString());
         TestCommand testCommand = new TestCommand(projectPath, printStream, printStream, false);
         // non existing bal file
-        new CommandLine(testCommand).parse();
+        new CommandLine(testCommand).parseArgs();
         testCommand.execute();
         String buildLog = readOutput(true);
         Assert.assertEquals(buildLog.replaceAll("\r", ""), getOutput("test-project.txt"));
@@ -165,7 +165,7 @@ public class TestCommandTest extends BaseCommandTest {
         System.setProperty(ProjectConstants.USER_DIR, projectPath.toString());
         TestCommand testCommand = new TestCommand(projectPath, printStream, printStream, false);
         // non existing bal file
-        new CommandLine(testCommand).parse();
+        new CommandLine(testCommand).parseArgs();
         testCommand.execute();
     }
 
@@ -174,7 +174,7 @@ public class TestCommandTest extends BaseCommandTest {
         Path projectPath = this.testResources.resolve("validProjectWithTests");
         TestCommand buildCommand = new TestCommand(projectPath, printStream, printStream, false);
         // non existing bal file
-        new CommandLine(buildCommand).parse(projectPath.toString());
+        new CommandLine(buildCommand).parseArgs(projectPath.toString());
         buildCommand.execute();
         String buildLog = readOutput(true);
         Assert.assertEquals(buildLog.replaceAll("\r", ""), getOutput("test-project.txt"));
@@ -185,7 +185,7 @@ public class TestCommandTest extends BaseCommandTest {
         Path projectPath = this.testResources.resolve("oom-project");
         System.setProperty(ProjectConstants.USER_DIR, projectPath.toString());
         TestCommand testCommand = new TestCommand(projectPath, printStream, printStream, false);
-        new CommandLine(testCommand).parse();
+        new CommandLine(testCommand).parseArgs();
 
         try {
             testCommand.execute();
@@ -202,7 +202,7 @@ public class TestCommandTest extends BaseCommandTest {
         System.setProperty(ProjectConstants.USER_DIR, projectPath.toString());
         // build the project
         BuildCommand buildCommand = new BuildCommand(projectPath, printStream, printStream, true , false);
-        new CommandLine(buildCommand).parse();
+        new CommandLine(buildCommand).parseArgs();
         buildCommand.execute();
         Assert.assertTrue(projectPath.resolve("target").resolve("bin").resolve("winery.jar").toFile().exists());
         String md5BinJar = DigestUtils.md5Hex(
@@ -210,7 +210,7 @@ public class TestCommandTest extends BaseCommandTest {
 
         // Run tests
         TestCommand testCommand = new TestCommand(projectPath, printStream, printStream, false);
-        new CommandLine(testCommand).parse();
+        new CommandLine(testCommand).parseArgs();
         testCommand.execute();
         Assert.assertTrue(projectPath.resolve("target").resolve("bin").resolve("winery.jar").toFile().exists());
         Assert.assertEquals(md5BinJar, DigestUtils.md5Hex(
@@ -229,7 +229,7 @@ public class TestCommandTest extends BaseCommandTest {
         TestCommand testCommand = new TestCommand(
                 projectPath, printStream, printStream, false, false, true, "html");
 
-        new CommandLine(testCommand).parse();
+        new CommandLine(testCommand).parseArgs();
         testCommand.execute();
         String buildLog = readOutput(true);
         Assert.assertTrue(buildLog.contains("unsupported coverage report format 'html' found. Only 'xml' format is " +
@@ -245,7 +245,7 @@ public class TestCommandTest extends BaseCommandTest {
         TestCommand testCommand = new TestCommand(
                 projectPath, printStream, printStream, false, true,
                 customTargetDir);
-        new CommandLine(testCommand).parse();
+        new CommandLine(testCommand).parseArgs();
         testCommand.execute();
 
         Assert.assertFalse(Files.exists(customTargetDir.resolve("bin")));
@@ -272,7 +272,7 @@ public class TestCommandTest extends BaseCommandTest {
 
         // Run bal test command
         TestCommand firstTestCommand = new TestCommand(projectPath, printStream, printStream, false);
-        new CommandLine(firstTestCommand).parse();
+        new CommandLine(firstTestCommand).parseArgs();
         firstTestCommand.execute();
         String buildLog = readOutput(true);
         Assert.assertEquals(buildLog.replaceAll("\r", ""), getOutput("bal-test-project.txt"));
@@ -289,7 +289,7 @@ public class TestCommandTest extends BaseCommandTest {
 
         // Run bal test command with sticky flag
         TestCommand secondTestCommand = new TestCommand(projectPath, printStream, printStream, false);
-        new CommandLine(secondTestCommand).parse("--sticky");
+        new CommandLine(secondTestCommand).parseArgs("--sticky");
         secondTestCommand.execute();
         String secondBuildLog = readOutput(true);
         Assert.assertEquals(secondBuildLog.replaceAll("\r", ""), getOutput("bal-test-project.txt"));
@@ -344,6 +344,19 @@ public class TestCommandTest extends BaseCommandTest {
                 .resolve("foo-package_a-0.1.0.jar").toFile().exists());
 
         ProjectUtils.deleteDirectory(projectPath.resolve("target"));
+    }
+
+    @Test(description = "Test an empty package")
+    public void testTestEmptyPackage() throws IOException {
+        Path projectPath = this.testResources.resolve("emptyPackage");
+        System.setProperty("user.dir", projectPath.toString());
+
+        TestCommand testCommand = new TestCommand(projectPath, printStream, printStream, false);
+        new CommandLine(testCommand).parseArgs();
+        testCommand.execute();
+
+        String buildLog = readOutput(true);
+        Assert.assertEquals(buildLog.replaceAll("\r", ""), getOutput("build-empty-package.txt"));
     }
 
     static class Copy extends SimpleFileVisitor<Path> {


### PR DESCRIPTION
## Purpose
$ subject

Fixes #36490

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
Additional refactoring was done for `PackCommand`, `TestCommandTest`, `RunCommandTest` classes.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
