### PR TITLE
Add support for deprecating packages

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/Constants.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/Constants.java
@@ -40,4 +40,5 @@ public class Constants {
     static final String SHELL_COMMAND = "shell";
     static final String PACK_COMMAND = "pack";
     static final String GRAPH_COMMAND = "graph";
+    static final String DEPRECATE_COMMAND = "deprecate";
 }

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/DeprecateCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/DeprecateCommand.java
@@ -1,0 +1,177 @@
+/*
+ *  Copyright (c) 2023, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.cli.cmd;
+
+import io.ballerina.cli.BLauncherCmd;
+import io.ballerina.projects.JvmTarget;
+import io.ballerina.projects.Settings;
+import org.ballerinalang.central.client.CentralAPIClient;
+import org.ballerinalang.central.client.exceptions.CentralClientException;
+import org.ballerinalang.toml.exceptions.SettingsTomlException;
+import org.wso2.ballerinalang.util.RepoUtils;
+import picocli.CommandLine;
+
+import java.io.PrintStream;
+import java.util.List;
+
+import static io.ballerina.cli.cmd.Constants.DEPRECATE_COMMAND;
+import static io.ballerina.projects.util.ProjectUtils.getAccessTokenOfCLI;
+import static io.ballerina.projects.util.ProjectUtils.initializeProxy;
+import static io.ballerina.runtime.api.constants.RuntimeConstants.SYSTEM_PROP_BAL_DEBUG;
+
+/**
+ * This class represents the "bal deprecate" command.
+ *
+ * @since 2201.5.0
+ */
+@CommandLine.Command(name = DEPRECATE_COMMAND, description = "deprecate a package in Ballerina Central")
+public class DeprecateCommand implements BLauncherCmd {
+
+    private PrintStream outStream;
+    private PrintStream errStream;
+    private boolean exitWhenFinish;
+
+    private static final String USAGE_TEXT =
+            "bal deprecate {<org-name>/<package-name>:<version>} [OPTIONS]";
+
+    @CommandLine.Parameters
+    private List<String> argList;
+
+    @CommandLine.Option(names = {"--help", "-h"}, hidden = true)
+    private boolean helpFlag;
+
+    @CommandLine.Option(names = "--debug", hidden = true)
+    private String debugPort;
+
+    @CommandLine.Option(names = {"--message"})
+    private String deprecationMsg;
+
+    @CommandLine.Option(names = {"--undo"})
+    private boolean undoFlag;
+
+    public DeprecateCommand() {
+        this.outStream = System.out;
+        this.errStream = System.err;
+        this.exitWhenFinish = true;
+    }
+
+    public DeprecateCommand(PrintStream outStream, PrintStream errStream, boolean exitWhenFinish) {
+        this.outStream = outStream;
+        this.errStream = errStream;
+        this.exitWhenFinish = exitWhenFinish;
+    }
+
+    @Override
+    public void execute() {
+        if (helpFlag) {
+            String commandUsageInfo = BLauncherCmd.getCommandUsageInfo(DEPRECATE_COMMAND);
+            outStream.println(commandUsageInfo);
+            return;
+        }
+
+        if (null != debugPort) {
+            System.setProperty(SYSTEM_PROP_BAL_DEBUG, debugPort);
+        }
+
+        if (argList == null || argList.isEmpty()) {
+            CommandUtil.printError(this.errStream, "no package given", "bal deprecate <package> [OPTIONS]",
+                    false);
+            CommandUtil.exitError(this.exitWhenFinish);
+            return;
+        }
+
+        if (argList.size() > 1) {
+            CommandUtil.printError(this.errStream, "too many arguments", "bal deprecate <package> ",
+                    false);
+            CommandUtil.exitError(this.exitWhenFinish);
+            return;
+        }
+
+        String packageValue = argList.get(0);
+        if (packageValue.split(":").length != 2) {
+            CommandUtil.printError(errStream, "invalid package. Provide the package with the version.",
+                    USAGE_TEXT, false);
+            CommandUtil.exitError(this.exitWhenFinish);
+            return;
+        }
+
+        // Skip --message flag if it is set with undo option
+        if (deprecationMsg != null && undoFlag) {
+            this.outStream.println("warning: ignoring --message flag since this is an undo request");
+        }
+        deprecateInCentral(packageValue);
+
+        if (this.exitWhenFinish) {
+            Runtime.getRuntime().exit(0);
+        }
+    }
+
+    @Override
+    public String getName() {
+        return DEPRECATE_COMMAND;
+    }
+
+    @Override
+    public void printLongDesc(StringBuilder out) {
+        out.append("deprecates a package in Ballerina Central \n");
+    }
+
+    @Override
+    public void printUsage(StringBuilder out) {
+        out.append(" bal deprecate {<org-name>/<package-name>:<version>} \n");
+    }
+
+    @Override
+    public void setParentCmdParser(CommandLine parentCmdParser) {
+    }
+
+    /**
+     * Deprecate a package in central.
+     *
+     * @param packageInfo package to deprecate.
+     */
+    private void deprecateInCentral(String packageInfo) {
+        try {
+            Settings settings;
+            try {
+                settings = RepoUtils.readSettings();
+                // Ignore Settings.toml diagnostics in the deprecate command
+            } catch (SettingsTomlException e) {
+                // Ignore 'Settings.toml' parsing errors and return empty Settings object
+                settings = Settings.from();
+            }
+            CentralAPIClient client = new CentralAPIClient(RepoUtils.getRemoteRepoURL(),
+                    initializeProxy(settings.getProxy()),
+                    getAccessTokenOfCLI(settings));
+            client.deprecatePackage(packageInfo, deprecationMsg,
+                    JvmTarget.JAVA_11.code(),
+                    RepoUtils.getBallerinaVersion(), this.undoFlag);
+        } catch (CentralClientException e) {
+            String errorMessage = e.getMessage();
+            if (null != errorMessage && !"".equals(errorMessage.trim())) {
+                // removing the error stack
+                if (errorMessage.contains("\n\tat")) {
+                    errorMessage = errorMessage.substring(0, errorMessage.indexOf("\n\tat"));
+                }
+                CommandUtil.printError(this.errStream, errorMessage, null, false);
+                CommandUtil.exitError(this.exitWhenFinish);
+            }
+        }
+    }
+}

--- a/cli/ballerina-cli/src/main/resources/META-INF/services/io.ballerina.cli.BLauncherCmd
+++ b/cli/ballerina-cli/src/main/resources/META-INF/services/io.ballerina.cli.BLauncherCmd
@@ -12,3 +12,4 @@ io.ballerina.cli.cmd.CleanCommand
 io.ballerina.cli.cmd.ShellCommand
 io.ballerina.cli.cmd.PackCommand
 io.ballerina.cli.cmd.GraphCommand
