### PR TITLE
[2201.4.0-stage] Fix `LocksInMainTest.throwErrorInsideLock` test

### DIFF
--- a/tests/jballerina-unit-test/src/test/resources/test-src/lock/locks-in-functions.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/lock/locks-in-functions.bal
@@ -136,7 +136,9 @@ function convertStringToInt() {
 }
 
 function testThrowErrorInsideLock() {
-    test:assertEquals(throwErrorInsideLock(), [51, "second worker string"]);
+    var [intResult, stringResult] = throwErrorInsideLock();
+    test:assertEquals(intResult, 51);
+    test:assertTrue(stringResult is "second worker string" || stringResult is "hello");
 }
 
 function throwErrorInsideLock() returns [int, string] {
@@ -159,7 +161,9 @@ function throwErrorInsideLock() returns [int, string] {
     if (waitResult is error) {
         test:assertEquals(waitResult.message(), "{ballerina/lang.int}NumberParsingError");
     }
-    return [lockWithinLockInt1, lockWithinLockString1];
+    lock {
+        return [lockWithinLockInt1, lockWithinLockString1];
+    }
 }
 
 function errorPanicInsideLock() {


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues.

Fixes #39397

## Approach
> Describe how you are implementing the solutions along with the design details.

After `throwErrorInsideLock` function is called if the thread running worker `w1` gets delayed more than 10 ms, the default worker thread may acquire the lock and the string gets changed to  `"second worker string"` first and at last to `"hello"` by the `w1` worker. Hence need to consider both the possibilities.
```bal
function convertStringToInt() {
    lock {
        sleep(50);
        lockWithinLockInt1 = lockWithinLockInt1 + 1;
        lockWithinLockString1 = "hello";
        int ddd;
        var result = ints:fromString(lockWithinLockString1);
        if (result is int) {
            ddd = result;
        } else {
            panic result;
        }
    }
}

function testThrowErrorInsideLock() {
    var [intResult, stringResult] = throwErrorInsideLock();
    test:assertEquals(intResult, 51);
    test:assertTrue(stringResult is "second worker string" || stringResult is "hello");
}

function throwErrorInsideLock() returns [int, string] {
    resetlockWithinLockInt1();

    @strand {thread: "any"}
    worker w1 {
        lock {
            convertStringToInt();
        }
    }

    sleep(10);
    lock {
        lockWithinLockString1 = "second worker string";
        lockWithinLockInt1 = lockWithinLockInt1 + 50;
    }
    error? waitResult = trap wait w1;
    test:assertTrue(waitResult is error);
    if (waitResult is error) {
        test:assertEquals(waitResult.message(), "{ballerina/lang.int}NumberParsingError");
    }
    lock {
        return [lockWithinLockInt1, lockWithinLockString1];
    }
}
```

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
