### PR TITLE
[2201.4.x] Fix issue with resolving closures in langlib calls with arrow expressions in query expressions

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
@@ -229,7 +229,7 @@ public class QueryDesugar extends BLangNodeVisitor {
     private SymbolEnv env;
     private SymbolEnv queryEnv;
     private boolean containsCheckExpr;
-    private boolean withinLambdaFunc = false;
+    private boolean withinLambdaOrArrowFunc = false;
     private HashSet<BType> checkedErrorList;
 
     private QueryDesugar(CompilerContext context) {
@@ -1518,10 +1518,10 @@ public class QueryDesugar extends BLangNodeVisitor {
             identifiers = prevIdentifiers;
             currentQueryLambdaBody = prevQueryLambdaBody;
         } else {
-            boolean prevWithinLambdaFunc = withinLambdaFunc;
-            withinLambdaFunc = true;
+            boolean prevWithinLambdaFunc = withinLambdaOrArrowFunc;
+            withinLambdaOrArrowFunc = true;
             function.getBody().accept(this);
-            withinLambdaFunc = prevWithinLambdaFunc;
+            withinLambdaOrArrowFunc = prevWithinLambdaFunc;
         }
     }
 
@@ -1705,7 +1705,7 @@ public class QueryDesugar extends BLangNodeVisitor {
                     symbol = originalSymbol;
                 }
             }
