### PR TITLE
Add snippet completions for string and xml templates

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/AbstractCompletionProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/AbstractCompletionProvider.java
@@ -526,6 +526,8 @@ public abstract class AbstractCompletionProvider<T extends Node> implements Ball
         completionItems.add(new SnippetCompletionItem(context, Snippet.EXPR_BASE64_LITERAL.get()));
         completionItems.add(new SnippetCompletionItem(context, Snippet.KW_FROM.get()));
         completionItems.add(new SnippetCompletionItem(context, Snippet.DEF_REG_EXP.get()));
+        completionItems.add(new SnippetCompletionItem(context, Snippet.DEF_STRING.get()));
+        completionItems.add(new SnippetCompletionItem(context, Snippet.DEF_XML.get()));
         
         Predicate<Symbol> symbolFilter = getExpressionContextSymbolFilter();
         List<Symbol> filteredList = visibleSymbols.stream()

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/ItemResolverConstants.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/ItemResolverConstants.java
@@ -88,6 +88,8 @@ public class ItemResolverConstants {
     public static final String RESOURCE = "resource";
     public static final String RESOURCE_FUNC_DEF = "resource function";
     public static final String REG_EXP = "re ``";
+    public static final String STRING_TEMP = "string ``";
+    public static final String XML_TEMP = "xml ``";
     
     public static final String FROM_CLAUSE = "from clause";
     public static final String LET_CLAUSE = "let clause";

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/Snippet.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/Snippet.java
@@ -129,6 +129,10 @@ public enum Snippet {
     DEF_DETACH_FUNCTION(SnippetGenerator.getDetachFunctionSnippet()),
 
     DEF_REG_EXP(SnippetGenerator.getRegularExpressionSnippet()),
+
+    DEF_STRING(SnippetGenerator.getStringSnippet()),
+
+    DEF_XML(SnippetGenerator.getXmlSnippet()),
     
     DEF_PARANTHESIS(SnippetGenerator.getParanthesisSnippet()),
     

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/SnippetGenerator.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/SnippetGenerator.java
@@ -1316,6 +1316,28 @@ public class SnippetGenerator {
     }
 
     /**
+     * Get string Snippet Block.
+     *
+     * @return {@link SnippetBlock}     Generated Snippet Block
+     */
+    public static SnippetBlock getStringSnippet() {
+        String snippet = "string `${1}`";
+        return new SnippetBlock(ItemResolverConstants.STRING_TEMP, ItemResolverConstants.STRING_TEMP, snippet,
+                ItemResolverConstants.SNIPPET_TYPE, Kind.SNIPPET);
+    }
+
+    /**
+     * Get xml Snippet Block.
+     *
+     * @return {@link SnippetBlock}     Generated Snippet Block
+     */
+    public static SnippetBlock getXmlSnippet() {
+        String snippet = "xml `${1}`";
+        return new SnippetBlock(ItemResolverConstants.XML_TEMP, ItemResolverConstants.XML_TEMP, snippet,
+                ItemResolverConstants.SNIPPET_TYPE, Kind.SNIPPET);
+    }
+
+    /**
      * Get Paranthesis Snippet Block.
      *
      * @return {@link SnippetBlock}     Generated Snippet Block

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_remote_action_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_remote_action_config1.json
@@ -739,6 +739,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_remote_action_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_remote_action_config3.json
@@ -754,6 +754,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config2.json
@@ -699,6 +699,24 @@
       "sortText": "N",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config20.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config20.json
@@ -727,6 +727,24 @@
       "filterText": "re ``",
       "insertText": "re `${1}`",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "BP",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "BP",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/client_resource_access_action_config3.json
@@ -735,6 +735,24 @@
       "sortText": "N",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/remote_action_config8.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action_node_context/config/remote_action_config8.json
@@ -736,6 +736,24 @@
       "filterText": "re ``",
       "insertText": "re `${1}`",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "BP",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "BP",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/class_def/config/config25.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/class_def/config/config25.json
@@ -663,6 +663,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/class_def/config/config28.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/class_def/config/config28.json
@@ -663,6 +663,24 @@
       "sortText": "DN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "DP",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "DP",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/class_def/config/config6.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/class_def/config/config6.json
@@ -675,6 +675,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/comment_context/config/comment_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/comment_context/config/comment_config5.json
@@ -711,6 +711,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/anon_func_expr_ctx_config11.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/anon_func_expr_ctx_config11.json
@@ -767,6 +767,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/anon_func_expr_ctx_config13.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/anon_func_expr_ctx_config13.json
@@ -789,6 +789,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/anon_func_expr_ctx_config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/anon_func_expr_ctx_config7.json
@@ -723,6 +723,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/anon_func_expr_ctx_config8.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/anon_func_expr_ctx_config8.json
@@ -739,6 +739,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/check_expression_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/check_expression_ctx_config1.json
@@ -727,6 +727,24 @@
       "sortText": "DN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "DP",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "DP",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/check_expression_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/check_expression_ctx_config2.json
@@ -719,6 +719,24 @@
       "sortText": "DN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "DP",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "DP",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/check_expression_ctx_config6.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/check_expression_ctx_config6.json
@@ -793,6 +793,24 @@
       "sortText": "DN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "DP",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "DP",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/check_expression_ctx_config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/check_expression_ctx_config7.json
@@ -803,6 +803,24 @@
       "sortText": "DN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "DP",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "DP",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config1.json
@@ -668,6 +668,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config10.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config10.json
@@ -680,6 +680,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config2.json
@@ -668,6 +668,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config3.json
@@ -668,6 +668,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config4.json
@@ -668,6 +668,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config8.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/conditional_expr_ctx_config8.json
@@ -668,6 +668,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/error_constructor_expr_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/error_constructor_expr_ctx_config1.json
@@ -727,6 +727,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/error_constructor_expr_ctx_config10.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/error_constructor_expr_ctx_config10.json
@@ -691,6 +691,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/error_constructor_expr_ctx_config11.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/error_constructor_expr_ctx_config11.json
@@ -785,6 +785,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/error_constructor_expr_ctx_config12.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/error_constructor_expr_ctx_config12.json
@@ -745,6 +745,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/error_constructor_expr_ctx_config13.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/error_constructor_expr_ctx_config13.json
@@ -719,6 +719,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/error_constructor_expr_ctx_config14.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/error_constructor_expr_ctx_config14.json
@@ -745,6 +745,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/error_constructor_expr_ctx_config15.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/error_constructor_expr_ctx_config15.json
@@ -745,6 +745,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/error_constructor_expr_ctx_config16.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/error_constructor_expr_ctx_config16.json
@@ -711,6 +711,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/error_constructor_expr_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/error_constructor_expr_ctx_config2.json
@@ -727,6 +727,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/error_constructor_expr_ctx_config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/error_constructor_expr_ctx_config7.json
@@ -736,6 +736,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/error_constructor_expr_ctx_config8.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/error_constructor_expr_ctx_config8.json
@@ -736,6 +736,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/error_constructor_expr_ctx_config9.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/error_constructor_expr_ctx_config9.json
@@ -736,6 +736,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/fail_expr_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/fail_expr_ctx_config1.json
@@ -676,6 +676,24 @@
       "sortText": "C",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "C",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "C",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/fail_expr_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/fail_expr_ctx_config2.json
@@ -676,6 +676,24 @@
       "sortText": "C",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "C",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "C",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config1.json
@@ -741,6 +741,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config10.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config10.json
@@ -799,6 +799,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config11.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config11.json
@@ -802,6 +802,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config12.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config12.json
@@ -783,6 +783,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config13.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config13.json
@@ -725,7 +725,7 @@
       "label": "string ``",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "T",
+      "sortText": "P",
       "filterText": "string ``",
       "insertText": "string `${1}`",
       "insertTextFormat": "Snippet"
@@ -734,7 +734,7 @@
       "label": "xml ``",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "T",
+      "sortText": "P",
       "filterText": "xml ``",
       "insertText": "xml `${1}`",
       "insertTextFormat": "Snippet"

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config13.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config13.json
@@ -720,6 +720,24 @@
       "sortText": "N",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config14.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config14.json
@@ -719,6 +719,24 @@
       "sortText": "N",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config15.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config15.json
@@ -737,7 +737,7 @@
       "label": "string ``",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "T",
+      "sortText": "P",
       "filterText": "string ``",
       "insertText": "string `${1}`",
       "insertTextFormat": "Snippet"
@@ -746,7 +746,7 @@
       "label": "xml ``",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "T",
+      "sortText": "P",
       "filterText": "xml ``",
       "insertText": "xml `${1}`",
       "insertTextFormat": "Snippet"

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config15.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config15.json
@@ -732,6 +732,24 @@
       "sortText": "N",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config16.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config16.json
@@ -686,6 +686,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config17.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config17.json
@@ -740,6 +740,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config18.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config18.json
@@ -722,6 +722,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config19.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config19.json
@@ -737,7 +737,7 @@
       "label": "string ``",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "T",
+      "sortText": "P",
       "filterText": "string ``",
       "insertText": "string `${1}`",
       "insertTextFormat": "Snippet"
@@ -746,7 +746,7 @@
       "label": "xml ``",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "T",
+      "sortText": "P",
       "filterText": "xml ``",
       "insertText": "xml `${1}`",
       "insertTextFormat": "Snippet"

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config19.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config19.json
@@ -732,6 +732,24 @@
       "sortText": "N",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config2.json
@@ -741,6 +741,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config20.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config20.json
@@ -748,6 +748,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config21.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config21.json
@@ -757,6 +757,24 @@
       "sortText": "CP",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "CR",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "CR",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config22.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config22.json
@@ -720,6 +720,24 @@
       "sortText": "CP",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "CR",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "CR",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config3.json
@@ -732,6 +732,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config4.json
@@ -732,6 +732,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config9.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/function_call_expression_ctx_config9.json
@@ -892,6 +892,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/list_constructor_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/list_constructor_ctx_config1.json
@@ -721,6 +721,24 @@
       "sortText": "BN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "ATP",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "ATP",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/list_constructor_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/list_constructor_ctx_config2.json
@@ -721,6 +721,24 @@
       "sortText": "BN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "ATP",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "ATP",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/list_constructor_ctx_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/list_constructor_ctx_config3.json
@@ -721,6 +721,24 @@
       "sortText": "BN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "ATP",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "ATP",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/list_constructor_ctx_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/list_constructor_ctx_config5.json
@@ -683,6 +683,24 @@
       "sortText": "BN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "ATP",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "ATP",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_constructor_expr_ctx_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_constructor_expr_ctx_config5.json
@@ -668,6 +668,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config1.json
@@ -719,7 +719,7 @@
       "label": "string ``",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "T",
       "filterText": "string ``",
       "insertText": "string `${1}`",
       "insertTextFormat": "Snippet"
@@ -728,7 +728,7 @@
       "label": "xml ``",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "T",
       "filterText": "xml ``",
       "insertText": "xml `${1}`",
       "insertTextFormat": "Snippet"

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config1.json
@@ -714,6 +714,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config2.json
@@ -719,7 +719,7 @@
       "label": "string ``",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "T",
       "filterText": "string ``",
       "insertText": "string `${1}`",
       "insertTextFormat": "Snippet"
@@ -728,7 +728,7 @@
       "label": "xml ``",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "T",
       "filterText": "xml ``",
       "insertText": "xml `${1}`",
       "insertTextFormat": "Snippet"

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config2.json
@@ -714,6 +714,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config55.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config55.json
@@ -776,6 +776,24 @@
       "sortText": "BN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "CP",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "CP",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config56.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config56.json
@@ -776,6 +776,24 @@
       "sortText": "BN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "CP",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "CP",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config65.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config65.json
@@ -695,6 +695,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config75.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config75.json
@@ -736,6 +736,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/member_access_expr_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/member_access_expr_ctx_config1.json
@@ -676,6 +676,24 @@
       "sortText": "N",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/member_access_expr_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/member_access_expr_ctx_config2.json
@@ -676,6 +676,24 @@
       "sortText": "N",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/method_call_expression_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/method_call_expression_ctx_config1.json
@@ -747,6 +747,24 @@
       "sortText": "CP",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "CR",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "CR",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/method_call_expression_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/method_call_expression_ctx_config2.json
@@ -790,6 +790,24 @@
       "sortText": "CP",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "CR",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "CR",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/method_call_expression_ctx_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/method_call_expression_ctx_config5.json
@@ -747,6 +747,24 @@
       "sortText": "CP",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "CR",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "CR",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/method_call_expression_ctx_config6.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/method_call_expression_ctx_config6.json
@@ -747,6 +747,24 @@
       "sortText": "CP",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "CR",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "CR",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/new_expr_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/new_expr_ctx_config1.json
@@ -760,6 +760,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/new_expr_ctx_config11.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/new_expr_ctx_config11.json
@@ -676,6 +676,24 @@
       "sortText": "N",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/new_expr_ctx_config12.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/new_expr_ctx_config12.json
@@ -676,6 +676,24 @@
       "sortText": "N",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/new_expr_ctx_config14.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/new_expr_ctx_config14.json
@@ -676,6 +676,24 @@
       "sortText": "N",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/new_expr_ctx_config15.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/new_expr_ctx_config15.json
@@ -676,6 +676,24 @@
       "sortText": "N",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/new_expr_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/new_expr_ctx_config2.json
@@ -741,6 +741,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/new_expr_ctx_config20.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/new_expr_ctx_config20.json
@@ -742,6 +742,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/new_expr_ctx_config21.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/new_expr_ctx_config21.json
@@ -742,6 +742,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/new_expr_ctx_config22.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/new_expr_ctx_config22.json
@@ -709,6 +709,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/new_expr_ctx_config23.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/new_expr_ctx_config23.json
@@ -709,6 +709,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/new_expr_ctx_config24.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/new_expr_ctx_config24.json
@@ -691,6 +691,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/new_expr_ctx_config25.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/new_expr_ctx_config25.json
@@ -725,6 +725,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/new_expr_ctx_config26.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/new_expr_ctx_config26.json
@@ -725,6 +725,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/new_expr_ctx_config27.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/new_expr_ctx_config27.json
@@ -695,6 +695,24 @@
       "filterText": "name",
       "insertText": "name = ${1:\"\"}",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/new_expr_ctx_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/new_expr_ctx_config3.json
@@ -741,6 +741,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/new_expr_ctx_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/new_expr_ctx_config4.json
@@ -745,6 +745,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/new_expr_ctx_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/new_expr_ctx_config5.json
@@ -730,6 +730,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/new_expr_ctx_config6.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/new_expr_ctx_config6.json
@@ -730,6 +730,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/object_constructor_expr_ctx_config9.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/object_constructor_expr_ctx_config9.json
@@ -698,6 +698,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/trap_expression_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/trap_expression_ctx_config1.json
@@ -727,6 +727,24 @@
       "sortText": "N",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/trap_expression_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/trap_expression_ctx_config2.json
@@ -719,6 +719,24 @@
       "sortText": "N",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/type_test_expression_ctx_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/type_test_expression_ctx_config5.json
@@ -668,6 +668,24 @@
       "sortText": "BBN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "BX",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "BX",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/typecast_expr_ctx_config6.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/typecast_expr_ctx_config6.json
@@ -720,6 +720,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/typeof_expression_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/typeof_expression_ctx_config1.json
@@ -675,6 +675,24 @@
       "sortText": "N",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/typeof_expression_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/typeof_expression_ctx_config2.json
@@ -675,6 +675,24 @@
       "sortText": "N",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/foreach_stmt_ctx_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/foreach_stmt_ctx_config5.json
@@ -726,6 +726,24 @@
       "sortText": "N",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/foreach_stmt_ctx_config6.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/foreach_stmt_ctx_config6.json
@@ -726,6 +726,24 @@
       "sortText": "N",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/function_body/config/config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function_body/config/config7.json
@@ -747,6 +747,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/function_body/config/config9.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function_body/config/config9.json
@@ -754,6 +754,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/function_def/config/config14.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function_def/config/config14.json
@@ -746,6 +746,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/function_def/config/config15.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function_def/config/config15.json
@@ -731,6 +731,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/function_def/config/config23.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function_def/config/config23.json
@@ -802,6 +802,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/let_expression_context/config/let_expr_ctx_config10.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/let_expression_context/config/let_expr_ctx_config10.json
@@ -703,6 +703,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/let_expression_context/config/let_expr_ctx_config11.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/let_expression_context/config/let_expr_ctx_config11.json
@@ -703,6 +703,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/let_expression_context/config/let_expr_ctx_config13.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/let_expression_context/config/let_expr_ctx_config13.json
@@ -687,6 +687,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/let_expression_context/config/let_expr_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/let_expression_context/config/let_expr_ctx_config2.json
@@ -715,6 +715,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/let_expression_context/config/let_expr_ctx_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/let_expression_context/config/let_expr_ctx_config3.json
@@ -723,6 +723,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/let_expression_context/config/let_expr_ctx_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/let_expression_context/config/let_expr_ctx_config4.json
@@ -687,6 +687,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/let_expression_context/config/let_expr_ctx_config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/let_expression_context/config/let_expr_ctx_config7.json
@@ -723,6 +723,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/let_expression_context/config/let_expr_ctx_config9.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/let_expression_context/config/let_expr_ctx_config9.json
@@ -731,6 +731,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/module_var_context/config/config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/module_var_context/config/config1.json
@@ -699,6 +699,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/module_var_context/config/config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/module_var_context/config/config2.json
@@ -699,6 +699,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/module_var_context/config/config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/module_var_context/config/config3.json
@@ -696,6 +696,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/module_var_context/config/config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/module_var_context/config/config4.json
@@ -711,6 +711,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/module_var_context/config/config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/module_var_context/config/config5.json
@@ -699,6 +699,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/module_var_context/config/config6.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/module_var_context/config/config6.json
@@ -714,6 +714,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/performance_completion/config/performance_completion.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/performance_completion/config/performance_completion.json
@@ -704,6 +704,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config14.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config14.json
@@ -688,6 +688,24 @@
       "sortText": "CN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "CP",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "CP",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config22.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config22.json
@@ -700,6 +700,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config23.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config23.json
@@ -700,6 +700,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config25.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config25.json
@@ -684,6 +684,24 @@
       "sortText": "BN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "BP",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "BP",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config26.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config26.json
@@ -684,6 +684,24 @@
       "sortText": "BN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "BP",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "BP",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config29.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config29.json
@@ -737,6 +737,24 @@
       "sortText": "CN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "CP",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "CP",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config30.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config30.json
@@ -754,6 +754,24 @@
       "sortText": "CN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "CP",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "CP",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_from_clause_config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_from_clause_config7.json
@@ -683,6 +683,24 @@
       "sortText": "CN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "CP",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "CP",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_from_clause_config8.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_from_clause_config8.json
@@ -683,6 +683,24 @@
       "sortText": "CN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "CP",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "CP",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_join_clause_config12.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_join_clause_config12.json
@@ -748,6 +748,24 @@
       "sortText": "N",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_join_clause_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_join_clause_config5.json
@@ -748,6 +748,24 @@
       "sortText": "N",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_let_clause_config11.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_let_clause_config11.json
@@ -748,6 +748,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_let_clause_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_let_clause_config4.json
@@ -748,6 +748,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_let_clause_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_let_clause_config5.json
@@ -748,6 +748,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_limit_clause_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_limit_clause_config1.json
@@ -740,6 +740,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_limit_clause_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_limit_clause_config2.json
@@ -740,6 +740,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_limit_clause_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_limit_clause_config4.json
@@ -751,6 +751,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_onconflict_clause_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_onconflict_clause_config2.json
@@ -716,6 +716,24 @@
       "sortText": "CN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "CP",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "CP",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_orderby_clause_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_orderby_clause_config1.json
@@ -748,6 +748,24 @@
       "sortText": "CN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "CP",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "CP",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_orderby_clause_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_orderby_clause_config2.json
@@ -748,6 +748,24 @@
       "sortText": "CN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "CP",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "CP",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_orderby_clause_config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_orderby_clause_config7.json
@@ -683,6 +683,24 @@
       "sortText": "CN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "CP",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "CP",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_orderby_clause_config8.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_orderby_clause_config8.json
@@ -755,6 +755,24 @@
       "sortText": "CN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "CP",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "CP",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_orderby_clause_config9.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_orderby_clause_config9.json
@@ -787,6 +787,24 @@
       "sortText": "CN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "CP",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "CP",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_select_clause_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_select_clause_config1.json
@@ -741,6 +741,24 @@
       "sortText": "BN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "BP",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "BP",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_select_clause_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_select_clause_config2.json
@@ -741,6 +741,24 @@
       "sortText": "BN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "BP",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "BP",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_select_clause_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_select_clause_config5.json
@@ -754,6 +754,24 @@
       "sortText": "CN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "CP",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "CP",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_where_clause_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_where_clause_config1.json
@@ -715,6 +715,24 @@
       "sortText": "BN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "BP",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "BP",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_where_clause_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_where_clause_config3.json
@@ -723,6 +723,24 @@
       "sortText": "BN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "BP",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "BP",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_where_clause_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_where_clause_config5.json
@@ -788,6 +788,24 @@
       "sortText": "BN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "BP",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "BP",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/record_type_desc/config/config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/record_type_desc/config/config5.json
@@ -796,6 +796,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/record_type_desc/config/config6.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/record_type_desc/config/config6.json
@@ -796,6 +796,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/record_type_desc/config/config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/record_type_desc/config/config7.json
@@ -778,6 +778,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/record_type_desc/config/config8.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/record_type_desc/config/config8.json
@@ -778,6 +778,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/service_decl/config/config12.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/service_decl/config/config12.json
@@ -668,6 +668,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/assignment_stmt_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/assignment_stmt_ctx_config1.json
@@ -704,6 +704,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/assignment_stmt_ctx_config10.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/assignment_stmt_ctx_config10.json
@@ -797,6 +797,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/assignment_stmt_ctx_config11.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/assignment_stmt_ctx_config11.json
@@ -805,6 +805,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/assignment_stmt_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/assignment_stmt_ctx_config2.json
@@ -704,6 +704,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/assignment_stmt_ctx_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/assignment_stmt_ctx_config3.json
@@ -722,6 +722,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/assignment_stmt_ctx_config6.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/assignment_stmt_ctx_config6.json
@@ -786,6 +786,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/assignment_stmt_ctx_config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/assignment_stmt_ctx_config7.json
@@ -780,6 +780,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/assignment_stmt_ctx_config8.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/assignment_stmt_ctx_config8.json
@@ -729,6 +729,24 @@
       "sortText": "DN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "DP",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "DP",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/assignment_stmt_ctx_config9.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/assignment_stmt_ctx_config9.json
@@ -732,6 +732,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/checking_call_stmt_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/checking_call_stmt_ctx_config1.json
@@ -727,6 +727,24 @@
       "sortText": "DN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "DP",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "DP",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/checking_call_stmt_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/checking_call_stmt_ctx_config2.json
@@ -727,6 +727,24 @@
       "sortText": "DN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "DP",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "DP",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/elseif_stmt_ctx_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/elseif_stmt_ctx_config4.json
@@ -690,6 +690,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/elseif_stmt_ctx_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/elseif_stmt_ctx_config5.json
@@ -690,6 +690,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/elseif_stmt_ctx_config6.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/elseif_stmt_ctx_config6.json
@@ -690,6 +690,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/fail_stmt_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/fail_stmt_ctx_config1.json
@@ -713,6 +713,24 @@
       "sortText": "C",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "C",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "C",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/fail_stmt_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/fail_stmt_ctx_config2.json
@@ -715,6 +715,24 @@
       "sortText": "C",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "C",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "C",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/if_stmt_ctx_config12.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/if_stmt_ctx_config12.json
@@ -698,6 +698,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/if_stmt_ctx_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/if_stmt_ctx_config3.json
@@ -682,6 +682,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/if_stmt_ctx_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/if_stmt_ctx_config4.json
@@ -682,6 +682,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/if_stmt_ctx_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/if_stmt_ctx_config5.json
@@ -682,6 +682,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/if_stmt_ctx_config6.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/if_stmt_ctx_config6.json
@@ -682,6 +682,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/lock_stmt_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/lock_stmt_ctx_config2.json
@@ -727,6 +727,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/match_stmt_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/match_stmt_ctx_config1.json
@@ -747,6 +747,24 @@
       "sortText": "N",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/match_stmt_ctx_config13.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/match_stmt_ctx_config13.json
@@ -705,6 +705,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/match_stmt_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/match_stmt_ctx_config2.json
@@ -732,6 +732,24 @@
       "sortText": "N",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/match_stmt_ctx_config20.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/match_stmt_ctx_config20.json
@@ -708,6 +708,24 @@
       "sortText": "N",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/match_stmt_ctx_config21.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/match_stmt_ctx_config21.json
@@ -708,6 +708,24 @@
       "sortText": "N",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/match_stmt_ctx_config22.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/match_stmt_ctx_config22.json
@@ -708,6 +708,24 @@
       "sortText": "N",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/panic_stmt_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/panic_stmt_ctx_config2.json
@@ -687,6 +687,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/panic_stmt_ctx_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/panic_stmt_ctx_config3.json
@@ -711,6 +711,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/transaction_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/transaction_config2.json
@@ -720,6 +720,24 @@
       "sortText": "DN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "DP",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "DP",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/transaction_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/transaction_config3.json
@@ -720,6 +720,24 @@
       "sortText": "DN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "DP",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "DP",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/while_stmt_ctx_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/while_stmt_ctx_config3.json
@@ -690,6 +690,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/while_stmt_ctx_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/while_stmt_ctx_config4.json
@@ -690,6 +690,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/while_stmt_ctx_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/while_stmt_ctx_config5.json
@@ -690,6 +690,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/while_stmt_ctx_config6.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/while_stmt_ctx_config6.json
@@ -690,6 +690,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/while_stmt_ctx_config8.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/while_stmt_ctx_config8.json
@@ -698,6 +698,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/template_expression/config/regex_template_expression_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/template_expression/config/regex_template_expression_config1.json
@@ -711,6 +711,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/template_expression/config/regex_template_expression_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/template_expression/config/regex_template_expression_config2.json
@@ -711,6 +711,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/template_expression/config/regex_template_expression_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/template_expression/config/regex_template_expression_config4.json
@@ -715,6 +715,24 @@
       "sortText": "ACN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "Q",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "Q",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/template_expression/config/string_template_expression_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/template_expression/config/string_template_expression_config2.json
@@ -699,6 +699,24 @@
       "sortText": "ACN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "Q",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "Q",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/template_expression/config/string_template_expression_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/template_expression/config/string_template_expression_config3.json
@@ -699,6 +699,24 @@
       "sortText": "ACN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "Q",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "Q",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/template_expression/config/string_template_expression_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/template_expression/config/string_template_expression_config4.json
@@ -738,6 +738,24 @@
       "sortText": "ACN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "Q",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "Q",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/template_expression/config/string_template_expression_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/template_expression/config/string_template_expression_config5.json
@@ -738,6 +738,24 @@
       "sortText": "ACN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "Q",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "Q",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/template_expression/config/xml_template_expression_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/template_expression/config/xml_template_expression_config1.json
@@ -768,6 +768,24 @@
       "sortText": "ACN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "Q",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "Q",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/template_expression/config/xml_template_expression_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/template_expression/config/xml_template_expression_config2.json
@@ -768,6 +768,24 @@
       "sortText": "ACN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "Q",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "Q",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/typedesc_context/config/function_typedesc15a.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/typedesc_context/config/function_typedesc15a.json
@@ -755,7 +755,7 @@
       "label": "string ``",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "T",
       "filterText": "string ``",
       "insertText": "string `${1}`",
       "insertTextFormat": "Snippet"
@@ -764,7 +764,7 @@
       "label": "xml ``",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "T",
       "filterText": "xml ``",
       "insertText": "xml `${1}`",
       "insertTextFormat": "Snippet"

--- a/language-server/modules/langserver-core/src/test/resources/completion/typedesc_context/config/function_typedesc15a.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/typedesc_context/config/function_typedesc15a.json
@@ -750,6 +750,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/typedesc_context/config/function_typedesc15b.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/typedesc_context/config/function_typedesc15b.json
@@ -755,7 +755,7 @@
       "label": "string ``",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "T",
       "filterText": "string ``",
       "insertText": "string `${1}`",
       "insertTextFormat": "Snippet"
@@ -764,7 +764,7 @@
       "label": "xml ``",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "T",
       "filterText": "xml ``",
       "insertText": "xml `${1}`",
       "insertTextFormat": "Snippet"

--- a/language-server/modules/langserver-core/src/test/resources/completion/typedesc_context/config/function_typedesc15b.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/typedesc_context/config/function_typedesc15b.json
@@ -750,6 +750,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/project_var_def_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/project_var_def_ctx_config1.json
@@ -799,6 +799,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/project_var_def_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/project_var_def_ctx_config2.json
@@ -807,6 +807,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/project_var_def_ctx_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/project_var_def_ctx_config3.json
@@ -784,6 +784,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/var_def_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/var_def_ctx_config1.json
@@ -711,6 +711,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/var_def_ctx_config12.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/var_def_ctx_config12.json
@@ -728,6 +728,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/var_def_ctx_config13.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/var_def_ctx_config13.json
@@ -801,6 +801,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/var_def_ctx_config14.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/var_def_ctx_config14.json
@@ -859,6 +859,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/var_def_ctx_config15.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/var_def_ctx_config15.json
@@ -801,6 +801,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/var_def_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/var_def_ctx_config2.json
@@ -711,6 +711,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/var_def_ctx_config20.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/var_def_ctx_config20.json
@@ -761,6 +761,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/var_def_ctx_config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/var_def_ctx_config7.json
@@ -712,6 +712,24 @@
       "sortText": "DN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "DP",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "DP",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/var_def_ctx_with_escape_char_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/var_def_ctx_with_escape_char_config1.json
@@ -719,6 +719,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/var_def_in_obj_constructor_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/var_def_in_obj_constructor_config1.json
@@ -759,6 +759,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "P",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/var_def_in_obj_constructor_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/var_def_in_obj_constructor_config1.json
@@ -764,7 +764,7 @@
       "label": "string ``",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "T",
       "filterText": "string ``",
       "insertText": "string `${1}`",
       "insertTextFormat": "Snippet"
@@ -773,7 +773,7 @@
       "label": "xml ``",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "P",
+      "sortText": "T",
       "filterText": "xml ``",
       "insertText": "xml `${1}`",
       "insertTextFormat": "Snippet"

--- a/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/var_def_with_anon_func_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/var_def_with_anon_func_config1.json
@@ -743,6 +743,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/var_def_with_anon_func_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/var_def_with_anon_func_config2.json
@@ -743,6 +743,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/var_def_with_anon_func_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/var_def_with_anon_func_config3.json
@@ -735,6 +735,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/var_def_with_anon_func_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/variable-declaration/config/var_def_with_anon_func_config4.json
@@ -759,6 +759,24 @@
       "sortText": "R",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
     }
   ]
 }


### PR DESCRIPTION
## Purpose
This PR adds completion support for string and xml templates. 

Fixes #39290

## Samples
1. 
<img width="738" alt="Screenshot 2023-01-25 at 15 47 56" src="https://user-images.githubusercontent.com/61020198/214537812-7e66bb49-6a2d-4dbb-800e-b0565bf120d1.png">

2.
<img width="738" alt="Screenshot 2023-01-25 at 15 48 04" src="https://user-images.githubusercontent.com/61020198/214538001-84f2b760-4d93-463a-beec-30237e26c10c.png">

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
