### PR TITLE
Refactor usage of `getMembers` & `getTupleTypes`

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -1641,11 +1641,12 @@ public class Desugar extends BLangNodeVisitor {
             boolean isIndexBasedAccessExpr = tupleExpr.getKind() == NodeKind.INDEX_BASED_ACCESS_EXPR;
             if (restType.tag == TypeTags.TUPLE) {
                 BTupleType restTupleType = (BTupleType) restType;
-                for (int index = 0; index < restTupleType.getMembers().size(); index++) {
+                List<BType> restTupleMemberTypes = restTupleType.getTupleTypes();
+                for (int index = 0; index < restTupleMemberTypes.size(); index++) {
                     BLangLiteral indexExpr = ASTBuilderUtil.createLiteral(pos, symTable.intType,
                             (long) index);
                     BLangIndexBasedAccess tupleValueExpr = ASTBuilderUtil.createIndexAccessExpr(arrayVarRef, indexExpr);
-                    tupleValueExpr.setBType(restTupleType.getTupleTypes().get(index));
+                    tupleValueExpr.setBType(restTupleMemberTypes.get(index));
                     if (isIndexBasedAccessExpr) {
                         createAssignmentStmt(tupleValueExpr, blockStmt, countExpr, tupleVarSymbol,
                                 (BLangIndexBasedAccess) tupleExpr);
@@ -2598,11 +2599,12 @@ public class Desugar extends BLangNodeVisitor {
             modifiedTupleExpr.setBType(tupleExpr.getBType());
             tupleExpr = modifiedTupleExpr;
             isIndexBasedAccessExpr = true;
-            for (int index = 0; index < restTupleType.getMembers().size(); index++) {
+            List<BType> restTupleMemberTypes = restTupleType.getTupleTypes();
+            for (int index = 0; index < restTupleMemberTypes.size(); index++) {
                 BLangLiteral indexExpr = ASTBuilderUtil.createLiteral(pos, symTable.intType,
                         (long) index);
                 BLangIndexBasedAccess tupleValueExpr = ASTBuilderUtil.createIndexAccessExpr(restParam, indexExpr);
-                tupleValueExpr.setBType(restTupleType.getTupleTypes().get(index));
+                tupleValueExpr.setBType(restTupleMemberTypes.get(index));
                 createAssignmentStmt(tupleValueExpr, blockStmt, indexExpr, tupleVarSymbol,
                         (BLangIndexBasedAccess) tupleExpr);
                 // Increment the count for each visited member in the tupleLiteral.

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -994,7 +994,7 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
         data.env = bType.tag == TypeTags.NONE ? data.env :
                 SymbolEnv.createTypeEnv(tupleTypeNode, new Scope(bType.tsymbol), data.env);
         boolean isTuple = bType.tag == TypeTags.TUPLE;
-        List<BTupleMember> members = ((BTupleType) bType).getMembers();
+        List<BTupleMember> members = isTuple ? ((BTupleType) bType).getMembers() : null;
 
         for (int i = 0; i < memberNodes.size(); i++) {
             BLangSimpleVariable member = memberNodes.get(i);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -994,12 +994,12 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
         data.env = bType.tag == TypeTags.NONE ? data.env :
                 SymbolEnv.createTypeEnv(tupleTypeNode, new Scope(bType.tsymbol), data.env);
         boolean isTuple = bType.tag == TypeTags.TUPLE;
+        List<BTupleMember> members = ((BTupleType) bType).getMembers();
 
         for (int i = 0; i < memberNodes.size(); i++) {
             BLangSimpleVariable member = memberNodes.get(i);
             analyzeNode(member, data);
             if (isTuple) {
-                List<BTupleMember> members = ((BTupleType) bType).getMembers();
                 for (BLangAnnotationAttachment ann : member.annAttachments) {
                     members.get(i).symbol.addAnnotation(ann.annotationAttachmentSymbol);
                 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -7746,14 +7746,14 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                 }
             } else if (listTypeRestArg.tag == TypeTags.TUPLE) {
                 BTupleType tupleType = (BTupleType) listTypeRestArg;
-                List<BType> tupleMembers = tupleType.getTupleTypes();
+                List<BType> tupleMemberTypes = tupleType.getTupleTypes();
                 BType tupleRestType = tupleType.restType;
 
-                int tupleMemCount = tupleMembers.size();
+                int tupleMemCount = tupleMemberTypes.size();
 
                 for (int j = 0; j < iExpr.restArgs.size(); j++) {
                     BLangExpression restArg = iExpr.restArgs.get(j);
-                    BType memType = j < tupleMemCount ? tupleMembers.get(j) : tupleRestType;
+                    BType memType = j < tupleMemCount ? tupleMemberTypes.get(j) : tupleRestType;
                     checkTypeParamExpr(restArg, memType, true, data);
                     if (restType != symTable.semanticError && data.resultType == symTable.semanticError) {
                         restType = data.resultType;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -7746,14 +7746,14 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                 }
             } else if (listTypeRestArg.tag == TypeTags.TUPLE) {
                 BTupleType tupleType = (BTupleType) listTypeRestArg;
-                List<BTupleMember> tupleMembers = tupleType.getMembers();
+                List<BType> tupleMembers = tupleType.getTupleTypes();
                 BType tupleRestType = tupleType.restType;
 
                 int tupleMemCount = tupleMembers.size();
 
                 for (int j = 0; j < iExpr.restArgs.size(); j++) {
                     BLangExpression restArg = iExpr.restArgs.get(j);
-                    BType memType = j < tupleMemCount ? tupleMembers.get(j).type : tupleRestType;
+                    BType memType = j < tupleMemCount ? tupleMembers.get(j) : tupleRestType;
                     checkTypeParamExpr(restArg, memType, true, data);
                     if (restType != symTable.semanticError && data.resultType == symTable.semanticError) {
                         restType = data.resultType;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
@@ -516,9 +516,10 @@ public class TypeParamAnalyzer {
 
     private void findTypeParamInTuple(Location loc, BTupleType expType, BTupleType actualType,
                                       SymbolEnv env, HashSet<BType> resolvedTypes, FindTypeParamResult result) {
-
-        for (int i = 0; i < expType.getMembers().size() && i < actualType.getMembers().size(); i++) {
-            findTypeParam(loc, expType.getMembers().get(i).type, actualType.getMembers().get(i).type, env,
+        List<BType> expTypeMemberTypes = expType.getTupleTypes();
+        List<BType> actualTypeMemberTypes = actualType.getTupleTypes();
+        for (int i = 0; i < expTypeMemberTypes.size() && i < actualTypeMemberTypes.size(); i++) {
+            findTypeParam(loc, expTypeMemberTypes.get(i), actualTypeMemberTypes.get(i), env,
                     resolvedTypes, result);
         }
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BResourceFunction.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BResourceFunction.java
@@ -55,10 +55,11 @@ public class BResourceFunction extends BAttachedFunction {
         StringBuilder sb = new StringBuilder();
         sb.append("resource function ").append(accessor).append(" ");
         List<String> resourcePathStrings = new ArrayList<>(resourcePath.size());
+        List<BType> resourcePathMemberTypes = resourcePathType.getTupleTypes();
         for (int i = 0; i < resourcePath.size(); i++) {
             Name resourcePath = this.resourcePath.get(i);
             if (resourcePath.value.equals("^") || resourcePath.value.equals("$^")) {
-                resourcePathStrings.add("[" + resourcePathType.getTupleTypes().get(i) + "]");
+                resourcePathStrings.add("[" + resourcePathMemberTypes.get(i) + "]");
             } else if (resourcePath.value.equals("^^") || resourcePath.value.equals("$^^")) {
                 resourcePathStrings.add("[" + resourcePathType.restType + "...]");
             } else {


### PR DESCRIPTION
## Purpose
> Refactor usage of `getMembers` & `getTupleTypes` methods of `BTupleType` to remove repeated invocations.

Fixes #39303 