### PR TITLE
[2201.3.x] Fix extract to local var code action

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToLocalVarCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToLocalVarCodeAction.java
@@ -126,8 +126,15 @@ public class ExtractToLocalVarCodeAction implements RangeBasedCodeActionProvider
         if (statementNode == null) {
             return Collections.emptyList();
         }
-        String paddingStr = StringUtils.repeat(" ", statementNode.lineRange().startLine().offset());
         String typeDescriptor = FunctionGenerator.getReturnTypeAsString(context, typeSymbol.get().signature());
+        if (statementNode.kind() == SyntaxKind.INVALID_EXPRESSION_STATEMENT) {
+            String variable = String.format("%s %s = %s", typeDescriptor, varName, value);
+            TextEdit edit = new TextEdit(new Range(PositionUtil.toPosition(replaceRange.startLine()),
+                    PositionUtil.toPosition(replaceRange.endLine())),  variable);
+            return Collections.singletonList(CodeActionUtil.createCodeAction(CommandConstants.EXTRACT_TO_VARIABLE,
+                    List.of(edit), context.fileUri(), CodeActionKind.RefactorExtract));
+        }
+        String paddingStr = StringUtils.repeat(" ", statementNode.lineRange().startLine().offset());
         String varDeclStr = String.format("%s %s = %s;%n%s", typeDescriptor, varName, value, paddingStr);
         Position varDeclPos = new Position(statementNode.lineRange().startLine().line(), 
                 statementNode.lineRange().startLine().offset());

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ExtractToLocalVarTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ExtractToLocalVarTest.java
@@ -74,7 +74,8 @@ public class ExtractToLocalVarTest extends AbstractCodeActionTest {
                 {"extractToVariableInFieldAccessInReturnStmt.json"},
                 {"extractToVariableInFieldAccessInAssignmentStmt.json"},
                 {"extractToVariableInObjectField.json"},
-                {"extractToVariableInXmlnsDecl.json"}
+                {"extractToVariableInXmlnsDecl.json"},
+                {"extractToVariableInvalidExpressionStatement.json"}
         };
     }
 

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInvalidExpressionStatement.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInvalidExpressionStatement.json
@@ -1,0 +1,35 @@
+{
+  "range": {
+    "start": {
+      "line": 7,
+      "character": 4
+    },
+    "end": {
+      "line": 7,
+      "character": 12
+    }
+  },
+  "source": "extractToVariableInvalidExpressionStatement.bal",
+  "expected": [
+    {
+      "title": "Extract to local variable",
+      "kind": "refactor.extract",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 7,
+              "character": 4
+            },
+            "end": {
+              "line": 7,
+              "character": 12
+            }
+          },
+          "newText": "string|int? var1 = myvar.id"
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/source/extractToVariableInvalidExpressionStatement.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/source/extractToVariableInvalidExpressionStatement.bal
@@ -1,0 +1,9 @@
+
+type Type1 record {|
+    string|int? id;
+|};
+
+public function main() {
+    Type1 myvar = {id: 10};
+    myvar.id;
+}


### PR DESCRIPTION
## Purpose
$subject
Avoid adding a variable reference when there is an expression statement. 

Fixes #38739 

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
