### PR TITLE
Fix several assignable issues in `XML Sequence` 

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -5766,17 +5766,19 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         }
         
         // Disallow unions with 'xml:T (singleton) items
-         for (BType item : ((BUnionType) expType).getMemberTypes()) {
-             item = Types.getReferredType(item);
-             if (item.tag == TypeTags.XML_TEXT || item.tag == TypeTags.XML || item.tag == TypeTags.ERROR
-                     || item.tag == TypeTags.ANY) {
-                 data.resultType = symTable.xmlType;
-                 return;
-             }
-         }
-         dlog.error(bLangXMLSequenceLiteral.pos, DiagnosticErrorCode.INCOMPATIBLE_TYPES, 
-                 expType, symTable.xmlType);
-         data.resultType = symTable.semanticError;
+        for (BType item : ((BUnionType) expType).getMemberTypes()) {
+            item = Types.getReferredType(item);
+//            if (item.tag == TypeTags.XML && !types.isAssignable(symTable.xmlType, item)) {
+//                item = ((BXMLType) item).constraint;
+//            }
+            if (item.tag == TypeTags.XML && types.isAssignable(symTable.xmlType, item) || item.tag == TypeTags.ANYDATA || item.tag == TypeTags.ANY) {
+                data.resultType = symTable.xmlType;
+                return;
+            }
+        }
+        dlog.error(bLangXMLSequenceLiteral.pos, DiagnosticErrorCode.INCOMPATIBLE_TYPES,
+                expType, symTable.xmlType);
+        data.resultType = symTable.semanticError;
     }
 
     public void visit(BLangXMLTextLiteral bLangXMLTextLiteral, AnalyzerData data) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -5768,10 +5768,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         // Disallow unions with 'xml:T (singleton) items
         for (BType item : ((BUnionType) expType).getMemberTypes()) {
             item = Types.getReferredType(item);
-//            if (item.tag == TypeTags.XML && !types.isAssignable(symTable.xmlType, item)) {
-//                item = ((BXMLType) item).constraint;
-//            }
-            if (item.tag == TypeTags.XML && types.isAssignable(symTable.xmlType, item) || item.tag == TypeTags.ANYDATA || item.tag == TypeTags.ANY) {
+            if (types.isAssignable(symTable.xmlType, item)) {
                 data.resultType = symTable.xmlType;
                 return;
             }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLIterationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLIterationTest.java
@@ -86,6 +86,9 @@ public class XMLIterationTest {
                 "incompatible types: expected '(xml:Element|xml:Text)', found 'xml'",
                 59, 34);
         BAssertUtil.validateError(negative, index++,
+                "incompatible types: expected '(xml<xml:Element>|xml<xml:Text>)', found 'xml'",
+                60, 44);
+        BAssertUtil.validateError(negative, index++,
                 "incompatible types: expected 'other', found '(xml:Element|xml:Text)'",
                 63, 13);
         BAssertUtil.validateError(negative, index++,

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLIterationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLIterationTest.java
@@ -83,9 +83,6 @@ public class XMLIterationTest {
                 "incompatible types: expected 'record {| xml:Comment value; |}?', found " +
                         "'record {| xml:ProcessingInstruction value; |}?'", 55, 49);
         BAssertUtil.validateError(negative, index++,
-                "incompatible types: expected '(xml:Element|xml:Text)', found 'xml'",
-                59, 34);
-        BAssertUtil.validateError(negative, index++,
                 "incompatible types: expected 'other', found '(xml:Element|xml:Text)'",
                 63, 13);
         BAssertUtil.validateError(negative, index++,

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLIterationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLIterationTest.java
@@ -83,6 +83,9 @@ public class XMLIterationTest {
                 "incompatible types: expected 'record {| xml:Comment value; |}?', found " +
                         "'record {| xml:ProcessingInstruction value; |}?'", 55, 49);
         BAssertUtil.validateError(negative, index++,
+                "incompatible types: expected '(xml:Element|xml:Text)', found 'xml'",
+                59, 34);
+        BAssertUtil.validateError(negative, index++,
                 "incompatible types: expected 'other', found '(xml:Element|xml:Text)'",
                 63, 13);
         BAssertUtil.validateError(negative, index++,

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLLiteralTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLLiteralTest.java
@@ -209,6 +209,8 @@ public class XMLLiteralTest {
                 "'(xml<xml:Text>|xml<xml:Comment>)', found 'xml'", 148, 44);
         BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected " +
                 "'(xml<xml:Element>|xml:Text)', found 'xml'", 149, 39);
+        BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected " +
+                "'(xml<xml<xml:Text>>|xml<xml<xml:Comment>>)', found 'xml'", 150, 54);
 
         Assert.assertEquals(index, negativeResult.getErrorCount());
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLLiteralTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLLiteralTest.java
@@ -106,9 +106,15 @@ public class XMLLiteralTest {
         BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected " +
                 "'(xml:Text|xml:Comment)', found 'xml:Element'", 74, 34);
         BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected " +
+                "'(xml:Text|xml:Comment)', found 'xml'", 75, 34);
+        BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected " +
                 "'(xml:Text|xml:Comment)', found 'xml:Element'", 75, 39);
         BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected " +
                 "'(xml:Text|xml:Comment)', found 'xml:ProcessingInstruction'", 75, 86);
