### PR TITLE
Correct the errors thrown when `bal test --rerun-failed` is used without a `rerun_test.json` file 

### DIFF
--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/DataProviderTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/DataProviderTest.java
@@ -53,8 +53,6 @@ public class DataProviderTest extends BaseTestCase {
 
     @Test (dependsOnMethods = "testValidDataProvider")
     public void testValidDataProviderWithFail() throws BallerinaTestException, IOException {
-        String msg1 = "1 passing";
-        String msg2 = "2 failing";
         String[] args = mergeCoverageArgs(new String[]{"--tests", "intDataProviderTest", "data-providers"});
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
@@ -63,8 +61,6 @@ public class DataProviderTest extends BaseTestCase {
 
     @Test (dependsOnMethods = "testValidDataProviderWithFail")
     public void testRerunFailedTest() throws BallerinaTestException, IOException {
-        String msg1 = "0 passing";
-        String msg2 = "2 failing";
         String[] args = mergeCoverageArgs(new String[]{"--rerun-failed", "data-providers"});
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
@@ -75,8 +71,6 @@ public class DataProviderTest extends BaseTestCase {
     public void testValidDataProviderCase() throws BallerinaTestException, IOException {
         String[] args = mergeCoverageArgs(new String[]{"--tests", "dataproviders:jsonDataProviderTest#'json1'",
                 "data-providers"});
-        String msg1 = "1 passing";
-        String msg2 = "0 failing";
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
         AssertionUtils.assertOutput("DataProviderTest-testValidDataProviderCase.txt", output);
@@ -84,8 +78,6 @@ public class DataProviderTest extends BaseTestCase {
 
     @Test (dependsOnMethods = "testValidDataProviderCase")
     public void testDataProviderWithMixedType() throws BallerinaTestException, IOException {
-        String msg1 = "2 passing";
-        String msg2 = "0 failing";
         String[] args = mergeCoverageArgs(new String[]{"--tests", "testFunction1#'CaseNew*'",
                 "data-providers"});
         String output = balClient.runMainAndReadStdOut("test", args,
@@ -104,8 +96,6 @@ public class DataProviderTest extends BaseTestCase {
 
     @Test (dependsOnMethods = "testWithSpecialKeys")
     public void testArrayDataProviderWithFail() throws BallerinaTestException, IOException {
-        String msg1 = "1 passing";
-        String msg2 = "2 failing";
         String[] args = mergeCoverageArgs(new String[]{"--tests", "intArrayDataProviderTest", "data-providers"});
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
@@ -114,8 +104,6 @@ public class DataProviderTest extends BaseTestCase {
 
     @Test (dependsOnMethods = "testArrayDataProviderWithFail")
     public void testArrayDataRerunFailedTest() throws BallerinaTestException, IOException {
-        String msg1 = "0 passing";
-        String msg2 = "2 failing";
         String[] args = mergeCoverageArgs(new String[]{"--rerun-failed", "data-providers"});
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
@@ -124,8 +112,6 @@ public class DataProviderTest extends BaseTestCase {
 
     @Test (dependsOnMethods = "testArrayDataRerunFailedTest")
     public void testMultiModuleSingleTestExec() throws BallerinaTestException, IOException {
-        String msg1 = "1 passing";
-        String msg2 = "0 failing";
         String[] args = mergeCoverageArgs(new String[]{"--tests", "stringDataProviderMod1Test#1", "data-providers"});
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
@@ -169,8 +155,6 @@ public class DataProviderTest extends BaseTestCase {
     @Test
     public void testMapValueDataProvider() throws BallerinaTestException, IOException {
 
-        String msg1 = "1 passing";
-        String msg2 = "1 failing";
         String[] args = mergeCoverageArgs(new String[]{"--tests", "testGetState", "data-providers"});
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
@@ -180,8 +164,6 @@ public class DataProviderTest extends BaseTestCase {
 
     @Test
     public void testValidDataProviderWithBeforeAfterFunctions() throws BallerinaTestException, IOException {
-        String msg1 = "6 passing";
-        String msg2 = "0 failing";
         String[] args = mergeCoverageArgs(new String[]{"--tests", "testExecutionOfBeforeAfter", "data-providers"});
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
@@ -191,9 +173,6 @@ public class DataProviderTest extends BaseTestCase {
 
     @Test
     public void testValidDataProviderWithBeforeFailing() throws BallerinaTestException, IOException {
-        String msg1 = "5 passing";
-        String msg2 = "0 failing";
-        String msg3 = "1 skipped";
         String[] args = mergeCoverageArgs(new String[]{"--tests",
                 "testDividingValuesWithBeforeFailing,testExecutionOfBeforeFailing", "data-providers"});
         String output = balClient.runMainAndReadStdOut("test", args,
@@ -203,9 +182,6 @@ public class DataProviderTest extends BaseTestCase {
 
     @Test
     public void testValidDataProviderWithAfterFailing() throws BallerinaTestException, IOException {
-        String msg1 = "6 passing";
-        String msg2 = "0 failing";
-        String msg3 = "0 skipped";
         String[] args = mergeCoverageArgs(new String[]{"--tests",
                 "testDividingValuesWithAfterFailing,testExecutionOfAfterFailing", "data-providers"});
         String output = balClient.runMainAndReadStdOut("test", args,
@@ -215,9 +191,6 @@ public class DataProviderTest extends BaseTestCase {
 
     @Test
     public void testDataProviderSingleFailure() throws BallerinaTestException, IOException {
-        String msg1 = "5 passing";
-        String msg2 = "1 failing";
-        String msg3 = "0 skipped";
         String[] args = mergeCoverageArgs(new String[]{"--tests",
                 "testExecutionOfDataValueFailing", "data-providers"});
         String output = balClient.runMainAndReadStdOut("test", args,

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/DisableTestsTestCase.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/DisableTestsTestCase.java
@@ -50,8 +50,6 @@ public class DisableTestsTestCase extends BaseTestCase {
 
     @Test
     public void testDisablingTestsWithDependsOn() throws BallerinaTestException, IOException {
-        String errMsg = "error: Test [testFunction3] depends on function [testDisableFunction2], " +
-                "but it is either disabled or not included.";
         String[] args = mergeCoverageArgs(new String[]{"disable-with-depends-on.bal"});
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/GroupingTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/GroupingTest.java
@@ -42,7 +42,6 @@ public class GroupingTest extends BaseTestCase {
 
     @Test
     public void testSingleGroupExecution() throws BallerinaTestException, IOException {
-        String msg = "3 passing";
         String[] args = mergeCoverageArgs(new String[]{"--groups", "g1", "groups-test.bal"});
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
@@ -51,7 +50,6 @@ public class GroupingTest extends BaseTestCase {
 
     @Test
     public void testMultipleGroupExecution() throws BallerinaTestException, IOException {
-        String msg = "3 passing";
         String[] args = mergeCoverageArgs(new String[]{"--groups", "g2,g4", "groups-test.bal"});
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
@@ -60,8 +58,6 @@ public class GroupingTest extends BaseTestCase {
 
     @Test
     public void testSingleGroupExclusion() throws BallerinaTestException, IOException {
-        String msg1 = "4 passing";
-        String msg2 = "1 failing";
         String[] args = mergeCoverageArgs(new String[]{"--disable-groups", "g5", "groups-test.bal"});
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
@@ -70,7 +66,6 @@ public class GroupingTest extends BaseTestCase {
 
     @Test
     public void testMultipleGroupExclusion() throws BallerinaTestException, IOException {
-        String msg = "1 passing";
         String[] args = mergeCoverageArgs(new String[]{"--disable-groups", "g1,g5,g6", "groups-test.bal"});
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
@@ -79,7 +74,6 @@ public class GroupingTest extends BaseTestCase {
 
     @Test
     public void testNonExistingGroupInclusion() throws BallerinaTestException, IOException {
-        String msg = "No tests found";
         String[] args = mergeCoverageArgs(new String[]{"--groups", "g10", "groups-test.bal"});
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
@@ -88,8 +82,6 @@ public class GroupingTest extends BaseTestCase {
 
     @Test
     public void testNonExistingGroupExclusion() throws BallerinaTestException, IOException {
-        String msg1 = "4 passing";
-        String msg2 = "2 failing";
         String[] args = mergeCoverageArgs(new String[]{"--disable-groups", "g10", "groups-test.bal"});
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
@@ -98,7 +90,6 @@ public class GroupingTest extends BaseTestCase {
 
     @Test
     public void testListingOfSingleTestGroups() throws BallerinaTestException, IOException {
-        String msg = "[g1, g2, g3, g4, g5, g6]";
         String[] args = mergeCoverageArgs(new String[]{"--list-groups", "groups-test.bal"});
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
@@ -107,7 +98,6 @@ public class GroupingTest extends BaseTestCase {
 
     @Test
     public void testListingOfTestGroups() throws BallerinaTestException, IOException {
-        String msg = "[g1, g2, g3, g4, g5, g6]";
         String[] args = {"--list-groups"};
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(),
@@ -118,7 +108,6 @@ public class GroupingTest extends BaseTestCase {
 
     @Test
     public void testListGroupsWithOtherFlags() throws BallerinaTestException, IOException {
-        String msg = "Warning: Other flags are skipped when list-groups flag is provided.";
         String[] args = mergeCoverageArgs(new String[]{"--groups", "g1", "--list-groups", "groups-test.bal"});
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
@@ -177,9 +166,6 @@ public class GroupingTest extends BaseTestCase {
 
     @Test
     public void testWhenAfterGroupsFails() throws BallerinaTestException, IOException {
-        String msg1 = "5 passing";
-        String msg2 = "0 failing";
-        String msg3 = "0 skipped";
         String[] args = mergeCoverageArgs(new String[]{"failed-after-groups-test.bal"});
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/MockTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/MockTest.java
@@ -62,8 +62,6 @@ public class MockTest extends BaseTestCase {
 
     @Test()
     public void testFunctionMocking() throws BallerinaTestException, IOException {
-        String msg1 = "14 passing";
-        String msg2 = "3 failing";
         String[] args = mergeCoverageArgs(new String[]{"function-mocking-tests"});
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
@@ -72,8 +70,6 @@ public class MockTest extends BaseTestCase {
 
     @Test
     public void testFunctionMockingLegacy() throws BallerinaTestException, IOException {
-        String msg1 = "1 passing";
-        String msg2 = "0 failing";
         String[] args = mergeCoverageArgs(new String[]{"legacy-function-mocking-tests"});
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
@@ -82,9 +78,6 @@ public class MockTest extends BaseTestCase {
 
     @Test()
     public void testObjectMocking() throws BallerinaTestException, IOException {
-        String msg1 = "9 passing";
-        String msg2 = "7 failing";
-
         String[] args = mergeCoverageArgs(new String[]{"object-mocking-tests"});
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
@@ -98,7 +91,6 @@ public class MockTest extends BaseTestCase {
      */
     @Test()
     public void testObjectMockDouble() throws BallerinaTestException, IOException {
-        String msg1 = "1 passing";
         String[] args = mergeCoverageArgs(new String[]{"object-mocking-tests2"});
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
@@ -107,8 +99,6 @@ public class MockTest extends BaseTestCase {
 
     @Test()
     public void testFunctionMockingModuleLevel() throws BallerinaTestException, IOException {
-        String msg1 = "3 passing";
-
         String[] args = mergeCoverageArgs(new String[]{"function-mocking-tests"});
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
@@ -117,7 +107,6 @@ public class MockTest extends BaseTestCase {
 
     @Test()
     public void testCoverageWithMocking() throws BallerinaTestException, IOException {
-        String msg1 = "2 passing";
         String[] args = mergeCoverageArgs(new String[]{"mocking-coverage-tests"});
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/ModuleExecutionTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/ModuleExecutionTest.java
@@ -58,8 +58,6 @@ public class ModuleExecutionTest extends BaseTestCase {
 
     @Test()
     public void test_DefaultModule_SingleTest() throws BallerinaTestException, IOException {
-        String msg1 = "1 passing";
-        String msg2 = "[pass] main_test1";
         String[] args = new String[]{"--code-coverage", "--includes=*", "--tests", "moduleExecution:main_test1"};
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
@@ -71,8 +69,6 @@ public class ModuleExecutionTest extends BaseTestCase {
 
     @Test()
     public void test_DefaultModule_StartWildCardTest() throws BallerinaTestException, IOException {
-        String msg1 = "1 passing";
-        String msg2 = "[pass] commonTest";
         String[] args = new String[]{"--code-coverage", "--includes=*", "--tests", "moduleExecution:*Test"};
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
@@ -85,10 +81,6 @@ public class ModuleExecutionTest extends BaseTestCase {
 
     @Test()
     public void test_DefaultModule_MiddleWildCardTest() throws BallerinaTestException, IOException {
-        String msg1 = "3 passing";
-        String msg2 = "[pass] main_test1";
-        String msg3 = "[pass] main_test2";
-        String msg4 = "[pass] main_test3";
         String[] args = new String[]{"--code-coverage", "--includes=*", "--tests", "moduleExecution:*test*"};
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
@@ -101,10 +93,6 @@ public class ModuleExecutionTest extends BaseTestCase {
 
     @Test()
     public void test_DefaultModule_EndWildCardTest() throws BallerinaTestException, IOException {
-        String msg1 = "3 passing";
-        String msg2 = "[pass] main_test1";
-        String msg3 = "[pass] main_test2";
-        String msg4 = "[pass] main_test3";
         String[] args = new String[]{"--code-coverage", "--includes=*", "--tests", "moduleExecution:main_*"};
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
@@ -129,8 +117,6 @@ public class ModuleExecutionTest extends BaseTestCase {
 
     @Test()
     public void test_Module1_SingleTest() throws BallerinaTestException, IOException {
-        String msg1 = "1 passing";
-        String msg2 = "[pass] module1_test1";
         String[] args = new String[]{"--code-coverage", "--includes=*", "--tests",
                 "moduleExecution.Module1:module1_test1"};
         String output = balClient.runMainAndReadStdOut("test", args,
@@ -159,9 +145,6 @@ public class ModuleExecutionTest extends BaseTestCase {
 
     @Test()
     public void test_WildCardTest() throws BallerinaTestException, IOException {
-        String msg1 = "1 passing";
-        String msg2 = "[pass] commonTest_Module1";
-        String msg3 = "[pass] commonTest";
         String[] args = mergeCoverageArgs(new String[]{"--tests", "common*"});
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
@@ -173,9 +156,6 @@ public class ModuleExecutionTest extends BaseTestCase {
 
     @Test()
     public void test_Module1_WithGroups() throws BallerinaTestException, IOException {
-        String msg1 = "1 passing";
-        String msg2 = "[pass] module1_test2";
-
         String[] args = mergeCoverageArgs(new String[]{"--tests", "moduleExecution.Module1:*", "--groups", "g1"});
         String output = balClient.runMainAndReadStdOut("test", args, new HashMap<>(), projectPath, false);
         String firstString = "Generating Test Report\n\t";

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/RerunFailedTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/RerunFailedTest.java
@@ -46,8 +46,6 @@ public class RerunFailedTest extends BaseTestCase {
 
     @Test
     public void testFullTest() throws BallerinaTestException, IOException {
-        String msg1 = "2 passing";
-        String msg2 = "2 failing";
         String[] args = mergeCoverageArgs(new String[]{"rerun-failed-tests"});
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
@@ -56,8 +54,6 @@ public class RerunFailedTest extends BaseTestCase {
 
     @Test (dependsOnMethods = "testFullTest")
     public void testRerunFailedTest() throws BallerinaTestException, IOException {
-        String msg1 = "0 passing";
-        String msg2 = "2 failing";
         String[] args = mergeCoverageArgs(new String[]{"--rerun-failed", "rerun-failed-tests"});
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/SelectedFunctionTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/SelectedFunctionTest.java
@@ -66,7 +66,6 @@ public class SelectedFunctionTest extends BaseTestCase {
 
     @Test
     public void testNonExistingFunctionExecution() throws BallerinaTestException, IOException {
-        String msg = "No tests found";
         String[] args = mergeCoverageArgs(new String[]{"--tests", "nonExistingFunc", "single-test-execution.bal"});
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
@@ -83,8 +82,6 @@ public class SelectedFunctionTest extends BaseTestCase {
 
     @Test
     public void testDependentDisabledFunctionExecution() throws BallerinaTestException, IOException {
-        String errMsg = "error: Test [testDependentDisabledFunc] depends on function [testDisabledFunc], " +
-                "but it is either disabled or not included.";
         String[] args = mergeCoverageArgs(
                 new String[]{"--tests", "testDependentDisabledFunc", "single-test-execution.bal"});
         String output = balClient.runMainAndReadStdOut("test", args,

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/SourcelessTestExecutionTests.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/SourcelessTestExecutionTests.java
@@ -26,8 +26,6 @@ public class SourcelessTestExecutionTests extends BaseTestCase {
     // Scenario : Modules only have tests and no sourcefiles. Default module doesnt have sources or tests
     @Test()
     public void test_SourcelessModule_TestExecution() throws BallerinaTestException, IOException {
-        String msg1 = "[pass] test1";
-        String msg2 = "[pass] test2";
         String[] args = mergeCoverageArgs(new String[]{"sourceless-modules-test"});
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
@@ -38,8 +36,6 @@ public class SourcelessTestExecutionTests extends BaseTestCase {
     // Scenario : Modules only have tests and no sourcefiles. Default module doesnt have tests but has a source file
     @Test()
     public void test_DefaultModuleSourceOnly_TestExecution() throws BallerinaTestException, IOException {
-        String msg1 = "[pass] test3";
-        String msg2 = "[pass] test4";
         String[] args = mergeCoverageArgs(new String[]{"default-module-source-only-test"});
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);
@@ -50,9 +46,6 @@ public class SourcelessTestExecutionTests extends BaseTestCase {
 
     @Test()
     public void test_SourcelessProject_TestExecution() throws BallerinaTestException, IOException {
-        String msg1 = "[pass] test5";
-        String msg2 = "[pass] test6";
-        String msg3 = "[pass] test7";
         String[] args = mergeCoverageArgs(new String[]{"sourceless-project-test"});
         String output = balClient.runMainAndReadStdOut("test", args,
                 new HashMap<>(), projectPath, false);

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/utils/AssertionUtils.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/utils/AssertionUtils.java
@@ -49,10 +49,10 @@ public class AssertionUtils {
     public static void assertOutput(String outputFileName, String output) throws IOException {
         if (isWindows) {
             String fileContent =  Files.readString(commandOutputsDir.resolve("windows").resolve(outputFileName));
-            Assert.assertEquals(fileContent, output);
+            Assert.assertEquals(output.replaceAll("\r\n|\r", "\n"), fileContent.replaceAll("\r\n|\r", "\n"));
         } else {
             String fileContent = Files.readString(commandOutputsDir.resolve("unix").resolve(outputFileName));
-            Assert.assertEquals(fileContent, output);
+            Assert.assertEquals(output, fileContent);
         }
     }
 }

--- a/tests/testerina-integration-test/src/test/resources/command-outputs/unix/RerunFailedTest-testRerunFailedTestWithInvalidRunTestJson.txt
+++ b/tests/testerina-integration-test/src/test/resources/command-outputs/unix/RerunFailedTest-testRerunFailedTestWithInvalidRunTestJson.txt
@@ -1,0 +1,8 @@
+Compiling source
+	intg_tests/rerun_failed:0.0.0
+
+Running Tests
+
+	rerun_failed
+error: error while running failed tests : Invalid failed test data. Please run `bal test` command.
+error: there are test failures

--- a/tests/testerina-integration-test/src/test/resources/command-outputs/unix/RerunFailedTest-testRerunFailedTestWithMissingModuleNameInRunTestJson.txt
+++ b/tests/testerina-integration-test/src/test/resources/command-outputs/unix/RerunFailedTest-testRerunFailedTestWithMissingModuleNameInRunTestJson.txt
@@ -1,0 +1,8 @@
+Compiling source
+	intg_tests/rerun_failed:0.0.0
+
+Running Tests
+
+	rerun_failed
+error: error while running failed tests : Invalid failed test data. Please run `bal test` command.
+error: there are test failures

--- a/tests/testerina-integration-test/src/test/resources/command-outputs/unix/RerunFailedTest-testRerunFailedTestWithoutAnInitialRun.txt
+++ b/tests/testerina-integration-test/src/test/resources/command-outputs/unix/RerunFailedTest-testRerunFailedTestWithoutAnInitialRun.txt
@@ -1,0 +1,8 @@
+Compiling source
+	intg_tests/rerun_failed:0.0.0
+
+Running Tests
+
+	rerun_failed
+error: error while running failed tests : No previous test executions found.
+error: there are test failures

--- a/tests/testerina-integration-test/src/test/resources/command-outputs/windows/RerunFailedTest-testFullTest.txt
+++ b/tests/testerina-integration-test/src/test/resources/command-outputs/windows/RerunFailedTest-testFullTest.txt
@@ -25,4 +25,4 @@ Running Tests with Coverage
 Generating Test Report
 	rerun-failed-tests\target\report\test_results.json
 
-error: there are test failures
+error: there are test failures

--- a/tests/testerina-integration-test/src/test/resources/command-outputs/windows/RerunFailedTest-testRerunFailedTest.txt
+++ b/tests/testerina-integration-test/src/test/resources/command-outputs/windows/RerunFailedTest-testRerunFailedTest.txt
@@ -23,4 +23,4 @@ Running Tests with Coverage
 Generating Test Report
 	rerun-failed-tests\target\report\test_results.json
 
-error: there are test failures
+error: there are test failures

--- a/tests/testerina-integration-test/src/test/resources/command-outputs/windows/RerunFailedTest-testRerunFailedTestWithInvalidRunTestJson.txt
+++ b/tests/testerina-integration-test/src/test/resources/command-outputs/windows/RerunFailedTest-testRerunFailedTestWithInvalidRunTestJson.txt
@@ -1,0 +1,8 @@
+Compiling source
+	intg_tests/rerun_failed:0.0.0
+
+Running Tests
+
+	rerun_failed
+error: error while running failed tests : Invalid failed test data. Please run `bal test` command.
+error: there are test failures

--- a/tests/testerina-integration-test/src/test/resources/command-outputs/windows/RerunFailedTest-testRerunFailedTestWithMissingModuleNameInRunTestJson.txt
+++ b/tests/testerina-integration-test/src/test/resources/command-outputs/windows/RerunFailedTest-testRerunFailedTestWithMissingModuleNameInRunTestJson.txt
@@ -1,0 +1,8 @@
+Compiling source
+	intg_tests/rerun_failed:0.0.0
+
+Running Tests
+
+	rerun_failed
+error: error while running failed tests : Invalid failed test data. Please run `bal test` command.
+error: there are test failures

--- a/tests/testerina-integration-test/src/test/resources/command-outputs/windows/RerunFailedTest-testRerunFailedTestWithoutAnInitialRun.txt
+++ b/tests/testerina-integration-test/src/test/resources/command-outputs/windows/RerunFailedTest-testRerunFailedTestWithoutAnInitialRun.txt
@@ -1,0 +1,8 @@
+Compiling source
+	intg_tests/rerun_failed:0.0.0
+
+Running Tests
+
+	rerun_failed
+error: error while running failed tests : No previous test executions found.
+error: there are test failures

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/rerun-failed-tests-with-invalid-json/Ballerina.toml
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/rerun-failed-tests-with-invalid-json/Ballerina.toml
@@ -1,0 +1,7 @@
+[package]
+org = "intg_tests"
+name = "rerun_failed"
+version = "0.0.0"
+
+[build-options]
+observabilityIncluded = false

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/rerun-failed-tests-with-invalid-json/main.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/rerun-failed-tests-with-invalid-json/main.bal
@@ -1,0 +1,18 @@
+// Copyright (c) 2023 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+public function main() {
+}

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/rerun-failed-tests-with-invalid-json/target/rerun_test.json
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/rerun-failed-tests-with-invalid-json/target/rerun_test.json
@@ -1,0 +1,1 @@
+This is an invalid json file. Testerina will throw an error when it tries to parse this as a json file.

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/rerun-failed-tests-with-invalid-json/tests/main_test.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/rerun-failed-tests-with-invalid-json/tests/main_test.bal
@@ -1,0 +1,42 @@
+// Copyright (c) 2023 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+
+
+# Passing Test function
+@test:Config {}
+function testFunctionPass1() {
+    test:assertTrue(true, msg = "Failed!");
+}
+
+# Passing Test function
+@test:Config {}
+function testFunctionPass2() {
+    test:assertTrue(true, msg = "Failed!");
+}
+
+# Failing Test function
+@test:Config {}
+function testFunctionFail1() {
+    test:assertTrue(false, msg = "Failed!");
+}
+
+# Failing Test function
+@test:Config {}
+function testFunctionFail2() {
+    test:assertTrue(false, msg = "Failed!");
+}

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/rerun-failed-tests-with-missing-module-name/Ballerina.toml
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/rerun-failed-tests-with-missing-module-name/Ballerina.toml
@@ -1,0 +1,7 @@
+[package]
+org = "intg_tests"
+name = "rerun_failed"
+version = "0.0.0"
+
+[build-options]
+observabilityIncluded = false

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/rerun-failed-tests-with-missing-module-name/main.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/rerun-failed-tests-with-missing-module-name/main.bal
@@ -1,0 +1,18 @@
+// Copyright (c) 2023 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+public function main() {
+}

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/rerun-failed-tests-with-missing-module-name/target/rerun_test.json
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/rerun-failed-tests-with-missing-module-name/target/rerun_test.json
@@ -1,0 +1,1 @@
+{"non_existent_module":{"testNames":["testFunctionFail1","testFunctionFail2"],"testModuleNames":{"testFunctionFail1":"rerun_failed","testFunctionFail2":"rerun_failed"},"subTestNames":{}}}

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/rerun-failed-tests-with-missing-module-name/tests/main_test.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/rerun-failed-tests-with-missing-module-name/tests/main_test.bal
@@ -1,0 +1,42 @@
+// Copyright (c) 2023 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+
+
+# Passing Test function
+@test:Config {}
+function testFunctionPass1() {
+    test:assertTrue(true, msg = "Failed!");
+}
+
+# Passing Test function
+@test:Config {}
+function testFunctionPass2() {
+    test:assertTrue(true, msg = "Failed!");
+}
+
+# Failing Test function
+@test:Config {}
+function testFunctionFail1() {
+    test:assertTrue(false, msg = "Failed!");
+}
+
+# Failing Test function
+@test:Config {}
+function testFunctionFail2() {
+    test:assertTrue(false, msg = "Failed!");
+}


### PR DESCRIPTION
## Purpose
$subject

Fixes #39664

## Approach
If the rerun_test.json is missing, throw an error requesting user to run bal test and terminate without running the tests.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
