### PR TITLE
Fix extract to constant code action when there's no newline between the import and content

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToConstantCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToConstantCodeAction.java
@@ -179,7 +179,7 @@ public class ExtractToConstantCodeAction implements RangeBasedCodeActionProvider
             return PositionUtil.toPosition(modulePartNode.lineRange().startLine());
         }
         ImportDeclarationNode lastImport = importsList.get(importsList.size() - 1);
-        return new Position(lastImport.lineRange().endLine().line() + 2, 0);
+        return new Position(lastImport.lineRange().endLine().line() + 1, 0);
     }
 
     /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToConstantCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToConstantCodeAction.java
@@ -20,6 +20,7 @@ import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.syntax.tree.BasicLiteralNode;
 import io.ballerina.compiler.syntax.tree.BinaryExpressionNode;
+import io.ballerina.compiler.syntax.tree.ConstantDeclarationNode;
 import io.ballerina.compiler.syntax.tree.ImportDeclarationNode;
 import io.ballerina.compiler.syntax.tree.ModuleMemberDeclarationNode;
 import io.ballerina.compiler.syntax.tree.ModulePartNode;
@@ -76,8 +77,8 @@ public class ExtractToConstantCodeAction implements RangeBasedCodeActionProvider
     public boolean validate(CodeActionContext context, RangeBasedPositionDetails positionDetails) {
         Node node = positionDetails.matchedCodeActionNode();
         SyntaxKind parentKind = node.parent().kind();
-        return  context.currentSyntaxTree().isPresent() && context.currentSemanticModel().isPresent() 
-                && parentKind != SyntaxKind.CONST_DECLARATION 
+        return context.currentSyntaxTree().isPresent() && context.currentSemanticModel().isPresent()
+                && parentKind != SyntaxKind.CONST_DECLARATION
                 && parentKind != SyntaxKind.INVALID_EXPRESSION_STATEMENT
                 && CodeActionNodeValidator.validate(context.nodeAtRange());
     }
