### PR TITLE
Add quick pick for infer sub expressions in extract to function and extract to local variable code actions

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionUtil.java
@@ -707,7 +707,7 @@ public class CodeActionUtil {
                 objectFieldNode.fieldName().lineRange().endLine().offset();
     }
 
-    public static boolean isRange(Range range) {
+    public static boolean isRangeSelection(Range range) {
         return !range.getStart().equals(range.getEnd());
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionUtil.java
@@ -707,6 +707,10 @@ public class CodeActionUtil {
                 objectFieldNode.fieldName().lineRange().endLine().offset();
     }
 
+    public static boolean isRange(Range range) {
+        return !range.getStart().equals(range.getEnd());
+    }
+
     public static List<TextEdit> getGetterSetterCodeEdits(ObjectFieldNode objectFieldNode,
                                                           Optional<FunctionDefinitionNode> initNode,
                                                           String fieldName,

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/ExpressionNodeValidator.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/ExpressionNodeValidator.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.langserver.codeaction;
+
+import io.ballerina.compiler.syntax.tree.BasicLiteralNode;
+import io.ballerina.compiler.syntax.tree.BinaryExpressionNode;
+import io.ballerina.compiler.syntax.tree.FieldAccessExpressionNode;
+import io.ballerina.compiler.syntax.tree.FunctionCallExpressionNode;
+import io.ballerina.compiler.syntax.tree.ImplicitNewExpressionNode;
+import io.ballerina.compiler.syntax.tree.IndexedExpressionNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NodeVisitor;
+import io.ballerina.compiler.syntax.tree.OptionalFieldAccessExpressionNode;
+import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
+import io.ballerina.compiler.syntax.tree.SimpleNameReferenceNode;
+import io.ballerina.compiler.syntax.tree.TypeCastExpressionNode;
+import io.ballerina.compiler.syntax.tree.UnaryExpressionNode;
+
+/**
+ * Visitor to validate an expression node.
+ *
+ * @since 2201.5.0
+ */
+public class ExpressionNodeValidator extends NodeVisitor {
+
+    private boolean invalidNode = false;
+
+    @Override
+    public void visit(BinaryExpressionNode node) {
+        node.lhsExpr().accept(this);
+        node.rhsExpr().accept(this);
+    }
+
+    @Override
+    public void visit(BasicLiteralNode node) {
+    }
+
+    @Override
+    public void visit(UnaryExpressionNode node) {
+    }
+
+    @Override
+    public void visit(FieldAccessExpressionNode fieldAccessExpressionNode) {
+
+    }
+
+    @Override
+    public void visit(SimpleNameReferenceNode simpleNameReferenceNode) {
+    }
+
+    @Override
+    public void visit(FunctionCallExpressionNode functionCallExpressionNode) {
+
+    }
+
+    @Override
+    public void visit(OptionalFieldAccessExpressionNode optionalFieldAccessExpressionNode) {
+
+    }
+
+    @Override
+    public void visit(IndexedExpressionNode indexedExpressionNode) {
+
+    }
+
+    @Override
+    public void visit(TypeCastExpressionNode typeCastExpressionNode) {
+
+    }
+
+    @Override
+    public void visit(ImplicitNewExpressionNode implicitNewExpressionNode) {
+
+    }
+
+    @Override
+    public void visit(QualifiedNameReferenceNode qualifiedNameReferenceNode) {
+
+    }
+
+    @Override
+    protected void visitSyntaxNode(Node node) {
+        invalidNode = true;
+    }
+
+    public Boolean isInvalidNode() {
+        return invalidNode;
+    }
+}

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToFunctionCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToFunctionCodeAction.java
@@ -34,7 +34,6 @@ import io.ballerina.compiler.syntax.tree.ModuleMemberDeclarationNode;
 import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.compiler.syntax.tree.NodeVisitor;
 import io.ballerina.compiler.syntax.tree.NonTerminalNode;
-import io.ballerina.compiler.syntax.tree.SimpleNameReferenceNode;
 import io.ballerina.compiler.syntax.tree.OptionalFieldAccessExpressionNode;
 import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
 import io.ballerina.compiler.syntax.tree.SimpleNameReferenceNode;
@@ -385,7 +384,7 @@ public class ExtractToFunctionCodeAction implements RangeBasedCodeActionProvider
                 return Collections.emptyList();
             }
 
-            Optional<ArgListsHolder> argLists = getArgLists(context, varAndParamSymbolsWithinRange.get(), 
+            Optional<ArgListsHolder> argLists = getArgLists(context, varAndParamSymbolsWithinRange.get(),
                     matchedCodeActionNode);
 
             if (argLists.isEmpty()) {
@@ -429,7 +428,7 @@ public class ExtractToFunctionCodeAction implements RangeBasedCodeActionProvider
             String key = extractableNode.toSourceCode().strip();
             Optional<List<Symbol>> varAndParamSymbolsWithinRange =
                     getVarAndParamSymbolsWithinRangeForExprs(extractableNode.lineRange(), context);
-            Optional<ArgListsHolder> argListsHolder = getArgLists(context, 
+            Optional<ArgListsHolder> argListsHolder = getArgLists(context,
                     varAndParamSymbolsWithinRange.get(), extractableNode);
             textEditMap.put(key,
                     getTextEdits(context, extractableNode, newLineAtEnd,
@@ -462,7 +461,8 @@ public class ExtractToFunctionCodeAction implements RangeBasedCodeActionProvider
         return NameUtil.generateTypeName(EXTRACTED_PREFIX, visibleSymbolNames);
     }
 
-    private List<NonTerminalNode> getPossibleExpressionNodes(NonTerminalNode node, ExpressionNodeValidator nodeValidator) {
+    private List<NonTerminalNode> getPossibleExpressionNodes(NonTerminalNode node, 
+                                                             ExpressionNodeValidator nodeValidator) {
         // Identify the sub-expressions to be extracted
         List<NonTerminalNode> nodeList = new ArrayList<>();
         while (node != null && !isExtractableExpressionNode(node) && node.kind() != SyntaxKind.OBJECT_FIELD
@@ -539,12 +539,18 @@ public class ExtractToFunctionCodeAction implements RangeBasedCodeActionProvider
                                                                             CodeActionContext context) {
         List<Symbol> varAndParamSymbols =
                 getVisibleSymbols(context, PositionUtil.toPosition(matchedLineRange.endLine())).stream()
-                        .filter(symbol -> symbol.kind() == SymbolKind.VARIABLE || symbol.kind() == SymbolKind.PARAMETER)
-                        .filter(symbol -> symbol.getLocation().get().lineRange().filePath().equals(matchedLineRange.filePath()))
-                        .filter(symbol -> context.currentSemanticModel().get().references(symbol).stream()
-                                .anyMatch(location -> PositionUtil.isRangeWithinRange(PositionUtil
-                                                .getRangeFromLineRange(location.lineRange()),
-                                        PositionUtil.toRange(matchedLineRange))))
+                        .filter(symbol -> 
+                                symbol.kind() == SymbolKind.VARIABLE || symbol.kind() == SymbolKind.PARAMETER)
+                        .filter(symbol -> 
+                                symbol.getLocation().get().lineRange().filePath().equals(matchedLineRange.filePath()))
+                        .filter(symbol -> 
+                                context.currentSemanticModel().get()
+                                        .references(symbol)
+                                        .stream()
+                                        .anyMatch(location -> 
+                                                PositionUtil.isRangeWithinRange(
+                                                        PositionUtil.getRangeFromLineRange(location.lineRange()), 
+                                                        PositionUtil.toRange(matchedLineRange))))
                         .collect(Collectors.toList());
 
         if (varAndParamSymbols.stream().anyMatch(symbol -> symbol.getLocation().isEmpty())) {
@@ -780,7 +786,7 @@ public class ExtractToFunctionCodeAction implements RangeBasedCodeActionProvider
 
         @Override
         public void visit(QualifiedNameReferenceNode qualifiedNameReferenceNode) {
-            
+
         }
 
         @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/visitors/IsolatedBlockResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/visitors/IsolatedBlockResolver.java
@@ -35,7 +35,7 @@ import java.util.Optional;
  */
 public class IsolatedBlockResolver extends NodeTransformer<Boolean> {
 
-    public Boolean findIsolatedBlock(NonTerminalNode node) {
+    public Boolean findIsolatedBlock(Node node) {
         if (node.kind() == SyntaxKind.LIST) {
             return node.parent().apply(this);
         }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/constants/CommandConstants.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/constants/CommandConstants.java
@@ -189,6 +189,8 @@ public class CommandConstants {
 
     public static final String POSITIONAL_RENAME_COMMAND = "ballerina.action.positional.rename";
 
+    public static final String EXTRACT_COMMAND = "ballerina.action.extract";
+
     public static final String RENAME_COMMAND_TITLE_FOR_VARIABLE = "Rename variable";
 
     public static final String RENAME_COMMAND_TITLE_FOR_CONSTANT = "Rename constant";

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/AbstractCodeActionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/AbstractCodeActionTest.java
@@ -197,12 +197,6 @@ public abstract class AbstractCodeActionTest extends AbstractLSTest {
                         }
                         actual.command = actualCommand;
                     }
-                } else {
-                    if (right.has("command") && !right.get("command").isJsonNull() &&
-                            !isReportUsageStatsCommand(right.getAsJsonObject("command"))) {
-                        actual.command = right.getAsJsonObject("command");
-                        misMatched = true;
-                    }
                 }
 
                 // Code-action matched
@@ -487,8 +481,7 @@ public abstract class AbstractCodeActionTest extends AbstractLSTest {
         return TestUtil.isArgumentsSubArray(actualArgs, expArgs);
     }
 
-    private boolean validateExtractCmd(JsonObject actualCommand, JsonArray actualArgs,
-                                       JsonArray expArgs, Path sourceRoot) {
+    private boolean validateExtractCmd(JsonObject actualCommand, JsonArray actualArgs, JsonArray expArgs, Path sourceRoot) {
         String actualName = actualArgs.get(0).getAsString();
         String expectedName = expArgs.get(0).getAsString();
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/AbstractCodeActionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/AbstractCodeActionTest.java
@@ -481,7 +481,8 @@ public abstract class AbstractCodeActionTest extends AbstractLSTest {
         return TestUtil.isArgumentsSubArray(actualArgs, expArgs);
     }
 
-    private boolean validateExtractCmd(JsonObject actualCommand, JsonArray actualArgs, JsonArray expArgs, Path sourceRoot) {
+    private boolean validateExtractCmd(JsonObject actualCommand, JsonArray actualArgs, JsonArray expArgs, 
+                                       Path sourceRoot) {
         String actualName = actualArgs.get(0).getAsString();
         String expectedName = expArgs.get(0).getAsString();
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ExtractToFunctionCodeActionWithPositionalRenameAndQuickPickTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ExtractToFunctionCodeActionWithPositionalRenameAndQuickPickTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.ballerinalang.langserver.codeaction;
 
 import org.ballerinalang.langserver.commons.capability.InitializationOptions;
@@ -13,7 +28,7 @@ import java.nio.file.Path;
 /**
  * Test class to test the functionality of the extract to function code action with quick pick and positional
  * rename capability.
- * Since:2201.3.3
+ * @since 2201.5.0
  */
 public class ExtractToFunctionCodeActionWithPositionalRenameAndQuickPickTest extends AbstractCodeActionTest {
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ExtractToFunctionCodeActionWithPositionalRenameAndQuickPickTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ExtractToFunctionCodeActionWithPositionalRenameAndQuickPickTest.java
@@ -1,0 +1,59 @@
+package org.ballerinalang.langserver.codeaction;
+
+import org.ballerinalang.langserver.commons.capability.InitializationOptions;
+import org.ballerinalang.langserver.commons.workspace.WorkspaceDocumentException;
+import org.ballerinalang.langserver.util.FileUtils;
+import org.ballerinalang.langserver.util.TestUtil;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * Test class to test the functionality of the extract to function code action with quick pick and positional
+ * rename capability.
+ * Since:2201.3.3
+ */
+public class ExtractToFunctionCodeActionWithPositionalRenameAndQuickPickTest extends AbstractCodeActionTest {
+
+    @Override
+    protected void setupLanguageServer(TestUtil.LanguageServerBuilder builder) {
+        builder.withInitOption(InitializationOptions.KEY_QUICKPICK_SUPPORT, true);
+        builder.withInitOption(InitializationOptions.KEY_POSITIONAL_RENAME_SUPPORT, true);
+    }
+
+    @Override
+    protected Path getConfigJsonPath(String configFilePath) {
+        return FileUtils.RES_DIR.resolve("codeaction")
+                .resolve(getResourceDir())
+                .resolve("config-positional-rename-and-quickpick")
+                .resolve(configFilePath);
+    }
+
+    @Test(dataProvider = "codeaction-data-provider")
+    @Override
+    public void test(String config) throws IOException, WorkspaceDocumentException {
+        super.test(config);
+    }
+
+    @DataProvider(name = "codeaction-data-provider")
+    @Override
+    public Object[][] dataProvider() {
+        return new Object[][]{
+                {"extractToFunctionExpr1.json"},
+                {"extractToFunctionExpr2.json"},
+                {"extractToFunctionExpr3.json"},
+                {"extractToFunctionExpr4.json"},
+                {"extractToFunctionExpr5.json"},
+                {"extractToFunctionExpr6.json"},
+                {"extractToFunctionExpr7.json"},
+                {"extractToFunctionExpr8.json"}
+        };
+    }
+
+    @Override
+    public String getResourceDir() {
+        return "extract-to-function";
+    }
+}

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ExtractToFunctionCodeActionWithQuickPickTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ExtractToFunctionCodeActionWithQuickPickTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.ballerinalang.langserver.codeaction;
 
 import org.ballerinalang.langserver.commons.capability.InitializationOptions;
@@ -12,7 +27,7 @@ import java.nio.file.Path;
 
 /**
  * Test class to test the functionality of the extract to function code action with quick pick capability.
- * Since:2201.3.3
+ * @since 2201.5.0
  */
 public class ExtractToFunctionCodeActionWithQuickPickTest extends AbstractCodeActionTest {
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ExtractToFunctionCodeActionWithQuickPickTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ExtractToFunctionCodeActionWithQuickPickTest.java
@@ -1,0 +1,57 @@
+package org.ballerinalang.langserver.codeaction;
+
+import org.ballerinalang.langserver.commons.capability.InitializationOptions;
+import org.ballerinalang.langserver.commons.workspace.WorkspaceDocumentException;
+import org.ballerinalang.langserver.util.FileUtils;
+import org.ballerinalang.langserver.util.TestUtil;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * Test class to test the functionality of the extract to function code action with quick pick capability.
+ * Since:2201.3.3
+ */
+public class ExtractToFunctionCodeActionWithQuickPickTest extends AbstractCodeActionTest {
+
+    @Override
+    protected void setupLanguageServer(TestUtil.LanguageServerBuilder builder) {
+        builder.withInitOption(InitializationOptions.KEY_QUICKPICK_SUPPORT, true);
+    }
+
+    @Override
+    protected Path getConfigJsonPath(String configFilePath) {
+        return FileUtils.RES_DIR.resolve("codeaction")
+                .resolve(getResourceDir())
+                .resolve("config-quick-pick-capability")
+                .resolve(configFilePath);
+    }
+
+    @Test(dataProvider = "codeaction-data-provider")
+    @Override
+    public void test(String config) throws IOException, WorkspaceDocumentException {
+        super.test(config);
+    }
+
+    @DataProvider(name = "codeaction-data-provider")
+    @Override
+    public Object[][] dataProvider() {
+        return new Object[][]{
+                {"extractToFunctionExpr1.json"},
+                {"extractToFunctionExpr2.json"},
+                {"extractToFunctionExpr3.json"},
+                {"extractToFunctionExpr4.json"},
+                {"extractToFunctionExpr5.json"},
+                {"extractToFunctionExpr6.json"},
+                {"extractToFunctionExpr7.json"},
+                {"extractToFunctionExpr8.json"}
+        };
+    }
+
+    @Override
+    public String getResourceDir() {
+        return "extract-to-function";
+    }
+}

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ExtractToLocalVarCodeActionWithPositionalRenameAndQuickPickTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ExtractToLocalVarCodeActionWithPositionalRenameAndQuickPickTest.java
@@ -1,0 +1,71 @@
+package org.ballerinalang.langserver.codeaction;
+
+import org.ballerinalang.langserver.commons.capability.InitializationOptions;
+import org.ballerinalang.langserver.commons.workspace.WorkspaceDocumentException;
+import org.ballerinalang.langserver.util.FileUtils;
+import org.ballerinalang.langserver.util.TestUtil;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * Test class to test the functionality of the extract to local variable code action with quick pick and positional
+ * rename capability.
+ * Since:2201.3.3
+ */
+public class ExtractToLocalVarCodeActionWithPositionalRenameAndQuickPickTest extends AbstractCodeActionTest {
+
+    @Override
+    protected void setupLanguageServer(TestUtil.LanguageServerBuilder builder) {
+        builder.withInitOption(InitializationOptions.KEY_QUICKPICK_SUPPORT, true);
+        builder.withInitOption(InitializationOptions.KEY_POSITIONAL_RENAME_SUPPORT, true);
+    }
+
+    @Override
+    protected Path getConfigJsonPath(String configFilePath) {
+        return FileUtils.RES_DIR.resolve("codeaction")
+                .resolve(getResourceDir())
+                .resolve("config-positional-rename-and-quickpick")
+                .resolve(configFilePath);
+    }
+
+    @Test(dataProvider = "codeaction-data-provider")
+    @Override
+    public void test(String config) throws IOException, WorkspaceDocumentException {
+        super.test(config);
+    }
+
+    @Override
+    @Test(dataProvider = "negative-test-data-provider")
+    public void negativeTest(String config) throws IOException, WorkspaceDocumentException {
+        super.negativeTest(config);
+    }
+
+    @DataProvider(name = "codeaction-data-provider")
+    @Override
+    public Object[][] dataProvider() {
+        return new Object[][]{
+                {"extractToLocalVarExpr1.json"},
+                {"extractToLocalVarExpr2.json"},
+                {"extractToLocalVarExpr3.json"},
+                {"extractToLocalVarExpr4.json"},
+                {"extractToLocalVarExpr5.json"},
+                {"extractToLocalVarExpr6.json"},
+                {"extractToLocalVarExpr7.json"}
+        };
+    }
+
+    @DataProvider(name = "negative-test-data-provider")
+    public Object[][] negativeDataProvider() {
+        return new Object[][]{
+                {"negativeExtractToLocalVarExpr.json"}
+        };
+    }
+
+    @Override
+    public String getResourceDir() {
+        return "extract-to-local-variable";
+    }
+}

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ExtractToLocalVarCodeActionWithPositionalRenameAndQuickPickTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ExtractToLocalVarCodeActionWithPositionalRenameAndQuickPickTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.ballerinalang.langserver.codeaction;
 
 import org.ballerinalang.langserver.commons.capability.InitializationOptions;
@@ -13,7 +28,7 @@ import java.nio.file.Path;
 /**
  * Test class to test the functionality of the extract to local variable code action with quick pick and positional
  * rename capability.
- * Since:2201.3.3
+ * @since 2201.5.0
  */
 public class ExtractToLocalVarCodeActionWithPositionalRenameAndQuickPickTest extends AbstractCodeActionTest {
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ExtractToLocalVarCodeActionWithQuickPickTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ExtractToLocalVarCodeActionWithQuickPickTest.java
@@ -1,0 +1,69 @@
+package org.ballerinalang.langserver.codeaction;
+
+import org.ballerinalang.langserver.commons.capability.InitializationOptions;
+import org.ballerinalang.langserver.commons.workspace.WorkspaceDocumentException;
+import org.ballerinalang.langserver.util.FileUtils;
+import org.ballerinalang.langserver.util.TestUtil;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * Test class to test the functionality of the extract to local variable code action with quick pick capability.
+ * Since:2201.3.3
+ */
+public class ExtractToLocalVarCodeActionWithQuickPickTest extends AbstractCodeActionTest {
+
+    @Override
+    protected void setupLanguageServer(TestUtil.LanguageServerBuilder builder) {
+        builder.withInitOption(InitializationOptions.KEY_QUICKPICK_SUPPORT, true);
+    }
+
+    @Override
+    protected Path getConfigJsonPath(String configFilePath) {
+        return FileUtils.RES_DIR.resolve("codeaction")
+                .resolve(getResourceDir())
+                .resolve("config-quick-pick-capability")
+                .resolve(configFilePath);
+    }
+
+    @Test(dataProvider = "codeaction-data-provider")
+    @Override
+    public void test(String config) throws IOException, WorkspaceDocumentException {
+        super.test(config);
+    }
+
+    @Override
+    @Test(dataProvider = "negative-test-data-provider")
+    public void negativeTest(String config) throws IOException, WorkspaceDocumentException {
+        super.negativeTest(config);
+    }
+
+    @DataProvider(name = "codeaction-data-provider")
+    @Override
+    public Object[][] dataProvider() {
+        return new Object[][]{
+                {"extractToLocalVarExpr1.json"},
+                {"extractToLocalVarExpr2.json"},
+                {"extractToLocalVarExpr3.json"},
+                {"extractToLocalVarExpr4.json"},
+                {"extractToLocalVarExpr5.json"},
+                {"extractToLocalVarExpr6.json"},
+                {"extractToLocalVarExpr7.json"}
+        };
+    }
+
+    @DataProvider(name = "negative-test-data-provider")
+    public Object[][] negativeDataProvider() {
+        return new Object[][]{
+                {"negativeExtractToLocalVarExpr.json"}
+        };
+    }
+
+    @Override
+    public String getResourceDir() {
+        return "extract-to-local-variable";
+    }
+}

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ExtractToLocalVarCodeActionWithQuickPickTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ExtractToLocalVarCodeActionWithQuickPickTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.ballerinalang.langserver.codeaction;
 
 import org.ballerinalang.langserver.commons.capability.InitializationOptions;
@@ -12,7 +27,7 @@ import java.nio.file.Path;
 
 /**
  * Test class to test the functionality of the extract to local variable code action with quick pick capability.
- * Since:2201.3.3
+ * @since 2201.5.0
  */
 public class ExtractToLocalVarCodeActionWithQuickPickTest extends AbstractCodeActionTest {
 

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-function/config-positional-rename-and-quickpick/extractToFunctionExpr1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-function/config-positional-rename-and-quickpick/extractToFunctionExpr1.json
@@ -1,0 +1,122 @@
+{
+  "position": {
+    "line": 1,
+    "character": 22
+  },
+  "source": "extract_to_function_exprs_with_quickpick.bal",
+  "expected": [
+    {
+      "title": "Extract to function",
+      "kind": "refactor.extract",
+      "command": {
+        "title": "Extract to function",
+        "command": "ballerina.action.extract",
+        "arguments": [
+          "Extract to function",
+          "extract_to_function_exprs_with_quickpick.bal",
+          {
+            "10": [
+              {
+                "range": {
+                  "start": {
+                    "line": 6,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 6,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction extracted() returns int {\n    return 10;\n}"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 1,
+                    "character": 21
+                  },
+                  "end": {
+                    "line": 1,
+                    "character": 23
+                  }
+                },
+                "newText": "extracted()"
+              }
+            ],
+            "10 * 20": [
+              {
+                "range": {
+                  "start": {
+                    "line": 6,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 6,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction extracted() returns int {\n    return 10 * 20;\n}"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 1,
+                    "character": 21
+                  },
+                  "end": {
+                    "line": 1,
+                    "character": 28
+                  }
+                },
+                "newText": "extracted()"
+              }
+            ],
+            "10 * 20 + 30": [
+              {
+                "range": {
+                  "start": {
+                    "line": 6,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 6,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction extracted() returns int {\n    return 10 * 20 + 30;\n}"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 1,
+                    "character": 21
+                  },
+                  "end": {
+                    "line": 1,
+                    "character": 33
+                  }
+                },
+                "newText": "extracted()"
+              }
+            ]
+          },
+          {
+            "10": {
+              "line": 1,
+              "character": 21
+            },
+            "10 * 20": {
+              "line": 1,
+              "character": 21
+            },
+            "10 * 20 + 30": {
+              "line": 1,
+              "character": 21
+            }
+          }
+        ]
+      },
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-function/config-positional-rename-and-quickpick/extractToFunctionExpr2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-function/config-positional-rename-and-quickpick/extractToFunctionExpr2.json
@@ -1,0 +1,90 @@
+{
+  "position": {
+    "line": 1,
+    "character": 32
+  },
+  "source": "extract_to_function_exprs_with_quickpick.bal",
+  "expected": [
+    {
+      "title": "Extract to function",
+      "kind": "refactor.extract",
+      "command": {
+        "title": "Extract to function",
+        "command": "ballerina.action.extract",
+        "arguments": [
+          "Extract to function",
+          "extract_to_function_exprs_with_quickpick.bal",
+          {
+            "30": [
+              {
+                "range": {
+                  "start": {
+                    "line": 6,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 6,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction extracted() returns int {\n    return 30;\n}"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 1,
+                    "character": 31
+                  },
+                  "end": {
+                    "line": 1,
+                    "character": 33
+                  }
+                },
+                "newText": "extracted()"
+              }
+            ],
+            "10 * 20 + 30": [
+              {
+                "range": {
+                  "start": {
+                    "line": 6,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 6,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction extracted() returns int {\n    return 10 * 20 + 30;\n}"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 1,
+                    "character": 21
+                  },
+                  "end": {
+                    "line": 1,
+                    "character": 33
+                  }
+                },
+                "newText": "extracted()"
+              }
+            ]
+          },
+          {
+            "30": {
+              "line": 1,
+              "character": 31
+            },
+            "10 * 20 + 30": {
+              "line": 1,
+              "character": 21
+            }
+          }
+        ]
+      },
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-function/config-positional-rename-and-quickpick/extractToFunctionExpr3.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-function/config-positional-rename-and-quickpick/extractToFunctionExpr3.json
@@ -1,0 +1,154 @@
+{
+  "position": {
+    "line": 3,
+    "character": 34
+  },
+  "source": "extract_to_function_exprs_with_quickpick.bal",
+  "expected": [
+    {
+      "title": "Extract to function",
+      "kind": "refactor.extract",
+      "command": {
+        "title": "Extract to function",
+        "command": "ballerina.action.extract",
+        "arguments": [
+          "Extract to function",
+          "extract_to_function_exprs_with_quickpick.bal",
+          {
+            "60": [
+              {
+                "range": {
+                  "start": {
+                    "line": 6,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 6,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction extracted() returns int {\n    return 60;\n}"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 3,
+                    "character": 32
+                  },
+                  "end": {
+                    "line": 3,
+                    "character": 34
+                  }
+                },
+                "newText": "extracted()"
+              }
+            ],
+            "60 * two": [
+              {
+                "range": {
+                  "start": {
+                    "line": 6,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 6,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction extracted(int two) returns int {\n    return 60 * two;\n}"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 3,
+                    "character": 32
+                  },
+                  "end": {
+                    "line": 3,
+                    "character": 40
+                  }
+                },
+                "newText": "extracted(two)"
+              }
+            ],
+            "40 + 50 + 60 * two": [
+              {
+                "range": {
+                  "start": {
+                    "line": 6,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 6,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction extracted(int two) returns int {\n    return 40 + 50 + 60 * two;\n}"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 3,
+                    "character": 22
+                  },
+                  "end": {
+                    "line": 3,
+                    "character": 40
+                  }
+                },
+                "newText": "extracted(two)"
+              }
+            ],
+            "intLiteral == 40 + 50 + 60 * two": [
+              {
+                "range": {
+                  "start": {
+                    "line": 6,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 6,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction extracted(int intLiteral, int two) returns boolean {\n    return intLiteral == 40 + 50 + 60 * two;\n}"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 3,
+                    "character": 8
+                  },
+                  "end": {
+                    "line": 3,
+                    "character": 40
+                  }
+                },
+                "newText": "extracted(intLiteral, two)"
+              }
+            ]
+          },
+          {
+            "60": {
+              "line": 3,
+              "character": 32
+            },
+            "60 * two": {
+              "line": 3,
+              "character": 32
+            },
+            "40 + 50 + 60 * two": {
+              "line": 3,
+              "character": 22
+            },
+            "intLiteral == 40 + 50 + 60 * two": {
+              "line": 3,
+              "character": 8
+            }
+          }
+        ]
+      },
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-function/config-positional-rename-and-quickpick/extractToFunctionExpr4.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-function/config-positional-rename-and-quickpick/extractToFunctionExpr4.json
@@ -1,0 +1,154 @@
+{
+  "position": {
+    "line": 8,
+    "character": 21
+  },
+  "source": "extract_to_function_exprs_with_quickpick.bal",
+  "expected": [
+    {
+      "title": "Extract to function",
+      "kind": "refactor.extract",
+      "command": {
+        "title": "Extract to function",
+        "command": "ballerina.action.extract",
+        "arguments": [
+          "Extract to function",
+          "extract_to_function_exprs_with_quickpick.bal",
+          {
+            "10": [
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 37
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 37
+                  }
+                },
+                "newText": "\n\nfunction extracted() returns int {\n    return 10;\n}"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 20
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 22
+                  }
+                },
+                "newText": "extracted()"
+              }
+            ],
+            "10 / 2": [
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 37
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 37
+                  }
+                },
+                "newText": "\n\nfunction extracted() returns int {\n    return 10 / 2;\n}"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 20
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 26
+                  }
+                },
+                "newText": "extracted()"
+              }
+            ],
+            "10 / 2 + 20": [
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 37
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 37
+                  }
+                },
+                "newText": "\n\nfunction extracted() returns int {\n    return 10 / 2 + 20;\n}"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 20
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 31
+                  }
+                },
+                "newText": "extracted()"
+              }
+            ],
+            "10 / 2 + 20 + 30": [
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 37
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 37
+                  }
+                },
+                "newText": "\n\nfunction extracted() returns int {\n    return 10 / 2 + 20 + 30;\n}"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 20
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 36
+                  }
+                },
+                "newText": "extracted()"
+              }
+            ]
+          },
+          {
+            "10": {
+              "line": 8,
+              "character": 20
+            },
+            "10 / 2": {
+              "line": 8,
+              "character": 20
+            },
+            "10 / 2 + 20": {
+              "line": 8,
+              "character": 20
+            },
+            "10 / 2 + 20 + 30": {
+              "line": 8,
+              "character": 20
+            }
+          }
+        ]
+      },
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-function/config-positional-rename-and-quickpick/extractToFunctionExpr5.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-function/config-positional-rename-and-quickpick/extractToFunctionExpr5.json
@@ -1,0 +1,90 @@
+{
+  "position": {
+    "line": 8,
+    "character": 28
+  },
+  "source": "extract_to_function_exprs_with_quickpick.bal",
+  "expected": [
+    {
+      "title": "Extract to function",
+      "kind": "refactor.extract",
+      "command": {
+        "title": "Extract to function",
+        "command": "ballerina.action.extract",
+        "arguments": [
+          "Extract to function",
+          "extract_to_function_exprs_with_quickpick.bal",
+          {
+            "10 / 2 + 20": [
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 37
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 37
+                  }
+                },
+                "newText": "\n\nfunction extracted() returns int {\n    return 10 / 2 + 20;\n}"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 20
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 31
+                  }
+                },
+                "newText": "extracted()"
+              }
+            ],
+            "10 / 2 + 20 + 30": [
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 37
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 37
+                  }
+                },
+                "newText": "\n\nfunction extracted() returns int {\n    return 10 / 2 + 20 + 30;\n}"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 20
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 36
+                  }
+                },
+                "newText": "extracted()"
+              }
+            ]
+          },
+          {
+            "10 / 2 + 20": {
+              "line": 8,
+              "character": 20
+            },
+            "10 / 2 + 20 + 30": {
+              "line": 8,
+              "character": 20
+            }
+          }
+        ]
+      },
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-function/config-positional-rename-and-quickpick/extractToFunctionExpr6.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-function/config-positional-rename-and-quickpick/extractToFunctionExpr6.json
@@ -1,0 +1,90 @@
+{
+  "position": {
+    "line": 11,
+    "character": 18
+  },
+  "source": "extract_to_function_exprs_with_quickpick.bal",
+  "expected": [
+    {
+      "title": "Extract to function",
+      "kind": "refactor.extract",
+      "command": {
+        "title": "Extract to function",
+        "command": "ballerina.action.extract",
+        "arguments": [
+          "Extract to function",
+          "extract_to_function_exprs_with_quickpick.bal",
+          {
+            "4": [
+              {
+                "range": {
+                  "start": {
+                    "line": 17,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 17,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nisolated function extracted() returns int {\n    return 4;\n}"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 11,
+                    "character": 17
+                  },
+                  "end": {
+                    "line": 11,
+                    "character": 18
+                  }
+                },
+                "newText": "extracted()"
+              }
+            ],
+            "4 * 5": [
+              {
+                "range": {
+                  "start": {
+                    "line": 17,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 17,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nisolated function extracted() returns int {\n    return 4 * 5;\n}"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 11,
+                    "character": 17
+                  },
+                  "end": {
+                    "line": 11,
+                    "character": 22
+                  }
+                },
+                "newText": "extracted()"
+              }
+            ]
+          },
+          {
+            "4": {
+              "line": 11,
+              "character": 17
+            },
+            "4 * 5": {
+              "line": 11,
+              "character": 17
+            }
+          }
+        ]
+      },
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-function/config-positional-rename-and-quickpick/extractToFunctionExpr7.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-function/config-positional-rename-and-quickpick/extractToFunctionExpr7.json
@@ -1,0 +1,122 @@
+{
+  "position": {
+    "line": 14,
+    "character": 22
+  },
+  "source": "extract_to_function_exprs_with_quickpick.bal",
+  "expected": [
+    {
+      "title": "Extract to function",
+      "kind": "refactor.extract",
+      "command": {
+        "title": "Extract to function",
+        "command": "ballerina.action.extract",
+        "arguments": [
+          "Extract to function",
+          "extract_to_function_exprs_with_quickpick.bal",
+          {
+            "3.14": [
+              {
+                "range": {
+                  "start": {
+                    "line": 17,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 17,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction extracted() returns float {\n    return 3.14;\n}"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 14,
+                    "character": 21
+                  },
+                  "end": {
+                    "line": 14,
+                    "character": 25
+                  }
+                },
+                "newText": "extracted()"
+              }
+            ],
+            "3.14 * 3": [
+              {
+                "range": {
+                  "start": {
+                    "line": 17,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 17,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction extracted() returns float {\n    return 3.14 * 3;\n}"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 14,
+                    "character": 21
+                  },
+                  "end": {
+                    "line": 14,
+                    "character": 29
+                  }
+                },
+                "newText": "extracted()"
+              }
+            ],
+            "3.14 * 3 * 4": [
+              {
+                "range": {
+                  "start": {
+                    "line": 17,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 17,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction extracted() returns float {\n    return 3.14 * 3 * 4;\n}"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 14,
+                    "character": 21
+                  },
+                  "end": {
+                    "line": 14,
+                    "character": 33
+                  }
+                },
+                "newText": "extracted()"
+              }
+            ]
+          },
+          {
+            "3.14": {
+              "line": 14,
+              "character": 21
+            },
+            "3.14 * 3": {
+              "line": 14,
+              "character": 21
+            },
+            "3.14 * 3 * 4": {
+              "line": 14,
+              "character": 21
+            }
+          }
+        ]
+      },
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-function/config-positional-rename-and-quickpick/extractToFunctionExpr8.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-function/config-positional-rename-and-quickpick/extractToFunctionExpr8.json
@@ -1,0 +1,90 @@
+{
+  "position": {
+    "line": 20,
+    "character": 18
+  },
+  "source": "extract_to_function_exprs_with_quickpick.bal",
+  "expected": [
+    {
+      "title": "Extract to function",
+      "kind": "refactor.extract",
+      "command": {
+        "title": "Extract to function",
+        "command": "ballerina.action.extract",
+        "arguments": [
+          "Extract to function",
+          "extract_to_function_exprs_with_quickpick.bal",
+          {
+            "r * r": [
+              {
+                "range": {
+                  "start": {
+                    "line": 20,
+                    "character": 30
+                  },
+                  "end": {
+                    "line": 20,
+                    "character": 30
+                  }
+                },
+                "newText": "\n\nfunction extracted(int r) returns int {\n    return r * r;\n}\n"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 20,
+                    "character": 13
+                  },
+                  "end": {
+                    "line": 20,
+                    "character": 18
+                  }
+                },
+                "newText": "extracted(r)"
+              }
+            ],
+            "r * r * float:PI": [
+              {
+                "range": {
+                  "start": {
+                    "line": 20,
+                    "character": 30
+                  },
+                  "end": {
+                    "line": 20,
+                    "character": 30
+                  }
+                },
+                "newText": "\n\nfunction extracted(int r) returns float {\n    return r * r * float:PI;\n}\n"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 20,
+                    "character": 13
+                  },
+                  "end": {
+                    "line": 20,
+                    "character": 29
+                  }
+                },
+                "newText": "extracted(r)"
+              }
+            ]
+          },
+          {
+            "r * r": {
+              "line": 20,
+              "character": 13
+            },
+            "r * r * float:PI": {
+              "line": 20,
+              "character": 13
+            }
+          }
+        ]
+      },
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-function/config-quick-pick-capability/extractToFunctionExpr1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-function/config-quick-pick-capability/extractToFunctionExpr1.json
@@ -1,0 +1,108 @@
+{
+  "position": {
+    "line": 1,
+    "character": 22
+  },
+  "source": "extract_to_function_exprs_with_quickpick.bal",
+  "expected": [
+    {
+      "title": "Extract to function",
+      "kind": "refactor.extract",
+      "command": {
+        "title": "Extract to function",
+        "command": "ballerina.action.extract",
+        "arguments": [
+          "Extract to function",
+          "extract_to_function_exprs_with_quickpick.bal",
+          {
+            "10": [
+              {
+                "range": {
+                  "start": {
+                    "line": 6,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 6,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction extracted() returns int {\n    return 10;\n}"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 1,
+                    "character": 21
+                  },
+                  "end": {
+                    "line": 1,
+                    "character": 23
+                  }
+                },
+                "newText": "extracted()"
+              }
+            ],
+            "10 * 20": [
+              {
+                "range": {
+                  "start": {
+                    "line": 6,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 6,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction extracted() returns int {\n    return 10 * 20;\n}"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 1,
+                    "character": 21
+                  },
+                  "end": {
+                    "line": 1,
+                    "character": 28
+                  }
+                },
+                "newText": "extracted()"
+              }
+            ],
+            "10 * 20 + 30": [
+              {
+                "range": {
+                  "start": {
+                    "line": 6,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 6,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction extracted() returns int {\n    return 10 * 20 + 30;\n}"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 1,
+                    "character": 21
+                  },
+                  "end": {
+                    "line": 1,
+                    "character": 33
+                  }
+                },
+                "newText": "extracted()"
+              }
+            ]
+          }
+        ]
+      },
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-function/config-quick-pick-capability/extractToFunctionExpr2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-function/config-quick-pick-capability/extractToFunctionExpr2.json
@@ -1,0 +1,80 @@
+{
+  "position": {
+    "line": 1,
+    "character": 32
+  },
+  "source": "extract_to_function_exprs_with_quickpick.bal",
+  "expected": [
+    {
+      "title": "Extract to function",
+      "kind": "refactor.extract",
+      "command": {
+        "title": "Extract to function",
+        "command": "ballerina.action.extract",
+        "arguments": [
+          "Extract to function",
+          "extract_to_function_exprs_with_quickpick.bal",
+          {
+            "30": [
+              {
+                "range": {
+                  "start": {
+                    "line": 6,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 6,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction extracted() returns int {\n    return 30;\n}"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 1,
+                    "character": 31
+                  },
+                  "end": {
+                    "line": 1,
+                    "character": 33
+                  }
+                },
+                "newText": "extracted()"
+              }
+            ],
+            "10 * 20 + 30": [
+              {
+                "range": {
+                  "start": {
+                    "line": 6,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 6,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction extracted() returns int {\n    return 10 * 20 + 30;\n}"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 1,
+                    "character": 21
+                  },
+                  "end": {
+                    "line": 1,
+                    "character": 33
+                  }
+                },
+                "newText": "extracted()"
+              }
+            ]
+          }
+        ]
+      },
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-function/config-quick-pick-capability/extractToFunctionExpr3.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-function/config-quick-pick-capability/extractToFunctionExpr3.json
@@ -1,0 +1,136 @@
+{
+  "position": {
+    "line": 3,
+    "character": 34
+  },
+  "source": "extract_to_function_exprs_with_quickpick.bal",
+  "expected": [
+    {
+      "title": "Extract to function",
+      "kind": "refactor.extract",
+      "command": {
+        "title": "Extract to function",
+        "command": "ballerina.action.extract",
+        "arguments": [
+          "Extract to function",
+          "extract_to_function_exprs_with_quickpick.bal",
+          {
+            "60": [
+              {
+                "range": {
+                  "start": {
+                    "line": 6,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 6,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction extracted() returns int {\n    return 60;\n}"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 3,
+                    "character": 32
+                  },
+                  "end": {
+                    "line": 3,
+                    "character": 34
+                  }
+                },
+                "newText": "extracted()"
+              }
+            ],
+            "60 * two": [
+              {
+                "range": {
+                  "start": {
+                    "line": 6,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 6,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction extracted(int two) returns int {\n    return 60 * two;\n}"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 3,
+                    "character": 32
+                  },
+                  "end": {
+                    "line": 3,
+                    "character": 40
+                  }
+                },
+                "newText": "extracted(two)"
+              }
+            ],
+            "40 + 50 + 60 * two": [
+              {
+                "range": {
+                  "start": {
+                    "line": 6,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 6,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction extracted(int two) returns int {\n    return 40 + 50 + 60 * two;\n}"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 3,
+                    "character": 22
+                  },
+                  "end": {
+                    "line": 3,
+                    "character": 40
+                  }
+                },
+                "newText": "extracted(two)"
+              }
+            ],
+            "intLiteral == 40 + 50 + 60 * two": [
+              {
+                "range": {
+                  "start": {
+                    "line": 6,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 6,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction extracted(int intLiteral, int two) returns boolean {\n    return intLiteral == 40 + 50 + 60 * two;\n}"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 3,
+                    "character": 8
+                  },
+                  "end": {
+                    "line": 3,
+                    "character": 40
+                  }
+                },
+                "newText": "extracted(intLiteral, two)"
+              }
+            ]
+          }
+        ]
+      },
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-function/config-quick-pick-capability/extractToFunctionExpr4.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-function/config-quick-pick-capability/extractToFunctionExpr4.json
@@ -1,0 +1,136 @@
+{
+  "position": {
+    "line": 8,
+    "character": 21
+  },
+  "source": "extract_to_function_exprs_with_quickpick.bal",
+  "expected": [
+    {
+      "title": "Extract to function",
+      "kind": "refactor.extract",
+      "command": {
+        "title": "Extract to function",
+        "command": "ballerina.action.extract",
+        "arguments": [
+          "Extract to function",
+          "extract_to_function_exprs_with_quickpick.bal",
+          {
+            "10": [
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 37
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 37
+                  }
+                },
+                "newText": "\n\nfunction extracted() returns int {\n    return 10;\n}"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 20
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 22
+                  }
+                },
+                "newText": "extracted()"
+              }
+            ],
+            "10 / 2": [
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 37
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 37
+                  }
+                },
+                "newText": "\n\nfunction extracted() returns int {\n    return 10 / 2;\n}"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 20
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 26
+                  }
+                },
+                "newText": "extracted()"
+              }
+            ],
+            "10 / 2 + 20": [
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 37
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 37
+                  }
+                },
+                "newText": "\n\nfunction extracted() returns int {\n    return 10 / 2 + 20;\n}"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 20
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 31
+                  }
+                },
+                "newText": "extracted()"
+              }
+            ],
+            "10 / 2 + 20 + 30": [
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 37
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 37
+                  }
+                },
+                "newText": "\n\nfunction extracted() returns int {\n    return 10 / 2 + 20 + 30;\n}"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 20
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 36
+                  }
+                },
+                "newText": "extracted()"
+              }
+            ]
+          }
+        ]
+      },
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-function/config-quick-pick-capability/extractToFunctionExpr5.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-function/config-quick-pick-capability/extractToFunctionExpr5.json
@@ -1,0 +1,80 @@
+{
+  "position": {
+    "line": 8,
+    "character": 28
+  },
+  "source": "extract_to_function_exprs_with_quickpick.bal",
+  "expected": [
+    {
+      "title": "Extract to function",
+      "kind": "refactor.extract",
+      "command": {
+        "title": "Extract to function",
+        "command": "ballerina.action.extract",
+        "arguments": [
+          "Extract to function",
+          "extract_to_function_exprs_with_quickpick.bal",
+          {
+            "10 / 2 + 20": [
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 37
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 37
+                  }
+                },
+                "newText": "\n\nfunction extracted() returns int {\n    return 10 / 2 + 20;\n}"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 20
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 31
+                  }
+                },
+                "newText": "extracted()"
+              }
+            ],
+            "10 / 2 + 20 + 30": [
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 37
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 37
+                  }
+                },
+                "newText": "\n\nfunction extracted() returns int {\n    return 10 / 2 + 20 + 30;\n}"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 20
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 36
+                  }
+                },
+                "newText": "extracted()"
+              }
+            ]
+          }
+        ]
+      },
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-function/config-quick-pick-capability/extractToFunctionExpr6.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-function/config-quick-pick-capability/extractToFunctionExpr6.json
@@ -1,0 +1,80 @@
+{
+  "position": {
+    "line": 11,
+    "character": 18
+  },
+  "source": "extract_to_function_exprs_with_quickpick.bal",
+  "expected": [
+    {
+      "title": "Extract to function",
+      "kind": "refactor.extract",
+      "command": {
+        "title": "Extract to function",
+        "command": "ballerina.action.extract",
+        "arguments": [
+          "Extract to function",
+          "extract_to_function_exprs_with_quickpick.bal",
+          {
+            "4": [
+              {
+                "range": {
+                  "start": {
+                    "line": 17,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 17,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nisolated function extracted() returns int {\n    return 4;\n}"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 11,
+                    "character": 17
+                  },
+                  "end": {
+                    "line": 11,
+                    "character": 18
+                  }
+                },
+                "newText": "extracted()"
+              }
+            ],
+            "4 * 5": [
+              {
+                "range": {
+                  "start": {
+                    "line": 17,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 17,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nisolated function extracted() returns int {\n    return 4 * 5;\n}"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 11,
+                    "character": 17
+                  },
+                  "end": {
+                    "line": 11,
+                    "character": 22
+                  }
+                },
+                "newText": "extracted()"
+              }
+            ]
+          }
+        ]
+      },
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-function/config-quick-pick-capability/extractToFunctionExpr7.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-function/config-quick-pick-capability/extractToFunctionExpr7.json
@@ -1,0 +1,108 @@
+{
+  "position": {
+    "line": 14,
+    "character": 22
+  },
+  "source": "extract_to_function_exprs_with_quickpick.bal",
+  "expected": [
+    {
+      "title": "Extract to function",
+      "kind": "refactor.extract",
+      "command": {
+        "title": "Extract to function",
+        "command": "ballerina.action.extract",
+        "arguments": [
+          "Extract to function",
+          "extract_to_function_exprs_with_quickpick.bal",
+          {
+            "3.14": [
+              {
+                "range": {
+                  "start": {
+                    "line": 17,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 17,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction extracted() returns float {\n    return 3.14;\n}"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 14,
+                    "character": 21
+                  },
+                  "end": {
+                    "line": 14,
+                    "character": 25
+                  }
+                },
+                "newText": "extracted()"
+              }
+            ],
+            "3.14 * 3": [
+              {
+                "range": {
+                  "start": {
+                    "line": 17,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 17,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction extracted() returns float {\n    return 3.14 * 3;\n}"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 14,
+                    "character": 21
+                  },
+                  "end": {
+                    "line": 14,
+                    "character": 29
+                  }
+                },
+                "newText": "extracted()"
+              }
+            ],
+            "3.14 * 3 * 4": [
+              {
+                "range": {
+                  "start": {
+                    "line": 17,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 17,
+                    "character": 1
+                  }
+                },
+                "newText": "\n\nfunction extracted() returns float {\n    return 3.14 * 3 * 4;\n}"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 14,
+                    "character": 21
+                  },
+                  "end": {
+                    "line": 14,
+                    "character": 33
+                  }
+                },
+                "newText": "extracted()"
+              }
+            ]
+          }
+        ]
+      },
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-function/config-quick-pick-capability/extractToFunctionExpr8.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-function/config-quick-pick-capability/extractToFunctionExpr8.json
@@ -1,0 +1,80 @@
+{
+  "position": {
+    "line": 20,
+    "character": 18
+  },
+  "source": "extract_to_function_exprs_with_quickpick.bal",
+  "expected": [
+    {
+      "title": "Extract to function",
+      "kind": "refactor.extract",
+      "command": {
+        "title": "Extract to function",
+        "command": "ballerina.action.extract",
+        "arguments": [
+          "Extract to function",
+          "extract_to_function_exprs_with_quickpick.bal",
+          {
+            "r * r": [
+              {
+                "range": {
+                  "start": {
+                    "line": 20,
+                    "character": 30
+                  },
+                  "end": {
+                    "line": 20,
+                    "character": 30
+                  }
+                },
+                "newText": "\n\nfunction extracted(int r) returns int {\n    return r * r;\n}\n"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 20,
+                    "character": 13
+                  },
+                  "end": {
+                    "line": 20,
+                    "character": 18
+                  }
+                },
+                "newText": "extracted(r)"
+              }
+            ],
+            "r * r * float:PI": [
+              {
+                "range": {
+                  "start": {
+                    "line": 20,
+                    "character": 30
+                  },
+                  "end": {
+                    "line": 20,
+                    "character": 30
+                  }
+                },
+                "newText": "\n\nfunction extracted(int r) returns float {\n    return r * r * float:PI;\n}\n"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 20,
+                    "character": 13
+                  },
+                  "end": {
+                    "line": 20,
+                    "character": 29
+                  }
+                },
+                "newText": "extracted(r)"
+              }
+            ]
+          }
+        ]
+      },
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-function/source/extract_to_function_exprs_with_quickpick.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-function/source/extract_to_function_exprs_with_quickpick.bal
@@ -1,0 +1,21 @@
+function testFunction() {
+    int intLiteral = 10 * 20 + 30;
+    int two = 2;
+    if (intLiteral == 40 + 50 + 60 * two) {
+        // do something
+    }
+}
+
+int intModLiteral = 10 / 2 + 20 + 30;
+
+class Square {
+    int length = 4 * 5;
+
+	function getArea() returns float {
+        float area = 3.14 * 3 * 4;
+	    return area;
+	}
+}
+
+int r = 12;
+float area = r * r * float:PI;

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config-positional-rename-and-quickpick/extractToLocalVarExpr1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config-positional-rename-and-quickpick/extractToLocalVarExpr1.json
@@ -1,0 +1,122 @@
+{
+  "position": {
+    "line": 1,
+    "character": 22
+  },
+  "source": "extractToLocalVariableExprsWithQuickPick.bal",
+  "expected": [
+    {
+      "title": "Extract to local variable",
+      "kind": "refactor.extract",
+      "command": {
+        "title": "Extract To Local Variable",
+        "command": "ballerina.action.extract",
+        "arguments": [
+          "Extract To Local Variable",
+          "extractToLocalVariableExprsWithQuickPick.bal",
+          {
+            "10": [
+              {
+                "range": {
+                  "start": {
+                    "line": 1,
+                    "character": 4
+                  },
+                  "end": {
+                    "line": 1,
+                    "character": 4
+                  }
+                },
+                "newText": "int var1 = 10;\n    "
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 1,
+                    "character": 21
+                  },
+                  "end": {
+                    "line": 1,
+                    "character": 23
+                  }
+                },
+                "newText": "var1"
+              }
+            ],
+            "10 * 20": [
+              {
+                "range": {
+                  "start": {
+                    "line": 1,
+                    "character": 4
+                  },
+                  "end": {
+                    "line": 1,
+                    "character": 4
+                  }
+                },
+                "newText": "int var1 = 10 * 20;\n    "
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 1,
+                    "character": 21
+                  },
+                  "end": {
+                    "line": 1,
+                    "character": 28
+                  }
+                },
+                "newText": "var1"
+              }
+            ],
+            "10 * 20 + 30": [
+              {
+                "range": {
+                  "start": {
+                    "line": 1,
+                    "character": 4
+                  },
+                  "end": {
+                    "line": 1,
+                    "character": 4
+                  }
+                },
+                "newText": "int var1 = 10 * 20 + 30;\n    "
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 1,
+                    "character": 21
+                  },
+                  "end": {
+                    "line": 1,
+                    "character": 33
+                  }
+                },
+                "newText": "var1"
+              }
+            ]
+          },
+          {
+            "10": {
+              "line": 2,
+              "character": 21
+            },
+            "10 * 20": {
+              "line": 2,
+              "character": 21
+            },
+            "10 * 20 + 30": {
+              "line": 2,
+              "character": 21
+            }
+          }
+        ]
+      },
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config-positional-rename-and-quickpick/extractToLocalVarExpr2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config-positional-rename-and-quickpick/extractToLocalVarExpr2.json
@@ -1,0 +1,90 @@
+{
+  "position": {
+    "line": 1,
+    "character": 32
+  },
+  "source": "extractToLocalVariableExprsWithQuickPick.bal",
+  "expected": [
+    {
+      "title": "Extract to local variable",
+      "kind": "refactor.extract",
+      "command": {
+        "title": "Extract To Local Variable",
+        "command": "ballerina.action.extract",
+        "arguments": [
+          "Extract To Local Variable",
+          "extractToLocalVariableExprsWithQuickPick.bal",
+          {
+            "30": [
+              {
+                "range": {
+                  "start": {
+                    "line": 1,
+                    "character": 4
+                  },
+                  "end": {
+                    "line": 1,
+                    "character": 4
+                  }
+                },
+                "newText": "int var1 = 30;\n    "
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 1,
+                    "character": 31
+                  },
+                  "end": {
+                    "line": 1,
+                    "character": 33
+                  }
+                },
+                "newText": "var1"
+              }
+            ],
+            "10 * 20 + 30": [
+              {
+                "range": {
+                  "start": {
+                    "line": 1,
+                    "character": 4
+                  },
+                  "end": {
+                    "line": 1,
+                    "character": 4
+                  }
+                },
+                "newText": "int var1 = 10 * 20 + 30;\n    "
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 1,
+                    "character": 21
+                  },
+                  "end": {
+                    "line": 1,
+                    "character": 33
+                  }
+                },
+                "newText": "var1"
+              }
+            ]
+          },
+          {
+            "30": {
+              "line": 2,
+              "character": 31
+            },
+            "10 * 20 + 30": {
+              "line": 2,
+              "character": 21
+            }
+          }
+        ]
+      },
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config-positional-rename-and-quickpick/extractToLocalVarExpr3.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config-positional-rename-and-quickpick/extractToLocalVarExpr3.json
@@ -1,0 +1,154 @@
+{
+  "position": {
+    "line": 3,
+    "character": 34
+  },
+  "source": "extractToLocalVariableExprsWithQuickPick.bal",
+  "expected": [
+    {
+      "title": "Extract to local variable",
+      "kind": "refactor.extract",
+      "command": {
+        "title": "Extract To Local Variable",
+        "command": "ballerina.action.extract",
+        "arguments": [
+          "Extract To Local Variable",
+          "extractToLocalVariableExprsWithQuickPick.bal",
+          {
+            "60": [
+              {
+                "range": {
+                  "start": {
+                    "line": 3,
+                    "character": 4
+                  },
+                  "end": {
+                    "line": 3,
+                    "character": 4
+                  }
+                },
+                "newText": "int var1 = 60;\n    "
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 3,
+                    "character": 32
+                  },
+                  "end": {
+                    "line": 3,
+                    "character": 34
+                  }
+                },
+                "newText": "var1"
+              }
+            ],
+            "60 * two": [
+              {
+                "range": {
+                  "start": {
+                    "line": 3,
+                    "character": 4
+                  },
+                  "end": {
+                    "line": 3,
+                    "character": 4
+                  }
+                },
+                "newText": "int var1 = 60 * two;\n    "
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 3,
+                    "character": 32
+                  },
+                  "end": {
+                    "line": 3,
+                    "character": 40
+                  }
+                },
+                "newText": "var1"
+              }
+            ],
+            "40 + 50 + 60 * two": [
+              {
+                "range": {
+                  "start": {
+                    "line": 3,
+                    "character": 4
+                  },
+                  "end": {
+                    "line": 3,
+                    "character": 4
+                  }
+                },
+                "newText": "int var1 = 40 + 50 + 60 * two;\n    "
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 3,
+                    "character": 22
+                  },
+                  "end": {
+                    "line": 3,
+                    "character": 40
+                  }
+                },
+                "newText": "var1"
+              }
+            ],
+            "intLiteral == 40 + 50 + 60 * two": [
+              {
+                "range": {
+                  "start": {
+                    "line": 3,
+                    "character": 4
+                  },
+                  "end": {
+                    "line": 3,
+                    "character": 4
+                  }
+                },
+                "newText": "boolean var1 = intLiteral == 40 + 50 + 60 * two;\n    "
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 3,
+                    "character": 8
+                  },
+                  "end": {
+                    "line": 3,
+                    "character": 40
+                  }
+                },
+                "newText": "var1"
+              }
+            ]
+          },
+          {
+            "60": {
+              "line": 4,
+              "character": 32
+            },
+            "60 * two": {
+              "line": 4,
+              "character": 32
+            },
+            "40 + 50 + 60 * two": {
+              "line": 4,
+              "character": 22
+            },
+            "intLiteral == 40 + 50 + 60 * two": {
+              "line": 4,
+              "character": 8
+            }
+          }
+        ]
+      },
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config-positional-rename-and-quickpick/extractToLocalVarExpr4.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config-positional-rename-and-quickpick/extractToLocalVarExpr4.json
@@ -1,0 +1,154 @@
+{
+  "position": {
+    "line": 8,
+    "character": 21
+  },
+  "source": "extractToLocalVariableExprsWithQuickPick.bal",
+  "expected": [
+    {
+      "title": "Extract to local variable",
+      "kind": "refactor.extract",
+      "command": {
+        "title": "Extract To Local Variable",
+        "command": "ballerina.action.extract",
+        "arguments": [
+          "Extract To Local Variable",
+          "extractToLocalVariableExprsWithQuickPick.bal",
+          {
+            "10": [
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 0
+                  }
+                },
+                "newText": "int var1 = 10;\n"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 20
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 22
+                  }
+                },
+                "newText": "var1"
+              }
+            ],
+            "10 / 2": [
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 0
+                  }
+                },
+                "newText": "int var1 = 10 / 2;\n"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 20
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 26
+                  }
+                },
+                "newText": "var1"
+              }
+            ],
+            "10 / 2 + 20": [
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 0
+                  }
+                },
+                "newText": "int var1 = 10 / 2 + 20;\n"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 20
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 31
+                  }
+                },
+                "newText": "var1"
+              }
+            ],
+            "10 / 2 + 20 + 30": [
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 0
+                  }
+                },
+                "newText": "int var1 = 10 / 2 + 20 + 30;\n"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 20
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 36
+                  }
+                },
+                "newText": "var1"
+              }
+            ]
+          },
+          {
+            "10": {
+              "line": 9,
+              "character": 20
+            },
+            "10 / 2": {
+              "line": 9,
+              "character": 20
+            },
+            "10 / 2 + 20": {
+              "line": 9,
+              "character": 20
+            },
+            "10 / 2 + 20 + 30": {
+              "line": 9,
+              "character": 20
+            }
+          }
+        ]
+      },
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config-positional-rename-and-quickpick/extractToLocalVarExpr5.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config-positional-rename-and-quickpick/extractToLocalVarExpr5.json
@@ -1,0 +1,90 @@
+{
+  "position": {
+    "line": 8,
+    "character": 28
+  },
+  "source": "extractToLocalVariableExprsWithQuickPick.bal",
+  "expected": [
+    {
+      "title": "Extract to local variable",
+      "kind": "refactor.extract",
+      "command": {
+        "title": "Extract To Local Variable",
+        "command": "ballerina.action.extract",
+        "arguments": [
+          "Extract To Local Variable",
+          "extractToLocalVariableExprsWithQuickPick.bal",
+          {
+            "10 / 2 + 20": [
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 0
+                  }
+                },
+                "newText": "int var1 = 10 / 2 + 20;\n"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 20
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 31
+                  }
+                },
+                "newText": "var1"
+              }
+            ],
+            "10 / 2 + 20 + 30": [
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 0
+                  }
+                },
+                "newText": "int var1 = 10 / 2 + 20 + 30;\n"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 20
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 36
+                  }
+                },
+                "newText": "var1"
+              }
+            ]
+          },
+          {
+            "10 / 2 + 20": {
+              "line": 9,
+              "character": 20
+            },
+            "10 / 2 + 20 + 30": {
+              "line": 9,
+              "character": 20
+            }
+          }
+        ]
+      },
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config-positional-rename-and-quickpick/extractToLocalVarExpr6.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config-positional-rename-and-quickpick/extractToLocalVarExpr6.json
@@ -1,0 +1,122 @@
+{
+  "position": {
+    "line": 14,
+    "character": 22
+  },
+  "source": "extractToLocalVariableExprsWithQuickPick.bal",
+  "expected": [
+    {
+      "title": "Extract to local variable",
+      "kind": "refactor.extract",
+      "command": {
+        "title": "Extract To Local Variable",
+        "command": "ballerina.action.extract",
+        "arguments": [
+          "Extract To Local Variable",
+          "extractToLocalVariableExprsWithQuickPick.bal",
+          {
+            "3.14": [
+              {
+                "range": {
+                  "start": {
+                    "line": 14,
+                    "character": 8
+                  },
+                  "end": {
+                    "line": 14,
+                    "character": 8
+                  }
+                },
+                "newText": "float var1 = 3.14;\n        "
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 14,
+                    "character": 21
+                  },
+                  "end": {
+                    "line": 14,
+                    "character": 25
+                  }
+                },
+                "newText": "var1"
+              }
+            ],
+            "3.14 * 3": [
+              {
+                "range": {
+                  "start": {
+                    "line": 14,
+                    "character": 8
+                  },
+                  "end": {
+                    "line": 14,
+                    "character": 8
+                  }
+                },
+                "newText": "float var1 = 3.14 * 3;\n        "
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 14,
+                    "character": 21
+                  },
+                  "end": {
+                    "line": 14,
+                    "character": 29
+                  }
+                },
+                "newText": "var1"
+              }
+            ],
+            "3.14 * 3 * 4": [
+              {
+                "range": {
+                  "start": {
+                    "line": 14,
+                    "character": 8
+                  },
+                  "end": {
+                    "line": 14,
+                    "character": 8
+                  }
+                },
+                "newText": "float var1 = 3.14 * 3 * 4;\n        "
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 14,
+                    "character": 21
+                  },
+                  "end": {
+                    "line": 14,
+                    "character": 33
+                  }
+                },
+                "newText": "var1"
+              }
+            ]
+          },
+          {
+            "3.14": {
+              "line": 15,
+              "character": 21
+            },
+            "3.14 * 3": {
+              "line": 15,
+              "character": 21
+            },
+            "3.14 * 3 * 4": {
+              "line": 15,
+              "character": 21
+            }
+          }
+        ]
+      },
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config-positional-rename-and-quickpick/extractToLocalVarExpr7.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config-positional-rename-and-quickpick/extractToLocalVarExpr7.json
@@ -1,0 +1,90 @@
+{
+  "position": {
+    "line": 20,
+    "character": 18
+  },
+  "source": "extractToLocalVariableExprsWithQuickPick.bal",
+  "expected": [
+    {
+      "title": "Extract to local variable",
+      "kind": "refactor.extract",
+      "command": {
+        "title": "Extract To Local Variable",
+        "command": "ballerina.action.extract",
+        "arguments": [
+          "Extract To Local Variable",
+          "extractToLocalVariableExprsWithQuickPick.bal",
+          {
+            "r * r": [
+              {
+                "range": {
+                  "start": {
+                    "line": 20,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 20,
+                    "character": 0
+                  }
+                },
+                "newText": "int var1 = r * r;\n"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 20,
+                    "character": 13
+                  },
+                  "end": {
+                    "line": 20,
+                    "character": 18
+                  }
+                },
+                "newText": "var1"
+              }
+            ],
+            "r * r * float:PI": [
+              {
+                "range": {
+                  "start": {
+                    "line": 20,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 20,
+                    "character": 0
+                  }
+                },
+                "newText": "float var1 = r * r * float:PI;\n"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 20,
+                    "character": 13
+                  },
+                  "end": {
+                    "line": 20,
+                    "character": 29
+                  }
+                },
+                "newText": "var1"
+              }
+            ]
+          },
+          {
+            "r * r": {
+              "line": 21,
+              "character": 13
+            },
+            "r * r * float:PI": {
+              "line": 21,
+              "character": 13
+            }
+          }
+        ]
+      },
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config-positional-rename-and-quickpick/negativeExtractToLocalVarExpr.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config-positional-rename-and-quickpick/negativeExtractToLocalVarExpr.json
@@ -1,0 +1,11 @@
+{
+  "position": {
+    "line": 11,
+    "character": 18
+  },
+  "source": "extractToLocalVariableExprsWithQuickPick.bal",
+  "expected": [
+    {
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config-quick-pick-capability/extractToLocalVarExpr1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config-quick-pick-capability/extractToLocalVarExpr1.json
@@ -1,0 +1,108 @@
+{
+  "position": {
+    "line": 1,
+    "character": 22
+  },
+  "source": "extractToLocalVariableExprsWithQuickPick.bal",
+  "expected": [
+    {
+      "title": "Extract to local variable",
+      "kind": "refactor.extract",
+      "command": {
+        "title": "Extract To Local Variable",
+        "command": "ballerina.action.extract",
+        "arguments": [
+          "Extract To Local Variable",
+          "extractToLocalVariableExprsWithQuickPick.bal",
+          {
+            "10": [
+              {
+                "range": {
+                  "start": {
+                    "line": 1,
+                    "character": 4
+                  },
+                  "end": {
+                    "line": 1,
+                    "character": 4
+                  }
+                },
+                "newText": "int var1 = 10;\n    "
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 1,
+                    "character": 21
+                  },
+                  "end": {
+                    "line": 1,
+                    "character": 23
+                  }
+                },
+                "newText": "var1"
+              }
+            ],
+            "10 * 20": [
+              {
+                "range": {
+                  "start": {
+                    "line": 1,
+                    "character": 4
+                  },
+                  "end": {
+                    "line": 1,
+                    "character": 4
+                  }
+                },
+                "newText": "int var1 = 10 * 20;\n    "
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 1,
+                    "character": 21
+                  },
+                  "end": {
+                    "line": 1,
+                    "character": 28
+                  }
+                },
+                "newText": "var1"
+              }
+            ],
+            "10 * 20 + 30": [
+              {
+                "range": {
+                  "start": {
+                    "line": 1,
+                    "character": 4
+                  },
+                  "end": {
+                    "line": 1,
+                    "character": 4
+                  }
+                },
+                "newText": "int var1 = 10 * 20 + 30;\n    "
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 1,
+                    "character": 21
+                  },
+                  "end": {
+                    "line": 1,
+                    "character": 33
+                  }
+                },
+                "newText": "var1"
+              }
+            ]
+          }
+        ]
+      },
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config-quick-pick-capability/extractToLocalVarExpr2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config-quick-pick-capability/extractToLocalVarExpr2.json
@@ -1,0 +1,80 @@
+{
+  "position": {
+    "line": 1,
+    "character": 32
+  },
+  "source": "extractToLocalVariableExprsWithQuickPick.bal",
+  "expected": [
+    {
+      "title": "Extract to local variable",
+      "kind": "refactor.extract",
+      "command": {
+        "title": "Extract To Local Variable",
+        "command": "ballerina.action.extract",
+        "arguments": [
+          "Extract To Local Variable",
+          "extractToLocalVariableExprsWithQuickPick.bal",
+          {
+            "30": [
+              {
+                "range": {
+                  "start": {
+                    "line": 1,
+                    "character": 4
+                  },
+                  "end": {
+                    "line": 1,
+                    "character": 4
+                  }
+                },
+                "newText": "int var1 = 30;\n    "
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 1,
+                    "character": 31
+                  },
+                  "end": {
+                    "line": 1,
+                    "character": 33
+                  }
+                },
+                "newText": "var1"
+              }
+            ],
+            "10 * 20 + 30": [
+              {
+                "range": {
+                  "start": {
+                    "line": 1,
+                    "character": 4
+                  },
+                  "end": {
+                    "line": 1,
+                    "character": 4
+                  }
+                },
+                "newText": "int var1 = 10 * 20 + 30;\n    "
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 1,
+                    "character": 21
+                  },
+                  "end": {
+                    "line": 1,
+                    "character": 33
+                  }
+                },
+                "newText": "var1"
+              }
+            ]
+          }
+        ]
+      },
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config-quick-pick-capability/extractToLocalVarExpr3.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config-quick-pick-capability/extractToLocalVarExpr3.json
@@ -1,0 +1,136 @@
+{
+  "position": {
+    "line": 3,
+    "character": 34
+  },
+  "source": "extractToLocalVariableExprsWithQuickPick.bal",
+  "expected": [
+    {
+      "title": "Extract to local variable",
+      "kind": "refactor.extract",
+      "command": {
+        "title": "Extract To Local Variable",
+        "command": "ballerina.action.extract",
+        "arguments": [
+          "Extract To Local Variable",
+          "extractToLocalVariableExprsWithQuickPick.bal",
+          {
+            "60": [
+              {
+                "range": {
+                  "start": {
+                    "line": 3,
+                    "character": 4
+                  },
+                  "end": {
+                    "line": 3,
+                    "character": 4
+                  }
+                },
+                "newText": "int var1 = 60;\n    "
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 3,
+                    "character": 32
+                  },
+                  "end": {
+                    "line": 3,
+                    "character": 34
+                  }
+                },
+                "newText": "var1"
+              }
+            ],
+            "60 * two": [
+              {
+                "range": {
+                  "start": {
+                    "line": 3,
+                    "character": 4
+                  },
+                  "end": {
+                    "line": 3,
+                    "character": 4
+                  }
+                },
+                "newText": "int var1 = 60 * two;\n    "
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 3,
+                    "character": 32
+                  },
+                  "end": {
+                    "line": 3,
+                    "character": 40
+                  }
+                },
+                "newText": "var1"
+              }
+            ],
+            "40 + 50 + 60 * two": [
+              {
+                "range": {
+                  "start": {
+                    "line": 3,
+                    "character": 4
+                  },
+                  "end": {
+                    "line": 3,
+                    "character": 4
+                  }
+                },
+                "newText": "int var1 = 40 + 50 + 60 * two;\n    "
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 3,
+                    "character": 22
+                  },
+                  "end": {
+                    "line": 3,
+                    "character": 40
+                  }
+                },
+                "newText": "var1"
+              }
+            ],
+            "intLiteral == 40 + 50 + 60 * two": [
+              {
+                "range": {
+                  "start": {
+                    "line": 3,
+                    "character": 4
+                  },
+                  "end": {
+                    "line": 3,
+                    "character": 4
+                  }
+                },
+                "newText": "boolean var1 = intLiteral == 40 + 50 + 60 * two;\n    "
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 3,
+                    "character": 8
+                  },
+                  "end": {
+                    "line": 3,
+                    "character": 40
+                  }
+                },
+                "newText": "var1"
+              }
+            ]
+          }
+        ]
+      },
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config-quick-pick-capability/extractToLocalVarExpr4.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config-quick-pick-capability/extractToLocalVarExpr4.json
@@ -1,0 +1,136 @@
+{
+  "position": {
+    "line": 8,
+    "character": 21
+  },
+  "source": "extractToLocalVariableExprsWithQuickPick.bal",
+  "expected": [
+    {
+      "title": "Extract to local variable",
+      "kind": "refactor.extract",
+      "command": {
+        "title": "Extract To Local Variable",
+        "command": "ballerina.action.extract",
+        "arguments": [
+          "Extract To Local Variable",
+          "extractToLocalVariableExprsWithQuickPick.bal",
+          {
+            "10": [
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 0
+                  }
+                },
+                "newText": "int var1 = 10;\n"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 20
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 22
+                  }
+                },
+                "newText": "var1"
+              }
+            ],
+            "10 / 2": [
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 0
+                  }
+                },
+                "newText": "int var1 = 10 / 2;\n"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 20
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 26
+                  }
+                },
+                "newText": "var1"
+              }
+            ],
+            "10 / 2 + 20": [
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 0
+                  }
+                },
+                "newText": "int var1 = 10 / 2 + 20;\n"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 20
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 31
+                  }
+                },
+                "newText": "var1"
+              }
+            ],
+            "10 / 2 + 20 + 30": [
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 0
+                  }
+                },
+                "newText": "int var1 = 10 / 2 + 20 + 30;\n"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 20
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 36
+                  }
+                },
+                "newText": "var1"
+              }
+            ]
+          }
+        ]
+      },
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config-quick-pick-capability/extractToLocalVarExpr5.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config-quick-pick-capability/extractToLocalVarExpr5.json
@@ -1,0 +1,80 @@
+{
+  "position": {
+    "line": 8,
+    "character": 28
+  },
+  "source": "extractToLocalVariableExprsWithQuickPick.bal",
+  "expected": [
+    {
+      "title": "Extract to local variable",
+      "kind": "refactor.extract",
+      "command": {
+        "title": "Extract To Local Variable",
+        "command": "ballerina.action.extract",
+        "arguments": [
+          "Extract To Local Variable",
+          "extractToLocalVariableExprsWithQuickPick.bal",
+          {
+            "10 / 2 + 20": [
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 0
+                  }
+                },
+                "newText": "int var1 = 10 / 2 + 20;\n"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 20
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 31
+                  }
+                },
+                "newText": "var1"
+              }
+            ],
+            "10 / 2 + 20 + 30": [
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 0
+                  }
+                },
+                "newText": "int var1 = 10 / 2 + 20 + 30;\n"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 8,
+                    "character": 20
+                  },
+                  "end": {
+                    "line": 8,
+                    "character": 36
+                  }
+                },
+                "newText": "var1"
+              }
+            ]
+          }
+        ]
+      },
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config-quick-pick-capability/extractToLocalVarExpr6.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config-quick-pick-capability/extractToLocalVarExpr6.json
@@ -1,0 +1,108 @@
+{
+  "position": {
+    "line": 14,
+    "character": 22
+  },
+  "source": "extractToLocalVariableExprsWithQuickPick.bal",
+  "expected": [
+    {
+      "title": "Extract to local variable",
+      "kind": "refactor.extract",
+      "command": {
+        "title": "Extract To Local Variable",
+        "command": "ballerina.action.extract",
+        "arguments": [
+          "Extract To Local Variable",
+          "extractToLocalVariableExprsWithQuickPick.bal",
+          {
+            "3.14": [
+              {
+                "range": {
+                  "start": {
+                    "line": 14,
+                    "character": 8
+                  },
+                  "end": {
+                    "line": 14,
+                    "character": 8
+                  }
+                },
+                "newText": "float var1 = 3.14;\n        "
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 14,
+                    "character": 21
+                  },
+                  "end": {
+                    "line": 14,
+                    "character": 25
+                  }
+                },
+                "newText": "var1"
+              }
+            ],
+            "3.14 * 3": [
+              {
+                "range": {
+                  "start": {
+                    "line": 14,
+                    "character": 8
+                  },
+                  "end": {
+                    "line": 14,
+                    "character": 8
+                  }
+                },
+                "newText": "float var1 = 3.14 * 3;\n        "
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 14,
+                    "character": 21
+                  },
+                  "end": {
+                    "line": 14,
+                    "character": 29
+                  }
+                },
+                "newText": "var1"
+              }
+            ],
+            "3.14 * 3 * 4": [
+              {
+                "range": {
+                  "start": {
+                    "line": 14,
+                    "character": 8
+                  },
+                  "end": {
+                    "line": 14,
+                    "character": 8
+                  }
+                },
+                "newText": "float var1 = 3.14 * 3 * 4;\n        "
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 14,
+                    "character": 21
+                  },
+                  "end": {
+                    "line": 14,
+                    "character": 33
+                  }
+                },
+                "newText": "var1"
+              }
+            ]
+          }
+        ]
+      },
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config-quick-pick-capability/extractToLocalVarExpr7.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config-quick-pick-capability/extractToLocalVarExpr7.json
@@ -1,0 +1,80 @@
+{
+  "position": {
+    "line": 20,
+    "character": 18
+  },
+  "source": "extractToLocalVariableExprsWithQuickPick.bal",
+  "expected": [
+    {
+      "title": "Extract to local variable",
+      "kind": "refactor.extract",
+      "command": {
+        "title": "Extract To Local Variable",
+        "command": "ballerina.action.extract",
+        "arguments": [
+          "Extract To Local Variable",
+          "extractToLocalVariableExprsWithQuickPick.bal",
+          {
+            "r * r": [
+              {
+                "range": {
+                  "start": {
+                    "line": 20,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 20,
+                    "character": 0
+                  }
+                },
+                "newText": "int var1 = r * r;\n"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 20,
+                    "character": 13
+                  },
+                  "end": {
+                    "line": 20,
+                    "character": 18
+                  }
+                },
+                "newText": "var1"
+              }
+            ],
+            "r * r * float:PI": [
+              {
+                "range": {
+                  "start": {
+                    "line": 20,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 20,
+                    "character": 0
+                  }
+                },
+                "newText": "float var1 = r * r * float:PI;\n"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 20,
+                    "character": 13
+                  },
+                  "end": {
+                    "line": 20,
+                    "character": 29
+                  }
+                },
+                "newText": "var1"
+              }
+            ]
+          }
+        ]
+      },
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config-quick-pick-capability/negativeExtractToLocalVarExpr.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config-quick-pick-capability/negativeExtractToLocalVarExpr.json
@@ -1,0 +1,11 @@
+{
+  "position": {
+    "line": 11,
+    "character": 18
+  },
+  "source": "extractToLocalVariableExprsWithQuickPick.bal",
+  "expected": [
+    {
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInObjectField.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInObjectField.json
@@ -11,49 +11,5 @@
   },
   "source": "extractToVariableInFieldAccess.bal",
   "expected": [
-    {
-      "title": "Extract to local variable",
-      "kind": "refactor.extract",
-      "edits": [
-        {
-          "range": {
-            "start": {
-              "line": 11,
-              "character": 4
-            },
-            "end": {
-              "line": 11,
-              "character": 4
-            }
-          },
-          "newText": "int var1 = 40;\n    "
-        },
-        {
-          "range": {
-            "start": {
-              "line": 11,
-              "character": 22
-            },
-            "end": {
-              "line": 11,
-              "character": 24
-            }
-          },
-          "newText": "var1"
-        }
-      ],
-      "command": {
-        "title": "Rename variable",
-        "command": "ballerina.action.positional.rename",
-        "arguments": [
-          "extractToVariableInFieldAccess.bal",
-          {
-            "line": 12,
-            "character": 22
-          }
-        ]
-      },
-      "resolvable": false
-    }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInvalidExpressionStatement.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInvalidExpressionStatement.json
@@ -23,10 +23,23 @@
             },
             "end": {
               "line": 7,
+              "character": 4
+            }
+          },
+          "newText": "string|int? var1 = myvar.id;\n    "
+        },
+        {
+          "range": {
+            "start": {
+              "line": 7,
+              "character": 4
+            },
+            "end": {
+              "line": 7,
               "character": 12
             }
           },
-          "newText": "string|int? var1 = myvar.id"
+          "newText": "var1"
         }
       ],
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/source/extractToLocalVariableExprsWithQuickPick.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/source/extractToLocalVariableExprsWithQuickPick.bal
@@ -1,0 +1,21 @@
+function testFunction() {
+    int intLiteral = 10 * 20 + 30;
+    int two = 2;
+    if (intLiteral == 40 + 50 + 60 * two) {
+        // do something
+    }
+}
+
+int intModLiteral = 10 / 2 + 20 + 30;
+
+class Square {
+    int length = 4 * 5;
+
+	function getArea() returns float {
+        float area = 3.14 * 3 * 4;
+	    return area;
+	}
+}
+
+int r = 12;
+float area = r * r * float:PI;


### PR DESCRIPTION
## Purpose
The purpose of this PR is to add quick pick (extract command) for extract to local variable and extract to function code actions.

Fixes #38555

Plugin PR [https://github.com/wso2-enterprise/ballerina-plugin-vscode/pull/801](https://github.com/wso2-enterprise/ballerina-plugin-vscode/pull/801)

## Approach
This feature has been previously introduced to extract to constant code action. This PR also follow the same approach used in #38208.

## Samples

https://user-images.githubusercontent.com/46857198/214311379-92f39116-d5ba-47fc-a4b9-d8155b1a29af.mov


## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
