### PR TITLE
[master] Update visible endpoint generation to identify client object files with annotations

### DIFF
--- a/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/SyntaxTreeMapGenerator.java
+++ b/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/SyntaxTreeMapGenerator.java
@@ -162,6 +162,8 @@ public class SyntaxTreeMapGenerator extends NodeTransformer<JsonElement> {
                         }
                     }
                 }
+            } catch (RuntimeException e) {
+                // Ignore as semantic API calls cannot break the ST JSON creation.
             } catch (Exception | AssertionError e) {
                 // TODO: Remove the AssertionError catcher when fix the symbolVisitor to be extended from BaseVisitor.
                 // Ignore as semantic API calls cannot break the ST JSON creation.

--- a/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/SyntaxTreeMapGenerator.java
+++ b/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/SyntaxTreeMapGenerator.java
@@ -124,6 +124,13 @@ public class SyntaxTreeMapGenerator extends NodeTransformer<JsonElement> {
             try {
                 if (semanticModel != null) {
                     Optional<TypeSymbol> typeSymbol = this.semanticModel.type(lineRange);
+                    if (node.kind() == SyntaxKind.OBJECT_FIELD) {
+                        // HACK: Cannot identify client qualifier with display annotation
+                        ObjectFieldNode objectFieldNode = (ObjectFieldNode) node;
+                        if (objectFieldNode.metadata().isPresent()) {
+                            typeSymbol = this.semanticModel.type(objectFieldNode.children().get(1));
+                        }
+                    }
                     if (typeSymbol.isPresent()) {
                         TypeSymbol rawType = getRawType(typeSymbol.get());
                         if (rawType.typeKind() == TypeDescKind.OBJECT) {

--- a/misc/diagram-util/src/test/java/org/ballerinalang/diagramutil/SyntaxTreeGenTest.java
+++ b/misc/diagram-util/src/test/java/org/ballerinalang/diagramutil/SyntaxTreeGenTest.java
@@ -364,7 +364,7 @@ public class SyntaxTreeGenTest {
 
         Assert.assertEquals(stJson.getAsJsonObject().get("kind").getAsString(), "ModulePart");
         Assert.assertTrue(stJson.getAsJsonObject().get("members").isJsonArray());
-        Assert.assertTrue(stJson.getAsJsonObject().get("members").getAsJsonArray().size() == 9);
+        Assert.assertTrue(stJson.getAsJsonObject().get("members").getAsJsonArray().size() == 10);
         JsonArray members = stJson.getAsJsonObject().get("members").getAsJsonArray();
 
         // Verify main function
@@ -748,5 +748,36 @@ public class SyntaxTreeGenTest {
         Assert.assertEquals(exEp11Position.get("startLine").getAsInt(), 90);
         Assert.assertEquals(exEp11Position.get("endLine").getAsInt(), 90);
 
+        // Verify /abc service declaration
+        Assert.assertEquals(members.get(9).getAsJsonObject().get("kind").getAsString(), "ServiceDeclaration");
+        JsonObject abcServiceDec = members.get(9).getAsJsonObject();
+        JsonArray abcServiceMembers = abcServiceDec.get("members").getAsJsonArray();
+        Assert.assertTrue(abcServiceMembers.size() == 3);
+        JsonArray abcServiceVEp = abcServiceDec.get("VisibleEndpoints").getAsJsonArray();
+        Assert.assertTrue(serviceVEp.size() == 3);
+
+        Assert.assertEquals(abcServiceVEp.get(0).getAsJsonObject().get("name").getAsString(), "exEp0");
+        Assert.assertEquals(abcServiceVEp.get(1).getAsJsonObject().get("name").getAsString(), "exEpOut");
+        Assert.assertEquals(abcServiceVEp.get(2).getAsJsonObject().get("name").getAsString(), "inEp3");
+
+        JsonArray abcGetResourceVEps = abcServiceMembers.get(2).getAsJsonObject().get("functionBody").getAsJsonObject()
+                .get("VisibleEndpoints").getAsJsonArray();
+
+        Assert.assertEquals(abcGetResourceVEps.get(0).getAsJsonObject().get("name").getAsString(), "exEp0");
+        Assert.assertEquals(abcGetResourceVEps.get(1).getAsJsonObject().get("name").getAsString(), "exEpOut");
+
+        JsonObject inEp3 = abcGetResourceVEps.get(2).getAsJsonObject();
+        Assert.assertEquals(inEp3.get("name").getAsString(), "inEp3");
+        Assert.assertEquals(inEp3.get("typeName").getAsString(), "InternalClient");
+        Assert.assertEquals(inEp3.get("orgName").getAsString(), "gayanOrg");
+        Assert.assertEquals(inEp3.get("packageName").getAsString(), "testEps");
+        Assert.assertEquals(inEp3.get("moduleName").getAsString(), "testEps");
+        Assert.assertEquals(inEp3.get("version").getAsString(), "0.1.0");
+        Assert.assertEquals(inEp3.get("isModuleVar").getAsBoolean(), false);
+        Assert.assertEquals(inEp3.get("isExternal").getAsBoolean(), true);
+        Assert.assertEquals(inEp3.get("isClassField").getAsBoolean(), true);
+        JsonObject inEp3Position = inEp3.get("position").getAsJsonObject();
+        Assert.assertEquals(inEp3Position.get("startLine").getAsInt(), 110);
+        Assert.assertEquals(inEp3Position.get("endLine").getAsInt(), 114);
     }
 }

--- a/misc/diagram-util/src/test/resources/multiLevelEndpoints/main.bal
+++ b/misc/diagram-util/src/test/resources/multiLevelEndpoints/main.bal
@@ -105,3 +105,21 @@ service /next on new http:Listener(9090) {
     }
 
 }
+
+service /abc on new http:Listener(9090) {
+
+    @display {
+        label: "InternalClientService",
+        id: "InternalClient-b704fd5e-06b8-47df-89fe-6c462b5cdf4e"
+    }
+    InternalClient inEp3;
+
+    function init() returns error? {
+        self.inEp3 = check new InternalClient("http://example.com/internal/1");
+    }
+
+    resource function get repos(string orgName, int max = 5) returns string|error? {
+
+    }
+
+}


### PR DESCRIPTION
## Purpose
Update visible endpoint generation to identify `client object` files with annotations.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/39657

## Approach

Semantic API doesn't send CLIENT qualifier for `client object node` with annotations. This PR will skip annotation from the node and request Semantic TypeSymbol just only for the `client object`. 



```ballerina
service /abc on new http:Listener(9090) {

    @display {
        label: "InternalClientService",
    }
    InternalClient inEp3;

    function init() returns error? {
        self.inEp3 = check new InternalClient("http://example.com/internal/1");
    }

    resource function get repos(string orgName, int max = 5) returns string|error? {

    }

}
```
In the above example `@display {
        label: "InternalClientService",
    }
    InternalClient inEp3` node won't get the CLIENT qualifier. But just creating a new node with `InternalClient inEp3` will send the  CLIENT qualifier.
## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [x] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
