### PR TITLE
[2201.3.x] Fix getting redeclared symbol error when the same symbol is used in two if-else blocks 

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -2711,9 +2711,7 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
             Map<BVarSymbol, BType.NarrowedTypes> existingNarrowedTypeInfo = ifNode.expr.narrowedTypeInfo;
             for (Map.Entry<BVarSymbol, BType.NarrowedTypes> entry : data.narrowedTypeInfo.entrySet()) {
                 BVarSymbol key = entry.getKey();
-                if (!existingNarrowedTypeInfo.containsKey(key)) {
-                    existingNarrowedTypeInfo.put(key, entry.getValue());
-                } else {
+                if (existingNarrowedTypeInfo.containsKey(key)) {
                     BType.NarrowedTypes existingNarrowTypes = existingNarrowedTypeInfo.get(key);
                     BUnionType unionType =
                             BUnionType.create(null, existingNarrowTypes.trueType, existingNarrowTypes.falseType);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/IfElseStmtTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/IfElseStmtTest.java
@@ -27,6 +27,7 @@ import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 /**
@@ -285,6 +286,21 @@ public class IfElseStmtTest {
         Object returns = BRunUtil.invoke(result, "testTypeNarrowing", args);
         
         Assert.assertEquals(returns.toString(), "ballerina");
+    }
+
+    @Test(dataProvider = "dataToTestSymbolsInIfElseStmt")
+    public void testSymbolsInIfElseStmt(String functionName) {
+        BRunUtil.invoke(result, functionName);
+    }
+
+    @DataProvider
+    public Object[] dataToTestSymbolsInIfElseStmt() {
+        return new Object[]{
+                "testSymbolsInIfElse1",
+                "testSymbolsInIfElse2",
+                "testSymbolsInIfElse3",
+                "testSymbolsInIfElse4"
+        };
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/ifelse/if-stmt.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/ifelse/if-stmt.bal
@@ -217,6 +217,125 @@ function testResetTypeNarrowingWithBlockStmt() {
     }
 }
 
+function testSymbolsInIfElse1() {
+    int? x = ();
+    if x is () {
+        int a = 3;
+        int b = 12;
+        b += 1;
+        if b == 13 {
+            a += 1;
+            b = 1;
+        }
+    } else {
+        int a = 3;
+        int b = 12;
+    }
+}
+
+function testSymbolsInIfElse2() {
+    int? x = ();
+    if x is () {
+        int a = 2;
+        int b = 6;
+        b += 1;
+        if b == 7 {
+            a += 1;
+            b = 1;
+            if a == 3 {
+                a += 2;
+                b += 2;
+            }
+        }
+        int c = 10;
+        int d = 20;
+        if c == 7 {
+            a += 1;
+            b = 1;
+            if a == 6 {
+                a += 2;
+                b += 2;
+            }
+        }
+    } else {
+        int a = 5;
+        int b = 12;
+        if a == 4 {
+            int c = 2;
+            int d = 3;
+        } else {
+            int c = 2;
+            int d = 3;
+        }
+    }
+}
+
+function testSymbolsInIfElse3() {
+    int|string? x = ();
+    if x is () {
+        int a = 12;
+        int b = 12;
+        b += 1;
+        if b == 13 {
+            a += 1;
+            b = 1;
+        }
+        if a == 2 {
+            a += 2;
+            b += 2;
+        }
+    } else if x is string {
+        int a = 2022;
+        int b = 12;
+    } else {
+        int a = 10;
+        int b = 12;
+    }
+}
+
+function testSymbolsInIfElse4() {
+    int|string? x = ();
+    if x is () {
+        int? a = 12;
+        int? b = 12;
+        if b is int {
+            b += 1;
+            int? c = 1;
+            if c is int {
+                int|string? d = ();
+                if d is int {
+                    c = 2;
+                    a = 2;
+                }
+                if d is string {
+                    d = 2;
+                    b = 3;
+                }
+            } else {
+                int d = 2;
+                a = 2;
+                b = 3;
+                c = 10;
+            }
+        }
+        if a is int {
+            if a == 0 {
+                int d = 12;
+            }
+            int c = 10;
+        }
+    } else {
+        int a = 12;
+        int b = 10;
+        if a == 10 {
+            int c = 10;
+            if c == 10 {
+                int d = 12;
+            }
+        }
+    }
+}
+
 function assertTrue(any|error actual) {
     assertEquality(true, actual);
 }


### PR DESCRIPTION
## Purpose
$title

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/39065

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
