### PR TITLE
[2201.3.x] Add langlib examples for decimal

### DIFF
--- a/langlib/lang.decimal/src/main/ballerina/decimal.bal
+++ b/langlib/lang.decimal/src/main/ballerina/decimal.bal
@@ -23,6 +23,9 @@ import ballerina/jballerina.java;
 #
 # decimal[] scores = [11.1, 22.2, 33.3];
 # decimal:sum(...scores) ⇒ 66.6
+# 
+# [decimal, decimal, decimal] marks = [7.21, 10.32, 9.2];
+# decimal:sum(...marks) ⇒ 26.73
 #
 # decimal d = 21.2;
 # d.sum(10.5, 21, 32.4) ⇒ 85.1
@@ -42,6 +45,9 @@ public isolated function sum(decimal... xs) returns decimal = @java:Method {
 #
 # decimal[] marks = [70.3, 80.5, 98.1, 92.3];
 # decimal:max(30.5, ...marks) ⇒ 98.1
+# 
+# [decimal, decimal, decimal] scores = [7.21, 10.32, 9.2];
+# decimal:max(...scores) ⇒ 10.32
 #
 # decimal d = 21.2;
 # d.max(40.5, 21, 32.4) ⇒ 40.5
@@ -62,7 +68,10 @@ public isolated function max(decimal x, decimal... xs) returns decimal = @java:M
 #
 # decimal[] marks = [90.3, 80.5, 98, 92.3];
 # decimal:min(82.1, ...marks) ⇒ 80.5
-#
+# 
+# [decimal, decimal, decimal] scores = [7.21, 10.32, 9.2];
+# decimal:min(...scores) ⇒ 7.21
+# 
 # decimal d = 1.2;
 # d.min(10.5, 21, 32.4) ⇒ 1.2
 #```
@@ -113,6 +122,9 @@ public isolated function abs(decimal x) returns decimal = @java:Method {
 # 
 # decimal h = 3.5;
 # h.round(0) ⇒ 4
+#
+# decimal e = 4345.55;
+# e.round(-3) ⇒ 4E+3
 # ```
 #
 # + x - decimal value to operate on
@@ -134,9 +146,7 @@ public isolated function round(decimal x, int fractionDigits = 0) returns decima
 # 
 # decimal:quantize(4.1626, 3.512) ⇒ 4.163
 # 
-# decimal:quantize(4.1624, 3.512) ⇒ 4.162
-# 
-# decimal:quantize(4.16, 3.512) ⇒ 4.160
+# decimal:quantize(4.1624, 3.51) ⇒ 4.16
 # ```
 #
 # + x - decimal value to operate on

--- a/langlib/lang.decimal/src/main/ballerina/decimal.bal
+++ b/langlib/lang.decimal/src/main/ballerina/decimal.bal
@@ -18,6 +18,16 @@ import ballerina/jballerina.java;
 
 # Returns the sum of zero or more decimal values.
 #
+# ```ballerina
+# decimal:sum(1.2, 2.3, 3.4) ⇒ 6.9
+#
+# decimal[] scores = [11.1, 22.2, 33.3];
+# decimal:sum(...scores) ⇒ 66.6
+#
+# decimal d = 21.2;
+# d.sum(10.5, 21, 32.4) ⇒ 85.1
+# ```
+#
 # + xs - decimal values to sum
 # + return - sum of all the parameter `xs`; 0 if parameter `xs` is empty
 public isolated function sum(decimal... xs) returns decimal = @java:Method {
@@ -26,6 +36,16 @@ public isolated function sum(decimal... xs) returns decimal = @java:Method {
 } external;
 
 # Returns the maximum of one or more decimal values.
+#
+# ```ballerina
+# decimal:max(1.2, 12.3, 3.4) ⇒ 12.3
+#
+# decimal[] marks = [70.3, 80.5, 98.1, 92.3];
+# decimal:max(30.5, ...marks) ⇒ 98.1
+#
+# decimal d = 21.2;
+# d.max(40.5, 21, 32.4) ⇒ 40.5
+#```
 #
 # + x - first decimal value
 # + xs - other decimal values
@@ -37,6 +57,16 @@ public isolated function max(decimal x, decimal... xs) returns decimal = @java:M
 
 # Returns the minimum of one or more decimal values.
 #
+# ```ballerina
+# decimal:min(5.2, 2.3, 3.4) ⇒ 2.3
+#
+# decimal[] marks = [90.3, 80.5, 98, 92.3];
+# decimal:min(82.1, ...marks) ⇒ 80.5
+#
+# decimal d = 1.2;
+# d.min(10.5, 21, 32.4) ⇒ 1.2
+#```
+#
 # + x - first decimal value
 # + xs - other decimal values
 # + return - minimum value of parameter `x` and all the parameter `xs`.
@@ -46,6 +76,11 @@ public isolated function min(decimal x, decimal... xs) returns decimal = @java:M
 } external;
 
 # Returns the IEEE absolute value of a decimal value.
+#
+# ```ballerina
+# decimal d = -3.21;
+# d.abs() ⇒ 3.21
+# ```
 #
 # + x - decimal value to operate on
 # + return - absolute value of parameter `x`
@@ -66,6 +101,20 @@ public isolated function abs(decimal x) returns decimal = @java:Method {
 # roundToIntegralTiesToEven will return a value with a positive exponent when the operand has a positive exponent.
 # Note that `<int>x` is the same as `<int>x.round(0)`.
 #
+# ```ballerina
+# decimal d = 3.55;
+# d.round() ⇒ 4
+#
+# decimal e = 4.55555;
+# e.round(3) ⇒ 4.556
+# 
+# decimal g = 2.5;
+# g.round(0) ⇒ 2
+# 
+# decimal h = 3.5;
+# h.round(0) ⇒ 4
+# ```
+#
 # + x - decimal value to operate on
 # + fractionDigits - the number of digits after the decimal point
 # + return - closest decimal value to `x` that is an integral multiple of 10 raised to the power of `-fractionDigits`
@@ -74,8 +123,22 @@ public isolated function round(decimal x, int fractionDigits = 0) returns decima
     name: "round"
 } external;
 
-# IEEE quantize operation.
-
+# Return a decimal with a specified value and exponent.
+# Return a decimal value that has the same value (except for rounding) as the first
+# argument, and the same exponent as the second argument.
+# This is the IEEE quantize operation.
+#
+# ```ballerina
+# decimal d = 4.1626;
+# d.quantize(3.512) ⇒ 4.163
+# 
+# decimal:quantize(4.1626, 3.512) ⇒ 4.163
+# 
+# decimal:quantize(4.1624, 3.512) ⇒ 4.162
+# 
+# decimal:quantize(4.16, 3.512) ⇒ 4.160
+# ```
+#
 # + x - decimal value to operate on
 # + y - decimal value from which to get the quantum
 # + return - `x` with the quantum of `y`
@@ -86,6 +149,11 @@ public isolated function quantize(decimal x, decimal y) returns decimal = @java:
 
 # Rounds a decimal down to the closest integral value.
 #
+# ```ballerina
+# decimal d = 3.51;
+# d.floor() ⇒ 3
+# ```
+#
 # + x - decimal value to operate on
 # + return - largest (closest to +∞) decimal value not greater than parameter `x` that is a mathematical integer.
 public isolated function floor(decimal x) returns decimal = @java:Method {
@@ -94,6 +162,11 @@ public isolated function floor(decimal x) returns decimal = @java:Method {
 } external;
 
 # Rounds a decimal up to the closest integral value.
+#
+# ```ballerina
+# decimal d = 3.51;
+# d.ceiling() ⇒ 4
+# ```
 #
 # + x - decimal value to operate on
 # + return - smallest (closest to -∞) decimal value not less than parameter `x` that is a mathematical integer
@@ -109,6 +182,14 @@ public isolated function ceiling(decimal x) returns decimal = @java:Method {
 # - the DecimalFloatingPointLiteral may have a leading `+` or `-` sign
 # - a FloatingPointTypeSuffix is not allowed
 # This is the inverse of function ``value:toString`` applied to an `decimal`.
+#
+# ```ballerina
+# decimal:fromString("0.2453") ⇒ 0.2453
+# 
+# decimal:fromString("-10") ⇒ -10
+# 
+# decimal:fromString("123d") ⇒ error
+# ```
 #
 # + s - string representation of a decimal
 # + return - decimal representation of the argument or error


### PR DESCRIPTION
## Purpose
> Add lang library examples for decimal langlib apidocs.

Fixes #38911 
