### PR TITLE
[2201.3.x] Add missing order direction keywords in order by context

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/QueryPipelineNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/QueryPipelineNodeContext.java
@@ -15,12 +15,18 @@
  */
 package org.ballerinalang.langserver.completions.providers.context;
 
+import io.ballerina.compiler.syntax.tree.IntermediateClauseNode;
 import io.ballerina.compiler.syntax.tree.JoinClauseNode;
 import io.ballerina.compiler.syntax.tree.NonTerminalNode;
+import io.ballerina.compiler.syntax.tree.OrderByClauseNode;
+import io.ballerina.compiler.syntax.tree.OrderKeyNode;
 import io.ballerina.compiler.syntax.tree.QueryPipelineNode;
+import io.ballerina.compiler.syntax.tree.SeparatedNodeList;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.compiler.syntax.tree.WhereClauseNode;
+import io.ballerina.tools.text.LinePosition;
 import org.ballerinalang.annotation.JavaSPIService;
+import org.ballerinalang.langserver.common.utils.PositionUtil;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.SnippetCompletionItem;
@@ -29,6 +35,7 @@ import org.ballerinalang.langserver.completions.providers.context.util.QueryExpr
 import org.ballerinalang.langserver.completions.util.Snippet;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -67,6 +74,15 @@ public class QueryPipelineNodeContext extends AbstractCompletionProvider<QueryPi
             completionItems.add(new SnippetCompletionItem(context, Snippet.KW_FROM.get()));
             completionItems.add(new SnippetCompletionItem(context, Snippet.CLAUSE_FROM.get()));
             completionItems.addAll(QueryExpressionUtil.getCommonKeywordCompletions(context));
