### PR TITLE
[2201.3.x] Fix annotation passing for immutable inline records

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/creators/TypeCreator.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/creators/TypeCreator.java
@@ -224,7 +224,7 @@ public class TypeCreator {
      */
     public static RecordType createRecordType(String typeName, Module module, long flags, boolean sealed,
                                               int typeFlags) {
-        return new BRecordType(typeName, module, flags, sealed, typeFlags);
+        return new BRecordType(typeName, typeName, module, flags, sealed, typeFlags);
     }
 
     /**

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BRecordType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BRecordType.java
@@ -44,7 +44,7 @@ import java.util.Optional;
  * @since 0.995.0
  */
 public class BRecordType extends BStructureType implements RecordType {
-
+    private String internalName = null;
     public boolean sealed;
     public Type restFieldType;
     public int typeFlags;
@@ -61,8 +61,9 @@ public class BRecordType extends BStructureType implements RecordType {
      * @param sealed flag indicating the sealed status
      * @param typeFlags flags associated with the type
      */
-    public BRecordType(String typeName, Module pkg, long flags, boolean sealed, int typeFlags) {
+    public BRecordType(String typeName, String internalName, Module pkg, long flags, boolean sealed, int typeFlags) {
         super(typeName, pkg, flags, MapValueImpl.class);
+        this.internalName = internalName;
         this.sealed = sealed;
         this.typeFlags = typeFlags;
         this.readonly = SymbolFlags.isFlagOn(flags, SymbolFlags.READONLY);
@@ -141,6 +142,9 @@ public class BRecordType extends BStructureType implements RecordType {
 
     @Override
     public String getAnnotationKey() {
+        if (this.internalName != null) {
+            return Utils.decodeIdentifier(this.internalName);
+        }
         return Utils.decodeIdentifier(this.typeName);
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmSignatures.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmSignatures.java
@@ -386,7 +386,8 @@ public class JvmSignatures {
     public static final String RECORD_REMOVE = "(L" + STRING_VALUE + ";L" + OBJECT + ";)L" + OBJECT + ";";
     public static final String RECORD_SET = "()L" + SET + ";";
     public static final String RECORD_SET_MAP_ENTRY = "()L" + SET + "<L" + MAP_ENTRY + "<TK;TV;>;>;";
-    public static final String RECORD_TYPE_IMPL_INIT = "(L" + STRING_VALUE + ";L" + MODULE + ";JZI)V";
+    public static final String RECORD_TYPE_IMPL_INIT =
+            "(L" + STRING_VALUE + ";L" + STRING_VALUE + ";L" + MODULE + ";JZI)V";
     public static final String RECORD_VALUE_CLASS = "<K:L" + OBJECT + ";V:L" + OBJECT + ";>L" + MAP_VALUE_IMPL +
             "<TK;TV;>;L" + MAP_VALUE + "<TK;TV;>;";
     public static final String RESOURCE_METHOD_TYPE_ARRAY_PARAM = "([L" + RESOURCE_METHOD_TYPE + ";)V";

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/types/JvmRecordTypeGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/types/JvmRecordTypeGen.java
@@ -154,6 +154,9 @@ public class JvmRecordTypeGen {
         String name = getFullName(recordType);
         mv.visitLdcInsn(Utils.decodeIdentifier(name));
 
+        // Load internal name
+        mv.visitLdcInsn(Utils.decodeIdentifier(internalName));
+
         // Load package path
         // TODO: get it from the type
         String varName = jvmConstantsGen.getModuleConstantVar(recordType.tsymbol.pkgID);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
@@ -53,6 +53,7 @@ import io.ballerina.runtime.api.values.BMapInitialValueEntry;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
 import io.ballerina.runtime.api.values.BTypedesc;
+import io.ballerina.runtime.internal.TypeChecker;
 import io.ballerina.runtime.internal.types.BArrayType;
 import io.ballerina.runtime.internal.types.BFunctionType;
 import io.ballerina.runtime.internal.types.BRecordType;
@@ -435,4 +436,21 @@ public class Values {
         return ValueCreator.createTupleValue(tupleType, elements);
     }
 
+    public static Boolean checkInlineRecordAnnotations(BTypedesc typedesc, BTypedesc constraint) {
+        Type describingType = typedesc.getDescribingType();
+        if (describingType.getTag() == TypeTags.TYPE_REFERENCED_TYPE_TAG &&
+                ((ReferenceType) describingType).getReferredType().getTag() == TypeTags.INTERSECTION_TAG) {
+            describingType = ((IntersectionType)
+                    ((ReferenceType) describingType).getReferredType()).getConstituentTypes().get(0);
+        }
+        if (!(describingType instanceof AnnotatableType)) {
+            throw ErrorCreator.createError(StringUtils.fromString("Invalid type found."));
+        }
+        Object annotation = ((AnnotatableType) describingType).getAnnotation(StringUtils.fromString("$field$.title"));
+        if (annotation == null) {
+            throw ErrorCreator.createError(StringUtils.fromString("Annotation is not available."));
+        }
+        BString annotKey = StringUtils.fromString("testorg/runtime_api_types.typeref:1:String");
+        return TypeChecker.checkIsType(((BMap) annotation).get(annotKey), constraint.getDescribingType());
+    }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/types/modules/typeref/typeref.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/types/modules/typeref/typeref.bal
@@ -84,6 +84,7 @@ public function validateTypeRef() {
     testRuntimeTypeRef();
     validateArray();
     validateFunctionParameters();
+    validateInlineRecordField();
 }
 
 function validateFunctionParameters() {
@@ -427,6 +428,65 @@ function validateArray() {
         test:assertFail("Expected error not found.");
     }
 }
+
+public type StringConstraints record {|
+    int length?;
+    int minLength?;
+    int maxLength?;
+|};
+
+public annotation StringConstraints String on record field;
+
+type InlineAlbum readonly & record {|
+    @String {
+        minLength: 1
+    }
+    string title;
+    string artist;
+|};
+
+type MutableAlbum record {|
+    @String {
+        maxLength: 5,
+        minLength: 1
+    }
+    string title;
+    string artist;
+|};
+
+MutableAlbum mutableAlbum = {
+    artist: "testA",
+    title: "testssA"
+};
+
+InlineAlbum inlineImmutableAlbum = {
+    artist: "testB",
+    title: "testssB"
+};
+
+record {|
+    @String {
+        minLength: 1
+    }
+    string title;
+    string artist;
+|} inlineAlbum = {
+    artist: "testC",
+    title: "testssC"
+};
+
+function validateInlineRecordField() {
+    boolean s1 = checkInlineRecordAnnotations(MutableAlbum, StringConstraints);
+    boolean s2 = checkInlineRecordAnnotations(InlineAlbum, StringConstraints);
+    boolean s3 = checkInlineRecordAnnotations(typeof inlineAlbum, StringConstraints);
+    test:assertTrue(s1);
+    test:assertTrue(s2);
+    test:assertTrue(s3);
+}
+
+public isolated function checkInlineRecordAnnotations(typedesc<any> t1, typedesc<any> t2) returns boolean = @java:Method {
+    'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Values"
+} external;
 
 # Validates the provided value against the configured annotations.
 #


### PR DESCRIPTION
## Purpose
$subject
Fixes #39156

## Approach
As for inline records, the global annotation map is passed with `anonaType` key, it is not populated to the runtime record type.  So, we don't pass the `anonType` internal name to the runtime for retrieving the annotations which causes the issue. 
This PR passes the internal name to runtime to be used when populating annotations. 

## Samples
```ballerina
import ballerina/io;
import ballerina/constraint;

type Album readonly & record {|
    @constraint:String {
        maxLength: 5,
        minLength: 1
    }
    string title;
    string artist;
|};

public function main() returns error? {
    Album a = {
        artist: "test",
        title: "testss"
    };
    Album validAlbum = check constraint:validate(a); // should fail
    io:println(validAlbum);
}
```
## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
