### PR TITLE
[2201.4.x] Add resource kind in api-doc generation

### DIFF
--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
@@ -76,6 +76,7 @@ import org.ballerinalang.docgen.generator.model.DefaultableVariable;
 import org.ballerinalang.docgen.generator.model.Enum;
 import org.ballerinalang.docgen.generator.model.Error;
 import org.ballerinalang.docgen.generator.model.Function;
+import org.ballerinalang.docgen.generator.model.FunctionKind;
 import org.ballerinalang.docgen.generator.model.Listener;
 import org.ballerinalang.docgen.generator.model.Module;
 import org.ballerinalang.docgen.generator.model.Record;
@@ -437,7 +438,8 @@ public class Generator {
         for (Node member : classDefinitionNode.members()) {
             if (member instanceof FunctionDefinitionNode && (containsToken(((FunctionDefinitionNode) member)
                     .qualifierList(), SyntaxKind.PUBLIC_KEYWORD) || containsToken(((FunctionDefinitionNode) member)
-                    .qualifierList(), SyntaxKind.REMOTE_KEYWORD))) {
+                    .qualifierList(), SyntaxKind.REMOTE_KEYWORD) || containsToken(((FunctionDefinitionNode) member)
+                    .qualifierList(), SyntaxKind.RESOURCE_KEYWORD))) {
                 classFunctions.add(getFunctionModel((FunctionDefinitionNode) member, semanticModel));
             } else if (member instanceof TypeReferenceNode) {
                 Type originType = Type.fromNode(member, semanticModel);
@@ -483,8 +485,20 @@ public class Generator {
             if (member instanceof MethodDeclarationNode) {
                 MethodDeclarationNode methodNode = (MethodDeclarationNode) member;
                 if (containsToken(methodNode.qualifierList(), SyntaxKind.PUBLIC_KEYWORD) ||
-                        containsToken(methodNode.qualifierList(), SyntaxKind.REMOTE_KEYWORD)) {
-                    String methodName = methodNode.methodName().text();
+                        containsToken(methodNode.qualifierList(), SyntaxKind.REMOTE_KEYWORD) ||
+                        containsToken(methodNode.qualifierList(), SyntaxKind.RESOURCE_KEYWORD)) {
+                    String methodName = "";
+                    String accessor = "";
+                    String resourcePath = "";
+                    if (methodNode.kind() == SyntaxKind.RESOURCE_ACCESSOR_DEFINITION) {
+                        accessor = methodNode.methodName().text();
+                        resourcePath = methodNode.relativeResourcePath().stream().
+                                collect(StringBuilder::new, (firstString,
+                                                             secondString) -> firstString.append(secondString),
+                                        (nodeA, nodeB) -> nodeA.append(nodeB)).toString();
+                    } else {
+                        methodName = methodNode.methodName().text();
+                    }
 
                     List<Variable> returnParams = new ArrayList<>();
                     FunctionSignatureNode methodSignature = methodNode.methodSignature();
@@ -501,12 +515,19 @@ public class Generator {
                                 methodNode.metadata()), false, type));
                     }
 
-                    boolean isRemote = containsToken(methodNode.qualifierList(), SyntaxKind.REMOTE_KEYWORD);
+                    FunctionKind functionKind;
+                    if (containsToken(methodNode.qualifierList(), SyntaxKind.REMOTE_KEYWORD)) {
+                        functionKind = FunctionKind.REMOTE;
+                    } else if (containsToken(methodNode.qualifierList(), SyntaxKind.RESOURCE_KEYWORD)) {
+                        functionKind = FunctionKind.RESOURCE;
+                    } else {
+                        functionKind = FunctionKind.OTHER;
+                    }
 
-                    objectFunctions.add(new Function(methodName, getDocFromMetadata(methodNode.metadata()),
-                            isRemote, false, isDeprecated(methodNode.metadata()),
-                            containsToken(methodNode.qualifierList(), SyntaxKind.ISOLATED_KEYWORD), parameters,
-                            returnParams));
+                    objectFunctions.add(new Function(methodName, accessor, resourcePath,
+                            getDocFromMetadata(methodNode.metadata()), functionKind, false,
+                            isDeprecated(methodNode.metadata()), containsToken(methodNode.qualifierList(),
+                            SyntaxKind.ISOLATED_KEYWORD), parameters, returnParams));
                 }
             } else if (member instanceof TypeReferenceNode) {
                 Type originType = Type.fromNode(member, semanticModel);
@@ -542,9 +563,9 @@ public class Generator {
                         functionType.returnType.isDeprecated, functionType.returnType));
             }
 