+        BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected " +
+                "'(xml:Text|xml:Comment)', found 'xml'", 76, 34);
+        BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected " +
+                "'(xml<xml:Text>|xml:Comment)', found 'xml'", 77, 39);
         BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected " +
                 "'xml:Element', found 'XML Sequence'", 78, 24);
         BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected " +

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLLiteralTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLLiteralTest.java
@@ -100,6 +100,8 @@ public class XMLLiteralTest {
         BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected " +
                 "'(xml<xml:Text>|xml<xml:Comment>)', found 'xml:Element'", 72, 44);
         BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected " +
+                "'(xml<xml:Text>|xml<xml:Comment>)', found 'xml'", 73, 44);
+        BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected " +
                 "'(xml<xml:Text>|xml<xml:Comment>)', found 'xml:Element'", 73, 49);
         BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected " +
                 "'(xml<xml:Text>|xml<xml:Comment>)', found 'xml:ProcessingInstruction'", 73, 96);
@@ -202,6 +204,11 @@ public class XMLLiteralTest {
                         "found 'ballerina/lang.object:0.0.0:RawTemplate[]'", 143, 25);
         BAssertUtil.validateError(negativeResult, index++,
                 "incompatible types: 'ballerina/lang.object:0.0.0:RawTemplate[]' cannot be cast to 'string'", 144, 25);
+
+        BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected " +
+                "'(xml<xml:Text>|xml<xml:Comment>)', found 'xml'", 148, 44);
+        BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected " +
+                "'(xml<xml:Element>|xml:Text)', found 'xml'", 149, 39);
 
         Assert.assertEquals(index, negativeResult.getErrorCount());
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLLiteralTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLLiteralTest.java
@@ -106,15 +106,9 @@ public class XMLLiteralTest {
         BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected " +
                 "'(xml:Text|xml:Comment)', found 'xml:Element'", 74, 34);
         BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected " +
-                "'(xml:Text|xml:Comment)', found 'xml'", 75, 34);
-        BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected " +
                 "'(xml:Text|xml:Comment)', found 'xml:Element'", 75, 39);
         BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected " +
                 "'(xml:Text|xml:Comment)', found 'xml:ProcessingInstruction'", 75, 86);
