### PR TITLE
Sanitize the multipart boundary header parameter value

### DIFF
--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/HttpUtil.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/HttpUtil.java
@@ -1102,8 +1102,8 @@ public class HttpUtil {
     public static String addBoundaryIfNotExist(HttpCarbonMessage transportMessage, String contentType) {
         String boundaryString;
         String boundaryValue = HeaderUtil.extractBoundaryParameter(contentType);
-        boundaryString = boundaryValue != null ? boundaryValue : HttpUtil.addBoundaryParameter(transportMessage,
-                                                                                               contentType);
+        boundaryString = boundaryValue != null ? sanitizeBoundary(boundaryValue) :
+                HttpUtil.addBoundaryParameter(transportMessage, contentType);
         return boundaryString;
     }
 
@@ -1122,6 +1122,16 @@ public class HttpUtil {
                     boundaryString);
         }
         return boundaryString;
+    }
+
+    /**
+     * Sanitize the boundary string by removing leading and trailing double quotes.
+     *
+     * @param boundaryString Represent boundary string
+     * @return Sanitized boundary string
+     */
+    private static String sanitizeBoundary(String boundaryString) {
+        return boundaryString.replaceAll("^\"|\"$", "");
     }
 
     public static HttpWsConnectorFactory createHttpWsConnectionFactory() {

--- a/stdlib/http/src/test/java/org/ballerinalang/stdlib/multipart/MultipartEncoderTest.java
+++ b/stdlib/http/src/test/java/org/ballerinalang/stdlib/multipart/MultipartEncoderTest.java
@@ -1,25 +1,26 @@
 /*
-*  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-*  WSO2 Inc. licenses this file to you under the Apache License,
-*  Version 2.0 (the "License"); you may not use this file except
-*  in compliance with the License.
-*  You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-*  Unless required by applicable law or agreed to in writing,
-*  software distributed under the License is distributed on an
-*  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-*  KIND, either express or implied.  See the License for the
-*  specific language governing permissions and limitations
-*  under the License.
-*/
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
 
 package org.ballerinalang.stdlib.multipart;
 
 import io.netty.handler.codec.http.HttpHeaderNames;
 import org.ballerinalang.jvm.values.ObjectValue;
+import org.ballerinalang.mime.util.EntityBodyHandler;
 import org.ballerinalang.mime.util.MimeUtil;
 import org.ballerinalang.mime.util.MultipartDataSource;
 import org.ballerinalang.mime.util.MultipartDecoder;
@@ -94,7 +95,7 @@ public class MultipartEncoderTest {
         InputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
         try {
             List<MIMEPart> mimeParts = MultipartDecoder.decodeBodyParts("multipart/mixed; boundary=" +
-                    multipartDataBoundary, inputStream);
+                                                                                multipartDataBoundary, inputStream);
             Assert.assertEquals(mimeParts.size(), 4);
             ObjectValue bodyPart = createEntityObject();
             validateBodyPartContent(mimeParts, bodyPart);
@@ -115,7 +116,7 @@ public class MultipartEncoderTest {
         InputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
         try {
             List<MIMEPart> mimeParts = MultipartDecoder.decodeBodyParts("multipart/new-sub-type; boundary=" +
-                    multipartDataBoundary, inputStream);
+                                                                                multipartDataBoundary, inputStream);
             Assert.assertEquals(mimeParts.size(), 4);
             ObjectValue bodyPart = createEntityObject();
             validateBodyPartContent(mimeParts, bodyPart);
@@ -136,7 +137,7 @@ public class MultipartEncoderTest {
         InputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
         try {
             List<MIMEPart> mimeParts = MultipartDecoder.decodeBodyParts("multipart/mixed; boundary=" +
-                    multipartDataBoundary, inputStream);
+                                                                                multipartDataBoundary, inputStream);
             Assert.assertEquals(mimeParts.size(), 4);
             for (MIMEPart mimePart : mimeParts) {
                 testNestedPartContent(mimePart);
@@ -155,7 +156,7 @@ public class MultipartEncoderTest {
      */
     private void testNestedPartContent(MIMEPart mimePart) throws MimeTypeParseException, IOException {
         List<MIMEPart> nestedParts = MultipartDecoder.decodeBodyParts(mimePart.getContentType(),
-                mimePart.readOnce());
+                                                                      mimePart.readOnce());
         Assert.assertEquals(nestedParts.size(), 4);
         ObjectValue ballerinaBodyPart = createEntityObject();
         validateBodyPartContent(nestedParts, ballerinaBodyPart);
@@ -167,7 +168,7 @@ public class MultipartEncoderTest {
         ObjectValue bodyPart = createEntityObject();
         ObjectValue contentDispositionStruct = getContentDispositionStruct();
         MimeUtil.setContentDisposition(contentDispositionStruct, bodyPart,
-                                   "form-data; name=\"filepart\"; filename=\"file-01.txt\"");
+                                       "form-data; name=\"filepart\"; filename=\"file-01.txt\"");
         ObjectValue contentDisposition =
                 (ObjectValue) bodyPart.get(CONTENT_DISPOSITION_FIELD);
         Assert.assertEquals(contentDisposition.get(CONTENT_DISPOSITION_FILENAME_FIELD).toString(), "file-01.txt");
@@ -184,7 +185,7 @@ public class MultipartEncoderTest {
         InputStream inputStream = new HttpMessageDataStreamer(response).getInputStream();
         try {
             List<MIMEPart> mimeParts = MultipartDecoder.decodeBodyParts("multipart/mixed; boundary=" +
-                    "e3a0b9ad7b4e7cdb", inputStream);
+                                                                                "e3a0b9ad7b4e7cdb", inputStream);
             Assert.assertEquals(mimeParts.size(), 4);
             ObjectValue bodyPart = createEntityObject();
             validateBodyPartContent(mimeParts, bodyPart);
@@ -204,11 +205,11 @@ public class MultipartEncoderTest {
         InputStream inputStream = new HttpMessageDataStreamer(response).getInputStream();
         try {
             List<MIMEPart> mimeParts = MultipartDecoder.decodeBodyParts(inRequestMsg.getHeader(HttpHeaderNames.
-                            CONTENT_TYPE.toString()),
-                    inputStream);
+                                                                                CONTENT_TYPE.toString()),
+                                                                        inputStream);
             Assert.assertEquals(mimeParts.size(), 2);
             List<MIMEPart> childParts = MultipartDecoder.decodeBodyParts(mimeParts.get(1).getContentType(),
-                    mimeParts.get(1).readOnce());
+                                                                         mimeParts.get(1).readOnce());
             Assert.assertEquals(childParts.size(), 2);
         } catch (MimeTypeParseException e) {
             log.error("Error occurred while testing mulitpart/mixed encoding", e.getMessage());
@@ -223,15 +224,37 @@ public class MultipartEncoderTest {
         Base64ByteChannel base64ByteChannel = new Base64ByteChannel(inputStream);
         byteChannelStruct.addNativeData(IOConstants.BYTE_CHANNEL_NAME, new Base64Wrapper(base64ByteChannel));
         BValue[] returnValues = BRunUtil.invoke(compileResult, "testBase64EncodeByteChannel",
-                                                new Object[]{ byteChannelStruct });
+                                                new Object[]{byteChannelStruct});
         Assert.assertFalse(returnValues == null || returnValues.length == 0 || returnValues[0] == null,
-                "Invalid return value");
+                           "Invalid return value");
         BMap<String, BValue> decodedByteChannel = (BMap<String, BValue>) returnValues[0];
         Channel byteChannel = (Channel) decodedByteChannel.getNativeData(IOConstants.BYTE_CHANNEL_NAME);
         try {
             Assert.assertEquals(StringUtils.getStringFromInputStream(byteChannel.getInputStream()), expectedValue);
         } catch (IOException e) {
             Assert.fail(e.getMessage());
+        }
+    }
+
+    @Test()
+    public void testBoundaryWithQuotes() {
+        String path = "/multipart/boundaryCheck";
+        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_GET);
+        HttpCarbonMessage response = Services.invoke(EP_PORT, inRequestMsg);
+        Assert.assertNotNull(response, "Response message not found");
+        InputStream inputStream = new HttpMessageDataStreamer(response).getInputStream();
+        try {
+            List<MIMEPart> mimeParts = MultipartDecoder.decodeBodyParts(
+                    "multipart/mixed; boundary=\"------=_Part_0_814051860.1675096572056\"", inputStream);
+            Assert.assertEquals(mimeParts.size(), 1);
+            ObjectValue bodyPart = createEntityObject();
+            EntityBodyHandler.populateBodyContent(bodyPart, mimeParts.get(0));
+            Object jsonData = EntityBodyHandler.constructJsonDataSource(bodyPart);
+            Assert.assertNotNull(jsonData);
+            Assert.assertEquals(org.ballerinalang.jvm.values.utils.StringUtils.getJsonString(jsonData),
+                                "{\"" + "bodyPart" + "\":\"" + "jsonPart" + "\"}");
+        } catch (MimeTypeParseException e) {
+            log.error("Error occurred while testing mulitpart/mixed encoding", e.getMessage());
         }
     }
 }

--- a/stdlib/http/src/test/resources/test-src/multipart/multipart-response.bal
+++ b/stdlib/http/src/test/resources/test-src/multipart/multipart-response.bal
@@ -56,4 +56,20 @@ service test on mockEP {
         }
         checkpanic caller->respond(outResponse);
     }
+
+    @http:ResourceConfig {
+        methods:["GET"],
+        path:"/boundaryCheck"
+    }
+    resource function multipartOutResponseWithBoundaryQuotes(http:Caller caller, http:Request request) {
+        mime:Entity bodyPart1 = new;
+        bodyPart1.setJson({"bodyPart":"jsonPart"});
+        mime:Entity[] bodyParts = [bodyPart1];
+
+        //Set the body parts to outbound response.
+        http:Response outResponse = new;
+        string contentType = mime:MULTIPART_MIXED + "; boundary=\"------=_Part_0_814051860.1675096572056\"";
+        outResponse.setBodyParts(bodyParts, contentType);
+        checkpanic caller->respond(outResponse);
+    }
 }


### PR DESCRIPTION
## Purpose
> Fixes https://github.com/wso2-enterprise/internal-support-ballerina/issues/255
> Related to https://github.com/ballerina-platform/ballerina-standard-library/issues/4083

## Example
```
POST /v3/20f75062-b1cd-4629-90f3-951a35fb708b/ HTTP/1.1
Content-Type: multipart/form-data; boundary="hello"
Accept: */*
Postman-Token: b1dfe16d-d79e-40ce-bfa5-1c0c28ee4120
Accept-Encoding: gzip, deflate, br
name_header: header_value
host: run.mocky.io
user-agent: ballerina
connection: keep-alive
content-length: 126  

--hello
content-type: application/octet-stream
content-disposition: form-data;name="test"
content-id: 0

man
--hello--
```
