### PR TITLE
Fix `fromBytes` and `equalsIgnoreCaseAscii` langlib methods to support async calls

### DIFF
--- a/langlib/lang.string/src/main/java/org/ballerinalang/langlib/string/EqualsIgnoreCaseAscii.java
+++ b/langlib/lang.string/src/main/java/org/ballerinalang/langlib/string/EqualsIgnoreCaseAscii.java
@@ -22,8 +22,8 @@ import io.ballerina.runtime.api.values.BString;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.CharacterCodingException;
-import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Extern function lang.string:equalsIgnoreCase(string, string).
@@ -31,12 +31,9 @@ import java.nio.charset.CharsetDecoder;
  * @since 1.2
  */
 public class EqualsIgnoreCaseAscii {
-    private static CharsetDecoder decoder;
 
-    static {
-        decoder = Charset.forName("US-ASCII").newDecoder();
+    private EqualsIgnoreCaseAscii() {
     }
-
     public static boolean equalsIgnoreCaseAscii(BString s1, BString s2) {
         if (s1.length() != s2.length()) {
             return false;
@@ -59,13 +56,14 @@ public class EqualsIgnoreCaseAscii {
     }
 
     private static boolean isPureAscii(String  str) {
-        byte byteArray[] = str.getBytes();
+        byte[] byteArray = str.getBytes();
+        CharsetDecoder decoder = StandardCharsets.US_ASCII.newDecoder();
         try {
-            decoder.decode(ByteBuffer.wrap(byteArray)).toString();
+            decoder.decode(ByteBuffer.wrap(byteArray));
+            decoder.reset();
         } catch (CharacterCodingException e) {
             return false;
         }
-
         return true;
     }
 }

--- a/langlib/lang.string/src/main/java/org/ballerinalang/langlib/string/EqualsIgnoreCaseAscii.java
+++ b/langlib/lang.string/src/main/java/org/ballerinalang/langlib/string/EqualsIgnoreCaseAscii.java
@@ -20,9 +20,6 @@ package org.ballerinalang.langlib.string;
 
 import io.ballerina.runtime.api.values.BString;
 
-import java.nio.ByteBuffer;
-import java.nio.charset.CharacterCodingException;
-import java.nio.charset.CharsetDecoder;
 import java.nio.charset.StandardCharsets;
 
 /**
@@ -34,6 +31,7 @@ public class EqualsIgnoreCaseAscii {
 
     private EqualsIgnoreCaseAscii() {
     }
+
     public static boolean equalsIgnoreCaseAscii(BString s1, BString s2) {
         if (s1.length() != s2.length()) {
             return false;
@@ -56,14 +54,6 @@ public class EqualsIgnoreCaseAscii {
     }
 
     private static boolean isPureAscii(String  str) {
-        byte[] byteArray = str.getBytes();
-        CharsetDecoder decoder = StandardCharsets.US_ASCII.newDecoder();
-        try {
-            decoder.decode(ByteBuffer.wrap(byteArray));
-            decoder.reset();
-        } catch (CharacterCodingException e) {
-            return false;
-        }
-        return true;
+        return StandardCharsets.US_ASCII.newEncoder().canEncode(str);
     }
 }

--- a/langlib/lang.string/src/main/java/org/ballerinalang/langlib/string/FromBytes.java
+++ b/langlib/lang.string/src/main/java/org/ballerinalang/langlib/string/FromBytes.java
@@ -44,13 +44,12 @@ import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReason
 //)
 public class FromBytes {
 
-    private static final CharsetDecoder charsetDecoder = StandardCharsets.UTF_8.newDecoder();
-
     private FromBytes() {
     }
 
     public static Object fromBytes(BArray bytes) {
         try {
+            CharsetDecoder charsetDecoder = StandardCharsets.UTF_8.newDecoder();
             String str = charsetDecoder.decode(ByteBuffer.wrap(bytes.getBytes())).toString();
             charsetDecoder.reset();
             return StringUtils.fromString(str);

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibStringTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibStringTest.java
@@ -65,19 +65,9 @@ public class LangLibStringTest {
     }
 
     @Test
-    public void testLength() {
-        BRunUtil.invoke(compileResult, "testLength");
-    }
-
-    @Test
     public void testSubString() {
         Object returns = BRunUtil.invoke(compileResult, "testSubString");
         assertEquals(returns.toString(), "[\"Bal\",\"Ballerina!\",\"Ballerina!\"]");
-    }
-
-    @Test
-    public void testIterator() {
-        BRunUtil.invoke(compileResult, "testIterator");
     }
 
     @Test
@@ -90,11 +80,6 @@ public class LangLibStringTest {
     public void testFromBytes() {
         Object returns = BRunUtil.invoke(compileResult, "testFromBytes");
         assertEquals(returns.toString(), "Hello Ballerina!");
-    }
-
-    @Test
-    public void testFromBytesInvalidValues() {
-        BRunUtil.invoke(compileResult, "testFromBytesInvalidValues");
     }
 
     @Test
@@ -124,11 +109,6 @@ public class LangLibStringTest {
         } else {
             assertEquals(returns, expected, "For substring: " + substr);
         }
-    }
-
-    @Test(description = "Test the lastIndexOf() method.")
-    public void testLastIndexOf() {
-        BRunUtil.invoke(compileResult, "testLastIndexOf");
     }
 
     @Test(dataProvider = "codePointCompareProvider")
@@ -253,11 +233,6 @@ public class LangLibStringTest {
                 "error(\"{ballerina/lang.string}StringOperationError\",message=\"" + result + "\")");
     }
 
-    @Test
-    public void testEqualsIgnoreCaseAscii() {
-        BRunUtil.invoke(compileResult, "testEqualsIgnoreCaseAscii");
-    }
-
     @DataProvider(name = "testSubstringDataProvider")
     public Object[][] testSubstringDataProvider() {
         return new Object[][]{
@@ -279,16 +254,6 @@ public class LangLibStringTest {
     public void testChainedStringFunctions() {
         Object returns = BRunUtil.invoke(compileResult, "testChainedStringFunctions");
         assertEquals(returns.toString(), "foo1foo2foo3foo4");
-    }
-
-    @Test
-    public void testLangLibCallOnStringSubTypes() {
-        BRunUtil.invoke(compileResult, "testLangLibCallOnStringSubTypes");
-    }
-
-    @Test
-    public void testLangLibCallOnFiniteType() {
-        BRunUtil.invoke(compileResult, "testLangLibCallOnFiniteType");
     }
 
     @Test(dataProvider = "unicodeCharProvider")
@@ -333,32 +298,6 @@ public class LangLibStringTest {
     public Object[] testBMPStringProvider() {
         return new String[]{"ascii~?", "£ßóµ¥", "ęЯλĢŃ", "☃✈௸ऴᛤ", "😀🄰🍺" };
     }
-
-    @Test
-    public void testPadStart() {
-        BRunUtil.invoke(compileResult, "testPadStart");
-    }
-
-    @Test
-    public void testPadEnd() {
-        BRunUtil.invoke(compileResult, "testPadEnd");
-    }
-
-    @Test
-    public void testPadZero() {
-        BRunUtil.invoke(compileResult, "testPadZero");
-    }
-
-    @Test
-    public void testMatches() {
-        BRunUtil.invoke(compileResult, "testMatches");
-    }
-
-    @Test
-    public void testIncludesMatch() {
-        BRunUtil.invoke(compileResult, "testIncludesMatch");
-    }
-
 
     @Test
     public void stringlibNegativeTest() {
@@ -486,4 +425,31 @@ public class LangLibStringTest {
         Assert.assertEquals(returns.toString(), "error(\"{ballerina/lang.string}length greater that '2147483647' not" +
                 " yet supported\")");
     }
+
+    @Test(dataProvider = "stringFunctionProvider")
+    public void testStringLibFunctions(String functionName) {
+        BRunUtil.invoke(compileResult, functionName);
+    }
+
+    @DataProvider(name = "stringFunctionProvider")
+    public Object[] testStringFunctionProvider() {
+
+        return new String[]{
+                "testLength",
+                "testIterator",
+                "testFromBytesInvalidValues",
+                "testLastIndexOf",
+                "testEqualsIgnoreCaseAscii",
+                "testLangLibCallOnStringSubTypes",
+                "testLangLibCallOnFiniteType",
+                "testPadStart",
+                "testPadEnd",
+                "testPadZero",
+                "testMatches",
+                "testIncludesMatch",
+                "testFromBytesAsync",
+                "testEqualsIgnoreCaseAsciiAsync"
+        };
+    }
+
 }

--- a/langlib/langlib-test/src/test/resources/test-src/stringlib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/stringlib_test.bal
@@ -15,6 +15,7 @@
 // under the License.
 
 import ballerina/lang.'string as strings;
+import ballerina/lang.runtime as runtime;
 
 string str = "Hello Ballerina!";
 string str1 = "Hello Hello Ballerina!";
@@ -685,6 +686,138 @@ function testIncludesMatch() {
     string:RegExp regex6 = re `apple|orange|pear|banana|kiwi`;
     boolean result6 = stringToMatch6.includesMatch(regex6);
     assertTrue(result6);
+}
+
+function testFromBytesAsync() {
+    foreach int i in 0 ... 4 {
+        callFromBytesAsync();
+    }
+}
+
+function callFromBytesAsync() {
+    string append = "";
+    worker w1 {
+        future<string|error> bytesFuture = start callFromBytes1();
+        runtime:sleep(2);
+        string|error str = wait bytesFuture;
+        assertTrue(str is string);
+        if (str is string) {
+            append += str + " ";
+        }
+    }
+    worker w2 {
+        future<string|error> bytesFuture = start callFromBytes2();
+        string|error str = wait bytesFuture;
+        assertTrue(str is string);
+        if (str is string) {
+            append += str + " ";
+        }
+    }
+    _ = wait {w1, w2};
+    assertTrue(append == "Hello Ballerina! Hello!~?£ßЯλ☃✈௸😀🄰🍺 " ||
+    append == "Hello!~?£ßЯλ☃✈௸😀🄰🍺 Hello Ballerina! ");
+}
+
+function callFromBytes1() returns string|error {
+    byte[] bytes = [
+        72,
+        101,
+        108,
+        108,
+        111,
+        33,
+        126,
+        63,
+        194,
+        163,
+        195,
+        159,
+        208,
+        175,
+        206,
+        187,
+        226,
+        152,
+        131,
+        226,
+        156,
+        136,
+        224,
+        175,
+        184,
+        240,
+        159,
+        152,
+        128,
+        240,
+        159,
+        132,
+        176,
+        240,
+        159,
+        141,
+        186
+    ];
+    return check string:fromBytes(bytes);
+}
+
+function callFromBytes2() returns string|error {
+    byte[] bytes = [
+        72,
+        101,
+        108,
+        108,
+        111,
+        32,
+        66,
+        97,
+        108,
+        108,
+        101,
+        114,
+        105,
+        110,
+        97,
+        33
+    ];
+    return checkpanic string:fromBytes(bytes);
+}
+
+function testEqualsIgnoreCaseAsciiAsync() {
+    foreach int i in 0 ... 4 {
+        callEqualsIgnoreCaseAsciiAsync();
+    }
+}
+
+function callEqualsIgnoreCaseAsciiAsync() {
+    boolean append = true;
+    worker w1 {
+        future<boolean|error> equalsFuture = start callEqualsIgnoreCaseAscii1();
+        runtime:sleep(2);
+        boolean|error result = wait equalsFuture;
+        assertTrue(result is boolean);
+        if (result is boolean) {
+            append = append && result;
+        }
+    }
+    worker w2 {
+        future<boolean|error> equalsFuture = start callEqualsIgnoreCaseAscii2();
+        boolean|error result = wait equalsFuture;
+        assertTrue(result is boolean);
+        if (result is boolean) {
+            append = append && result;
+        }
+    }
+    _ = wait {w1, w2};
+    assertTrue(append);
+}
+
+function callEqualsIgnoreCaseAscii1() returns boolean {
+    return string:equalsIgnoreCaseAscii("aBCdeFg", "aBCdeFg");
+}
+
+function callEqualsIgnoreCaseAscii2() returns boolean {
+    return string:equalsIgnoreCaseAscii("Duල්Viන්", "Duල්Viන්");
 }
 
 const ASSERTION_ERROR_REASON = "AssertionError";

--- a/langlib/langlib-test/src/test/resources/test-src/stringlib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/stringlib_test.bal
@@ -15,7 +15,6 @@
 // under the License.
 
 import ballerina/lang.'string as strings;
-import ballerina/lang.runtime as runtime;
 
 string str = "Hello Ballerina!";
 string str1 = "Hello Hello Ballerina!";
@@ -689,20 +688,18 @@ function testIncludesMatch() {
 }
 
 function testFromBytesAsync() {
-    foreach int i in 0 ... 4 {
+    foreach int i in 0 ... 15 {
         callFromBytesAsync();
     }
 }
 
-function callFromBytesAsync() {
-    string append = "";
+isolated function callFromBytesAsync() {
     worker w1 {
         future<string|error> bytesFuture = start callFromBytes1();
-        runtime:sleep(2);
         string|error str = wait bytesFuture;
         assertTrue(str is string);
         if (str is string) {
-            append += str + " ";
+            assertEquals(str, "Hello!~?£ßЯλ☃✈௸😀🄰🍺");
         }
     }
     worker w2 {
@@ -710,15 +707,13 @@ function callFromBytesAsync() {
         string|error str = wait bytesFuture;
         assertTrue(str is string);
         if (str is string) {
-            append += str + " ";
+            assertEquals(str, "Hello Ballerina!");
         }
     }
     _ = wait {w1, w2};
-    assertTrue(append == "Hello Ballerina! Hello!~?£ßЯλ☃✈௸😀🄰🍺 " ||
-    append == "Hello!~?£ßЯλ☃✈௸😀🄰🍺 Hello Ballerina! ");
 }
 
-function callFromBytes1() returns string|error {
+isolated function callFromBytes1() returns string|error {
     byte[] bytes = [
         72,
         101,
@@ -761,7 +756,7 @@ function callFromBytes1() returns string|error {
     return check string:fromBytes(bytes);
 }
 
-function callFromBytes2() returns string|error {
+isolated function callFromBytes2() returns string|error {
     byte[] bytes = [
         72,
         101,
@@ -784,20 +779,18 @@ function callFromBytes2() returns string|error {
 }
 
 function testEqualsIgnoreCaseAsciiAsync() {
-    foreach int i in 0 ... 4 {
+    foreach int i in 0 ... 15 {
         callEqualsIgnoreCaseAsciiAsync();
     }
 }
 
-function callEqualsIgnoreCaseAsciiAsync() {
-    boolean append = true;
+isolated function callEqualsIgnoreCaseAsciiAsync() {
     worker w1 {
         future<boolean|error> equalsFuture = start callEqualsIgnoreCaseAscii1();
-        runtime:sleep(2);
         boolean|error result = wait equalsFuture;
         assertTrue(result is boolean);
         if (result is boolean) {
-            append = append && result;
+            assertTrue(result);
         }
     }
     worker w2 {
@@ -805,24 +798,23 @@ function callEqualsIgnoreCaseAsciiAsync() {
         boolean|error result = wait equalsFuture;
         assertTrue(result is boolean);
         if (result is boolean) {
-            append = append && result;
+            assertTrue(result);
         }
     }
     _ = wait {w1, w2};
-    assertTrue(append);
 }
 
-function callEqualsIgnoreCaseAscii1() returns boolean {
+isolated function callEqualsIgnoreCaseAscii1() returns boolean {
     return string:equalsIgnoreCaseAscii("aBCdeFg", "aBCdeFg");
 }
 
-function callEqualsIgnoreCaseAscii2() returns boolean {
+isolated function callEqualsIgnoreCaseAscii2() returns boolean {
     return string:equalsIgnoreCaseAscii("Duල්Viන්", "Duල්Viන්");
 }
 
 const ASSERTION_ERROR_REASON = "AssertionError";
 
-function assertEquals(anydata expected, anydata actual) {
+isolated function assertEquals(anydata expected, anydata actual) {
     if (expected == actual) {
         return;
     }
@@ -834,7 +826,7 @@ function assertEquals(anydata expected, anydata actual) {
     panic error(ASSERTION_ERROR_REASON, message = msg);
 }
 
-function assertTrue(anydata actual) {
+isolated function assertTrue(anydata actual) {
     assertEquals(true, actual);
 }
 


### PR DESCRIPTION
## Purpose
$subject

Fixes #39157 
Fixes https://github.com/wso2-enterprise/internal-support-ballerina/issues/237

## Approach
The issue happens due to the static `CharSetDecoder` instances used in these methods are not thread-safe. Therefore `IllegalStateException` is thrown when these methods are called asynchronously.
The PR fixes it by creating decoder instances only when the method is called.  

## Samples
```ballerina
import ballerina/lang.runtime;

public function main() {
    foreach int i in 0 ... 4 {
        callFromBytesAsync();
    }
}

function callFromBytesAsync() {
    string append = "";
    worker w1 {
        future<string|error> bytesFuture = start callFromBytes1();
        runtime:sleep(2);
        string|error str = wait bytesFuture;
        assertTrue(str is string);
        if (str is string) {
            append += str + " ";
        }
    }
    worker w2 {
        future<string|error> bytesFuture = start callFromBytes2();
        string|error str = wait bytesFuture;
        assertTrue(str is string);
        if (str is string) {
            append += str + " ";
        }
    }
    _ = wait {w1, w2};
}

function callFromBytes1() returns string|error {
    byte[] bytes = [
        72,
        101,
        108,
        108,
        111,
        33,
        126,
        63,
        194,
        163,
        195,
        159,
        208,
        175,
        206,
        187,
        226,
        152,
        131,
        226,
        156,
        136,
        224,
        175,
        184,
        240,
        159,
        152,
        128,
        240,
        159,
        132,
        176,
        240,
        159,
        141,
        186
    ];
    return check string:fromBytes(bytes);
}

function callFromBytes2() returns string|error {
    byte[] bytes = [
        72,
        101,
        108,
        108,
        111,
        32,
        66,
        97,
        108,
        108,
        101,
        114,
        105,
        110,
        97,
        33
    ];
    return checkpanic string:fromBytes(bytes);
}

```

## CheckList 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