-        BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected " +
-                "'(xml:Text|xml:Comment)', found 'xml'", 76, 34);
-        BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected " +
-                "'(xml<xml:Text>|xml:Comment)', found 'xml'", 77, 39);
         BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected " +
                 "'xml:Element', found 'XML Sequence'", 78, 24);
         BAssertUtil.validateError(negativeResult, index++, "incompatible types: expected " +

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/add-operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/add-operation.bal
@@ -428,14 +428,14 @@ type Foo3 Foo|Foo2;
 
 function testXmlSubtypesAddition() {
     xml a = xml `<foo>foo</foo><?foo?>text1<!--comment-->`;
-    xml<'xml:Element>|Foo b = xml `<foo>Anne</foo><fuu>Peter</fuu>`;
+    xml<'xml:Element>|Foo b = xml `<foo></foo>`;
     Foo2 c = xml `<?foo?><?faa?>`;
     Foo3 d = xml `text1 text2`;
     xml<'xml:Comment> e = xml `<!--comment1--><!--comment2-->`;
     xml<'xml:Text|'xml:Comment> f = xml `<!--comment-->`;
     xml<'xml:Text>|xml<'xml:Comment> g = xml `<!--comment-->`;
     xml<'xml:Element|'xml:ProcessingInstruction> h = xml `<root> text1<foo>100</foo><foo>200</foo></root><?foo?>`;
-    xml<'xml:Element>|'xml:Text i = xml `<root> text1<foo>100</foo><foo>200</foo></root> text1`;
+    xml<'xml:Element>|'xml:Text i = xml `text1 text2`;
     xml j = a + b;
     xml k = a + c;
     xml l = a + d;
@@ -444,7 +444,7 @@ function testXmlSubtypesAddition() {
     xml o = d + f;
     xml p = g + h;
     
-    xml result1 = xml `<foo>foo</foo><?foo ?>text1<!--comment--><foo>Anne</foo><fuu>Peter</fuu>`;
+    xml result1 = xml `<foo>foo</foo><?foo ?>text1<!--comment--><foo></foo>`;
     xml result2 = xml `<foo>foo</foo><?foo ?>text1<!--comment--><?foo ?><?faa ?>`;
     xml result3 = xml `<foo>foo</foo><?foo ?>text1<!--comment-->text1 text2`;
     xml result4 = xml `<?foo ?><?faa ?><!--comment-->`;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-literals-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-literals-negative.bal
@@ -143,3 +143,8 @@ function testQueryInXMLTemplateExprNegative() {
     var _ = xml `<doc>${from int i in 0..<2 select `<foo></foo>`}</doc>`;
     var _ = xml `<doc>${<string>from int i in 0..<2 select `<foo></foo>`}</doc>`;
 }
+
+function textInvalidXmlSequence() {
+    xml<'xml:Text>|xml<'xml:Comment> x38 = xml `<!--comment-->text1`;
+    xml<'xml:Element>|'xml:Text x39 = xml `<root><foo><foo></foo>3</foo></root>3`;
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-literals-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-literals-negative.bal
@@ -147,4 +147,5 @@ function testQueryInXMLTemplateExprNegative() {
 function textInvalidXmlSequence() {
     xml<'xml:Text>|xml<'xml:Comment> x38 = xml `<!--comment-->text1`;
     xml<'xml:Element>|'xml:Text x39 = xml `<root><foo><foo></foo>3</foo></root>3`;
+    xml<xml<'xml:Text>>|xml<xml<'xml:Comment>> x40 = xml `<!--comment-->text1`;
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-literals.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-literals.bal
@@ -92,6 +92,10 @@ function testXMLSequence() {
     if (x34 is xml) {
         test:assertEquals(x34.toString(), "world<elem></elem>");
     }
+    xml|xml<xml:Text>|xml:Text x35 = xml `hello<e></e>`;
+    test:assertEquals(x35.toString(), "hello<e></e>");
+    xml|xml<xml:Text|xml:Comment> x36 = xml `world<e></e>`;
+    test:assertEquals(x36.toString(), "world<e></e>");
 }
 
 public type Template object {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-literals.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-literals.bal
@@ -75,12 +75,8 @@ function testXMLSequence() {
     test:assertEquals(x10.toString(), "<!--comment-->text1");
     xml<'xml:Element|'xml:ProcessingInstruction> x11 = xml `<root> text1<foo>100</foo><foo>200</foo></root><?foo?>`;
     test:assertEquals(x11.toString(), "<root> text1<foo>100</foo><foo>200</foo></root><?foo ?>");
-    xml<'xml:Text>|xml<'xml:Comment> x13 = xml `<!--comment-->text1`;
-    test:assertEquals(x13.toString(), "<!--comment-->text1");
     xml<xml<'xml:Text>>|xml<xml<'xml:Comment>> x14 = xml `<!--comment-->text1`;
     test:assertEquals(x14.toString(), "<!--comment-->text1");
-    xml<'xml:Element>|'xml:Text x15 = xml `<root> text1<foo>100</foo><foo>200</foo></root> text1`;
-    test:assertEquals(x15.toString(), "<root> text1<foo>100</foo><foo>200</foo></root> text1");
     'xml:Text x16 = xml `text ${v1}`;
     test:assertEquals(x16.toString(), "text interpolation1");
     

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-literals.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-literals.bal
@@ -75,8 +75,6 @@ function testXMLSequence() {
     test:assertEquals(x10.toString(), "<!--comment-->text1");
     xml<'xml:Element|'xml:ProcessingInstruction> x11 = xml `<root> text1<foo>100</foo><foo>200</foo></root><?foo?>`;
     test:assertEquals(x11.toString(), "<root> text1<foo>100</foo><foo>200</foo></root><?foo ?>");
-    xml<xml<'xml:Text>>|xml<xml<'xml:Comment>> x14 = xml `<!--comment-->text1`;
-    test:assertEquals(x14.toString(), "<!--comment-->text1");
     'xml:Text x16 = xml `text ${v1}`;
     test:assertEquals(x16.toString(), "text interpolation1");
     

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-literals.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-literals.bal
@@ -83,7 +83,25 @@ function testXMLSequence() {
     test:assertEquals(x15.toString(), "<root> text1<foo>100</foo><foo>200</foo></root> text1");
     'xml:Text x16 = xml `text ${v1}`;
     test:assertEquals(x16.toString(), "text interpolation1");
+    
+    any x30 = xml `foo<e></e>`; 
+    test:assertEquals(x30.toString(), "foo<e></e>");
+    anydata x31 = xml `bar<e></e>`; 
+    test:assertEquals(x31.toString(), "bar<e></e>");
+    any|Template x32 = xml `foo<elem></elem>`;
+    test:assertEquals(x32.toString(), "foo<elem></elem>");
+    Template|any x33 = xml `bar<elem></elem>`; 
+    test:assertEquals(x33.toString(), "bar<elem></elem>");
+    xml|error x34 = xml `world<elem></elem>`;
+    if (x34 is xml) {
+        test:assertEquals(x34.toString(), "world<elem></elem>");
+    }
 }
+
+public type Template object {
+    public string[] & readonly strings;
+    public anydata[] insertions;
+};
 
 function testXMLTextLiteral() returns [xml, xml, xml, xml, xml, xml] {
     string v1 = "11";


### PR DESCRIPTION
## Purpose
This PR fixes the issue of 'XML Sequence' being not assignable to any, anydata and union types.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/33230
Fixes https://github.com/ballerina-platform/ballerina-lang/issues/32957

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
