### PR TITLE
Fix `ClassFormatError: Truncated class file` error when mocking in multi module packages.

### DIFF
--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/BTestMain.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/BTestMain.java
@@ -197,6 +197,7 @@ public class BTestMain {
             modifiedClassDef.put(className, classFile);
         }
         classLoader = createClassLoader(jarFilePaths, modifiedClassDef);
+        clearMockFunctionMapBeforeNextModule();
     }
 
     private static void populateClassNameVsFunctionToMockMap(TestSuite suite) {
@@ -324,6 +325,10 @@ public class BTestMain {
                                                        Map<String, byte[]> modifiedClassDef) {
         return new CustomClassLoader(getURLList(jarFilePaths).toArray(new URL[0]),
                 ClassLoader.getSystemClassLoader(), modifiedClassDef);
+    }
+
+    private static void clearMockFunctionMapBeforeNextModule() {
+        classVsMockFunctionsMap.clear();
     }
 
     public static ClassLoader getClassLoader() {

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/MockTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/MockTest.java
@@ -144,6 +144,19 @@ public class MockTest extends BaseTestCase {
         Assert.assertEquals(moduleObj.get("coveragePercentage").toString(), "57.14");
     }
 
+    @Test
+    public void testFunctionMockingInMultipleModulesWithDependencies() throws BallerinaTestException {
+        String msg1 = "function_mocking_with_dependencies.a_dependency\n\t\t[pass] test1\n\n\n\t\t" +
+                "1 passing\n\t\t0 failing\n\t\t0 skipped";
+        String msg2 = "function_mocking_with_dependencies.b_dependent\n\t\t[pass] test1\n\n\n\t\t" +
+                "1 passing\n\t\t0 failing\n\t\t0 skipped";
+        String[] args = mergeCoverageArgs(new String[]{"function-mocking-tests-with-dependencies"});
+        String output = balClient.runMainAndReadStdOut("test", args, new HashMap<>(), projectPath, false);
+        if (!output.contains(msg1) || !output.contains(msg2)) {
+            Assert.fail("Test failed due to function mocking failure in test framework.\nOutput:\n" + output);
+        }
+    }
+
     @Test(dataProvider = "testNegativeCases")
     public void testObjectMocking_NegativeCases(String message, String test) throws BallerinaTestException {
         String[] args = mergeCoverageArgs(new String[]{"--tests", test});

--- a/tests/testerina-integration-test/src/test/resources/command-outputs/unix/MockTest/testFunctionMockingInMultipleModulesWithDependencies.txt
+++ b/tests/testerina-integration-test/src/test/resources/command-outputs/unix/MockTest/testFunctionMockingInMultipleModulesWithDependencies.txt
@@ -1,0 +1,23 @@
+Compiling source
+	intg_tests/function_mocking_with_dependencies:0.0.0
+
+Running Tests with Coverage
+
+	function_mocking_with_dependencies.a_dependency
+		[pass] test1
+
+
+		1 passing
+		0 failing
+		0 skipped
+
+	function_mocking_with_dependencies.b_dependent
+		[pass] test1
+
+
+		1 passing
+		0 failing
+		0 skipped
+
+Generating Test Report
+	function-mocking-tests-with-dependencies/target/report/test_results.json

--- a/tests/testerina-integration-test/src/test/resources/command-outputs/windows/MockTest.testFunctionMockingInMultipleModulesWithDependencies
+++ b/tests/testerina-integration-test/src/test/resources/command-outputs/windows/MockTest.testFunctionMockingInMultipleModulesWithDependencies
@@ -1,0 +1,23 @@
+Compiling source
+	intg_tests\function_mocking_with_dependencies:0.0.0
+
+Running Tests with Coverage
+
+	function_mocking_with_dependencies.a_dependency
+		[pass] test1
+
+
+		1 passing
+		0 failing
+		0 skipped
+
+	function_mocking_with_dependencies.b_dependent
+		[pass] test1
+
+
+		1 passing
+		0 failing
+		0 skipped
+
+Generating Test Report
+	function-mocking-tests-with-dependencies/target/report/test_results.json

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/function-mocking-tests-with-dependencies/Ballerina.toml
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/function-mocking-tests-with-dependencies/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "intg_tests"
+name = "function_mocking_with_dependencies"
+version = "0.0.0"

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/function-mocking-tests-with-dependencies/main.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/function-mocking-tests-with-dependencies/main.bal
@@ -1,0 +1,15 @@
+// Copyright (c) 2023 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/function-mocking-tests-with-dependencies/modules/a_dependency/main.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/function-mocking-tests-with-dependencies/modules/a_dependency/main.bal
@@ -1,0 +1,29 @@
+// Copyright (c) 2023 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// uncomment after fixing the lang issue #39682
+// var a = dependencyFunction1();
+var b = dependencyFunction2();
+
+function dependencyFunction1() returns string {
+    return "Hello from dependency function 1";
+}
+
+function dependencyFunction2() returns string {
+    return "Hello from dependency function 2";
+}
+
+public int rand_var = 5;

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/function-mocking-tests-with-dependencies/modules/a_dependency/tests/dependency_test.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/function-mocking-tests-with-dependencies/modules/a_dependency/tests/dependency_test.bal
@@ -1,0 +1,40 @@
+// Copyright (c) 2023 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+
+@test:Mock {
+    functionName: "dependencyFunction1"
+}
+test:MockFunction mockFn = new();
+
+function mockDependencyFunction1() returns string {
+    return "Hello from dependency mocking function 1";
+}
+
+@test:Mock {
+    functionName: "dependencyFunction2"
+}
+function mockDependencyFunction2Legacy() returns string {
+    return "Hello from dependency mocking function 2";
+}
+
+@test:Config
+function test1() {
+    test:when(mockFn).call("mockDependencyFunction1");
+    test:assertEquals(dependencyFunction1(), "Hello from dependency mocking function 1");
+    test:assertEquals(dependencyFunction2(), "Hello from dependency mocking function 2");
+}

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/function-mocking-tests-with-dependencies/modules/b_dependent/main.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/function-mocking-tests-with-dependencies/modules/b_dependent/main.bal
@@ -1,0 +1,27 @@
+// Copyright (c) 2023 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import function_mocking_with_dependencies.a_dependency;
+
+int imported_var = a_dependency:rand_var;
+
+function dependentFunction1() returns string {
+    return "Hello from dependent function 1";
+}
+
+function dependentFunction2() returns string {
+    return "Hello from dependent function 2";
+}

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/function-mocking-tests-with-dependencies/modules/b_dependent/tests/dependent_test.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/function-mocking-tests-with-dependencies/modules/b_dependent/tests/dependent_test.bal
@@ -1,0 +1,40 @@
+// Copyright (c) 2023 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+
+@test:Mock {
+    functionName: "dependentFunction1"
+}
+test:MockFunction mockFn = new();
+
+function mockDependentFunction1() returns string {
+    return "Hello from dependent mocking function 1";
+}
+
+@test:Mock {
+    functionName: "dependentFunction2"
+}
+function mockDependentFunction2Legacy() returns string {
+    return "Hello from dependent mocking function 2";
+}
+
+@test:Config
+function test1() {
+    test:when(mockFn).call("mockDependentFunction1");
+    test:assertEquals(dependentFunction1(), "Hello from dependent mocking function 1");
+    test:assertEquals(dependentFunction2(), "Hello from dependent mocking function 2");
+}


### PR DESCRIPTION
## Purpose
Map `classVsMockFunctionsMap` in BTestMain keeps track of the class to mockfunction mapping. In the current implementation, we are not clearing it after running each module. So it tries to mock functions that are mocked by previous modules (and not mocked in the current module). 

As a result the modified class files becomes an empty string. This is because the function we are trying to mock is not available in the module. Hence a truncated class file error is received due to the modified class missing some of the byte code. 

Fixes https://github.com/wso2-enterprise/internal-support-ballerina/issues/266

## Approach
Clear `classVsMockFunctionsMap` after replacing the mock functions of each module. 

Note - tests/testerina-integration-test/src/test/resources/project-based-tests/function-mocking-tests-with-dependencies/modules/a_dependency/main.bal#18 needs to be uncommented to test the fix for the new mocking framework once https://github.com/ballerina-platform/ballerina-lang/issues/39682 is fixed.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
