### PR TITLE
Fix `never` type included record fields shown in signature help

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
@@ -142,8 +142,9 @@ public class SignatureHelpUtil {
             }
         }
 
-        // Search function invocation symbol
-        List<SignatureInformation> signatures = new ArrayList<>(SignatureHelpUtil.getSignatureInformation(context));
+        // Get signature information
+        List<SignatureInformation> signatureInformation = SignatureHelpUtil.getSignatureInformation(context);
+        List<SignatureInformation> signatures = new ArrayList<>(signatureInformation);
         SignatureHelp signatureHelp = new SignatureHelp();
         signatureHelp.setActiveParameter(activeParamIndex);
         signatureHelp.setActiveSignature(0);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureInfoModelBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureInfoModelBuilder.java
@@ -60,7 +60,7 @@ public class SignatureInfoModelBuilder {
     private final SignatureContext context;
     private final List<ParameterInfoModel> parameterModels;
 
-    private ParameterInfoModel firstIncludedRecordParam;
+    private List<ParameterInfoModel> includedRecordParams;
     private Either<String, MarkupContent> signatureDescription;
     private final Map<String, String> paramsMap = new HashMap<>();
 
@@ -89,7 +89,7 @@ public class SignatureInfoModelBuilder {
         for (int i = 0; i < parameterModels.size(); i++) {
             ParameterInfoModel paramModel = parameterModels.get(i);
             int labelOffset = defaultLabelBuilder.toString().length();
-            if (firstIncludedRecordParam().isPresent() && firstIncludedRecordParam().get().equals(paramModel)) {
+            if (!includedRecordParams.isEmpty() && includedRecordParams.get(0).equals(paramModel)) {
                 expandedModelPrefix.append(defaultLabelBuilder.toString());
             }
             String parameterType = paramModel.getParameter().getType();
@@ -112,34 +112,48 @@ public class SignatureInfoModelBuilder {
             paramInfo.setLabel(Tuple.two(paramStart, paramEnd));
 
             defaultSignatureParamInfo.add(paramInfo);
-            if (firstIncludedRecordParam().isPresent() && !paramModel.isIncludedRecordParam()) {
+            if (!includedRecordParams.isEmpty() && !paramModel.isIncludedRecordParam()) {
                 expandedSignatureParamInfo.add(paramInfo);
             }
         }
 
-        if (firstIncludedRecordParam().isPresent()) {
-            int firstIncludedRecordParamIndex = this.parameterModels.indexOf(firstIncludedRecordParam().get());
-            List<ParameterInfoModel> includedRecordParams = this.parameterModels.stream()
-                    .filter(ParameterInfoModel::isIncludedRecordParam)
-                    .collect(Collectors.toList());
+        if (!includedRecordParams.isEmpty()) {
+            int firstIncludedRecordParamIndex = this.parameterModels.indexOf(includedRecordParams.get(0));
 
-            StringBuilder expandedLabelBuilder = new StringBuilder(expandedModelPrefix.toString());
+            List<String> expandedParamList = new ArrayList<>();
+            int labelOffset = expandedModelPrefix.toString().length();
             for (int i = 0; i < includedRecordParams.size(); i++) {
-                int labelOffset = expandedLabelBuilder.toString().length();
                 ParameterInfoModel includedParamInfo = includedRecordParams.get(i);
                 TypeSymbol paramTypeSymbol = includedParamInfo.getParameter().getParameterSymbol().typeDescriptor();
                 Pair<String, List<ParameterInformation>> includedRecordParamInfo =
                         getIncludedRecordParamInfo(paramTypeSymbol, labelOffset);
-                expandedLabelBuilder.append(includedRecordParamInfo.getKey());
-
-                if (firstIncludedRecordParamIndex + i < parameterModels.size() - 1) {
-                    expandedLabelBuilder.append(", ");
+                // If the params of included record param is empty, skip it. These params can be empty if the
+                // record only has never typed fields.
+                if (includedRecordParamInfo.getValue().isEmpty()) {
+                    continue;
                 }
-
+                
+                expandedParamList.add(includedRecordParamInfo.getKey());
                 expandedSignatureParamInfo.addAll(includedRecordParamInfo.getValue());
+                
+                labelOffset += includedRecordParamInfo.getKey().length();
+
+                // If there's more parameters, we add a comma between parameter segments.
+                if (firstIncludedRecordParamIndex + i < parameterModels.size() - 1) {
+                    // Comma + a space
+                    labelOffset += 2;
+                }
             }
-            expandedLabelBuilder.append(")");
-            result.add(getSignatureInfo(expandedLabelBuilder.toString(), expandedSignatureParamInfo));
+
+            // If there are expanded params coming from included record params, we add them as a separate signature.
+            if (!expandedParamList.isEmpty()) {
+                StringBuilder expandedLabelBuilder = new StringBuilder(expandedModelPrefix.toString());
+                
+                expandedLabelBuilder
+                        .append(String.join(", ", expandedParamList))
+                        .append(")");
+                result.add(getSignatureInfo(expandedLabelBuilder.toString(), expandedSignatureParamInfo));
+            }
         }
 
         defaultLabelBuilder.append(")");
@@ -182,10 +196,9 @@ public class SignatureInfoModelBuilder {
             parameterModels.add(new ParameterInfoModel(param, desc));
         }
 
-        firstIncludedRecordParam = this.parameterModels.stream()
+        includedRecordParams = this.parameterModels.stream()
                 .filter(ParameterInfoModel::isIncludedRecordParam)
-                .findFirst()
-                .orElse(null);
+                .collect(Collectors.toList());
     }
 
     /**
@@ -245,9 +258,15 @@ public class SignatureInfoModelBuilder {
 
         for (int i = 0; i < fieldSymbols.size(); i++) {
             RecordFieldSymbol recordFieldSymbol = fieldSymbols.get(i);
+            TypeSymbol fieldType = recordFieldSymbol.typeDescriptor();
+            // Never typed fields are used to prevent those fields from being specified as a parameter.
+            // log:printInfo() is one such example. Such fields should not be included in the signature help.
+            if (fieldType.typeKind() == TypeDescKind.NEVER) {
+                continue;
+            }
             int labelOffset = startOffset + paramLabelBuilder.length();
             ParameterInformation paramInfo = new ParameterInformation();
-            String typeSignature = recordFieldSymbol.typeDescriptor().signature();
+            String typeSignature = fieldType.signature();
             Optional<String> fieldName = recordFieldSymbol.getName();
             recordFieldSymbol.typeDescriptor().signature();
             String paramDocs = parameterDocumentation
@@ -314,10 +333,6 @@ public class SignatureInfoModelBuilder {
         paramDocumentation.setValue(markupContent.toString());
 
         return paramDocumentation;
-    }
-
-    private Optional<ParameterInfoModel> firstIncludedRecordParam() {
-        return Optional.ofNullable(this.firstIncludedRecordParam);
     }
 
     private Optional<FunctionTypeSymbol> getFunctionType(Symbol symbol) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureInfoModelBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureInfoModelBuilder.java
@@ -68,6 +68,7 @@ public class SignatureInfoModelBuilder {
         this.symbol = symbol;
         this.context = context;
         this.parameterModels = new ArrayList<>();
+        this.includedRecordParams = new ArrayList<>();
         fillParamInfoModels();
     }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/signature/AbstractSignatureHelpTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/signature/AbstractSignatureHelpTest.java
@@ -76,6 +76,7 @@ public abstract class AbstractSignatureHelpTest {
             // Fix test cases replacing expected using responses
 //            JsonObject obj = new JsonObject();
 //            obj.add("position", configJsonObject.get("position"));
+//            obj.add("source", configJsonObject.get("source"));
 //            obj.add("expected", responseJson);
 //            java.nio.file.Files.write(org.ballerinalang.langserver.util.FileUtils.RES_DIR.resolve(configJsonPath),
 //                                      obj.toString().getBytes(java.nio.charset.StandardCharsets.UTF_8));

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/signature/IncludedRecordParameterTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/signature/IncludedRecordParameterTest.java
@@ -27,6 +27,7 @@ import java.io.IOException;
  * @since 2201.1.1
  */
 public class IncludedRecordParameterTest extends AbstractSignatureHelpTest {
+    
     @Test(dataProvider = "signature-help-data-provider", description = "Test Signature Help for Included record params")
     public void test(String config, String source)
             throws WorkspaceDocumentException, InterruptedException, IOException {

--- a/language-server/modules/langserver-core/src/test/resources/signature/included_record/config/config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/included_record/config/config4.json
@@ -1,0 +1,77 @@
+{
+  "position": {
+    "line": 17,
+    "character": 14
+  },
+  "source": "included_record/source2.bal",
+  "expected": {
+    "result": {
+      "signatures": [
+        {
+          "label": "printInfo(string msg, error? 'error, error:StackFrame[]? stackTrace, KeyValues keyValues)",
+          "parameters": [
+            {
+              "label": {
+                "right": {
+                  "first": 17,
+                  "second": 20
+                }
+              },
+              "documentation": {
+                "right": {
+                  "kind": "markdown",
+                  "value": "**Parameter**  \n**`string`msg**"
+                }
+              }
+            },
+            {
+              "label": {
+                "right": {
+                  "first": 29,
+                  "second": 35
+                }
+              },
+              "documentation": {
+                "right": {
+                  "kind": "markdown",
+                  "value": "**Parameter**  \n**`error?`'error**"
+                }
+              }
+            },
+            {
+              "label": {
+                "right": {
+                  "first": 57,
+                  "second": 67
+                }
+              },
+              "documentation": {
+                "right": {
+                  "kind": "markdown",
+                  "value": "**Parameter**  \n**`error:StackFrame[]?`stackTrace**"
+                }
+              }
+            },
+            {
+              "label": {
+                "right": {
+                  "first": 79,
+                  "second": 88
+                }
+              },
+              "documentation": {
+                "right": {
+                  "kind": "markdown",
+                  "value": "**Parameter**  \n**`KeyValues`keyValues**"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "activeSignature": 0,
+      "activeParameter": 0
+    },
+    "jsonrpc": "2.0"
+  }
+}

--- a/language-server/modules/langserver-core/src/test/resources/signature/included_record/source2.bal
+++ b/language-server/modules/langserver-core/src/test/resources/signature/included_record/source2.bal
@@ -1,0 +1,19 @@
+
+public type KeyValues record {|
+    never msg?;
+    never 'error?;
+    never stackTrace?;
+    Value...;
+|};
+
+public isolated function printInfo(string msg, error? 'error = (), error:StackFrame[]? stackTrace = (), *KeyValues keyValues) {
+
+}
+
+public type Value anydata|Valuer;
+
+public type Valuer isolated function () returns anydata;
+
+public function main() {
+    printInfo();
+}


### PR DESCRIPTION
## Purpose
$subject

Fixes #39525

## Approach
Updated the signature help logic to consider if the included record fields are `never` type.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
