### PR TITLE
[Debugger Integration Tests] Increase variable request timeout and add info logs for monitoring

### DIFF
--- a/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/DebugTestRunner.java
+++ b/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/DebugTestRunner.java
@@ -786,8 +786,8 @@ public class DebugTestRunner {
             result.setVariablesReference(evaluateResp.getVariablesReference());
             return result;
         } catch (Exception e) {
-            LOGGER.warn("Error occurred when fetching debug hit variables", e);
-            throw new BallerinaTestException("Error occurred when fetching debug hit variables", e);
+            LOGGER.warn("Error occurred when evaluating expression", e);
+            throw new BallerinaTestException("Error occurred when evaluating expression", e);
         }
     }
 

--- a/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/client/DAPClientConnector.java
+++ b/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/client/DAPClientConnector.java
@@ -142,7 +142,7 @@ public class DAPClientConnector {
             debugServer.initialize(initParams).thenApply(res -> {
                 initializeResult = res;
                 LOGGER.info("initialize response received from the debug server.");
-                requestManager = new DAPRequestManager(this, debugClient, debugServer, initializeResult);
+                requestManager = new DAPRequestManager(this, debugServer);
                 debugClient.connect(requestManager);
                 myConnectionState = ConnectionState.CONNECTED;
                 return res;

--- a/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/client/DAPRequestManager.java
+++ b/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/client/DAPRequestManager.java
@@ -16,7 +16,6 @@
 package org.ballerinalang.debugger.test.utils.client;
 
 import org.eclipse.lsp4j.debug.BreakpointEventArguments;
-import org.eclipse.lsp4j.debug.Capabilities;
 import org.eclipse.lsp4j.debug.CapabilitiesEventArguments;
 import org.eclipse.lsp4j.debug.CompletionsArguments;
 import org.eclipse.lsp4j.debug.CompletionsResponse;
@@ -52,7 +51,11 @@ import org.eclipse.lsp4j.debug.ThreadsResponse;
 import org.eclipse.lsp4j.debug.VariablesArguments;
 import org.eclipse.lsp4j.debug.VariablesResponse;
 import org.eclipse.lsp4j.debug.services.IDebugProtocolServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -68,14 +71,11 @@ public class DAPRequestManager {
     private boolean didRunInIntegratedTerminal;
     private boolean isProjectBasedTest;
 
-    public DAPRequestManager(DAPClientConnector clientConnector, DAPClient client, IDebugProtocolServer server,
-                             Capabilities serverCapabilities) {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DAPRequestManager.class);
+
+    public DAPRequestManager(DAPClientConnector clientConnector, IDebugProtocolServer server) {
         this.clientConnector = clientConnector;
         this.server = server;
-    }
-
-    public DAPClientConnector getClientConnector() {
-        return clientConnector;
     }
 
     // ------------------------------- Client to Server --------------------------------------------//
@@ -190,8 +190,14 @@ public class DAPRequestManager {
 
     public VariablesResponse variables(VariablesArguments args, long timeoutMillis) throws Exception {
         if (checkStatus()) {
+            Instant start = Instant.now();
             CompletableFuture<VariablesResponse> resp = server.variables(args);
-            return resp.get(timeoutMillis, TimeUnit.MILLISECONDS);
+            VariablesResponse variablesResponse = resp.get(timeoutMillis, TimeUnit.MILLISECONDS);
+            Instant end = Instant.now();
+            // Todo - remove after monitoring if the debugger integration tests are failing due to averagely high
+            //  variable response times or, due to sudden spikes (potential concurrency issues?)
+            LOGGER.info(String.format("debug variables request took %s ms", Duration.between(start, end).toMillis()));
+            return variablesResponse;
         } else {
             throw new IllegalStateException("DAP request manager is not active");
         }
@@ -375,7 +381,7 @@ public class DAPRequestManager {
         THREADS(2000),
         STACK_TRACE(7000),
         SCOPES(2000),
-        VARIABLES(20000),
+        VARIABLES(30000),
         EVALUATE(15000),
         COMPLETIONS(10000),
         STEP_OVER(5000),

--- a/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/client/DAPRequestManager.java
+++ b/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/client/DAPRequestManager.java
@@ -195,7 +195,7 @@ public class DAPRequestManager {
             VariablesResponse variablesResponse = resp.get(timeoutMillis, TimeUnit.MILLISECONDS);
             Instant end = Instant.now();
             // Todo - remove after monitoring if the debugger integration tests are failing due to averagely high
-            //  variable response times or, due to sudden spikes (potential concurrency issues?)
+            //  response times or, due to sudden spikes (potential concurrency issues?)
             LOGGER.info(String.format("debug variables request took %s ms", Duration.between(start, end).toMillis()));
             return variablesResponse;
         } else {
@@ -209,8 +209,14 @@ public class DAPRequestManager {
 
     public EvaluateResponse evaluate(EvaluateArguments args, long timeoutMillis) throws Exception {
         if (checkStatus()) {
+            Instant start = Instant.now();
             CompletableFuture<EvaluateResponse> resp = server.evaluate(args);
-            return resp.get(timeoutMillis, TimeUnit.MILLISECONDS);
+            EvaluateResponse evaluateResponse = resp.get(timeoutMillis, TimeUnit.MILLISECONDS);
+            Instant end = Instant.now();
+            // Todo - remove after monitoring if the debugger integration tests are failing due to averagely high
+            //  response times or, due to sudden spikes (potential concurrency issues?)
+            LOGGER.info(String.format("evaluation request took %s ms", Duration.between(start, end).toMillis()));
+            return evaluateResponse;
         } else {
             throw new IllegalStateException("DAP request manager is not active");
         }
@@ -382,7 +388,7 @@ public class DAPRequestManager {
         STACK_TRACE(7000),
         SCOPES(2000),
         VARIABLES(30000),
-        EVALUATE(15000),
+        EVALUATE(20000),
         COMPLETIONS(10000),
         STEP_OVER(5000),
         STEP_IN(10000),


### PR DESCRIPTION
## Purpose
$subject to address intermittent debugger integration test failures in PR workflows.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
