### PR TITLE
Fix cloning type-reference target type error for arrays and tables

### DIFF
--- a/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/CloneWithType.java
+++ b/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/CloneWithType.java
@@ -278,6 +278,8 @@ public class CloneWithType {
             case TypeTags.INTERSECTION_TAG:
                 return convertArray(array, ((IntersectionType) targetType).getEffectiveType(),
                                     unresolvedValues, t);
+            case TypeTags.TYPE_REFERENCED_TYPE_TAG:
+                return convertArray(array, ((ReferenceType) targetType).getReferredType(), unresolvedValues, t);
             default:
                 break;
         }
@@ -287,6 +289,10 @@ public class CloneWithType {
 
     private static Object convertTable(BTable<?, ?> bTable, Type targetType,
                                        List<TypeValuePair> unresolvedValues, BTypedesc t) {
+        if (targetType.getTag() == TypeTags.TYPE_REFERENCED_TYPE_TAG) {
+            return convertTable(bTable, ((ReferenceType) targetType).getReferredType(), unresolvedValues, t);
+        }
+
         TableType tableType = (TableType) targetType;
         Object[] tableValues = new Object[bTable.size()];
         int count = 0;

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibValueTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibValueTest.java
@@ -370,7 +370,7 @@ public class LangLibValueTest {
                 "testCloneWithTypeNestedStructuredTypesNegative", "testCloneWithTypeJsonToRecordRestField",
                 "testCloneWithTypeWithAmbiguousUnion",
                 "testCloneWithTypeWithTuples",
-                "testCloneWithTypeToUnion"
+                "testCloneWithTypeToUnion", "testCloneWithTypeToUnionOfTypeReference"
         };
     }
 

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibValueTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibValueTest.java
@@ -440,7 +440,8 @@ public class LangLibValueTest {
                 { "testFromJsonWithTypeWithTypeReferences" },
                 { "testFromJsonWithTypeNestedRecordsNegative" },
                 { "testFromJsonWithTypeOnRegExp" },
-                { "testFromJsonWithTypeOnRegExpNegative" }
+                { "testFromJsonWithTypeOnRegExpNegative" },
+                {"testFromJsonWithTypeToUnionOfTypeReference"}
         };
     }
 

--- a/langlib/langlib-test/src/test/resources/test-src/valuelib_fromJson_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/valuelib_fromJson_test.bal
@@ -801,6 +801,36 @@ function testFromJsonWithTypeOnRegExpNegative() {
     }
 }
 
