### PR TITLE
Fix `thenReturn(())`, `doNothing()` not returning a nil value

### DIFF
--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/mock/FunctionMock.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/mock/FunctionMock.java
@@ -56,10 +56,9 @@ public class FunctionMock {
         String originalClass = splitInfo[2];
 
         originalFunctionPackage = getQualifiedClassName(originalOrg, originalPackage, originalVersion, originalClass);
-        Object returnVal = null;
         for (String caseId : caseIds) {
             if (MockRegistry.getInstance().hasCase(caseId)) {
-                returnVal = MockRegistry.getInstance().getReturnValue(caseId);
+                Object returnVal = MockRegistry.getInstance().getReturnValue(caseId);
                 if (returnVal instanceof BString) {
                     if (returnVal.toString().contains(MockConstants.FUNCTION_CALL_PLACEHOLDER)) {
                         return callMockFunction(originalFunction, originalFunctionPackage,
@@ -70,19 +69,16 @@ public class FunctionMock {
                                 originalFunctionPackage, args);
                     }
                 }
-                break;
+                return returnVal;
             }
         }
-        if (returnVal == null) {
-            String message = "no return value or action registered for function";
-            throw ErrorCreator.createError(
-                    MockConstants.TEST_PACKAGE_ID,
-                    MockConstants.FUNCTION_CALL_ERROR,
-                    StringUtils.fromString(message),
-                    null,
-                    new MapValueImpl<>(PredefinedTypes.TYPE_ERROR_DETAIL));
-        }
-        return returnVal;
+        String message = "no return value or action registered for function";
+        throw ErrorCreator.createError(
+                MockConstants.TEST_PACKAGE_ID,
+                MockConstants.FUNCTION_CALL_ERROR,
+                StringUtils.fromString(message),
+                null,
+                new MapValueImpl<>(PredefinedTypes.TYPE_ERROR_DETAIL));
     }
 
     private static Object callOriginalFunction(String originalFunction, String originalClassName, Object... args) {
@@ -289,4 +285,3 @@ public class FunctionMock {
         return caseIdList;
     }
 }
-

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/MockTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/MockTest.java
@@ -146,6 +146,14 @@ public class MockTest extends BaseTestCase {
         AssertionUtils.assertOutput("MockTest-testFuncMockInMultiModulesWDepen.txt", output);
     }
 
+    @Test
+    public void testFunctionMockingThenReturnWithNilReturnValue() throws BallerinaTestException, IOException {
+        String[] args = mergeCoverageArgs(new String[]{"function-mocking-tests-then-return-with-nil-ret-val"});
+        String output = balClient.runMainAndReadStdOut("test", args, new HashMap<>(), projectPath, false);
+        AssertionUtils.assertOutput("MockTest-testFunctionMockingThenReturnWithNilRetVal.txt",
+                output.replaceAll("\r\n|\r", "\n"));
+    }
+
     @Test(dataProvider = "testNegativeCases")
     public void testObjectMocking_NegativeCases(String message, String test, String baseOutputFile) throws
             BallerinaTestException, IOException {

--- a/tests/testerina-integration-test/src/test/resources/command-outputs/unix/MockTest-testFunctionMockingThenReturnWithNilRetVal.txt
+++ b/tests/testerina-integration-test/src/test/resources/command-outputs/unix/MockTest-testFunctionMockingThenReturnWithNilRetVal.txt
@@ -1,0 +1,23 @@
+Compiling source
+	intg_tests/function_mocking:0.0.0
+
+Running Tests with Coverage
+
+	function_mocking
+		[pass] testFunctionMock
+		[pass] testFunctionMock2
+
+		[fail] testFunctionMock3:
+
+		    no return value or action registered for function
+			
+
+
+		2 passing
+		1 failing
+		0 skipped
+
+Generating Test Report
+	function-mocking-tests-then-return-with-nil-ret-val/target/report/test_results.json
+
+error: there are test failures

--- a/tests/testerina-integration-test/src/test/resources/command-outputs/windows/MockTest-testFunctionMockingThenReturnWithNilRetVal.txt
+++ b/tests/testerina-integration-test/src/test/resources/command-outputs/windows/MockTest-testFunctionMockingThenReturnWithNilRetVal.txt
@@ -1,0 +1,23 @@
+Compiling source
+	intg_tests/function_mocking:0.0.0
+
+Running Tests with Coverage
+
+	function_mocking
+		[pass] testFunctionMock
+		[pass] testFunctionMock2
+
+		[fail] testFunctionMock3:
+
+		    no return value or action registered for function
+			
+
+
+		2 passing
+		1 failing
+		0 skipped
+
+Generating Test Report
+	function-mocking-tests-then-return-with-nil-ret-val\target\report\test_results.json
+
+error: there are test failures

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/function-mocking-tests-then-return-with-nil-ret-val/Ballerina.toml
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/function-mocking-tests-then-return-with-nil-ret-val/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "intg_tests"
+name = "function_mocking"
+version = "0.0.0"

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/function-mocking-tests-then-return-with-nil-ret-val/main.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/function-mocking-tests-then-return-with-nil-ret-val/main.bal
@@ -1,0 +1,21 @@
+// Copyright (c) 2023 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+function f1() returns int? { return 2; }
+
+function f2() returns int? { return 3; }
+
+function f3() returns int? { return 4; }

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/function-mocking-tests-then-return-with-nil-ret-val/tests/tests.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/function-mocking-tests-then-return-with-nil-ret-val/tests/tests.bal
@@ -1,0 +1,44 @@
+// Copyright (c) 2023 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+
+@test:Mock { functionName: "f1"}
+test:MockFunction mockFn1 = new();
+
+@test:Mock { functionName: "f2"}
+test:MockFunction mockFn2 = new();
+
+@test:Mock { functionName: "f3"}
+test:MockFunction mockFn3 = new();
+
+@test:Config {}
+function testFunctionMock() {
+    test:when(mockFn1).thenReturn(());
+    test:assertEquals(f1(), ());
+}
+
+@test:Config {}
+function testFunctionMock2() {
+    test:when(mockFn2).doNothing();
+    test:assertEquals(f2(), ());
+}
+
+@test:Config {}
+function testFunctionMock3() {
+    // no return value set
+    test:assertEquals(f3(), ());
+}


### PR DESCRIPTION
## Purpose
$subject

Fixes #32903

## Approach
Removed the validation that checks if returnVal == null and throws an error.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