+io.ballerina.cli.cmd.DeprecateCommand

--- a/cli/ballerina-cli/src/main/resources/cli-help/ballerina-deprecate.help
+++ b/cli/ballerina-cli/src/main/resources/cli-help/ballerina-deprecate.help
@@ -1,0 +1,29 @@
+NAME
+       ballerina-deprecate - Deprecates a published package
+
+SYNOPSIS
+       bal deprecate [OPTIONS] <package>
+
+
+DESCRIPTION
+       The deprecate commands marks the specified package as deprecated in Ballerina central.
+
+       A deprecated package will not be used as a dependency of a package unless the deprecated package is already recorded in
+       the `Dependencies.toml` and the `--sticky` option is used to build the package. Also, a deprecated package will be used as
+       a dependency of a package if there are no other versions that can satisfy dependency constraints.
+
+       A warning diagnostic will be issued whenever a deprecated package is used as a dependency.
+
+       This command does not delete the package from Ballerina central, and the package can be undeprecated using the `--undo` option.
+
+
+OPTIONS
+       --message=<msg>
+           Use the given <msg> as the deprecation message
+       -- undo
+           Undeprecate a deprecated package
+
+EXAMPLES
+
+       Deprecates the package ballerina/io:1.1.1
+            bal deprecate ballerina/io:1.1.1

--- a/cli/ballerina-cli/src/main/resources/cli-help/ballerina-deprecate.help
+++ b/cli/ballerina-cli/src/main/resources/cli-help/ballerina-deprecate.help
@@ -6,7 +6,7 @@ SYNOPSIS
 
 
 DESCRIPTION
-       The deprecate commands marks the specified package as deprecated in Ballerina central.
+       The deprecate command marks the specified package as deprecated in Ballerina central.
 
        A deprecated package will not be used as a dependency of a package unless the deprecated package is already recorded in
        the `Dependencies.toml` and the `--sticky` option is used to build the package. Also, a deprecated package will be used as
@@ -20,7 +20,7 @@ DESCRIPTION
 OPTIONS
        --message=<msg>
            Use the given <msg> as the deprecation message
