### PR TITLE
[master] Fix `No such function error` thrown for default functions with special characters

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmDesugarPhase.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmDesugarPhase.java
@@ -347,7 +347,20 @@ public class JvmDesugarPhase {
                 }
                 parameter.name = getInitialIdString(parameter.name, encodedVsInitialIds);
             }
+            replaceEncodedDefaultFunctionName(function.type, encodedVsInitialIds);
             replaceEncodedWorkerName(function, encodedVsInitialIds);
+        }
+    }
+
+    private static void replaceEncodedDefaultFunctionName(BInvokableType type, HashMap<String, String> encodedVsInitialIds) {
+        BInvokableTypeSymbol typeSymbol = (BInvokableTypeSymbol) type.tsymbol;
+        if (typeSymbol == null) {
+            return;
+        }
+        for (BInvokableSymbol defaultFunc : typeSymbol.defaultValues.values()) {
+            defaultFunc.name = Names.fromString(getInitialIdString(defaultFunc.name.value, encodedVsInitialIds));
+            defaultFunc.originalName =
+                    Names.fromString(getInitialIdString(defaultFunc.originalName.value, encodedVsInitialIds));
         }
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmDesugarPhase.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmDesugarPhase.java
@@ -357,7 +357,7 @@ public class JvmDesugarPhase {
             return;
         }
         for (BInvokableSymbol defaultFunc : typeSymbol.defaultValues.values()) {
-            defaultFunc.name = Names.fromString(getInitialIdString(defaultFunc.name.value, encodedVsInitialIds));
+            defaultFunc.name = getInitialIdString(defaultFunc.name, encodedVsInitialIds);
         }
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmDesugarPhase.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmDesugarPhase.java
@@ -250,8 +250,6 @@ public class JvmDesugarPhase {
         for (BInvokableSymbol defaultFunc : typeSymbol.defaultValues.values()) {
             defaultFunc.name = Names.fromString(encodeFunctionIdentifier(defaultFunc.name.value,
                     encodedVsInitialIds));
-            defaultFunc.originalName = Names.fromString(encodeFunctionIdentifier(defaultFunc.originalName.value,
-                    encodedVsInitialIds));
         }
     }
 
@@ -360,8 +358,6 @@ public class JvmDesugarPhase {
         }
         for (BInvokableSymbol defaultFunc : typeSymbol.defaultValues.values()) {
             defaultFunc.name = Names.fromString(getInitialIdString(defaultFunc.name.value, encodedVsInitialIds));
-            defaultFunc.originalName =
-                    Names.fromString(getInitialIdString(defaultFunc.originalName.value, encodedVsInitialIds));
         }
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmDesugarPhase.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmDesugarPhase.java
@@ -30,6 +30,8 @@ import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRTypeDefinition;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRVariableDcl;
 import org.wso2.ballerinalang.compiler.bir.model.VarKind;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BAttachedFunction;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BObjectTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BField;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BInvokableType;
@@ -235,7 +237,21 @@ public class JvmDesugarPhase {
                 parameter.name = Names.fromString(encodeNonFunctionIdentifier(parameter.name.value,
                                                                               encodedVsInitialIds));
             }
+            encodeDefaultFunctionName(function.type, encodedVsInitialIds);
             encodeWorkerName(function, encodedVsInitialIds);
+        }
+    }
+
+    private static void encodeDefaultFunctionName(BInvokableType type, HashMap<String, String> encodedVsInitialIds) {
+        BInvokableTypeSymbol typeSymbol = (BInvokableTypeSymbol) type.tsymbol;
+        if (typeSymbol == null) {
+            return;
+        }
+        for (BInvokableSymbol defaultFunc : typeSymbol.defaultValues.values()) {
+            defaultFunc.name = Names.fromString(encodeFunctionIdentifier(defaultFunc.name.value,
+                    encodedVsInitialIds));
+            defaultFunc.originalName = Names.fromString(encodeFunctionIdentifier(defaultFunc.originalName.value,
+                    encodedVsInitialIds));
         }
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmDesugarPhase.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmDesugarPhase.java
@@ -352,7 +352,8 @@ public class JvmDesugarPhase {
         }
     }
 
-    private static void replaceEncodedDefaultFunctionName(BInvokableType type, HashMap<String, String> encodedVsInitialIds) {
+    private static void replaceEncodedDefaultFunctionName(BInvokableType type,
+                                                          HashMap<String, String> encodedVsInitialIds) {
         BInvokableTypeSymbol typeSymbol = (BInvokableTypeSymbol) type.tsymbol;
         if (typeSymbol == null) {
             return;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Async.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Async.java
@@ -71,6 +71,18 @@ public class Async {
         return 0;
     }
 
+    public static long getFieldValWithDefaultValSpecialChars(Environment env, BObject obj) {
+        invokeMethodAsyncSequentially(env, obj, "getFieldValWithDefaultValSpecialChars", 0, false, 0, false, 0,
+                false);
+        return 0;
+    }
+
+    public static long getFieldValWithDefaultValSpecialCharsAsync(Environment env, BObject obj) {
+        invokeMethodAsyncSequentially(env, obj, "getFieldValWithDefaultValSpecialCharsAsync", 0, false, 0, false, 0,
+                false);
+        return 0;
+    }
+
     public static long getA(Environment env, BObject obj) {
         invokeAsync(env, obj, "getA");
         return 0;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/async/main.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/runtime/api/async/main.bal
@@ -49,6 +49,15 @@ public class ObjectMethodsCallClass {
         return a + b + c;
     }
 
+    function getFieldValWithDefaultValSpecialChars(int param\.a = 3, int param\:b = param\.a, int param\;c = param\.a + param\:b) returns int {
+        return param\.a + param\:b + param\;c;
+    }
+
+    function getFieldValWithDefaultValSpecialCharsAsync(int param\.a = asyncFunction(3), int param\:b = asyncFunction(param\.a),
+                                                      int param\;c = asyncFunction(param\.a + param\:b)) returns int {
+        return param\.a + param\:b + param\;c;
+    }
+
     public function callGetFieldValWithNoArgs() returns int = @java:Method {
         name: "getFieldValWithNoArgs",
         'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Async"
@@ -76,6 +85,16 @@ public class ObjectMethodsCallClass {
 
     public function callGetFieldValWithProvidedOptionalArgVal(string fieldName) returns int = @java:Method {
         name: "getFieldValWithProvidedOptionalArgVal",
+        'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Async"
+    } external;
+
+    public function callGetFieldValWithDefaultValSpecialChars() returns int = @java:Method {
+        name: "getFieldValWithDefaultValSpecialChars",
+        'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Async"
+    } external;
+
+    public function callGetFieldValWithDefaultValSpecialCharsAsync() returns int = @java:Method {
+        name: "getFieldValWithDefaultValSpecialCharsAsync",
         'class: "org.ballerinalang.nativeimpl.jvm.runtime.api.tests.Async"
     } external;
 }
@@ -296,6 +315,8 @@ public function main() {
     test:assertEquals(objectMethodsCallClass.callGetFieldValWithMultipleOptionalArgsDefaultVal(), 12);
     test:assertEquals(objectMethodsCallClass.callGetFieldValWithMultipleOptionalArgsDefaultValAsync(), 12);
     test:assertEquals(objectMethodsCallClass.callGetFieldValWithProvidedOptionalArgVal("not a field"), -1);
+    test:assertEquals(objectMethodsCallClass.callGetFieldValWithDefaultValSpecialChars(), 12);
+    test:assertEquals(objectMethodsCallClass.callGetFieldValWithDefaultValSpecialCharsAsync(), 12);
 
     IsolatedClass isolatedClass = new ();
     test:assertEquals(isolatedClass.callGetA(), 1);


### PR DESCRIPTION
## Purpose

$subject
Fixes #39515

## Approach
Encoded the default function names for code generation

## Samples
```ballerina
function foo(string artist, string? ti\.t\:le = ()) returns string {
    return artist + ti\.t\:le.toString();    
}
```
Calling the function using runtime Asyn API throws an error.

## CheckList 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
