### PR TITLE
Use a temp dir for Package Resolution Test resources

### DIFF
--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/GraphCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/GraphCommandTest.java
@@ -21,7 +21,6 @@ package io.ballerina.cli.cmd;
 import org.ballerinalang.compiler.BLangCompilerException;
 import org.ballerinalang.test.BCompileUtil;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.ballerinalang.util.RepoUtils;
@@ -338,11 +337,6 @@ public class GraphCommandTest extends BaseCommandTest {
         Assert.assertEquals(actualLog, expectedLog);
     }
 
-    @AfterClass
-    public void cleanUp() throws IOException {
-        deleteDependenciesToml(projectsWithDependencyConflicts);
-    }
-
     private void copyTestResourcesToTmpDir() throws URISyntaxException, IOException {
         URI testResourcesURI = Objects.requireNonNull(getClass().getClassLoader().getResource("test-resources"))
                 .toURI();
@@ -383,9 +377,5 @@ public class GraphCommandTest extends BaseCommandTest {
                 writer.newLine();
             }
         }
-    }
-
-    private void deleteDependenciesToml(Path projectPath) throws IOException {
-        Files.deleteIfExists(projectPath.resolve("Dependencies.toml"));
     }
 }

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/OldPackageMigrationTests.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/OldPackageMigrationTests.java
@@ -21,10 +21,12 @@ import io.ballerina.projects.DiagnosticResult;
 import io.ballerina.projects.PackageCompilation;
 import io.ballerina.projects.directory.BuildProject;
 import io.ballerina.tools.diagnostics.Diagnostic;
