### PR TITLE
Remove compilationUnits without a function to resolve function mocking failure 

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/MockDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/MockDesugar.java
@@ -19,6 +19,7 @@ package org.wso2.ballerinalang.compiler.desugar;
 
 import org.ballerinalang.model.TreeBuilder;
 import org.ballerinalang.model.tree.IdentifierNode;
+import org.ballerinalang.model.tree.TopLevelNode;
 import org.wso2.ballerinalang.compiler.semantics.analyzer.SymbolResolver;
 import org.wso2.ballerinalang.compiler.semantics.model.Scope;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
@@ -379,6 +380,18 @@ public class MockDesugar {
     private BLangListConstructorExpr generateClassListConstructorExpr() {
         List<BLangCompilationUnit> compUnitList = this.bLangPackage.getTestablePkg().getCompilationUnits();
         BArrayType bArrayType = new BArrayType(symTable.stringType, null, -1, BArrayState.OPEN);
+
+        List<BLangCompilationUnit> modifiedcompUnitList = new ArrayList<>();
+        for (BLangCompilationUnit compUnit : compUnitList) {
+            List<TopLevelNode> topLevelNodes = compUnit.getTopLevelNodes();
+            for (TopLevelNode topLevelNode : topLevelNodes) {
+                if (topLevelNode instanceof BLangFunction) {
+                    modifiedcompUnitList.add(compUnit);
+                    break;
+                }
+            }
+        }
+        compUnitList = modifiedcompUnitList;
 
         BLangListConstructorExpr bLangListConstructorExpr =
                 ASTBuilderUtil.createListConstructorExpr(bLangPackage.pos, bArrayType);


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues.

Fixes #39134 

## Approach
> [`mockFunctionClasses`](https://github.com/ballerina-platform/ballerina-lang/blob/10044895c5d7b48bb982f246827d0d546d358405/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/mock/FunctionMock.java#L49) array contains the classes associated with test files which contains certain functions(`functionToBeCalled` functions in `test:when(mockobj).call("functionToBeCalled")`). To obtains those classes, we need to traverse all test files and identify such functions first. Then we need search those functions in all test files. This is computationally inefficient as it involves with  lot of loops. To resolve the issue, It is sufficient to make list of classes which has at least a function in the test file. 

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
