### PR TITLE
Allow using the nil conditional expressions with `json`, `anydata`, and `any`

### DIFF
--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/elvis/ElvisExpressionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/elvis/ElvisExpressionTest.java
@@ -236,6 +236,11 @@ public class ElvisExpressionTest {
         BRunUtil.invoke(compileResult, "testElvisExprWithIntersectionTypes");
     }
 
+    @Test
+    public void testElvisExprWithBuiltInNilableUnion() {
+        BRunUtil.invoke(compileResult, "testElvisExprWithBuiltInNilableUnion");
+    }
+
     @Test(description = "Negative test cases.")
     public void testElvisOperatorNegative() {
         int index = 0;
@@ -293,6 +298,14 @@ public class ElvisExpressionTest {
                 "'NonOptionalType'", 133, 15);
         BAssertUtil.validateError(negativeResult, index++, "operator '?:' cannot be applied to type " +
                 "'(int[]|string)'", 135, 15);
+        BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected 'json', found 'xml:Text'",
+                                  142, 20);
+        BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected 'anydata', found " +
+                "'stream<int>'", 143, 23);
+        BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected 'anydata', found " +
+                "'stream<int>'", 146, 23);
+        BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected 'any', found 'error'", 149,
+                                  20);
         Assert.assertEquals(negativeResult.getErrorCount(), index);
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/elvis/elvis-expr-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/elvis/elvis-expr-negative.bal
@@ -134,3 +134,17 @@ function testInvalidElvisExpr(NonOptionalType i) {
     int[]|string j = "str";
     int[] _ = j ?: [1, 2, 3]; // error
 }
+
+function testElvisExprWithBuiltInNilableUnionNegative() {
+    stream<int> str = new;
+
+    json j1 = 1;
+    json _ = j1 ?: xml `text`;
+    anydata _ = j1 ?: str;
+
+    anydata k1 = 12;
+    anydata _ = k1 ?: str;
+
+    any l1 = 3;
+    any l2 = l1 ?: error("Oops!");
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/elvis/elvis-expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/elvis/elvis-expr.bal
@@ -442,6 +442,33 @@ function testElvisExprWithIntersectionTypes() {
     assertEquals([30, 21], d);
 }
 
+function testElvisExprWithBuiltInNilableUnion() {
+    json j1 = 1;
+    json j2 = j1 ?: "nil";
+    assertEquals(1, j2);
+    json j3 = ();
+    json j4 = j3 ?: "nil";
+    assertEquals("nil", j4);
+    anydata a1 = j3 ?: xml `text`;
+    assertEquals(xml `text`, a1);
+
+    anydata k1 = 12;
+    anydata k2 = k1 ?: 123;
+    assertEquals(12, k2);
+    anydata k3 = ();
+    anydata k4 = k3 ?: 123;
+    assertEquals(123, k4);
+    any k5 = k3 ?: "nil value 2";
+    assertEquals("nil value 2", <anydata> k5);
+
+    any l1 = 3;
+    any l2 = l1 ?: "empty";
+    assertEquals(3, <anydata> l2);
+    any l3 = ();
+    any l4 = l3 ?: "empty";
+    assertEquals("empty", <anydata> l4);
+}
+
 const ASSERTION_ERROR_REASON = "AssertionError";
 
 function assertEquals(anydata expected, anydata actual) {


### PR DESCRIPTION
## Purpose
$title.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/39669

Note: since we cannot represent type - nil (a type by removing nil) at the moment for `json`, `anydata`, and `any`, the type of `L` in `L ?: R`, where `L` is originally of `json`, `anydata`, or `any`, is considered to be the original type itself.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
