### PR TITLE
Add .exe to windows native image path

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunNativeImageTestTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunNativeImageTestTask.java
@@ -106,6 +106,7 @@ import static org.ballerinalang.test.runtime.util.TesterinaConstants.TESTABLE;
 public class RunNativeImageTestTask implements Task {
 
     private static final String OS = System.getProperty("os.name").toLowerCase(Locale.getDefault());
+    private static final String WIN_EXEC_EXT = "exe";
 
     private static class StreamGobbler extends Thread {
         private InputStream inputStream;
@@ -525,7 +526,8 @@ public class RunNativeImageTestTask implements Task {
             cmdArgs = new ArrayList<>();
 
             // Run the generated image
-            cmdArgs.add(nativeTargetPath.resolve(packageName).toString());
+            String generatedImagePath = nativeTargetPath.resolve(packageName) + getGeneratedImageExtension();
+            cmdArgs.add(generatedImagePath);
 
             // Test Runner Class arguments
             cmdArgs.add(target.path().toString());                                  // 0
@@ -734,4 +736,10 @@ public class RunNativeImageTestTask implements Task {
         return unmodifiedFiles;
     }
 
+    private String getGeneratedImageExtension() {
+        if (OS.contains("win")) {
+            return DOT + WIN_EXEC_EXT;
+        }
+        return "";
+    }
 }


### PR DESCRIPTION
## Purpose
When function mocking is available in many modules of a project, separate GraalVM executables are created and the tests are run separately for each module.
The executables created for the `function-mocking-tests` in `testerina-integration-tests` are as follows.
- ./target/native/function_mocking.exe
- ./target/native/function_mocking.mock2.exe

Here the modules are the default module and the `mock2` module.

However when running these executables, we pass `function_mocking.mock2` as the executable. Usually the `.exe` is not required. However in this case since the submodule name is preceded with a ".", it throws cannot find file error.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/39443

## Approach
Added a `.exe` extension to the image path if the tests are running on windows.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
