### PR TITLE
Fix bugs in regex:replaceAll function with index parameter

### DIFF
--- a/langlib/lang.regexp/src/main/ballerina/regexp.bal
+++ b/langlib/lang.regexp/src/main/ballerina/regexp.bal
@@ -378,10 +378,6 @@ public isolated function replaceAll(RegExp re, string str, Replacement replaceme
     if findResult.length() == 0 {
         return str;
     }
-    string prefixStr = "";
-    if (startIndex != 0) {
-        prefixStr = substring(str, 0, startIndex);
-    }
     string updatedString = "";
     int index = 0;
     foreach Groups groups in findResult {
@@ -393,7 +389,7 @@ public isolated function replaceAll(RegExp re, string str, Replacement replaceme
     if index < length(str) {
         updatedString += substring(str, index, length(str));
     }
-    return prefixStr + updatedString;
+    return updatedString;
 }
 
 isolated function substring(string str, int startIndex, int endIndex = length(str)) returns string =

--- a/langlib/langlib-test/src/test/resources/test-src/regexp_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/regexp_test.bal
@@ -533,31 +533,41 @@ function testReplaceAll() {
     string str1 = "ReplaceTTTGGGThis";
     var regExpr1 = re `T.*G`;
     string replacement1 = " ";
-    string result1 = regExpr1.replaceAll(str1, replacement1);
-    assertEquality("Replace This", result1);
+    string result11 = regExpr1.replaceAll(str1, replacement1);
+    assertEquality("Replace This", result11);
+    string result12 = regExpr1.replaceAll(str1, replacement1, 2);
+    assertEquality("Replace This", result12);
 
     string str2 = "100100011";
     var regExpr2 = re `0+`;
     string replacement2 = "*";
-    string result2 = regExpr2.replaceAll(str2, replacement2);
-    assertEquality("1*1*11", result2);
+    string result21 = regExpr2.replaceAll(str2, replacement2);
+    assertEquality("1*1*11", result21);
+    string result22 = regExpr2.replaceAll(str2, replacement2, 3);
+    assertEquality("1001*11", result22);
 
     //non matching
     string str3 = "100100011";
     var regExpr3 = re `95`;
     string replacement3 = "*";
-    string result3 = regExpr3.replaceAll(str3, replacement3);
-    assertEquality(str3, result3);
+    string result31 = regExpr3.replaceAll(str3, replacement3);
+    assertEquality(str3, result31);
+    string result32 = regExpr3.replaceAll(str3, replacement3, 7);
+    assertEquality(str3, result32);
 
     string str4 = "100100011";
     var regExpr4 = re `0+`;
     string replacement4 = "";
-    string result4 = regExpr4.replaceAll(str4, replacement4);
-    assertEquality("1111", result4);
+    string result41 = regExpr4.replaceAll(str4, replacement4);
+    assertEquality("1111", result41);
+    string result42 = regExpr4.replaceAll(str4, replacement4, 3);
+    assertEquality("100111", result42);
 
     string str5 = "100000100011";
-    string result5 = regExpr4.replaceAll(str5, replacementFunctionForReplaceAll);
-    assertEquality("151311", result5);
+    string result51 = regExpr4.replaceAll(str5, replacementFunctionForReplaceAll);
+    assertEquality("151311", result51);
+    string result52 = regExpr4.replaceAll(str5, replacementFunctionForReplaceAll, 6);
+    assertEquality("1000001311", result52);
 }
 
 isolated function replacementFunctionForReplaceAll(regexp:Groups groups) returns string {


### PR DESCRIPTION
## Purpose
> Fix bugs in regex:replaceAll function with index parameter.

Fixes #39655

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