-            Function function = new Function(functionType.name, functionType.description, functionType.isRemote,
-                    functionType.isExtern, functionType.isDeprecated, functionType.isIsolated, parameters,
-                    returnParameters);
+            Function function = new Function(functionType.name, functionType.accessor, functionType.resourcePath,
+                    functionType.description, functionType.functionKind, functionType.isExtern,
+                    functionType.isDeprecated, functionType.isIsolated, parameters, returnParameters);
             function.inclusionType = originType.isPublic ? originType : null;
             functions.add(function);
         }
@@ -553,7 +574,17 @@ public class Generator {
 
     private static Function getFunctionModel(FunctionDefinitionNode functionDefinitionNode,
                                              SemanticModel semanticModel) {
-        String functionName = functionDefinitionNode.functionName().text();
+        String functionName = "";
+        String accessor = "";
+        String resourcePath = "";
+        if (functionDefinitionNode.kind() == SyntaxKind.RESOURCE_ACCESSOR_DEFINITION) {
+            accessor = functionDefinitionNode.functionName().text();
+            resourcePath = functionDefinitionNode.relativeResourcePath().stream().
+                    collect(StringBuilder::new, (firstString, secondString) -> firstString.append(secondString),
+                            (nodeA, nodeB) -> nodeA.append(nodeB)).toString();
+        } else {
+            functionName = functionDefinitionNode.functionName().text();
+        }
 
         List<DefaultableVariable> parameters = new ArrayList<>();
         List<Variable> returnParams = new ArrayList<>();
@@ -574,10 +605,17 @@ public class Generator {
         }
 
         boolean isExtern = functionDefinitionNode.functionBody() instanceof ExternalFunctionBodyNode;
-        boolean isRemote = containsToken(functionDefinitionNode.qualifierList(), SyntaxKind.REMOTE_KEYWORD);
+        FunctionKind functionKind;
+        if (containsToken(functionDefinitionNode.qualifierList(), SyntaxKind.REMOTE_KEYWORD)) {
+            functionKind = FunctionKind.REMOTE;
+        } else if (containsToken(functionDefinitionNode.qualifierList(), SyntaxKind.RESOURCE_KEYWORD)) {
+            functionKind = FunctionKind.RESOURCE;
+        } else {
+            functionKind = FunctionKind.OTHER;
+        }
 
-        return new Function(functionName, getDocFromMetadata(functionDefinitionNode.metadata()),
-                isRemote, isExtern, isDeprecated(functionDefinitionNode.metadata()),
+        return new Function(functionName, accessor, resourcePath, getDocFromMetadata(functionDefinitionNode.metadata()),
+                functionKind, isExtern, isDeprecated(functionDefinitionNode.metadata()),
                 containsToken(functionDefinitionNode.qualifierList(), SyntaxKind.ISOLATED_KEYWORD), parameters,
                 returnParams, annotationAttachments);
     }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Client.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Client.java
@@ -27,24 +27,33 @@ public class Client extends BClass {
 
     @Expose
     public List<Function> remoteMethods;
+    @Expose
+    public List<Function> resourceMethods;
 
     public Client(String name, String description, boolean isDeprecated, List<DefaultableVariable> fields,
             List<Function> methods, boolean isReadOnly, boolean isIsolated) {
         super(name, description, isDeprecated, fields, methods, isReadOnly, isIsolated);
         this.remoteMethods = getRemoteMethods();
+        this.resourceMethods = getResourceMethods();
         this.otherMethods = getOtherMethods(methods);
     }
 
     @Override
     public List<Function> getOtherMethods(List<Function> methods) {
         return super.getOtherMethods(methods).stream()
-                .filter(function -> !function.isRemote)
+                .filter(function -> !function.isRemote && !function.isResource)
                 .collect(Collectors.toList());
     }
 
     public List<Function> getRemoteMethods() {
         return this.methods.stream()
                 .filter(function -> function.isRemote)
+                .collect(Collectors.toList());
+    }
+
+    public List<Function> getResourceMethods() {
+        return this.methods.stream()
+                .filter(function -> function.isResource)
                 .collect(Collectors.toList());
     }
 }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Function.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Function.java
@@ -24,9 +24,15 @@ import java.util.List;
  */
 public class Function extends Construct {
     @Expose
+    public String accessor = "";
+    @Expose
+    public String resourcePath = "";
+    @Expose
     public boolean isIsolated;
     @Expose
     public boolean isRemote;
+    @Expose
+    public boolean isResource;
     @Expose
     public boolean isExtern;
     @Expose
@@ -36,11 +42,12 @@ public class Function extends Construct {
     @Expose
     List<AnnotationAttachment> annotationAttachments;
 
-    public Function(String name, String description, boolean isRemote, boolean isExtern, boolean isDeprecated,
+    public Function(String name, String description, FunctionKind functionKind, boolean isExtern, boolean isDeprecated,
                     boolean isIsolated, List<DefaultableVariable> parameters, List<Variable> returnParameters,
                     List<AnnotationAttachment> annotationAttachments) {
         super(name, description, isDeprecated);
-        this.isRemote = isRemote;
+        this.isRemote = checkRemote(functionKind);
+        this.isResource = checkResource(functionKind);
         this.isExtern = isExtern;
         this.parameters = parameters;
         this.returnParameters = returnParameters;
@@ -48,13 +55,51 @@ public class Function extends Construct {
         this.annotationAttachments = annotationAttachments;
     }
 
-    public Function(String name, String description, boolean isRemote, boolean isExtern, boolean isDeprecated,
-                    boolean isIsolated, List<DefaultableVariable> parameters, List<Variable> returnParameters) {
+    public Function(String name, String accessor, String resourcePath, String description, FunctionKind functionKind,
+                    boolean isExtern, boolean isDeprecated, boolean isIsolated, List<DefaultableVariable> parameters,
+                    List<Variable> returnParameters, List<AnnotationAttachment> annotationAttachments) {
         super(name, description, isDeprecated);
-        this.isRemote = isRemote;
+        this.accessor = accessor;
+        this.resourcePath = resourcePath;
+        this.isRemote = checkRemote(functionKind);
+        this.isResource = checkResource(functionKind);
         this.isExtern = isExtern;
         this.parameters = parameters;
         this.returnParameters = returnParameters;
         this.isIsolated = isIsolated;
+        this.annotationAttachments = annotationAttachments;
+    }
+
+    public Function(String name, String description, FunctionKind functionKind, boolean isExtern, boolean isDeprecated,
+                    boolean isIsolated, List<DefaultableVariable> parameters, List<Variable> returnParameters) {
+        super(name, description, isDeprecated);
+        this.isRemote = checkRemote(functionKind);
+        this.isResource = checkResource(functionKind);
+        this.isExtern = isExtern;
+        this.parameters = parameters;
+        this.returnParameters = returnParameters;
+        this.isIsolated = isIsolated;
+    }
+
+    public Function(String name, String accessor, String resourcePath, String description, FunctionKind functionKind,
+                    boolean isExtern, boolean isDeprecated, boolean isIsolated, List<DefaultableVariable> parameters,
+                    List<Variable> returnParameters) {
+        super(name, description, isDeprecated);
+        this.accessor = accessor;
+        this.resourcePath = resourcePath;
+        this.isRemote = checkRemote(functionKind);
+        this.isResource = checkResource(functionKind);
+        this.isExtern = isExtern;
+        this.parameters = parameters;
+        this.returnParameters = returnParameters;
+        this.isIsolated = isIsolated;
+    }
+
+    private boolean checkRemote(FunctionKind functionKind) {
+        return functionKind == FunctionKind.REMOTE;
+    }
+
+    private boolean checkResource(FunctionKind functionKind) {
+        return functionKind == FunctionKind.RESOURCE;
     }
 }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/FunctionKind.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/FunctionKind.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.docgen.generator.model;
+
+/**
+ * Represent kinds for a Function.
+ */
+public enum FunctionKind {
+    REMOTE,
+    RESOURCE,
+    OTHER
+}

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/FunctionKind.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/FunctionKind.java
@@ -1,17 +1,19 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *  Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
  */
 package org.ballerinalang.docgen.generator.model;
 

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Type.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Type.java
@@ -401,7 +401,16 @@ public class Type {
                         methodSymbol.documentation().get().description().get() : null;
                 functionType.category = "included_function";
                 functionType.isIsolated = methodSymbol.qualifiers().contains(Qualifier.ISOLATED);
-                functionType.isRemote = methodSymbol.qualifiers().contains(Qualifier.REMOTE);
+                FunctionKind functionKind;
+                if (methodSymbol.qualifiers().contains(Qualifier.REMOTE)) {
+                    functionKind = FunctionKind.REMOTE;
+                } else if (methodSymbol.qualifiers().contains(Qualifier.RESOURCE)) {
+                    functionKind = FunctionKind.RESOURCE;
+                } else {
+                    functionKind = FunctionKind.OTHER;
+                }
+                functionType.functionKind = functionKind;
+
                 functionType.isExtern = methodSymbol.external();
                 methodSymbol.typeDescriptor().params().ifPresent(parameterSymbols -> {
                     parameterSymbols.forEach(parameterSymbol -> {

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/types/FunctionType.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/types/FunctionType.java
@@ -16,6 +16,7 @@
 package org.ballerinalang.docgen.generator.model.types;
 
 import com.google.gson.annotations.Expose;
+import org.ballerinalang.docgen.generator.model.FunctionKind;
 import org.ballerinalang.docgen.generator.model.Type;
 
 import java.util.ArrayList;
@@ -29,13 +30,17 @@ import java.util.List;
 public class FunctionType extends Type {
 
     @Expose
+    public String accessor;
+    @Expose
+    public String resourcePath;
+    @Expose
     public boolean isLambda;
     @Expose
     public boolean isIsolated;
     @Expose
     public boolean isExtern;
     @Expose
-    public boolean isRemote;
+    public FunctionKind functionKind;
     @Expose
     public List<Type> paramTypes = new ArrayList<>();
     @Expose


### PR DESCRIPTION
## Purpose
$subject

Fixes #39668 #39694

## Approach
The existing way of differentiating function kind is to check whether the function is remote or not. Instead of that, there will be three function kinds `REMOTE`, `RESOURCE` & `OTHER`.
There will be a seperate method kind for resource functions. Apart from the function name, there will be `accessor` and `resoucePath` for the resource functions (For other methods including remote functions, those values will be empty strings in the `api-doc.json`).

## Samples
<img width="791" alt="Screenshot 2023-02-28 at 16 04 08" src="https://user-images.githubusercontent.com/51471998/221829276-bf47c3de-39fc-47ab-bdb7-e09216176ae2.png">

## Related PRs
https://github.com/ballerina-platform/ballerina-lang/pull/39695
https://github.com/ballerina-platform/ballerina-lang/pull/39784

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples

