### PR TITLE
Improve convert to `xml` or `string` code action to support regex template

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/Types.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/Types.java
@@ -62,6 +62,7 @@ public abstract class Types {
     public final TypeSymbol JSON;
     public final TypeSymbol BYTE;
     public final TypeSymbol COMPILATION_ERROR;
+    public final TypeSymbol REGEX;
 
     protected Types(CompilerContext context) {
         this.context = context;
@@ -90,6 +91,7 @@ public abstract class Types {
         this.JSON = typesFactory.getTypeDescriptor(symbolTable.jsonType);
         this.BYTE = typesFactory.getTypeDescriptor(symbolTable.byteType);
         this.COMPILATION_ERROR = typesFactory.getTypeDescriptor(symbolTable.semanticError);
+        this.REGEX = typesFactory.getTypeDescriptor(symbolTable.regExpType);
     }
 
     /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/ConvertToXmlOrStringTemplateCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/ConvertToXmlOrStringTemplateCodeAction.java
@@ -28,6 +28,7 @@ import org.ballerinalang.langserver.codeaction.CodeActionContextTypeResolver;
 import org.ballerinalang.langserver.codeaction.CodeActionNodeValidator;
 import org.ballerinalang.langserver.codeaction.CodeActionUtil;
 import org.ballerinalang.langserver.common.constants.CommandConstants;
+import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.common.utils.PositionUtil;
 import org.ballerinalang.langserver.commons.CodeActionContext;
 import org.ballerinalang.langserver.commons.codeaction.spi.DiagBasedPositionDetails;
@@ -69,7 +70,6 @@ public class ConvertToXmlOrStringTemplateCodeAction implements DiagnosticBasedCo
 
         Set<String> typeSet = new HashSet<>();
         if (typeSymbol.isPresent()) {
-            Optional<String> name = typeSymbol.get().getName();
             if (typeSymbol.get().typeKind() == TypeDescKind.UNION) {
                 UnionTypeSymbol unionTypeSymbol = (UnionTypeSymbol) typeSymbol.get();
                 Types types = context.currentSemanticModel().get().types();
@@ -86,7 +86,7 @@ public class ConvertToXmlOrStringTemplateCodeAction implements DiagnosticBasedCo
                 typeSet.add("string");
             } else if (typeSymbol.get().typeKind() == TypeDescKind.XML) {
                 typeSet.add("xml");
-            } else if (name.isPresent() && name.get().equals("RegExp")) {
+            } else if (isRegexTemplate(typeSymbol.get())) {
                 typeSet.add("re");
             }
         }
@@ -106,6 +106,14 @@ public class ConvertToXmlOrStringTemplateCodeAction implements DiagnosticBasedCo
         });
 
         return codeActions;
