### PR TITLE
Add runtime error and compile time diagnostics for empty character class in regexp ([])

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/regexp/TreeBuilder.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/regexp/TreeBuilder.java
@@ -45,7 +45,6 @@ import java.util.Set;
  * @since 2201.3.0
  */
 public class TreeBuilder {
-
     private final TokenReader tokenReader;
 
     public TreeBuilder(TokenReader tokenReader) {
@@ -122,7 +121,7 @@ public class TreeBuilder {
         }
         return new RegExpAtomQuantifier(reAtom, quantifier);
     }
-
+    
     private RegExpAssertion readRegAssertion() {
         return new RegExpAssertion(consume().value);
     }
@@ -150,7 +149,7 @@ public class TreeBuilder {
                 return consumedToken.value;
         }
     }
-
+    
     private String readRegUnicodePropertyEscape(String backSlash) {
         Token consumedPropertyToken = consume();
         String property = consumedPropertyToken.value;
@@ -159,7 +158,7 @@ public class TreeBuilder {
         String closeBrace = readCloseBrace();
         return backSlash + property + openBrace + unicodeProperty + closeBrace;
     }
-
+    
     private String readOpenBrace() {
         Token consumedToken = consume();
         return consumedToken.value;
@@ -207,7 +206,7 @@ public class TreeBuilder {
         Token simpleCharClassCode = consume();
         return backSlash + simpleCharClassCode.value;
     }
-
+    
     private RegExpCharacterClass readRegCharacterClass() {
         String characterClassStart = consume().value;
         // Read ^ char.
@@ -259,7 +258,7 @@ public class TreeBuilder {
         RegExpCharSet reCharSetNoDash = readCharSetNoDash(nextToken);
         return new RegExpCharSet(new Object[]{startReCharSetAtom, reCharSetNoDash});
     }
-
+    
     private RegExpCharSet readCharSetNoDash(Token nextToken) {
         String startReCharSetAtomNoDash = readCharSetAtom(nextToken);
         nextToken = peek();
@@ -333,7 +332,7 @@ public class TreeBuilder {
         }
         return digits.toString();
     }
-
+    
     private String readCloseBrace() {
         Token nextToken = peek();
         if (nextToken.kind == TokenKind.CLOSE_BRACE_TOKEN) {
@@ -342,7 +341,7 @@ public class TreeBuilder {
         }
         throw new BallerinaException("Missing '}' character");
     }
-
+    
     private String readNonGreedyChar() {
         Token nextToken = peek();
         if (nextToken.kind == TokenKind.QUESTION_MARK_TOKEN) {
@@ -352,7 +351,7 @@ public class TreeBuilder {
         // Return empty string if there is no non greedy char.
         return "";
     }
-
+    
     private RegExpCapturingGroup readRegCapturingGroups() {
         String openParenthesis = consume().value;
         Token nextToken = peek();
@@ -415,7 +414,7 @@ public class TreeBuilder {
         }
         throw new BallerinaException("Missing ')' character");
     }
-
+    
     private boolean isEndOfReDisjunction(TokenKind kind) {
         switch (kind) {
             case EOF_TOKEN:

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/regexp/TreeBuilder.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/regexp/TreeBuilder.java
@@ -45,6 +45,7 @@ import java.util.Set;
  * @since 2201.3.0
  */
 public class TreeBuilder {
+
     private final TokenReader tokenReader;
 
     public TreeBuilder(TokenReader tokenReader) {
@@ -121,7 +122,7 @@ public class TreeBuilder {
         }
         return new RegExpAtomQuantifier(reAtom, quantifier);
     }
-    
+
     private RegExpAssertion readRegAssertion() {
         return new RegExpAssertion(consume().value);
     }
@@ -149,7 +150,7 @@ public class TreeBuilder {
                 return consumedToken.value;
         }
     }
-    
+
     private String readRegUnicodePropertyEscape(String backSlash) {
         Token consumedPropertyToken = consume();
         String property = consumedPropertyToken.value;
@@ -158,7 +159,7 @@ public class TreeBuilder {
         String closeBrace = readCloseBrace();
         return backSlash + property + openBrace + unicodeProperty + closeBrace;
     }
-    
+
     private String readOpenBrace() {
         Token consumedToken = consume();
         return consumedToken.value;
@@ -206,13 +207,16 @@ public class TreeBuilder {
         Token simpleCharClassCode = consume();
         return backSlash + simpleCharClassCode.value;
     }
-    
+
     private RegExpCharacterClass readRegCharacterClass() {
         String characterClassStart = consume().value;
         // Read ^ char.
         String negation = readNegation();
         RegExpCharSet characterSet = readRegCharSet();
         String characterClassEnd = readCharacterClassEnd();
+        if (negation.isEmpty() && characterSet.getCharSetAtoms().length == 0) {
+            throw new BallerinaException("Empty character class disallowed");
+        }
         return new RegExpCharacterClass(characterClassStart, negation, characterSet, characterClassEnd);
     }
 
@@ -255,7 +259,7 @@ public class TreeBuilder {
         RegExpCharSet reCharSetNoDash = readCharSetNoDash(nextToken);
         return new RegExpCharSet(new Object[]{startReCharSetAtom, reCharSetNoDash});
     }
-    
+
     private RegExpCharSet readCharSetNoDash(Token nextToken) {
         String startReCharSetAtomNoDash = readCharSetAtom(nextToken);
         nextToken = peek();
@@ -329,7 +333,7 @@ public class TreeBuilder {
         }
         return digits.toString();
     }
-    
+
     private String readCloseBrace() {
         Token nextToken = peek();
         if (nextToken.kind == TokenKind.CLOSE_BRACE_TOKEN) {
@@ -338,7 +342,7 @@ public class TreeBuilder {
         }
         throw new BallerinaException("Missing '}' character");
     }
-    
+
     private String readNonGreedyChar() {
         Token nextToken = peek();
         if (nextToken.kind == TokenKind.QUESTION_MARK_TOKEN) {
@@ -348,7 +352,7 @@ public class TreeBuilder {
         // Return empty string if there is no non greedy char.
         return "";
     }
-    
+
     private RegExpCapturingGroup readRegCapturingGroups() {
         String openParenthesis = consume().value;
         Token nextToken = peek();
@@ -411,7 +415,7 @@ public class TreeBuilder {
         }
         throw new BallerinaException("Missing ')' character");
     }
-    
+
     private boolean isEndOfReDisjunction(TokenKind kind) {
         switch (kind) {
             case EOF_TOKEN:

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
@@ -798,6 +798,8 @@ public enum DiagnosticErrorCode implements DiagnosticCode {
             "BCE4043", "worker.receive.action.not.allowed.in.lock.statement"),
     EMPTY_REGEXP_STRING_DISALLOWED(
             "BCS4044", "empty.regexp.string.disallowed"),
+    UNSUPPORTED_EMPTY_CHARACTER_CLASS(
+            "BCS4045", "unsupported.empty.character.class")
     ;
 
     private String diagnosticId;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -1114,7 +1114,7 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
         if ((ownerSymTag & SymTag.INVOKABLE) == SymTag.INVOKABLE || (ownerSymTag & SymTag.LET) == SymTag.LET
                 || currentEnv.node.getKind() == NodeKind.LET_CLAUSE) {
             // This is a variable declared in a function, let expression, an action or a resource
-            // If the variable is parameter then the variable symbol is already defined`
+            // If the variable is parameter then the variable symbol is already defined
             if (varNode.symbol == null) {
                 analyzeVarNode(varNode, data, AttachPoint.Point.VAR);
             } else {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -1325,9 +1325,7 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
 
     @Override
     public void visit(BLangReCapturingGroups node, AnalyzerData data) {
-        if (node.disjunction != null) {
-            analyzeNode(node.disjunction, data);
-        }
+        analyzeNode(node.disjunction, data);
     }
 
     @Override
@@ -4286,12 +4284,14 @@ public class SemanticAnalyzer extends SimpleBLangNodeAnalyzer<SemanticAnalyzer.A
     }
 
     void analyzeNode(BLangNode node, BType expType, AnalyzerData data) {
-        data.prevEnvs.push(data.env);
-        BType preExpType = data.expType;
-        data.expType = expType;
-        node.accept(this, data);
-        data.env = data.prevEnvs.pop();
-        data.expType = preExpType;
+        if (node != null) {
+            data.prevEnvs.push(data.env);
+            BType preExpType = data.expType;
+            data.expType = expType;
+            node.accept(this, data);
+            data.env = data.prevEnvs.pop();
+            data.expType = preExpType;
+        }
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1964,3 +1964,6 @@ error.worker.receive.action.not.allowed.in.lock.statement=\
 
 error.empty.regexp.string.disallowed=\
   regular expression is not allowed: empty RegExp
+
+error.unsupported.empty.character.class=\
+  unsupported empty character class

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1966,4 +1966,4 @@ error.empty.regexp.string.disallowed=\
   regular expression is not allowed: empty RegExp
 
 error.unsupported.empty.character.class=\
-  unsupported empty character class
+  empty character class disallowed

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibRegexpTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibRegexpTest.java
@@ -140,17 +140,16 @@ public class LangLibRegexpTest {
         Assert.assertEquals(returns.toString(), "error(\"{ballerina}RegularExpressionParsingError\",message=\"invalid" +
                 " regexp pattern: " + message + "\")");
     }
-
+    
     @DataProvider(name = "invalidRegexpPatternSyntaxProvider")
     private Object[][] getInvalidRegexpPatternSyntax() {
         return new Object[][] {
                 {"testInvalidRegexpPatternSyntax1", "Unclosed character class near index 24" + NEW_LINE_CHAR +
                         "(?i-s:[[A\\\\sB\\WC\\Dd\\\\]\\])" + NEW_LINE_CHAR + "                        ^"},
-                {"testInvalidRegexpPatternSyntax2", "Unclosed character class near index 23" + NEW_LINE_CHAR +
-                        "(?xsmi:[]\\P{sc=Braille})" + NEW_LINE_CHAR +
-                        "                       ^"},
-                {"testInvalidRegexpPatternSyntax3", "Unclosed character class near index 23" + NEW_LINE_CHAR +
-                        "(?xsmi:[]\\P{sc=Braille})" + NEW_LINE_CHAR + "                       ^"},
+                {"testInvalidRegexpPatternSyntax2", "Unclosed character class near index 27" + NEW_LINE_CHAR +
+                        "(?xsmi:[[ABC]\\P{sc=Braille})" + NEW_LINE_CHAR + "                           ^"},
+                {"testInvalidRegexpPatternSyntax3", "Unclosed character class near index 27" + NEW_LINE_CHAR +
+                        "(?xsmi:[[ABC]\\P{sc=Braille})" + NEW_LINE_CHAR + "                           ^"},
         };
     }
 
@@ -203,6 +202,21 @@ public class LangLibRegexpTest {
                 {"testNegativeInvalidFlags2"},
                 {"testNegativeInvalidFlags3"},
                 {"testNegativeInvalidFlags4"},
+        };
+    }
+    
+    @Test(dataProvider = "negativeRegexpEmptyCharClassInterpolationProvider")
+    public void negativeTestRegexpEmptyCharClassInsertion(String functionName) {
+        Object returns = BRunUtil.invoke(negativeTests, functionName);
+        Assert.assertEquals(returns.toString(),String.format("error(\"{ballerina}RegularExpressionParsingError\"," +
+                "message=\"Invalid insertion in regular expression: Empty character class disallowed\")"));
+    }
+
+    @DataProvider(name = "negativeRegexpEmptyCharClassInterpolationProvider")
+    private Object[][] negativeRegexpEmptyCharClassInsertion() {
+        return new Object[][] {
+                {"testNegativeEmptyCharClass1"},
+                {"testNegativeEmptyCharClass2"}
         };
     }
 }

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibRegexpTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibRegexpTest.java
@@ -140,7 +140,7 @@ public class LangLibRegexpTest {
         Assert.assertEquals(returns.toString(), "error(\"{ballerina}RegularExpressionParsingError\",message=\"invalid" +
                 " regexp pattern: " + message + "\")");
     }
-    
+
     @DataProvider(name = "invalidRegexpPatternSyntaxProvider")
     private Object[][] getInvalidRegexpPatternSyntax() {
         return new Object[][] {
@@ -207,9 +207,7 @@ public class LangLibRegexpTest {
     
     @Test(dataProvider = "negativeRegexpEmptyCharClassInterpolationProvider")
     public void negativeTestRegexpEmptyCharClassInsertion(String functionName) {
-        Object returns = BRunUtil.invoke(negativeTests, functionName);
-        Assert.assertEquals(returns.toString(),String.format("error(\"{ballerina}RegularExpressionParsingError\"," +
-                "message=\"Invalid insertion in regular expression: Empty character class disallowed\")"));
+        BRunUtil.invoke(negativeTests, functionName);
     }
 
     @DataProvider(name = "negativeRegexpEmptyCharClassInterpolationProvider")

--- a/langlib/langlib-test/src/test/resources/test-src/regexp_negative_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/regexp_negative_test.bal
@@ -95,16 +95,18 @@ public function testInvalidRegexpPatternSyntax3() returns error? {
 
 public function testNegativeEmptyCharClass1() returns error? {
     string pattern = "[]";
-    var r = check (trap re `${pattern}`);
+    anydata|error result = trap re `${pattern}`;
+    check assertEqual(result, "Invalid insertion in regular expression: Empty character class disallowed");
 }
 
 public function testNegativeEmptyCharClass2() returns error? {
-    var r = check (trap re `(abc${"[]"})`);
+    anydata|error result = trap re `(abc${"[]"})`;
+    check assertEqual(result, "Invalid insertion in regular expression: Empty character class disallowed");
 }
 
 public function testNegativeEmptyCharClass3() returns error? {
-    string:RegExp r = check regexp:fromString("(([abc])|([]))");
-    _ = check (trap r.findAll("Hello"));
+    anydata|error result = trap regexp:fromString("(([abc])|([]))");
+    check assertEqual(result, "Failed to parse regular expression: Empty character class disallowed");
 }
 
 public function testNegativeDuplicateFlags1() returns error? {

--- a/langlib/langlib-test/src/test/resources/test-src/regexp_negative_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/regexp_negative_test.bal
@@ -84,13 +84,27 @@ public function testInvalidRegexpPatternSyntax1() returns error? {
 }
 
 public function testInvalidRegexpPatternSyntax2() returns error? {
-    string:RegExp x = re `(?xsmi:[]\P{sc=Braille})`;
+    string:RegExp x = re `(?xsmi:[[ABC]\P{sc=Braille})`;
     _ = check (trap x.findAll(":*A*a").toBalString());
 }
 
 public function testInvalidRegexpPatternSyntax3() returns error? {
-    string:RegExp x = re `(?xsmi:[]\P{sc=Braille})`;
+    string:RegExp x = re `(?xsmi:[[ABC]\P{sc=Braille})`;
     _ = check (trap x.matchGroupsAt(":*A*a"));
+}
+
+public function testNegativeEmptyCharClass1() returns error? {
+    string pattern = "[]";
+    var r = check (trap re `${pattern}`);
+}
+
+public function testNegativeEmptyCharClass2() returns error? {
+    var r = check (trap re `(abc${"[]"})`);
+}
+
+public function testNegativeEmptyCharClass3() returns error? {
+    string:RegExp r = check regexp:fromString("(([abc])|([]))");
+    _ = check (trap r.findAll("Hello"));
 }
 
 public function testNegativeDuplicateFlags1() returns error? {

--- a/langlib/langlib-test/src/test/resources/test-src/regexp_negative_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/regexp_negative_test.bal
@@ -96,17 +96,17 @@ public function testInvalidRegexpPatternSyntax3() returns error? {
 public function testNegativeEmptyCharClass1() returns error? {
     string pattern = "[]";
     anydata|error result = trap re `${pattern}`;
-    check assertEqual(result, "Invalid insertion in regular expression: Empty character class disallowed");
+    check assertEqualMessage(result, "Invalid insertion in regular expression: Empty character class disallowed");
 }
 
 public function testNegativeEmptyCharClass2() returns error? {
     anydata|error result = trap re `(abc${"[]"})`;
-    check assertEqual(result, "Invalid insertion in regular expression: Empty character class disallowed");
+    check assertEqualMessage(result, "Invalid insertion in regular expression: Empty character class disallowed");
 }
 
 public function testNegativeEmptyCharClass3() returns error? {
     anydata|error result = trap regexp:fromString("(([abc])|([]))");
-    check assertEqual(result, "Failed to parse regular expression: Empty character class disallowed");
+    check assertEqualMessage(result, "Failed to parse regular expression: Empty character class disallowed");
 }
 
 public function testNegativeDuplicateFlags1() returns error? {

--- a/langlib/langlib-test/src/test/resources/test-src/valuelib_toBalString_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/valuelib_toBalString_test.bal
@@ -493,8 +493,8 @@ function testToBalStringOnRegExpValueWithCapturingGroups5() {
     string:RegExp x7 = re `(?i:a|b)`;
     assert("re `(?i:a|b)`", x7.toBalString());
 
-    string:RegExp x8 = re `(?im:a|b|[])`;
-    assert("re `(?im:a|b|[])`", x8.toBalString());
+    string:RegExp x8 = re `(?im:a|b)`;
+    assert("re `(?im:a|b)`", x8.toBalString());
 
     string:RegExp x9 = re `(?i-m:[0-9])`;
     assert("re `(?i-m:[0-9])`", x9.toBalString());

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/regexp/RegExpValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/regexp/RegExpValueTest.java
@@ -101,8 +101,8 @@ public class RegExpValueTest {
         validateError(negativeResult, index++, START_CHAR_CODE_GREATER_THAN_END_CHAR_CODE, 31, 43);
         validateError(negativeResult, index++, START_CHAR_CODE_GREATER_THAN_END_CHAR_CODE, 32, 14);
         validateError(negativeResult, index++, START_CHAR_CODE_GREATER_THAN_END_CHAR_CODE, 33, 21);
-        validateError(negativeResult, index++, "unsupported empty character class", 34, 27);
-        validateError(negativeResult, index++, "unsupported empty character class", 35, 37);
+        validateError(negativeResult, index++, "empty character class disallowed", 34, 27);
+        validateError(negativeResult, index++, "empty character class disallowed", 35, 37);
         validateError(negativeResult, index++, "incompatible types: expected 'boolean', found " +
                 "'regexp:RegExp'", 36, 9);
         validateError(negativeResult, index++, "missing backtick token", 38, 1);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/regexp/RegExpValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/regexp/RegExpValueTest.java
@@ -101,13 +101,15 @@ public class RegExpValueTest {
         validateError(negativeResult, index++, START_CHAR_CODE_GREATER_THAN_END_CHAR_CODE, 31, 43);
         validateError(negativeResult, index++, START_CHAR_CODE_GREATER_THAN_END_CHAR_CODE, 32, 14);
         validateError(negativeResult, index++, START_CHAR_CODE_GREATER_THAN_END_CHAR_CODE, 33, 21);
+        validateError(negativeResult, index++, "unsupported empty character class", 34, 27);
+        validateError(negativeResult, index++, "unsupported empty character class", 35, 37);
         validateError(negativeResult, index++, "incompatible types: expected 'boolean', found " +
-                "'regexp:RegExp'", 34, 9);
-        validateError(negativeResult, index++, "missing backtick token", 36, 1);
-        validateError(negativeResult, index++, "missing close brace token", 36, 1);
-        validateError(negativeResult, index++, "missing colon token", 36, 1);
-        validateError(negativeResult, index++, "missing expression", 36, 1);
-        validateError(negativeResult, index++, "missing semicolon token", 36, 1);
+                "'regexp:RegExp'", 36, 9);
+        validateError(negativeResult, index++, "missing backtick token", 38, 1);
+        validateError(negativeResult, index++, "missing close brace token", 38, 1);
+        validateError(negativeResult, index++, "missing colon token", 38, 1);
+        validateError(negativeResult, index++, "missing expression", 38, 1);
+        validateError(negativeResult, index++, "missing semicolon token", 38, 1);
         assertEquals(negativeResult.getErrorCount(), index);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/regexp/RegExpValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/regexp/RegExpValueTest.java
@@ -103,13 +103,14 @@ public class RegExpValueTest {
         validateError(negativeResult, index++, START_CHAR_CODE_GREATER_THAN_END_CHAR_CODE, 33, 21);
         validateError(negativeResult, index++, "empty character class disallowed", 34, 27);
         validateError(negativeResult, index++, "empty character class disallowed", 35, 37);
+        validateError(negativeResult, index++, "empty character class disallowed", 36, 31);
         validateError(negativeResult, index++, "incompatible types: expected 'boolean', found " +
-                "'regexp:RegExp'", 36, 9);
-        validateError(negativeResult, index++, "missing backtick token", 38, 1);
-        validateError(negativeResult, index++, "missing close brace token", 38, 1);
-        validateError(negativeResult, index++, "missing colon token", 38, 1);
-        validateError(negativeResult, index++, "missing expression", 38, 1);
-        validateError(negativeResult, index++, "missing semicolon token", 38, 1);
+                "'regexp:RegExp'", 37, 9);
+        validateError(negativeResult, index++, "missing backtick token", 39, 1);
+        validateError(negativeResult, index++, "missing close brace token", 39, 1);
+        validateError(negativeResult, index++, "missing colon token", 39, 1);
+        validateError(negativeResult, index++, "missing expression", 39, 1);
+        validateError(negativeResult, index++, "missing semicolon token", 39, 1);
         assertEquals(negativeResult.getErrorCount(), index);
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/query-expr-with-query-construct-type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/query-expr-with-query-construct-type.bal
@@ -1502,11 +1502,11 @@ function testJoinedQueryExprConstructingMapWithRegExp() {
     map<string> arr3 = map from var re1 in arr1
         join string:RegExp re2 in arr2
         on re1 equals re2
-        let string:RegExp a = re `AB*[](A|B|[ab-fgh]+(?im-x:[cdeg-k]??${v})|)|^|PQ?`
+        let string:RegExp a = re `AB*(A|B|[ab-fgh]+(?im-x:[cdeg-k]??${v})|)|^|PQ?`
         select [re1.toString() + "1", re1.toString() + a.toString()];
     assertEqual({
-        A1: "AAB*[](A|B|[ab-fgh]+(?im-x:[cdeg-k]??1)|)|^|PQ?",
-        B1: "BAB*[](A|B|[ab-fgh]+(?im-x:[cdeg-k]??1)|)|^|PQ?"
+        A1: "AAB*(A|B|[ab-fgh]+(?im-x:[cdeg-k]??1)|)|^|PQ?",
+        B1: "BAB*(A|B|[ab-fgh]+(?im-x:[cdeg-k]??1)|)|^|PQ?"
     }, arr3);
 }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/regexp/regexp_value_negative_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/regexp/regexp_value_negative_test.bal
@@ -33,5 +33,6 @@ function testRegExpNegative() {
     _ = re `([^a-b${b-a}])`;
     string:RegExp _ = re `[]`;
     string:RegExp _ = re `(([abc])|([]))`;
+    string:RegExp _ = re `(?: [])`;
     _ = re `[AB\p{gc=Lu}]+` ? `;
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/regexp/regexp_value_negative_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/regexp/regexp_value_negative_test.bal
@@ -31,5 +31,7 @@ function testRegExpNegative() {
     _ = re `[\\uD834\\uDF06-\\uD834\\uDF08z-a]`;
     _ = re `[\p{sc=Katakana}-\p{sc=Hiragana}]`;
     _ = re `([^a-b${b-a}])`;
+    string:RegExp _ = re `[]`;
+    string:RegExp _ = re `(([abc])|([]))`;
     _ = re `[AB\p{gc=Lu}]+` ? `;
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/regexp/regexp_value_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/regexp/regexp_value_test.bal
@@ -220,8 +220,8 @@ function testRegExpValueWithCapturingGroups5() {
     string:RegExp x7 = re `(?i:a|b)`;
     assertEquality("(?i:a|b)", x7.toString());
 
-    string:RegExp x8 = re `(?im:a|b|[])`;
-    assertEquality("(?im:a|b|[])", x8.toString());
+    string:RegExp x8 = re `(?im:a|b|())`;
+    assertEquality("(?im:a|b|())", x8.toString());
 
     string:RegExp x9 = re `(?i-m:[0-9])`;
     assertEquality("(?i-m:[0-9])", x9.toString());

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/regexp/regexp_value_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/regexp/regexp_value_test.bal
@@ -220,8 +220,8 @@ function testRegExpValueWithCapturingGroups5() {
     string:RegExp x7 = re `(?i:a|b)`;
     assertEquality("(?i:a|b)", x7.toString());
 
-    string:RegExp x8 = re `(?im:a|b|())`;
-    assertEquality("(?im:a|b|())", x8.toString());
+    string:RegExp x8 = re `(?im:a|b)`;
+    assertEquality("(?im:a|b)", x8.toString());
 
     string:RegExp x9 = re `(?i-m:[0-9])`;
     assertEquality("(?i-m:[0-9])", x9.toString());

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/table/table_key_field_value_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/table/table_key_field_value_test.bal
@@ -500,21 +500,21 @@ function testRegExpAsKeyValue() {
     }
 
     table<Row9> key(k) tbl3 = table [
-       {k: re `[]??|(AB)*`, value: 17}
+       {k: re `[a-z]??|(AB)*`, value: 17}
     ];
 
-    tbl3.add({k: re `[]?|(AC){1}`, value: 25});
-    var tbl4 = table key(k) [{ k: re `[]??|(AB)*`, value: 17 },
-                             {k: re `[]?|(AC){1}`, value: 25}];
+    tbl3.add({k: re `[a-z]?|(AC){1}`, value: 25});
+    var tbl4 = table key(k) [{ k: re `[a-z]??|(AB)*`, value: 17 },
+                             {k: re `[a-z]?|(AC){1}`, value: 25}];
     assertEqual(tbl4, tbl3);
 
-    Row9 row2 = {k: re `[]?|(AC){1}`, value: 25};
-    assertEqual(row2, tbl3.get(re `[]?|(AC){1}`));
+    Row9 row2 = {k: re `[a-z]?|(AC){1}`, value: 25};
+    assertEqual(row2, tbl3.get(re `[a-z]?|(AC){1}`));
 
-    error? err3 = trap tbl3.add({k: re `[]??|(AB)*`, value: 20});
+    error? err3 = trap tbl3.add({k: re `[a-z]??|(AB)*`, value: 20});
     assertEqual(true, err3 is error);
     if (err3 is error) {
-        map<string> msg = {"message":"a value found for key '[]??|(AB)*'"};
+        map<string> msg = {"message":"a value found for key '[a-z]??|(AB)*'"};
         assertEqual(msg, err3.detail());
     }
 


### PR DESCRIPTION
## Purpose
$subject
Even though our regex grammar is allowed to use empty character classes java runtime throws an exception. Hence we have introduced a diagnostic during the compile time and add a new run time error to catch this scenario. 

Fixes #39489

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
