### PR TITLE
Allow access field annotations in tuple type descriptors without a type definition at the package level

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureGenerator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureGenerator.java
@@ -176,6 +176,7 @@ import org.wso2.ballerinalang.compiler.tree.types.BLangValueType;
 import org.wso2.ballerinalang.compiler.util.ClosureVarSymbol;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Name;
+import org.wso2.ballerinalang.compiler.util.Names;
 import org.wso2.ballerinalang.util.Flags;
 
 import java.util.ArrayList;
@@ -197,7 +198,7 @@ import static org.ballerinalang.model.symbols.SymbolOrigin.VIRTUAL;
 public class ClosureGenerator extends BLangNodeVisitor {
     private static final CompilerContext.Key<ClosureGenerator> CLOSURE_GENERATOR_KEY = new CompilerContext.Key<>();
     private Queue<BLangSimpleVariableDef> queue;
-    private List<BLangSimpleVariableDef> annotationClosureReferences;
+    private Queue<BLangSimpleVariableDef> annotationClosureReferences;
     private SymbolTable symTable;
     private SymbolEnv env;
     private BLangNode result;
@@ -217,7 +218,7 @@ public class ClosureGenerator extends BLangNodeVisitor {
         context.put(CLOSURE_GENERATOR_KEY, this);
         this.symTable = SymbolTable.getInstance(context);
         this.queue = new LinkedList<>();
-        this.annotationClosureReferences = new ArrayList<>();
+        this.annotationClosureReferences = new LinkedList<>();
         this.symResolver = SymbolResolver.getInstance(context);
         this.annotationDesugar = AnnotationDesugar.getInstance(context);
     }
@@ -240,7 +241,7 @@ public class ClosureGenerator extends BLangNodeVisitor {
         pkgNode.annotations.forEach(annotation -> rewrite(annotation, pkgEnv));
         pkgNode.initFunction = rewrite(pkgNode.initFunction, pkgEnv);
         pkgNode.classDefinitions = rewrite(pkgNode.classDefinitions, pkgEnv);
-        pkgNode.globalVars.forEach(globalVar -> rewrite(globalVar, pkgEnv));
+        rewrite(pkgNode.globalVars, pkgEnv);
         addClosuresToGlobalVariableList(pkgEnv);
         for (int i = 0; i < pkgNode.functions.size(); i++) {
             BLangFunction bLangFunction = pkgNode.functions.get(i);
@@ -410,7 +411,7 @@ public class ClosureGenerator extends BLangNodeVisitor {
 
     private void desugarFieldAnnotations(BSymbol owner, BTypeSymbol typeSymbol, List<BLangSimpleVariable> fields,
                                          Location pos) {
-        if (owner.getKind() != SymbolKind.PACKAGE) {
+        if (owner.getKind() != SymbolKind.PACKAGE || typeSymbol.name == Names.EMPTY) {
             owner = getOwner(env);
             BLangLambdaFunction lambdaFunction = annotationDesugar.defineFieldAnnotations(fields, pos, env.enclPkg, env,
                                                                                           typeSymbol.pkgID, owner);
@@ -1598,9 +1599,18 @@ public class ClosureGenerator extends BLangNodeVisitor {
     }
 
     private <E extends BLangNode> List<E> rewrite(List<E> nodeList, SymbolEnv env) {
-        for (int i = 0; i < nodeList.size(); i++) {
-            nodeList.set(i, rewrite(nodeList.get(i), env));
+        Queue<BLangSimpleVariableDef> previousQueue = this.annotationClosureReferences;
+        this.annotationClosureReferences = new LinkedList<>();
+        int size = nodeList.size();
+        for (int i = 0; i < size; i++) {
+            E node = rewrite(nodeList.remove(0), env);
+            Iterator<BLangSimpleVariableDef> iterator = annotationClosureReferences.iterator();
+            while (iterator.hasNext()) {
+                nodeList.add(rewrite((E) annotationClosureReferences.poll().var, env));
+            }
+            nodeList.add(node);
         }
+        this.annotationClosureReferences = previousQueue;
         return nodeList;
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/annotations/AnonymousTupleAnnotationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/annotations/AnonymousTupleAnnotationTest.java
@@ -32,16 +32,16 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 /**
- * Class to test annotation evaluation within local tuple types.
+ * Class to test annotation evaluation within anonymous tuple types.
  *
  * @since 2201.4.0
  */
-public class LocalTupleAnnotationTest {
+public class AnonymousTupleAnnotationTest {
     private CompileResult result;
 
     @BeforeClass
     public void setup() {
-        result = BCompileUtil.compile("test-src/annotations/local_tuple_annotation_test.bal");
+        result = BCompileUtil.compile("test-src/annotations/anonymous_tuple_annotation_test.bal");
         Assert.assertEquals(result.getErrorCount(), 0);
     }
 
@@ -85,7 +85,7 @@ public class LocalTupleAnnotationTest {
         };
     }
 
-    public static BMap getLocalTupleAnnotations(TypedescValue typedescValue, BString annotName) {
+    public static BMap getAnonymousTupleAnnotations(TypedescValue typedescValue, BString annotName) {
         return (BMap) TypeChecker.getAnnotValue(typedescValue, annotName);
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/annotations/anonymous_tuple_annotation_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/annotations/anonymous_tuple_annotation_test.bal
@@ -45,6 +45,8 @@ function testAnnotationOnTupleFields() {
 }
 
 string gVar0 = "foo";
+
+// This test evaluates the reordering of global variables
 [@details {name: gVar0, age: gVar4} int, @details {name: "name", age: 0} int, string...] g4 =  [1, 2, "hello", "world"];
 
 function testAnnotationOnTupleFields2() {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/annotations/anonymous_tuple_annotation_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/annotations/anonymous_tuple_annotation_test.bal
@@ -24,8 +24,6 @@ type Details record {|
     string name;
     int age;
 |};
-
-type TupleType [@annotOne {value: "10"} int, @annotOne {value: "k"} int, string...]|int;
  
 annotation AnnotTupleOne annotOne on type, field;
 annotation AnnotTupleOne annotTwo on type, field;
@@ -36,10 +34,10 @@ annotation Details details on field;
 function testAnnotationOnTupleFields() {
     string k = "chiranS";
     [@annotOne {value: "10"} int, @annotOne {value: k} int, string...] x1 =  [1, 2, "hello", "world"];
-    map<any> m1 = getLocalTupleAnnotations(typeof x1, "$field$.0");
-    map<any> m2 = getLocalTupleAnnotations(typeof x1, "$field$.1");
-    map<any> m3 = getLocalTupleAnnotations(typeof g1, "$field$.0");
-    map<any> m4 = getLocalTupleAnnotations(typeof g1, "$field$.1");
+    map<any> m1 = getAnonymousTupleAnnotations(typeof x1, "$field$.0");
+    map<any> m2 = getAnonymousTupleAnnotations(typeof x1, "$field$.1");
+    map<any> m3 = getAnonymousTupleAnnotations(typeof g1, "$field$.0");
+    map<any> m4 = getAnonymousTupleAnnotations(typeof g1, "$field$.1");
     assertEquality({value: "10"}, <map<anydata>>m1["annotOne"]);
     assertEquality({value: "chiranS"}, <map<anydata>>m2["annotOne"]);
     assertEquality({value: "10"}, <map<anydata>>m3["annotOne"]);
@@ -53,10 +51,10 @@ function testAnnotationOnTupleFields2() {
     string name = "chiranS";
     int age = 26;
     [@details {name: name, age: age} int, @details {name: "name", age: 0} int, string...] x1 =  [1, 2, "hello", "world"];
-    map<any> m1 = getLocalTupleAnnotations(typeof x1, "$field$.0");
-    map<any> m2 = getLocalTupleAnnotations(typeof x1, "$field$.1");
-    map<any> m3 = getLocalTupleAnnotations(typeof g4, "$field$.0");
-    map<any> m4 = getLocalTupleAnnotations(typeof g4, "$field$.1");
+    map<any> m1 = getAnonymousTupleAnnotations(typeof x1, "$field$.0");
+    map<any> m2 = getAnonymousTupleAnnotations(typeof x1, "$field$.1");
+    map<any> m3 = getAnonymousTupleAnnotations(typeof g4, "$field$.0");
+    map<any> m4 = getAnonymousTupleAnnotations(typeof g4, "$field$.1");
     assertEquality({name: "chiranS", age: 26},  <map<anydata>>m1["details"]);
     assertEquality({name: "name", age: 0},  <map<anydata>>m2["details"]);
     assertEquality({name: "foo", age: 15},  <map<anydata>>m3["details"]);
@@ -69,8 +67,8 @@ string gVar1 = "bar";
 
 function testAnnotationOnTupleWithGlobalVariable() {
     [@annotOne {value: gVar} int, int, string...] x1 =  [1, 2, "hello", "world"];
-    map<any> m1 = getLocalTupleAnnotations(typeof x1, "$field$.0");
-    map<any> m2 = getLocalTupleAnnotations(typeof g2, "$field$.0");
+    map<any> m1 = getAnonymousTupleAnnotations(typeof x1, "$field$.0");
+    map<any> m2 = getAnonymousTupleAnnotations(typeof g2, "$field$.0");
     assertEquality({value: "foo"}, <map<anydata>>m1["annotOne"]);
     assertEquality({value: "foo"}, <map<anydata>>m2["annotOne"]);
 }
@@ -80,10 +78,10 @@ function testAnnotationOnTupleWithGlobalVariable() {
 function testMultipleAnnotationsOnLocalTuple() {
     string k = "chiranS";
     [@annotOne {value: "foo"} @annotTwo {value: "bar"} int, @details {name: k, age: 0} int, string...] x1 =  [1, 2, "hello", "world"];
-    map<any> m1 = getLocalTupleAnnotations(typeof x1, "$field$.0");
-    map<any> m2 = getLocalTupleAnnotations(typeof x1, "$field$.1");
-    map<any> m3 = getLocalTupleAnnotations(typeof g3, "$field$.0");
-    map<any> m4 = getLocalTupleAnnotations(typeof g3, "$field$.1");
+    map<any> m1 = getAnonymousTupleAnnotations(typeof x1, "$field$.0");
+    map<any> m2 = getAnonymousTupleAnnotations(typeof x1, "$field$.1");
+    map<any> m3 = getAnonymousTupleAnnotations(typeof g3, "$field$.0");
+    map<any> m4 = getAnonymousTupleAnnotations(typeof g3, "$field$.1");
     assertEquality({value: "foo"}, <map<anydata>>m1["annotOne"]);
     assertEquality({value: "bar"}, <map<anydata>>m1["annotTwo"]);
     assertEquality({name: "chiranS", age: 0},  <map<anydata>>m2["details"]);
@@ -97,10 +95,10 @@ function() returns [int] x2 = function() returns [@annotOne {value: gVar1} @anno
 function() returns [int, int] x3 = function() returns [@annotOne {value: gVar1} int, @details {name: "name", age: gVar3} int] {return [1, 1];};
 
 function testGlobalAnnotationsOnFunctionPointerReturnType() {
-    map<any> m1 = getLocalTupleAnnotations(typeof x(), "$field$.0");
-    map<any> m2 = getLocalTupleAnnotations(typeof x2(), "$field$.0");
-    map<any> m3 = getLocalTupleAnnotations(typeof x3(), "$field$.0");
-    map<any> m4 = getLocalTupleAnnotations(typeof x3(), "$field$.1");
+    map<any> m1 = getAnonymousTupleAnnotations(typeof x(), "$field$.0");
+    map<any> m2 = getAnonymousTupleAnnotations(typeof x2(), "$field$.0");
+    map<any> m3 = getAnonymousTupleAnnotations(typeof x3(), "$field$.0");
+    map<any> m4 = getAnonymousTupleAnnotations(typeof x3(), "$field$.1");
     assertEquality({value: "foo"}, <map<anydata>>m1["annotOne"]);
     assertEquality({value: "bar"}, <map<anydata>>m2["annotOne"]);
     assertEquality({value: "baz"}, <map<anydata>>m2["annotTwo"]);
@@ -132,10 +130,10 @@ function func2() returns [@details {name: "name", age: gVar4} int, @annotTwo {va
 }
 
 function testGlobalAnnotationsOnFunctionReturnType() {
-    map<any> m1 = getLocalTupleAnnotations(typeof func(), "$field$.0");
-    map<any> m2 = getLocalTupleAnnotations(typeof func1(), "$field$.0");
-    map<any> m3 = getLocalTupleAnnotations(typeof func2(), "$field$.0");
-    map<any> m4 = getLocalTupleAnnotations(typeof func2(), "$field$.1");
+    map<any> m1 = getAnonymousTupleAnnotations(typeof func(), "$field$.0");
+    map<any> m2 = getAnonymousTupleAnnotations(typeof func1(), "$field$.0");
+    map<any> m3 = getAnonymousTupleAnnotations(typeof func2(), "$field$.0");
+    map<any> m4 = getAnonymousTupleAnnotations(typeof func2(), "$field$.1");
     assertEquality({value: "foo"}, <map<anydata>>m1["annotOne"]);
     assertEquality({value: "foo"}, <map<anydata>>m2["annotOne"]);
     assertEquality({value: "baz"}, <map<anydata>>m2["annotTwo"]);
@@ -148,13 +146,13 @@ function testGlobalAnnotationsOnFunctionReturnType() {
 int gVar4 = 15;
 
 function func3([@annotOne {value: "foo"} int] a) {
-    map<any> m1 = getLocalTupleAnnotations(typeof a, "$field$.0");
+    map<any> m1 = getAnonymousTupleAnnotations(typeof a, "$field$.0");
     assertEquality({value: "foo"}, <map<anydata>>m1["annotOne"]);
 }
 
 function func4([@annotOne {value: "foo"} int, @annotTwo {value: "foo"} @details {name: "name", age: gVar4} int] a) {
-    map<any> m1 = getLocalTupleAnnotations(typeof a, "$field$.0");
-    map<any> m2 = getLocalTupleAnnotations(typeof a, "$field$.1");
+    map<any> m1 = getAnonymousTupleAnnotations(typeof a, "$field$.0");
+    map<any> m2 = getAnonymousTupleAnnotations(typeof a, "$field$.1");
 
     assertEquality({value: "foo"}, <map<anydata>>m1["annotOne"]);
     assertEquality({value: "foo"}, <map<anydata>>m2["annotTwo"]);
@@ -166,10 +164,10 @@ function testGlobalAnnotationsOnFunctionParameterType() {
     func4([10, 10]);
 }
 
-function getLocalTupleAnnotations(typedesc<any> obj, string annotName) returns map<any> =
+function getAnonymousTupleAnnotations(typedesc<any> obj, string annotName) returns map<any> =
 @java:Method {
-    'class: "org/ballerinalang/test/annotations/LocalTupleAnnotationTest",
-    name: "getLocalTupleAnnotations"
+    'class: "org/ballerinalang/test/annotations/AnonymousTupleAnnotationTest",
+    name: "getAnonymousTupleAnnotations"
 } external;
 
 function assertEquality(anydata expected, anydata  actual) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/annotations/local_tuple_annotation_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/annotations/local_tuple_annotation_test.bal
@@ -24,19 +24,30 @@ type Details record {|
     string name;
     int age;
 |};
+
+type TupleType [@annotOne {value: "10"} int, @annotOne {value: "k"} int, string...]|int;
  
 annotation AnnotTupleOne annotOne on type, field;
 annotation AnnotTupleOne annotTwo on type, field;
 annotation Details details on field;
+
+[@annotOne {value: "10"} int, @annotOne {value: "k"} int, string...] g1 =  [1, 2, "hello", "world"];
 
 function testAnnotationOnTupleFields() {
     string k = "chiranS";
     [@annotOne {value: "10"} int, @annotOne {value: k} int, string...] x1 =  [1, 2, "hello", "world"];
     map<any> m1 = getLocalTupleAnnotations(typeof x1, "$field$.0");
     map<any> m2 = getLocalTupleAnnotations(typeof x1, "$field$.1");
+    map<any> m3 = getLocalTupleAnnotations(typeof g1, "$field$.0");
+    map<any> m4 = getLocalTupleAnnotations(typeof g1, "$field$.1");
     assertEquality({value: "10"}, <map<anydata>>m1["annotOne"]);
     assertEquality({value: "chiranS"}, <map<anydata>>m2["annotOne"]);
+    assertEquality({value: "10"}, <map<anydata>>m3["annotOne"]);
+    assertEquality({value: "k"}, <map<anydata>>m4["annotOne"]);
 }
+
+string gVar0 = "foo";
+[@details {name: gVar0, age: gVar4} int, @details {name: "name", age: 0} int, string...] g4 =  [1, 2, "hello", "world"];
 
 function testAnnotationOnTupleFields2() {
     string name = "chiranS";
@@ -44,27 +55,41 @@ function testAnnotationOnTupleFields2() {
     [@details {name: name, age: age} int, @details {name: "name", age: 0} int, string...] x1 =  [1, 2, "hello", "world"];
     map<any> m1 = getLocalTupleAnnotations(typeof x1, "$field$.0");
     map<any> m2 = getLocalTupleAnnotations(typeof x1, "$field$.1");
+    map<any> m3 = getLocalTupleAnnotations(typeof g4, "$field$.0");
+    map<any> m4 = getLocalTupleAnnotations(typeof g4, "$field$.1");
     assertEquality({name: "chiranS", age: 26},  <map<anydata>>m1["details"]);
     assertEquality({name: "name", age: 0},  <map<anydata>>m2["details"]);
+    assertEquality({name: "foo", age: 15},  <map<anydata>>m3["details"]);
+    assertEquality({name: "name", age: 0},  <map<anydata>>m4["details"]);
 }
 
 string gVar = "foo";
 string gVar1 = "bar";
+[@annotOne {value: gVar} int, int, string...] g2 =  [1, 2, "hello", "world"];
 
 function testAnnotationOnTupleWithGlobalVariable() {
     [@annotOne {value: gVar} int, int, string...] x1 =  [1, 2, "hello", "world"];
-    map<any> m = getLocalTupleAnnotations(typeof x1, "$field$.0");
-    assertEquality({value: "foo"}, <map<anydata>>m["annotOne"]);
+    map<any> m1 = getLocalTupleAnnotations(typeof x1, "$field$.0");
+    map<any> m2 = getLocalTupleAnnotations(typeof g2, "$field$.0");
+    assertEquality({value: "foo"}, <map<anydata>>m1["annotOne"]);
+    assertEquality({value: "foo"}, <map<anydata>>m2["annotOne"]);
 }
+
+[@annotOne {value: "foo"} @annotTwo {value: "bar"} int, @details {name: gVar2, age: 0} int, string...] g3 =  [1, 2, "hello", "world"];
 
 function testMultipleAnnotationsOnLocalTuple() {
     string k = "chiranS";
     [@annotOne {value: "foo"} @annotTwo {value: "bar"} int, @details {name: k, age: 0} int, string...] x1 =  [1, 2, "hello", "world"];
     map<any> m1 = getLocalTupleAnnotations(typeof x1, "$field$.0");
     map<any> m2 = getLocalTupleAnnotations(typeof x1, "$field$.1");
+    map<any> m3 = getLocalTupleAnnotations(typeof g3, "$field$.0");
+    map<any> m4 = getLocalTupleAnnotations(typeof g3, "$field$.1");
     assertEquality({value: "foo"}, <map<anydata>>m1["annotOne"]);
     assertEquality({value: "bar"}, <map<anydata>>m1["annotTwo"]);
     assertEquality({name: "chiranS", age: 0},  <map<anydata>>m2["details"]);
+    assertEquality({value: "foo"}, <map<anydata>>m3["annotOne"]);
+    assertEquality({value: "bar"}, <map<anydata>>m3["annotTwo"]);
+    assertEquality({name: "baz", age: 0},  <map<anydata>>m4["details"]);
 }
 
 function() returns [int] x = function() returns [@annotOne {value: "foo"} int] {return [1];};

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/annotations/annotation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/annotations/annotation.bal
@@ -37,10 +37,14 @@ function testAnnotOnRecordFields() {
 }
 
 function testAnnotOnTupleFields() {
-    map<any> m = getLocalTupleAnnotations(typeof foo:testAnnotationsOnLocalTupleFields(), "$field$.0");
+    map<any> m = getAnonymousTupleAnnotations(typeof foo:testAnnotationsOnLocalTupleFields(), "$field$.0");
     assertEquality({value : "10"} , <map<anydata>>m["testorg/foo:1:annotOne"]);
-    m = getLocalTupleAnnotations(typeof foo:testTupleFieldAnnotationsOnReturnType(), "$field$.0");
+    m = getAnonymousTupleAnnotations(typeof foo:testTupleFieldAnnotationsOnReturnType(), "$field$.0");
     assertEquality({value : "100"} , <map<anydata>>m["testorg/foo:1:annotOne"]);
+    m = getAnonymousTupleAnnotations(typeof foo:g1, "$field$.0");
+    assertEquality({value : "chiranS"} , <map<anydata>>m["testorg/foo:1:annotOne"]);
+    m = getAnonymousTupleAnnotations(typeof foo:g1, "$field$.1");
+    assertEquality({value : "k"} , <map<anydata>>m["testorg/foo:1:annotOne"]);
 }
 
 function getLocalRecordAnnotations(typedesc<any> obj, string annotName) returns map<any> =
@@ -49,10 +53,10 @@ function getLocalRecordAnnotations(typedesc<any> obj, string annotName) returns 
     name: "getLocalRecordAnnotations"
 } external;
 
-function getLocalTupleAnnotations(typedesc<any> obj, string annotName) returns map<any> =
+function getAnonymousTupleAnnotations(typedesc<any> obj, string annotName) returns map<any> =
 @java:Method {
-    'class: "org/ballerinalang/test/annotations/LocalTupleAnnotationTest",
-    name: "getLocalTupleAnnotations"
+    'class: "org/ballerinalang/test/annotations/AnonymousTupleAnnotationTest",
+    name: "getAnonymousTupleAnnotations"
 } external;
 
 function assertEquality(anydata expected, anydata actual) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/test_project/annotations.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/test_project/annotations.bal
@@ -45,3 +45,7 @@ public function testAnnotationsOnLocalTupleFields() returns [@annotOne {value: "
     [@annotOne {value: "10"} string] r = [""];
     return r;
 }
+
+public string gVar = "chiranS";
+
+public [@annotOne {value: gVar} int, @annotOne {value: "k"} int, string...] g1 =  [1, 2, "hello", "world"];


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues.

Fixes #39552

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
