### PR TITLE
Fix incorrectly creating a union with one member as the inferred parameter type with tuples

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
@@ -580,8 +580,9 @@ public class TypeParamAnalyzer {
         if (actualType.restType != null) {
             tupleTypes.add(actualType.restType);
         }
-        BUnionType tupleElementType = BUnionType.create(null, tupleTypes);
-        findTypeParam(loc, expType.eType, tupleElementType, env, resolvedTypes, result);
+
+        BType type = tupleTypes.size() == 1 ? tupleTypes.iterator().next() : BUnionType.create(null, tupleTypes);
+        findTypeParam(loc, expType.eType, type, env, resolvedTypes, result);
     }
 
     private void findTypeParamInUnion(Location loc, BType expType, BUnionType actualType,

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/ArrowExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/ArrowExprTest.java
@@ -42,8 +42,8 @@ public class ArrowExprTest {
     @BeforeClass
     public void setup() {
         basic = BCompileUtil.compile("test-src/expressions/lambda/arrow-expression.bal");
-        resultSemanticsNegative = BCompileUtil.compile("test-src/expressions/lambda/arrow-expression-semantics-" +
-                "negative.bal");
+        resultSemanticsNegative = BCompileUtil.compile(
+                "test-src/expressions/lambda/arrow-expression-semantics-negative.bal");
         resultNegative = BCompileUtil.compile("test-src/expressions/lambda/arrow-expression-negative.bal");
         resultTypeNarrowNegative = BCompileUtil.compile("test-src/expressions/lambda/" +
                 "arrow-expression-type-narrow-negative.bal");
@@ -204,7 +204,6 @@ public class ArrowExprTest {
     @Test(description = "Test compile time errors for arrow expression")
     public void testArrowExprSemanticsNegative() {
         int i = 0;
-        Assert.assertEquals(resultSemanticsNegative.getErrorCount(), 12);
         BAssertUtil.validateError(resultSemanticsNegative, i++,
                 "operator '/' not defined for 'string' and 'int'", 18, 54);
         BAssertUtil.validateError(resultSemanticsNegative, i++,
@@ -229,6 +228,17 @@ public class ArrowExprTest {
                 "undefined symbol 'm'", 60, 58);
         BAssertUtil.validateError(resultSemanticsNegative, i++,
                 "invalid number of parameters used in arrow expression. expected: '0' but found '1'", 68, 40);
+        BAssertUtil.validateError(resultSemanticsNegative, i++,
+                                  "operator '+' not defined for 'string' and 'int'", 78, 38);
+        BAssertUtil.validateError(resultSemanticsNegative, i++,
+                                  "operator '+' not defined for 'string' and 'int'", 81, 25);
+        BAssertUtil.validateError(resultSemanticsNegative, i++,
+                                  "operator '+' not defined for 'int' and 'string'", 84, 25);
+        BAssertUtil.validateError(resultSemanticsNegative, i++,
+                                  "operator '+' not defined for 'string' and 'int'", 87, 25);
+        BAssertUtil.validateError(resultSemanticsNegative, i++,
+                                  "operator '+' not defined for 'int' and 'string'", 90, 25);
+        Assert.assertEquals(resultSemanticsNegative.getErrorCount(), i);
     }
 
     @Test(description = "Test compile time errors for arrow expression")
@@ -260,6 +270,11 @@ public class ArrowExprTest {
     @Test(description = "Test type narrowing in arrow expression")
     public void testTypeNarrowingInArrowExpression() {
         BRunUtil.invoke(basic, "testTypeNarrowingInArrowExpression");
+    }
+
+    @Test
+    public void testExpressionBodiedFunctionWithBinaryExpr() {
+        BRunUtil.invoke(basic, "testExpressionBodiedFunctionWithBinaryExpr");
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/lambda/arrow-expression-semantics-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/lambda/arrow-expression-semantics-negative.bal
@@ -73,3 +73,19 @@ function testArrowExprWithUninitializedClosureVars() {
     int m;
     function (int) returns (int) addFunc1 = a => a + i + m ;
 }
+
+function testInvalidBinaryExprInExprFuncBody() {
+    _ = ["foo","bar","baz"].map(s => s + 1);
+
+    int[] intArr = [1, 2];
+    _ = intArr.map(i => "s" + i);
+
+    string[] strArr = [];
+    _ = strArr.map(s => 1 + s);
+
+    [int, int] intTup = [1, 2];
+    _ = intTup.map(i => "s" + i);
+
+    [string] strTup = ["str"];
+    _ = strTup.map(s => 1 + s);
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/lambda/arrow-expression.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/lambda/arrow-expression.bal
@@ -256,6 +256,27 @@ function testGlobalArrowExpressionsWithClosure() {
     assertEquality(expected, result);
 }
 
+function testExpressionBodiedFunctionWithBinaryExpr() {
+    string[] a = ["foo","bar","baz"].map(s => s + "1");
+    assertEquality(<string[]> ["foo1", "bar1", "baz1"], a);
+
+    int[] intArr = [1, 2];
+    int[]b = intArr.map(i => 10 + i);
+    assertEquality(<int[]> [11, 12], b);
+
+    string[] strArr = [];
+    string[] c = strArr.map(s => "1" + s);
+    assertEquality(<string[]> [], c);
+
+    [int, int] intTup = [100, 200];
+    int[] d = intTup.map(i => 1 + i);
+    assertEquality(<int[]> [101, 201], d);
+
+    [string] strTup = ["str"];
+    string[] e = strTup.map(s => "1" + s);
+    assertEquality(<string[]> ["1str"], e);
+}
+
 const ASSERTION_ERR_REASON = "AssertionError";
 
 function assertEquality(any|error expected, any|error actual) {


### PR DESCRIPTION
## Purpose
$title, this was causing invalid analysis elsewhere where we assume a union to have > 1 member.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/39680

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
