### PR TITLE
Fix incorrectly creating a union with no members as the inferred parameter type with empty tuples

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
@@ -581,7 +581,9 @@ public class TypeParamAnalyzer {
             tupleTypes.add(actualType.restType);
         }
 
-        BType type = tupleTypes.size() == 1 ? tupleTypes.iterator().next() : BUnionType.create(null, tupleTypes);
+        int size = tupleTypes.size();
+        BType type = size == 0 ? symTable.neverType :
+                (size == 1 ? tupleTypes.iterator().next() : BUnionType.create(null, tupleTypes));
         findTypeParam(loc, expType.eType, type, env, resolvedTypes, result);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/ArrowExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/ArrowExprTest.java
@@ -238,6 +238,15 @@ public class ArrowExprTest {
                                   "operator '+' not defined for 'string' and 'int'", 87, 25);
         BAssertUtil.validateError(resultSemanticsNegative, i++,
                                   "operator '+' not defined for 'int' and 'string'", 90, 25);
+        BAssertUtil.validateError(resultSemanticsNegative, i++,
+                                  "cannot define a variable of type 'never' or equivalent to type 'never'", 92, 16);
+        BAssertUtil.validateError(resultSemanticsNegative, i++,
+                                  "operator '+' not defined for 'never' and 'int'", 92, 21);
+//        https://github.com/ballerina-platform/ballerina-lang/issues/26191
+//        BAssertUtil.validateError(resultSemanticsNegative, i++,
+//                                  "cannot define a variable of type 'never' or equivalent to type 'never'", 95, 22);
+//        BAssertUtil.validateError(resultSemanticsNegative, i++,
+//                                  "operator '+' not defined for 'int' and 'never'", 95, 27);
         Assert.assertEquals(resultSemanticsNegative.getErrorCount(), i);
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/lambda/arrow-expression-semantics-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/lambda/arrow-expression-semantics-negative.bal
@@ -88,4 +88,9 @@ function testInvalidBinaryExprInExprFuncBody() {
 
     [string] strTup = ["str"];
     _ = strTup.map(s => 1 + s);
+
+    _ = [].map(m => m + 1);
+
+    // [] emptyTup = [];
+    // _ = emptyTup.map(m => 1 + m);
 }


### PR DESCRIPTION
## Purpose
$title.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/39699

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
