### PR TITLE
[persist-improvement] Bundle resource path parameters of external functions into anydata array

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/PredefinedTypes.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/PredefinedTypes.java
@@ -170,6 +170,7 @@ public class PredefinedTypes {
     public static final ArrayType TYPE_JSON_ARRAY;
     public static final AnydataType TYPE_ANYDATA;
     public static final AnydataType TYPE_READONLY_ANYDATA;
+    public static final ArrayType TYPE_ANYDATA_ARRAY;
     public static final MapType TYPE_DETAIL;
     public static final Type TYPE_ERROR_DETAIL;
     public static final ErrorType TYPE_ERROR;
@@ -196,6 +197,7 @@ public class PredefinedTypes {
         members.add(TYPE_XML);
         TYPE_ANYDATA = getAnydataType(members, TypeConstants.ANYDATA_TNAME, false);
         TYPE_READONLY_ANYDATA = getAnydataType(members, TypeConstants.READONLY_ANYDATA_TNAME, true);
+        TYPE_ANYDATA_ARRAY = new BArrayType(TYPE_ANYDATA);
     }
 
     private PredefinedTypes() {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -872,11 +872,11 @@ public class BIRGen extends BLangNodeVisitor {
 
     private void addParam(BIRFunction birFunc, BVarSymbol paramSymbol, BLangExpression defaultValExpr,
                           Location pos, List<? extends AnnotationAttachmentSymbol> annots) {
+        boolean isPathParam = paramSymbol.kind == SymbolKind.PATH_PARAMETER ||
+                paramSymbol.kind == SymbolKind.PATH_REST_PARAMETER;
         BIRFunctionParameter birVarDcl = new BIRFunctionParameter(pos, paramSymbol.type,
                 this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.ARG,
-                paramSymbol.name.value, defaultValExpr != null,
-                paramSymbol.kind == SymbolKind.PATH_PARAMETER ||
-                        paramSymbol.kind == SymbolKind.PATH_REST_PARAMETER);
+                paramSymbol.name.value, defaultValExpr != null, isPathParam);
 
         birFunc.localVars.add(birVarDcl);
 
@@ -907,9 +907,11 @@ public class BIRGen extends BLangNodeVisitor {
     }
 
     private void addRequiredParam(BIRFunction birFunc, BVarSymbol paramSymbol, Location pos) {
+        boolean isPathParam = paramSymbol.kind == SymbolKind.PATH_PARAMETER ||
+                paramSymbol.kind == SymbolKind.PATH_REST_PARAMETER;
         BIRFunctionParameter birVarDcl = new BIRFunctionParameter(pos, paramSymbol.type,
-                this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.ARG, paramSymbol.name.value, false,
-                paramSymbol.kind == SymbolKind.PATH_PARAMETER);
+                this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.ARG, paramSymbol.name.value,
+                false, isPathParam);
         birFunc.parameters.add(birVarDcl);
         birFunc.localVars.add(birVarDcl);
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -875,7 +875,8 @@ public class BIRGen extends BLangNodeVisitor {
         BIRFunctionParameter birVarDcl = new BIRFunctionParameter(pos, paramSymbol.type,
                 this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.ARG,
                 paramSymbol.name.value, defaultValExpr != null,
-                paramSymbol.kind == SymbolKind.PATH_PARAMETER);
+                paramSymbol.kind == SymbolKind.PATH_PARAMETER ||
+                        paramSymbol.kind == SymbolKind.PATH_REST_PARAMETER);
 
         birFunc.localVars.add(birVarDcl);
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -25,6 +25,7 @@ import org.ballerinalang.model.TreeBuilder;
 import org.ballerinalang.model.elements.Flag;
 import org.ballerinalang.model.elements.PackageID;
 import org.ballerinalang.model.symbols.AnnotationAttachmentSymbol;
+import org.ballerinalang.model.symbols.SymbolKind;
 import org.ballerinalang.model.symbols.SymbolOrigin;
 import org.ballerinalang.model.tree.BlockNode;
 import org.ballerinalang.model.tree.NodeKind;
@@ -583,8 +584,8 @@ public class BIRGen extends BLangNodeVisitor {
         this.currentScope = new BirScope(0, null);
         if (astFunc.receiver != null) {
             BIRFunctionParameter birVarDcl = new BIRFunctionParameter(astFunc.pos, astFunc.receiver.getBType(),
-                                                                      this.env.nextLocalVarId(names), VarScope.FUNCTION,
-                                                                      VarKind.ARG, astFunc.receiver.name.value, false);
+                    this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.ARG, astFunc.receiver.name.value,
+                    false, false);
             this.env.symbolVarMap.put(astFunc.receiver.symbol, birVarDcl);
             birFunc.receiver = getSelf(astFunc.receiver.symbol);
         }
@@ -873,7 +874,8 @@ public class BIRGen extends BLangNodeVisitor {
                           Location pos, List<? extends AnnotationAttachmentSymbol> annots) {
         BIRFunctionParameter birVarDcl = new BIRFunctionParameter(pos, paramSymbol.type,
                 this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.ARG,
-                paramSymbol.name.value, defaultValExpr != null);
+                paramSymbol.name.value, defaultValExpr != null,
+                paramSymbol.kind == SymbolKind.PATH_PARAMETER);
 
         birFunc.localVars.add(birVarDcl);
 
@@ -889,7 +891,8 @@ public class BIRGen extends BLangNodeVisitor {
 
     private void addRestParam(BIRFunction birFunc, BVarSymbol paramSymbol, Location pos) {
         BIRFunctionParameter birVarDcl = new BIRFunctionParameter(pos, paramSymbol.type,
-                this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.ARG, paramSymbol.name.value, false);
+                this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.ARG, paramSymbol.name.value, false,
+                paramSymbol.kind == SymbolKind.PATH_REST_PARAMETER);
         birFunc.parameters.add(birVarDcl);
         birFunc.localVars.add(birVarDcl);
 
@@ -904,7 +907,8 @@ public class BIRGen extends BLangNodeVisitor {
 
     private void addRequiredParam(BIRFunction birFunc, BVarSymbol paramSymbol, Location pos) {
         BIRFunctionParameter birVarDcl = new BIRFunctionParameter(pos, paramSymbol.type,
-                this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.ARG, paramSymbol.name.value, false);
+                this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.ARG, paramSymbol.name.value, false,
+                paramSymbol.kind == SymbolKind.PATH_PARAMETER);
         birFunc.parameters.add(birVarDcl);
         birFunc.localVars.add(birVarDcl);
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCastGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCastGen.java
@@ -1297,7 +1297,7 @@ public class JvmCastGen {
         }
     }
 
-    private void generateCheckCastToAnyData(MethodVisitor mv, BType type) {
+    public void generateCheckCastToAnyData(MethodVisitor mv, BType type) {
         BType sourceType = JvmCodeGenUtil.getReferredType(type);
         if (sourceType.tag == TypeTags.UNION || sourceType.tag == TypeTags.INTERSECTION ||
                 (types.isAssignable(sourceType, symbolTable.anyType) &&

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
@@ -258,6 +258,7 @@ public class JvmConstants {
 
     // types related constants
     public static final String TYPES_ERROR = "TYPE_ERROR";
+    public static final String TYPE_ANYDATA_ARRAY = "TYPE_ANYDATA_ARRAY";
 
     // error related constants
     public static final String PANIC_FIELD = "panic";

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmDesugarPhase.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmDesugarPhase.java
@@ -141,7 +141,7 @@ public class JvmDesugarPhase {
 
         // Inject an additional parameter to accept the self-record value into the init function
         BIRFunctionParameter selfParam = new BIRFunctionParameter(null, receiver.type, receiver.name,
-                                                                  receiver.scope, VarKind.ARG, paramName, false);
+                receiver.scope, VarKind.ARG, paramName, false, false);
 
         List<BType> updatedParamTypes = Lists.of(receiver.type);
         updatedParamTypes.addAll(func.type.paramTypes);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
@@ -400,11 +400,11 @@ class JvmObservabilityGen {
                 BIRFunctionParameter funcParam;
                 if (arg.variableDcl.kind == VarKind.SELF) {
                     funcParam = new BIRFunctionParameter(asyncCallIns.pos, arg.variableDcl.type, selfArgName,
-                            VarScope.FUNCTION, VarKind.SELF, selfArgName.getValue(), false);
+                            VarScope.FUNCTION, VarKind.SELF, selfArgName.getValue(), false, false);
                 } else {
                     Name argName = new Name("$funcParam%d" + i);
                     funcParam = new BIRFunctionParameter(asyncCallIns.pos, arg.variableDcl.type,
-                            argName, VarScope.FUNCTION, VarKind.ARG, argName.getValue(), false);
+                            argName, VarScope.FUNCTION, VarKind.ARG, argName.getValue(), false, false);
                     desugaredFunc.localVars.add(funcParam);
                     desugaredFunc.parameters.add(funcParam);
                     desugaredFunc.requiredParams.add(new BIRParameter(asyncCallIns.pos, argName, 0));

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmSignatures.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmSignatures.java
@@ -339,6 +339,7 @@ public class JvmSignatures {
     public static final String LOAD_JOBJECT_TYPE = "L" + OBJECT + ";";
     public static final String LOAD_ANY_TYPE = "L" + ANY_TYPE + ";";
     public static final String LOAD_ANYDATA_TYPE = "L" + ANYDATA_TYPE + ";";
+    public static final String LOAD_ARRAY_TYPE = "L" + ARRAY_TYPE + ";";
     public static final String INIT_ANYDATA_ARRAY = "([L" + OBJECT + ";L" + ARRAY_TYPE + ";)V";
     public static final String LOAD_BOOLEAN_TYPE = "L" + BOOLEAN_TYPE + ";";
     public static final String LOAD_BYTE_TYPE = "L" + BYTE_TYPE + ";";

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmSignatures.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmSignatures.java
@@ -336,9 +336,10 @@ public class JvmSignatures {
     public static final String LAMBDA_MAIN = "([L" + OBJECT + ";)L" + OBJECT + ";";
     public static final String LAMBDA_STOP_DYNAMIC = "([L" + OBJECT + ";)L" + OBJECT + ";";
     public static final String LINKED_HASH_SET_OP = "(L" + LINKED_HASH_SET + ";)V";
+    public static final String LOAD_JOBJECT_TYPE = "L" + OBJECT + ";";
     public static final String LOAD_ANY_TYPE = "L" + ANY_TYPE + ";";
     public static final String LOAD_ANYDATA_TYPE = "L" + ANYDATA_TYPE + ";";
-    public static final String ANYDATA_ARRAY_INIT = "([L" + OBJECT + ";L" + ARRAY_TYPE + ";)V";
+    public static final String INIT_ANYDATA_ARRAY = "([L" + OBJECT + ";L" + ARRAY_TYPE + ";)V";
     public static final String LOAD_BOOLEAN_TYPE = "L" + BOOLEAN_TYPE + ";";
     public static final String LOAD_BYTE_TYPE = "L" + BYTE_TYPE + ";";
     public static final String LOAD_DECIMAL_TYPE = "L" + DECIMAL_TYPE + ";";

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmSignatures.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmSignatures.java
@@ -20,6 +20,7 @@ package org.wso2.ballerinalang.compiler.bir.codegen;
 
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.ANYDATA_TYPE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.ANY_TYPE;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.ARRAY_TYPE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.ARRAY_TYPE_IMPL;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.ARRAY_VALUE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.BAL_ENV;
@@ -337,6 +338,7 @@ public class JvmSignatures {
     public static final String LINKED_HASH_SET_OP = "(L" + LINKED_HASH_SET + ";)V";
     public static final String LOAD_ANY_TYPE = "L" + ANY_TYPE + ";";
     public static final String LOAD_ANYDATA_TYPE = "L" + ANYDATA_TYPE + ";";
+    public static final String ANYDATA_ARRAY_INIT = "([L" + OBJECT + ";L" + ARRAY_TYPE + ";)V";
     public static final String LOAD_BOOLEAN_TYPE = "L" + BOOLEAN_TYPE + ";";
     public static final String LOAD_BYTE_TYPE = "L" + BYTE_TYPE + ";";
     public static final String LOAD_DECIMAL_TYPE = "L" + DECIMAL_TYPE + ";";

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTerminatorGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTerminatorGen.java
@@ -616,6 +616,12 @@ public class JvmTerminatorGen {
             mv.visitMethodInsn(INVOKESPECIAL, BAL_ENV, JVM_INIT_METHOD, INIT_BAL_ENV_WITH_FUNC_NAME, false);
         }
 
+        if (callIns.receiverArgs != null && !callIns.receiverArgs.isEmpty()) {
+            for (BIROperand arg : callIns.receiverArgs) {
+                this.loadVar(arg.variableDcl);
+            }
+        }
+
         if (callIns.resourcePathArgs != null && !callIns.resourcePathArgs.isEmpty()) {
             List<BIROperand> pathArgs = callIns.resourcePathArgs;
             int pathVarArrayIndex = this.indexMap.addIfNotExists("$pathVarArray", symbolTable.anyType);
@@ -646,7 +652,6 @@ public class JvmTerminatorGen {
             mv.visitMethodInsn(INVOKESPECIAL, ARRAY_TYPE_IMPL, JVM_INIT_METHOD, TYPE_PARAMETER, false);
             mv.visitMethodInsn(INVOKESPECIAL, ARRAY_VALUE_IMPL, JVM_INIT_METHOD, ANYDATA_ARRAY_INIT, false);
             mv.visitVarInsn(ASTORE, bundledArrayIndex);
-
             mv.visitVarInsn(ALOAD, bundledArrayIndex);
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTerminatorGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTerminatorGen.java
@@ -146,6 +146,7 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.WORKER_DA
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.WORKER_UTILS;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmInstructionGen.addJUnboxInsn;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.ANNOTATION_GET_STRAND;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.ANYDATA_ARRAY_INIT;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.ANY_TO_JBOOLEAN;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.BAL_ENV_PARAM;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.BOBJECT_CALL;
@@ -174,6 +175,7 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.INIT_DEC
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.INT_TO_STRING;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.INT_VALUE_OF_METHOD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.IS_CONCURRENT;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.LOAD_ANYDATA_TYPE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.LOCK;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.MAP_PUT;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.PANIC_IF_IN_LOCK;
@@ -184,6 +186,7 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.SCHEDULE
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.SEND_DATA;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.SYNC_SEND_DATA;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.TRY_TAKE_DATA;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.TYPE_PARAMETER;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.VALUE_OF_DECIMAL;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.WAIT_RESULT;
 import static org.wso2.ballerinalang.compiler.bir.codegen.interop.InteropMethodGen.genVarArg;
@@ -613,22 +616,25 @@ public class JvmTerminatorGen {
             mv.visitMethodInsn(INVOKESPECIAL, BAL_ENV, JVM_INIT_METHOD, INIT_BAL_ENV_WITH_FUNC_NAME, false);
         }
 
-        if (callIns.resourcePathArgs != null && callIns.targetResourcePathArgsType != null) {
-
+        if (callIns.resourcePathArgs != null && !callIns.resourcePathArgs.isEmpty()) {
+            List<BIROperand> pathArgs = callIns.resourcePathArgs;
             int pathVarArrayIndex = this.indexMap.addIfNotExists("$pathVarArray", symbolTable.anyType);
             int bundledArrayIndex = this.indexMap.addIfNotExists("$bundledPathArgs", symbolTable.anyType);
 
-            mv.visitInsn(ICONST_0);
-            mv.visitTypeInsn(ANEWARRAY, "java/lang/Object");
+            mv.visitLdcInsn((long) pathArgs.size());
+            mv.visitInsn(L2I);
+            mv.visitTypeInsn(ANEWARRAY, OBJECT);
             mv.visitVarInsn(ASTORE, pathVarArrayIndex);
 
-            for (int i = 0; i < callIns.resourcePathArgs.size(); i++) {
-                BIROperand arg = callIns.resourcePathArgs.get(i);
+            int i = 0;
+            for (BIROperand arg : pathArgs) {
                 mv.visitVarInsn(ALOAD, pathVarArrayIndex);
                 mv.visitLdcInsn((long) i);
                 mv.visitInsn(L2I);
                 this.loadVar(arg.variableDcl);
+                jvmCastGen.generateCheckCastToAnyData(mv, arg.variableDcl.type);
                 mv.visitInsn(AASTORE);
+                i++;
             }
 
             mv.visitTypeInsn(NEW, ARRAY_VALUE_IMPL);
@@ -636,9 +642,9 @@ public class JvmTerminatorGen {
             mv.visitVarInsn(ALOAD, pathVarArrayIndex);
             mv.visitTypeInsn(NEW, ARRAY_TYPE_IMPL);
             mv.visitInsn(DUP);
-            mv.visitFieldInsn(GETSTATIC, PREDEFINED_TYPES, "TYPE_ANYDATA", "Lio/ballerina/runtime/api/types/AnydataType;");
-            mv.visitMethodInsn(INVOKESPECIAL, "io/ballerina/runtime/internal/types/BArrayType", JVM_INIT_METHOD, "(Lio/ballerina/runtime/api/types/Type;)V", false);
-            mv.visitMethodInsn(INVOKESPECIAL, ARRAY_VALUE_IMPL, JVM_INIT_METHOD, "([Ljava/lang/Object;Lio/ballerina/runtime/api/types/ArrayType;)V", false);
+            mv.visitFieldInsn(GETSTATIC, PREDEFINED_TYPES, "TYPE_ANYDATA", LOAD_ANYDATA_TYPE);
+            mv.visitMethodInsn(INVOKESPECIAL, ARRAY_TYPE_IMPL, JVM_INIT_METHOD, TYPE_PARAMETER, false);
+            mv.visitMethodInsn(INVOKESPECIAL, ARRAY_VALUE_IMPL, JVM_INIT_METHOD, ANYDATA_ARRAY_INIT, false);
             mv.visitVarInsn(ASTORE, bundledArrayIndex);
 
             mv.visitVarInsn(ALOAD, bundledArrayIndex);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTerminatorGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTerminatorGen.java
@@ -146,7 +146,6 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.WORKER_DA
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.WORKER_UTILS;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmInstructionGen.addJUnboxInsn;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.ANNOTATION_GET_STRAND;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.ANYDATA_ARRAY_INIT;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.ANY_TO_JBOOLEAN;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.BAL_ENV_PARAM;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.BOBJECT_CALL;
@@ -170,12 +169,14 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.HANDLE_F
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.HANDLE_WAIT_ANY;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.HANDLE_WAIT_MULTIPLE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.HANDLE_WORKER_ERROR;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.INIT_ANYDATA_ARRAY;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.INIT_BAL_ENV_WITH_FUNC_NAME;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.INIT_DECIMAL;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.INT_TO_STRING;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.INT_VALUE_OF_METHOD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.IS_CONCURRENT;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.LOAD_ANYDATA_TYPE;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.LOAD_JOBJECT_TYPE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.LOCK;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.MAP_PUT;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.PANIC_IF_IN_LOCK;
@@ -512,8 +513,7 @@ public class JvmTerminatorGen {
 
         if (callIns.lhsOp != null && callIns.lhsOp.variableDcl != null) {
             this.mv.visitVarInsn(ALOAD, localVarOffset);
-            this.mv.visitFieldInsn(GETFIELD, STRAND_CLASS, "returnValue",
-                                   "Ljava/lang/Object;");
+            this.mv.visitFieldInsn(GETFIELD, STRAND_CLASS, "returnValue", LOAD_JOBJECT_TYPE);
             jvmCastGen.addUnboxInsn(this.mv, callIns.lhsOp.variableDcl.type); // store return
             this.storeToVar(callIns.lhsOp.variableDcl);
         }
@@ -560,7 +560,7 @@ public class JvmTerminatorGen {
         genHandlingBlockedOnExternal(localVarOffset, blockedOnExternLabel);
         if (callIns.lhsOp != null) {
             this.mv.visitVarInsn(ALOAD, localVarOffset);
-            this.mv.visitFieldInsn(GETFIELD, STRAND_CLASS, "returnValue", "Ljava/lang/Object;");
+            this.mv.visitFieldInsn(GETFIELD, STRAND_CLASS, "returnValue", LOAD_JOBJECT_TYPE);
             // store return
             BIROperand lhsOpVarDcl = callIns.lhsOp;
             addJUnboxInsn(this.mv, ((JType) lhsOpVarDcl.variableDcl.type));
@@ -1282,7 +1282,7 @@ public class JvmTerminatorGen {
 
     private void genResourcePathArgs(List<BIROperand> pathArgs) {
         int pathVarArrayIndex = this.indexMap.addIfNotExists("$pathVarArray", symbolTable.anyType);
-        int bundledArrayIndex = this.indexMap.addIfNotExists("$bundledPathArgs", symbolTable.anyType);
+        int bundledArrayIndex = this.indexMap.addIfNotExists("$pathArrayArgs", symbolTable.anyType);
 
         mv.visitLdcInsn((long) pathArgs.size());
         mv.visitInsn(L2I);
@@ -1307,7 +1307,7 @@ public class JvmTerminatorGen {
         mv.visitInsn(DUP);
         mv.visitFieldInsn(GETSTATIC, PREDEFINED_TYPES, "TYPE_ANYDATA", LOAD_ANYDATA_TYPE);
         mv.visitMethodInsn(INVOKESPECIAL, ARRAY_TYPE_IMPL, JVM_INIT_METHOD, TYPE_PARAMETER, false);
-        mv.visitMethodInsn(INVOKESPECIAL, ARRAY_VALUE_IMPL, JVM_INIT_METHOD, ANYDATA_ARRAY_INIT, false);
+        mv.visitMethodInsn(INVOKESPECIAL, ARRAY_VALUE_IMPL, JVM_INIT_METHOD, INIT_ANYDATA_ARRAY, false);
         mv.visitVarInsn(ASTORE, bundledArrayIndex);
         mv.visitVarInsn(ALOAD, bundledArrayIndex);
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTerminatorGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTerminatorGen.java
@@ -96,6 +96,8 @@ import static org.objectweb.asm.Opcodes.POP;
 import static org.objectweb.asm.Opcodes.PUTFIELD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.ANNOTATION_UTILS;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.ARRAY_LIST;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.ARRAY_TYPE_IMPL;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.ARRAY_VALUE_IMPL;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.BAL_ENV;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.BAL_ERROR_REASONS;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.BAL_EXTENSION;
@@ -124,6 +126,7 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.MAP;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.MODULE_INIT_CLASS_NAME;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.OBJECT;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.PANIC_FIELD;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.PREDEFINED_TYPES;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.RUNTIME_ERRORS;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.SCHEDULER;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.SCHEDULE_FUNCTION_METHOD;
@@ -554,8 +557,7 @@ public class JvmTerminatorGen {
         genHandlingBlockedOnExternal(localVarOffset, blockedOnExternLabel);
         if (callIns.lhsOp != null) {
             this.mv.visitVarInsn(ALOAD, localVarOffset);
-            this.mv.visitFieldInsn(GETFIELD, STRAND_CLASS, "returnValue",
-                                   "Ljava/lang/Object;");
+            this.mv.visitFieldInsn(GETFIELD, STRAND_CLASS, "returnValue", "Ljava/lang/Object;");
             // store return
             BIROperand lhsOpVarDcl = callIns.lhsOp;
             addJUnboxInsn(this.mv, ((JType) lhsOpVarDcl.variableDcl.type));
@@ -572,8 +574,7 @@ public class JvmTerminatorGen {
             // check whether function params already include the self
             BIRNode.BIRVariableDcl selfArg = callIns.args.get(0).variableDcl;
             this.loadVar(selfArg);
-            this.mv.visitMethodInsn(INVOKEVIRTUAL, HANDLE_VALUE, GET_VALUE_METHOD, RETURN_OBJECT,
-                    false);
+            this.mv.visitMethodInsn(INVOKEVIRTUAL, HANDLE_VALUE, GET_VALUE_METHOD, RETURN_OBJECT, false);
             this.mv.visitTypeInsn(CHECKCAST, callIns.jClassName);
 
             Label ifNonNullLabel = this.labelGen.getLabel("receiver_null_check");
@@ -609,8 +610,38 @@ public class JvmTerminatorGen {
             // load function name
             mv.visitLdcInsn(func.name.getValue());
             this.jvmTypeGen.loadFunctionPathParameters(mv, (BInvokableTypeSymbol) func.type.tsymbol);
-            mv.visitMethodInsn(INVOKESPECIAL, BAL_ENV, JVM_INIT_METHOD,
-                               INIT_BAL_ENV_WITH_FUNC_NAME, false);
+            mv.visitMethodInsn(INVOKESPECIAL, BAL_ENV, JVM_INIT_METHOD, INIT_BAL_ENV_WITH_FUNC_NAME, false);
+        }
+
+        if (callIns.resourcePathArgs != null && callIns.targetResourcePathArgsType != null) {
+
+            int pathVarArrayIndex = this.indexMap.addIfNotExists("$pathVarArray", symbolTable.anyType);
+            int bundledArrayIndex = this.indexMap.addIfNotExists("$bundledPathArgs", symbolTable.anyType);
+
+            mv.visitInsn(ICONST_0);
+            mv.visitTypeInsn(ANEWARRAY, "java/lang/Object");
+            mv.visitVarInsn(ASTORE, pathVarArrayIndex);
+
+            for (int i = 0; i < callIns.resourcePathArgs.size(); i++) {
+                BIROperand arg = callIns.resourcePathArgs.get(i);
+                mv.visitVarInsn(ALOAD, pathVarArrayIndex);
+                mv.visitLdcInsn((long) i);
+                mv.visitInsn(L2I);
+                this.loadVar(arg.variableDcl);
+                mv.visitInsn(AASTORE);
+            }
+
+            mv.visitTypeInsn(NEW, ARRAY_VALUE_IMPL);
+            mv.visitInsn(DUP);
+            mv.visitVarInsn(ALOAD, pathVarArrayIndex);
+            mv.visitTypeInsn(NEW, ARRAY_TYPE_IMPL);
+            mv.visitInsn(DUP);
+            mv.visitFieldInsn(GETSTATIC, PREDEFINED_TYPES, "TYPE_ANYDATA", "Lio/ballerina/runtime/api/types/AnydataType;");
+            mv.visitMethodInsn(INVOKESPECIAL, "io/ballerina/runtime/internal/types/BArrayType", JVM_INIT_METHOD, "(Lio/ballerina/runtime/api/types/Type;)V", false);
+            mv.visitMethodInsn(INVOKESPECIAL, ARRAY_VALUE_IMPL, JVM_INIT_METHOD, "([Ljava/lang/Object;Lio/ballerina/runtime/api/types/ArrayType;)V", false);
+            mv.visitVarInsn(ASTORE, bundledArrayIndex);
+
+            mv.visitVarInsn(ALOAD, bundledArrayIndex);
         }
 
         int argsCount = callIns.varArgExist ? callIns.args.size() - 1 : callIns.args.size();

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTerminatorGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTerminatorGen.java
@@ -616,43 +616,13 @@ public class JvmTerminatorGen {
             mv.visitMethodInsn(INVOKESPECIAL, BAL_ENV, JVM_INIT_METHOD, INIT_BAL_ENV_WITH_FUNC_NAME, false);
         }
 
-        if (callIns.receiverArgs != null && !callIns.receiverArgs.isEmpty()) {
-            for (BIROperand arg : callIns.receiverArgs) {
-                this.loadVar(arg.variableDcl);
-            }
+        if (callIns.receiver != null) {
+            this.loadVar(callIns.receiver.variableDcl);
         }
 
-        if (callIns.resourcePathArgs != null && !callIns.resourcePathArgs.isEmpty()) {
-            List<BIROperand> pathArgs = callIns.resourcePathArgs;
-            int pathVarArrayIndex = this.indexMap.addIfNotExists("$pathVarArray", symbolTable.anyType);
-            int bundledArrayIndex = this.indexMap.addIfNotExists("$bundledPathArgs", symbolTable.anyType);
-
-            mv.visitLdcInsn((long) pathArgs.size());
-            mv.visitInsn(L2I);
-            mv.visitTypeInsn(ANEWARRAY, OBJECT);
-            mv.visitVarInsn(ASTORE, pathVarArrayIndex);
-
-            int i = 0;
-            for (BIROperand arg : pathArgs) {
-                mv.visitVarInsn(ALOAD, pathVarArrayIndex);
-                mv.visitLdcInsn((long) i);
-                mv.visitInsn(L2I);
-                this.loadVar(arg.variableDcl);
-                jvmCastGen.generateCheckCastToAnyData(mv, arg.variableDcl.type);
-                mv.visitInsn(AASTORE);
-                i++;
-            }
-
-            mv.visitTypeInsn(NEW, ARRAY_VALUE_IMPL);
-            mv.visitInsn(DUP);
-            mv.visitVarInsn(ALOAD, pathVarArrayIndex);
-            mv.visitTypeInsn(NEW, ARRAY_TYPE_IMPL);
-            mv.visitInsn(DUP);
-            mv.visitFieldInsn(GETSTATIC, PREDEFINED_TYPES, "TYPE_ANYDATA", LOAD_ANYDATA_TYPE);
-            mv.visitMethodInsn(INVOKESPECIAL, ARRAY_TYPE_IMPL, JVM_INIT_METHOD, TYPE_PARAMETER, false);
-            mv.visitMethodInsn(INVOKESPECIAL, ARRAY_VALUE_IMPL, JVM_INIT_METHOD, ANYDATA_ARRAY_INIT, false);
-            mv.visitVarInsn(ASTORE, bundledArrayIndex);
-            mv.visitVarInsn(ALOAD, bundledArrayIndex);
+        List<BIROperand> resourcePathArgs = callIns.resourcePathArgs;
+        if (resourcePathArgs != null && !resourcePathArgs.isEmpty()) {
+            genResourcePathArgs(resourcePathArgs);
         }
 
         int argsCount = callIns.varArgExist ? callIns.args.size() - 1 : callIns.args.size();
@@ -1308,6 +1278,38 @@ public class JvmTerminatorGen {
     private void storeToVar(BIRNode.BIRVariableDcl varDcl) {
 
         jvmInstructionGen.generateVarStore(this.mv, varDcl, this.getJVMIndexOfVarRef(varDcl));
+    }
+
+    private void genResourcePathArgs(List<BIROperand> pathArgs) {
+        int pathVarArrayIndex = this.indexMap.addIfNotExists("$pathVarArray", symbolTable.anyType);
+        int bundledArrayIndex = this.indexMap.addIfNotExists("$bundledPathArgs", symbolTable.anyType);
+
+        mv.visitLdcInsn((long) pathArgs.size());
+        mv.visitInsn(L2I);
+        mv.visitTypeInsn(ANEWARRAY, OBJECT);
+        mv.visitVarInsn(ASTORE, pathVarArrayIndex);
+
+        int i = 0;
+        for (BIROperand arg : pathArgs) {
+            mv.visitVarInsn(ALOAD, pathVarArrayIndex);
+            mv.visitLdcInsn((long) i);
+            mv.visitInsn(L2I);
+            this.loadVar(arg.variableDcl);
+            jvmCastGen.generateCheckCastToAnyData(mv, arg.variableDcl.type);
+            mv.visitInsn(AASTORE);
+            i++;
+        }
+
+        mv.visitTypeInsn(NEW, ARRAY_VALUE_IMPL);
+        mv.visitInsn(DUP);
+        mv.visitVarInsn(ALOAD, pathVarArrayIndex);
+        mv.visitTypeInsn(NEW, ARRAY_TYPE_IMPL);
+        mv.visitInsn(DUP);
+        mv.visitFieldInsn(GETSTATIC, PREDEFINED_TYPES, "TYPE_ANYDATA", LOAD_ANYDATA_TYPE);
+        mv.visitMethodInsn(INVOKESPECIAL, ARRAY_TYPE_IMPL, JVM_INIT_METHOD, TYPE_PARAMETER, false);
+        mv.visitMethodInsn(INVOKESPECIAL, ARRAY_VALUE_IMPL, JVM_INIT_METHOD, ANYDATA_ARRAY_INIT, false);
+        mv.visitVarInsn(ASTORE, bundledArrayIndex);
+        mv.visitVarInsn(ALOAD, bundledArrayIndex);
     }
 
     public void genReturnTerm(int returnVarRefIndex, BIRNode.BIRFunction func, int invocationVarIndex) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTerminatorGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTerminatorGen.java
@@ -96,7 +96,6 @@ import static org.objectweb.asm.Opcodes.POP;
 import static org.objectweb.asm.Opcodes.PUTFIELD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.ANNOTATION_UTILS;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.ARRAY_LIST;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.ARRAY_TYPE_IMPL;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.ARRAY_VALUE_IMPL;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.BAL_ENV;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.BAL_ERROR_REASONS;
@@ -140,6 +139,7 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.STRAND_PO
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.STRAND_THREAD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.STRAND_VALUE_ANY;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.STRING_CONCAT_FACTORY;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.TYPE_ANYDATA_ARRAY;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.VALUE_OF_METHOD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.WD_CHANNELS;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.WORKER_DATA_CHANNEL;
@@ -175,7 +175,7 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.INIT_DEC
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.INT_TO_STRING;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.INT_VALUE_OF_METHOD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.IS_CONCURRENT;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.LOAD_ANYDATA_TYPE;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.LOAD_ARRAY_TYPE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.LOAD_JOBJECT_TYPE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.LOCK;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.MAP_PUT;
@@ -187,7 +187,6 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.SCHEDULE
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.SEND_DATA;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.SYNC_SEND_DATA;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.TRY_TAKE_DATA;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.TYPE_PARAMETER;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.VALUE_OF_DECIMAL;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.WAIT_RESULT;
 import static org.wso2.ballerinalang.compiler.bir.codegen.interop.InteropMethodGen.genVarArg;
@@ -1303,10 +1302,7 @@ public class JvmTerminatorGen {
         mv.visitTypeInsn(NEW, ARRAY_VALUE_IMPL);
         mv.visitInsn(DUP);
         mv.visitVarInsn(ALOAD, pathVarArrayIndex);
-        mv.visitTypeInsn(NEW, ARRAY_TYPE_IMPL);
-        mv.visitInsn(DUP);
-        mv.visitFieldInsn(GETSTATIC, PREDEFINED_TYPES, "TYPE_ANYDATA", LOAD_ANYDATA_TYPE);
-        mv.visitMethodInsn(INVOKESPECIAL, ARRAY_TYPE_IMPL, JVM_INIT_METHOD, TYPE_PARAMETER, false);
+        mv.visitFieldInsn(GETSTATIC, PREDEFINED_TYPES, TYPE_ANYDATA_ARRAY, LOAD_ARRAY_TYPE);
         mv.visitMethodInsn(INVOKESPECIAL, ARRAY_VALUE_IMPL, JVM_INIT_METHOD, INIT_ANYDATA_ARRAY, false);
         mv.visitVarInsn(ASTORE, bundledArrayIndex);
         mv.visitVarInsn(ALOAD, bundledArrayIndex);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropMethodGen.java
@@ -299,7 +299,6 @@ public class InteropMethodGen {
         }
 
         JType varArgType = null;
-        JType resourcePathArgType = null;
         int jMethodParamIndex = 0;
         if (jMethod.getReceiverType() != null) {
             jMethodParamIndex++;
@@ -308,10 +307,6 @@ public class InteropMethodGen {
 
         if (jMethod.isBalEnvAcceptingMethod()) {
             jMethodParamIndex++;
-        }
-
-        if (jMethod.hasBundledPathParams) {
-            resourcePathArgType = JInterop.getJType(jMethodParamTypes[jMethodParamIndex]);
         }
 
         int paramCount = birFuncParams.size();
@@ -323,17 +318,6 @@ public class InteropMethodGen {
             JType jPType = JInterop.getJType(jMethodParamTypes[jMethodParamIndex]);
 
             if (jMethod.hasBundledPathParams && pathParamTypes.contains(bPType)) {
-                String varName = "$_param_jobject_var" + birFuncParamIndex + "_$";
-                BIRVariableDcl paramVarDcl = new BIRVariableDcl(jPType, new Name(varName), null, VarKind.LOCAL);
-                birFunc.localVars.add(paramVarDcl);
-                BIROperand paramVarRef = new BIROperand(paramVarDcl);
-                JCast jToBCast = new JCast(birFunc.pos);
-                jToBCast.lhsOp = paramVarRef;
-                jToBCast.rhsOp = argRef;
-                jToBCast.targetType = jPType;
-                argRef = paramVarRef;
-                beginBB.instructions.add(jToBCast);
-
                 resourcePathArgs.add(argRef);
                 birFuncParamIndex++;
                 continue;
@@ -416,7 +400,6 @@ public class InteropMethodGen {
             jCall.resourcePathArgs = resourcePathArgs;
             jCall.varArgExist = birFunc.restParam != null;
             jCall.varArgType = varArgType;
-            jCall.targetResourcePathArgsType = resourcePathArgType;
             jCall.lhsOp = jRetVarRef;
             jCall.jClassName = jMethod.getClassName().replace(".", "/");
             jCall.name = jMethod.getName();
@@ -429,7 +412,6 @@ public class InteropMethodGen {
             jCall.resourcePathArgs = resourcePathArgs;
             jCall.varArgExist = birFunc.restParam != null;
             jCall.varArgType = varArgType;
-            jCall.targetResourcePathArgsType = resourcePathArgType;
             jCall.lhsOp = jRetVarRef;
             jCall.jClassName = jMethod.getClassName().replace(".", "/");
             jCall.name = jMethod.getName();

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropMethodGen.java
@@ -265,7 +265,7 @@ public class InteropMethodGen {
 
         BIRBasicBlock beginBB = insertAndGetNextBasicBlock(birFunc.basicBlocks, bbPrefix, initMethodGen);
         BIRBasicBlock retBB = new BIRBasicBlock(getNextDesugarBBId(bbPrefix, initMethodGen));
-        List<BIROperand> receiverArgs = new ArrayList<>();
+        BIROperand receiverOp = null;
         List<BIROperand> args = new ArrayList<>();
         List<BIROperand> resourcePathArgs = new ArrayList<>();
         List<BIRNode.BIRFunctionParameter> birFuncParams = birFunc.parameters;
@@ -275,7 +275,7 @@ public class InteropMethodGen {
         if (jMethod.kind == JMethodKind.METHOD && !jMethod.isStatic()) {
             BIRNode.BIRFunctionParameter birFuncParam = birFuncParams.get(birFuncParamIndex);
             BIROperand argRef = new BIROperand(birFuncParam);
-            receiverArgs.add(argRef);
+            args.add(argRef);
             birFuncParamIndex = 1;
         }
 
@@ -283,7 +283,7 @@ public class InteropMethodGen {
         int jMethodParamIndex = 0;
         if (jMethod.getReceiverType() != null) {
             jMethodParamIndex++;
-            receiverArgs.add(new BIROperand(birFunc.receiver));
+            receiverOp = new BIROperand(birFunc.receiver);
         }
 
         if (jMethod.isBalEnvAcceptingMethod()) {
@@ -380,7 +380,7 @@ public class InteropMethodGen {
         if (jMethod.kind == JMethodKind.CONSTRUCTOR) {
             JIConstructorCall jCall = new JIConstructorCall(birFunc.pos);
             jCall.args = args;
-            jCall.receiverArgs = receiverArgs;
+            jCall.receiver = receiverOp;
             jCall.resourcePathArgs = resourcePathArgs;
             jCall.varArgExist = birFunc.restParam != null;
             jCall.varArgType = varArgType;
@@ -393,7 +393,7 @@ public class InteropMethodGen {
         } else {
             JIMethodCall jCall = new JIMethodCall(birFunc.pos);
             jCall.args = args;
-            jCall.receiverArgs = receiverArgs;
+            jCall.receiver = receiverOp;
             jCall.resourcePathArgs = resourcePathArgs;
             jCall.varArgExist = birFunc.restParam != null;
             jCall.varArgType = varArgType;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropMethodGen.java
@@ -273,18 +273,12 @@ public class InteropMethodGen {
         List<BIROperand> resourcePathArgs = new ArrayList<>();
 
         List<BIRNode.BIRFunctionParameter> birFuncParams = birFunc.parameters;
-        List<BType> birFuncParamTypes = new ArrayList<>();
-        for (BIRNode.BIRFunctionParameter birFuncParam : birFuncParams) {
-            birFuncParamTypes.add(birFuncParam.type);
-        }
         List<BVarSymbol> birFuncParamSymbols = ((BInvokableTypeSymbol) birFunc.type.tsymbol).params;
-        List<BVarSymbol> pathParamSymbols = new ArrayList<>();
         List<BType> pathParamTypes = new ArrayList<>();
 
         for (BVarSymbol birFuncParamSymbol : birFuncParamSymbols) {
             if (birFuncParamSymbol.kind == SymbolKind.PATH_PARAMETER ||
                     birFuncParamSymbol.kind == SymbolKind.PATH_REST_PARAMETER) {
-                pathParamSymbols.add(birFuncParamSymbol);
                 pathParamTypes.add(birFuncParamSymbol.type);
             }
         }
@@ -315,14 +309,17 @@ public class InteropMethodGen {
             BType bPType = birFuncParam.type;
             BIROperand argRef = new BIROperand(birFuncParam);
             boolean isVarArg = (birFuncParamIndex == (paramCount - 1)) && birFunc.restParam != null;
-            JType jPType = JInterop.getJType(jMethodParamTypes[jMethodParamIndex]);
 
             if (jMethod.hasBundledPathParams && pathParamTypes.contains(bPType)) {
+                if (resourcePathArgs.isEmpty()) {
+                    jMethodParamIndex++;
+                }
                 resourcePathArgs.add(argRef);
                 birFuncParamIndex++;
                 continue;
             }
 
+            JType jPType = JInterop.getJType(jMethodParamTypes[jMethodParamIndex]);
             // we generate cast operations for unmatching B to J types
             if (!isVarArg && !isMatchingBAndJType(bPType, jPType)) {
                 String varName = "$_param_jobject_var" + birFuncParamIndex + "_$";

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JIConstructorCall.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JIConstructorCall.java
@@ -30,7 +30,7 @@ import java.util.List;
  */
 public class JIConstructorCall extends JTerminator {
 
-    public List<BIROperand> receiverArgs;
+    public BIROperand receiver;
     public List<BIROperand> args;
     public List<BIROperand> resourcePathArgs;
     public String jClassName;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JIConstructorCall.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JIConstructorCall.java
@@ -31,9 +31,11 @@ import java.util.List;
 public class JIConstructorCall extends JTerminator {
 
     public List<BIROperand> args;
+    public List<BIROperand> resourcePathArgs;
     public String jClassName;
     public String jMethodVMSig;
     public String name;
+    public JType targetResourcePathArgsType;
     boolean varArgExist;
     JType varArgType;
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JIConstructorCall.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JIConstructorCall.java
@@ -30,6 +30,7 @@ import java.util.List;
  */
 public class JIConstructorCall extends JTerminator {
 
+    public List<BIROperand> receiverArgs;
     public List<BIROperand> args;
     public List<BIROperand> resourcePathArgs;
     public String jClassName;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JIConstructorCall.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JIConstructorCall.java
@@ -35,7 +35,6 @@ public class JIConstructorCall extends JTerminator {
     public String jClassName;
     public String jMethodVMSig;
     public String name;
-    public JType targetResourcePathArgsType;
     boolean varArgExist;
     JType varArgType;
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JIMethodCall.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JIMethodCall.java
@@ -37,7 +37,6 @@ public class JIMethodCall extends JTerminator {
     public String jClassName;
     public String jMethodVMSig;
     public String name;
-    public JType targetResourcePathArgsType;
     public int invocationType;
 
     public JIMethodCall(Location pos) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JIMethodCall.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JIMethodCall.java
@@ -30,7 +30,7 @@ import java.util.List;
  */
 public class JIMethodCall extends JTerminator {
 
-    public List<BIROperand> receiverArgs;
+    public BIROperand receiver;
     public List<BIROperand> args;
     public List<BIROperand> resourcePathArgs;
     public boolean varArgExist;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JIMethodCall.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JIMethodCall.java
@@ -31,11 +31,13 @@ import java.util.List;
 public class JIMethodCall extends JTerminator {
 
     public List<BIROperand> args;
+    public List<BIROperand> resourcePathArgs;
     public boolean varArgExist;
     public JType varArgType;
     public String jClassName;
     public String jMethodVMSig;
     public String name;
+    public JType targetResourcePathArgsType;
     public int invocationType;
 
     public JIMethodCall(Location pos) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JIMethodCall.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JIMethodCall.java
@@ -30,6 +30,7 @@ import java.util.List;
  */
 public class JIMethodCall extends JTerminator {
 
+    public List<BIROperand> receiverArgs;
     public List<BIROperand> args;
     public List<BIROperand> resourcePathArgs;
     public boolean varArgExist;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JMethod.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JMethod.java
@@ -47,6 +47,7 @@ class JMethod {
     JMethodKind kind;
     private Executable method;
     private BType receiverType;
+    public boolean hasBundledPathParams = false;
 
     private JMethod(JMethodKind kind, Executable executable, BType receiverType) {
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JMethodRequest.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JMethodRequest.java
@@ -45,6 +45,7 @@ class JMethodRequest {
     int pathParamCount;
 
     BType[] bParamTypes = null;
+    List<BVarSymbol> paramSymbols = new ArrayList<>();
     List<BVarSymbol> pathParamSymbols = new ArrayList<>();
     BType bReturnType = null;
     boolean returnsBErrorType = false;
@@ -69,20 +70,22 @@ class JMethodRequest {
                 JInterop.buildParamTypeConstraints(methodValidationRequest.paramTypeConstraints, classLoader);
 
         BInvokableType bFuncType = methodValidationRequest.bFuncType;
-        List<BType> paramTypes = new ArrayList<>(bFuncType.paramTypes);
         BInvokableTypeSymbol typeSymbol = (BInvokableTypeSymbol) bFuncType.tsymbol;
-        List<BVarSymbol> params = typeSymbol.params;
+        jMethodReq.paramSymbols.addAll(typeSymbol.params);
         List<BVarSymbol> pathParams = new ArrayList<>();
+        List<BType> paramTypes = new ArrayList<>();
 
-        for (BVarSymbol param : params) {
+        for (BVarSymbol param : typeSymbol.params) {
+            paramTypes.add(param.type);
             if (param.kind == SymbolKind.PATH_PARAMETER || param.kind == SymbolKind.PATH_REST_PARAMETER) {
                 pathParams.add(param);
             }
         }
 
-        BType restType = bFuncType.restType;
-        if (restType != null) {
-            paramTypes.add(restType);
+        BVarSymbol restParam = typeSymbol.restParam;
+        if (restParam != null) {
+            jMethodReq.paramSymbols.add(restParam);
+            paramTypes.add(restParam.type);
         }
 
         jMethodReq.bFuncParamCount = paramTypes.size();

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JMethodRequest.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JMethodRequest.java
@@ -17,6 +17,9 @@
  */
 package org.wso2.ballerinalang.compiler.bir.codegen.interop;
 
+import org.ballerinalang.model.symbols.SymbolKind;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableTypeSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BVarSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BInvokableType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BUnionType;
@@ -39,8 +42,10 @@ class JMethodRequest {
     ParamTypeConstraint[] paramTypeConstraints = {};
     // Parameter count of the Ballerina function
     int bFuncParamCount;
+    int pathParamCount;
 
     BType[] bParamTypes = null;
+    List<BVarSymbol> pathParamSymbols = new ArrayList<>();
     BType bReturnType = null;
     boolean returnsBErrorType = false;
     boolean restParamExist = false;
@@ -65,6 +70,15 @@ class JMethodRequest {
 
         BInvokableType bFuncType = methodValidationRequest.bFuncType;
         List<BType> paramTypes = new ArrayList<>(bFuncType.paramTypes);
+        BInvokableTypeSymbol typeSymbol = (BInvokableTypeSymbol) bFuncType.tsymbol;
+        List<BVarSymbol> params = typeSymbol.params;
+        List<BVarSymbol> pathParams = new ArrayList<>();
+
+        for (BVarSymbol param : params) {
+            if (param.kind == SymbolKind.PATH_PARAMETER || param.kind == SymbolKind.PATH_REST_PARAMETER) {
+                pathParams.add(param);
+            }
+        }
 
         BType restType = bFuncType.restType;
         if (restType != null) {
@@ -72,7 +86,9 @@ class JMethodRequest {
         }
 
         jMethodReq.bFuncParamCount = paramTypes.size();
+        jMethodReq.pathParamCount = pathParams.size();
         jMethodReq.bParamTypes = paramTypes.toArray(new BType[0]);
+        jMethodReq.pathParamSymbols = pathParams;
 
         BType returnType = unifier.build(bFuncType.retType);
         jMethodReq.bReturnType = returnType;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JMethodResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JMethodResolver.java
@@ -32,7 +32,6 @@ import io.ballerina.runtime.api.values.BString;
 import io.ballerina.runtime.api.values.BTable;
 import io.ballerina.runtime.api.values.BTypedesc;
 import io.ballerina.runtime.api.values.BXml;
-import org.ballerinalang.model.symbols.SymbolKind;
 import org.ballerinalang.util.diagnostic.DiagnosticErrorCode;
 import org.wso2.ballerinalang.compiler.bir.codegen.JvmCodeGenUtil;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
@@ -195,7 +194,7 @@ class JMethodResolver {
             if (count == reducedParamCount && this.classLoader.loadClass(BArray.class.getCanonicalName())
                     .isAssignableFrom(paramTypes[0])) {
                 return true;
-            } else if (count == reducedParamCount + 1 && this.classLoader.loadClass(BArray.class.getCanonicalName())
+            } else if ((count == reducedParamCount + 1) && this.classLoader.loadClass(BArray.class.getCanonicalName())
                     .isAssignableFrom(paramTypes[1])) {
                 // This is for object interop functions when self is passed as a parameter
                 if (jMethod.isBalEnvAcceptingMethod()) {
@@ -203,7 +202,7 @@ class JMethodResolver {
                 }
                 jMethod.setReceiverType(jMethodRequest.receiverType);
                 return jMethodRequest.receiverType != null;
-            } else if (count == reducedParamCount + 2 && this.classLoader.loadClass(BArray.class.getCanonicalName())
+            } else if ((count == reducedParamCount + 2) && this.classLoader.loadClass(BArray.class.getCanonicalName())
                     .isAssignableFrom(paramTypes[2])) {
                 // This is for object interop functions when both BalEnv and self is passed as parameters.
                 if (jMethodRequest.receiverType != null) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/optimizer/LargeMethodOptimizer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/optimizer/LargeMethodOptimizer.java
@@ -586,7 +586,7 @@ public class LargeMethodOptimizer {
             Name argName = funcArg.name;
             birFunc.requiredParams.add(new BIRParameter(lastIns.pos, argName, 0));
             BIRFunctionParameter funcParameter = new BIRFunctionParameter(lastIns.pos, funcArg.type, argName,
-                    VarScope.FUNCTION, VarKind.ARG, argName.getValue(), false);
+                    VarScope.FUNCTION, VarKind.ARG, argName.getValue(), false, false);
             functionParams.add(funcParameter);
             birFunc.parameters.add(funcParameter);
             if (funcArg.kind == VarKind.SELF) {
@@ -741,7 +741,7 @@ public class LargeMethodOptimizer {
             Name argName = funcArg.name;
             birFunc.requiredParams.add(new BIRParameter(currentIns.pos, argName, 0));
             BIRFunctionParameter funcParameter = new BIRFunctionParameter(currentIns.pos, funcArg.type, argName,
-                    VarScope.FUNCTION, VarKind.ARG, argName.getValue(), false);
+                    VarScope.FUNCTION, VarKind.ARG, argName.getValue(), false, false);
             functionParams.add(funcParameter);
             birFunc.parameters.add(funcParameter);
             if (funcArg.kind == VarKind.SELF) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRNode.java
@@ -243,11 +243,18 @@ public abstract class BIRNode {
      */
     public static class BIRFunctionParameter extends BIRVariableDcl {
         public final boolean hasDefaultExpr;
+        public boolean isPathParameter;
 
         public BIRFunctionParameter(Location pos, BType type, Name name,
                                     VarScope scope, VarKind kind, String metaVarName, boolean hasDefaultExpr) {
             super(pos, type, name, scope, kind, metaVarName);
             this.hasDefaultExpr = hasDefaultExpr;
+        }
+
+        public BIRFunctionParameter(Location pos, BType type, Name name, VarScope scope, VarKind kind,
+                                    String metaVarName, boolean hasDefaultExpr, boolean isPathParameter) {
+            this(pos, type, name, scope, kind, metaVarName, hasDefaultExpr);
+            this.isPathParameter = isPathParameter;
         }
 
         @Override

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/StaticMethods.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/StaticMethods.java
@@ -37,6 +37,7 @@ import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.api.values.BFuture;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BMapInitialValueEntry;
+import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
 import io.ballerina.runtime.api.values.BTypedesc;
 import io.ballerina.runtime.api.values.BXml;
@@ -746,5 +747,25 @@ public class StaticMethods {
 
     public static int getResource(BArray paths) {
         return paths.size();
+    }
+
+    public static int getResource(BObject client, BArray path) {
+        return path.size();
+    }
+
+    public static int getResource(BObject client, BArray paths, double value, BString str) {
+        return paths.size();
+    }
+
+    public static int getResource(BObject client, BArray path, BString p2, double value, BString str) {
+        return path.size();
+    }
+
+    public static int getResource(BObject client, long p1, BString p2, double value, BString str) {
+        return 1;
+    }
+
+    public static BString getResource(Environment env, BObject client, BArray path, BString str) {
+        return str;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/StaticMethods.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/StaticMethods.java
@@ -31,6 +31,7 @@ import io.ballerina.runtime.api.types.Field;
 import io.ballerina.runtime.api.types.RecordType;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.utils.StringUtils;
+import io.ballerina.runtime.api.values.BArray;
 import io.ballerina.runtime.api.values.BDecimal;
 import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.api.values.BFuture;
@@ -741,5 +742,9 @@ public class StaticMethods {
         integers.forEach(i -> {
             throw ErrorCreator.createError(StringUtils.fromString("error!!!"));
         });
+    }
+
+    public static int getResource(BArray paths) {
+        return paths.size();
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/ResourcePathArgumentsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/ResourcePathArgumentsTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.ballerinalang.test.javainterop;
+
+import org.ballerinalang.test.BCompileUtil;
+import org.ballerinalang.test.BRunUtil;
+import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * Test cases for java interop functions with variable number of resource path params.
+ *
+ * @since 2201.5.0
+ */
+
+public class ResourcePathArgumentsTest {
+
+    private CompileResult result;
+
+    @BeforeClass
+    public void setup() {
+        result = BCompileUtil.compile("test-src/javainterop/basic/variable_number_of_resource_paths.bal");
+    }
+
+    @Test
+    public void testResourcePathArguments() {
+        BRunUtil.invoke(result, "testResourceFuncWithMultiplePathParams");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
+    }
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/variable_number_of_resource_paths.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/variable_number_of_resource_paths.bal
@@ -25,28 +25,67 @@ public client isolated class Client {
 
     isolated resource function get abc/[string ...path] () returns int = @java:Method {
         'class: "org/ballerinalang/nativeimpl/jvm/tests/StaticMethods",
-        name: "getResource"
+        name: "getResource",
+        paramTypes: ["io.ballerina.runtime.api.values.BObject", "io.ballerina.runtime.api.values.BArray"]
     } external;
 
-    isolated resource function get abc/[int id]/[string path]/[string ...paths] () returns int = @java:Method {
+    isolated resource function get abc/[int id]/[float v]/[string path]/[string ...paths] () returns int = @java:Method {
         'class: "org/ballerinalang/nativeimpl/jvm/tests/StaticMethods",
-        name: "getResource"
+        name: "getResource",
+        paramTypes: ["io.ballerina.runtime.api.values.BObject", "io.ballerina.runtime.api.values.BArray"]
     } external;
 
-    isolated resource function get abc/[string path]/[int path1]/[string path2]/[int ...path3] () returns int = @java:Method {
+    isolated resource function get def/[string path]/[int path1]/[string path2]/[int ...path3] () returns int = @java:Method {
         'class: "org/ballerinalang/nativeimpl/jvm/tests/StaticMethods",
-        name: "getResource"
+        name: "getResource",
+        paramTypes: ["io.ballerina.runtime.api.values.BObject", "io.ballerina.runtime.api.values.BArray"]
+    } external;
+
+    isolated resource function get abc/[int id]/[string path] (float f, string s) returns int = @java:Method {
+        'class: "org/ballerinalang/nativeimpl/jvm/tests/StaticMethods",
+        name: "getResource",
+        paramTypes: ["io.ballerina.runtime.api.values.BObject", "io.ballerina.runtime.api.values.BArray", "double", "io.ballerina.runtime.api.values.BString"]
+    } external;
+
+    isolated resource function get abc/[int id]/[string path]/[string p2] (string a, float f, string s) returns int = @java:Method {
+        'class: "org/ballerinalang/nativeimpl/jvm/tests/StaticMethods",
+        name: "getResource",
+        paramTypes: ["io.ballerina.runtime.api.values.BObject", "io.ballerina.runtime.api.values.BArray", "io.ballerina.runtime.api.values.BString", "double", "io.ballerina.runtime.api.values.BString"]
+    } external;
+
+    isolated resource function get def/[int id]/[string path]/[string p2] (string s) returns string = @java:Method {
+        'class: "org/ballerinalang/nativeimpl/jvm/tests/StaticMethods",
+        name: "getResource",
+        paramTypes: ["io.ballerina.runtime.api.Environment", "io.ballerina.runtime.api.values.BObject", "io.ballerina.runtime.api.values.BArray", "io.ballerina.runtime.api.values.BString"]
+    } external;
+
+    isolated resource function get ghi/[int id]/[string p1]/[string p2]/[int ...ids] (string s) returns string = @java:Method {
+        'class: "org/ballerinalang/nativeimpl/jvm/tests/StaticMethods",
+        name: "getResource",
+        paramTypes: ["io.ballerina.runtime.api.Environment", "io.ballerina.runtime.api.values.BObject", "io.ballerina.runtime.api.values.BArray", "io.ballerina.runtime.api.values.BString"]
     } external;
 }
 
 public function testResourceFuncWithMultiplePathParams() {
     Client cl = new;
-    var response = cl->/abc/[1]/abc/def/ghi/jkl/mno/pqr/stu/vwx/yz ();
-    test:assertEquals(response, 3);
+    var response = cl->/abc/[1]/[2.5]/abc/def/ghi/jkl/mno/pqr/stu/vwx/yz();
+    test:assertEquals(response, 4);
 
-    response = cl->/abc/abc/def/ghi/jkl/mno/pqr/stu/vwx/yz ();
+    response = cl->/abc/abc/def/ghi/jkl/mno/pqr/stu/vwx/yz();
     test:assertEquals(response, 9);
 
-    response = cl -> /abc/abc/[1001]/def/[101]/[10002] ();
+    response = cl->/def/abc/[1001]/def/[101]/[10002]();
     test:assertEquals(response, 4);
+
+    response = cl->/abc/[1]/["2"](1.2, "a");
+    test:assertEquals(response, 2);
+
+    response = cl->/abc/[1]/["2"]/["3"]("a", 1.2, "a");
+    test:assertEquals(response, 3);
+
+    string res = cl->/def/[1]/["2"]/["3"]("a");
+    test:assertEquals(res, "a");
+
+    res = cl->/ghi/[1]/["aaa"]/["bbb"]/[4]/[5]/[6]/[7]/[8]/[9]("xyz");
+    test:assertEquals(res, "xyz");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/variable_number_of_resource_paths.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/variable_number_of_resource_paths.bal
@@ -1,0 +1,52 @@
+// Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/jballerina.java;
+import ballerina/test;
+
+public client isolated class Client {
+
+    public isolated function init() {
+
+    }
+
+    isolated resource function get abc/[string ...path] () returns int = @java:Method {
+        'class: "org/ballerinalang/nativeimpl/jvm/tests/StaticMethods",
+        name: "getResource"
+    } external;
+
+    isolated resource function get abc/[int id]/[string path]/[string ...paths] () returns int = @java:Method {
+        'class: "org/ballerinalang/nativeimpl/jvm/tests/StaticMethods",
+        name: "getResource"
+    } external;
+
+    isolated resource function get abc/[string path]/[int path1]/[string path2]/[int ...path3] () returns int = @java:Method {
+        'class: "org/ballerinalang/nativeimpl/jvm/tests/StaticMethods",
+        name: "getResource"
+    } external;
+}
+
+public function testResourceFuncWithMultiplePathParams() {
+    Client cl = new;
+    var response = cl->/abc/[1]/abc/def/ghi/jkl/mno/pqr/stu/vwx/yz ();
+    test:assertEquals(response, 3);
+
+    response = cl->/abc/abc/def/ghi/jkl/mno/pqr/stu/vwx/yz ();
+    test:assertEquals(response, 9);
+
+    response = cl -> /abc/abc/[1001]/def/[101]/[10002] ();
+    test:assertEquals(response, 4);
+}


### PR DESCRIPTION
## Purpose
> $title
Fixes #39781 

## Approach

## Samples
If there are conflicting number of parameters, user need to provide the constraint types by using the `paramTypes` annotation.
e.g:
```ballerina
isolated resource function get abc/[int id]/[string path]/[string p2] (string a, float f, string s) returns int = @java:Method {
        'class: "org/ballerinalang/nativeimpl/jvm/tests/StaticMethods",
        name: "getResource",
        paramTypes: ["io.ballerina.runtime.api.values.BObject", "io.ballerina.runtime.api.values.BArray", "io.ballerina.runtime.api.values.BString", "double", "io.ballerina.runtime.api.values.BString"]
} external;
```

## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
