### PR TITLE
[2201.4.0-stage] Fix incorrect rename popup on create var

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/ErrorHandleOutsideCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/ErrorHandleOutsideCodeAction.java
@@ -103,7 +103,7 @@ public class ErrorHandleOutsideCodeAction extends CreateVariableCodeAction {
                 positionDetails.matchedNode(), context));
         edits.addAll(importsAcceptor.getNewImportTextEdits());
 
-        int renamePosition = modifiedTextEdits.renamePositions.get(0) - UNION_ERROR_CHAR_OFFSET;
+        int renamePosition = modifiedTextEdits.renamePositions.get(0);
         CodeAction codeAction = CodeActionUtil.createCodeAction(CommandConstants.CREATE_VAR_ADD_CHECK_TITLE,
                 edits, uri, CodeActionKind.QuickFix);
         addRenamePopup(context, edits, modifiedTextEdits.edits.get(0), codeAction, renamePosition,
@@ -133,9 +133,13 @@ public class ErrorHandleOutsideCodeAction extends CreateVariableCodeAction {
         String typeWithError = createVarTextEdits.types.get(0);
         String typeWithoutError = getTypeWithoutError(unionTypeDesc, context, importsAcceptor);
 
+        int lengthtDiff = typeWithError.length() - typeWithoutError.length();
+
         Position varRenamePosition = createVarTextEdits.varRenamePosition.get(0);
-        varRenamePosition.setCharacter(
-                varRenamePosition.getCharacter() - (typeWithError.length() - typeWithoutError.length()));
+        varRenamePosition.setCharacter(varRenamePosition.getCharacter() - lengthtDiff);
+
+        Integer renamePos = createVarTextEdits.renamePositions.get(0);
+        createVarTextEdits.renamePositions.add(0, renamePos - lengthtDiff);
 
         TextEdit textEdit = createVarTextEdits.edits.get(0);
         textEdit.setNewText(typeWithoutError + textEdit.getNewText().substring(typeWithError.length()));

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/CreateVariableTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/CreateVariableTest.java
@@ -192,7 +192,8 @@ public class CreateVariableTest extends AbstractCodeActionTest {
                 {"createVariableWithCheck3.json"},
                 {"createVariableWithCheck4.json"},
                 {"createVariableWithCheck5.json"},
-                {"createVariableWithCheck6.json"}
+                {"createVariableWithCheck6.json"},
+                {"createVariableWithCheck7.json"}
         };
     }
 

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithCheck7.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithCheck7.json
@@ -1,0 +1,64 @@
+{
+  "position": {
+    "line": 1,
+    "character": 7
+  },
+  "source": "createVariableWithCheck2.bal",
+  "description": "Create variable with check error for a function call that returns a user defined error",
+  "expected": [
+    {
+      "title": "Create variable and check error",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 4
+            },
+            "end": {
+              "line": 1,
+              "character": 4
+            }
+          },
+          "newText": "json data = "
+        },
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 4
+            },
+            "end": {
+              "line": 1,
+              "character": 4
+            }
+          },
+          "newText": "check "
+        },
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 22
+            },
+            "end": {
+              "line": 0,
+              "character": 22
+            }
+          },
+          "newText": " returns error?"
+        }
+      ],
+      "command": {
+        "title": "Rename variable",
+        "command": "ballerina.action.rename",
+        "arguments": [
+          "createVariableWithCheck2.bal",
+          49
+        ]
+      },
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithRemoteMethodInvocation.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/createVariableWithRemoteMethodInvocation.json
@@ -108,7 +108,7 @@
         "command": "ballerina.action.rename",
         "arguments": [
           "createVariable9.bal",
-          398
+          401
         ]
       },
       "resolvable": false

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/source/createVariableWithCheck2.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/source/createVariableWithCheck2.bal
@@ -1,0 +1,9 @@
+public function main() {
+    getData();
+}
+
+type MyError error;
+
+function getData() returns json|MyError {
+    return {};
+}


### PR DESCRIPTION
## Purpose
$subject with check error code action

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/39301

## Approach
The logic of calculating the new rename position was incorrect for the text position based approach. Improved that.

## Samples
![rename_popup_fix](https://user-images.githubusercontent.com/11285165/216211767-72510357-96b7-40e9-a1db-089ca9bffbf9.gif)


## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
