### PR TITLE
Fix multiple signature help, completion and completion sorting issues

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -231,6 +231,17 @@ public class CommonUtil {
     }
 
     /**
+     * As per LSP, characters like \ and $ should be escaped when using them as insert text.
+     *
+     * @param text The text to be processed
+     * @return Processed text
+     */
+    public static String escapeSpecialCharsInInsertText(String text) {
+        return text.replaceAll("\\\\", "\\\\\\\\")
+                .replaceAll("\\$", Matcher.quoteReplacement("\\$"));
+    }
+
+    /**
      * Find node of this range.
      *
      * @param range      {@link Range}

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/FieldCompletionItemBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/FieldCompletionItemBuilder.java
@@ -59,7 +59,7 @@ public class FieldCompletionItemBuilder {
 
         CompletionItem completionItem = new CompletionItem();
         completionItem.setLabel(recordFieldName);
-        completionItem.setInsertText(CommonUtil.escapeEscapeCharsInIdentifier(recordFieldName));
+        completionItem.setInsertText(CommonUtil.escapeSpecialCharsInInsertText(recordFieldName));
         completionItem.setKind(CompletionItemKind.Field);
         return completionItem;
     }
@@ -72,7 +72,7 @@ public class FieldCompletionItemBuilder {
      * @return {@link CompletionItem} generated completion item
      */
     public static CompletionItem build(RecordFieldSymbol symbol, BallerinaCompletionContext context) {
-        String recordFieldName = CommonUtil.escapeEscapeCharsInIdentifier(symbol.getName().orElseThrow());
+        String recordFieldName = symbol.getName().orElseThrow();
         CompletionItem completionItem = new CompletionItem();
         completionItem.setLabel(recordFieldName);
         completionItem.setKind(CompletionItemKind.Field);
@@ -89,7 +89,7 @@ public class FieldCompletionItemBuilder {
             }
         }
 
-        completionItem.setInsertText(insertText);
+        completionItem.setInsertText(CommonUtil.escapeSpecialCharsInInsertText(insertText));
 
         return completionItem;
     }
