### PR TITLE
Fix invalid temporary variable name created when desugaring nullable binary expressions

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -7245,7 +7245,7 @@ public class Desugar extends BLangNodeVisitor {
             binaryExpr.lhsExpr = rewriteExpr(binaryExpr.lhsExpr);
         }
 
-        BLangSimpleVariableDef tempVarDef = createVarDef("result",
+        BLangSimpleVariableDef tempVarDef = createVarDef("$result$",
                 binaryExpr.getBType(), null, binaryExpr.pos);
         BLangSimpleVarRef tempVarRef = ASTBuilderUtil.createVariableRef(binaryExpr.pos, tempVarDef.var.symbol);
         blockStmt.addStatement(tempVarDef);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/AddOperationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/AddOperationTest.java
@@ -159,7 +159,7 @@ public class AddOperationTest {
                 "testStringXmlSubtypesAddition",
                 "testStringSubtypesAddition",
                 "testXmlSubtypesAddition",
-                "testNullableIntAdd"
+                "testNullableIntAddition"
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/AddOperationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/AddOperationTest.java
@@ -158,7 +158,8 @@ public class AddOperationTest {
                 "testStringCharAddition",
                 "testStringXmlSubtypesAddition",
                 "testStringSubtypesAddition",
-                "testXmlSubtypesAddition"
+                "testXmlSubtypesAddition",
+                "testNullableIntAdd"
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/add-operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/add-operation.bal
@@ -531,8 +531,12 @@ function bam() returns int {
 
 function testNullableIntAdd() {
     int[] result = [1, 2];
-    int? val = bar() + result[0];
+    int? val = baz() + result[0];
     assertEquality(val, ());
+}
+
+function baz() returns int? {
+    return ();
 }
 
 function assertEquality(any actual, any expected) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/add-operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/add-operation.bal
@@ -529,7 +529,7 @@ function bam() returns int {
     return 5;
 }
 
-function testNullableIntAdd() {
+function testNullableIntAddition() {
     int[] result = [1, 2];
     int? val = baz() + result[0];
     assertEquality(val, ());

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/add-operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/add-operation.bal
@@ -529,6 +529,12 @@ function bam() returns int {
     return 5;
 }
 
+function testNullableIntAdd() {
+    int[] result = [1, 2];
+    int? val = bar() + result[0];
+    assertEquality(val, ());
+}
+
 function assertEquality(any actual, any expected) {
     if actual is anydata && expected is anydata && actual == expected {
         return;


### PR DESCRIPTION
## Purpose
> A temporary variable names created during desugaring nullable binary expressions are not following the naming convention of synthetic variables, which should start and end with `$` symbol.  

Fixes #39050 

## Approach
> Changed the generated temporary variable name form `result` to `$result$`

## Samples

## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
