### PR TITLE
[2201.3.x] Add missing completion items for record fields 

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/ContextTypeResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/ContextTypeResolver.java
@@ -565,7 +565,10 @@ public class ContextTypeResolver extends NodeTransformer<Optional<TypeSymbol>> {
                 if (fieldSymbol.isPresent()) {
                     return Optional.of(fieldSymbol.get().typeDescriptor());
                 }
+                break;
             }
+            case PARENTHESIZED_ARG_LIST:
+               return this.visit(namedArgumentNode.parent());
         }
 
         return Optional.empty();

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_in_named_arg.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_in_named_arg.json
@@ -1,0 +1,26 @@
+{
+  "position": {
+    "line": 11,
+    "character": 43
+  },
+  "source": "expression_context/source/mapping_expr_in_named_arg.bal",
+  "items": [
+    {
+      "label": "readonly",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "readonly",
+      "insertText": "readonly ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "name",
+      "kind": "Field",
+      "detail": "Config.name",
+      "sortText": "K",
+      "insertText": "name: ${1:\"\"}",
+      "insertTextFormat": "Snippet"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/new_expr_ctx_config24.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/new_expr_ctx_config24.json
@@ -265,7 +265,7 @@
       "label": "service",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "service",
       "insertText": "service",
       "insertTextFormat": "Snippet"
@@ -274,7 +274,7 @@
       "label": "new",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "new",
       "insertText": "new ",
       "insertTextFormat": "Snippet"
@@ -283,7 +283,7 @@
       "label": "isolated",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "isolated",
       "insertText": "isolated ",
       "insertTextFormat": "Snippet"
@@ -292,7 +292,7 @@
       "label": "transactional",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "transactional",
       "insertText": "transactional",
       "insertTextFormat": "Snippet"
@@ -301,7 +301,7 @@
       "label": "function",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "function",
       "insertText": "function ",
       "insertTextFormat": "Snippet"
@@ -310,7 +310,7 @@
       "label": "let",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "let",
       "insertText": "let",
       "insertTextFormat": "Snippet"
@@ -319,7 +319,7 @@
       "label": "typeof",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "typeof",
       "insertText": "typeof ",
       "insertTextFormat": "Snippet"
@@ -328,7 +328,7 @@
       "label": "trap",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "trap",
       "insertText": "trap",
       "insertTextFormat": "Snippet"
@@ -337,7 +337,7 @@
       "label": "client",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "client",
       "insertText": "client ",
       "insertTextFormat": "Snippet"
@@ -346,7 +346,7 @@
       "label": "true",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "true",
       "insertText": "true",
       "insertTextFormat": "Snippet"
@@ -355,7 +355,7 @@
       "label": "false",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "false",
       "insertText": "false",
       "insertTextFormat": "Snippet"
@@ -364,7 +364,7 @@
       "label": "check",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "check",
       "insertText": "check ",
       "insertTextFormat": "Snippet"
@@ -373,7 +373,7 @@
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "checkpanic",
       "insertText": "checkpanic ",
       "insertTextFormat": "Snippet"
@@ -382,7 +382,7 @@
       "label": "is",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "is",
       "insertText": "is",
       "insertTextFormat": "Snippet"
@@ -391,7 +391,7 @@
       "label": "error constructor",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "T",
       "filterText": "error",
       "insertText": "error(\"${1}\")",
       "insertTextFormat": "Snippet"
@@ -400,7 +400,7 @@
       "label": "object constructor",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "T",
       "filterText": "object",
       "insertText": "object {${1}}",
       "insertTextFormat": "Snippet"
@@ -409,7 +409,7 @@
       "label": "base16",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "T",
       "filterText": "base16",
       "insertText": "base16 `${1}`",
       "insertTextFormat": "Snippet"
@@ -418,7 +418,7 @@
       "label": "base64",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "T",
       "filterText": "base64",
       "insertText": "base64 `${1}`",
       "insertTextFormat": "Snippet"
@@ -427,7 +427,7 @@
       "label": "from",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "from",
       "insertText": "from ",
       "insertTextFormat": "Snippet"
@@ -439,7 +439,7 @@
       "documentation": {
         "left": "Describes Strand execution details for the runtime.\n"
       },
-      "sortText": "M",
+      "sortText": "Q",
       "insertText": "StrandData",
       "insertTextFormat": "Snippet"
     },
@@ -447,7 +447,7 @@
       "label": "Thread",
       "kind": "TypeParameter",
       "detail": "Union",
-      "sortText": "N",
+      "sortText": "R",
       "insertText": "Thread",
       "insertTextFormat": "Snippet"
     },
@@ -455,7 +455,7 @@
       "label": "c1",
       "kind": "Variable",
       "detail": "MyClass",
-      "sortText": "B",
+      "sortText": "F",
       "insertText": "c1",
       "insertTextFormat": "Snippet"
     },
@@ -463,7 +463,7 @@
       "label": "MyClass",
       "kind": "Interface",
       "detail": "Class",
-      "sortText": "K",
+      "sortText": "O",
       "insertText": "MyClass",
       "insertTextFormat": "Snippet"
     },
@@ -477,7 +477,7 @@
           "value": "**Package:** _._  \n  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "G",
       "filterText": "myFunc",
       "insertText": "myFunc()",
       "insertTextFormat": "Snippet"
@@ -486,7 +486,7 @@
       "label": "MyType",
       "kind": "Struct",
       "detail": "Record",
-      "sortText": "M",
+      "sortText": "Q",
       "insertText": "MyType",
       "insertTextFormat": "Snippet"
     },
@@ -550,7 +550,7 @@
       "label": "null",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "Q",
+      "sortText": "U",
       "filterText": "null",
       "insertText": "null",
       "insertTextFormat": "Snippet"

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/mapping_expr_in_named_arg.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/mapping_expr_in_named_arg.bal
@@ -1,0 +1,12 @@
+type Config record {|
+    int count = 10;
+    string name = "mock";
+|};
+
+client class MyClient {
+    function init(string url, *Config config) {
+
+    }
+}
+
+MyClient cli = new ("", config = {count: 0,});


### PR DESCRIPTION
## Purpose
Add missing completion items for record fields in named args of new expressions. 

Fixes #38875 


## Approach
Improve context type resolver

## Samples
![image](https://user-images.githubusercontent.com/35211477/205561147-7639a737-8c69-4fb3-8343-0207778e5cfd.png)



## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