+import org.apache.commons.io.FileUtils;
 import org.ballerinalang.test.BCompileUtil;
 import org.testng.Assert;
 import org.testng.ITestContext;
 import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -49,6 +51,14 @@ public class OldPackageMigrationTests extends BaseTest {
 
     private static final Path RESOURCE_DIRECTORY =
             Paths.get("src/test/resources/projects_for_resolution_tests").toAbsolutePath();
+    private static Path tempResourceDir;
+
+    @BeforeClass
+    public void setup() throws IOException {
+        // copy the resource directory to a temp directory
+        tempResourceDir = Files.createTempDirectory("project-api-test");
+        FileUtils.copyDirectory(RESOURCE_DIRECTORY.toFile(), tempResourceDir.toFile());
+    }
 
     @Test
     public void testOldPackage(ITestContext ctx) throws IOException {
@@ -56,7 +66,7 @@ public class OldPackageMigrationTests extends BaseTest {
         // package_d --> package_b --> package_c
         // package_d --> package_e
         BCompileUtil.compileAndCacheBala("projects_for_resolution_tests/package_d");
-        Path packagePath = RESOURCE_DIRECTORY.resolve("package_f");
+        Path packagePath = tempResourceDir.resolve("package_f");
         ctx.getCurrentXmlTest().addParameter("packagePath", String.valueOf(packagePath));
 
         deleteBuildFileAndDependenciesToml(packagePath);
@@ -89,9 +99,9 @@ public class OldPackageMigrationTests extends BaseTest {
         // package_d --> package_b --> package_c
         // package_d --> package_e
         // package_b and package_d are local packages
-        cacheDependencyToLocalRepository(RESOURCE_DIRECTORY.resolve("package_b"));
-        cacheDependencyToLocalRepository(RESOURCE_DIRECTORY.resolve("package_d"));
-        Path packagePath = RESOURCE_DIRECTORY.resolve("package_f_old_local");
+        cacheDependencyToLocalRepository(tempResourceDir.resolve("package_b"));
+        cacheDependencyToLocalRepository(tempResourceDir.resolve("package_d"));
+        Path packagePath = tempResourceDir.resolve("package_f_old_local");
         ctx.getCurrentXmlTest().addParameter("packagePath", String.valueOf(packagePath));
 
         deleteBuildFileAndDependenciesToml(packagePath);

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/SubsequentBuildTests.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/SubsequentBuildTests.java
@@ -20,6 +20,7 @@ package io.ballerina.projects.test;
 import io.ballerina.projects.DiagnosticResult;
 import io.ballerina.projects.PackageCompilation;
 import io.ballerina.projects.directory.BuildProject;
+import org.apache.commons.io.FileUtils;
 import org.ballerinalang.test.BCompileUtil;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -49,12 +50,17 @@ public class SubsequentBuildTests {
 
     private static final Path RESOURCE_DIRECTORY =
             Paths.get("src/test/resources/projects_for_resolution_tests").toAbsolutePath();
+    private static Path tempResourceDir;
     private static final PrintStream OUT = System.out;
     private Path packagePath;
 
     @BeforeClass
     public void setUp() throws IOException {
-        packagePath = RESOURCE_DIRECTORY.resolve("package_f");
+        // copy the resource directory to a temp directory
+        tempResourceDir = Files.createTempDirectory("project-api-test");
+        FileUtils.copyDirectory(RESOURCE_DIRECTORY.toFile(), tempResourceDir.toFile());
+
+        packagePath = tempResourceDir.resolve("package_f");
         // Delete build file if exists
         Files.deleteIfExists(packagePath.resolve(TARGET_DIR_NAME).resolve(BUILD_FILE));
         // Delete Dependencies.toml file if exists
@@ -97,7 +103,7 @@ public class SubsequentBuildTests {
                 + "name = \"package_c\"\n"
                 + "version = \"0.2.0\"\n"
                 + "export = [\"package_c\", \"package_c.mod_c1\", \"package_c.mod_c2\"]\n";
-        Files.write(RESOURCE_DIRECTORY.resolve("package_c").resolve(BALLERINA_TOML),
+        Files.write(tempResourceDir.resolve("package_c").resolve(BALLERINA_TOML),
                     pkgDBallerinaTomlContent.getBytes(StandardCharsets.UTF_8));
         BCompileUtil.compileAndCacheBala("projects_for_resolution_tests/package_c");
 
@@ -126,9 +132,9 @@ public class SubsequentBuildTests {
                 + "name = \"package_c\"\n"
                 + "version = \"0.1.0\"\n"
                 + "export = [\"package_c\", \"package_c.mod_c1\", \"package_c.mod_c2\"]\n";
-        Files.write(RESOURCE_DIRECTORY.resolve("package_c").resolve(BALLERINA_TOML),
+        Files.write(tempResourceDir.resolve("package_c").resolve(BALLERINA_TOML),
                     pkgDBallerinaTomlContent.getBytes(StandardCharsets.UTF_8));
         // Delete package_c build file
-        Files.deleteIfExists(RESOURCE_DIRECTORY.resolve("package_c").resolve(TARGET_DIR_NAME).resolve(BUILD_FILE));
+        Files.deleteIfExists(tempResourceDir.resolve("package_c").resolve(TARGET_DIR_NAME).resolve(BUILD_FILE));
     }
 }

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProject.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProject.java
@@ -120,12 +120,12 @@ public class TestBuildProject extends BaseTest {
     @BeforeClass
     public void setup() throws IOException {
         tempResourceDir = Files.createTempDirectory("project-api-test");
-        FileUtils.copyDirectory(RESOURCE_DIRECTORY.resolve("project_no_permission").toFile(),
-                tempResourceDir.resolve("project_no_permission").toFile());
+        FileUtils.copyDirectory(RESOURCE_DIRECTORY.toFile(), tempResourceDir.toFile());
     }
+
     @Test (description = "tests loading a valid build project")
     public void testBuildProjectAPI() {
-        Path projectPath = RESOURCE_DIRECTORY.resolve("myproject");
+        Path projectPath = tempResourceDir.resolve("myproject");
 
         // 1) Initialize the project instance
         BuildProject project = loadBuildProject(projectPath);
@@ -162,9 +162,9 @@ public class TestBuildProject extends BaseTest {
 
     }
 
-    @Test (description = "tests loading a build project containing invalid platformdependency paths")
+    @Test (description = "tests loading a build project containing invalid platform dependency paths")
     public void testBuildProjectWithInvalidDependencyPaths() {
-        Path projectPath = RESOURCE_DIRECTORY.resolve("myproject_invalidDependencyPath");
+        Path projectPath = tempResourceDir.resolve("myproject_invalidDependencyPath");
 
         // 1) Initialize the project instance
         BuildProject project = loadBuildProject(projectPath);
@@ -253,7 +253,7 @@ public class TestBuildProject extends BaseTest {
 
     @Test(description = "tests package compilation")
     public void testPackageCompilation() {
-        Path projectPath = RESOURCE_DIRECTORY.resolve("test_proj_pkg_compilation");
+        Path projectPath = tempResourceDir.resolve("test_proj_pkg_compilation");
 
         // 1) Initialize the project instance
         BuildProject project = loadBuildProject(projectPath);
@@ -271,7 +271,7 @@ public class TestBuildProject extends BaseTest {
 
     @Test(description = "tests package diagnostics")
     public void testDiagnostics() {
-        Path projectPath = RESOURCE_DIRECTORY.resolve("test_proj_pkg_compilation");
+        Path projectPath = tempResourceDir.resolve("test_proj_pkg_compilation");
 
         // 1) Initialize the project instance
         BuildProject project = loadBuildProject(projectPath);
@@ -322,7 +322,7 @@ public class TestBuildProject extends BaseTest {
 
     @Test(description = "tests codegen with native libraries")
     public void testJBallerinaBackend() {
-        Path projectPath = RESOURCE_DIRECTORY.resolve("test_proj_pkg_compilation_simple");
+        Path projectPath = tempResourceDir.resolve("test_proj_pkg_compilation_simple");
 
         // 1) Initialize the project instance
         BuildProject project = loadBuildProject(projectPath);
@@ -350,7 +350,7 @@ public class TestBuildProject extends BaseTest {
 
     @Test(description = "tests package compilation with errors in test source files")
     public void testPackageCompilationWithTests() {
-        Path projectPath = RESOURCE_DIRECTORY.resolve("project_with_tests");
+        Path projectPath = tempResourceDir.resolve("project_with_tests");
 
         // 1) Initialize the project instance
         BuildProject project = loadBuildProject(projectPath);
@@ -367,7 +367,7 @@ public class TestBuildProject extends BaseTest {
 
     @Test(description = "tests loading a valid build project using project compilation")
     public void testBuildProjectAPIWithPackageCompilation() {
-        Path projectPath = RESOURCE_DIRECTORY.resolve("myproject");
+        Path projectPath = tempResourceDir.resolve("myproject");
 
         // 1) Initialize the project instance
         BuildProject project = loadBuildProject(projectPath);
@@ -394,7 +394,7 @@ public class TestBuildProject extends BaseTest {
 
     @Test (description = "tests loading an invalid Ballerina project")
     public void testLoadBallerinaProjectNegative() {
-        Path projectPath = RESOURCE_DIRECTORY.resolve("myproject").resolve("modules").resolve("services")
+        Path projectPath = tempResourceDir.resolve("myproject").resolve("modules").resolve("services")
                 .resolve("svc.bal");
         try {
             TestUtils.loadBuildProject(projectPath);
@@ -402,14 +402,14 @@ public class TestBuildProject extends BaseTest {
             Assert.assertTrue(e.getMessage().contains("Invalid Ballerina package directory: " + projectPath));
         }
 
-        projectPath = RESOURCE_DIRECTORY.resolve("myproject").resolve("modules").resolve("services");
+        projectPath = tempResourceDir.resolve("myproject").resolve("modules").resolve("services");
         try {
             TestUtils.loadBuildProject(projectPath);
         } catch (ProjectException e) {
             Assert.assertTrue(e.getMessage().contains("Invalid Ballerina package directory: " + projectPath));
         }
 
-        projectPath = RESOURCE_DIRECTORY.resolve("single_file");
+        projectPath = tempResourceDir.resolve("single_file");
         try {
             TestUtils.loadBuildProject(projectPath);
             Assert.fail("expected an invalid project exception");
@@ -420,7 +420,7 @@ public class TestBuildProject extends BaseTest {
 
     @Test (description = "tests loading another invalid Ballerina project")
     public void testLoadBallerinaProjectInProject() {
-        Path projectPath = RESOURCE_DIRECTORY.resolve("myproject").resolve("modules").resolve("services")
+        Path projectPath = tempResourceDir.resolve("myproject").resolve("modules").resolve("services")
                 .resolve("resources").resolve("invalidProject");
         try {
             TestUtils.loadBuildProject(projectPath);
@@ -433,7 +433,7 @@ public class TestBuildProject extends BaseTest {
 
     @Test(description = "tests loading a valid build project with build options from toml")
     public void testLoadingBuildOptionsFromToml() {
-        Path projectPath = RESOURCE_DIRECTORY.resolve("projectWithBuildOptions");
+        Path projectPath = tempResourceDir.resolve("projectWithBuildOptions");
         // 1) Initialize the project instance
         BuildProject project = null;
         try {
@@ -452,7 +452,7 @@ public class TestBuildProject extends BaseTest {
 
     @Test(description = "tests loading a valid build project with build options from toml")
     public void testOverrideBuildOptions() {
-        Path projectPath = RESOURCE_DIRECTORY.resolve("projectWithBuildOptions");
+        Path projectPath = tempResourceDir.resolve("projectWithBuildOptions");
         // 1) Initialize the project instance
         BuildProject project = null;
         BuildOptions buildOptions = BuildOptions.builder().setSkipTests(false).build();
@@ -472,7 +472,7 @@ public class TestBuildProject extends BaseTest {
 
     @Test(description = "tests overriding build options when editing Toml")
     public void testOverrideBuildOptionsOnTomlEdit() {
-        Path projectPath = RESOURCE_DIRECTORY.resolve("projectWithBuildOptions");
+        Path projectPath = tempResourceDir.resolve("projectWithBuildOptions");
         // Initialize the project instance
         BuildOptions buildOptions = BuildOptions.builder().setOffline(true).build();
         BuildProject project = loadBuildProject(projectPath, buildOptions);
@@ -504,7 +504,7 @@ public class TestBuildProject extends BaseTest {
     @Test
     public void testUpdateDocument() {
         // Inputs from langserver
-        Path filePath = RESOURCE_DIRECTORY.resolve("myproject").resolve("main.bal").toAbsolutePath();
+        Path filePath = tempResourceDir.resolve("myproject").resolve("main.bal").toAbsolutePath();
 
         // Load the project from document filepath
         Project buildProject = TestUtils.loadProject(filePath);
@@ -544,7 +544,7 @@ public class TestBuildProject extends BaseTest {
     @Test
     public void testUpdateTestDocument() {
         // Inputs from langserver
-        Path filePath = RESOURCE_DIRECTORY.resolve("myproject").resolve(ProjectConstants.TEST_DIR_NAME)
+        Path filePath = tempResourceDir.resolve("myproject").resolve(ProjectConstants.TEST_DIR_NAME)
                 .resolve("main_tests.bal").toAbsolutePath();
 
         // Load the project from document filepath
@@ -577,8 +577,8 @@ public class TestBuildProject extends BaseTest {
 
     @Test
     public void testAddDocument() {
-        Path projectPath = RESOURCE_DIRECTORY.resolve("myproject");
-        Path filePath = RESOURCE_DIRECTORY.resolve("myproject").resolve("db.bal").toAbsolutePath();
+        Path projectPath = tempResourceDir.resolve("myproject");
+        Path filePath = tempResourceDir.resolve("myproject").resolve("db.bal").toAbsolutePath();
         String newFileContent = "import ballerina/io;\n";
 
         BuildProject buildProject = (BuildProject) TestUtils.loadProject(projectPath);
@@ -614,9 +614,9 @@ public class TestBuildProject extends BaseTest {
 
     @Test
     public void testAddTestDocument() {
-        Path projectPath = RESOURCE_DIRECTORY.resolve("myproject");
+        Path projectPath = tempResourceDir.resolve("myproject");
         Path filePath =
-                RESOURCE_DIRECTORY.resolve("myproject").resolve(ProjectConstants.TEST_DIR_NAME).resolve("db_test.bal")
+                tempResourceDir.resolve("myproject").resolve(ProjectConstants.TEST_DIR_NAME).resolve("db_test.bal")
                         .toAbsolutePath();
         String newFileContent = "import ballerina/io;\n";
 
@@ -653,7 +653,7 @@ public class TestBuildProject extends BaseTest {
 
     @Test
     public void testRemoveDocument() {
-        Path filePath = RESOURCE_DIRECTORY.resolve("myproject").resolve("utils.bal").toAbsolutePath();
+        Path filePath = tempResourceDir.resolve("myproject").resolve("utils.bal").toAbsolutePath();
 
         Project buildProject = TestUtils.loadProject(filePath);
         DocumentId removeDocumentId = buildProject.documentId(filePath);
@@ -680,7 +680,7 @@ public class TestBuildProject extends BaseTest {
     @Test
     public void testRemoveTestDocument() {
         Path filePath =
-                RESOURCE_DIRECTORY.resolve("myproject").resolve(ProjectConstants.MODULES_ROOT).resolve("services")
+                tempResourceDir.resolve("myproject").resolve(ProjectConstants.MODULES_ROOT).resolve("services")
                         .resolve(ProjectConstants.TEST_DIR_NAME).resolve("svc_tests.bal").toAbsolutePath();
 
         Project buildProject = TestUtils.loadProject(filePath);
@@ -708,7 +708,7 @@ public class TestBuildProject extends BaseTest {
     @Test
     public void testAddEmptyModule() {
         Path filePath =
-                RESOURCE_DIRECTORY.resolve("myproject").resolve(ProjectConstants.MODULES_ROOT).resolve("newModule")
+                tempResourceDir.resolve("myproject").resolve(ProjectConstants.MODULES_ROOT).resolve("newModule")
                         .toAbsolutePath();
         Path projectRoot = ProjectUtils.findProjectRoot(filePath);
         BuildProject buildProject = (BuildProject) TestUtils.loadProject(projectRoot);
@@ -750,7 +750,7 @@ public class TestBuildProject extends BaseTest {
     @Test
     public void testAddModuleWithFiles() {
         Path filePath =
-                RESOURCE_DIRECTORY.resolve("myproject").resolve(ProjectConstants.MODULES_ROOT).resolve("newModule")
+                tempResourceDir.resolve("myproject").resolve(ProjectConstants.MODULES_ROOT).resolve("newModule")
                         .toAbsolutePath();
         Path projectRoot = ProjectUtils.findProjectRoot(filePath);
         BuildProject buildProject = (BuildProject) TestUtils.loadProject(projectRoot);
@@ -789,8 +789,8 @@ public class TestBuildProject extends BaseTest {
 
     @Test
     public void testAccessNonExistingDocument() {
-        Path projectPath = RESOURCE_DIRECTORY.resolve("myproject");
-        Path filePath = RESOURCE_DIRECTORY.resolve("myproject").resolve("db.bal").toAbsolutePath();
+        Path projectPath = tempResourceDir.resolve("myproject");
+        Path filePath = tempResourceDir.resolve("myproject").resolve("db.bal").toAbsolutePath();
 
         // Load the project from document filepath
         Project buildProject = TestUtils.loadProject(projectPath);
@@ -805,7 +805,7 @@ public class TestBuildProject extends BaseTest {
     @Test
     public void testLoadFromNonExistentModule() {
         Path filePath =
-                RESOURCE_DIRECTORY.resolve("myproject").resolve(ProjectConstants.MODULES_ROOT)
+                tempResourceDir.resolve("myproject").resolve(ProjectConstants.MODULES_ROOT)
                         .resolve("db");
 
         try {
@@ -817,7 +817,7 @@ public class TestBuildProject extends BaseTest {
 
     @Test(description = "tests get semantic model in module compilation")
     public void testGetSemanticModel() {
-        Path projectPath = RESOURCE_DIRECTORY.resolve("myproject");
+        Path projectPath = tempResourceDir.resolve("myproject");
 
         // 1) Initialize the project instance
         BuildProject project = loadBuildProject(projectPath);
@@ -857,7 +857,7 @@ public class TestBuildProject extends BaseTest {
 
     @Test(description = "tests if other documents exists ie. Ballerina.toml, Package.md")
     public void testOtherDocuments() {
-        Path projectPath = RESOURCE_DIRECTORY.resolve("myproject");
+        Path projectPath = tempResourceDir.resolve("myproject");
 
         // 1) Initialize the project instance
         BuildProject project = loadBuildProject(projectPath);
@@ -894,7 +894,7 @@ public class TestBuildProject extends BaseTest {
 
     @Test(description = "test editing Ballerina.toml")
     public void testModifyBallerinaToml() {
-        Path projectPath = RESOURCE_DIRECTORY.resolve("project_with_tests");
+        Path projectPath = tempResourceDir.resolve("project_with_tests");
 
         // 1) Initialize the project instance
         BuildProject project = loadBuildProject(projectPath);
@@ -952,7 +952,7 @@ public class TestBuildProject extends BaseTest {
 
     @Test(description = "test editing Ballerina.toml")
     public void testModifyDependenciesToml() {
-        Path projectPath = RESOURCE_DIRECTORY.resolve("projects_for_edit_api_tests/package_test_dependencies_toml");
+        Path projectPath = tempResourceDir.resolve("projects_for_edit_api_tests/package_test_dependencies_toml");
         BuildProject project = loadBuildProject(projectPath, BuildOptions.builder().setSticky(true).build());
 
         PackageCompilation compilation = project.currentPackage().getCompilation();
@@ -1024,7 +1024,7 @@ public class TestBuildProject extends BaseTest {
 
     @Test(description = "tests if other documents can be edited ie. Dependencies.toml, Package.md")
     public void testOtherDocumentModify() {
-        Path projectPath = RESOURCE_DIRECTORY.resolve("myproject");
+        Path projectPath = tempResourceDir.resolve("myproject");
 
         // 1) Initialize the project instance
         BuildProject project = loadBuildProject(projectPath);
@@ -1094,7 +1094,7 @@ public class TestBuildProject extends BaseTest {
 
     @Test(description = "tests adding Dependencies.toml, Package.md")
     public void testOtherDocumentAdd() {
-        Path projectPath = RESOURCE_DIRECTORY.resolve("project_without_k8s");
+        Path projectPath = tempResourceDir.resolve("project_without_k8s");
 
         // 1) Initialize the project instance
         BuildProject project = loadBuildProject(projectPath);
@@ -1155,7 +1155,7 @@ public class TestBuildProject extends BaseTest {
 
     @Test(description = "tests if other documents can be edited ie. Ballerina.toml, Package.md")
     public void testOtherMinimalistProjectEdit() {
-        Path projectPath = RESOURCE_DIRECTORY.resolve("myproject_minimalist");
+        Path projectPath = tempResourceDir.resolve("myproject_minimalist");
 
         // 1) Initialize the project instance
         BuildProject project = loadBuildProject(projectPath);
@@ -1219,7 +1219,7 @@ public class TestBuildProject extends BaseTest {
 
     @Test
     public void testEditDependantModuleDocument() {
-        Path projectPath = RESOURCE_DIRECTORY.resolve("projects_for_edit_api_tests/package_with_dependencies");
+        Path projectPath = tempResourceDir.resolve("projects_for_edit_api_tests/package_with_dependencies");
         String updatedFunctionStr = "public function concatStrings(string a, string b, string c) returns string {\n" +
                 "\treturn a + b;\n" +
                 "}\n";
@@ -1249,7 +1249,7 @@ public class TestBuildProject extends BaseTest {
 
     @Test
     public void testRemoveDependantModuleDocument() {
-        Path projectPath = RESOURCE_DIRECTORY.resolve("projects_for_edit_api_tests/package_with_dependencies");
+        Path projectPath = tempResourceDir.resolve("projects_for_edit_api_tests/package_with_dependencies");
 
         // 1) Initialize the project instance
         BuildProject project = loadBuildProject(projectPath);
@@ -1276,7 +1276,7 @@ public class TestBuildProject extends BaseTest {
 
     @Test
     public void testEditTransitivelyDependantModuleDocument() {
-        Path projectPath = RESOURCE_DIRECTORY
+        Path projectPath = tempResourceDir
                 .resolve("projects_for_edit_api_tests/package_with_transitive_dependencies");
         String updatedFunctionStr = "public function concatStrings(string a, string b) returns string {\n" +
                 "\treturn a + b;\n" +
@@ -1308,7 +1308,7 @@ public class TestBuildProject extends BaseTest {
 
     @Test
     public void testEditPackageWithCyclicDependency() {
-        Path projectPath = RESOURCE_DIRECTORY
+        Path projectPath = tempResourceDir
                 .resolve("projects_for_edit_api_tests/package_with_cyclic_dependencies");
         String updatedFunctionStr = "public function concatStrings(string a, string b) returns string {\n" +
                 "\treturn a + b;\n" +
@@ -1345,7 +1345,7 @@ public class TestBuildProject extends BaseTest {
      */
     @Test
     public void testDocumentIdWhichModuleContainsPackageName() {
-        Path projectPath = RESOURCE_DIRECTORY.resolve("projectForDocumentIdTest");
+        Path projectPath = tempResourceDir.resolve("projectForDocumentIdTest");
 
         // 1) Initialize the project instance
         BuildProject project = loadBuildProject(projectPath);
@@ -1357,7 +1357,7 @@ public class TestBuildProject extends BaseTest {
         Assert.assertFalse(compilation.diagnosticResult().hasErrors());
 
         // Inputs from langserver
-        Path filePath = RESOURCE_DIRECTORY.resolve("projectForDocumentIdTest").resolve("modules").resolve("winery1")
+        Path filePath = tempResourceDir.resolve("projectForDocumentIdTest").resolve("modules").resolve("winery1")
                 .resolve("winery1.bal").toAbsolutePath();
 
         // Load the project from document filepath
@@ -1367,7 +1367,7 @@ public class TestBuildProject extends BaseTest {
 
     @Test(description = "test auto updating dependencies using build file")
     public void testAutoUpdateWithBuildFile() throws IOException {
-        Path projectPath = RESOURCE_DIRECTORY.resolve("myproject");
+        Path projectPath = tempResourceDir.resolve("myproject");
         // Delete build file if already exists
         if (projectPath.resolve(TARGET_DIR_NAME).resolve(BUILD_FILE).toFile().exists()) {
             Files.delete(projectPath.resolve(TARGET_DIR_NAME).resolve(BUILD_FILE));
@@ -1416,7 +1416,7 @@ public class TestBuildProject extends BaseTest {
 
     @Test(description = "test auto updating dependencies with build file after removing Dependencies.toml")
     public void testAutoUpdateWithBuildFileWithoutDepsToml() throws IOException {
-        Path projectPath = RESOURCE_DIRECTORY.resolve("myproject");
+        Path projectPath = tempResourceDir.resolve("myproject");
         // Delete build file and Dependencies.toml file if already exists
         Files.deleteIfExists(projectPath.resolve(TARGET_DIR_NAME).resolve(BUILD_FILE));
         Files.deleteIfExists(projectPath.resolve(DEPENDENCIES_TOML));
@@ -1464,7 +1464,7 @@ public class TestBuildProject extends BaseTest {
 
     @Test(description = "test auto updating dependencies with old distribution version")
     public void testAutoUpdateWithOldDistVersion() throws IOException {
-        Path projectPath = RESOURCE_DIRECTORY.resolve("old_dist_version_project");
+        Path projectPath = tempResourceDir.resolve("old_dist_version_project");
         // Delete build file and Dependencies.toml file if already exists
         Files.deleteIfExists(projectPath.resolve(TARGET_DIR_NAME).resolve(BUILD_FILE));
         Files.deleteIfExists(projectPath.resolve(DEPENDENCIES_TOML));
@@ -1526,7 +1526,7 @@ public class TestBuildProject extends BaseTest {
 
     @Test(description = "test build package without dependencies")
     public void testPackageWithoutDependencies() throws IOException {
-        Path projectPath = RESOURCE_DIRECTORY.resolve("project_wo_deps");
+        Path projectPath = tempResourceDir.resolve("project_wo_deps");
         // Delete Dependencies.toml and build file if already exists
         Files.deleteIfExists(projectPath.resolve(DEPENDENCIES_TOML));
         Files.deleteIfExists(projectPath.resolve(TARGET_DIR_NAME).resolve(BUILD_FILE));
@@ -1566,7 +1566,7 @@ public class TestBuildProject extends BaseTest {
     public void testDependenciesTomlCreationAndItsContent() throws IOException {
         // package_d --> package_b --> package_c
         // package_d --> package_e
-        Path projectDirPath = RESOURCE_DIRECTORY.resolve("projects_for_resolution_tests").resolve("package_d");
+        Path projectDirPath = tempResourceDir.resolve("projects_for_resolution_tests").resolve("package_d");
 
         // Delete build file and Dependencies.toml if exists
         Files.deleteIfExists(projectDirPath.resolve(TARGET_DIR_NAME).resolve(BUILD_FILE));
@@ -1593,7 +1593,7 @@ public class TestBuildProject extends BaseTest {
     @Test
     public void testGetResources() {
         // 1. load the project
-        Path projectPath = RESOURCE_DIRECTORY.resolve("myproject");
+        Path projectPath = tempResourceDir.resolve("myproject");
         BuildProject buildProject = loadBuildProject(projectPath);
         for (ModuleId moduleId : buildProject.currentPackage().moduleIds()) {
             Module module = buildProject.currentPackage().module(moduleId);
@@ -1628,7 +1628,7 @@ public class TestBuildProject extends BaseTest {
 
     @Test
     public void testGetResourcesOfDependencies() throws IOException {
-        Path projectPath = RESOURCE_DIRECTORY.resolve("projects_for_resources_tests/package_e");
+        Path projectPath = tempResourceDir.resolve("projects_for_resources_tests/package_e");
         BuildProject buildProject = loadBuildProject(projectPath);
         Module defaultModule = buildProject.currentPackage().getDefaultModule();
         DocumentId documentId = defaultModule.resourceIds().stream().findFirst().orElseThrow();
@@ -1665,7 +1665,7 @@ public class TestBuildProject extends BaseTest {
     @Test
     public void testAddResources() throws IOException {
         // 1. load the project
-        Path projectPath = RESOURCE_DIRECTORY.resolve("projects_for_resources_tests/myproject");
+        Path projectPath = tempResourceDir.resolve("projects_for_resources_tests/myproject");
         BuildProject buildProject = loadBuildProject(projectPath);
         Module defaultModule = buildProject.currentPackage().getDefaultModule();
 
@@ -1783,7 +1783,7 @@ public class TestBuildProject extends BaseTest {
 
     @Test
     public void testProjectClearCaches() {
-        Path projectDirPath = RESOURCE_DIRECTORY.resolve("projects_for_refresh_tests").resolve("package_refresh_one");
+        Path projectDirPath = tempResourceDir.resolve("projects_for_refresh_tests").resolve("package_refresh_one");
         BuildProject buildProject = TestUtils.loadBuildProject(projectDirPath);
         PackageCompilation compilation = buildProject.currentPackage().getCompilation();
         int errorCount = compilation.diagnosticResult().errorCount();
@@ -1800,7 +1800,7 @@ public class TestBuildProject extends BaseTest {
 
     @Test
     public void testProjectDuplicate() {
-        Path projectPath = RESOURCE_DIRECTORY.resolve("myproject");
+        Path projectPath = tempResourceDir.resolve("myproject");
         BuildOptions.BuildOptionsBuilder optionsBuilder = BuildOptions.builder().setCodeCoverage(true);
         Project project = loadProject(projectPath, optionsBuilder.build());
 
@@ -1890,7 +1890,7 @@ public class TestBuildProject extends BaseTest {
 
     @Test (description = "tests calling targetDir for Build Project")
     public void testBuildProjectTargetDir() {
-        Path projectPath = RESOURCE_DIRECTORY.resolve("myproject");
+        Path projectPath = tempResourceDir.resolve("myproject");
         BuildOptions.BuildOptionsBuilder buildOptionsBuilder = BuildOptions.builder();
         buildOptionsBuilder.setSticky(false);
         BuildProject project = loadBuildProject(projectPath, buildOptionsBuilder.build());
@@ -2093,7 +2093,7 @@ public class TestBuildProject extends BaseTest {
     @Test(description = "test accessing semantic model after first build",
             dependsOnMethods = "testGetSemanticModel")
     public void testAccessSemanticModelAfterFirstBuild() throws IOException {
-        Path projectPath = RESOURCE_DIRECTORY.resolve("myproject");
+        Path projectPath = tempResourceDir.resolve("myproject");
         // Delete build file if already exists
         if (projectPath.resolve(TARGET_DIR_NAME).resolve(BUILD_FILE).toFile().exists()) {
             Files.delete(projectPath.resolve(TARGET_DIR_NAME).resolve(BUILD_FILE));
@@ -2130,7 +2130,7 @@ public class TestBuildProject extends BaseTest {
 
     @Test(description = "tests the order of module documents")
     public void testDocumentsOrder() {
-        Path projectPath = RESOURCE_DIRECTORY.resolve("project_documents");
+        Path projectPath = tempResourceDir.resolve("project_documents");
         String sourceFileName = "types.bal";
         String testFileName = "tests/types.bal";
         String newFileContent = "type Integer 1|2";
@@ -2208,8 +2208,8 @@ public class TestBuildProject extends BaseTest {
 
     @Test (description = "tests jar resolution for Build Project")
     public void testConflictingJars() {
-        Path dep1Path = RESOURCE_DIRECTORY.resolve("conflicting_jars_test/platformLibPkg1").toAbsolutePath();
-        Path dep2Path = RESOURCE_DIRECTORY.resolve("conflicting_jars_test/platformLibPkg2").toAbsolutePath();
+        Path dep1Path = tempResourceDir.resolve("conflicting_jars_test/platformLibPkg1").toAbsolutePath();
+        Path dep2Path = tempResourceDir.resolve("conflicting_jars_test/platformLibPkg2").toAbsolutePath();
         Path customUserHome = Paths.get("build", "userHome");
         Environment environment = EnvironmentBuilder.getBuilder().setUserHome(customUserHome).build();
         ProjectEnvironmentBuilder envBuilder = ProjectEnvironmentBuilder.getBuilder(environment);
@@ -2225,7 +2225,7 @@ public class TestBuildProject extends BaseTest {
                     + getErrorsAsString(compileResult.getDiagnosticResult()));
         }
 
-        Path projectPath = RESOURCE_DIRECTORY.resolve("conflicting_jars_test/platformLibPkg3");
+        Path projectPath = tempResourceDir.resolve("conflicting_jars_test/platformLibPkg3");
         BuildProject project = TestUtils.loadBuildProject(envBuilder, projectPath);
         PackageCompilation compilation = project.currentPackage().getCompilation();
         JBallerinaBackend jBallerinaBackend = JBallerinaBackend.from(compilation, JvmTarget.JAVA_11);
@@ -2275,8 +2275,8 @@ public class TestBuildProject extends BaseTest {
 
     @Test (description = "tests jar resolution with non ballerina packages for Build Project")
     public void testConflictingJarsInNonBalPackages() {
-        Path dep1Path = RESOURCE_DIRECTORY.resolve("conflicting_jars_test/platformLibNonBalPkg1").toAbsolutePath();
-        Path dep2Path = RESOURCE_DIRECTORY.resolve("conflicting_jars_test/platformLibNonBalPkg2").toAbsolutePath();
+        Path dep1Path = tempResourceDir.resolve("conflicting_jars_test/platformLibNonBalPkg1").toAbsolutePath();
+        Path dep2Path = tempResourceDir.resolve("conflicting_jars_test/platformLibNonBalPkg2").toAbsolutePath();
         Path customUserHome = Paths.get("build", "userHome");
         Environment environment = EnvironmentBuilder.getBuilder().setUserHome(customUserHome).build();
         ProjectEnvironmentBuilder envBuilder = ProjectEnvironmentBuilder.getBuilder(environment);
@@ -2292,7 +2292,7 @@ public class TestBuildProject extends BaseTest {
                     + getErrorsAsString(compileResult.getDiagnosticResult()));
         }
 
-        Path projectPath = RESOURCE_DIRECTORY.resolve("conflicting_jars_test/platformLibNonBalPkg3");
+        Path projectPath = tempResourceDir.resolve("conflicting_jars_test/platformLibNonBalPkg3");
         BuildProject project = TestUtils.loadBuildProject(envBuilder, projectPath);
         PackageCompilation compilation = project.currentPackage().getCompilation();
         JBallerinaBackend jBallerinaBackend = JBallerinaBackend.from(compilation, JvmTarget.JAVA_11);


### PR DESCRIPTION
## Purpose
$ subject
The `PackageResolutionTests`, `PackageResolutionIntegrationTests` resources are not copied to a temp directory when running tests as of now. This results in creating and modifying existing resources during test runs (eg-Dependencies.toml) which can be accidentally comited.

This PR makes changes to copy the resources to a temp location and run tests on the temp resources.

Related to https://github.com/ballerina-platform/ballerina-lang/issues/39850

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