+type Assertion [string, string];
+
+type BoundAssertion ["let", int];
+
+type UnionTuple Assertion|BoundAssertion;
+
+type Table1 table<map<int>>;
+
+type Table2 table<map<string>>;
+
+type UnionTable Table1|Table2;
+
+function testFromJsonWithTypeToUnionOfTypeReference() {
+    json[] arrValue = ["let", 3];
+
+    BoundAssertion|error t1 = arrValue.fromJsonWithType(); 
+    assertFalse(t1 is error);
+    assertEquality(t1, <BoundAssertion> ["let", 3]);
+
+    Assertion|BoundAssertion|error t2 = arrValue.fromJsonWithType(); 
+    assertFalse(t2 is error);
+    assertTrue(t2 is BoundAssertion);
+    assertEquality(t2, <BoundAssertion> ["let", 3]);
+
+    UnionTuple|error t3 = arrValue.fromJsonWithType(); 
+    assertFalse(t3 is error);
+    assertTrue(t3 is BoundAssertion);
+    assertEquality(t3, <BoundAssertion> ["let", 3]);
+}
+
 function assert(anydata actual, anydata expected) {
     if (expected == actual) {
         return;
@@ -815,6 +845,14 @@ function assert(anydata actual, anydata expected) {
 type AssertionError distinct error;
 
 const ASSERTION_ERROR_REASON = "AssertionError";
+
+function assertFalse(any|error actual) {
+    assertEquality(false, actual);
+}
+
+function assertTrue(any|error actual) {
+    assertEquality(true, actual);
+}
 
 function assertEquality(any|error expected, any|error actual) {
     if expected is anydata && actual is anydata && expected == actual {

--- a/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
@@ -2322,28 +2322,28 @@ function testCloneWithTypeToUnionOfTypeReference() {
 
     BoundAssertion|error t1 = arrValue.cloneWithType(); 
     assertFalse(t1 is error);
-    assertTrue(t1 == ["let", 3]);
+    assertEquality(t1, <BoundAssertion> ["let", 3]);
 
     Assertion|BoundAssertion|error t2 = arrValue.cloneWithType(); 
     assertFalse(t2 is error);
     assertTrue(t2 is BoundAssertion);
-    assertTrue(t2 == ["let", 3]);
+    assertEquality(t2, <BoundAssertion> ["let", 3]);
 
     UnionTuple|error t3 = arrValue.cloneWithType(); 
     assertFalse(t3 is error);
     assertTrue(t3 is BoundAssertion);
-    assertTrue(t3 == ["let", 3]);
+    assertEquality(t3, <BoundAssertion> ["let", 3]);
 
     table<map<anydata>> tab = table [{a: "a", b: "b"}];
     Table1|Table2|error t4 = tab.cloneWithType(); 
     assertFalse(t4 is error);
     assertTrue(t4 is Table2);
-    assertTrue(t4 == table [{a: "a", b: "b"}]);
+    assertEquality(t4, <Table2> table [{a: "a", b: "b"}]);
 
     UnionTable|error t5 = tab.cloneWithType(); 
     assertFalse(t5 is error);
     assertTrue(t5 is Table2);
-    assertTrue(t5 == table [{a: "a", b: "b"}]);
+    assertEquality(t5, <Table2> table [{a: "a", b: "b"}]);
 }
 
 /////////////////////////// Tests for `toJson()` ///////////////////////////

--- a/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
@@ -2305,6 +2305,47 @@ function testCloneWithTypeWithTuples() returns error? {
     assertFalse(x is Array);
 }
 
+type Assertion [string, string];
+
+type BoundAssertion ["let", int];
+
+type UnionTuple Assertion|BoundAssertion;
+
+type Table1 table<map<int>>;
+
+type Table2 table<map<string>>;
+
+type UnionTable Table1|Table2;
+
+function testCloneWithTypeToUnionOfTypeReference() {
+    anydata[] arrValue = ["let", 3];
+
+    BoundAssertion|error t1 = arrValue.cloneWithType(); 
+    assertFalse(t1 is error);
+    assertTrue(t1 == ["let", 3]);
+
+    Assertion|BoundAssertion|error t2 = arrValue.cloneWithType(); 
+    assertFalse(t2 is error);
+    assertTrue(t2 is BoundAssertion);
+    assertTrue(t2 == ["let", 3]);
+
+    UnionTuple|error t3 = arrValue.cloneWithType(); 
+    assertFalse(t3 is error);
+    assertTrue(t3 is BoundAssertion);
+    assertTrue(t3 == ["let", 3]);
+
+    table<map<anydata>> tab = table [{a: "a", b: "b"}];
+    Table1|Table2|error t4 = tab.cloneWithType(); 
+    assertFalse(t4 is error);
+    assertTrue(t4 is Table2);
+    assertTrue(t4 == table [{a: "a", b: "b"}]);
+
+    UnionTable|error t5 = tab.cloneWithType(); 
+    assertFalse(t5 is error);
+    assertTrue(t5 is Table2);
+    assertTrue(t5 == table [{a: "a", b: "b"}]);
+}
+
 /////////////////////////// Tests for `toJson()` ///////////////////////////
 
 type Student2 record {


### PR DESCRIPTION
## Purpose
$subject

Fixes #39379

## Approach
Added missing implementation for type-reference type in type-converter

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
