### PR TITLE
Fix `tsymbol` getting `null` in first param in `function:call` lang-lib

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
@@ -1420,8 +1420,13 @@ public class BIRPackageSymbolEnter {
                     return bMapType;
                 case TypeTags.INVOKABLE:
                     BInvokableType bInvokableType = new BInvokableType(null, null, null, null);
+                    bInvokableType.tsymbol = Symbols.createInvokableTypeSymbol(SymTag.FUNCTION_TYPE, flags,
+                            env.pkgSymbol.pkgID, bInvokableType,
+                            env.pkgSymbol.owner, symTable.builtinPos,
+                            COMPILED_SOURCE);
                     bInvokableType.flags = flags;
                     if (inputStream.readBoolean()) {
+                        // Return if an any function
                         return bInvokableType;
                     }
                     int paramCount = inputStream.readInt();

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/expectedtype/FunctionCallExpressionTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/expectedtype/FunctionCallExpressionTest.java
@@ -85,6 +85,7 @@ public class FunctionCallExpressionTest {
                 {123, 20, TypeDescKind.INT},
                 {124, 22, TypeDescKind.INT},
                 {136, 32, TypeDescKind.STRING},
+                {144, 39, TypeDescKind.FUNCTION}
         };
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/expected-type/function_call_expression_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/expected-type/function_call_expression_test.bal
@@ -140,3 +140,7 @@ public function main() {
 function myFunction(string arg1, string arg2, int arg3 = 101) {
 
 }
+
+public function testLangLibFunctionCall() {
+    any|error johnName = function:call();
+}


### PR DESCRIPTION
## Purpose
$title

Fixes #38932

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