@@ -103,12 +103,13 @@ public class FieldCompletionItemBuilder {
      */
     public static CompletionItem build(ObjectFieldSymbol objectFieldSymbol, boolean withSelfPrefix) {
         if (withSelfPrefix) {
-            String label = "self." + 
-                    CommonUtil.escapeEscapeCharsInIdentifier(objectFieldSymbol.getName().orElse(""));
+            String label = String.format("self.%s", objectFieldSymbol.getName().orElse(""));
+            String insertText = "self." +
+                    CommonUtil.escapeSpecialCharsInInsertText(objectFieldSymbol.getName().orElse(""));
 
             CompletionItem item = new CompletionItem();
             item.setLabel(label);
-            item.setInsertText(label);
+            item.setInsertText(insertText);
             item.setKind(CompletionItemKind.Field);
 
             return item;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/FunctionCompletionItemBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/FunctionCompletionItemBuilder.java
@@ -109,7 +109,7 @@ public final class FunctionCompletionItemBuilder {
         if (functionSymbol != null) {
             // Override function signature
             String funcName = functionSymbol.getName().orElse("");
-            item.setInsertText(CommonUtil.escapeEscapeCharsInIdentifier(funcName));
+            item.setInsertText(CommonUtil.escapeSpecialCharsInInsertText(funcName));
             item.setLabel(funcName);
             item.setFilterText(funcName);
             item.setKind(CompletionItemKind.Variable);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/NamedArgCompletionItemBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/NamedArgCompletionItemBuilder.java
@@ -45,7 +45,7 @@ public class NamedArgCompletionItemBuilder {
         String defaultValueToInsert = DefaultValueGenerationUtil.getDefaultPlaceholderForType(argSymbol).orElse("");
         String defaultValueToDetail = DefaultValueGenerationUtil.getDefaultValueForType(argSymbol).orElse("");
         String label = argName + " = ...";
-        String insertText = CommonUtil.escapeEscapeCharsInIdentifier(argName) + " = ${1:" + defaultValueToInsert + "}";
+        String insertText = CommonUtil.escapeSpecialCharsInInsertText(argName) + " = ${1:" + defaultValueToInsert + "}";
         String detail = argName + " = " + defaultValueToDetail;
         CompletionItem item = new CompletionItem();
         item.setLabel(label);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/ParameterCompletionItemBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/ParameterCompletionItemBuilder.java
@@ -41,7 +41,7 @@ public final class ParameterCompletionItemBuilder {
     public static CompletionItem build(String label, String type) {
         CompletionItem item = new CompletionItem();
         item.setLabel(label);
-        String insertText = CommonUtil.escapeEscapeCharsInIdentifier(label);
+        String insertText = CommonUtil.escapeSpecialCharsInInsertText(label);
         item.setInsertText(insertText);
         item.setDetail((type.equals("")) ? ItemResolverConstants.NONE : type);
         item.setKind(CompletionItemKind.Variable);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/TypeCompletionItemBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/TypeCompletionItemBuilder.java
@@ -53,7 +53,7 @@ public class TypeCompletionItemBuilder {
     public static CompletionItem build(Symbol bSymbol, String label) {
         CompletionItem item = new CompletionItem();
         item.setLabel(label);
-        String insertText = CommonUtil.escapeEscapeCharsInIdentifier(label);
+        String insertText = CommonUtil.escapeSpecialCharsInInsertText(label);
         item.setInsertText(insertText);
         setMeta(item, bSymbol);
         return item;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/VariableCompletionItemBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/VariableCompletionItemBuilder.java
@@ -43,7 +43,7 @@ public final class VariableCompletionItemBuilder {
     public static CompletionItem build(VariableSymbol varSymbol, String label, String type) {
         CompletionItem item = new CompletionItem();
         item.setLabel(label);
-        String insertText = CommonUtil.escapeEscapeCharsInIdentifier(label);
+        String insertText = CommonUtil.escapeSpecialCharsInInsertText(label);
         item.setInsertText(insertText);
         item.setDetail((type.equals("")) ? ItemResolverConstants.NONE : type);
         setMeta(item, varSymbol);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/WorkerCompletionItemBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/WorkerCompletionItemBuilder.java
@@ -42,7 +42,7 @@ public final class WorkerCompletionItemBuilder {
         CompletionItem item = new CompletionItem();
         String name = workerSymbol.getName().orElse("");
         item.setLabel(name);
-        item.setInsertText(CommonUtil.escapeEscapeCharsInIdentifier(name));
+        item.setInsertText(CommonUtil.escapeSpecialCharsInInsertText(name));
         item.setDetail(ItemResolverConstants.WORKER);
         item.setKind(CompletionItemKind.Variable);
         return item;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/HoverObjectResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/HoverObjectResolver.java
@@ -31,7 +31,10 @@ import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
 import io.ballerina.compiler.api.symbols.VariableSymbol;
+import io.ballerina.compiler.syntax.tree.DefaultableParameterNode;
 import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NonTerminalNode;
+import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.projects.Module;
 import io.ballerina.projects.Package;
 import io.ballerina.projects.Project;
@@ -169,11 +172,22 @@ public class HoverObjectResolver {
                 String desc = paramsMap.getOrDefault(paramName, "");
                 String defaultValueEdit = "";
                 if (param.paramKind() == ParameterKind.DEFAULTABLE) {
-                    Optional<String> defaultValueForParam = DefaultValueGenerationUtil
-                            .getDefaultValueForType(param.typeDescriptor());
-                    if (defaultValueForParam.isPresent()) {
+                    // Lookup the parameter node from syntax tree using the parameter symbol
+                    Optional<NonTerminalNode> paramNode = context.currentSyntaxTree()
+                            .flatMap(syntaxTree -> CommonUtil.findNode(param, syntaxTree));
+                    if (paramNode.isPresent() && paramNode.get().kind() == SyntaxKind.DEFAULTABLE_PARAM
+                            && !((DefaultableParameterNode) paramNode.get()).expression().isMissing()) {
+                        // If there's a default value, use that instead of the default value of the type
+                        DefaultableParameterNode node = (DefaultableParameterNode) paramNode.get();
                         defaultValueEdit = MarkupUtils
-                                .quotedString(String.format("(default: %s)", defaultValueForParam.get()));
+                                .quotedString(String.format("(default: %s)", node.expression().toSourceCode()));
+                    } else {
+                        Optional<String> defaultValueForParam = DefaultValueGenerationUtil
+                                .getDefaultValueForType(param.typeDescriptor());
+                        if (defaultValueForParam.isPresent()) {
+                            defaultValueEdit = MarkupUtils
+                                    .quotedString(String.format("(default: %s)", defaultValueForParam.get()));
+                        }
                     }
                 }
                 return MarkupUtils.quotedString(NameUtil.getModifiedTypeName(context, param.typeDescriptor())) + " "

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/HoverObjectResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/HoverObjectResolver.java
@@ -166,7 +166,7 @@ public class HoverObjectResolver {
                             .getModifiedTypeName(context, param.typeDescriptor()));
                 }
                 String paramName = param.getName().get();
-                String desc = paramsMap.get(paramName);
+                String desc = paramsMap.getOrDefault(paramName, "");
                 String defaultValueEdit = "";
                 if (param.paramKind() == ParameterKind.DEFAULTABLE) {
                     Optional<String> defaultValueForParam = DefaultValueGenerationUtil
@@ -176,8 +176,7 @@ public class HoverObjectResolver {
                                 .quotedString(String.format("(default: %s)", defaultValueForParam.get()));
                     }
                 }
-                return MarkupUtils.quotedString(NameUtil.getModifiedTypeName(context,
-                        param.typeDescriptor())) + " "
+                return MarkupUtils.quotedString(NameUtil.getModifiedTypeName(context, param.typeDescriptor())) + " "
                         + MarkupUtils.italicString(MarkupUtils.boldString(paramName)) + " : " + desc + defaultValueEdit;
             }).collect(Collectors.toList()));
 

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config50.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config50.json
@@ -1,9 +1,10 @@
 {
   "position": {
-    "line": 6,
+    "line": 7,
     "character": 12
   },
   "source": "expression_context/source/mapping_expr_ctx_source50.bal",
+  "description": "",
   "items": [
     {
       "label": "readonly",
@@ -15,6 +16,14 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "map1",
+      "kind": "Variable",
+      "detail": "map<RecordName>",
+      "sortText": "AB",
+      "insertText": "map1",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "recMap",
       "kind": "Variable",
       "detail": "map<map<RecordName>>",
@@ -23,12 +32,12 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "...recMap",
+      "label": "...map1",
       "kind": "Variable",
-      "detail": "map<map<RecordName>>",
-      "sortText": "F",
-      "filterText": "recMap",
-      "insertText": "...recMap",
+      "detail": "map<RecordName>",
+      "sortText": "AB",
+      "filterText": "map1",
+      "insertText": "...map1",
       "insertTextFormat": "Snippet"
     }
   ]

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config69.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_expr_ctx_config69.json
@@ -4,6 +4,7 @@
     "character": 21
   },
   "source": "expression_context/source/mapping_expr_ctx_source69.bal",
+  "description": "Test completions in mapping constructor field name context with a similar type map in visible symbols (completion sorting with spread operator)",
   "items": [
     {
       "label": "readonly",
@@ -34,7 +35,7 @@
       "label": "...map2",
       "kind": "Variable",
       "detail": "map<int>",
-      "sortText": "F",
+      "sortText": "AB",
       "filterText": "map2",
       "insertText": "...map2",
       "insertTextFormat": "Snippet"
@@ -43,7 +44,7 @@
       "label": "...map1",
       "kind": "Variable",
       "detail": "map<int>",
-      "sortText": "F",
+      "sortText": "AB",
       "filterText": "map1",
       "insertText": "...map1",
       "insertTextFormat": "Snippet"

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/mapping_expr_ctx_source50.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/mapping_expr_ctx_source50.bal
@@ -1,6 +1,7 @@
 import ballerina/module1;
 
 function name() {
+    map<RecordName> map1 = {};
     map<map<RecordName>> recMap;
     recMap = {
         "rec1": {

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_with_special_chars_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/config/field_access_ctx_with_special_chars_config1.json
@@ -1,0 +1,444 @@
+{
+  "position": {
+    "line": 2,
+    "character": 23
+  },
+  "source": "field_access_expression_context/source/field_access_ctx_with_special_chars1.bal",
+  "description": "",
+  "items": [
+    {
+      "label": "reduce(function (map:Type1 accum, map:Type val) returns map:Type1 func, map:Type1 initial)",
+      "kind": "Function",
+      "detail": "map:Type1",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:0.0.0_  \n  \nCombines the members of a map using a combining function.\n\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n\n```ballerina\nmap<int> marks = {\"Carl\": 85, \"Bob\": 50, \"Max\": 60};\nmarks.reduce(isolated function (int total, int next) returns int => total + next, 0) ⇒ 195\n```\n  \n**Params**  \n- `function (map:Type1 accum, map:Type val) returns map:Type1` func: combining function  \n- `map:Type1` initial: initial value for the first argument of combining parameter `func`  \n  \n**Return** `map:Type1`   \n- result of combining the members of parameter `m` using parameter `func`  \n  \n"
+        }
+      },
+      "sortText": "CD",
+      "filterText": "reduce",
+      "insertText": "reduce(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "hasKey(string k)",
+      "kind": "Function",
+      "detail": "boolean",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:0.0.0_  \n  \nTests whether a map value has a member with a given key.\n\n```ballerina\nmap<int> marks = {\"Carl\": 85, \"Bob\": 50, \"Max\": 60};\nmarks.hasKey(\"Carl\") ⇒ true\nmarks.hasKey(\"John\") ⇒ false\n```\n  \n**Params**  \n- `string` k: the key  \n  \n**Return** `boolean`   \n- true if parameter `m` has a member with key parameter `k`  \n  \n"
+        }
+      },
+      "sortText": "CD",
+      "filterText": "hasKey",
+      "insertText": "hasKey(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "forEach(function (map:Type val) returns () func)",
+      "kind": "Function",
+      "detail": "()",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:0.0.0_  \n  \nApplies a function to each member of a map.\n\nThe parameter `func` is applied to each member of parameter `m`.\n\n```ballerina\nint total = 0;\n{\"Carl\": 85, \"Bob\": 50, \"Max\": 60}.forEach(function (int m) {\n    total += m;\n});\ntotal ⇒ 195\n```\n  \n**Params**  \n- `function (map:Type val) returns ()` func: a function to apply to each member"
+        }
+      },
+      "sortText": "CD",
+      "filterText": "forEach",
+      "insertText": "forEach(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "remove(string k)",
+      "kind": "Function",
+      "detail": "map:Type",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:0.0.0_  \n  \nRemoves a member of a map.\n\nThis removes the member of parameter `m` with key parameter `k` and returns it.\nIt panics if there is no such member.\n\n```ballerina\nmap<int> marks = {\"Carl\": 85, \"Bob\": 50, \"Max\": 60};\nmarks.remove(\"Carl\") ⇒ 85\nmarks ⇒ {\"Bob\":50,\"Max\":60}\nmarks.remove(\"John\") ⇒ panic\n```\n  \n**Params**  \n- `string` k: the key  \n  \n**Return** `map:Type`   \n- the member of parameter `m` that had key parameter `k`  \n  \n"
+        }
+      },
+      "sortText": "CD",
+      "filterText": "remove",
+      "insertText": "remove(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "filter(function (map:Type val) returns boolean func)",
+      "kind": "Function",
+      "detail": "map<map:Type>",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:0.0.0_  \n  \nSelects the members from a map for which a function returns true.\n\n```ballerina\nmap<int> marks = {\"Carl\": 85, \"Bob\": 50, \"Max\": 60};\nmarks.filter(m => m >= 60) ⇒ {\"Carl\":85,\"Max\":60}\n```\n  \n**Params**  \n- `function (map:Type val) returns boolean` func: a predicate to apply to each element to test whether it should be included  \n  \n**Return** `map<map:Type>`   \n- new map containing members for which parameter `func` evaluates to true  \n  \n"
+        }
+      },
+      "sortText": "CD",
+      "filterText": "filter",
+      "insertText": "filter(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "removeIfHasKey(string k)",
+      "kind": "Function",
+      "detail": "map:Type?",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:0.0.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n\nIf parameter `m` has a member with key parameter `k`, it removes and returns it;\notherwise it returns `()`.\n\n```ballerina\nmap<int> marks = {\"Carl\": 85, \"Bob\": 50, \"Max\": 60};\nmarks.removeIfHasKey(\"Carl\") ⇒ 85\nmarks ⇒ {\"Bob\":50,\"Max\":60}\nmarks.removeIfHasKey(\"John\") is () ⇒ true\n```\n  \n**Params**  \n- `string` k: the key  \n  \n**Return** `map:Type?`   \n- the member of parameter `m` that had key parameter `k`, or `()` if parameter `m` does not have a key parameter `k`  \n  \n"
+        }
+      },
+      "sortText": "CD",
+      "filterText": "removeIfHasKey",
+      "insertText": "removeIfHasKey(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "get(string k)",
+      "kind": "Function",
+      "detail": "map:Type",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:0.0.0_  \n  \nReturns the member of a map with given key.\n\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if parameter `m` does not have a member with parameter `k` key.\n\n```ballerina\nmap<int> marks = {\"Carl\": 85, \"Bob\": 50, \"Max\": 60};\nmarks.get(\"Carl\") ⇒ 85\nmarks.get(\"John\") ⇒ panic\n```\n  \n**Params**  \n- `string` k: the key  \n  \n**Return** `map:Type`   \n- member with parameter `k` key  \n  \n"
+        }
+      },
+      "sortText": "CD",
+      "filterText": "get",
+      "insertText": "get(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "cloneWithType(typedesc<anydata> t)",
+      "kind": "Function",
+      "detail": "t|error",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nConstructs a value with a specified type by cloning another value.\n\nWhen parameter `v` is a structural value, the inherent type of the value to be constructed\ncomes from parameter `t`. When parameter `t` is a union, it must be possible to determine which\nmember of the union to use for the inherent type by following the same rules\nthat are used by list constructor expressions and mapping constructor expressions\nwith the contextually expected type. If not, then an error is returned.\nThe `cloneWithType` operation is recursively applied to each member of parameter `v` using\nthe type descriptor that the inherent type requires for that member.\n\nLike the Clone abstract operation, this does a deep copy, but differs in\nthe following respects:\n- the inherent type of any structural values constructed comes from the specified\ntype descriptor rather than the value being constructed\n- the read-only bit of values and fields comes from the specified type descriptor\n- the graph structure of `v` is not preserved; the result will always be a tree;\nan error will be returned if `v` has cycles\n- immutable structural values are copied rather being returned as is; all\nstructural values in the result will be mutable.\n- numeric values can be converted using the NumericConvert abstract operation\n- if a record type descriptor specifies default values, these will be used\nto supply any missing members\n\n```ballerina\nanydata[] arr = [1, 2, 3, 4];\nint[] intArray = check arr.cloneWithType();\nintArray ⇒ [1,2,3,4]\narr === intArray ⇒ false\ntype Vowels string:Char[];\nstring[] vowels = [\"a\", \"e\", \"i\", \"o\", \"u\"];\nvowels.cloneWithType(Vowels) ⇒ [\"a\",\"e\",\"i\",\"o\",\"u\"]\nvowels.cloneWithType(string) ⇒ error\n```\n  \n**Params**  \n- `typedesc<anydata>` t: the type for the cloned to be constructed(Defaultable)  \n  \n**Return** `t|error`   \n- a new value that belongs to parameter `t`, or an error if this cannot be done  \n  \n"
+        }
+      },
+      "sortText": "CD",
+      "filterText": "cloneWithType",
+      "insertText": "cloneWithType(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "ensureType(typedesc<any> t)",
+      "kind": "Function",
+      "detail": "t|error",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nSafely casts a value to a type.\n\nThis casts a value to a type in the same way as a type cast expression,\nbut returns an error if the cast cannot be done, rather than panicking.\n\n```ballerina\njson student = {name: \"Jo\", subjects: [\"CS1212\", \"CS2021\"]};\njson[] subjects = check student.subjects.ensureType();\nsubjects ⇒ [\"CS1212\",\"CS2021\"]\nanydata vowel = \"I\";\nvowel.ensureType(string:Char) ⇒ I;\nvowel.ensureType(int) ⇒ error\n```\n  \n**Params**  \n- `typedesc<any>` t: a typedesc for the type to which to cast it(Defaultable)  \n  \n**Return** `t|error`   \n- `v` cast to the type described by parameter `t`, or an error, if the cast cannot be done  \n  \n"
+        }
+      },
+      "sortText": "CD",
+      "filterText": "ensureType",
+      "insertText": "ensureType(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "name",
+      "kind": "Field",
+      "detail": "string",
+      "sortText": "AA",
+      "insertText": "name",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "age",
+      "kind": "Field",
+      "detail": "int",
+      "sortText": "CA",
+      "insertText": "age",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "'map(function (map:Type val) returns map:Type1 func)",
+      "kind": "Function",
+      "detail": "map<map:Type1>",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:0.0.0_  \n  \nApplies a function each member of a map and returns a map of the result.\n\nThe resulting map will have the same keys as the argument map.\n\n```ballerina\nmap<int> marks = {\"Carl\": 85, \"Bob\": 50, \"Max\": 60};\nmarks.map(m => m > 50) ⇒ {\"Carl\":true,\"Bob\":false,\"Max\":true}\n```\n  \n**Params**  \n- `function (map:Type val) returns map:Type1` func: a function to apply to each member  \n  \n**Return** `map<map:Type1>`   \n- new map containing result of applying parameter `func` to each member  \n  \n"
+        }
+      },
+      "sortText": "CD",
+      "filterText": "'map",
+      "insertText": "'map(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "keys()",
+      "kind": "Function",
+      "detail": "string[]",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:0.0.0_  \n  \nReturns a list of all the keys of a map.\n\n```ballerina\n{\"Carl\": 85, \"Bob\": 50, \"Max\": 60}.keys() ⇒ [\"Carl\",\"Bob\",\"Max\"]\n```\n  \n  \n  \n**Return** `string[]`   \n- a new list of all keys  \n  \n"
+        }
+      },
+      "sortText": "CD",
+      "filterText": "keys",
+      "insertText": "keys()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "length()",
+      "kind": "Function",
+      "detail": "int",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:0.0.0_  \n  \nReturns number of members of a map.\n\n```ballerina\n{\"Carl\": 85, \"Bob\": 50, \"Max\": 60}.length() ⇒ 3\n```\n  \n  \n  \n**Return** `int`   \n- number of members in parameter `m`  \n  \n"
+        }
+      },
+      "sortText": "CD",
+      "filterText": "length",
+      "insertText": "length()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "iterator()",
+      "kind": "Function",
+      "detail": "object {public isolated function next() returns record {|map:Type value;|}?;}",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:0.0.0_  \n  \nReturns an iterator over a map.\n\nThe iterator will iterate over the members of the map not the keys.\nThe function `entries` can be used to iterate over the keys and members together.\nThe function `keys` can be used to iterator over just the keys.\n\n```ballerina\nobject {\n    public isolated function next() returns record {|int value;|}?;\n} iterator = {\"Carl\": 85, \"Bob\": 50, \"Max\": 60}.iterator();\niterator.next() ⇒ {\"value\":85}\n```\n  \n  \n  \n**Return** `object {public isolated function next() returns record {|map:Type value;|}?;}`   \n- a new iterator object that will iterate over the members of parameter `m`  \n  \n"
+        }
+      },
+      "sortText": "CD",
+      "filterText": "iterator",
+      "insertText": "iterator()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "entries()",
+      "kind": "Function",
+      "detail": "map<[string, map:Type]>",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:0.0.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n\n```ballerina\n{\"Carl\": 85, \"Bob\": 50}.entries() ⇒ {\"Carl\":[\"Carl\",85],\"Bob\":[\"Bob\",50]}\n```\n  \n  \n  \n**Return** `map<[string, map:Type]>`   \n- a new map of [key, member] pairs  \n  \n"
+        }
+      },
+      "sortText": "CD",
+      "filterText": "entries",
+      "insertText": "entries()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "removeAll()",
+      "kind": "Function",
+      "detail": "()",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:0.0.0_  \n  \nRemoves all members of a map.\n\nThis panics if any member cannot be removed.\n\n```ballerina\nmap<int> marks = {\"Carl\": 85, \"Bob\": 50, \"Max\": 60};\nmarks.removeAll();\nmarks ⇒ {}\nmap<int> values = <record {|int x; int y;|}> {x: 10, y: 20};\nvalues.removeAll() ⇒ panic;\n```\n  \n"
+        }
+      },
+      "sortText": "CD",
+      "filterText": "removeAll",
+      "insertText": "removeAll()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "toArray()",
+      "kind": "Function",
+      "detail": "map:Type[]",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:0.0.0_  \n  \nReturns a list of all the members of a map.\n\n```ballerina\n{\"Carl\": 85, \"Bob\": 50, \"Max\": 60}.toArray() ⇒ [85,50,60]\n```\n  \n  \n  \n**Return** `map:Type[]`   \n- an array whose members are the members of parameter `m`  \n  \n"
+        }
+      },
+      "sortText": "CD",
+      "filterText": "toArray",
+      "insertText": "toArray()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "cloneReadOnly()",
+      "kind": "Function",
+      "detail": "value:CloneableType & readonly",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nReturns a clone of a value that is read-only, i.e., immutable.\n\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n\n```ballerina\nint[] arr = [1, 2, 3, 4];\nint[] & readonly immutableClone = arr.cloneReadOnly();\nimmutableClone ⇒ [1,2,3,4]\nimmutableClone is readonly ⇒ true \n```\n  \n  \n  \n**Return** `value:CloneableType & readonly`   \n- immutable clone of parameter `v`  \n  \n"
+        }
+      },
+      "sortText": "CD",
+      "filterText": "cloneReadOnly",
+      "insertText": "cloneReadOnly()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "toBalString()",
+      "kind": "Function",
+      "detail": "string",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nConverts a value to a string that describes the value in Ballerina syntax.\n\nIf parameter `v` is anydata and does not have cycles, then the result will\nconform to the grammar for a Ballerina expression and when evaluated\nwill result in a value that is == to parameter `v`.\n\nThe details of the conversion are specified by the ToString abstract operation\ndefined in the Ballerina Language Specification, using the expression style.\n\n```ballerina\ndecimal value = 12.12d;\nvalue.toBalString() ⇒ 12.12d\nanydata[] data = [1, \"Sam\", 12.3f, 12.12d, {value: 12}];\ndata.toBalString() ⇒ [1,\"Sam\",12.3,12.12d,{\"value\":12}]\n```\n  \n  \n  \n**Return** `string`   \n- a string resulting from the conversion  \n  \n"
+        }
+      },
+      "sortText": "AD",
+      "filterText": "toBalString",
+      "insertText": "toBalString()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "toJson()",
+      "kind": "Function",
+      "detail": "json",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nConverts a value of type `anydata` to `json`.\n\nThis does a deep copy of parameter `v` converting values that do\nnot belong to json into values that do.\nA value of type `xml` is converted into a string as if\nby the `toString` function.\nA value of type `table` is converted into a list of\nmappings one for each row.\nThe inherent type of arrays in the return value will be\n`json[]` and of mappings will be `map<json>`.\nA new copy is made of all structural values, including\nimmutable values.\nThis panics if parameter `v` has cycles.\n\n```ballerina\nanydata student = {name: \"Jo\", age: 11};\nstudent.toJson() ⇒ {\"name\":\"Jo\",\"age\":11}\nanydata[] array = [];\narray.push(array);\narray.toJson() ⇒ panic\n```\n  \n  \n  \n**Return** `json`   \n- representation of `v` as value of type json  \n  \n"
+        }
+      },
+      "sortText": "CD",
+      "filterText": "toJson",
+      "insertText": "toJson()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "isReadOnly()",
+      "kind": "Function",
+      "detail": "boolean",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nTests whether a value is read-only, i.e., immutable.\n\nReturns true if read-only, false otherwise.\n\n```ballerina\nint[] scores = <readonly> [21, 12, 33, 45, 81];\nscores.isReadOnly() ⇒ true\nstring[] sports = [\"cricket\", \"football\", \"rugby\"];\nsports.isReadOnly() ⇒ false\n```\n  \n  \n  \n**Return** `boolean`   \n- true if read-only, false otherwise  \n  \n"
+        }
+      },
+      "sortText": "CD",
+      "filterText": "isReadOnly",
+      "insertText": "isReadOnly()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "clone()",
+      "kind": "Function",
+      "detail": "value:CloneableType",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nReturns a clone of a value.\n\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n\n```ballerina\nint[] arr = [1, 2, 3, 4];\nint[] clone = arr.clone();\nclone ⇒ [1,2,3,4]\narr === clone ⇒ false\n```\n  \n  \n  \n**Return** `value:CloneableType`   \n- clone of parameter `v`  \n  \n"
+        }
+      },
+      "sortText": "CD",
+      "filterText": "clone",
+      "insertText": "clone()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "toString()",
+      "kind": "Function",
+      "detail": "string",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nPerforms a direct conversion of a value to a string.\n\nThe conversion is direct in the sense that when applied to a value that is already\na string it leaves the value unchanged.\n\nThe details of the conversion are specified by the ToString abstract operation\ndefined in the Ballerina Language Specification, using the direct style.\n\n```ballerina\ndecimal value = 12.12d;\nvalue.toString() ⇒ 12.12\nanydata[] data = [1, \"Sam\", 12.3f, 12.12d, {value: 12}];\ndata.toString() ⇒ [1,\"Sam\",12.3,12.12,{\"value\":12}]\n```\n  \n  \n  \n**Return** `string`   \n- a string resulting from the conversion  \n  \n"
+        }
+      },
+      "sortText": "AD",
+      "filterText": "toString",
+      "insertText": "toString()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "toJsonString()",
+      "kind": "Function",
+      "detail": "string",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:0.0.0_  \n  \nReturns the string that represents a anydata value in JSON format.\n\nparameter `v` is first converted to `json` as if by the function `toJson`.\n\n```ballerina\nanydata marks = {\"Alice\": 90, \"Bob\": 85, \"Jo\": 91};\nmarks.toJsonString() ⇒ {\"Alice\":90, \"Bob\":85, \"Jo\":91}\n```\n  \n  \n  \n**Return** `string`   \n- string representation of parameter `v` converted to `json`  \n  \n"
+        }
+      },
+      "sortText": "AD",
+      "filterText": "toJsonString",
+      "insertText": "toJsonString()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "country\\$name",
+      "kind": "Field",
+      "detail": "string",
+      "sortText": "AA",
+      "insertText": "country\\\\\\$name",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "[\"\"]",
+      "kind": "Snippet",
+      "documentation": {
+        "left": "Convert to a member access expression"
+      },
+      "sortText": "CR",
+      "insertText": "[\"${1}\"]",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 2,
+              "character": 22
+            },
+            "end": {
+              "line": 2,
+              "character": 23
+            }
+          },
+          "newText": ""
+        }
+      ]
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/source/field_access_ctx_with_special_chars1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/field_access_expression_context/source/field_access_ctx_with_special_chars1.bal
@@ -1,0 +1,11 @@
+public function main() returns error? {
+    foo f = {name: "John", age: 30, country\$name: "USA"};
+    string country = f.
+}
+
+
+type foo record {  
+    string name;
+    int age;
+    string country\$name;
+};