+    }
+
+    private boolean isRegexTemplate(TypeSymbol typeSymbol) {
+        typeSymbol = CommonUtil.getRawType(typeSymbol);
+        if (typeSymbol.typeKind() == TypeDescKind.TYPE_REFERENCE) {
+            typeSymbol = CommonUtil.getRawType(typeSymbol);
+        }
+        return typeSymbol.typeKind() == TypeDescKind.REGEXP;
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/ConvertToXmlOrStringTemplateCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/ConvertToXmlOrStringTemplateCodeAction.java
@@ -69,6 +69,7 @@ public class ConvertToXmlOrStringTemplateCodeAction implements DiagnosticBasedCo
 
         Set<String> typeSet = new HashSet<>();
         if (typeSymbol.isPresent()) {
+            Optional<String> name = typeSymbol.get().getName();
             if (typeSymbol.get().typeKind() == TypeDescKind.UNION) {
                 UnionTypeSymbol unionTypeSymbol = (UnionTypeSymbol) typeSymbol.get();
                 Types types = context.currentSemanticModel().get().types();
@@ -78,14 +79,19 @@ public class ConvertToXmlOrStringTemplateCodeAction implements DiagnosticBasedCo
                 if (unionTypeSymbol.memberTypeDescriptors().contains(types.XML)) {
                     typeSet.add("xml");
                 }
+                if (unionTypeSymbol.memberTypeDescriptors().contains(types.REGEX)) {
+                    typeSet.add("re");
+                }
             } else if (typeSymbol.get().typeKind() == TypeDescKind.STRING) {
                 typeSet.add("string");
             } else if (typeSymbol.get().typeKind() == TypeDescKind.XML) {
                 typeSet.add("xml");
+            } else if (name.isPresent() && name.get().equals("RegExp")) {
+                typeSet.add("re");
             }
         }
         if (typeSet.isEmpty()) {
-            typeSet.addAll(Set.of("string", "xml"));
+            typeSet.addAll(Set.of("string", "xml", "re"));
         }
 
         List<CodeAction> codeActions = new ArrayList<>();

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ConvertToXmlOrStringTemplateCodeActionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ConvertToXmlOrStringTemplateCodeActionTest.java
@@ -50,7 +50,9 @@ public class ConvertToXmlOrStringTemplateCodeActionTest extends AbstractCodeActi
                 {"config10.json"},
                 {"config11.json"},
                 {"config12.json"},
-                {"config13.json"}
+                {"config13.json"},
+                {"config14.json"},
+                {"config15.json"}
         };
     }
 

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/convert-to-str-xml-tmplt/config/config14.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/convert-to-str-xml-tmplt/config/config14.json
@@ -1,0 +1,30 @@
+{
+  "position": {
+    "line": 32,
+    "character": 44
+  },
+  "source": "source.bal",
+  "description": "Test module variable declaration with a raw template",
+  "expected": [
+    {
+      "title": "Convert to 're' template",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 32,
+              "character": 38
+            },
+            "end": {
+              "line": 32,
+              "character": 62
+            }
+          },
+          "newText": "re `Module Var Declaration`"
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/convert-to-str-xml-tmplt/config/config15.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/convert-to-str-xml-tmplt/config/config15.json
@@ -1,0 +1,30 @@
+{
+  "position": {
+    "line": 35,
+    "character": 16
+  },
+  "source": "source.bal",
+  "description": "Test return raw template when expecting a regex",
+  "expected": [
+    {
+      "title": "Convert to 're' template",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 35,
+              "character": 11
+            },
+            "end": {
+              "line": 35,
+              "character": 22
+            }
+          },
+          "newText": "re `Ballerina`"
+        }
+      ],
+      "resolvable": false
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/convert-to-str-xml-tmplt/config/config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/convert-to-str-xml-tmplt/config/config4.json
@@ -43,6 +43,25 @@
           "newText": "xml `Ballerina`"
         }
       ]
+    },
+    {
+      "title": "Convert to 're' template",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 11,
+              "character": 11
+            },
+            "end": {
+              "line": 11,
+              "character": 22
+            }
+          },
+          "newText": "re `Ballerina`"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/convert-to-str-xml-tmplt/config/config6.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/convert-to-str-xml-tmplt/config/config6.json
@@ -43,6 +43,25 @@
           "newText": "xml `123`"
         }
       ]
+    },
+    {
+      "title": "Convert to 're' template",
+      "kind": "quickfix",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 19,
+              "character": 12
+            },
+            "end": {
+              "line": 19,
+              "character": 17
+            }
+          },
+          "newText": "re `123`"
+        }
+      ]
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/convert-to-str-xml-tmplt/source/source.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/convert-to-str-xml-tmplt/source/source.bal
@@ -29,3 +29,9 @@ const string myConst = `sample template`;
 function testDefaultableParam(xml name = `test`) returns string {
     return "test";
 }
+
+string:RegExp moduleVarDeclaration2 = `Module Var Declaration`;
+
+function testFunctionWithRegExpReturn() returns string:RegExp {
+    return `Ballerina`;
+}


### PR DESCRIPTION
## Purpose
This PR improves the convert to `xml` or `string` code action to support regex template.

Fixes #38804 

## Samples

https://user-images.githubusercontent.com/61020198/217436695-43355037-dd94-438a-8416-2f0a7240d002.mov


## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