-            if ((withinLambdaFunc || queryEnv == null || !queryEnv.scope.entries.containsKey(symbol.name))
+            if ((withinLambdaOrArrowFunc || queryEnv == null || !queryEnv.scope.entries.containsKey(symbol.name))
                     && !identifiers.containsKey(identifier)) {
                 Location pos = currentQueryLambdaBody.pos;
                 BLangFieldBasedAccess frameAccessExpr = desugar.getFieldAccessExpression(pos, identifier,
@@ -1715,7 +1715,7 @@ public class QueryDesugar extends BLangNodeVisitor {
 
                 if (symbol instanceof BVarSymbol) {
                     ((BVarSymbol) symbol).originalSymbol = null;
-                    if (withinLambdaFunc) {
+                    if (withinLambdaOrArrowFunc) {
                         if (symbol.closure) {
                             // When there's a closure in a lambda inside a query lambda the symbol.closure is
                             // true for all its usages. Therefore mark symbol.closure = false for the existing
@@ -1744,7 +1744,7 @@ public class QueryDesugar extends BLangNodeVisitor {
                     }
                 }
                 identifiers.put(identifier, symbol);
-            } else if (identifiers.containsKey(identifier) && withinLambdaFunc) {
+            } else if (identifiers.containsKey(identifier) && withinLambdaOrArrowFunc) {
                 symbol = identifiers.get(identifier);
                 bLangSimpleVarRef.symbol = symbol;
                 bLangSimpleVarRef.varSymbol = symbol;
@@ -1971,7 +1971,10 @@ public class QueryDesugar extends BLangNodeVisitor {
     @Override
     public void visit(BLangArrowFunction bLangArrowFunction) {
         bLangArrowFunction.params.forEach(this::acceptNode);
+        boolean prevWithinLambdaFunc = this.withinLambdaOrArrowFunc;
+        this.withinLambdaOrArrowFunc = true;
         this.acceptNode(bLangArrowFunction.body);
+        this.withinLambdaOrArrowFunc = prevWithinLambdaFunc;
     }
 
     @Override

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/InnerQueryTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/InnerQueryTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static org.ballerinalang.test.BAssertUtil.validateError;
@@ -120,6 +121,18 @@ public class InnerQueryTest {
     @Test
     public void testQueryAsFuncArgument() {
         BRunUtil.invoke(result, "testQueryAsFuncArgument");
+    }
+
+    @Test(dataProvider = "dataToTestInnerQueryExpr")
+    public void testInnerQueryExpr(String functionName) {
+        BRunUtil.invoke(result, functionName);
+    }
+
+    @DataProvider
+    public Object[] dataToTestInnerQueryExpr() {
+        return new Object[]{
+                "testInnerQueryExprWithLangLibCallsWithArrowFunctions"
+        };
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/SimpleQueryExpressionWithDefinedTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/SimpleQueryExpressionWithDefinedTypeTest.java
@@ -367,6 +367,11 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         BRunUtil.invoke(result, "testUsingAnIntersectionTypeInQueryExpr");
     }
 
+    @Test
+    public void testQueryExprWithLangLibCallsWithArrowFunctions() {
+        BRunUtil.invoke(result, "testQueryExprWithLangLibCallsWithArrowFunctions");
+    }
+
     @AfterClass
     public void tearDown() {
         result = null;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/inner-queries.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/inner-queries.bal
@@ -685,6 +685,32 @@ function fooFunc(string[] s) returns string[] {
     return s;
 }
 
+function testInnerQueryExprWithLangLibCallsWithArrowFunctions() {
+    int[] idList = [4, 5];
+
+    int[] v1 = from var i in (from int id in idList
+            where personList.some(person => person.id == id)
+            select id)
+        where [40, 50].some(k => k == i * 10)
+        select i + 10;
+    assertEquality(true, v1 == [14]);
+
+    boolean[] v2 = from Person[] personList in (from int id in [4]
+            let string name = personList.filter(person => person.id == id).pop().fname
+            select personList.filter(person => person.fname == name))
+        select personList.some(person => person.lname == "Crowley");
+    assertEquality(true, v2 == [true]);
+
+    boolean[] v3 = from var i in (from int id in idList
+            where personList.some(person => person.id == id)
+            select id)
+        from Person[] personList in (from int k in [40]
+            let string name = personList.filter(person => person.id == k/10).pop().fname
+            select personList.filter(person => person.fname == name))
+        select personList.some(person => person.lname == "Crowley");
+    assertEquality(true, v3 == [true]);
+}
+
 function assertEquality(any|error expected, any|error actual) {
     if expected is anydata && actual is anydata && expected == actual {
         return;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/simple-query-with-defined-type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/simple-query-with-defined-type.bal
@@ -679,6 +679,33 @@ function testUsingAnIntersectionTypeInQueryExpr() {
     assertEquality(true, [{email: "anne@abc.com", score: 95.0}] == j);
 }
 
+function testQueryExprWithLangLibCallsWithArrowFunctions() {
+    Person p1 = {firstName: "Alex", lastName: "George", age: 30};
+    Person p2 = {firstName: "Anne", lastName: "Frank", age: 40};
+    Person p3 = {firstName: "John", lastName: "David", age: 50};
+    Person[] personList = [p1, p2, p3];
+
+    int[] ageList = [50, 60];
+    int[] filteredAges = from int age in ageList
+        where personList.some(person => person.age == age)
+        select age;
+    assertEquality(true, filteredAges == [50]);
+
+    string[] filteredNames = from int age in [50]
+        select personList.filter(person => person.age == age).pop().firstName;
+    assertEquality(true, filteredNames == ["John"]);
+
+    string[] filteredNames2 = from var {firstName, lastName, age} in personList
+        where ageList.some(a => a == age)
+        select ["John", "Frank"].filter(names => names == firstName).pop();
+    assertEquality(true, filteredNames2 == ["John"]);
+
+    Person[][] filteredPersons = from int age in [50]
+        let string name = personList.filter(person => person.age == age).pop().firstName
+        select personList.filter(person => person.firstName == name);
+    assertEquality(true, filteredPersons == [[{"firstName":"John", "lastName":"David", "age":50}]]);
+}
+
 function assertEquality(any|error expected, any|error actual) {
     if expected is anydata && actual is anydata && expected == actual {
         return;


### PR DESCRIPTION
## Purpose
$title
Same as https://github.com/ballerina-platform/ballerina-lang/pull/39608

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/38783

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
