### PR TITLE
[2201.3.x] Add examples for `lang.typedesc` langlib functions

### DIFF
--- a/langlib/lang.typedesc/src/main/ballerina/typedesc_lib.bal
+++ b/langlib/lang.typedesc/src/main/ballerina/typedesc_lib.bal
@@ -42,8 +42,18 @@ public type TypeId readonly & record {|
 # Returns the type-ids induced by a typedesc value.
 # 
 # ```ballerina
-# type MyError distinct error;
-# typedesc:TypeId[]? & readonly typeIds = MyError.typeIds();
+# type Error distinct error;
+# type SampleError distinct (Error & error<record {string msg;}>);
+# 
+# typedesc:TypeId[]? & readonly typeIds = SampleError.typeIds();
+# if (typeIds is typedesc:TypeId[]) {
+#   io:println(typeIds[typeIds.length() - 1]["localId"]) ⇒ Error
+# }
+# 
+# typedesc:TypeId[]? & readonly primaryTypeIds = SampleError.typeIds(true);
+# if (primaryTypeIds is typedesc:TypeId[]) {
+#   io:println(primaryTypeIds[primaryTypeIds.length() - 1]["localId"]) ⇒ SampleError
+# }
 # ```
 # 
 # + t - the typedesc

--- a/langlib/lang.typedesc/src/main/ballerina/typedesc_lib.bal
+++ b/langlib/lang.typedesc/src/main/ballerina/typedesc_lib.bal
@@ -40,6 +40,12 @@ public type TypeId readonly & record {|
 |};
 
 # Returns the type-ids induced by a typedesc value.
+# 
+# ```ballerina
+# type MyError distinct error;
+# typedesc:TypeId[]? & readonly typeIds = MyError.typeIds();
+# ```
+# 
 # + t - the typedesc
 # + primaryOnly - if true, only the primary type-ids will be returned; otherwise, all type-ids will be returned
 # + return - an array containing the type-ids induced by `t` or nil if `t` is not definite

--- a/langlib/lang.typedesc/src/main/ballerina/typedesc_lib.bal
+++ b/langlib/lang.typedesc/src/main/ballerina/typedesc_lib.bal
@@ -46,14 +46,9 @@ public type TypeId readonly & record {|
 # 
 # type SampleError distinct (Error & error<record {string msg;}>);
 # 
-# SampleError.typeIds() ⇒ [
-#       {"moduleId":{"organization":"$anon","name":".","platformParts":["0"]},"localId":"SampleError"},
-#       {"moduleId":{"organization":"$anon","name":".","platformParts":["0"]},"localId":"Error"}
-# ]
+# SampleError.typeIds() ⇒ [{"moduleId":{"organization":"$anon","name":".","platformParts":["0"]},"localId":"SampleError"},{"moduleId":{"organization":"$anon","name":".","platformParts":["0"]},"localId":"Error"}]
 # 
-# SampleError.typeIds(true) ⇒ [
-#       {"moduleId":{"organization":"$anon","name":".","platformParts":["0"]},"localId":"SampleError"}
-# ]
+# SampleError.typeIds(true) ⇒ [{"moduleId":{"organization":"$anon","name":".","platformParts":["0"]},"localId":"SampleError"}]
 # ```
 # 
 # + t - the typedesc

--- a/langlib/lang.typedesc/src/main/ballerina/typedesc_lib.bal
+++ b/langlib/lang.typedesc/src/main/ballerina/typedesc_lib.bal
@@ -43,6 +43,7 @@ public type TypeId readonly & record {|
 # 
 # ```ballerina
 # type Error distinct error;
+# 
 # type SampleError distinct (Error & error<record {string msg;}>);
 # 
 # typedesc:TypeId[] typeIds = <typedesc:TypeId[]>SampleError.typeIds();

--- a/langlib/lang.typedesc/src/main/ballerina/typedesc_lib.bal
+++ b/langlib/lang.typedesc/src/main/ballerina/typedesc_lib.bal
@@ -46,11 +46,14 @@ public type TypeId readonly & record {|
 # 
 # type SampleError distinct (Error & error<record {string msg;}>);
 # 
-# typedesc:TypeId[] typeIds = <typedesc:TypeId[]>SampleError.typeIds();
-# typeIds[typeIds.length() - 1]["localId"] ⇒ Error
+# SampleError.typeIds() ⇒ [
+#       {"moduleId":{"organization":"$anon","name":".","platformParts":["0"]},"localId":"SampleError"},
+#       {"moduleId":{"organization":"$anon","name":".","platformParts":["0"]},"localId":"Error"}
+# ]
 # 
-# typedesc:TypeId[] primaryTypeIds = <typedesc:TypeId[]>SampleError.typeIds(true);
-# primaryTypeIds[primaryTypeIds.length() - 1]["localId"] ⇒ SampleError
+# SampleError.typeIds(true) ⇒ [
+#       {"moduleId":{"organization":"$anon","name":".","platformParts":["0"]},"localId":"SampleError"}
+# ]
 # ```
 # 
 # + t - the typedesc

--- a/langlib/lang.typedesc/src/main/ballerina/typedesc_lib.bal
+++ b/langlib/lang.typedesc/src/main/ballerina/typedesc_lib.bal
@@ -45,15 +45,11 @@ public type TypeId readonly & record {|
 # type Error distinct error;
 # type SampleError distinct (Error & error<record {string msg;}>);
 # 
-# typedesc:TypeId[]? & readonly typeIds = SampleError.typeIds();
-# if (typeIds is typedesc:TypeId[]) {
-#   io:println(typeIds[typeIds.length() - 1]["localId"]) ⇒ Error
-# }
+# typedesc:TypeId[] typeIds = <typedesc:TypeId[]>SampleError.typeIds();
+# typeIds[typeIds.length() - 1]["localId"] ⇒ Error
 # 
-# typedesc:TypeId[]? & readonly primaryTypeIds = SampleError.typeIds(true);
-# if (primaryTypeIds is typedesc:TypeId[]) {
-#   io:println(primaryTypeIds[primaryTypeIds.length() - 1]["localId"]) ⇒ SampleError
-# }
+# typedesc:TypeId[] primaryTypeIds = <typedesc:TypeId[]>SampleError.typeIds(true);
+# primaryTypeIds[primaryTypeIds.length() - 1]["localId"] ⇒ SampleError
 # ```
 # 
 # + t - the typedesc

--- a/langlib/lang.typedesc/src/main/ballerina/typedesc_lib.bal
+++ b/langlib/lang.typedesc/src/main/ballerina/typedesc_lib.bal
@@ -46,6 +46,8 @@ public type TypeId readonly & record {|
 # 
 # type SampleError distinct (Error & error<record {string msg;}>);
 # 
+# Error.typeIds() ⇒ [{"moduleId":{"organization":"$anon","name":".","platformParts":["0"]},"localId":"Error"}]
+# 
 # SampleError.typeIds() ⇒ [{"moduleId":{"organization":"$anon","name":".","platformParts":["0"]},"localId":"SampleError"},{"moduleId":{"organization":"$anon","name":".","platformParts":["0"]},"localId":"Error"}]
 # 
 # SampleError.typeIds(true) ⇒ [{"moduleId":{"organization":"$anon","name":".","platformParts":["0"]},"localId":"SampleError"}]


### PR DESCRIPTION
## Purpose
> $title

Fixes #38982

## Approach

## Samples

## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [x] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
