### PR TITLE
Revert "Allow access field annotations in tuple type descriptors without a type definition at the package level"

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureGenerator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureGenerator.java
@@ -176,7 +176,6 @@ import org.wso2.ballerinalang.compiler.tree.types.BLangValueType;
 import org.wso2.ballerinalang.compiler.util.ClosureVarSymbol;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Name;
-import org.wso2.ballerinalang.compiler.util.Names;
 import org.wso2.ballerinalang.util.Flags;
 
 import java.util.ArrayList;
@@ -198,7 +197,7 @@ import static org.ballerinalang.model.symbols.SymbolOrigin.VIRTUAL;
 public class ClosureGenerator extends BLangNodeVisitor {
     private static final CompilerContext.Key<ClosureGenerator> CLOSURE_GENERATOR_KEY = new CompilerContext.Key<>();
     private Queue<BLangSimpleVariableDef> queue;
-    private Queue<BLangSimpleVariableDef> annotationClosureReferences;
+    private List<BLangSimpleVariableDef> annotationClosureReferences;
     private SymbolTable symTable;
     private SymbolEnv env;
     private BLangNode result;
@@ -218,7 +217,7 @@ public class ClosureGenerator extends BLangNodeVisitor {
         context.put(CLOSURE_GENERATOR_KEY, this);
         this.symTable = SymbolTable.getInstance(context);
         this.queue = new LinkedList<>();
-        this.annotationClosureReferences = new LinkedList<>();
+        this.annotationClosureReferences = new ArrayList<>();
         this.symResolver = SymbolResolver.getInstance(context);
         this.annotationDesugar = AnnotationDesugar.getInstance(context);
     }
@@ -241,7 +240,7 @@ public class ClosureGenerator extends BLangNodeVisitor {
         pkgNode.annotations.forEach(annotation -> rewrite(annotation, pkgEnv));
         pkgNode.initFunction = rewrite(pkgNode.initFunction, pkgEnv);
         pkgNode.classDefinitions = rewrite(pkgNode.classDefinitions, pkgEnv);
-        rewrite(pkgNode.globalVars, pkgEnv);
+        pkgNode.globalVars.forEach(globalVar -> rewrite(globalVar, pkgEnv));
         addClosuresToGlobalVariableList(pkgEnv);
         for (int i = 0; i < pkgNode.functions.size(); i++) {
             BLangFunction bLangFunction = pkgNode.functions.get(i);
@@ -411,7 +410,7 @@ public class ClosureGenerator extends BLangNodeVisitor {
 
     private void desugarFieldAnnotations(BSymbol owner, BTypeSymbol typeSymbol, List<BLangSimpleVariable> fields,
                                          Location pos) {
-        if (owner.getKind() != SymbolKind.PACKAGE || typeSymbol.name == Names.EMPTY) {
+        if (owner.getKind() != SymbolKind.PACKAGE) {
             owner = getOwner(env);
             BLangLambdaFunction lambdaFunction = annotationDesugar.defineFieldAnnotations(fields, pos, env.enclPkg, env,
                                                                                           typeSymbol.pkgID, owner);
@@ -1599,18 +1598,9 @@ public class ClosureGenerator extends BLangNodeVisitor {
     }
 
     private <E extends BLangNode> List<E> rewrite(List<E> nodeList, SymbolEnv env) {
-        Queue<BLangSimpleVariableDef> previousQueue = this.annotationClosureReferences;
-        this.annotationClosureReferences = new LinkedList<>();
-        int size = nodeList.size();
-        for (int i = 0; i < size; i++) {
-            E node = rewrite(nodeList.remove(0), env);
-            Iterator<BLangSimpleVariableDef> iterator = annotationClosureReferences.iterator();
-            while (iterator.hasNext()) {
-                nodeList.add(rewrite((E) annotationClosureReferences.poll().var, env));
-            }
-            nodeList.add(node);
+        for (int i = 0; i < nodeList.size(); i++) {
+            nodeList.set(i, rewrite(nodeList.get(i), env));
         }
-        this.annotationClosureReferences = previousQueue;
         return nodeList;
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/annotations/LocalTupleAnnotationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/annotations/LocalTupleAnnotationTest.java
@@ -32,16 +32,16 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 /**
- * Class to test annotation evaluation within anonymous tuple types.
+ * Class to test annotation evaluation within local tuple types.
  *
  * @since 2201.4.0
  */
-public class AnonymousTupleAnnotationTest {
+public class LocalTupleAnnotationTest {
     private CompileResult result;
 
     @BeforeClass
     public void setup() {
-        result = BCompileUtil.compile("test-src/annotations/anonymous_tuple_annotation_test.bal");
+        result = BCompileUtil.compile("test-src/annotations/local_tuple_annotation_test.bal");
         Assert.assertEquals(result.getErrorCount(), 0);
     }
 
@@ -85,7 +85,7 @@ public class AnonymousTupleAnnotationTest {
         };
     }
 
-    public static BMap getAnonymousTupleAnnotations(TypedescValue typedescValue, BString annotName) {
+    public static BMap getLocalTupleAnnotations(TypedescValue typedescValue, BString annotName) {
         return (BMap) TypeChecker.getAnnotValue(typedescValue, annotName);
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/annotations/local_tuple_annotation_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/annotations/local_tuple_annotation_test.bal
@@ -29,67 +29,42 @@ annotation AnnotTupleOne annotOne on type, field;
 annotation AnnotTupleOne annotTwo on type, field;
 annotation Details details on field;
 
-[@annotOne {value: "10"} int, @annotOne {value: "k"} int, string...] g1 =  [1, 2, "hello", "world"];
-
 function testAnnotationOnTupleFields() {
     string k = "chiranS";
     [@annotOne {value: "10"} int, @annotOne {value: k} int, string...] x1 =  [1, 2, "hello", "world"];
-    map<any> m1 = getAnonymousTupleAnnotations(typeof x1, "$field$.0");
-    map<any> m2 = getAnonymousTupleAnnotations(typeof x1, "$field$.1");
-    map<any> m3 = getAnonymousTupleAnnotations(typeof g1, "$field$.0");
-    map<any> m4 = getAnonymousTupleAnnotations(typeof g1, "$field$.1");
+    map<any> m1 = getLocalTupleAnnotations(typeof x1, "$field$.0");
+    map<any> m2 = getLocalTupleAnnotations(typeof x1, "$field$.1");
     assertEquality({value: "10"}, <map<anydata>>m1["annotOne"]);
     assertEquality({value: "chiranS"}, <map<anydata>>m2["annotOne"]);
-    assertEquality({value: "10"}, <map<anydata>>m3["annotOne"]);
-    assertEquality({value: "k"}, <map<anydata>>m4["annotOne"]);
 }
-
-string gVar0 = "foo";
-
-// This test evaluates the reordering of global variables
-[@details {name: gVar0, age: gVar4} int, @details {name: "name", age: 0} int, string...] g4 =  [1, 2, "hello", "world"];
 
 function testAnnotationOnTupleFields2() {
     string name = "chiranS";
     int age = 26;
     [@details {name: name, age: age} int, @details {name: "name", age: 0} int, string...] x1 =  [1, 2, "hello", "world"];
-    map<any> m1 = getAnonymousTupleAnnotations(typeof x1, "$field$.0");
-    map<any> m2 = getAnonymousTupleAnnotations(typeof x1, "$field$.1");
-    map<any> m3 = getAnonymousTupleAnnotations(typeof g4, "$field$.0");
-    map<any> m4 = getAnonymousTupleAnnotations(typeof g4, "$field$.1");
+    map<any> m1 = getLocalTupleAnnotations(typeof x1, "$field$.0");
+    map<any> m2 = getLocalTupleAnnotations(typeof x1, "$field$.1");
     assertEquality({name: "chiranS", age: 26},  <map<anydata>>m1["details"]);
     assertEquality({name: "name", age: 0},  <map<anydata>>m2["details"]);
-    assertEquality({name: "foo", age: 15},  <map<anydata>>m3["details"]);
-    assertEquality({name: "name", age: 0},  <map<anydata>>m4["details"]);
 }
 
 string gVar = "foo";
 string gVar1 = "bar";
-[@annotOne {value: gVar} int, int, string...] g2 =  [1, 2, "hello", "world"];
 
 function testAnnotationOnTupleWithGlobalVariable() {
     [@annotOne {value: gVar} int, int, string...] x1 =  [1, 2, "hello", "world"];
-    map<any> m1 = getAnonymousTupleAnnotations(typeof x1, "$field$.0");
-    map<any> m2 = getAnonymousTupleAnnotations(typeof g2, "$field$.0");
-    assertEquality({value: "foo"}, <map<anydata>>m1["annotOne"]);
-    assertEquality({value: "foo"}, <map<anydata>>m2["annotOne"]);
+    map<any> m = getLocalTupleAnnotations(typeof x1, "$field$.0");
+    assertEquality({value: "foo"}, <map<anydata>>m["annotOne"]);
 }
-
-[@annotOne {value: "foo"} @annotTwo {value: "bar"} int, @details {name: gVar2, age: 0} int, string...] g3 =  [1, 2, "hello", "world"];
 
 function testMultipleAnnotationsOnLocalTuple() {
     string k = "chiranS";
     [@annotOne {value: "foo"} @annotTwo {value: "bar"} int, @details {name: k, age: 0} int, string...] x1 =  [1, 2, "hello", "world"];
-    map<any> m1 = getAnonymousTupleAnnotations(typeof x1, "$field$.0");
-    map<any> m2 = getAnonymousTupleAnnotations(typeof x1, "$field$.1");
-    map<any> m3 = getAnonymousTupleAnnotations(typeof g3, "$field$.0");
-    map<any> m4 = getAnonymousTupleAnnotations(typeof g3, "$field$.1");
+    map<any> m1 = getLocalTupleAnnotations(typeof x1, "$field$.0");
+    map<any> m2 = getLocalTupleAnnotations(typeof x1, "$field$.1");
     assertEquality({value: "foo"}, <map<anydata>>m1["annotOne"]);
     assertEquality({value: "bar"}, <map<anydata>>m1["annotTwo"]);
     assertEquality({name: "chiranS", age: 0},  <map<anydata>>m2["details"]);
-    assertEquality({value: "foo"}, <map<anydata>>m3["annotOne"]);
-    assertEquality({value: "bar"}, <map<anydata>>m3["annotTwo"]);
-    assertEquality({name: "baz", age: 0},  <map<anydata>>m4["details"]);
 }
 
 function() returns [int] x = function() returns [@annotOne {value: "foo"} int] {return [1];};
@@ -97,10 +72,10 @@ function() returns [int] x2 = function() returns [@annotOne {value: gVar1} @anno
 function() returns [int, int] x3 = function() returns [@annotOne {value: gVar1} int, @details {name: "name", age: gVar3} int] {return [1, 1];};
 
 function testGlobalAnnotationsOnFunctionPointerReturnType() {
-    map<any> m1 = getAnonymousTupleAnnotations(typeof x(), "$field$.0");
-    map<any> m2 = getAnonymousTupleAnnotations(typeof x2(), "$field$.0");
-    map<any> m3 = getAnonymousTupleAnnotations(typeof x3(), "$field$.0");
-    map<any> m4 = getAnonymousTupleAnnotations(typeof x3(), "$field$.1");
+    map<any> m1 = getLocalTupleAnnotations(typeof x(), "$field$.0");
+    map<any> m2 = getLocalTupleAnnotations(typeof x2(), "$field$.0");
+    map<any> m3 = getLocalTupleAnnotations(typeof x3(), "$field$.0");
+    map<any> m4 = getLocalTupleAnnotations(typeof x3(), "$field$.1");
     assertEquality({value: "foo"}, <map<anydata>>m1["annotOne"]);
     assertEquality({value: "bar"}, <map<anydata>>m2["annotOne"]);
     assertEquality({value: "baz"}, <map<anydata>>m2["annotTwo"]);
@@ -132,10 +107,10 @@ function func2() returns [@details {name: "name", age: gVar4} int, @annotTwo {va
 }
 
 function testGlobalAnnotationsOnFunctionReturnType() {
-    map<any> m1 = getAnonymousTupleAnnotations(typeof func(), "$field$.0");
-    map<any> m2 = getAnonymousTupleAnnotations(typeof func1(), "$field$.0");
-    map<any> m3 = getAnonymousTupleAnnotations(typeof func2(), "$field$.0");
-    map<any> m4 = getAnonymousTupleAnnotations(typeof func2(), "$field$.1");
+    map<any> m1 = getLocalTupleAnnotations(typeof func(), "$field$.0");
+    map<any> m2 = getLocalTupleAnnotations(typeof func1(), "$field$.0");
+    map<any> m3 = getLocalTupleAnnotations(typeof func2(), "$field$.0");
+    map<any> m4 = getLocalTupleAnnotations(typeof func2(), "$field$.1");
     assertEquality({value: "foo"}, <map<anydata>>m1["annotOne"]);
     assertEquality({value: "foo"}, <map<anydata>>m2["annotOne"]);
     assertEquality({value: "baz"}, <map<anydata>>m2["annotTwo"]);
@@ -148,13 +123,13 @@ function testGlobalAnnotationsOnFunctionReturnType() {
 int gVar4 = 15;
 
 function func3([@annotOne {value: "foo"} int] a) {
-    map<any> m1 = getAnonymousTupleAnnotations(typeof a, "$field$.0");
+    map<any> m1 = getLocalTupleAnnotations(typeof a, "$field$.0");
     assertEquality({value: "foo"}, <map<anydata>>m1["annotOne"]);
 }
 
 function func4([@annotOne {value: "foo"} int, @annotTwo {value: "foo"} @details {name: "name", age: gVar4} int] a) {
-    map<any> m1 = getAnonymousTupleAnnotations(typeof a, "$field$.0");
-    map<any> m2 = getAnonymousTupleAnnotations(typeof a, "$field$.1");
+    map<any> m1 = getLocalTupleAnnotations(typeof a, "$field$.0");
+    map<any> m2 = getLocalTupleAnnotations(typeof a, "$field$.1");
 
     assertEquality({value: "foo"}, <map<anydata>>m1["annotOne"]);
     assertEquality({value: "foo"}, <map<anydata>>m2["annotTwo"]);
@@ -166,10 +141,10 @@ function testGlobalAnnotationsOnFunctionParameterType() {
     func4([10, 10]);
 }
 
-function getAnonymousTupleAnnotations(typedesc<any> obj, string annotName) returns map<any> =
+function getLocalTupleAnnotations(typedesc<any> obj, string annotName) returns map<any> =
 @java:Method {
-    'class: "org/ballerinalang/test/annotations/AnonymousTupleAnnotationTest",
-    name: "getAnonymousTupleAnnotations"
+    'class: "org/ballerinalang/test/annotations/LocalTupleAnnotationTest",
+    name: "getLocalTupleAnnotations"
 } external;
 
 function assertEquality(anydata expected, anydata  actual) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/annotations/annotation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/annotations/annotation.bal
@@ -37,14 +37,10 @@ function testAnnotOnRecordFields() {
 }
 
 function testAnnotOnTupleFields() {
-    map<any> m = getAnonymousTupleAnnotations(typeof foo:testAnnotationsOnLocalTupleFields(), "$field$.0");
+    map<any> m = getLocalTupleAnnotations(typeof foo:testAnnotationsOnLocalTupleFields(), "$field$.0");
     assertEquality({value : "10"} , <map<anydata>>m["testorg/foo:1:annotOne"]);
-    m = getAnonymousTupleAnnotations(typeof foo:testTupleFieldAnnotationsOnReturnType(), "$field$.0");
+    m = getLocalTupleAnnotations(typeof foo:testTupleFieldAnnotationsOnReturnType(), "$field$.0");
     assertEquality({value : "100"} , <map<anydata>>m["testorg/foo:1:annotOne"]);
-    m = getAnonymousTupleAnnotations(typeof foo:g1, "$field$.0");
-    assertEquality({value : "chiranS"} , <map<anydata>>m["testorg/foo:1:annotOne"]);
-    m = getAnonymousTupleAnnotations(typeof foo:g1, "$field$.1");
-    assertEquality({value : "k"} , <map<anydata>>m["testorg/foo:1:annotOne"]);
 }
 
 function getLocalRecordAnnotations(typedesc<any> obj, string annotName) returns map<any> =
@@ -53,10 +49,10 @@ function getLocalRecordAnnotations(typedesc<any> obj, string annotName) returns 
     name: "getLocalRecordAnnotations"
 } external;
 
-function getAnonymousTupleAnnotations(typedesc<any> obj, string annotName) returns map<any> =
+function getLocalTupleAnnotations(typedesc<any> obj, string annotName) returns map<any> =
 @java:Method {
-    'class: "org/ballerinalang/test/annotations/AnonymousTupleAnnotationTest",
-    name: "getAnonymousTupleAnnotations"
+    'class: "org/ballerinalang/test/annotations/LocalTupleAnnotationTest",
+    name: "getLocalTupleAnnotations"
 } external;
 
 function assertEquality(anydata expected, anydata actual) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/test_project/annotations.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/test_project/annotations.bal
@@ -45,7 +45,3 @@ public function testAnnotationsOnLocalTupleFields() returns [@annotOne {value: "
     [@annotOne {value: "10"} string] r = [""];
     return r;
 }
-
-public string gVar = "chiranS";
-
-public [@annotOne {value: gVar} int, @annotOne {value: "k"} int, string...] g1 =  [1, 2, "hello", "world"];


### PR DESCRIPTION
Reverts ballerina-platform/ballerina-lang#39568