### PR TITLE
[Bindgen Tool] Allow passing null values into Ballerina bindings generated on java string objects

### DIFF
--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JField.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JField.java
@@ -23,6 +23,8 @@ import org.ballerinalang.bindgen.utils.BindgenEnv;
 import java.lang.reflect.Field;
 import java.util.Collections;
 
+import static org.ballerinalang.bindgen.utils.BindgenConstants.BALLERINA_NILLABLE_STRING;
+import static org.ballerinalang.bindgen.utils.BindgenConstants.BALLERINA_NILLABLE_STRING_ARRAY;
 import static org.ballerinalang.bindgen.utils.BindgenConstants.BALLERINA_STRING;
 import static org.ballerinalang.bindgen.utils.BindgenConstants.BALLERINA_STRING_ARRAY;
 import static org.ballerinalang.bindgen.utils.BindgenUtils.getBallerinaHandleType;
@@ -63,10 +65,10 @@ public class JField extends BFunction {
         if (type.isPrimitive() || type.equals(String.class)) {
             isObject = false;
         }
-        if (fieldType.equals(BALLERINA_STRING)) {
+        if (fieldType.equals(BALLERINA_STRING) || fieldType.equals(BALLERINA_NILLABLE_STRING)) {
             isString = true;
         }
-        if (fieldType.equals(BALLERINA_STRING_ARRAY)) {
+        if (fieldType.equals(BALLERINA_STRING_ARRAY) || fieldType.equals(BALLERINA_NILLABLE_STRING_ARRAY)) {
             isStringArray = true;
         }
         if (type.isArray()) {
@@ -121,7 +123,7 @@ public class JField extends BFunction {
         StringBuilder returnString = new StringBuilder();
         if (super.getKind() == BFunctionKind.FIELD_GET) {
             returnString.append(fieldObj.getShortTypeName());
-            if (isString || isStringArray) {
+            if (isStringArray) {
                 returnString.append("?");
             }
             if (returnError) {

--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JMethod.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JMethod.java
@@ -240,10 +240,6 @@ public class JMethod extends BFunction {
         return hasException;
     }
 
-    public boolean getIsStringReturn() {
-        return isStringReturn;
-    }
-
     public String getReturnType() {
         return returnType;
     }

--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JMethod.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JMethod.java
@@ -300,7 +300,7 @@ public class JMethod extends BFunction {
         StringBuilder returnString = new StringBuilder();
         if (getHasReturn()) {
             returnString.append(this.returnType);
-            if (getIsStringReturn() || isStringArrayReturn()) {
+            if (isStringArrayReturn()) {
                 returnString.append("?");
             }
             if (getHasException()) {

--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JParameter.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JParameter.java
@@ -23,9 +23,9 @@ import java.lang.reflect.Parameter;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.ballerinalang.bindgen.utils.BindgenConstants.BALLERINA_NILLABLE_STRING;
+import static org.ballerinalang.bindgen.utils.BindgenConstants.BALLERINA_NILLABLE_STRING_ARRAY;
 import static org.ballerinalang.bindgen.utils.BindgenConstants.BALLERINA_RESERVED_WORDS;
-import static org.ballerinalang.bindgen.utils.BindgenConstants.BALLERINA_STRING;
-import static org.ballerinalang.bindgen.utils.BindgenConstants.BALLERINA_STRING_ARRAY;
 import static org.ballerinalang.bindgen.utils.BindgenConstants.EXCEPTION_CLASS_PREFIX;
 import static org.ballerinalang.bindgen.utils.BindgenUtils.getBallerinaHandleType;
 import static org.ballerinalang.bindgen.utils.BindgenUtils.getBallerinaParamType;
@@ -78,10 +78,10 @@ public class JParameter {
         }
         if (parameterClass.equals(String.class)) {
             isString = true;
-            shortTypeName = BALLERINA_STRING;
+            shortTypeName = BALLERINA_NILLABLE_STRING;
         } else if (parameterClass.equals(String[].class)) {
             isStringArray = true;
-            shortTypeName = BALLERINA_STRING_ARRAY;
+            shortTypeName = BALLERINA_NILLABLE_STRING_ARRAY;
             componentType = String.class.getName();
         } else {
             if (!parameterClass.isPrimitive()) {

--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/utils/BindgenConstants.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/utils/BindgenConstants.java
@@ -56,6 +56,8 @@ public class BindgenConstants {
     static final String HANDLE = "handle";
     public static final String BALLERINA_STRING = "string";
     public static final String BALLERINA_STRING_ARRAY = "string[]";
+    public static final String BALLERINA_NILLABLE_STRING = "string?";
+    public static final String BALLERINA_NILLABLE_STRING_ARRAY = "string?[]";
     public static final String EXCEPTION_CLASS_PREFIX = "J";
     public static final String[] BALLERINA_RESERVED_WORDS = {"import", "as", "public", "private", "external", "final",
             "service", "resource", "function", "object", "record", "annotation", "parameter", "transformer",

--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/utils/BindgenNodeFactory.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/utils/BindgenNodeFactory.java
@@ -1025,10 +1025,11 @@ class BindgenNodeFactory {
         }
         for (JParameter jParameter : bFunction.getParameters()) {
             if (jParameter.getIsString()) {
-                argValues.add("java:fromString(" + jParameter.getFieldName() + ")");
+                argValues.add(String.format("%s is () ? java:createNull() : java:fromString(%s)",
+                        jParameter.getFieldName(), jParameter.getFieldName()));
             } else if (jParameter.isArray()) {
-                argValues.add("check jarrays:toHandle(" + jParameter.getFieldName() + ", \"" +
-                        jParameter.getComponentType() + "\")");
+                argValues.add(String.format("check jarrays:toHandle(%s, \"%s\")",
+                        jParameter.getFieldName(), jParameter.getComponentType()));
             } else if (jParameter.getIsObj()) {
                 argValues.add(jParameter.getFieldName() + ".jObj");
             } else {

--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/utils/BindgenUtils.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/utils/BindgenUtils.java
@@ -44,8 +44,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.ballerinalang.bindgen.utils.BindgenConstants.BALLERINA_STRING;
-import static org.ballerinalang.bindgen.utils.BindgenConstants.BALLERINA_STRING_ARRAY;
+import static org.ballerinalang.bindgen.utils.BindgenConstants.BALLERINA_NILLABLE_STRING;
+import static org.ballerinalang.bindgen.utils.BindgenConstants.BALLERINA_NILLABLE_STRING_ARRAY;
 import static org.ballerinalang.bindgen.utils.BindgenConstants.BOOLEAN;
 import static org.ballerinalang.bindgen.utils.BindgenConstants.BOOLEAN_ARRAY;
 import static org.ballerinalang.bindgen.utils.BindgenConstants.BYTE;
@@ -208,7 +208,7 @@ public class BindgenUtils {
         if (javaType.isPrimitive()) {
             return javaType.getSimpleName();
         } else if (javaType.getSimpleName().equals(JAVA_STRING)) {
-            return BALLERINA_STRING;
+            return BALLERINA_NILLABLE_STRING;
         } else {
             return HANDLE;
         }
@@ -233,9 +233,9 @@ public class BindgenUtils {
             case LONG:
                 return INT;
             case JAVA_STRING:
-                return BALLERINA_STRING;
+                return BALLERINA_NILLABLE_STRING;
             case JAVA_STRING_ARRAY:
-                return BALLERINA_STRING_ARRAY;
+                return BALLERINA_NILLABLE_STRING_ARRAY;
             default:
                 return HANDLE;
         }
@@ -296,7 +296,7 @@ public class BindgenUtils {
                 if (file.isDirectory()) {
                     File[] paths = file.listFiles();
                     if (paths != null) {
-                        for (File filePath: paths) {
+                        for (File filePath : paths) {
                             if (isJarFile(filePath)) {
                                 urls.add(filePath.toURI().toURL());
                                 classPaths.add(filePath.getName());

--- a/misc/ballerina-bindgen/src/test/resources/unit-test-resources/constructors.bal
+++ b/misc/ballerina-bindgen/src/test/resources/unit-test-resources/constructors.bal
@@ -108,11 +108,11 @@ function newConstructorsTestResource1() returns ConstructorsTestResource {
 # The constructor function to generate an object of `org.ballerinalang.bindgen.ConstructorsTestResource`.
 #
 # + arg0 - The `boolean` value required to map with the Java constructor parameter.
-# + arg1 - The `string` value required to map with the Java constructor parameter.
+# + arg1 - The `string?` value required to map with the Java constructor parameter.
 # + arg2 - The `StringBuffer` value required to map with the Java constructor parameter.
 # + return - The new `ConstructorsTestResource` class generated.
-function newConstructorsTestResource2(boolean arg0, string arg1, StringBuffer arg2) returns ConstructorsTestResource {
-    handle externalObj = org_ballerinalang_bindgen_ConstructorsTestResource_newConstructorsTestResource2(arg0, java:fromString(arg1), arg2.jObj);
+function newConstructorsTestResource2(boolean arg0, string? arg1, StringBuffer arg2) returns ConstructorsTestResource {
+    handle externalObj = org_ballerinalang_bindgen_ConstructorsTestResource_newConstructorsTestResource2(arg0, arg1 is () ? java:createNull() : java:fromString(arg1), arg2.jObj);
     ConstructorsTestResource newObj = new (externalObj);
     return newObj;
 }
@@ -203,10 +203,10 @@ function newConstructorsTestResource9(int[] arg0) returns ConstructorsTestResour
 # The constructor function to generate an object of `org.ballerinalang.bindgen.ConstructorsTestResource`.
 #
 # + arg0 - The `int[]` value required to map with the Java constructor parameter.
-# + arg1 - The `string` value required to map with the Java constructor parameter.
+# + arg1 - The `string?` value required to map with the Java constructor parameter.
 # + return - The new `ConstructorsTestResource` class generated.
-function newConstructorsTestResource10(int[] arg0, string arg1) returns ConstructorsTestResource|error {
-    handle externalObj = org_ballerinalang_bindgen_ConstructorsTestResource_newConstructorsTestResource10(check jarrays:toHandle(arg0, "int"), java:fromString(arg1));
+function newConstructorsTestResource10(int[] arg0, string? arg1) returns ConstructorsTestResource|error {
+    handle externalObj = org_ballerinalang_bindgen_ConstructorsTestResource_newConstructorsTestResource10(check jarrays:toHandle(arg0, "int"), arg1 is () ? java:createNull() : java:fromString(arg1));
     ConstructorsTestResource newObj = new (externalObj);
     return newObj;
 }
@@ -236,9 +236,9 @@ function newConstructorsTestResource12(Object[] arg0) returns ConstructorsTestRe
 #
 # + arg0 - The `Object[]` value required to map with the Java constructor parameter.
 # + arg1 - The `boolean` value required to map with the Java constructor parameter.
-# + arg2 - The `string[]` value required to map with the Java constructor parameter.
+# + arg2 - The `string?[]` value required to map with the Java constructor parameter.
 # + return - The new `ConstructorsTestResource` class generated.
-function newConstructorsTestResource13(Object[] arg0, boolean arg1, string[] arg2) returns ConstructorsTestResource|error {
+function newConstructorsTestResource13(Object[] arg0, boolean arg1, string?[] arg2) returns ConstructorsTestResource|error {
     handle externalObj = org_ballerinalang_bindgen_ConstructorsTestResource_newConstructorsTestResource13(check jarrays:toHandle(arg0, "java.lang.Object"), arg1, check jarrays:toHandle(arg2, "java.lang.String"));
     ConstructorsTestResource newObj = new (externalObj);
     return newObj;
@@ -246,19 +246,19 @@ function newConstructorsTestResource13(Object[] arg0, boolean arg1, string[] arg
 
 # The constructor function to generate an object of `org.ballerinalang.bindgen.ConstructorsTestResource`.
 #
-# + arg0 - The `string` value required to map with the Java constructor parameter.
+# + arg0 - The `string?` value required to map with the Java constructor parameter.
 # + return - The new `ConstructorsTestResource` class generated.
-function newConstructorsTestResource14(string arg0) returns ConstructorsTestResource {
-    handle externalObj = org_ballerinalang_bindgen_ConstructorsTestResource_newConstructorsTestResource14(java:fromString(arg0));
+function newConstructorsTestResource14(string? arg0) returns ConstructorsTestResource {
+    handle externalObj = org_ballerinalang_bindgen_ConstructorsTestResource_newConstructorsTestResource14(arg0 is () ? java:createNull() : java:fromString(arg0));
     ConstructorsTestResource newObj = new (externalObj);
     return newObj;
 }
 
 # The constructor function to generate an object of `org.ballerinalang.bindgen.ConstructorsTestResource`.
 #
-# + arg0 - The `string[]` value required to map with the Java constructor parameter.
+# + arg0 - The `string?[]` value required to map with the Java constructor parameter.
 # + return - The new `ConstructorsTestResource` class generated.
-function newConstructorsTestResource15(string[] arg0) returns ConstructorsTestResource|error {
+function newConstructorsTestResource15(string?[] arg0) returns ConstructorsTestResource|error {
     handle externalObj = org_ballerinalang_bindgen_ConstructorsTestResource_newConstructorsTestResource15(check jarrays:toHandle(arg0, "java.lang.String"));
     ConstructorsTestResource newObj = new (externalObj);
     return newObj;
@@ -266,10 +266,10 @@ function newConstructorsTestResource15(string[] arg0) returns ConstructorsTestRe
 
 # The constructor function to generate an object of `org.ballerinalang.bindgen.ConstructorsTestResource`.
 #
-# + arg0 - The `string[]` value required to map with the Java constructor parameter.
-# + arg1 - The `string[]` value required to map with the Java constructor parameter.
+# + arg0 - The `string?[]` value required to map with the Java constructor parameter.
+# + arg1 - The `string?[]` value required to map with the Java constructor parameter.
 # + return - The new `ConstructorsTestResource` class generated.
-function newConstructorsTestResource16(string[] arg0, string[] arg1) returns ConstructorsTestResource|error {
+function newConstructorsTestResource16(string?[] arg0, string?[] arg1) returns ConstructorsTestResource|error {
     handle externalObj = org_ballerinalang_bindgen_ConstructorsTestResource_newConstructorsTestResource16(check jarrays:toHandle(arg0, "java.lang.String"), check jarrays:toHandle(arg1, "java.lang.String"));
     ConstructorsTestResource newObj = new (externalObj);
     return newObj;
@@ -277,23 +277,23 @@ function newConstructorsTestResource16(string[] arg0, string[] arg1) returns Con
 
 # The constructor function to generate an object of `org.ballerinalang.bindgen.ConstructorsTestResource`.
 #
-# + arg0 - The `string` value required to map with the Java constructor parameter.
+# + arg0 - The `string?` value required to map with the Java constructor parameter.
 # + arg1 - The `byte` value required to map with the Java constructor parameter.
 # + arg2 - The `int` value required to map with the Java constructor parameter.
 # + return - The new `ConstructorsTestResource` class generated.
-function newConstructorsTestResource17(string arg0, byte arg1, int arg2) returns ConstructorsTestResource {
-    handle externalObj = org_ballerinalang_bindgen_ConstructorsTestResource_newConstructorsTestResource17(java:fromString(arg0), arg1, arg2);
+function newConstructorsTestResource17(string? arg0, byte arg1, int arg2) returns ConstructorsTestResource {
+    handle externalObj = org_ballerinalang_bindgen_ConstructorsTestResource_newConstructorsTestResource17(arg0 is () ? java:createNull() : java:fromString(arg0), arg1, arg2);
     ConstructorsTestResource newObj = new (externalObj);
     return newObj;
 }
 
 # The constructor function to generate an object of `org.ballerinalang.bindgen.ConstructorsTestResource`.
 #
-# + arg0 - The `string` value required to map with the Java constructor parameter.
+# + arg0 - The `string?` value required to map with the Java constructor parameter.
 # + arg1 - The `int` value required to map with the Java constructor parameter.
 # + return - The new `ConstructorsTestResource` class or `IOException` error generated.
-function newConstructorsTestResource18(string arg0, int arg1) returns ConstructorsTestResource|IOException {
-    handle|error externalObj = org_ballerinalang_bindgen_ConstructorsTestResource_newConstructorsTestResource18(java:fromString(arg0), arg1);
+function newConstructorsTestResource18(string? arg0, int arg1) returns ConstructorsTestResource|IOException {
+    handle|error externalObj = org_ballerinalang_bindgen_ConstructorsTestResource_newConstructorsTestResource18(arg0 is () ? java:createNull() : java:fromString(arg0), arg1);
     if (externalObj is error) {
         IOException e = error IOException(IOEXCEPTION, externalObj, message = externalObj.message());
         return e;
@@ -305,11 +305,11 @@ function newConstructorsTestResource18(string arg0, int arg1) returns Constructo
 
 # The constructor function to generate an object of `org.ballerinalang.bindgen.ConstructorsTestResource`.
 #
-# + arg0 - The `string` value required to map with the Java constructor parameter.
-# + arg1 - The `string` value required to map with the Java constructor parameter.
+# + arg0 - The `string?` value required to map with the Java constructor parameter.
+# + arg1 - The `string?` value required to map with the Java constructor parameter.
 # + return - The new `ConstructorsTestResource` class generated.
-function newConstructorsTestResource19(string arg0, string arg1) returns ConstructorsTestResource {
-    handle externalObj = org_ballerinalang_bindgen_ConstructorsTestResource_newConstructorsTestResource19(java:fromString(arg0), java:fromString(arg1));
+function newConstructorsTestResource19(string? arg0, string? arg1) returns ConstructorsTestResource {
+    handle externalObj = org_ballerinalang_bindgen_ConstructorsTestResource_newConstructorsTestResource19(arg0 is () ? java:createNull() : java:fromString(arg0), arg1 is () ? java:createNull() : java:fromString(arg1));
     ConstructorsTestResource newObj = new (externalObj);
     return newObj;
 }

--- a/misc/ballerina-bindgen/src/test/resources/unit-test-resources/fields.bal
+++ b/misc/ballerina-bindgen/src/test/resources/unit-test-resources/fields.bal
@@ -60,8 +60,8 @@ distinct class FieldsTestResource {
 
     # The function that maps to the `returnStringArray` method of `org.ballerinalang.bindgen.FieldsTestResource`.
     #
-    # + return - The `string[]` value returning from the Java mapping.
-    function returnStringArray() returns string[]?|error {
+    # + return - The `string?[]` value returning from the Java mapping.
+    function returnStringArray() returns string?[]?|error {
         handle externalObj = org_ballerinalang_bindgen_FieldsTestResource_returnStringArray(self.jObj);
         if java:isNull(externalObj) {
             return null;
@@ -227,16 +227,16 @@ distinct class FieldsTestResource {
 
     # The function that retrieves the value of the public field `getInstanceString`.
     #
-    # + return - The `string` value of the field.
+    # + return - The `string?` value of the field.
     function getGetInstanceString() returns string? {
         return java:toString(org_ballerinalang_bindgen_FieldsTestResource_getGetInstanceString(self.jObj));
     }
 
     # The function to set the value of the public field `getInstanceString`.
     #
-    # + arg - The `string` value that is to be set for the field.
-    function setGetInstanceString(string arg) {
-        org_ballerinalang_bindgen_FieldsTestResource_setGetInstanceString(self.jObj, java:fromString(arg));
+    # + arg - The `string?` value that is to be set for the field.
+    function setGetInstanceString(string? arg) {
+        org_ballerinalang_bindgen_FieldsTestResource_setGetInstanceString(self.jObj, arg is () ? java:createNull() : java:fromString(arg));
     }
 
     # The function that retrieves the value of the public field `getInstanceByteArray`.
@@ -361,8 +361,8 @@ distinct class FieldsTestResource {
 
     # The function that retrieves the value of the public field `getInstanceStringArray`.
     #
-    # + return - The `string[]` value of the field.
-    function getGetInstanceStringArray() returns string[]?|error {
+    # + return - The `string?[]` value of the field.
+    function getGetInstanceStringArray() returns string?[]?|error {
         handle externalObj = org_ballerinalang_bindgen_FieldsTestResource_getGetInstanceStringArray(self.jObj);
         if java:isNull(externalObj) {
             return null;
@@ -372,8 +372,8 @@ distinct class FieldsTestResource {
 
     # The function to set the value of the public field `getInstanceStringArray`.
     #
-    # + arg - The `string[]` value that is to be set for the field.
-    function setGetInstanceStringArray(string[] arg) {
+    # + arg - The `string?[]` value that is to be set for the field.
+    function setGetInstanceStringArray(string?[] arg) {
         org_ballerinalang_bindgen_FieldsTestResource_setGetInstanceStringArray(self.jObj, check jarrays:toHandle(arg, "java.lang.String"));
     }
 
@@ -730,16 +730,16 @@ function FieldsTestResource_setGetStaticBoolean(boolean arg) {
 
 # The function that retrieves the value of the public field `getStaticString`.
 #
-# + return - The `string` value of the field.
+# + return - The `string?` value of the field.
 function FieldsTestResource_getGetStaticString() returns string? {
     return java:toString(org_ballerinalang_bindgen_FieldsTestResource_getGetStaticString());
 }
 
 # The function to set the value of the public field `getStaticString`.
 #
-# + arg - The `string` value that is to be set for the field.
-function FieldsTestResource_setGetStaticString(string arg) {
-    org_ballerinalang_bindgen_FieldsTestResource_setGetStaticString(java:fromString(arg));
+# + arg - The `string?` value that is to be set for the field.
+function FieldsTestResource_setGetStaticString(string? arg) {
+    org_ballerinalang_bindgen_FieldsTestResource_setGetStaticString(arg is () ? java:createNull() : java:fromString(arg));
 }
 
 # The function that retrieves the value of the public field `GET_STATIC_FINAL_BYTE`.
@@ -800,7 +800,7 @@ function FieldsTestResource_getGET_STATIC_FINAL_BOOLEAN() returns boolean {
 
 # The function that retrieves the value of the public field `GET_STATIC_FINAL_STRING`.
 #
-# + return - The `string` value of the field.
+# + return - The `string?` value of the field.
 function FieldsTestResource_getGET_STATIC_FINAL_STRING() returns string? {
     return java:toString(org_ballerinalang_bindgen_FieldsTestResource_getGET_STATIC_FINAL_STRING());
 }
@@ -927,8 +927,8 @@ function FieldsTestResource_setGetStaticBooleanArray(boolean[] arg) {
 
 # The function that retrieves the value of the public field `getStaticStringArray`.
 #
-# + return - The `string[]` value of the field.
-function FieldsTestResource_getGetStaticStringArray() returns string[]?|error {
+# + return - The `string?[]` value of the field.
+function FieldsTestResource_getGetStaticStringArray() returns string?[]?|error {
     handle externalObj = org_ballerinalang_bindgen_FieldsTestResource_getGetStaticStringArray();
     if java:isNull(externalObj) {
         return null;
@@ -938,8 +938,8 @@ function FieldsTestResource_getGetStaticStringArray() returns string[]?|error {
 
 # The function to set the value of the public field `getStaticStringArray`.
 #
-# + arg - The `string[]` value that is to be set for the field.
-function FieldsTestResource_setGetStaticStringArray(string[] arg) {
+# + arg - The `string?[]` value that is to be set for the field.
+function FieldsTestResource_setGetStaticStringArray(string?[] arg) {
     org_ballerinalang_bindgen_FieldsTestResource_setGetStaticStringArray(check jarrays:toHandle(arg, "java.lang.String"));
 }
 

--- a/misc/ballerina-bindgen/src/test/resources/unit-test-resources/interfaceMapping.bal
+++ b/misc/ballerina-bindgen/src/test/resources/unit-test-resources/interfaceMapping.bal
@@ -25,8 +25,8 @@ public distinct class InterfaceTestResource {
     }
     # The function that maps to the `returnStringArray` method of `org.ballerinalang.bindgen.InterfaceTestResource`.
     #
-    # + return - The `string[]` value returning from the Java mapping.
-    public function returnStringArray() returns string[]?|error {
+    # + return - The `string?[]` value returning from the Java mapping.
+    public function returnStringArray() returns string?[]?|error {
         handle externalObj = org_ballerinalang_bindgen_InterfaceTestResource_returnStringArray(self.jObj);
         if java:isNull(externalObj) {
             return null;

--- a/misc/ballerina-bindgen/src/test/resources/unit-test-resources/methods.bal
+++ b/misc/ballerina-bindgen/src/test/resources/unit-test-resources/methods.bal
@@ -28,9 +28,9 @@ distinct class MethodsTestResource {
     #
     # + arg0 - The `AbstractSet` value required to map with the Java method parameter.
     # + arg1 - The `Object` value required to map with the Java method parameter.
-    # + arg2 - The `string` value required to map with the Java method parameter.
-    function abstractObjectParam(AbstractSet arg0, Object arg1, string arg2) {
-        org_ballerinalang_bindgen_MethodsTestResource_abstractObjectParam(self.jObj, arg0.jObj, arg1.jObj, java:fromString(arg2));
+    # + arg2 - The `string?` value required to map with the Java method parameter.
+    function abstractObjectParam(AbstractSet arg0, Object arg1, string? arg2) {
+        org_ballerinalang_bindgen_MethodsTestResource_abstractObjectParam(self.jObj, arg0.jObj, arg1.jObj, arg2 is () ? java:createNull() : java:fromString(arg2));
     }
 
     # The function that maps to the `enumParam` method of `org.ballerinalang.bindgen.MethodsTestResource`.
@@ -54,9 +54,9 @@ distinct class MethodsTestResource {
     # The function that maps to the `errorParam` method of `org.ballerinalang.bindgen.MethodsTestResource`.
     #
     # + arg0 - The `JIOException` value required to map with the Java method parameter.
-    # + arg1 - The `string[]` value required to map with the Java method parameter.
+    # + arg1 - The `string?[]` value required to map with the Java method parameter.
     # + return - The `error?` value returning from the Java mapping.
-    function errorParam(JIOException arg0, string[] arg1) returns error? {
+    function errorParam(JIOException arg0, string?[] arg1) returns error? {
         org_ballerinalang_bindgen_MethodsTestResource_errorParam(self.jObj, arg0.jObj, check jarrays:toHandle(arg1, "java.lang.String"));
     }
 
@@ -64,9 +64,9 @@ distinct class MethodsTestResource {
     #
     # + arg0 - The `Set` value required to map with the Java method parameter.
     # + arg1 - The `int` value required to map with the Java method parameter.
-    # + arg2 - The `string[]` value required to map with the Java method parameter.
+    # + arg2 - The `string?[]` value required to map with the Java method parameter.
     # + return - The `Set` value returning from the Java mapping.
-    function genericObjectParam(Set arg0, int arg1, string[] arg2) returns Set|error {
+    function genericObjectParam(Set arg0, int arg1, string?[] arg2) returns Set|error {
         handle externalObj = org_ballerinalang_bindgen_MethodsTestResource_genericObjectParam(self.jObj, arg0.jObj, arg1, check jarrays:toHandle(arg2, "java.lang.String"));
         Set newObj = new (externalObj);
         return newObj;
@@ -273,19 +273,19 @@ distinct class MethodsTestResource {
     # The function that maps to the `returnFloat` method of `org.ballerinalang.bindgen.MethodsTestResource`.
     #
     # + arg0 - The `float` value required to map with the Java method parameter.
-    # + arg1 - The `string` value required to map with the Java method parameter.
+    # + arg1 - The `string?` value required to map with the Java method parameter.
     # + return - The `float` value returning from the Java mapping.
-    function returnFloat2(float arg0, string arg1) returns float {
-        return org_ballerinalang_bindgen_MethodsTestResource_returnFloat2(self.jObj, arg0, java:fromString(arg1));
+    function returnFloat2(float arg0, string? arg1) returns float {
+        return org_ballerinalang_bindgen_MethodsTestResource_returnFloat2(self.jObj, arg0, arg1 is () ? java:createNull() : java:fromString(arg1));
     }
 
     # The function that maps to the `returnFloatArray` method of `org.ballerinalang.bindgen.MethodsTestResource`.
     #
     # + arg0 - The `float[]` value required to map with the Java method parameter.
-    # + arg1 - The `string` value required to map with the Java method parameter.
+    # + arg1 - The `string?` value required to map with the Java method parameter.
     # + return - The `float[]` value returning from the Java mapping.
-    function returnFloatArray(float[] arg0, string arg1) returns float[]|error {
-        handle externalObj = org_ballerinalang_bindgen_MethodsTestResource_returnFloatArray(self.jObj, check jarrays:toHandle(arg0, "float"), java:fromString(arg1));
+    function returnFloatArray(float[] arg0, string? arg1) returns float[]|error {
+        handle externalObj = org_ballerinalang_bindgen_MethodsTestResource_returnFloatArray(self.jObj, check jarrays:toHandle(arg0, "float"), arg1 is () ? java:createNull() : java:fromString(arg1));
         return <float[]>check jarrays:fromHandle(externalObj, "float");
     }
 
@@ -479,16 +479,16 @@ distinct class MethodsTestResource {
 
     # The function that maps to the `returnString` method of `org.ballerinalang.bindgen.MethodsTestResource`.
     #
-    # + arg0 - The `string` value required to map with the Java method parameter.
-    # + return - The `string` value returning from the Java mapping.
-    function returnString(string arg0) returns string? {
-        return java:toString(org_ballerinalang_bindgen_MethodsTestResource_returnString(self.jObj, java:fromString(arg0)));
+    # + arg0 - The `string?` value required to map with the Java method parameter.
+    # + return - The `string?` value returning from the Java mapping.
+    function returnString(string? arg0) returns string? {
+        return java:toString(org_ballerinalang_bindgen_MethodsTestResource_returnString(self.jObj, arg0 is () ? java:createNull() : java:fromString(arg0)));
     }
 
     # The function that maps to the `returnStringArray` method of `org.ballerinalang.bindgen.MethodsTestResource`.
     #
-    # + return - The `string[]` value returning from the Java mapping.
-    function returnStringArray() returns string[]?|error {
+    # + return - The `string?[]` value returning from the Java mapping.
+    function returnStringArray() returns string?[]?|error {
         handle externalObj = org_ballerinalang_bindgen_MethodsTestResource_returnStringArray(self.jObj);
         if java:isNull(externalObj) {
             return null;
@@ -498,11 +498,11 @@ distinct class MethodsTestResource {
 
     # The function that maps to the `returnStringArray1` method of `org.ballerinalang.bindgen.MethodsTestResource`.
     #
-    # + arg0 - The `string[]` value required to map with the Java method parameter.
+    # + arg0 - The `string?[]` value required to map with the Java method parameter.
     # + arg1 - The `StringBuffer` value required to map with the Java method parameter.
     # + arg2 - The `int` value required to map with the Java method parameter.
-    # + return - The `string[]` value returning from the Java mapping.
-    function returnStringArray1(string[] arg0, StringBuffer arg1, int arg2) returns string[]?|error {
+    # + return - The `string?[]` value returning from the Java mapping.
+    function returnStringArray1(string?[] arg0, StringBuffer arg1, int arg2) returns string?[]?|error {
         handle externalObj = org_ballerinalang_bindgen_MethodsTestResource_returnStringArray1(self.jObj, check jarrays:toHandle(arg0, "java.lang.String"), arg1.jObj, arg2);
         if java:isNull(externalObj) {
             return null;
@@ -512,11 +512,11 @@ distinct class MethodsTestResource {
 
     # The function that maps to the `returnStringArray2` method of `org.ballerinalang.bindgen.MethodsTestResource`.
     #
-    # + arg0 - The `string[]` value required to map with the Java method parameter.
+    # + arg0 - The `string?[]` value required to map with the Java method parameter.
     # + arg1 - The `StringBuffer` value required to map with the Java method parameter.
     # + arg2 - The `int` value required to map with the Java method parameter.
-    # + return - The `string[]` or the `InterruptedException` value returning from the Java mapping.
-    function returnStringArray2(string[] arg0, StringBuffer arg1, int arg2) returns string[]?|InterruptedException|error {
+    # + return - The `string?[]` or the `InterruptedException` value returning from the Java mapping.
+    function returnStringArray2(string?[] arg0, StringBuffer arg1, int arg2) returns string?[]?|InterruptedException|error {
         handle|error externalObj = org_ballerinalang_bindgen_MethodsTestResource_returnStringArray2(self.jObj, check jarrays:toHandle(arg0, "java.lang.String"), arg1.jObj, arg2);
         if java:isNull(externalObj) {
             return null;

--- a/misc/ballerina-bindgen/src/test/resources/unit-test-resources/moduleMapping1.bal
+++ b/misc/ballerina-bindgen/src/test/resources/unit-test-resources/moduleMapping1.bal
@@ -311,10 +311,10 @@ public function newFileInputStream2(FileDescriptor arg0) returns FileInputStream
 
 # The constructor function to generate an object of `java.io.FileInputStream`.
 #
-# + arg0 - The `string` value required to map with the Java constructor parameter.
+# + arg0 - The `string?` value required to map with the Java constructor parameter.
 # + return - The new `FileInputStream` class or `FileNotFoundException` error generated.
-public function newFileInputStream3(string arg0) returns FileInputStream|FileNotFoundException {
-    handle|error externalObj = java_io_FileInputStream_newFileInputStream3(java:fromString(arg0));
+public function newFileInputStream3(string? arg0) returns FileInputStream|FileNotFoundException {
+    handle|error externalObj = java_io_FileInputStream_newFileInputStream3(arg0 is () ? java:createNull() : java:fromString(arg0));
     if (externalObj is error) {
         FileNotFoundException e = error FileNotFoundException(FILENOTFOUNDEXCEPTION, externalObj, message = externalObj.message());
         return e;

--- a/misc/ballerina-bindgen/src/test/resources/unit-test-resources/throwableMapping.bal
+++ b/misc/ballerina-bindgen/src/test/resources/unit-test-resources/throwableMapping.bal
@@ -68,14 +68,14 @@ distinct class JIOException {
 
     # The function that maps to the `getLocalizedMessage` method of `java.io.IOException`.
     #
-    # + return - The `string` value returning from the Java mapping.
+    # + return - The `string?` value returning from the Java mapping.
     function getLocalizedMessage() returns string? {
         return java:toString(java_io_IOException_getLocalizedMessage(self.jObj));
     }
 
     # The function that maps to the `getMessage` method of `java.io.IOException`.
     #
-    # + return - The `string` value returning from the Java mapping.
+    # + return - The `string?` value returning from the Java mapping.
     function getMessage() returns string? {
         return java:toString(java_io_IOException_getMessage(self.jObj));
     }
@@ -213,21 +213,21 @@ function newJIOException1() returns JIOException {
 
 # The constructor function to generate an object of `java.io.IOException`.
 #
-# + arg0 - The `string` value required to map with the Java constructor parameter.
+# + arg0 - The `string?` value required to map with the Java constructor parameter.
 # + return - The new `JIOException` class generated.
-function newJIOException2(string arg0) returns JIOException {
-    handle externalObj = java_io_IOException_newJIOException2(java:fromString(arg0));
+function newJIOException2(string? arg0) returns JIOException {
+    handle externalObj = java_io_IOException_newJIOException2(arg0 is () ? java:createNull() : java:fromString(arg0));
     JIOException newObj = new (externalObj);
     return newObj;
 }
 
 # The constructor function to generate an object of `java.io.IOException`.
 #
-# + arg0 - The `string` value required to map with the Java constructor parameter.
+# + arg0 - The `string?` value required to map with the Java constructor parameter.
 # + arg1 - The `Throwable` value required to map with the Java constructor parameter.
 # + return - The new `JIOException` class generated.
-function newJIOException3(string arg0, Throwable arg1) returns JIOException {
-    handle externalObj = java_io_IOException_newJIOException3(java:fromString(arg0), arg1.jObj);
+function newJIOException3(string? arg0, Throwable arg1) returns JIOException {
+    handle externalObj = java_io_IOException_newJIOException3(arg0 is () ? java:createNull() : java:fromString(arg0), arg1.jObj);
     JIOException newObj = new (externalObj);
     return newObj;
 }


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/ballerina-lang/issues/39059

## Approach
Refer to the table below to see the list of impacted changes, related to Ballerina bindings generation for java `String` objects

| Context   | Existing | New |
| -------- | ----------- | ----------- |
| function parameter types    | string       | string? |
|    | string[]       | string?[] |
| function return types   |  string?       | string? |        
|   | string[]?       | string?[]? |

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [x] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [x] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
