### PR TITLE
[2201.3.x] Add Resource kind for API doc generation

### DIFF
--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
@@ -76,6 +76,7 @@ import org.ballerinalang.docgen.generator.model.DefaultableVariable;
 import org.ballerinalang.docgen.generator.model.Enum;
 import org.ballerinalang.docgen.generator.model.Error;
 import org.ballerinalang.docgen.generator.model.Function;
+import org.ballerinalang.docgen.generator.model.FunctionKind;
 import org.ballerinalang.docgen.generator.model.Listener;
 import org.ballerinalang.docgen.generator.model.Module;
 import org.ballerinalang.docgen.generator.model.Record;
@@ -501,10 +502,18 @@ public class Generator {
                                 methodNode.metadata()), false, type));
                     }
 
-                    boolean isRemote = containsToken(methodNode.qualifierList(), SyntaxKind.REMOTE_KEYWORD);
+//                    boolean isRemote = containsToken(methodNode.qualifierList(), SyntaxKind.REMOTE_KEYWORD);
+                    FunctionKind functionKind;
+                    if (containsToken(methodNode.qualifierList(), SyntaxKind.REMOTE_KEYWORD)) {
+                        functionKind = FunctionKind.REMOTE;
+                    } else if (containsToken(methodNode.qualifierList(), SyntaxKind.RESOURCE_KEYWORD)) {
+                        functionKind = FunctionKind.RESOURCE;
+                    } else {
+                        functionKind = FunctionKind.OTHER;
+                    }
 
                     objectFunctions.add(new Function(methodName, getDocFromMetadata(methodNode.metadata()),
-                            isRemote, false, isDeprecated(methodNode.metadata()),
+                            functionKind, false, isDeprecated(methodNode.metadata()),
                             containsToken(methodNode.qualifierList(), SyntaxKind.ISOLATED_KEYWORD), parameters,
                             returnParams));
                 }
@@ -542,7 +551,7 @@ public class Generator {
                         functionType.returnType.isDeprecated, functionType.returnType));
             }
 
-            Function function = new Function(functionType.name, functionType.description, functionType.isRemote,
+            Function function = new Function(functionType.name, functionType.description, functionType.functionKind,
                     functionType.isExtern, functionType.isDeprecated, functionType.isIsolated, parameters,
                     returnParameters);
             function.inclusionType = originType.isPublic ? originType : null;
@@ -574,10 +583,18 @@ public class Generator {
         }
 
         boolean isExtern = functionDefinitionNode.functionBody() instanceof ExternalFunctionBodyNode;
-        boolean isRemote = containsToken(functionDefinitionNode.qualifierList(), SyntaxKind.REMOTE_KEYWORD);
+//        boolean isRemote = containsToken(functionDefinitionNode.qualifierList(), SyntaxKind.REMOTE_KEYWORD);
+        FunctionKind functionKind;
+        if (containsToken(functionDefinitionNode.qualifierList(), SyntaxKind.REMOTE_KEYWORD)) {
+            functionKind = FunctionKind.REMOTE;
+        } else if (containsToken(functionDefinitionNode.qualifierList(), SyntaxKind.RESOURCE_KEYWORD)) {
+            functionKind = FunctionKind.RESOURCE;
+        } else {
+            functionKind = FunctionKind.OTHER;
+        }
 
         return new Function(functionName, getDocFromMetadata(functionDefinitionNode.metadata()),
-                isRemote, isExtern, isDeprecated(functionDefinitionNode.metadata()),
+                functionKind, isExtern, isDeprecated(functionDefinitionNode.metadata()),
                 containsToken(functionDefinitionNode.qualifierList(), SyntaxKind.ISOLATED_KEYWORD), parameters,
                 returnParams, annotationAttachments);
     }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