@@ -87,48 +88,51 @@ public class ExtractToConstantCodeAction implements RangeBasedCodeActionProvider
      */
     @Override
     public List<CodeAction> getCodeActions(CodeActionContext context,
-                                                    RangeBasedPositionDetails posDetails) {
-        
+                                           RangeBasedPositionDetails posDetails) {
+
         Node node = posDetails.matchedCodeActionNode();
         BasicLiteralNodeValidator nodeValidator = new BasicLiteralNodeValidator();
         node.accept(nodeValidator);
         if (nodeValidator.getInvalidNode()) {
             return Collections.emptyList();
         }
-        
+
         String constName = getConstantName(context);
         Optional<TypeSymbol> typeSymbol = context.currentSemanticModel().get().typeOf(node);
         if (typeSymbol.isEmpty() || typeSymbol.get().typeKind() == TypeDescKind.COMPILATION_ERROR) {
             return Collections.emptyList();
         }
-        Position constDeclPosition = getPosition(context);
-        
+        ConstantData constantData = getConstantData(context);
+        Position constDeclPosition = constantData.getPosition();
+        boolean addNewLineAtStart = constantData.isAddNewLineAtStart();
+
         // Check if the selection is a range or a position, and whether quick picks are supported by the client
         LSClientCapabilities lsClientCapabilities = context.languageServercontext().get(LSClientCapabilities.class);
         if (isRange(context.range()) || !lsClientCapabilities.getInitializationOptions().isQuickPickSupported()) {
-            
+
             // Selection is a range
-            List<TextEdit> textEdits = getTextEdits(node, typeSymbol.get(), constName, constDeclPosition);
+            List<TextEdit> textEdits =
+                    getTextEdits(node, typeSymbol.get(), constName, constDeclPosition, addNewLineAtStart);
             return Collections.singletonList(CodeActionUtil.createCodeAction(CommandConstants.EXTRACT_TO_CONSTANT,
                     textEdits, context.fileUri(), CodeActionKind.RefactorExtract));
         }
-        
+
         // Selection is a position
         List<Node> nodeList = getPossibleExpressionNodes(node, nodeValidator);
         LinkedHashMap<String, List<TextEdit>> textEditMap = new LinkedHashMap<>();
-        
-        nodeList.forEach(extractableNode -> textEditMap.put(extractableNode.toSourceCode().strip(), 
-                getTextEdits(extractableNode, typeSymbol.get(), constName, constDeclPosition)));
-        
+
+        nodeList.forEach(extractableNode -> textEditMap.put(extractableNode.toSourceCode().strip(),
+                getTextEdits(extractableNode, typeSymbol.get(), constName, constDeclPosition, addNewLineAtStart)));
+
         return Collections.singletonList(CodeActionUtil.createCodeAction(CommandConstants.EXTRACT_TO_CONSTANT,
-                    new Command(NAME, EXTRACT_COMMAND, List.of(NAME, context.filePath().toString(), 
-                            textEditMap)), CodeActionKind.RefactorExtract));
+                new Command(NAME, EXTRACT_COMMAND, List.of(NAME, context.filePath().toString(),
+                        textEditMap)), CodeActionKind.RefactorExtract));
     }
 
     private List<Node> getPossibleExpressionNodes(Node node, BasicLiteralNodeValidator nodeValidator) {
         // Identify the sub-expressions to be extracted
         List<Node> nodeList = new ArrayList<>();
-        while (node != null && !isExpressionNode(node) && node.kind() != SyntaxKind.OBJECT_FIELD 
+        while (node != null && !isExpressionNode(node) && node.kind() != SyntaxKind.OBJECT_FIELD
                 && !nodeValidator.getInvalidNode()) {
             nodeList.add(node);
             node = node.parent();
@@ -146,10 +150,16 @@ public class ExtractToConstantCodeAction implements RangeBasedCodeActionProvider
         return NAME;
     }
 
-    private List<TextEdit> getTextEdits(Node node, TypeSymbol typeSymbol, String constName, Position constDeclPos) {
+    private List<TextEdit> getTextEdits(Node node, TypeSymbol typeSymbol, String constName, Position constDeclPos,
+                                        boolean newLineAtStart) {
         String value = node.toSourceCode().strip();
         LineRange replaceRange = node.lineRange();
-        String constDeclStr = String.format("const %s %s = %s;%n", typeSymbol.signature(), constName, value);
+        String constDeclStr;
+        if (newLineAtStart) {
+            constDeclStr = String.format("%n" + "const %s %s = %s;%n", typeSymbol.signature(), constName, value);
+        } else {
+            constDeclStr = String.format("const %s %s = %s;%n", typeSymbol.signature(), constName, value);
+        }
         TextEdit constDeclEdit = new TextEdit(new Range(constDeclPos, constDeclPos), constDeclStr);
         TextEdit replaceEdit = new TextEdit(new Range(PositionUtil.toPosition(replaceRange.startLine()),
                 PositionUtil.toPosition(replaceRange.endLine())), constName);
@@ -171,15 +181,29 @@ public class ExtractToConstantCodeAction implements RangeBasedCodeActionProvider
         return NameUtil.generateTypeName(CONSTANT_NAME_PREFIX, allNames);
     }
 
-    private Position getPosition(CodeActionContext context) {
+    private ConstantData getConstantData(CodeActionContext context) {
         ModulePartNode modulePartNode = context.currentSyntaxTree().get().rootNode();
         NodeList<ImportDeclarationNode> importsList = modulePartNode.imports();
-        
-        if (importsList.isEmpty()) {
-            return PositionUtil.toPosition(modulePartNode.lineRange().startLine());
+
+        ConstantDeclarationNode declarationNode = null;
+        for (Node node : modulePartNode.children()) {
+            if (node.kind() == SyntaxKind.CONST_DECLARATION) {
+                declarationNode = (ConstantDeclarationNode) node;
+                break;
+            }
         }
-        ImportDeclarationNode lastImport = importsList.get(importsList.size() - 1);
-        return new Position(lastImport.lineRange().endLine().line() + 1, 0);
+
+        if (importsList.isEmpty()) {
+            return new ConstantData(
+                    PositionUtil.toPosition(modulePartNode.lineRange().startLine()), false);
+        } else if (declarationNode == null) {
+            ImportDeclarationNode lastImport = importsList.get(importsList.size() - 1);
+            return new ConstantData(
+                    new Position(lastImport.lineRange().endLine().line() + 1, 0), true);
+        } else {
+            return new ConstantData(new Position(declarationNode.lineRange().startLine().line(), 0),
+                    !declarationNode.toString().startsWith("\n"));
+        }
     }
 
     /**
@@ -210,6 +234,24 @@ public class ExtractToConstantCodeAction implements RangeBasedCodeActionProvider
 
         public Boolean getInvalidNode() {
             return invalidNode;
+        }
+    }
+
+    private static class ConstantData {
+        Position position;
+        boolean addNewLineAtStart;
+
+        public ConstantData(Position position, boolean addNewLineAtStart) {
+            this.position = position;
+            this.addNewLineAtStart = addNewLineAtStart;
+        }
+
+        public Position getPosition() {
+            return position;
+        }
+
+        public boolean isAddNewLineAtStart() {
+            return addNewLineAtStart;
         }
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToConstantCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToConstantCodeAction.java
@@ -154,12 +154,12 @@ public class ExtractToConstantCodeAction implements RangeBasedCodeActionProvider
                                         boolean newLineAtStart) {
         String value = node.toSourceCode().strip();
         LineRange replaceRange = node.lineRange();
-        String constDeclStr;
+        String constDeclStr = "";
         if (newLineAtStart) {
-            constDeclStr = String.format("%n" + "const %s %s = %s;%n", typeSymbol.signature(), constName, value);
-        } else {
-            constDeclStr = String.format("const %s %s = %s;%n", typeSymbol.signature(), constName, value);
+            constDeclStr += String.format("%n");
         }
+        constDeclStr = String.format(constDeclStr + "const %s %s = %s;%n", typeSymbol.signature(), constName, value);
+
         TextEdit constDeclEdit = new TextEdit(new Range(constDeclPos, constDeclPos), constDeclStr);
         TextEdit replaceEdit = new TextEdit(new Range(PositionUtil.toPosition(replaceRange.startLine()),
                 PositionUtil.toPosition(replaceRange.endLine())), constName);
@@ -202,7 +202,7 @@ public class ExtractToConstantCodeAction implements RangeBasedCodeActionProvider
                     new Position(lastImport.lineRange().endLine().line() + 1, 0), true);
         } else {
             return new ConstantData(new Position(declarationNode.lineRange().startLine().line(), 0),
-                    !declarationNode.toString().startsWith("\n"));
+                    !declarationNode.toString().startsWith(System.lineSeparator()));
         }
     }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ExtractToConstantTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ExtractToConstantTest.java
@@ -56,6 +56,7 @@ public class ExtractToConstantTest extends AbstractCodeActionTest {
                 {"extractConstDeclToConstant1.json"},
                 {"extractToConstantWithImports.json"},
                 {"extractToConstantWithImports2.json"},
+                {"extractToConstantWithImports3.json"},
                 {"extractUnaryNumericExprToConstant.json"},
                 {"extractUnaryNumericExprToConstant2.json"},
                 {"extractUnaryLogicalExprToConstant.json"},

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ExtractToConstantTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ExtractToConstantTest.java
@@ -55,6 +55,7 @@ public class ExtractToConstantTest extends AbstractCodeActionTest {
                 {"extractExpressionToConstant.json"},
                 {"extractConstDeclToConstant1.json"},
                 {"extractToConstantWithImports.json"},
+                {"extractToConstantWithImports2.json"},
                 {"extractUnaryNumericExprToConstant.json"},
                 {"extractUnaryNumericExprToConstant2.json"},
                 {"extractUnaryLogicalExprToConstant.json"},

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractToConstantWithImports.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractToConstantWithImports.json
@@ -20,7 +20,7 @@
               "character": 0
             }
           },
-          "newText": "const string CONST = \"Hello World\";\n"
+          "newText": "\nconst string CONST = \"Hello World\";\n"
         },
         {
           "range": {

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractToConstantWithImports2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractToConstantWithImports2.json
@@ -1,9 +1,9 @@
 {
   "position": {
-    "line": 4,
-    "character": 25
+    "line": 7,
+    "character": 13
   },
-  "source": "extractToConstantWithImports.bal",
+  "source": "extractToConstantWithImports2.bal",
   "expected": [
     {
       "title": "Extract to constant",
@@ -12,25 +12,25 @@
         {
           "range": {
             "start": {
-              "line": 2,
+              "line": 1,
               "character": 0
             },
             "end": {
-              "line": 2,
+              "line": 1,
               "character": 0
             }
           },
-          "newText": "const string CONST = \"Hello World\";\n"
+          "newText": "const int CONST = 0;\n"
         },
         {
           "range": {
             "start": {
-              "line": 4,
-              "character": 22
+              "line": 7,
+              "character": 12
             },
             "end": {
-              "line": 4,
-              "character": 35
+              "line": 7,
+              "character": 13
             }
           },
           "newText": "CONST"

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractToConstantWithImports2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractToConstantWithImports2.json
@@ -20,7 +20,7 @@
               "character": 0
             }
           },
-          "newText": "const int CONST = 0;\n"
+          "newText": "\nconst int CONST = 0;\n"
         },
         {
           "range": {

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractToConstantWithImports3.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/config/extractToConstantWithImports3.json
@@ -1,0 +1,41 @@
+{
+  "position": {
+    "line": 10,
+    "character": 13
+  },
+  "source": "extractToConstantWithImports3.bal",
+  "expected": [
+    {
+      "title": "Extract to constant",
+      "kind": "refactor.extract",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 2,
+              "character": 0
+            },
+            "end": {
+              "line": 2,
+              "character": 0
+            }
+          },
+          "newText": "const int CONST1 = 0;\n"
+        },
+        {
+          "range": {
+            "start": {
+              "line": 10,
+              "character": 12
+            },
+            "end": {
+              "line": 10,
+              "character": 13
+            }
+          },
+          "newText": "CONST1"
+        }
+      ]
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/source/extractToConstantWithImports2.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/source/extractToConstantWithImports2.bal
@@ -1,0 +1,9 @@
+import ballerina/module1;
+type RecordType record {
+    string name;
+    int age;
+};
+
+function testFunction(RecordType rec) {
+    int x = 0;
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/source/extractToConstantWithImports3.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-constant/source/extractToConstantWithImports3.bal
@@ -1,0 +1,12 @@
+import ballerina/module1;
+
+const int CONST = 10;
+
+type RecordType record {
+    string name;
+    int age;
+};
+
+function testFunction(RecordType rec) {
+    int x = 0;
+}


### PR DESCRIPTION
## Purpose
This PR fixes the position of the constant created with the extract to constant code action.

Fixes #38843

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
