### PR TITLE
Fix runtime error when there is an empty character class in regexp

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ASTBuilderUtil.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ASTBuilderUtil.java
@@ -71,7 +71,6 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangListConstructorExpr
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangLiteral;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangMatchGuard;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangNamedArgsExpression;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangReCharSet;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangReFlagExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangReFlagsOnOff;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangReQuantifier;
@@ -1026,16 +1025,11 @@ public class ASTBuilderUtil {
     static BLangReQuantifier createEmptyQuantifier(Location pos, BType exprType, BType valueType) {
         BLangReQuantifier quantifier = (BLangReQuantifier) TreeBuilder.createReQuantifierNode();
         quantifier.quantifier = ASTBuilderUtil.createLiteral(pos, valueType, "");
+        quantifier.nonGreedyChar = ASTBuilderUtil.createLiteral(pos, valueType, "");
         quantifier.setBType(exprType);
         return quantifier;
     }
-
-    static BLangReCharSet createEmptyCharSet(BType exprType) {
-        BLangReCharSet charSet = (BLangReCharSet) TreeBuilder.createReCharSetNode();
-        charSet.setBType(exprType);
-        return charSet;
-    }
-
+    
     static BLangReFlagExpression createEmptyFlagExpression(Location pos, BType exprType, BType valueType) {
         BLangReFlagExpression flagExpr = (BLangReFlagExpression) TreeBuilder.createReFlagExpressionNode();
         flagExpr.questionMark = ASTBuilderUtil.createLiteral(pos, valueType, "");

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -322,6 +322,7 @@ import java.util.Set;
 import java.util.Stack;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
+
 import javax.xml.XMLConstants;
 
 import static io.ballerina.runtime.api.constants.RuntimeConstants.UNDERSCORE;
@@ -8589,7 +8590,7 @@ public class Desugar extends BLangNodeVisitor {
                 && reSequence.termList.get(0).getKind() == NodeKind.REG_EXP_ATOM_QUANTIFIER) {
             BLangReAtomQuantifier reAtomQuantifier = ((BLangReAtomQuantifier) reSequence.termList.get(0));
             if (reAtomQuantifier.atom.getKind() == NodeKind.REG_EXP_CHARACTER_CLASS 
-                    && ((BLangReCharacterClass)((BLangReCharacterClass) reAtomQuantifier.atom)).charSet == null) {
+                    && ((BLangReCharacterClass) ((BLangReCharacterClass) reAtomQuantifier.atom)).charSet == null) {
                     desugared = true;
                     reAtomQuantifier.atom = createLiteral(
                             reAtomQuantifier.pos, symTable.stringType, RE_CAPTURING_GROUP_PATTERN);

--- a/langlib/langlib-test/src/test/resources/test-src/regexp_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/regexp_test.bal
@@ -209,6 +209,26 @@ function testFindAll() {
     assertEquality(16, resultSpan1_5.startIndex);
     assertEquality(19, resultSpan1_5.endIndex);
     assertEquality("GFG", resultSpan1_5.substring());
+    
+    string str2 = "ABCD";
+    var regExp2 = re `[]`;
+    regexp:Span[]? res2 = regExp2.findAll(str2);
+    assertTrue(res2 is regexp:Span[]);
+    regexp:Span[] resultSpanArr2 = <regexp:Span[]> res2;
+    assertEquality(5, resultSpanArr2.length());
+    
+    string str3 = "ABBAABB";
+    var regExp3 = re `AB[]`;
+    regexp:Span[]? res3 = regExp3.findAll(str3);
+    assertTrue(res3 is regexp:Span[]);
+    regexp:Span[] resultSpanArr3 = <regexp:Span[]> res3;
+    assertEquality(2, resultSpanArr3.length());
+    
+    var regExp4 = re `AB[]B`;
+    regexp:Span[]? res4 = regExp4.findAll(str3);
+    assertTrue(res4 is regexp:Span[]);
+    regexp:Span[] resultSpanArr4 = <regexp:Span[]> res4;
+    assertEquality(2, resultSpanArr4.length());
 }
 
 function testFindAllGroups() {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/regexp/regexp_value_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/regexp/regexp_value_test.bal
@@ -81,6 +81,12 @@ function testRegExpValueWithCharacterClass() {
 
     string:RegExp x7 = re `[\p{sc=Latin}\p{gc=Lu}\p{Lt}\tA\)]??`;
     assertEquality("[\\p{sc=Latin}\\p{gc=Lu}\\p{Lt}\\tA\\)]??", x7.toString());
+    
+    string:RegExp x8 = re `[]`;
+    assertEquality("(?:)", x8.toString());
+    
+    string:RegExp x9 = re `AB[]`;
+    assertEquality("AB", x9.toString());
 }
 
 function testRegExpValueWithCharacterClass2() {
@@ -221,7 +227,7 @@ function testRegExpValueWithCapturingGroups5() {
     assertEquality("(?i:a|b)", x7.toString());
 
     string:RegExp x8 = re `(?im:a|b|[])`;
-    assertEquality("(?im:a|b|[])", x8.toString());
+    assertEquality("(?im:a|b|(?:))", x8.toString());
 
     string:RegExp x9 = re `(?i-m:[0-9])`;
     assertEquality("(?i-m:[0-9])", x9.toString());
@@ -358,7 +364,7 @@ function testComplexRegExpValue2() {
     assertEquality("$[^a-b\\tx-z]+(?i:ab^c[d-f]){12,}", x2.toString());
 
     string:RegExp x3 = re `(x|y)|z|[cde-j]*|(?ms:[^])`;
-    assertEquality("(x|y)|z|[cde-j]*|(?ms:[^])", x3.toString());
+    assertEquality("(x|y)|z|[cde-j]*|(?ms:(?:))", x3.toString());
 
     string:RegExp x4 = re `[^ab-cdk-l]*${val}+|(?:pqr{1,}[a=cdegf\s-\Seg-ijk-])`;
     assertEquality("[^ab-cdk-l]*10+|(?:pqr{1,}[a=cdegf\\s-\\Seg-ijk-])", x4.toString());


### PR DESCRIPTION
## Purpose
$subject

Fixes #39489 

## Approach
There were two cases to consider when we try to solve this issue.
1. Empty character is being at the ReDisjunction
```
re `[]`, re `abc|[]`
```
In this case I replaced the `[]` with a `(?:)` in the Desugar.

2. Empty character is not being a ReDisjunction
```
re `abc[]`
```
In this case I replaced the `[]` with an empty string literal. 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