--- a/language-server/modules/langserver-core/src/test/resources/completion/import_decl/config/config20.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/import_decl/config/config20.json
@@ -4,174 +4,196 @@
     "character": 18
   },
   "source": "import_decl/source/source11.bal",
+  "description": "",
   "items": [
     {
       "label": "lang.object",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "lang.'object;",
-      "insertTextFormat": "Snippet"
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     },
     {
       "label": "lang.boolean",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "lang.'boolean;",
-      "insertTextFormat": "Snippet"
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     },
     {
       "label": "lang.xml",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "lang.'xml;",
-      "insertTextFormat": "Snippet"
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     },
     {
       "label": "lang.test",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "lang.test;",
-      "insertTextFormat": "Snippet"
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     },
     {
       "label": "lang.array",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "lang.array;",
-      "insertTextFormat": "Snippet"
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     },
     {
       "label": "lang.transaction",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "lang.'transaction;",
-      "insertTextFormat": "Snippet"
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     },
     {
       "label": "jballerina.java",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "jballerina.java",
-      "insertTextFormat": "Snippet"
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     },
     {
       "label": "lang.string",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "lang.'string;",
-      "insertTextFormat": "Snippet"
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     },
     {
       "label": "lang.future",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "lang.'future;",
-      "insertTextFormat": "Snippet"
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     },
     {
       "label": "lang.value",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "lang.value;",
-      "insertTextFormat": "Snippet"
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     },
     {
       "label": "lang.float",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "lang.'float;",
-      "insertTextFormat": "Snippet"
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     },
     {
       "label": "lang.decimal",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "lang.'decimal;",
-      "insertTextFormat": "Snippet"
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     },
     {
       "label": "lang.table",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "lang.'table;",
-      "insertTextFormat": "Snippet"
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     },
     {
       "label": "lang.stream",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "lang.'stream;",
-      "insertTextFormat": "Snippet"
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     },
     {
       "label": "lang.error",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "lang.'error;",
-      "insertTextFormat": "Snippet"
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     },
     {
       "label": "lang.typedesc",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "lang.'typedesc;",
-      "insertTextFormat": "Snippet"
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     },
     {
       "label": "lang.map",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "lang.'map;",
-      "insertTextFormat": "Snippet"
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     },
     {
       "label": "lang.int",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "lang.'int;",
-      "insertTextFormat": "Snippet"
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     },
     {
       "label": "lang.runtime",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "lang.runtime;",
-      "insertTextFormat": "Snippet"
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     },
     {
       "label": "lang.function",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "lang.'function;",
-      "insertTextFormat": "Snippet"
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     },
     {
       "label": "lang.regexp",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "lang.regexp;",
-      "insertTextFormat": "Snippet"
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/import_decl/config/config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/import_decl/config/config4.json
@@ -4,182 +4,205 @@
     "character": 18
   },
   "source": "import_decl/source/source4.bal",
+  "description": "",
   "items": [
     {
       "label": "lang.object",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "lang.'object;",
-      "insertTextFormat": "Snippet"
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     },
     {
       "label": "lang.boolean",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "lang.'boolean;",
-      "insertTextFormat": "Snippet"
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     },
     {
       "label": "lang.xml",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "lang.'xml;",
-      "insertTextFormat": "Snippet"
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     },
     {
       "label": "lang.test",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "lang.test;",
-      "insertTextFormat": "Snippet"
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     },
     {
       "label": "lang.array",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "lang.array;",
-      "insertTextFormat": "Snippet"
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     },
     {
       "label": "lang.transaction",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "lang.'transaction;",
-      "insertTextFormat": "Snippet"
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     },
     {
       "label": "jballerina.java",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "jballerina.java",
-      "insertTextFormat": "Snippet"
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     },
     {
       "label": "lang.string",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "lang.'string;",
-      "insertTextFormat": "Snippet"
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     },
     {
       "label": "lang.future",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "lang.'future;",
-      "insertTextFormat": "Snippet"
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     },
     {
       "label": "lang.value",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "lang.value;",
-      "insertTextFormat": "Snippet"
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     },
     {
       "label": "lang.float",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "lang.'float;",
-      "insertTextFormat": "Snippet"
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     },
     {
       "label": "lang.decimal",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "lang.'decimal;",
-      "insertTextFormat": "Snippet"
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     },
     {
       "label": "lang.table",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "lang.'table;",
-      "insertTextFormat": "Snippet"
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     },
     {
       "label": "lang.stream",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "lang.'stream;",
-      "insertTextFormat": "Snippet"
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     },
     {
       "label": "lang.error",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "lang.'error;",
-      "insertTextFormat": "Snippet"
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     },
     {
       "label": "lang.typedesc",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "lang.'typedesc;",
-      "insertTextFormat": "Snippet"
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     },
     {
       "label": "module1",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "module1",
-      "insertTextFormat": "Snippet"
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     },
     {
       "label": "lang.map",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "lang.'map;",
-      "insertTextFormat": "Snippet"
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     },
     {
       "label": "lang.int",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "lang.'int;",
-      "insertTextFormat": "Snippet"
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     },
     {
       "label": "lang.runtime",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "lang.runtime;",
-      "insertTextFormat": "Snippet"
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     },
     {
       "label": "lang.function",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "lang.'function;",
-      "insertTextFormat": "Snippet"
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     },
     {
       "label": "lang.regexp",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "lang.regexp;",
-      "insertTextFormat": "Snippet"
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": []
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/import_decl/config/import_decl_with_partial_module_name1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/import_decl/config/import_decl_with_partial_module_name1.json
@@ -4,12 +4,13 @@
     "character": 22
   },
   "source": "import_decl/source/import_decl_with_partial_module_name1.bal",
+  "description": "",
   "items": [
     {
       "label": "module1",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "module1",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -32,7 +33,7 @@
       "label": "lang.int",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "A",
       "insertText": "lang.'int;",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -55,7 +56,7 @@
       "label": "lang.boolean",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "A",
       "insertText": "lang.'boolean;",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -78,7 +79,7 @@
       "label": "lang.decimal",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "A",
       "insertText": "lang.'decimal;",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -101,7 +102,7 @@
       "label": "lang.runtime",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "A",
       "insertText": "lang.runtime;",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -124,7 +125,7 @@
       "label": "lang.future",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "A",
       "insertText": "lang.'future;",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -147,7 +148,7 @@
       "label": "lang.error",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "A",
       "insertText": "lang.'error;",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -170,7 +171,7 @@
       "label": "lang.regexp",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "A",
       "insertText": "lang.regexp;",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -193,7 +194,7 @@
       "label": "lang.transaction",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "A",
       "insertText": "lang.'transaction;",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -216,7 +217,7 @@
       "label": "lang.object",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "A",
       "insertText": "lang.'object;",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -239,7 +240,7 @@
       "label": "lang.function",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "A",
       "insertText": "lang.'function;",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -262,7 +263,7 @@
       "label": "lang.typedesc",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "A",
       "insertText": "lang.'typedesc;",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -285,7 +286,7 @@
       "label": "lang.table",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "A",
       "insertText": "lang.'table;",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -308,7 +309,7 @@
       "label": "lang.string",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "A",
       "insertText": "lang.'string;",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -331,7 +332,7 @@
       "label": "lang.test",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "A",
       "insertText": "lang.test;",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -354,7 +355,7 @@
       "label": "lang.value",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "A",
       "insertText": "lang.value;",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -377,7 +378,7 @@
       "label": "lang.xml",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "A",
       "insertText": "lang.'xml;",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -400,7 +401,7 @@
       "label": "jballerina.java",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "jballerina.java",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -423,7 +424,7 @@
       "label": "lang.stream",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "A",
       "insertText": "lang.'stream;",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -446,7 +447,7 @@
       "label": "lang.map",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "A",
       "insertText": "lang.'map;",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -469,7 +470,7 @@
       "label": "lang.array",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "A",
       "insertText": "lang.array;",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -492,7 +493,7 @@
       "label": "lang.float",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "A",
       "insertText": "lang.'float;",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [

--- a/language-server/modules/langserver-core/src/test/resources/completion/import_decl/config/import_decl_with_partial_module_name2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/import_decl/config/import_decl_with_partial_module_name2.json
@@ -4,12 +4,13 @@
     "character": 25
   },
   "source": "import_decl/source/import_decl_with_partial_module_name2.bal",
+  "description": "",
   "items": [
     {
       "label": "module1",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "module1",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -32,7 +33,7 @@
       "label": "lang.int",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "A",
       "insertText": "lang.'int;",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -55,7 +56,7 @@
       "label": "lang.boolean",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "A",
       "insertText": "lang.'boolean;",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -78,7 +79,7 @@
       "label": "lang.decimal",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "A",
       "insertText": "lang.'decimal;",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -101,7 +102,7 @@
       "label": "lang.runtime",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "A",
       "insertText": "lang.runtime;",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -124,7 +125,7 @@
       "label": "lang.future",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "A",
       "insertText": "lang.'future;",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -147,7 +148,7 @@
       "label": "lang.error",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "A",
       "insertText": "lang.'error;",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -170,7 +171,7 @@
       "label": "lang.regexp",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "A",
       "insertText": "lang.regexp;",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -193,7 +194,7 @@
       "label": "lang.transaction",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "A",
       "insertText": "lang.'transaction;",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -216,7 +217,7 @@
       "label": "lang.object",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "A",
       "insertText": "lang.'object;",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -239,7 +240,7 @@
       "label": "lang.function",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "A",
       "insertText": "lang.'function;",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -262,7 +263,7 @@
       "label": "lang.typedesc",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "A",
       "insertText": "lang.'typedesc;",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -285,7 +286,7 @@
       "label": "lang.table",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "A",
       "insertText": "lang.'table;",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -308,7 +309,7 @@
       "label": "lang.string",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "A",
       "insertText": "lang.'string;",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -331,7 +332,7 @@
       "label": "lang.test",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "A",
       "insertText": "lang.test;",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -354,7 +355,7 @@
       "label": "lang.value",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "A",
       "insertText": "lang.value;",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -377,7 +378,7 @@
       "label": "lang.xml",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "A",
       "insertText": "lang.'xml;",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -400,7 +401,7 @@
       "label": "jballerina.java",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "jballerina.java",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -423,7 +424,7 @@
       "label": "lang.stream",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "A",
       "insertText": "lang.'stream;",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -446,7 +447,7 @@
       "label": "lang.map",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "A",
       "insertText": "lang.'map;",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -469,7 +470,7 @@
       "label": "lang.array",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "A",
       "insertText": "lang.array;",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
@@ -492,7 +493,7 @@
       "label": "lang.float",
       "kind": "Module",
       "detail": "Module",
-      "sortText": "C",
+      "sortText": "A",
       "insertText": "lang.'float;",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [

--- a/language-server/modules/langserver-core/src/test/resources/hover/configs/hover_with_missing_param_in_doc1.json
+++ b/language-server/modules/langserver-core/src/test/resources/hover/configs/hover_with_missing_param_in_doc1.json
@@ -1,0 +1,21 @@
+{
+  "position": {
+    "line": 11,
+    "character": 16
+  },
+  "source": {
+    "file": "hover_with_missing_param_in_doc1.bal"
+  },
+  "expected": {
+    "result": {
+      "contents": {
+        "kind": "markdown",
+        "value": "Creates a person\n  \n  \n---  \n  \n### Parameters  \n  \n`string` ***name*** : Name of the person  \n`int` ***age*** : `(default: 0)`"
+      }
+    },
+    "id": {
+      "left": "324"
+    },
+    "jsonrpc": "2.0"
+  }
+}

--- a/language-server/modules/langserver-core/src/test/resources/hover/configs/hover_with_missing_param_in_doc1.json
+++ b/language-server/modules/langserver-core/src/test/resources/hover/configs/hover_with_missing_param_in_doc1.json
@@ -10,7 +10,7 @@
     "result": {
       "contents": {
         "kind": "markdown",
-        "value": "Creates a person\n  \n  \n---  \n  \n### Parameters  \n  \n`string` ***name*** : Name of the person  \n`int` ***age*** : `(default: 0)`"
+        "value": "Creates a person\n  \n  \n---  \n  \n### Parameters  \n  \n`string` ***name*** : Name of the person  \n`int` ***age*** : `(default: 18)`"
       }
     },
     "id": {

--- a/language-server/modules/langserver-core/src/test/resources/hover/source/hover_with_missing_param_in_doc1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/hover/source/hover_with_missing_param_in_doc1.bal
@@ -1,0 +1,13 @@
+public class Person {
+
+    # Creates a person
+    #
+    # + name - Name of the person
+    public function init(string name, int age = 18) {
+
+    }
+}
+
+public function main() {
+    Person p = new ();
+}


### PR DESCRIPTION
## Purpose
$subject

Fixes #39853
Fixes #39415
Fixes #39554
Fixes #39894

## Approach
* Fix showing `null` in hover in front of missing parameters in documentation
* Fix completion sorting in import statement context after partially written module names like `import ballerina/lang.<cursor>`
* Fix completion sorting inside mapping constructor context
* Escape `$` signs in insert texts of completion items

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
