### PR TITLE
[2201.4.1-stage] Add resource kind in API docs generation

### DIFF
--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
@@ -418,7 +418,7 @@ public class Generator {
         List<Type> memberTypes = new ArrayList<>();
         Type.addUnionMemberTypes(unionTypeDescriptor, semanticModel, memberTypes);
         BType bType = new BType(unionName, getDocFromMetadata(optionalMetadataNode),
-                isDeprecated(optionalMetadataNode), memberTypes);
+                                isDeprecated(optionalMetadataNode), memberTypes);
         bType.isAnonymousUnionType = true;
         return bType;
     }
@@ -452,9 +452,9 @@ public class Generator {
 
         // Get functions that are not overridden
         List<Function> functions = includedFunctions.stream().filter(includedFunction ->
-                        classFunctions
-                                .stream()
-                                .noneMatch(objFunction -> objFunction.name.equals(includedFunction.name)))
+                classFunctions
+                        .stream()
+                        .noneMatch(objFunction -> objFunction.name.equals(includedFunction.name)))
                 .collect(Collectors.toList());
 
         functions.addAll(classFunctions);
@@ -505,7 +505,7 @@ public class Generator {
 
                     // Iterate through the parameters
                     List<DefaultableVariable> parameters = new ArrayList<>(getDefaultableVariableList(methodSignature
-                            .parameters(), methodNode.metadata(), semanticModel));
+                                    .parameters(), methodNode.metadata(), semanticModel));
 
                     // return params
                     if (methodSignature.returnTypeDesc().isPresent()) {
@@ -540,9 +540,9 @@ public class Generator {
 
         // Get functions that are not overridden
         List<Function> functions = includedFunctions.stream().filter(includedFunction ->
-                        objectFunctions
-                                .stream()
-                                .noneMatch(objFunction -> objFunction.name.equals(includedFunction.name)))
+                objectFunctions
+                        .stream()
+                        .noneMatch(objFunction -> objFunction.name.equals(includedFunction.name)))
                 .collect(Collectors.toList());
 
         functions.addAll(objectFunctions);
@@ -634,7 +634,7 @@ public class Generator {
             fields.add(restVariable);
         }
         return new Record(recordName, getDocFromMetadata(optionalMetadataNode),
-                isDeprecated(optionalMetadataNode), isClosed, fields);
+                          isDeprecated(optionalMetadataNode), isClosed, fields);
     }
 
     public static List<DefaultableVariable> getDefaultableVariableList(NodeList nodeList,
@@ -746,7 +746,7 @@ public class Generator {
     }
 
     private static List<AnnotationAttachment> extractAnnotationAttachmentsFromMetadataNode(SemanticModel semanticModel,
-                                                                                           Optional<MetadataNode> metadata) {
+                                                 Optional<MetadataNode> metadata) {
         List<AnnotationAttachment> annotationAttachments = new ArrayList<>();
         metadata.ifPresent(metadataNode -> metadataNode.annotations().forEach(annotationNode -> {
             Symbol symbol = semanticModel.symbol(annotationNode).orElse(null);

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Client.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Client.java
@@ -31,7 +31,7 @@ public class Client extends BClass {
     public List<Function> resourceMethods;
 
     public Client(String name, String description, boolean isDeprecated, List<DefaultableVariable> fields,
-                  List<Function> methods, boolean isReadOnly, boolean isIsolated) {
+            List<Function> methods, boolean isReadOnly, boolean isIsolated) {
         super(name, description, isDeprecated, fields, methods, isReadOnly, isIsolated);
         this.remoteMethods = getRemoteMethods();
         this.resourceMethods = getResourceMethods();

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Client.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Client.java
@@ -27,24 +27,33 @@ public class Client extends BClass {
 
     @Expose
     public List<Function> remoteMethods;
+    @Expose
+    public List<Function> resourceMethods;
 
     public Client(String name, String description, boolean isDeprecated, List<DefaultableVariable> fields,
-            List<Function> methods, boolean isReadOnly, boolean isIsolated) {
+                  List<Function> methods, boolean isReadOnly, boolean isIsolated) {
         super(name, description, isDeprecated, fields, methods, isReadOnly, isIsolated);
         this.remoteMethods = getRemoteMethods();
+        this.resourceMethods = getResourceMethods();
         this.otherMethods = getOtherMethods(methods);
     }
 
     @Override
     public List<Function> getOtherMethods(List<Function> methods) {
         return super.getOtherMethods(methods).stream()
-                .filter(function -> !function.isRemote)
+                .filter(function -> !function.isRemote && !function.isResource)
                 .collect(Collectors.toList());
     }
 
     public List<Function> getRemoteMethods() {
         return this.methods.stream()
                 .filter(function -> function.isRemote)
+                .collect(Collectors.toList());
+    }
+
+    public List<Function> getResourceMethods() {
+        return this.methods.stream()
+                .filter(function -> function.isResource)
                 .collect(Collectors.toList());
     }
 }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Function.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Function.java
@@ -24,9 +24,15 @@ import java.util.List;
  */
 public class Function extends Construct {
     @Expose
+    public String accessor = "";
+    @Expose
+    public String resourcePath = "";
+    @Expose
     public boolean isIsolated;
     @Expose
     public boolean isRemote;
+    @Expose
+    public boolean isResource;
     @Expose
     public boolean isExtern;
     @Expose
@@ -36,11 +42,12 @@ public class Function extends Construct {
     @Expose
     List<AnnotationAttachment> annotationAttachments;
 
-    public Function(String name, String description, boolean isRemote, boolean isExtern, boolean isDeprecated,
+    public Function(String name, String description, FunctionKind functionKind, boolean isExtern, boolean isDeprecated,
                     boolean isIsolated, List<DefaultableVariable> parameters, List<Variable> returnParameters,
                     List<AnnotationAttachment> annotationAttachments) {
         super(name, description, isDeprecated);
-        this.isRemote = isRemote;
+        this.isRemote = checkRemote(functionKind);
+        this.isResource = checkResource(functionKind);
         this.isExtern = isExtern;
         this.parameters = parameters;
         this.returnParameters = returnParameters;
@@ -48,13 +55,51 @@ public class Function extends Construct {
         this.annotationAttachments = annotationAttachments;
     }
 
-    public Function(String name, String description, boolean isRemote, boolean isExtern, boolean isDeprecated,
-                    boolean isIsolated, List<DefaultableVariable> parameters, List<Variable> returnParameters) {
+    public Function(String name, String accessor, String resourcePath, String description, FunctionKind functionKind,
+                    boolean isExtern, boolean isDeprecated, boolean isIsolated, List<DefaultableVariable> parameters,
+                    List<Variable> returnParameters, List<AnnotationAttachment> annotationAttachments) {
         super(name, description, isDeprecated);
-        this.isRemote = isRemote;
+        this.accessor = accessor;
+        this.resourcePath = resourcePath;
+        this.isRemote = checkRemote(functionKind);
+        this.isResource = checkResource(functionKind);
         this.isExtern = isExtern;
         this.parameters = parameters;
         this.returnParameters = returnParameters;
         this.isIsolated = isIsolated;
+        this.annotationAttachments = annotationAttachments;
+    }
+
+    public Function(String name, String description, FunctionKind functionKind, boolean isExtern, boolean isDeprecated,
+                    boolean isIsolated, List<DefaultableVariable> parameters, List<Variable> returnParameters) {
+        super(name, description, isDeprecated);
+        this.isRemote = checkRemote(functionKind);
+        this.isResource = checkResource(functionKind);
+        this.isExtern = isExtern;
+        this.parameters = parameters;
+        this.returnParameters = returnParameters;
+        this.isIsolated = isIsolated;
+    }
+
+    public Function(String name, String accessor, String resourcePath, String description, FunctionKind functionKind,
+                    boolean isExtern, boolean isDeprecated, boolean isIsolated, List<DefaultableVariable> parameters,
+                    List<Variable> returnParameters) {
+        super(name, description, isDeprecated);
+        this.accessor = accessor;
+        this.resourcePath = resourcePath;
+        this.isRemote = checkRemote(functionKind);
+        this.isResource = checkResource(functionKind);
+        this.isExtern = isExtern;
+        this.parameters = parameters;
+        this.returnParameters = returnParameters;
+        this.isIsolated = isIsolated;
+    }
+
+    private boolean checkRemote(FunctionKind functionKind) {
+        return functionKind == FunctionKind.REMOTE;
+    }
+
+    private boolean checkResource(FunctionKind functionKind) {
+        return functionKind == FunctionKind.RESOURCE;
     }
 }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/FunctionKind.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/FunctionKind.java
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.docgen.generator.model;
+
+/**
+ * Represent kinds for a Function.
+ */
+public enum FunctionKind {
+    REMOTE,
+    RESOURCE,
+    OTHER
+}

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Type.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Type.java
@@ -422,19 +422,19 @@ public class Type {
                                 .anyMatch(annotationSymbol -> annotationSymbol.getName().get().equals("deprecated"));
                         functionType.paramTypes.add(paramType);
                     });
-                    if (methodSymbol.typeDescriptor().restParam().isPresent()) {
-                        ParameterSymbol restParam = methodSymbol.typeDescriptor().restParam().get();
-                        Type restType = fromSemanticSymbol(restParam, methodSymbol.documentation(), parentTypeRefSymbol,
-                                isTypeInclusion);
-                        restType.isDeprecated = restParam.annotations().stream()
-                                .anyMatch(annotationSymbol -> annotationSymbol.getName().get().equals("deprecated"));
-                        functionType.paramTypes.add(restType);
-                    }
-                    if (methodSymbol.typeDescriptor().returnTypeDescriptor().isPresent()) {
-                        Type returnType = fromSemanticSymbol(methodSymbol.typeDescriptor().returnTypeDescriptor().get(),
-                                methodSymbol.documentation(), parentTypeRefSymbol, isTypeInclusion);
-                        functionType.returnType = returnType;
-                    }
+                if (methodSymbol.typeDescriptor().restParam().isPresent()) {
+                    ParameterSymbol restParam = methodSymbol.typeDescriptor().restParam().get();
+                    Type restType = fromSemanticSymbol(restParam, methodSymbol.documentation(), parentTypeRefSymbol,
+                            isTypeInclusion);
+                    restType.isDeprecated = restParam.annotations().stream()
+                            .anyMatch(annotationSymbol -> annotationSymbol.getName().get().equals("deprecated"));
+                    functionType.paramTypes.add(restType);
+                }
+                if (methodSymbol.typeDescriptor().returnTypeDescriptor().isPresent()) {
+                    Type returnType = fromSemanticSymbol(methodSymbol.typeDescriptor().returnTypeDescriptor().get(),
+                            methodSymbol.documentation(), parentTypeRefSymbol, isTypeInclusion);
+                    functionType.returnType = returnType;
+                }
                 });
                 functionTypes.add(functionType);
             });

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/types/FunctionType.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/types/FunctionType.java
@@ -16,6 +16,7 @@
 package org.ballerinalang.docgen.generator.model.types;
 
 import com.google.gson.annotations.Expose;
+import org.ballerinalang.docgen.generator.model.FunctionKind;
 import org.ballerinalang.docgen.generator.model.Type;
 
 import java.util.ArrayList;
@@ -29,13 +30,17 @@ import java.util.List;
 public class FunctionType extends Type {
 
     @Expose
+    public String accessor;
+    @Expose
+    public String resourcePath;
+    @Expose
     public boolean isLambda;
     @Expose
     public boolean isIsolated;
     @Expose
     public boolean isExtern;
     @Expose
-    public boolean isRemote;
+    public FunctionKind functionKind;
     @Expose
     public List<Type> paramTypes = new ArrayList<>();
     @Expose


### PR DESCRIPTION
## Purpose
$subject

Fixes #39668 #39694

## Approach
The existing way of differentiating function kind is to check whether the function is remote or not. Instead of that, there will be three function kinds `REMOTE`, `RESOURCE` & `OTHER`.
There will be a seperate method kind for resource functions. Apart from the function name, there will be `accessor` and `resoucePath` for the resource functions (For other methods including remote functions, those values will be empty strings in the `api-doc.json`).

## Samples
<img width="791" alt="Screenshot 2023-02-28 at 16 04 08" src="https://user-images.githubusercontent.com/51471998/221829276-bf47c3de-39fc-47ab-bdb7-e09216176ae2.png">

## Related PRs
https://github.com/ballerina-platform/ballerina-lang/pull/39695
https://github.com/ballerina-platform/ballerina-lang/pull/39784

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples

