### PR TITLE
Disable suggesting extract to function and local variable code actions in match clause

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToFunctionCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToFunctionCodeAction.java
@@ -85,6 +85,7 @@ public class ExtractToFunctionCodeAction implements RangeBasedCodeActionProvider
     @Override
     public boolean validate(CodeActionContext context, RangeBasedPositionDetails positionDetails) {
         return context.currentSemanticModel().isPresent() && context.currentDocument().isPresent()
+                && positionDetails.matchedCodeActionNode().parent().kind() != SyntaxKind.MATCH_CLAUSE
                 && (!isExpressionNode(positionDetails.matchedCodeActionNode())
                 || isExpressionExtractable(positionDetails))
                 && CodeActionNodeValidator.validate(positionDetails.matchedCodeActionNode());

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToLocalVarCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ExtractToLocalVarCodeAction.java
@@ -98,6 +98,7 @@ public class ExtractToLocalVarCodeAction implements RangeBasedCodeActionProvider
                 && parentKind != SyntaxKind.RECORD_FIELD_WITH_DEFAULT_VALUE
                 && parentKind != SyntaxKind.ENUM_MEMBER
                 && !(nodeKind == SyntaxKind.FUNCTION_CALL && parentKind == SyntaxKind.START_ACTION)
+                && parentKind != SyntaxKind.MATCH_CLAUSE
                 && CodeActionNodeValidator.validate(context.nodeAtRange());
     }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ExtractToFunctionCodeActionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ExtractToFunctionCodeActionTest.java
@@ -267,7 +267,8 @@ public class ExtractToFunctionCodeActionTest extends AbstractCodeActionTest {
                 {"neg_extract_to_function_exprs_pos_in_type_definition.json"},
                 {"neg_extract_to_function_exprs_pos_in_function_call_with_qualNameRef.json"},
                 {"neg_extract_to_function_exprs_pos_mapping_cons_cur_inside_fields.json"},
-                {"negative_extract_to_function_exprs_pos_function_call_in_let_expr.json"}
+                {"negative_extract_to_function_exprs_pos_function_call_in_let_expr.json"},
+                {"negative_extract_to_function_exprs_match_clause.json"}
         };
     }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ExtractToLocalVarTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/ExtractToLocalVarTest.java
@@ -103,7 +103,8 @@ public class ExtractToLocalVarTest extends AbstractCodeActionTest {
                 {"extractToVariableInQNameRefNegative.json"},
                 {"extractToVariableInModLevelDeclNegative.json"},
                 {"extractToVariableInModLevelDeclNegative2.json"},
-                {"extractToVariableInStartActionNegative.json"}
+                {"extractToVariableInStartActionNegative.json"},
+                {"extractToVariableInMatchClauseNegative.json"}
         };
     }
 

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-function/config/negative_extract_to_function_exprs_match_clause.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-function/config/negative_extract_to_function_exprs_match_clause.json
@@ -1,0 +1,13 @@
+{
+  "position": {
+    "line": 2,
+    "character": 9
+  },
+  "source": "extract_to_function_exprs_match_clause.bal",
+  "expected": [
+    {
+      "title": "Extract to function"
+    }
+  ],
+  "description": "Extract to function when selected a match clause"
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-function/source/extract_to_function_exprs_match_clause.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-function/source/extract_to_function_exprs_match_clause.bal
@@ -1,0 +1,10 @@
+function testFunction(any v) returns string {
+    match v {
+        17 => {
+            return "number";
+        }
+        _ => {
+            return "any";
+        }
+    }
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInMatchClauseNegative.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/config/extractToVariableInMatchClauseNegative.json
@@ -1,0 +1,12 @@
+{
+  "position": {
+    "line": 2,
+    "character": 9
+  },
+  "source": "extractToVariableInMatchClause.bal",
+  "expected": [
+    {
+      "title": "Extract to local variable"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/source/extractToVariableInMatchClause.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/extract-to-local-variable/source/extractToVariableInMatchClause.bal
@@ -1,0 +1,10 @@
+function testFunction(any v) returns string {
+    match v {
+        17 => {
+            return "number";
+        }
+        _ => {
+            return "any";
+        }
+    }
+}


### PR DESCRIPTION
## Purpose
This PR fixes extract to function and extract to local variable code actions to not be suggested in match clause.

Fixes #39166 

## Samples
https://user-images.githubusercontent.com/61020198/220826913-a8d5be73-8aa3-4b14-9d20-12dd1c21f7d8.mov


## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