-       -- undo
+       --undo
            Undeprecate a deprecated package
 
 EXAMPLES

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/DeprecateCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/DeprecateCommandTest.java
@@ -1,0 +1,127 @@
+/*
+ *  Copyright (c) 2023, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.cli.cmd;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import picocli.CommandLine;
+
+import java.io.IOException;
+
+/**
+ * Deprecate command tests.
+ *
+ * @since 2201.5.0
+ */
+public class DeprecateCommandTest extends BaseCommandTest {
+
+    @Test(description = "Test deprecate without package version")
+    public void testDeprecationWithoutVersion() throws IOException {
+        DeprecateCommand deprecationCommand = new DeprecateCommand(printStream, printStream, false);
+        new CommandLine(deprecationCommand).parseArgs("mynewdil/deppack", "-message", "for testing");
+        deprecationCommand.execute();
+
+        String buildLog = readOutput(true);
+        String actual = buildLog.replaceAll("\r", "");
+        Assert.assertTrue(actual.contains("ballerina: invalid package. Provide the package with the version."));
+        Assert.assertTrue(actual.contains("bal deprecate {<org-name>/<package-name>:<version>} [OPTIONS]"));
+    }
+
+    @Test(description = "Test deprecate with invalid org name")
+    public void testDeprecationWithInvalidOrg() throws IOException {
+        DeprecateCommand deprecationCommand = new DeprecateCommand(printStream, printStream, false);
+        new CommandLine(deprecationCommand).parseArgs("my-newdil/deppack:0.1.0", "-message", "for testing");
+        deprecationCommand.execute();
+
+        String buildLog = readOutput(true);
+        String actual = buildLog.replaceAll("\r", "");
+        Assert.assertTrue(actual.contains("ballerina: invalid package organization. Only alphanumerics and " +
+                "underscores are allowed in organization name. Provide a valid package organization."));
+        Assert.assertTrue(actual.contains("bal deprecate {<org-name>/<package-name>:<version>} [OPTIONS]"));
+    }
+
+    @Test(description = "Test deprecate with invalid package name")
+    public void testDeprecationWithInvalidPackageName() throws IOException {
+        DeprecateCommand deprecationCommand = new DeprecateCommand(printStream, printStream, false);
+        new CommandLine(deprecationCommand).parseArgs("mynewdil/dep-pack:0.1.0", "-message", "for testing");
+        deprecationCommand.execute();
+
+        String buildLog = readOutput(true);
+        String actual = buildLog.replaceAll("\r", "");
+        Assert.assertTrue(actual.contains("ballerina: invalid package name. Only alphanumerics, underscores and " +
+                "periods are allowed in a package name and the maximum length is 256 characters. " +
+                "Provide a valid package name."));
+        Assert.assertTrue(actual.contains("bal deprecate {<org-name>/<package-name>:<version>} [OPTIONS]"));
+    }
+
+    @Test(description = "Test deprecate with invalid version")
+    public void testDeprecationWithInvalidVersion() throws IOException {
+        DeprecateCommand deprecationCommand = new DeprecateCommand(printStream, printStream, false);
+        new CommandLine(deprecationCommand).parseArgs("mynewdil/deppack:xxx", "-message", "for testing");
+        deprecationCommand.execute();
+
+        String buildLog = readOutput(true);
+        String actual = buildLog.replaceAll("\r", "");
+        Assert.assertTrue(actual.contains("ballerina: invalid package. Provide a valid package version."));
+        Assert.assertTrue(actual.contains("bal deprecate {<org-name>/<package-name>:<version>} [OPTIONS]"));
+    }
+
+    @Test(description = "Test deprecate with unused flags")
+    public void testDeprecationWithUnusedFlags() throws IOException {
+        DeprecateCommand deprecationCommand = new DeprecateCommand(printStream, printStream, false);
+        new CommandLine(deprecationCommand).parseArgs("mynewdil/deppack:0.1.0", "--undo", "-message", "for testing");
+        deprecationCommand.execute();
+
+        String buildLog = readOutput(true);
+        String actual = buildLog.replaceAll("\r", "");
+        Assert.assertTrue(actual.contains("warning: ignoring --message (-m) flag since this is an undo request"));
+    }
+
+    @Test(description = "Test deprecate with too many args")
+    public void testDeprecationWithTooManyArgs() throws IOException {
+        DeprecateCommand deprecationCommand = new DeprecateCommand(printStream, printStream, false);
+        new CommandLine(deprecationCommand).parseArgs("wso2", "tests");
+        deprecationCommand.execute();
+
+        String buildLog = readOutput(true);
+        String actual = buildLog.replaceAll("\r", "");
+        Assert.assertTrue(actual.contains("ballerina: too many arguments"));
+        Assert.assertTrue(actual.contains("bal deprecate <package>"));
+    }
+
+    @Test(description = "Test deprecate command with argument and a help")
+    public void testDeprecateCommandArgAndHelp() throws IOException {
+        String[] args = { "sample2", "--help" };
+        DeprecateCommand deprecationCommand = new DeprecateCommand(printStream, printStream, false);
+        new CommandLine(deprecationCommand).parseArgs(args);
+        deprecationCommand.execute();
+
+        Assert.assertTrue(readOutput().contains("ballerina-deprecate - Deprecates a published package"));
+    }
+
+    @Test(description = "Test deprecate command with help flag")
+    public void testDeprecateCommandWithHelp() throws IOException {
+        String[] args = { "-h" };
+        DeprecateCommand deprecateCommand = new DeprecateCommand(printStream, printStream, false);
+        new CommandLine(deprecateCommand).parseArgs(args);
+        deprecateCommand.execute();
+
+        Assert.assertTrue(readOutput().contains("ballerina-deprecate - Deprecates a published package"));
+    }
+}

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/DeprecateCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/DeprecateCommandTest.java
@@ -34,7 +34,7 @@ public class DeprecateCommandTest extends BaseCommandTest {
     @Test(description = "Test deprecate without package version")
     public void testDeprecationWithoutVersion() throws IOException {
         DeprecateCommand deprecationCommand = new DeprecateCommand(printStream, printStream, false);
-        new CommandLine(deprecationCommand).parseArgs("mynewdil/deppack", "-message", "for testing");
+        new CommandLine(deprecationCommand).parseArgs("mynewdil/deppack", "--message", "for testing");
         deprecationCommand.execute();
 
         String buildLog = readOutput(true);
@@ -46,7 +46,7 @@ public class DeprecateCommandTest extends BaseCommandTest {
     @Test(description = "Test deprecate with invalid org name")
     public void testDeprecationWithInvalidOrg() throws IOException {
         DeprecateCommand deprecationCommand = new DeprecateCommand(printStream, printStream, false);
-        new CommandLine(deprecationCommand).parseArgs("my-newdil/deppack:0.1.0", "-message", "for testing");
+        new CommandLine(deprecationCommand).parseArgs("my-newdil/deppack:0.1.0", "--message", "for testing");
         deprecationCommand.execute();
 
         String buildLog = readOutput(true);
@@ -59,7 +59,7 @@ public class DeprecateCommandTest extends BaseCommandTest {
     @Test(description = "Test deprecate with invalid package name")
     public void testDeprecationWithInvalidPackageName() throws IOException {
         DeprecateCommand deprecationCommand = new DeprecateCommand(printStream, printStream, false);
-        new CommandLine(deprecationCommand).parseArgs("mynewdil/dep-pack:0.1.0", "-message", "for testing");
+        new CommandLine(deprecationCommand).parseArgs("mynewdil/dep-pack:0.1.0");
         deprecationCommand.execute();
 
         String buildLog = readOutput(true);
@@ -73,7 +73,7 @@ public class DeprecateCommandTest extends BaseCommandTest {
     @Test(description = "Test deprecate with invalid version")
     public void testDeprecationWithInvalidVersion() throws IOException {
         DeprecateCommand deprecationCommand = new DeprecateCommand(printStream, printStream, false);
-        new CommandLine(deprecationCommand).parseArgs("mynewdil/deppack:xxx", "-message", "for testing");
+        new CommandLine(deprecationCommand).parseArgs("mynewdil/deppack:xxx");
         deprecationCommand.execute();
 
         String buildLog = readOutput(true);
@@ -85,12 +85,12 @@ public class DeprecateCommandTest extends BaseCommandTest {
     @Test(description = "Test deprecate with unused flags")
     public void testDeprecationWithUnusedFlags() throws IOException {
         DeprecateCommand deprecationCommand = new DeprecateCommand(printStream, printStream, false);
-        new CommandLine(deprecationCommand).parseArgs("mynewdil/deppack:0.1.0", "--undo", "-message", "for testing");
+        new CommandLine(deprecationCommand).parseArgs("mynewdil/deppack:0.1.0", "--undo", "--message", "for testing");
         deprecationCommand.execute();
 
         String buildLog = readOutput(true);
         String actual = buildLog.replaceAll("\r", "");
-        Assert.assertTrue(actual.contains("warning: ignoring --message (-m) flag since this is an undo request"));
+        Assert.assertTrue(actual.contains("warning: ignoring '--message' flag since this is an undo request"));
     }
 
     @Test(description = "Test deprecate with too many args")

--- a/cli/ballerina-cli/src/test/resources/testng.xml
+++ b/cli/ballerina-cli/src/test/resources/testng.xml
@@ -41,7 +41,8 @@ under the License.
             <class name="io.ballerina.cli.cmd.PackCommandTest" />
             <class name="io.ballerina.cli.cmd.CommandUtilTest" />
             <class name="io.ballerina.cli.cmd.TestNativeImageCommandTest"/>
-            <class name="io.ballerina.cli.cmd.BuildNativeImageCommandTest"></class>
+            <class name="io.ballerina.cli.cmd.BuildNativeImageCommandTest"/>
+            <class name="io.ballerina.cli.cmd.DeprecateCommandTest"/>
         </classes>
     </test>
 </suite>

--- a/cli/central-client/src/main/java/org/ballerinalang/central/client/CentralAPIClient.java
+++ b/cli/central-client/src/main/java/org/ballerinalang/central/client/CentralAPIClient.java
@@ -75,7 +75,9 @@ import static org.ballerinalang.central.client.CentralClientConstants.APPLICATIO
 import static org.ballerinalang.central.client.CentralClientConstants.AUTHORIZATION;
 import static org.ballerinalang.central.client.CentralClientConstants.BALLERINA_PLATFORM;
 import static org.ballerinalang.central.client.CentralClientConstants.CONTENT_DISPOSITION;
+import static org.ballerinalang.central.client.CentralClientConstants.DEPRECATE_MESSAGE;
 import static org.ballerinalang.central.client.CentralClientConstants.IDENTITY;
+import static org.ballerinalang.central.client.CentralClientConstants.IS_DEPRECATED;
 import static org.ballerinalang.central.client.CentralClientConstants.LOCATION;
 import static org.ballerinalang.central.client.CentralClientConstants.USER_AGENT;
 import static org.ballerinalang.central.client.Utils.ProgressRequestBody;
@@ -96,6 +98,8 @@ public class CentralAPIClient {
     private static final String TRIGGERS = "triggers";
     private static final String RESOLVE_DEPENDENCIES = "resolve-dependencies";
     private static final String RESOLVE_MODULES = "resolve-modules";
+    private static final String DEPRECATE = "deprecate";
+    private static final String UN_DEPRECATE = "undeprecate";
     private static final String ERR_CANNOT_FIND_PACKAGE = "error: could not connect to remote repository to find " +
             "package: ";
     private static final String ERR_CANNOT_FIND_VERSIONS = "error: could not connect to remote repository to find " +
@@ -106,6 +110,8 @@ public class CentralAPIClient {
     private static final String ERR_CANNOT_GET_CONNECTOR = "error: failed to find connector: ";
     private static final String ERR_CANNOT_GET_TRIGGERS = "error: failed to find triggers: ";
     private static final String ERR_CANNOT_GET_TRIGGER = "error: failed to find the trigger: ";
+    private static final String ERR_PACKAGE_DEPRECATE = "error: failed to deprecate the package: ";
+    private static final String ERR_PACKAGE_UN_DEPRECATE = "error: failed to undo deprecation of the package: ";
     private static final String ERR_PACKAGE_RESOLUTION = "error: while connecting to central: ";
     private static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
     // System property name for enabling central verbose
@@ -470,6 +476,15 @@ public class CentralAPIClient {
                 // get redirect url from "location" header field
                 Optional<String> balaUrl = Optional.ofNullable(packagePullResponse.header(LOCATION));
                 Optional<String> balaFileName = Optional.ofNullable(packagePullResponse.header(CONTENT_DISPOSITION));
+                Optional<String> deprecationFlag = Optional.ofNullable(packagePullResponse.header(IS_DEPRECATED));
+                Optional<String> deprecationMsg = Optional.ofNullable(packagePullResponse.header(DEPRECATE_MESSAGE));
+
+                boolean isDeprecated = deprecationFlag.isPresent() && Boolean.parseBoolean(deprecationFlag.get());
+                String deprecationMessage = deprecationMsg.isPresent() ? deprecationMsg.get() : "";
+                if (!isBuild && isDeprecated) {
+                    outStream.println("WARNING [" + name + "] " + packageSignature + " is deprecated due to : "
+                            + deprecationMessage);
+                }
 
                 if (balaUrl.isPresent() && balaFileName.isPresent()) {
                     Request downloadBalaRequest = getNewRequest(supportedPlatform, ballerinaVersion)
@@ -487,6 +502,7 @@ public class CentralAPIClient {
                     if (balaDownloadResponse.code() == HTTP_OK) {
                         boolean isNightlyBuild = ballerinaVersion.contains("SNAPSHOT");
                         createBalaInHomeRepo(balaDownloadResponse, packagePathInBalaCache, org, name, isNightlyBuild,
+                                isDeprecated ? deprecationMessage : null,
                                 balaUrl.get(), balaFileName.get(), enableOutputStream ? outStream : null, logFormatter);
                         return;
                     } else {
@@ -745,6 +761,97 @@ public class CentralAPIClient {
             throw new CentralClientException(ERR_CANNOT_SEARCH + "'" + query + "'.");
         } catch (IOException e) {
             throw new CentralClientException(ERR_CANNOT_SEARCH + "'" + query + "'. reason: " + e.getMessage());
+        } finally {
+            body.ifPresent(ResponseBody::close);
+            try {
+                this.closeClient(client);
+            } catch (IOException e) {
+                // ignore
+            }
+        }
+    }
+
+    /**
+     * Deprecate a package in registry.
+     */
+    public void deprecatePackage(String packageInfo, String deprecationMsg, String supportedPlatform,
+                                 String ballerinaVersion, Boolean isUndo) throws CentralClientException {
+        Optional<ResponseBody> body = Optional.empty();
+        OkHttpClient client = this.getClient();
+        try {
+            RequestBody requestBody;
+            String requestURL;
+            if (isUndo) {
+                requestURL = this.baseUrl + "/" + PACKAGES + "/" + UN_DEPRECATE + "/" +
+                        packageInfo.replace(":", "/");
+                requestBody = RequestBody.create(JSON, "{}");
+            } else {
+                requestBody = RequestBody.create(JSON, "{\"message\": \"" + deprecationMsg + "\"}");
+                requestURL = this.baseUrl + "/" + PACKAGES + "/" + DEPRECATE + "/" +
+                        packageInfo.replace(":", "/");
+            }
+
+            Request deprecationReq = getNewRequest(supportedPlatform, ballerinaVersion)
+                    .put(requestBody)
+                    .url(requestURL)
+                    .addHeader(ACCEPT_ENCODING, IDENTITY)
+                    .addHeader(ACCEPT, APPLICATION_JSON)
+                    .build();
+
+            Call httpRequestCall = client.newCall(deprecationReq);
+            Response deprecationResponse = httpRequestCall.execute();
+
+            body = Optional.ofNullable(deprecationResponse.body());
+            if (body.isPresent()) {
+                Optional<MediaType> contentType = Optional.ofNullable(body.get().contentType());
+                if (contentType.isPresent()  && isApplicationJsonContentType(contentType.get().toString())) {
+                    // If deprecation was successful
+                    if (deprecationResponse.code() == HTTP_OK) {
+                        Package packageResponse = new Gson().fromJson(body.get().string(), Package.class);
+                        if (packageResponse.getDeprecated()) {
+                            this.outStream.println(packageInfo + " marked as deprecated in central successfully");
+                        } else {
+                            this.outStream.println("deprecation of " + packageInfo +
+                                    " is successfully undone in central");
+                        }
+                    }
+
+                    // Unauthorized access token
+                    if (deprecationResponse.code() == HTTP_UNAUTHORIZED) {
+                        handleUnauthorizedResponse(body);
+                    }
+
+                    // If deprecation request was sent wrongly
+                    if (deprecationResponse.code() == HTTP_BAD_REQUEST) {
+                        Error error = new Gson().fromJson(body.get().string(), Error.class);
+                        if (error.getMessage() != null && !"".equals(error.getMessage())) {
+                            throw new CentralClientException(error.getMessage());
+                        }
+                    }
+
+                    // If deprecation request was sent wrongly
+                    if (deprecationResponse.code() == HTTP_NOT_FOUND) {
+                        Error error = new Gson().fromJson(body.get().string(), Error.class);
+                        if (error.getMessage() != null && !"".equals(error.getMessage())) {
+                            throw new CentralClientException(error.getMessage());
+                        }
+                    }
+
+                    // If error occurred at remote repository
+                    if (deprecationResponse.code() == HTTP_INTERNAL_ERROR ||
+                            deprecationResponse.code() == HTTP_UNAVAILABLE) {
+                        Error error = new Gson().fromJson(body.get().string(), Error.class);
+                        if (error.getMessage() != null && !"".equals(error.getMessage())) {
+                            String errorMsg = isUndo ? ERR_PACKAGE_UN_DEPRECATE : ERR_PACKAGE_DEPRECATE;
+                            throw new CentralClientException(errorMsg + "'" + packageInfo +
+                                    "' reason:" + error.getMessage());
+                        }
+                    }
+                }
+            }
+        } catch (IOException e) {
+            String errorMsg = isUndo ? ERR_PACKAGE_UN_DEPRECATE : ERR_PACKAGE_DEPRECATE;
+            throw new CentralClientException(errorMsg + "'" + packageInfo + "'. reason: " + e.getMessage());
         } finally {
             body.ifPresent(ResponseBody::close);
             try {

--- a/cli/central-client/src/main/java/org/ballerinalang/central/client/CentralClientConstants.java
+++ b/cli/central-client/src/main/java/org/ballerinalang/central/client/CentralClientConstants.java
@@ -40,5 +40,7 @@ public class CentralClientConstants {
     static final String CONTENT_DISPOSITION = "Content-Disposition";
     static final String APPLICATION_OCTET_STREAM = "application/octet-stream";
     static final String APPLICATION_JSON = "application/json";
+    static final String IS_DEPRECATED = "isdeprecated";
+    static final String DEPRECATE_MESSAGE = "deprecatemessage";
     public static final String ENABLE_OUTPUT_STREAM = "enableOutputStream";
 }

--- a/cli/central-client/src/main/java/org/ballerinalang/central/client/model/Package.java
+++ b/cli/central-client/src/main/java/org/ballerinalang/central/client/model/Package.java
@@ -43,6 +43,12 @@ public class Package {
     public static final String JSON_PROPERTY_LANGUAGE_SPECIFICATION_VERSION = "languageSpecificationVersion";
     @SerializedName(JSON_PROPERTY_LANGUAGE_SPECIFICATION_VERSION) private String languageSpecificationVersion;
 
+    public static final String JSON_PROPERTY_IS_DEPRECATED = "isDeprecated";
+    @SerializedName(JSON_PROPERTY_IS_DEPRECATED) private Boolean isDeprecated;
+
+    public static final String JSON_PROPERTY_DEPRECATE_MESSAGE = "deprecateMessage";
+    @SerializedName(JSON_PROPERTY_DEPRECATE_MESSAGE) private Boolean deprecateMessage;
+
     public static final String JSON_PROPERTY_U_R_L = "URL";
     @SerializedName(JSON_PROPERTY_U_R_L) private String url;
 
@@ -152,6 +158,22 @@ public class Package {
 
     public void setLanguageSpecificationVersion(String languageSpecificationVersion) {
         this.languageSpecificationVersion = languageSpecificationVersion;
+    }
+
+    public Boolean getDeprecated() {
+        return isDeprecated;
+    }
+
+    public void setDeprecated(Boolean deprecated) {
+        isDeprecated = deprecated;
+    }
+
+    public Boolean getDeprecateMessage() {
+        return deprecateMessage;
+    }
+
+    public void setDeprecateMessage(Boolean deprecateMessage) {
+        this.deprecateMessage = deprecateMessage;
     }
 
     public Package url(String url) {

--- a/cli/central-client/src/main/java/org/ballerinalang/central/client/model/PackageResolutionResponse.java
+++ b/cli/central-client/src/main/java/org/ballerinalang/central/client/model/PackageResolutionResponse.java
@@ -48,6 +48,10 @@ public class PackageResolutionResponse {
         private String version;
         private List<Dependency> dependencyGraph;
 
+        private Boolean isDeprecated;
+
+        private String deprecateMessage;
+
         public Package(String orgName, String name, String version, List<Dependency> dependencies) {
             this.org = orgName;
             this.name = name;
@@ -85,6 +89,22 @@ public class PackageResolutionResponse {
 
         public void setDependencies(List<Dependency> dependencies) {
             this.dependencyGraph = dependencies;
+        }
+
+        public Boolean getDeprecated() {
+            return isDeprecated;
+        }
+
+        public void setDeprecated(Boolean deprecated) {
+            isDeprecated = deprecated;
+        }
+
+        public String getDeprecateMessage() {
+            return deprecateMessage;
+        }
+
+        public void setDeprecateMessage(String deprecateMessage) {
+            this.deprecateMessage = deprecateMessage;
         }
     }
 

--- a/cli/central-client/src/test/java/org/ballerinalang/central/client/TestUtils.java
+++ b/cli/central-client/src/test/java/org/ballerinalang/central/client/TestUtils.java
@@ -179,7 +179,7 @@ public class TestUtils {
 
         final String balaUrl = "https://fileserver.dev-central.ballerina.io/2.0/wso2/sf/1.3.5/sf-2020r2-any-1.3.5.bala";
         createBalaInHomeRepo(mockResponse, tempBalaCache.resolve("wso2").resolve("sf"),
-                "wso2", "sf", false, balaUrl, "", System.out, new LogFormatter());
+                "wso2", "sf", false, null, balaUrl, "", System.out, new LogFormatter());
 
         Assert.assertTrue(tempBalaCache.resolve("wso2").resolve("sf").resolve("1.3.5").toFile().exists());
         cleanBalaCache();
@@ -213,7 +213,7 @@ public class TestUtils {
         final String balaUrl = "https://fileserver.dev-central.ballerina.io/2.0/wso2/sf/1.3.5/sf-2020r2-any-1.3.5.bala";
         try {
             createBalaInHomeRepo(mockResponse,
-                    tempBalaCache.resolve("wso2").resolve("sf"), "wso2", "sf", false,
+                    tempBalaCache.resolve("wso2").resolve("sf"), "wso2", "sf", false, null,
                     balaUrl, "", System.out, new LogFormatter());
         } catch (CentralClientException e) {
             Assert.assertTrue(e.getMessage().contains("package already exists in the home repository:"));

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageDescriptor.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageDescriptor.java
@@ -34,6 +34,10 @@ public class PackageDescriptor implements Comparable<PackageDescriptor> {
     private final PackageVersion packageVersion;
     private final String repository;
 
+    private final Boolean isDeprecated;
+
+    private final String deprecationMsg;
+
     private PackageDescriptor(PackageOrg packageOrg,
                               PackageName packageName,
                               PackageVersion packageVersion,
@@ -43,6 +47,21 @@ public class PackageDescriptor implements Comparable<PackageDescriptor> {
         this.repository = repository;
         this.packageVersion = ProjectUtils.isBuiltInPackage(packageOrg, packageName.value()) ?
                 PackageVersion.BUILTIN_PACKAGE_VERSION : packageVersion;
+        this.isDeprecated = false;
+        this.deprecationMsg = "";
+    }
+
+    private PackageDescriptor(PackageOrg packageOrg,
+                              PackageName packageName,
+                              PackageVersion packageVersion,
+                              String repository, Boolean isDeprecated, String deprecationMsg) {
+        this.packageName = packageName;
+        this.packageOrg = packageOrg;
+        this.repository = repository;
+        this.packageVersion = ProjectUtils.isBuiltInPackage(packageOrg, packageName.value()) ?
+                PackageVersion.BUILTIN_PACKAGE_VERSION : packageVersion;
+        this.isDeprecated = isDeprecated;
+        this.deprecationMsg = deprecationMsg;
     }
 
     public static PackageDescriptor from(PackageOrg packageOrg, PackageName packageName) {
@@ -57,6 +76,11 @@ public class PackageDescriptor implements Comparable<PackageDescriptor> {
     public static PackageDescriptor from(PackageOrg packageOrg, PackageName packageName,
                                          PackageVersion packageVersion, String repository) {
         return new PackageDescriptor(packageOrg, packageName, packageVersion, repository);
+    }
+
+    public static PackageDescriptor from(PackageOrg packageOrg, PackageName packageName,
+                                         PackageVersion packageVersion, Boolean isDeprecated, String deprecationMsg) {
+        return new PackageDescriptor(packageOrg, packageName, packageVersion, null, isDeprecated, deprecationMsg);
     }
 
     public PackageName name() {
@@ -81,6 +105,14 @@ public class PackageDescriptor implements Comparable<PackageDescriptor> {
 
     public boolean isBuiltInPackage() {
         return ProjectUtils.isBuiltInPackage(packageOrg, packageName.value());
+    }
+
+    public Boolean getDeprecated() {
+        return isDeprecated;
+    }
+
+    public String getDeprecationMsg() {
+        return deprecationMsg;
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageResolution.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageResolution.java
@@ -33,6 +33,7 @@ import io.ballerina.projects.internal.ImportModuleResponse;
 import io.ballerina.projects.internal.ModuleResolver;
 import io.ballerina.projects.internal.PackageContainer;
 import io.ballerina.projects.internal.PackageDiagnostic;
+import io.ballerina.projects.internal.ProjectDiagnosticErrorCode;
 import io.ballerina.projects.internal.ResolutionEngine;
 import io.ballerina.projects.internal.ResolutionEngine.DependencyNode;
 import io.ballerina.projects.internal.model.BuildJson;
@@ -335,7 +336,11 @@ public class PackageResolution {
         // Add resolved packages to the container
         for (ResolutionResponse resolutionResp : resolutionResponses) {
             if (resolutionResp.resolutionStatus().equals(ResolutionResponse.ResolutionStatus.RESOLVED)) {
-                PackageDescriptor pkgDesc = resolutionResp.responseDescriptor();
+                PackageDescriptor pkgDesc = resolutionResp.resolvedPackage().packageContext().
+                        packageManifest().descriptor();
+                if (Optional.ofNullable(pkgDesc.getDeprecated()).orElse(false)) {
+                    addDeprecationDiagnostic(pkgDesc);
+                }
                 ResolutionRequest resolutionReq = resolutionResp.resolutionRequest();
                 ResolvedPackageDependency resolvedPkg = new ResolvedPackageDependency(
                         resolutionResp.resolvedPackage(),
@@ -366,6 +371,16 @@ public class PackageResolution {
             }
         }
         return depGraphBuilder.build();
+    }
+
+    private void addDeprecationDiagnostic(PackageDescriptor pkgDesc) {
+        String deprecationMsg = Optional.ofNullable(pkgDesc.getDeprecationMsg()).orElse("");
+        DiagnosticInfo diagnosticInfo = new DiagnosticInfo(
+                ProjectDiagnosticErrorCode.DEPRECATED_PACKAGE.diagnosticId(), pkgDesc.toString() +
+                " is deprecated due to : " + deprecationMsg, DiagnosticSeverity.WARNING);
+        PackageDiagnostic diagnostic = new PackageDiagnostic(
+                diagnosticInfo, this.rootPackageContext.descriptor().name().toString());
+        this.diagnosticList.add(diagnostic);
     }
 
     private ResolutionRequest createFromDepNode(DependencyNode depNode) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ProjectDiagnosticErrorCode.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ProjectDiagnosticErrorCode.java
@@ -34,6 +34,7 @@ public enum ProjectDiagnosticErrorCode implements DiagnosticCode {
     INCOMPATIBLE_DEPENDENCY_VERSIONS("BCE5004", "incompatible.dependency.versions"),
     PACKAGE_NOT_FOUND("BCE5005", "package.not.found"),
     MISSING_PKG_INFO_IN_BALLERINA_TOML("BCE5006", "missing.package.info"),
+    DEPRECATED_PACKAGE("BCE5007", "deprecated.package"),
     MODULE_NOT_FOUND("BCE5100", "module.not.found"),
     UNSUPPORTED_COMPILER_PLUGIN_TYPE("BCE5200", "unsupported.compiler.plugin.type"),
     CONFLICTING_PLATFORM_JAR_FILES("BCE5300", "conflicting.platform.jars.type"),

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/FileSystemRepository.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/FileSystemRepository.java
@@ -36,6 +36,7 @@ import io.ballerina.projects.environment.ResolutionOptions;
 import io.ballerina.projects.environment.ResolutionRequest;
 import io.ballerina.projects.internal.BalaFiles;
 import io.ballerina.projects.repos.FileSystemCache;
+import io.ballerina.projects.util.FileUtils;
 import io.ballerina.projects.util.ProjectConstants;
 import io.ballerina.projects.util.ProjectUtils;
 import org.wso2.ballerinalang.util.RepoUtils;
@@ -44,6 +45,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -110,6 +112,26 @@ public class FileSystemRepository extends AbstractPackageRepository {
                 new FileSystemCache.FileSystemCacheFactory(cacheDir));
         Project project = BalaProject.loadProject(environmentBuilder, balaPath);
         return Optional.of(project.currentPackage());
+    }
+
+    /**
+     * Update the deprecated status of the package in file system cache.
+     *
+     * @param descriptor Package descriptor
+     */
+    void updateDeprecatedStatusForPackage(PackageDescriptor descriptor) {
+        Path balaPath = getPackagePath(descriptor.org().value(), descriptor.name().value(),
+                descriptor.version().value().toString());
+        if (balaPath != null && Files.exists(balaPath)) {
+            Path deprecateMsgMetaFile = Paths.get(balaPath.toString(), ProjectConstants.DEPRECATED_META_FILE_NAME);
+            if (descriptor.getDeprecated() && !deprecateMsgMetaFile.toFile().exists()) {
+                FileUtils.addDeprecatedMetaFile(deprecateMsgMetaFile, descriptor.getDeprecationMsg());
+            }
+
+            if (!descriptor.getDeprecated() && deprecateMsgMetaFile.toFile().exists()) {
+                FileUtils.deleteDeprecatedMetaFile(deprecateMsgMetaFile);
+            }
+        }
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/RemotePackageRepository.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/RemotePackageRepository.java
@@ -255,6 +255,7 @@ public class RemotePackageRepository implements PackageRepository {
 
         // Resolve all the requests locally
         Collection<PackageMetadataResponse> cachedPackages = fileSystemRepo.getPackageMetadata(requests, options);
+        List<PackageMetadataResponse> deprecatedPackages = new ArrayList<>();
         if (options.offline()) {
             return cachedPackages;
         }
@@ -264,6 +265,12 @@ public class RemotePackageRepository implements PackageRepository {
             if (response.packageLoadRequest().packageLockingMode().equals(PackageLockingMode.HARD)
                     && response.resolutionStatus().equals(ResolutionResponse.ResolutionStatus.RESOLVED)) {
                 updatedRequests.remove(response.packageLoadRequest());
+            }
+            if (response.resolutionStatus().equals(ResolutionResponse.ResolutionStatus.RESOLVED)) {
+                Optional<Package> pkg = fileSystemRepo.getPackage(response.packageLoadRequest(), options);
+                if (pkg.isPresent() && pkg.get().descriptor().getDeprecated()) {
+                    deprecatedPackages.add(response);
+                }
             }
         }
         // Resolve the requests from remote repository if there are unresolved requests
@@ -278,7 +285,7 @@ public class RemotePackageRepository implements PackageRepository {
                         fromPackageResolutionResponse(updatedRequests, packageResolutionResponse);
                 // Merge central requests and local requests
                 // Here we will pick the latest package from remote or local
-                return mergeResolution(remotePackages, cachedPackages);
+                return mergeResolution(remotePackages, cachedPackages, deprecatedPackages);
 
             } catch (ConnectionErrorException e) {
                 // ignore connect to remote repo failure
@@ -292,22 +299,47 @@ public class RemotePackageRepository implements PackageRepository {
     }
 
     private Collection<PackageMetadataResponse> mergeResolution(
-            Collection<PackageMetadataResponse> remoteResolution,
-            Collection<PackageMetadataResponse> filesystem) {
+            Collection<PackageMetadataResponse> remoteResolution, Collection<PackageMetadataResponse> filesystem,
+            List<PackageMetadataResponse> deprecatedPackages) {
         List<PackageMetadataResponse> mergedResults = new ArrayList<>(
                 Stream.of(filesystem, remoteResolution)
                         .flatMap(Collection::stream).collect(Collectors.toMap(
                         PackageMetadataResponse::packageLoadRequest, Function.identity(),
                         (PackageMetadataResponse x, PackageMetadataResponse y) -> {
                             if (y.resolutionStatus().equals(ResolutionResponse.ResolutionStatus.UNRESOLVED)) {
+                                // filesystem response is resolved &  remote response is unresolved
                                 return x;
                             } else if (x.resolutionStatus().equals(ResolutionResponse.ResolutionStatus.UNRESOLVED)) {
+                                // filesystem response is unresolved &  remote response is resolved
                                 return y;
-                            } else if (getLatest(x.resolvedDescriptor().version(), y.resolvedDescriptor().version())
-                                    .equals(y.resolvedDescriptor().version())) {
-                                return y;
+                            } else if (x.resolvedDescriptor().version().equals(y.resolvedDescriptor().version())) {
+                                // Both responses have the same version and there is a mismatch in deprecated status,
+                                // we need to update the deprecated status in the file system repo
+                                // to match the remote repo as it is the most up to date.
+                                if (deprecatedPackages != null && y.resolvedDescriptor() != null &&
+                                        deprecatedPackages.contains(x) ^ y.resolvedDescriptor().getDeprecated()) {
+                                    fileSystemRepo.updateDeprecatedStatusForPackage(y.resolvedDescriptor());
+                                }
+                                return x;
                             }
-                            return x;
+                            // x not deprecate & y not deprecate
+                            //      - x is the latest : return x (this will not happen in real)
+                            //      - y is the latest : return y
+                            // x not deprecated & y deprecated
+                            //      - x is the latest : outdated. return y
+                            //      - y is the latest : return y
+                            // x deprecated & y not deprecated
+                            //      - x is the latest : outdated. return y
+                            //      - y is the latest : return y
+                            // x deprecated & y deprecated
+                            //      - x is the latest : not possible
+                            //      - y is the latest : return y
+
+                            // If the equivalent package is available in the file system repo,
+                            // try to update the deprecated status.
+                            // Because if available in cache, it won't be pulled.
+                            fileSystemRepo.updateDeprecatedStatusForPackage(y.resolvedDescriptor());
+                            return y;
                         })).values());
         return mergedResults;
     }
@@ -328,7 +360,7 @@ public class RemotePackageRepository implements PackageRepository {
                 DependencyGraph<PackageDescriptor> dependencies = createPackageDependencyGraph(match.get());
                 PackageDescriptor packageDescriptor = PackageDescriptor.from(resolutionRequest.orgName(),
                         resolutionRequest.packageName(),
-                        version);
+                        version, match.get().getDeprecated(), match.get().getDeprecateMessage());
                 PackageMetadataResponse responseDescriptor = PackageMetadataResponse.from(resolutionRequest,
                         packageDescriptor,
                         dependencies);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/FileUtils.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/FileUtils.java
@@ -18,12 +18,15 @@
 package io.ballerina.projects.util;
 
 import java.io.BufferedReader;
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.math.BigInteger;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -240,6 +243,45 @@ public class FileUtils {
                 return false;
             }
             return false;
+        }
+    }
+
+    /**
+     * Add deprecated meta file.
+     *
+     * @param metaFilePath deprecated message meta file path
+     * @param message deprecated message
+     */
+    public static void addDeprecatedMetaFile(Path metaFilePath, String message) {
+        if (!metaFilePath.toFile().exists()) {
+            try {
+                Files.createFile(metaFilePath);
+            } catch (IOException ignored) {
+                // ignore and continue
+                return;
+            }
+        }
+        if (metaFilePath.toFile().exists()) {
+            try (FileWriter fileWriter = new FileWriter(metaFilePath.toAbsolutePath().toString(),
+                    Charset.defaultCharset());
+                 BufferedWriter bufferedWriter = new BufferedWriter(fileWriter)) {
+                bufferedWriter.write(message);
+            } catch (IOException ignored) {
+                // ignore and continue
+            }
+        }
+    }
+
+    /**
+     * Delete deprecated meta file.
+     *
+     * @param metaFilePath deprecated message meta file path
+     */
+    public static void deleteDeprecatedMetaFile(Path metaFilePath) {
+        try {
+            Files.deleteIfExists(metaFilePath);
+        } catch (IOException ignored) {
+            // ignore and continue
         }
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/ProjectConstants.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/ProjectConstants.java
@@ -42,6 +42,7 @@ public class ProjectConstants {
     public static final String BALA_JSON = "bala.json";
     public static final String COMPILER_PLUGIN_JSON = "compiler-plugin.json";
     public static final String DEPENDENCY_GRAPH_JSON = "dependency-graph.json";
+    public static final String DEPRECATED_META_FILE_NAME = "deprecated.txt";
     public static final String BUILD_FILE = "build";
 
     public static final String SOURCE_DIR_NAME = "src";

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/RemotePackageRepositoryTests.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/RemotePackageRepositoryTests.java
@@ -115,9 +115,14 @@ public class RemotePackageRepositoryTests {
         Assert.assertEquals(httpResult.resolvedDescriptor().version().toString(), "1.2.2");
         Assert.assertEquals(httpResult.resolutionStatus(), ResolutionResponse.ResolutionStatus.RESOLVED);
 
-        // If the remote repository version is lower than filesystem it should return filesystem version
+        // If the remote repository version is lower than filesystem
+        // This behavior changed with the introduction of deprecated packages
+        // filesystem version not deprecated & remote repository version not deprecate
+        //      - filesystem version is the latest :
+        //      This implies that remote repository has the same version as the filesystem but it is deprecated.
+        //      So, it returns a lower version which is not deprecated. Details in filesystem might not be up to date.
         PackageMetadataResponse covidResult =  resolutionResponseDescriptors.get(1);
-        Assert.assertEquals(covidResult.resolvedDescriptor().version().toString(), "1.5.9");
+        Assert.assertEquals(covidResult.resolvedDescriptor().version().toString(), "1.5.7");
         Assert.assertEquals(covidResult.resolutionStatus(), ResolutionResponse.ResolutionStatus.RESOLVED);
 
         // Check if dependencies are populated for two sub levels


### PR DESCRIPTION
## Purpose
This PR introduces the following to support deprecating Ballerina packages.

-  Introduce bal deprecate command
- `bal pull` : print a warning when pulling a deprecated package
- `bal push` : print error when trying to push a package with a deprecated dependency.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/39203

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples

### Valid requests

Deprecating a package:

```
> bal deprecate mynewdil/deprecate_sample:0.1.0 --message "for testing"
mynewdil/deprecate_sample:0.1.0 marked as deprecated in central successfully
```

Undo package deprecation:

```
> bal deprecate mynewdil/deprecate_sample:0.1.0 --undo
deprecation of mynewdil/deprecate_sample:0.1.0 is successfully undone in central
```

### Warnings and errors

Pull a deprecated package:

```
> bal pull mynewdil/deprecate_sample:0.1.0
WARNING [deprecate_sample] mynewdil/deprecate_sample:0.1.0 is deprecated due to : deprecating for testing
mynewdil/deprecate_sample:0.1.0 [central.ballerina.io -> home repo]  100% [====================================================================================================================================] 2/2 KB (0:00:00 / 0:00:00)
mynewdil/deprecate_sample:0.1.0 pulled from central successfully
```

`bal pack` with a dependency on a deprecated package

```
> bal pack
Compiling source
	mynewdil/deppack:1.0.0
mynewdil/deprecate_sample:0.1.0 [central.ballerina.io -> home repo]  100% [====================================================================================================================================] 2/2 KB (0:00:00 / 0:00:00)
	mynewdil/deprecate_sample:0.1.0 pulled from central successfully
WARNING [deppack] mynewdil/deprecate_sample:0.1.0 is deprecated due to : deprecating for testing

Creating bala
	target/bala/mynewdil-deppack-any-1.0.0.bala
```

Push a package with a dependency to a deprecated package

```
> bal push
mynewdil/deppack:1.0.0 [project repo -> central] 100% [===================================================================================================================================================] 2108/2108 B (0:00:00 / 0:00:00)
ballerina: unable to push package as the following dependency of the package is deprecated in the registry: mynewdil/deppack:1.0.0
```

Deprecate with unused flag:

```
> bal deprecate mynewdil/deprecate_sample:0.1.0 --undo -m "for testing"
warning: ignoring --message (-m) flag since this is an undo request
deprecation of mynewdil/deprecate_sample:0.1.0 is successfully undone in central
```

### Invalid requests
Deprecate command with invalid package(without version):

```
> bal deprecate mynewdil/deprecate_sample --message "for testing"
ballerina: invalid package. Provide the package with the version.

USAGE:
    bal deprecate {<org-name>/<package-name>:<version>} [OPTIONS]
```

Deprecate command with invalid package org:

```
> bal deprecate mynew-dil/deprecate_sample:0.1.0 --message "for testing"
ballerina: invalid organization name. Organization name can only contain alphanumeric values with lower case letters and cannot start with numeric values, org_name = mynew-dil
```

Deprecate command with invalid package name:

```
> bal deprecate mynewdil/deprecate-sample:0.1.0 --message "for testing"
ballerina: invalid package name provided. Only alphanumerics, underscores and periods are allowed in a package name and the maximum length is 256 characters, package_name = 'deprecate-sample'
```

Deprecate command with invalid package version:

```
> bal deprecate mynewdil/deprecate_sample:xxxx -m "for testing"
ballerina: invalid request received. error occurred finding package: mynewdil/deprecate_sample:xxxx_java11. Matched version is an error
```

Package not found:
```
> bal deprecate mynewdil/deprecatesample:0.1.0
ballerina: package not found for: mynewdil/deprecatesample:0.1.0
```

Trying to undo a package that is not deprecated:

```
> bal deprecate mynewdil/deprecate_sample:0.1.0 --undo
ballerina: invalid request received. package is not deprecated
```

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