+
+            if (onSuggestDirectionKeywords(context, node)) {
+                /*
+                    Covers the following. 
+                    order by key d<cursor>
+                 */
+                completionItems.add(new SnippetCompletionItem(context, Snippet.KW_ASCENDING.get()));
+                completionItems.add(new SnippetCompletionItem(context, Snippet.KW_DESCENDING.get()));
+            }
         } else if (onMissingJoinKeyword(context)) {
             /* Covers the following
             (1) [intermediate-clause] outer <cursor>
@@ -93,5 +109,44 @@ public class QueryPipelineNodeContext extends AbstractCompletionProvider<QueryPi
         
         return !evalNode.isMissing() && evalNode.kind() == SyntaxKind.JOIN_CLAUSE 
                 && ((JoinClauseNode) evalNode).joinKeyword().isMissing();
+    }
+
+    /**
+     * Check if order direction keywords can be suggested.
+     * @param context completion context
+     * @param node QueryPipeLine node
+     * @return
+     */
+    private boolean onSuggestDirectionKeywords(BallerinaCompletionContext context, QueryPipelineNode node) {
+        if (!onMissingWhereNode(context) || context.currentSyntaxTree().isEmpty()) {
+            return false;
+        }
+
+        int cursor = context.getCursorPositionInTree();
+        NonTerminalNode nextIntermediate = context.getNodeAtCursor().parent();
+        LinePosition startLinePosition = nextIntermediate.lineRange().startLine();
+        int startOffset = PositionUtil.getPositionOffset(PositionUtil.toPosition(startLinePosition),
+                context.currentSyntaxTree().get());
+
+        Iterator<IntermediateClauseNode> iterator = node.intermediateClauses().iterator();
+        IntermediateClauseNode closestNode = null;
+        while (iterator.hasNext()) {
+            IntermediateClauseNode next = iterator.next();
+            int endOffset = PositionUtil.getPositionOffset(PositionUtil.toPosition(next.lineRange().endLine()),
+                    context.currentSyntaxTree().get());
+            if (endOffset < startOffset) {
+                closestNode = next;
+            }
+        }
+        if (closestNode.kind() != SyntaxKind.ORDER_BY_CLAUSE) {
+            return false;
+        }
+        SeparatedNodeList<OrderKeyNode> orderKeyNodes = ((OrderByClauseNode) closestNode).orderKey();
+        if (orderKeyNodes.isEmpty()) {
+            return false;
+        }
+
+        OrderKeyNode lastOrderKey = orderKeyNodes.get(orderKeyNodes.size() - 1);
+        return cursor > lastOrderKey.textRange().endOffset();
     }
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_orderby_clause_config10.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_orderby_clause_config10.json
@@ -1,0 +1,144 @@
+{
+  "position": {
+    "line": 3,
+    "character": 20
+  },
+  "source": "query_expression/source/query_expr_ctx_orderby_clause_source10.bal",
+  "items": [
+    {
+      "label": "from",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "Q",
+      "filterText": "from",
+      "insertText": "from ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "from clause",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "from",
+      "insertText": "from ${1:var} ${2:item} in ${3}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "where",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "Q",
+      "filterText": "where",
+      "insertText": "where ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "let",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "Q",
+      "filterText": "let",
+      "insertText": "let",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "let clause",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "let",
+      "insertText": "let ${1:var} ${2:varName} = ${3}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "outer",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "Q",
+      "filterText": "outer",
+      "insertText": "outer ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "join",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "Q",
+      "filterText": "join",
+      "insertText": "join ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "join clause",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "join",
+      "insertText": "join ${1:var} ${2:varName} in ${3:expr} on ${4:onExpr} equals ${5:equalsExpr}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "order by",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "Q",
+      "filterText": "order by",
+      "insertText": "order by ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "limit",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "Q",
+      "filterText": "limit",
+      "insertText": "limit ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "do",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "do",
+      "insertText": "do {\n\t${1}\n}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "select",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "Q",
+      "filterText": "select",
+      "insertText": "select ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "from",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "Q",
+      "filterText": "from",
+      "insertText": "from ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ascending",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "Q",
+      "filterText": "ascending",
+      "insertText": "ascending",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "descending",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "Q",
+      "filterText": "descending",
+      "insertText": "descending",
+      "insertTextFormat": "Snippet"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_orderby_clause_config11.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_orderby_clause_config11.json
@@ -1,0 +1,126 @@
+{
+  "position": {
+    "line": 4,
+    "character": 18
+  },
+  "source": "query_expression/source/query_expr_ctx_orderby_clause_source11.bal",
+  "items": [
+    {
+      "label": "from",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "Q",
+      "filterText": "from",
+      "insertText": "from ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "from clause",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "from",
+      "insertText": "from ${1:var} ${2:item} in ${3}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "where",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "Q",
+      "filterText": "where",
+      "insertText": "where ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "let",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "Q",
+      "filterText": "let",
+      "insertText": "let",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "let clause",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "let",
+      "insertText": "let ${1:var} ${2:varName} = ${3}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "outer",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "Q",
+      "filterText": "outer",
+      "insertText": "outer ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "join",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "Q",
+      "filterText": "join",
+      "insertText": "join ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "join clause",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "join",
+      "insertText": "join ${1:var} ${2:varName} in ${3:expr} on ${4:onExpr} equals ${5:equalsExpr}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "order by",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "Q",
+      "filterText": "order by",
+      "insertText": "order by ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "limit",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "Q",
+      "filterText": "limit",
+      "insertText": "limit ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "do",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "do",
+      "insertText": "do {\n\t${1}\n}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "select",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "Q",
+      "filterText": "select",
+      "insertText": "select ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "from",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "Q",
+      "filterText": "from",
+      "insertText": "from ",
+      "insertTextFormat": "Snippet"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/source/query_expr_ctx_orderby_clause_source10.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/source/query_expr_ctx_orderby_clause_source10.bal
@@ -1,0 +1,7 @@
+function testQueryExpression() {
+
+    int[] topX = from int i in [1, 2, 3]
+        order by i d
+        limit 10
+        select i;
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/source/query_expr_ctx_orderby_clause_source11.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/source/query_expr_ctx_orderby_clause_source11.bal
@@ -1,0 +1,7 @@
+function testQueryExpression() {
+
+    int[] topX = from int i in [1, 2, 3]
+        order by i  
+        limit 10 d
+        select i;
+}


### PR DESCRIPTION
## Purpose
$subject

Fixes #38762

## Samples
![image](https://user-images.githubusercontent.com/35211477/207533628-d673853f-f95e-435d-b530-80dacef37d9c.png)

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
