### PR TITLE
Fix inferring isolated for infer-anonymous-function-expr when there's type narrowing for a parameter

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/IsolationAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/IsolationAnalyzer.java
@@ -1272,7 +1272,7 @@ public class IsolationAnalyzer extends BLangNodeVisitor {
             BLangArrowFunction bLangArrowFunction = (BLangArrowFunction) enclEnv.node;
 
             for (BLangSimpleVariable param : bLangArrowFunction.params) {
-                if (param.symbol == symbol) {
+                if (param.symbol == getOriginalSymbol(symbol)) {
                     return;
                 }
             }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/isolation/IsolationInferenceTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/isolation/IsolationInferenceTest.java
@@ -85,7 +85,8 @@ public class IsolationInferenceTest {
                 "testServiceClassMethodIsolationInference",
                 "testObjectConstructorIsolatedInference",
                 "testFunctionsAccessingModuleLevelVarsIsolatedInference",
-                "testFunctionCallingFunctionWithIsolatedParamAnnotatedParam"
+                "testFunctionCallingFunctionWithIsolatedParamAnnotatedParam",
+                "testInferringIsolatedForAnonFuncArgForIsolatedParamAnnotatedParam"
         };
     }
 
@@ -105,6 +106,9 @@ public class IsolationInferenceTest {
                 "test-src/isolation-analysis/isolation_inference_isolation_analysis_negative.bal");
         int i = 0;
         validateError(result, i++, "invalid invocation of a non-isolated function in an 'isolated' function", 20, 16);
+        validateError(result, i++, "incompatible types: expected an 'isolated' function", 26, 24);
+        validateError(result, i++, "incompatible types: expected an 'isolated' function", 30, 24);
+        validateError(result, i++, "incompatible types: expected an 'isolated' function", 31, 24);
         assertEquals(result.getErrorCount(), i);
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/isolation-analysis/isolation_inference.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/isolation-analysis/isolation_inference.bal
@@ -581,6 +581,38 @@ function testFunctionCallingFunctionWithIsolatedParamAnnotatedParam() {
     assertFalse(<any> nonIsolatedConcat is isolated function);
 }
 
+isolated function inferAnonFuncWithParamTypeNarrowingForIsolatedParam() {
+    (int|string)[] a = [];
+    string[] _ = a.map(n => n is int ? "int" : n);
+
+    (int|string|boolean)[] c = [];
+    string[] _ = c.map(n => n is int|boolean ? (n is int ? n.toString() : "boolean") : n);
+}
+
+function anonFuncWithParamTypeNarrowingForIsolatedParam() {
+    (int|string)[] a = [];
+    string[] _ = a.map(function (int|string n) returns string => n is int ? "int" : n);
+
+    (int|string|boolean)[] c = [];
+    string[] _ = c.map(n => n is int|boolean ? (n is int ? n.toString() : "boolean") : n);
+}
+
+function nonIsolatedAnonFuncWithTypeNarrowingForIsolatedParam() {
+    (int|string)[] a = [];
+    int|string a2 = 1;
+    string[] _ = a.map(function (int|string n) returns string => a2 is int ? "int" : n.toString());
+
+    (int|string|boolean)[] c = [];
+    string d = "";
+    string[] _ = c.map(n => n is int|boolean ? (n is int ? n.toString() : "boolean") : d);
+}
+
+function testInferringIsolatedForAnonFuncArgForIsolatedParamAnnotatedParam() {
+    assertTrue(inferAnonFuncWithParamTypeNarrowingForIsolatedParam is isolated function ());
+    assertTrue(anonFuncWithParamTypeNarrowingForIsolatedParam is isolated function ());
+    assertFalse(nonIsolatedAnonFuncWithTypeNarrowingForIsolatedParam is isolated function ());
+}
+
 class ListenerTwo {
 
     public function attach(service object {} s, string|string[]? name = ()) returns error?  {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/isolation-analysis/isolation_inference_isolation_analysis_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/isolation-analysis/isolation_inference_isolation_analysis_negative.bal
@@ -19,3 +19,14 @@ function hello() returns string => "hello";
 isolated function testFunctionCall() {
     string _ = hello();
 }
+
+isolated function testInferAnonFuncWithParamTypeNarrowingForIsolatedParamNegative() {
+    (int|string)[] a = [];
+    int|string b = 1;
+    string[] _ = a.map(n => b is int ? "int" : n.toString());
+
+    (int|string|boolean)[] c = [];
+    (int|string|boolean)[] d = [0];
+    string[] _ = c.map(n => d[0] is int|boolean ? (d[0] is int ? d[0].toString() : n.toString()) : n.toBalString());
+    string[] _ = c.map(n => n is int|boolean ? (d[0] is int ? d[0].toString() : n.toString()) : n.toBalString());
+}


### PR DESCRIPTION
## Purpose
$title.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/39803

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
