### PR TITLE
[2201.4.1] Fix `getType()` API change that causing runtime crash

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/values/BObject.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/values/BObject.java
@@ -43,7 +43,7 @@ public interface BObject extends RefValue {
      *
      * @return Ballerina object type.
      * @deprecated use {@link BObject#getOriginalType()} ()} instead.
-     * The API {@link BValue#getType()} should be used after fixing the cache issue (#39850).
+     * The API {@link BValue#getType()} should be used after fixing the cache issue #39850.
      */
     @Deprecated
     ObjectType getType();

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/values/BObject.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/values/BObject.java
@@ -43,7 +43,7 @@ public interface BObject extends RefValue {
      *
      * @return Ballerina object type.
      * @deprecated use {@link BObject#getOriginalType()} ()} instead.
-     * The API {@link BValue#getType()} should be used after fixing the cache issue.
+     * The API {@link BValue#getType()} should be used after fixing the cache issue (#39850).
      */
     @Deprecated
     ObjectType getType();

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/values/BObject.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/values/BObject.java
@@ -19,6 +19,7 @@ package io.ballerina.runtime.api.values;
 
 import io.ballerina.runtime.api.types.ObjectType;
 import io.ballerina.runtime.api.types.Type;
+import io.ballerina.runtime.api.utils.TypeUtils;
 import io.ballerina.runtime.internal.scheduling.Strand;
 import io.ballerina.runtime.internal.values.RefValue;
 
@@ -47,7 +48,9 @@ public interface BObject extends RefValue {
     @Deprecated
     ObjectType getType();
 
-    Type getOriginalType();
+    default Type getOriginalType() {
+        return TypeUtils.getType(this);
+    }
 
     Object get(BString fieldName);
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/values/BObject.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/values/BObject.java
@@ -42,6 +42,7 @@ public interface BObject extends RefValue {
      *
      * @return Ballerina object type.
      * @deprecated use {@link BObject#getOriginalType()} ()} instead.
+     * The API {@link BValue#getType()} should be used after fixing the cache issue.
      */
     @Deprecated
     ObjectType getType();

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/values/BObject.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/values/BObject.java
@@ -43,7 +43,7 @@ public interface BObject extends RefValue {
      *
      * @return Ballerina object type.
      * @deprecated use {@link BObject#getOriginalType()} ()} instead.
-     * The API {@link BValue#getType()} should be used after fixing the cache issue #39850.
+     * The API {@link BValue#getType()} should be used after fixing the issue #39850.
      */
     @Deprecated
     ObjectType getType();

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/values/BObject.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/values/BObject.java
@@ -17,6 +17,7 @@
  */
 package io.ballerina.runtime.api.values;
 
+import io.ballerina.runtime.api.types.ObjectType;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.internal.scheduling.Strand;
 import io.ballerina.runtime.internal.values.RefValue;
@@ -36,7 +37,16 @@ public interface BObject extends RefValue {
 
     BFuture start(Strand strand, String funcName, Object... args);
 
-    Type getType();
+    /**
+     * Gets the type of ballerina object.
+     *
+     * @return Ballerina object type.
+     * @deprecated use {@link BObject#getOriginalType()} ()} instead.
+     */
+    @Deprecated
+    ObjectType getType();
+
+    Type getOriginalType();
 
     Object get(BString fieldName);
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -408,6 +408,8 @@ public class TypeChecker {
             return TYPE_STRING;
         } else if (value instanceof Boolean) {
             return TYPE_BOOLEAN;
+        } else if (value instanceof BObject) {
+            return ((BObject) value).getOriginalType();
         }
 
         return ((BValue) value).getType();

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/AbstractObjectValue.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/AbstractObjectValue.java
@@ -20,6 +20,7 @@ package io.ballerina.runtime.internal.values;
 import io.ballerina.runtime.api.creators.ErrorCreator;
 import io.ballerina.runtime.api.flags.SymbolFlags;
 import io.ballerina.runtime.api.types.Field;
+import io.ballerina.runtime.api.types.ObjectType;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.types.TypeId;
 import io.ballerina.runtime.api.utils.StringUtils;
@@ -147,7 +148,12 @@ public abstract class AbstractObjectValue implements ObjectValue {
     }
 
     @Override
-    public Type getType() {
+    public ObjectType getType() {
+        return objectType;
+    }
+
+    @Override
+    public Type getOriginalType() {
         return type;
     }
 

--- a/langlib/lang.error/src/main/java/org/ballerinalang/langlib/error/StackTrace.java
+++ b/langlib/lang.error/src/main/java/org/ballerinalang/langlib/error/StackTrace.java
@@ -27,6 +27,7 @@ import io.ballerina.runtime.api.types.MethodType;
 import io.ballerina.runtime.api.types.ObjectType;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.utils.StringUtils;
+import io.ballerina.runtime.api.utils.TypeUtils;
 import io.ballerina.runtime.api.values.BArray;
 import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.api.values.BFuture;
@@ -140,7 +141,12 @@ public class StackTrace {
         }
 
         @Override
-        public Type getType() {
+        public ObjectType getType() {
+            return (ObjectType) TypeUtils.getReferredType(type);
+        }
+
+        @Override
+        public Type getOriginalType() {
             return type;
         }
 

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/mock/GenericMockObjectValue.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/mock/GenericMockObjectValue.java
@@ -165,7 +165,12 @@ public class GenericMockObjectValue implements BObject {
     }
 
     @Override
-    public Type getType() {
+    public ObjectType getType() {
+        return type;
+    }
+
+    @Override
+    public Type getOriginalType() {
         return type;
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Async.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Async.java
@@ -95,7 +95,7 @@ public class Async {
     }
 
     public static boolean isIsolatedFunctionWithName(BObject obj, BString method) {
-        ObjectType objectType = (ObjectType) obj.getType();
+        ObjectType objectType = obj.getType();
         return objectType.isIsolated() && objectType.isIsolated(method.getValue());
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/TypeReference.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/TypeReference.java
@@ -200,7 +200,7 @@ public class TypeReference {
     public static Boolean validateParameterizedType(ObjectValue objectValue) {
         BError error = ErrorCreator.createError(StringUtils.fromString("parameterized type API provided a non type " +
                 "reference type."));
-        ObjectType objectType = (ObjectType) objectValue.getType();
+        ObjectType objectType = objectValue.getType();
         BFunctionType functionType = (BFunctionType) objectType.getMethods()[0].getType();
         BParameterizedType parameterizedType =
                 (BParameterizedType) ((UnionType) functionType.getReturnType()).getMemberTypes().get(0);
@@ -264,7 +264,8 @@ public class TypeReference {
     }
 
     public static Boolean validateBObject(BObject value) {
-        if (value.getType().getTag() != TypeTags.TYPE_REFERENCED_TYPE_TAG) {
+        // TODO : change this to use `value.getType()`
+        if (value.getOriginalType().getTag() != TypeTags.TYPE_REFERENCED_TYPE_TAG) {
             throw ErrorCreator.createError(StringUtils.fromString("BObject getType API provided a non type " +
                     "reference type."));
         }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/runtime/api/tests/Values.java
@@ -131,7 +131,7 @@ public class Values {
     }
 
     public static BArray getParameters(BObject object, BString methodName) {
-        ObjectType objectType = (ObjectType) object.getType();
+        ObjectType objectType = object.getType();
         Optional<MethodType> funcType = Arrays.stream(objectType.getMethods())
                 .filter(r -> r.getName().equals(methodName.getValue())).findAny();
         TupleType tupleType = TypeCreator.createTupleType(List.of(PredefinedTypes.TYPE_STRING,
@@ -156,7 +156,7 @@ public class Values {
     }
 
     public static BString getFunctionString(BObject object, BString methodName) {
-        ObjectType objectType = (ObjectType) object.getType();
+        ObjectType objectType = object.getType();
         Optional<MethodType> funcType = Arrays.stream(objectType.getMethods())
                 .filter(r -> r.getName().equals(methodName.getValue())).findAny();
         if (funcType.isPresent()) {
@@ -406,7 +406,7 @@ public class Values {
     }
 
     public static Object validateFunctionParameterFromObject(BObject object) {
-        ObjectType type = (ObjectType) object.getType();
+        ObjectType type = object.getType();
         for (MethodType methodType : type.getMethods()) {
             if (methodType.getName() == "testFunction") {
                 return validateFunctionType(methodType.getType());

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/servicetests/ServiceValue.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/servicetests/ServiceValue.java
@@ -76,7 +76,7 @@ public class ServiceValue {
     }
 
     public static BArray getParamNames(BObject o, BString methodName) {
-        ObjectType type = (ObjectType) o.getType();
+        ObjectType type = o.getType();
         if (!(type instanceof ServiceType)) {
             return null;
         }


### PR DESCRIPTION
## Purpose
$subject

## Approach
Reverted the `getType()` API changes done on `BObject`.
Introduced a new API called `getOriginalType()` that returns a `Type` instance for type-reference support.


## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## CheckList 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
