### PR TITLE
Fix JSON to Record conversion failure with Ballerina identifier incompatible field names

### DIFF
--- a/misc/json-to-record-converter/src/test/java/io/ballerina/jsonmapper/JsonToRecordMapperTests.java
+++ b/misc/json-to-record-converter/src/test/java/io/ballerina/jsonmapper/JsonToRecordMapperTests.java
@@ -65,6 +65,8 @@ public class JsonToRecordMapperTests {
             .resolve("sample_3_person.bal");
     private final Path sample3PersonTypeDescBal = RES_DIR.resolve("ballerina")
             .resolve("sample_3_person_type_desc.bal");
+    private final Path sample3SpecialCharBal = RES_DIR.resolve("ballerina")
+            .resolve("sample_3_special_char.bal");
 
     private final Path sample4Json = RES_DIR.resolve("json")
             .resolve("sample_4.json");
@@ -330,6 +332,15 @@ public class JsonToRecordMapperTests {
         String generatedCodeBlock = JsonToRecordMapper.convert(jsonFileContent, "Person", true, false, false)
                 .getCodeBlock().replaceAll("\\s+", "");
         String expectedCodeBlock = Files.readString(sample3PersonTypeDescBal).replaceAll("\\s+", "");
+        Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
+    }
+
+    @Test(description = "Test for JSON with user defined record name with special chars")
+    public void testForUserDefinedRecordNameWithSpecialChars() throws IOException {
+        String jsonFileContent = Files.readString(sample3Json);
+        String generatedCodeBlock = JsonToRecordMapper.convert(jsonFileContent, "Special Person", false, false, false)
+                .getCodeBlock().replaceAll("\\s+", "");
+        String expectedCodeBlock = Files.readString(sample3SpecialCharBal).replaceAll("\\s+", "");
         Assert.assertEquals(generatedCodeBlock, expectedCodeBlock);
     }
 

--- a/misc/json-to-record-converter/src/test/resources/ballerina/sample_11.bal
+++ b/misc/json-to-record-converter/src/test/resources/ballerina/sample_11.bal
@@ -1,7 +1,21 @@
+type Special\ object record {
+    string name;
+    int age;
+};
+
+type Special\\array\-\?Item record {
+    string date;
+    int value;
+    string 'type?;
+    string[] \2\ favourite\-colors?;
+};
+
 type NewRecord record {
     string first\ Name;
     string last\+Name\?;
     string \007;
     int ϼ\ \+\-\+;
     boolean ōŊĖ;
+    Special\ object special\ object;
+    (Special\\array\-\?Item[]|Special\\array\-\?Item[][])[] special\\array\-\?;
 };

--- a/misc/json-to-record-converter/src/test/resources/ballerina/sample_3_special_char.bal
+++ b/misc/json-to-record-converter/src/test/resources/ballerina/sample_3_special_char.bal
@@ -1,0 +1,21 @@
+type Address record {
+    (int|string) streetAddress;
+    string city;
+    string state;
+};
+
+type Friend record {
+    string firstName;
+    string lastName;
+    Address address;
+};
+
+type Special\ Person record {
+    string firstName;
+    string lastName;
+    string gender;
+    int age;
+    Address address;
+    anydata phoneNumber;
+    Friend friend;
+};

--- a/misc/json-to-record-converter/src/test/resources/ballerina/sample_9.bal
+++ b/misc/json-to-record-converter/src/test/resources/ballerina/sample_9.bal
@@ -11,6 +11,13 @@ type Batters record {
 type ToppingItem record {
     string id;
     string 'type;
+    string color?;
+};
+
+type BaseItem record {
+    string id;
+    string 'type;
+    string color?;
 };
 
 type NewRecord record {
@@ -20,4 +27,5 @@ type NewRecord record {
     decimal ppu;
     Batters batters;
     (ToppingItem|string|ToppingItem[]|string[])[] topping;
+    BaseItem[][] base;
 };

--- a/misc/json-to-record-converter/src/test/resources/ballerina/sample_9_type_desc.bal
+++ b/misc/json-to-record-converter/src/test/resources/ballerina/sample_9_type_desc.bal
@@ -4,5 +4,6 @@ type NewRecord record {
     string name;
     decimal ppu;
     record {(decimal|int|record {string id; string 'type; boolean fresh?;}|string)[] batter;} batters;
-    (record {string id; string 'type;}|string|record {string id;string 'type;}[]|string[])[] topping;
+    (record {string id; string 'type; string color?;}|string|record {string id; string 'type; string color?;}[]|string[])[] topping;
+    record {stringid ; string 'type; stringcolor? ;}[][] base;
 };

--- a/misc/json-to-record-converter/src/test/resources/json/sample_11.json
+++ b/misc/json-to-record-converter/src/test/resources/json/sample_11.json
@@ -3,5 +3,33 @@
   "last+Name?": "Root",
   "007": "James Bond",
   "\\u{03FC} +-+": 123,
-  "ōŊĖ": false
+  "ōŊĖ": false,
+  "special object": {
+    "name": "Special",
+    "age": 100
+  },
+  "special\\array-?": [
+    [
+      {
+        "date": "2022-01-01",
+        "value": 2504,
+        "type": "None"
+      }
+    ],
+    [
+      {
+        "date": "2022-01-01",
+        "value": 2504
+      }
+    ],
+    [
+      [
+        {
+          "date": "2022-01-01",
+          "value": 2504,
+          "2 favourite-colors": ["Red", "Green"]
+        }
+      ]
+    ]
+  ]
 }

--- a/misc/json-to-record-converter/src/test/resources/json/sample_9.json
+++ b/misc/json-to-record-converter/src/test/resources/json/sample_9.json
@@ -23,10 +23,18 @@
     { "id": "5003", "type": "Chocolate" },
     { "id": "5004", "type": "Maple" },
     [
-      { "id": "5001", "type": "None" },
+      { "id": "5001", "type": "None", "color": "Red" },
       { "id": "5002", "type": "Glazed" }
     ],
     ["Chocolate", "Milk"],
     "Vanilla"
+  ],
+  "base": [
+    [
+      { "id": "1000", "type": "None" }
+    ],
+    [
+      { "id": "1001", "type": "None", "color": "Blue" }
+    ]
   ]
 }


### PR DESCRIPTION
## Purpose
> This PR addresses the following issues in the JSON to record converter tool
- JSON to record converter tool crashes when a provided JSON string contains array or object fields with the filed names that are Ballerina identifier incompatible.
- JSON to record converter tool crashes when a provided JSON string contains only array of array of objects
  ```json
  {
    "json_array_field" : [[{}], [{}]]
  }
  ```
- JSON to record converter tool does not analyze elements in a JSON array which are in the depth of more than 2.

Fixes #38838

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
