### PR TITLE
Fix passing tables with byte array to an union type parameter 

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -860,8 +860,9 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                 }
             }
         }
-
-        if (Types.getReferredType(literalExpr.getBType()).tag == TypeTags.BYTE_ARRAY) {
+        BType referedType = Types.getReferredType(literalExpr.getBType());
+        if (referedType.tag == TypeTags.BYTE_ARRAY ||
+                (referedType.tag == TypeTags.ARRAY && ((BArrayType) referedType).eType.tag == TypeTags.BYTE)) {
             // check whether this is a byte array
             byte[] byteArray = types.convertToByteArray((String) literalExpr.value);
             literalType = new BArrayType(symTable.byteType, null, byteArray.length,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -861,8 +861,12 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
             }
         }
         BType referedType = Types.getReferredType(literalExpr.getBType());
-        if (referedType.tag == TypeTags.BYTE_ARRAY ||
-                (referedType.tag == TypeTags.ARRAY && ((BArrayType) referedType).eType.tag == TypeTags.BYTE)) {
+
+        if (referedType.tag == TypeTags.ARRAY && ((BArrayType) referedType).eType.tag == TypeTags.BYTE) {
+            return referedType;
+        }
+
+        if (referedType.tag == TypeTags.BYTE_ARRAY) {
             // check whether this is a byte array
             byte[] byteArray = types.convertToByteArray((String) literalExpr.value);
             literalType = new BArrayType(symTable.byteType, null, byteArray.length,

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayTest.java
@@ -240,8 +240,8 @@ public class ArrayTest {
     }
 
     @Test
-    public void testPrintByteArrayInTable() {
-        BRunUtil.invoke(compileResult, "testPrintByteArrayInTable");
+    public void testPrintableByteArrayInTable() {
+        BRunUtil.invoke(compileResult, "testPrintableByteArrayInTable");
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayTest.java
@@ -240,8 +240,8 @@ public class ArrayTest {
     }
 
     @Test
-    public void testPrintableByteArrayInTable() {
-        BRunUtil.invoke(compileResult, "testPrintableByteArrayInTable");
+    public void testTableWithByteArrayArgForUnionParam() {
+        BRunUtil.invoke(compileResult, "testTableWithByteArrayArgForUnionParam");
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayTest.java
@@ -239,6 +239,11 @@ public class ArrayTest {
         Assert.assertEquals(compileResultNegative.getErrorCount(), index);
     }
 
+    @Test
+    public void testPrintByteArrayInTable() {
+        BRunUtil.invoke(compileResult, "testPrintByteArrayInTable");
+    }
+
     @AfterClass
     public void tearDown() {
         compileResult = null;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array-test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array-test.bal
@@ -15,6 +15,7 @@
 // under the License.
 
 import ballerina/test;
+import ballerina/io;
 
 function testVarArgsArray() {
     validateVarArgs("val0", "val1", "val2");
@@ -254,6 +255,11 @@ function testArrayTupleType() {
     [string[2],int,float[3][4]][][] arr = [];
     typedesc<any> t = typeof arr;
     test:assertEquals("typedesc [string[2],int,float[3][4]][][]", t.toString());
+}
+
+function testPrintByteArrayInTable() {
+    io:println(table [{ id:1, byteArray: base16 `abcd`}]);
+    io:println(table [{ id:1, byteArray: base64 `Cake`}]);
 }
 
 function testUpdatingJsonTupleViaArrayTypedVar() {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array-test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array-test.bal
@@ -15,7 +15,7 @@
 // under the License.
 
 import ballerina/test;
-import ballerina/io;
+import ballerinai/io;
 
 function testVarArgsArray() {
     validateVarArgs("val0", "val1", "val2");

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array-test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array-test.bal
@@ -15,7 +15,6 @@
 // under the License.
 
 import ballerina/test;
-import ballerinai/io;
 
 function testVarArgsArray() {
     validateVarArgs("val0", "val1", "val2");
@@ -257,10 +256,21 @@ function testArrayTupleType() {
     test:assertEquals("typedesc [string[2],int,float[3][4]][][]", t.toString());
 }
 
-function testPrintByteArrayInTable() {
-    io:println(table [{ id:1, byteArray: base16 `abcd`}]);
-    io:println(table [{ id:1, byteArray: base64 `Cake`}]);
+function testPrintableByteArrayInTable() {
+    testPrintable(table [{ id:1, byteArray: base16 `abcd`}]);
+    testPrintable(table [{ id:1, byteArray: base64 `Cake`}]);
 }
+
+function testPrintable(Printable p) {
+    test:assertTrue(p is Printable);
+}
+
+public type Printable any|error|PrintableRawTemplate;
+
+public type PrintableRawTemplate object {
+    public string[] & readonly strings;
+    public Printable[] insertions;
+};
 
 function testUpdatingJsonTupleViaArrayTypedVar() {
     [json...] a = [];

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array-test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array-test.bal
@@ -256,7 +256,7 @@ function testArrayTupleType() {
     test:assertEquals("typedesc [string[2],int,float[3][4]][][]", t.toString());
 }
 
-function testPrintableByteArrayInTable() {
+function testTableWithByteArrayArgForUnionParam() {
     testPrintable(table [{ id:1, byteArray: base16 `abcd`}]);
     testPrintable(table [{ id:1, byteArray: base64 `Cake`}]);
 }


### PR DESCRIPTION
## Purpose
> Fix using `println` with byte array literals in tables

Fixes #39242 

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
