### PR TITLE
[2201.3.x] Check service qualifier for object types in API docs generation

### DIFF
--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
@@ -477,6 +477,7 @@ public class Generator {
 
         String description = getDocFromMetadata(optionalMetadataNode);
         boolean isDeprecated = isDeprecated(optionalMetadataNode);
+        boolean isService = containsToken(typeDescriptorNode.objectTypeQualifiers(), SyntaxKind.SERVICE_KEYWORD);
 
         List<DefaultableVariable> fields = getDefaultableVariableList(typeDescriptorNode.members(),
                 optionalMetadataNode, semanticModel);
@@ -547,7 +548,7 @@ public class Generator {
 
         functions.addAll(objectFunctions);
 
-        return new BObjectType(objectName, description, isDeprecated, fields, functions);
+        return new BObjectType(objectName, description, isDeprecated, isService, fields, functions);
     }
 
     private static List<Function> mapFunctionTypesToFunctions(List<FunctionType> functionTypes, Type originType) {

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/BObjectType.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/BObjectType.java
@@ -31,10 +31,13 @@ public class BObjectType extends Construct {
     public List<Function> methods;
     @Expose
     public boolean isDistinct = false;
+    @Expose
+    public boolean isService;
 
-    public BObjectType(String name, String description, boolean isDeprecated, List<DefaultableVariable> fields,
-                       List<Function> methods) {
+    public BObjectType(String name, String description, boolean isDeprecated, boolean isService,
+                       List<DefaultableVariable> fields, List<Function> methods) {
         super(name, description, isDeprecated);
+        this.isService = isService;
         this.fields = fields;
         this.methods = methods;
     }


### PR DESCRIPTION
## Purpose
Currently service type objects are shown as object types. This will add a flag `isService` in object types to check whether the object type is a service type.

Fixes #39210

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