@@ -438,7 +438,8 @@ public class Generator {
         for (Node member : classDefinitionNode.members()) {
             if (member instanceof FunctionDefinitionNode && (containsToken(((FunctionDefinitionNode) member)
                     .qualifierList(), SyntaxKind.PUBLIC_KEYWORD) || containsToken(((FunctionDefinitionNode) member)
-                    .qualifierList(), SyntaxKind.REMOTE_KEYWORD))) {
+                    .qualifierList(), SyntaxKind.REMOTE_KEYWORD) || containsToken(((FunctionDefinitionNode) member)
+                    .qualifierList(), SyntaxKind.RESOURCE_KEYWORD))) {
                 classFunctions.add(getFunctionModel((FunctionDefinitionNode) member, semanticModel));
             } else if (member instanceof TypeReferenceNode) {
                 Type originType = Type.fromNode(member, semanticModel);
@@ -484,7 +485,8 @@ public class Generator {
             if (member instanceof MethodDeclarationNode) {
                 MethodDeclarationNode methodNode = (MethodDeclarationNode) member;
                 if (containsToken(methodNode.qualifierList(), SyntaxKind.PUBLIC_KEYWORD) ||
-                        containsToken(methodNode.qualifierList(), SyntaxKind.REMOTE_KEYWORD)) {
+                        containsToken(methodNode.qualifierList(), SyntaxKind.REMOTE_KEYWORD) ||
+                        containsToken(methodNode.qualifierList(), SyntaxKind.RESOURCE_KEYWORD)) {
                     String methodName = methodNode.methodName().text();
 
                     List<Variable> returnParams = new ArrayList<>();
@@ -502,7 +504,6 @@ public class Generator {
                                 methodNode.metadata()), false, type));
                     }
 
-//                    boolean isRemote = containsToken(methodNode.qualifierList(), SyntaxKind.REMOTE_KEYWORD);
                     FunctionKind functionKind;
                     if (containsToken(methodNode.qualifierList(), SyntaxKind.REMOTE_KEYWORD)) {
                         functionKind = FunctionKind.REMOTE;
@@ -583,7 +584,6 @@ public class Generator {
         }
 
         boolean isExtern = functionDefinitionNode.functionBody() instanceof ExternalFunctionBodyNode;
-//        boolean isRemote = containsToken(functionDefinitionNode.qualifierList(), SyntaxKind.REMOTE_KEYWORD);
         FunctionKind functionKind;
         if (containsToken(functionDefinitionNode.qualifierList(), SyntaxKind.REMOTE_KEYWORD)) {
             functionKind = FunctionKind.REMOTE;

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Client.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Client.java
@@ -41,19 +41,19 @@ public class Client extends BClass {
     @Override
     public List<Function> getOtherMethods(List<Function> methods) {
         return super.getOtherMethods(methods).stream()
-                .filter(function -> function.functionKind == FunctionKind.OTHER)
+                .filter(function -> !function.isRemote && !function.isResource)
                 .collect(Collectors.toList());
     }
 
     public List<Function> getRemoteMethods() {
         return this.methods.stream()
-                .filter(function -> function.functionKind == FunctionKind.REMOTE)
+                .filter(function -> function.isRemote)
                 .collect(Collectors.toList());
     }
 
     public List<Function> getResourceMethods() {
         return this.methods.stream()
-                .filter(function -> function.functionKind == FunctionKind.RESOURCE)
+                .filter(function -> function.isResource)
                 .collect(Collectors.toList());
     }
 }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Client.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Client.java
@@ -27,6 +27,8 @@ public class Client extends BClass {
 
     @Expose
     public List<Function> remoteMethods;
+    @Expose
+    public List<Function> resourceMethods;
 
     public Client(String name, String description, boolean isDeprecated, List<DefaultableVariable> fields,
             List<Function> methods, boolean isReadOnly, boolean isIsolated) {
@@ -37,14 +39,20 @@ public class Client extends BClass {
 
     @Override
     public List<Function> getOtherMethods(List<Function> methods) {
-        return super.getOtherMethods(methods).stream()
-                .filter(function -> !function.isRemote)
+        return this.methods.stream()
+                .filter(function -> function.functionKind == FunctionKind.OTHER)
                 .collect(Collectors.toList());
     }
 
     public List<Function> getRemoteMethods() {
         return this.methods.stream()
-                .filter(function -> function.isRemote)
+                .filter(function -> function.functionKind == FunctionKind.REMOTE)
+                .collect(Collectors.toList());
+    }
+
+    public List<Function> getResourceMethods() {
+        return this.methods.stream()
+                .filter(function -> function.functionKind == FunctionKind.RESOURCE)
                 .collect(Collectors.toList());
     }
 }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Client.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Client.java
@@ -34,12 +34,13 @@ public class Client extends BClass {
             List<Function> methods, boolean isReadOnly, boolean isIsolated) {
         super(name, description, isDeprecated, fields, methods, isReadOnly, isIsolated);
         this.remoteMethods = getRemoteMethods();
+        this.resourceMethods = getResourceMethods();
         this.otherMethods = getOtherMethods(methods);
     }
 
     @Override
     public List<Function> getOtherMethods(List<Function> methods) {
-        return this.methods.stream()
+        return super.getOtherMethods(methods).stream()
                 .filter(function -> function.functionKind == FunctionKind.OTHER)
                 .collect(Collectors.toList());
     }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Function.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Function.java
@@ -24,6 +24,10 @@ import java.util.List;
  */
 public class Function extends Construct {
     @Expose
+    public String accessor = "";
+    @Expose
+    public String resourcePath = "";
+    @Expose
     public boolean isIsolated;
     @Expose
     public FunctionKind functionKind;
@@ -48,9 +52,36 @@ public class Function extends Construct {
         this.annotationAttachments = annotationAttachments;
     }
 
+    public Function(String name, String accessor, String resourcePath, String description, FunctionKind functionKind,
+                    boolean isExtern, boolean isDeprecated, boolean isIsolated, List<DefaultableVariable> parameters,
+                    List<Variable> returnParameters, List<AnnotationAttachment> annotationAttachments) {
+        super(name, description, isDeprecated);
+        this.accessor = accessor;
+        this.resourcePath = resourcePath;
+        this.functionKind = functionKind;
+        this.isExtern = isExtern;
+        this.parameters = parameters;
+        this.returnParameters = returnParameters;
+        this.isIsolated = isIsolated;
+        this.annotationAttachments = annotationAttachments;
+    }
+
     public Function(String name, String description, FunctionKind functionKind, boolean isExtern, boolean isDeprecated,
                     boolean isIsolated, List<DefaultableVariable> parameters, List<Variable> returnParameters) {
         super(name, description, isDeprecated);
+        this.functionKind = functionKind;
+        this.isExtern = isExtern;
+        this.parameters = parameters;
+        this.returnParameters = returnParameters;
+        this.isIsolated = isIsolated;
+    }
+
+    public Function(String name, String accessor, String resourcePath, String description, FunctionKind functionKind,
+                    boolean isExtern, boolean isDeprecated, boolean isIsolated, List<DefaultableVariable> parameters,
+                    List<Variable> returnParameters) {
+        super(name, description, isDeprecated);
+        this.accessor = accessor;
+        this.resourcePath = resourcePath;
         this.functionKind = functionKind;
         this.isExtern = isExtern;
         this.parameters = parameters;

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Function.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Function.java
@@ -26,7 +26,7 @@ public class Function extends Construct {
     @Expose
     public boolean isIsolated;
     @Expose
-    public boolean isRemote;
+    public FunctionKind functionKind;
     @Expose
     public boolean isExtern;
     @Expose
@@ -36,11 +36,11 @@ public class Function extends Construct {
     @Expose
     List<AnnotationAttachment> annotationAttachments;
 
-    public Function(String name, String description, boolean isRemote, boolean isExtern, boolean isDeprecated,
+    public Function(String name, String description, FunctionKind functionKind, boolean isExtern, boolean isDeprecated,
                     boolean isIsolated, List<DefaultableVariable> parameters, List<Variable> returnParameters,
                     List<AnnotationAttachment> annotationAttachments) {
         super(name, description, isDeprecated);
-        this.isRemote = isRemote;
+        this.functionKind = functionKind;
         this.isExtern = isExtern;
         this.parameters = parameters;
         this.returnParameters = returnParameters;
@@ -48,10 +48,10 @@ public class Function extends Construct {
         this.annotationAttachments = annotationAttachments;
     }
 
-    public Function(String name, String description, boolean isRemote, boolean isExtern, boolean isDeprecated,
+    public Function(String name, String description, FunctionKind functionKind, boolean isExtern, boolean isDeprecated,
                     boolean isIsolated, List<DefaultableVariable> parameters, List<Variable> returnParameters) {
         super(name, description, isDeprecated);
-        this.isRemote = isRemote;
+        this.functionKind = functionKind;
         this.isExtern = isExtern;
         this.parameters = parameters;
         this.returnParameters = returnParameters;

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Function.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Function.java
@@ -30,7 +30,9 @@ public class Function extends Construct {
     @Expose
     public boolean isIsolated;
     @Expose
-    public FunctionKind functionKind;
+    public boolean isRemote;
+    @Expose
+    public boolean isResource;
     @Expose
     public boolean isExtern;
     @Expose
@@ -44,7 +46,8 @@ public class Function extends Construct {
                     boolean isIsolated, List<DefaultableVariable> parameters, List<Variable> returnParameters,
                     List<AnnotationAttachment> annotationAttachments) {
         super(name, description, isDeprecated);
-        this.functionKind = functionKind;
+        this.isRemote = isRemote(functionKind);
+        this.isResource = isResource(functionKind);
         this.isExtern = isExtern;
         this.parameters = parameters;
         this.returnParameters = returnParameters;
@@ -58,7 +61,8 @@ public class Function extends Construct {
         super(name, description, isDeprecated);
         this.accessor = accessor;
         this.resourcePath = resourcePath;
-        this.functionKind = functionKind;
+        this.isRemote = isRemote(functionKind);
+        this.isResource = isResource(functionKind);
         this.isExtern = isExtern;
         this.parameters = parameters;
         this.returnParameters = returnParameters;
@@ -69,7 +73,8 @@ public class Function extends Construct {
     public Function(String name, String description, FunctionKind functionKind, boolean isExtern, boolean isDeprecated,
                     boolean isIsolated, List<DefaultableVariable> parameters, List<Variable> returnParameters) {
         super(name, description, isDeprecated);
-        this.functionKind = functionKind;
+        this.isRemote = isRemote(functionKind);
+        this.isResource = isResource(functionKind);
         this.isExtern = isExtern;
         this.parameters = parameters;
         this.returnParameters = returnParameters;
@@ -82,10 +87,20 @@ public class Function extends Construct {
         super(name, description, isDeprecated);
         this.accessor = accessor;
         this.resourcePath = resourcePath;
-        this.functionKind = functionKind;
+        this.isRemote = isRemote(functionKind);
+        this.isResource = isResource(functionKind);
         this.isExtern = isExtern;
         this.parameters = parameters;
         this.returnParameters = returnParameters;
         this.isIsolated = isIsolated;
     }
+
+    private boolean isRemote(FunctionKind functionKind) {
+        return functionKind == FunctionKind.REMOTE;
+    }
+
+    private boolean isResource(FunctionKind functionKind) {
+        return functionKind == FunctionKind.RESOURCE;
+    }
+
 }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Function.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Function.java
@@ -46,8 +46,8 @@ public class Function extends Construct {
                     boolean isIsolated, List<DefaultableVariable> parameters, List<Variable> returnParameters,
                     List<AnnotationAttachment> annotationAttachments) {
         super(name, description, isDeprecated);
-        this.isRemote = isRemote(functionKind);
-        this.isResource = isResource(functionKind);
+        this.isRemote = checkRemote(functionKind);
+        this.isResource = checkResource(functionKind);
         this.isExtern = isExtern;
         this.parameters = parameters;
         this.returnParameters = returnParameters;
@@ -61,8 +61,8 @@ public class Function extends Construct {
         super(name, description, isDeprecated);
         this.accessor = accessor;
         this.resourcePath = resourcePath;
-        this.isRemote = isRemote(functionKind);
-        this.isResource = isResource(functionKind);
+        this.isRemote = checkRemote(functionKind);
+        this.isResource = checkResource(functionKind);
         this.isExtern = isExtern;
         this.parameters = parameters;
         this.returnParameters = returnParameters;
@@ -73,8 +73,8 @@ public class Function extends Construct {
     public Function(String name, String description, FunctionKind functionKind, boolean isExtern, boolean isDeprecated,
                     boolean isIsolated, List<DefaultableVariable> parameters, List<Variable> returnParameters) {
         super(name, description, isDeprecated);
-        this.isRemote = isRemote(functionKind);
-        this.isResource = isResource(functionKind);
+        this.isRemote = checkRemote(functionKind);
+        this.isResource = checkResource(functionKind);
         this.isExtern = isExtern;
         this.parameters = parameters;
         this.returnParameters = returnParameters;
@@ -87,19 +87,19 @@ public class Function extends Construct {
         super(name, description, isDeprecated);
         this.accessor = accessor;
         this.resourcePath = resourcePath;
-        this.isRemote = isRemote(functionKind);
-        this.isResource = isResource(functionKind);
+        this.isRemote = checkRemote(functionKind);
+        this.isResource = checkResource(functionKind);
         this.isExtern = isExtern;
         this.parameters = parameters;
         this.returnParameters = returnParameters;
         this.isIsolated = isIsolated;
     }
 
-    private boolean isRemote(FunctionKind functionKind) {
+    private boolean checkRemote(FunctionKind functionKind) {
         return functionKind == FunctionKind.REMOTE;
     }
 
-    private boolean isResource(FunctionKind functionKind) {
+    private boolean checkResource(FunctionKind functionKind) {
         return functionKind == FunctionKind.RESOURCE;
     }
 

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/FunctionKind.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/FunctionKind.java
@@ -1,0 +1,10 @@
+package org.ballerinalang.docgen.generator.model;
+
+/**
+ * Represent kinds for a Function.
+ */
+public enum FunctionKind {
+    REMOTE,
+    RESOURCE,
+    OTHER
+}

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/FunctionKind.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/FunctionKind.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.ballerinalang.docgen.generator.model;
 
 /**

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/FunctionKind.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/FunctionKind.java
@@ -1,17 +1,19 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *  Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
  */
 package org.ballerinalang.docgen.generator.model;
 

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Type.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Type.java
@@ -397,7 +397,15 @@ public class Type {
                         methodSymbol.documentation().get().description().get() : null;
                 functionType.category = "included_function";
                 functionType.isIsolated = methodSymbol.qualifiers().contains(Qualifier.ISOLATED);
-                functionType.isRemote = methodSymbol.qualifiers().contains(Qualifier.REMOTE);
+                FunctionKind functionKind;
+                if (methodSymbol.qualifiers().contains(Qualifier.REMOTE)) {
+                    functionKind = FunctionKind.REMOTE;
+                } else if (methodSymbol.qualifiers().contains(Qualifier.RESOURCE)) {
+                    functionKind = FunctionKind.RESOURCE;
+                } else {
+                    functionKind = FunctionKind.OTHER;
+                }
+                functionType.functionKind = functionKind;
                 functionType.isExtern = methodSymbol.external();
                 methodSymbol.typeDescriptor().params().ifPresent(parameterSymbols -> {
                     parameterSymbols.forEach(parameterSymbol -> {

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/types/FunctionType.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/types/FunctionType.java
@@ -16,6 +16,7 @@
 package org.ballerinalang.docgen.generator.model.types;
 
 import com.google.gson.annotations.Expose;
+import org.ballerinalang.docgen.generator.model.FunctionKind;
 import org.ballerinalang.docgen.generator.model.Type;
 
 import java.util.ArrayList;
@@ -35,7 +36,7 @@ public class FunctionType extends Type {
     @Expose
     public boolean isExtern;
     @Expose
-    public boolean isRemote;
+    public FunctionKind functionKind;
     @Expose
     public List<Type> paramTypes = new ArrayList<>();
     @Expose

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/types/FunctionType.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/types/FunctionType.java
@@ -30,6 +30,10 @@ import java.util.List;
 public class FunctionType extends Type {
 
     @Expose
+    public String accessor;
+    @Expose
+    public String resourcePath;
+    @Expose
     public boolean isLambda;
     @Expose
     public boolean isIsolated;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/documentation/DocModelTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/documentation/DocModelTest.java
@@ -22,7 +22,6 @@ import org.ballerinalang.docgen.generator.model.BType;
 import org.ballerinalang.docgen.generator.model.Client;
 import org.ballerinalang.docgen.generator.model.DefaultableVariable;
 import org.ballerinalang.docgen.generator.model.Function;
-import org.ballerinalang.docgen.generator.model.FunctionKind;
 import org.ballerinalang.docgen.generator.model.Listener;
 import org.ballerinalang.docgen.generator.model.Module;
 import org.ballerinalang.docgen.generator.model.ModuleDoc;
@@ -255,7 +254,7 @@ public class DocModelTest {
 
         Assert.assertEquals(caller.get().remoteMethods.size(), 1,
                 "Caller client should have one remote method");
-        Assert.assertTrue(caller.get().remoteMethods.get(0).functionKind == FunctionKind.REMOTE,
+        Assert.assertTrue(caller.get().remoteMethods.get(0).isRemote,
                 "Caller client method, `complete` should be a remote method");
         Assert.assertEquals(caller.get().remoteMethods.get(0).name, "complete",
                 "Caller client should have one remote method name complete");

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/documentation/DocModelTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/documentation/DocModelTest.java
@@ -22,6 +22,7 @@ import org.ballerinalang.docgen.generator.model.BType;
 import org.ballerinalang.docgen.generator.model.Client;
 import org.ballerinalang.docgen.generator.model.DefaultableVariable;
 import org.ballerinalang.docgen.generator.model.Function;
+import org.ballerinalang.docgen.generator.model.FunctionKind;
 import org.ballerinalang.docgen.generator.model.Listener;
 import org.ballerinalang.docgen.generator.model.Module;
 import org.ballerinalang.docgen.generator.model.ModuleDoc;
@@ -254,7 +255,7 @@ public class DocModelTest {
 
         Assert.assertEquals(caller.get().remoteMethods.size(), 1,
                 "Caller client should have one remote method");
-        Assert.assertTrue(caller.get().remoteMethods.get(0).isRemote,
+        Assert.assertTrue(caller.get().remoteMethods.get(0).functionKind == FunctionKind.REMOTE,
                 "Caller client method, `complete` should be a remote method");
         Assert.assertEquals(caller.get().remoteMethods.get(0).name, "complete",
                 "Caller client should have one remote method name complete");


### PR DESCRIPTION
## Purpose
$subject

Fixes #39668 #39694

## Approach
The existing way of differentiating function kind is to check whether the function is remote or not. Instead of that, there will be three function kinds `REMOTE`, `RESOURCE` & `OTHER`.
There will be a seperate method kind for resource functions. Apart from the function name, there will be `accessor` and `resoucePath` for the resource functions (For other methods including remote functions, those values will be empty strings in the `api-doc.json`).

## Samples
<img width="791" alt="Screenshot 2023-02-28 at 16 04 08" src="https://user-images.githubusercontent.com/51471998/221829276-bf47c3de-39fc-47ab-bdb7-e09216176ae2.png">

## Related PRs
https://github.com/ballerina-platform/ballerina-lang/pull/39780
https://github.com/ballerina-platform/ballerina-lang/pull/39784

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
