### PR TITLE
[2201.4.x] Add component model generation as a build option

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BuildOptions.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BuildOptions.java
@@ -21,6 +21,7 @@ package io.ballerina.projects;
  * Build options of a project.
  */
 public class BuildOptions {
+
     private Boolean testReport;
     private Boolean codeCoverage;
     private Boolean dumpBuildTime;
@@ -29,10 +30,11 @@ public class BuildOptions {
     private String targetDir;
     private Boolean enableCache;
     private Boolean nativeImage;
+    private Boolean exportComponentModel;
 
     BuildOptions(Boolean testReport, Boolean codeCoverage, Boolean dumpBuildTime, Boolean skipTests,
                  CompilationOptions compilationOptions, String targetPath, Boolean enableCache,
-                 Boolean nativeImage) {
+                 Boolean nativeImage, Boolean exportComponentModel) {
         this.testReport = testReport;
         this.codeCoverage = codeCoverage;
         this.dumpBuildTime = dumpBuildTime;
@@ -41,6 +43,7 @@ public class BuildOptions {
         this.targetDir = targetPath;
         this.enableCache = enableCache;
         this.nativeImage = nativeImage;
+        this.exportComponentModel = exportComponentModel;
     }
 
     public boolean testReport() {
@@ -154,6 +157,11 @@ public class BuildOptions {
         } else {
             buildOptionsBuilder.setNativeImage(this.nativeImage);
         }
+        if (theirOptions.exportComponentModel != null) {
+            buildOptionsBuilder.setExportComponentModel(theirOptions.exportComponentModel);
+        } else {
+            buildOptionsBuilder.setExportComponentModel(this.exportComponentModel);
+        }
 
         CompilationOptions compilationOptions = this.compilationOptions.acceptTheirs(theirOptions.compilationOptions());
         buildOptionsBuilder.setOffline(compilationOptions.offlineBuild);
@@ -204,7 +212,8 @@ public class BuildOptions {
         CODE_COVERAGE("codeCoverage"),
         DUMP_BUILD_TIME("dumpBuildTime"),
         TARGET_DIR("targetDir"),
-        NATIVE_IMAGE("native");
+        NATIVE_IMAGE("native"),
+        EXPORT_COMPONENT_MODEL("exportComponentModel");
 
         private final String name;
 
@@ -224,6 +233,7 @@ public class BuildOptions {
      * @since 2.0.0
      */
     public static class BuildOptionsBuilder {
+
         private Boolean testReport;
         private Boolean codeCoverage;
         private Boolean dumpBuildTime;
@@ -232,6 +242,7 @@ public class BuildOptions {
         private Boolean enableCache;
         private final CompilationOptions.CompilationOptionsBuilder compilationOptionsBuilder;
         private Boolean nativeImage;
+        private Boolean exportComponentModel;
 
         private BuildOptionsBuilder() {
             compilationOptionsBuilder = CompilationOptions.builder();
@@ -330,6 +341,7 @@ public class BuildOptions {
 
         public BuildOptionsBuilder setExportComponentModel(Boolean value) {
             compilationOptionsBuilder.setExportComponentModel(value);
+            exportComponentModel = value;
             return this;
         }
 
@@ -347,7 +359,7 @@ public class BuildOptions {
         public BuildOptions build() {
             CompilationOptions compilationOptions = compilationOptionsBuilder.build();
             return new BuildOptions(testReport, codeCoverage, dumpBuildTime, skipTests,
-                    compilationOptions, targetPath, enableCache, nativeImage);
+                    compilationOptions, targetPath, enableCache, nativeImage, exportComponentModel);
         }
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ManifestBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ManifestBuilder.java
@@ -477,16 +477,16 @@ public class ManifestBuilder {
         if (topLevelNode != null) {
             cloud = getStringFromTomlTableNode(topLevelNode);
         }
-        Boolean listConflictedClasses =
-                getBooleanFromBuildOptionsTableNode(tableNode, CompilerOptionName.LIST_CONFLICTED_CLASSES.toString());
-        String targetDir =
-                getStringFromBuildOptionsTableNode(tableNode, BuildOptions.OptionName.TARGET_DIR.toString());
-        Boolean enableCache =
-                getBooleanFromBuildOptionsTableNode(tableNode, CompilerOptionName.ENABLE_CACHE.toString());
-        Boolean nativeImage =
-                getBooleanFromBuildOptionsTableNode(tableNode, BuildOptions.OptionName.NATIVE_IMAGE.toString());
-        Boolean exportComponentModel =
-                getBooleanFromBuildOptionsTableNode(tableNode, BuildOptions.OptionName.EXPORT_COMPONENT_MODEL.toString());
+        Boolean listConflictedClasses = getBooleanFromBuildOptionsTableNode(tableNode,
+                CompilerOptionName.LIST_CONFLICTED_CLASSES.toString());
+        String targetDir = getStringFromBuildOptionsTableNode(tableNode,
+                BuildOptions.OptionName.TARGET_DIR.toString());
+        Boolean enableCache = getBooleanFromBuildOptionsTableNode(tableNode,
+                CompilerOptionName.ENABLE_CACHE.toString());
+        Boolean nativeImage = getBooleanFromBuildOptionsTableNode(tableNode,
+                BuildOptions.OptionName.NATIVE_IMAGE.toString());
+        Boolean exportComponentModel = getBooleanFromBuildOptionsTableNode(tableNode,
+                BuildOptions.OptionName.EXPORT_COMPONENT_MODEL.toString());
 
         buildOptionsBuilder
                 .setOffline(offline)

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ManifestBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ManifestBuilder.java
@@ -485,6 +485,8 @@ public class ManifestBuilder {
                 getBooleanFromBuildOptionsTableNode(tableNode, CompilerOptionName.ENABLE_CACHE.toString());
         Boolean nativeImage =
                 getBooleanFromBuildOptionsTableNode(tableNode, BuildOptions.OptionName.NATIVE_IMAGE.toString());
+        Boolean exportComponentModel =
+                getBooleanFromBuildOptionsTableNode(tableNode, BuildOptions.OptionName.EXPORT_COMPONENT_MODEL.toString());
 
         buildOptionsBuilder
                 .setOffline(offline)
@@ -496,7 +498,8 @@ public class ManifestBuilder {
                 .setDumpBuildTime(dumpBuildTime)
                 .setSticky(sticky)
                 .setEnableCache(enableCache)
-                .setNativeImage(nativeImage);
+                .setNativeImage(nativeImage)
+                .setExportComponentModel(exportComponentModel);
 
         if (targetDir != null) {
             buildOptionsBuilder.targetDir(targetDir);


### PR DESCRIPTION
## Purpose
$subject.
Now, the component model can be exported by setting up the below entry in `Ballerina.toml` file of the related package.

```toml
[build-options]
exportComponentModel = true
```

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/39584

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
