### PR TITLE
Add missing completions in let variable declaration node context

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/LetVariableDeclarationNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/LetVariableDeclarationNodeContext.java
@@ -72,18 +72,18 @@ public class LetVariableDeclarationNodeContext extends AbstractCompletionProvide
 
                 completionItems.addAll(this.getCompletionItemList(exprEntries, context));
                 this.sort(context, node, completionItems);
-            } else {
-                /*
-                Covers the following context
-                eg: let va<cursor>
-                    let int a = b, f<cursor>
-                 */
-                completionItems.addAll(this.getTypeDescContextItems(context));
-                completionItems.add(new SnippetCompletionItem(context, Snippet.KW_VAR.get()));
-                for (LSCompletionItem lsCItem : completionItems) {
-                    CompletionItem completionItem = lsCItem.getCompletionItem();
-                    completionItem.setSortText(SortingUtil.genSortTextForTypeDescContext(context, lsCItem));
-                }
+                return completionItems;
+            }
+            /*
+            Covers the following context
+            eg: let va<cursor>
+                let int a = b, f<cursor>
+             */
+            completionItems.addAll(this.getTypeDescContextItems(context));
+            completionItems.add(new SnippetCompletionItem(context, Snippet.KW_VAR.get()));
+            for (LSCompletionItem lsCItem : completionItems) {
+                CompletionItem completionItem = lsCItem.getCompletionItem();
+                completionItem.setSortText(SortingUtil.genSortTextForTypeDescContext(context, lsCItem));
             }
             return completionItems;
         }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/LetVariableDeclarationNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/LetVariableDeclarationNodeContext.java
@@ -20,11 +20,11 @@ import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.syntax.tree.BinaryExpressionNode;
 import io.ballerina.compiler.syntax.tree.ExpressionNode;
 import io.ballerina.compiler.syntax.tree.LetVariableDeclarationNode;
-import io.ballerina.compiler.syntax.tree.NonTerminalNode;
 import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
 import io.ballerina.compiler.syntax.tree.SimpleNameReferenceNode;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.compiler.syntax.tree.Token;
+import io.ballerina.compiler.syntax.tree.TypeDescriptorNode;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.common.utils.PositionUtil;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
@@ -58,38 +58,37 @@ public class LetVariableDeclarationNodeContext extends AbstractCompletionProvide
     public List<LSCompletionItem> getCompletions(BallerinaCompletionContext context, LetVariableDeclarationNode node) {
         List<LSCompletionItem> completionItems = new ArrayList<>();
         int cursor = context.getCursorPositionInTree();
-        if (node.typedBindingPattern().typeDescriptor().textRange().endOffset() >= cursor) {
-            /*
-            Covers the following context
-            eg: let va<cursor>
-                let int a = b, f<cursor>
-             */
-            completionItems.addAll(this.getTypeDescContextItems(context));
-            completionItems.add(new SnippetCompletionItem(context, Snippet.KW_VAR.get()));
-            for (LSCompletionItem lsCItem : completionItems) {
-                CompletionItem completionItem = lsCItem.getCompletionItem();
-                completionItem.setSortText(SortingUtil.genSortTextForTypeDescContext(context, lsCItem));
+        TypeDescriptorNode typeDescriptor = node.typedBindingPattern().typeDescriptor();
+        if (typeDescriptor.textRange().endOffset() >= cursor) {
+            if (typeDescriptor.kind() == SyntaxKind.QUALIFIED_NAME_REFERENCE) {
+                /*
+                Covers the following context
+                eg: let var x = <cursor>
+                    let var x = h<cursor>
+                    let var x = mod1:<cursor>
+                */
+                QualifiedNameReferenceNode qNameRef = (QualifiedNameReferenceNode) typeDescriptor;
+                List<Symbol> exprEntries = QNameRefCompletionUtil.getExpressionContextEntries(context, qNameRef);
+
+                completionItems.addAll(this.getCompletionItemList(exprEntries, context));
+                this.sort(context, node, completionItems);
+            } else {
+                /*
+                Covers the following context
+                eg: let va<cursor>
+                    let int a = b, f<cursor>
+                 */
+                completionItems.addAll(this.getTypeDescContextItems(context));
+                completionItems.add(new SnippetCompletionItem(context, Snippet.KW_VAR.get()));
+                for (LSCompletionItem lsCItem : completionItems) {
+                    CompletionItem completionItem = lsCItem.getCompletionItem();
+                    completionItem.setSortText(SortingUtil.genSortTextForTypeDescContext(context, lsCItem));
+                }
             }
             return completionItems;
         }
-        
-        /*
-        Covers the following context
-        eg: let var x = <cursor>
-            let var x = h<cursor>
-            let var x = mod1:<cursor>
-         */
-        NonTerminalNode nodeAtCursor = context.getNodeAtCursor();
 
-        if (nodeAtCursor.kind() == SyntaxKind.QUALIFIED_NAME_REFERENCE) {
-            /*
-            Covers the cases where the cursor is within the expression context
-             */
-            QualifiedNameReferenceNode qNameRef = (QualifiedNameReferenceNode) nodeAtCursor;
-            List<Symbol> exprEntries = QNameRefCompletionUtil.getExpressionContextEntries(context, qNameRef);
-
-            completionItems.addAll(this.getCompletionItemList(exprEntries, context));
-        } else if (cursorAtTheEndOfExpression(context, node)) {
+        if (cursorAtTheEndOfExpression(context, node)) {
             completionItems.addAll(QueryExpressionUtil.getCommonKeywordCompletions(context));
         } else {
             completionItems.addAll(this.expressionCompletions(context));

--- a/language-server/modules/langserver-core/src/test/resources/completion/let_expression_context/config/let_expr_ctx_config17.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/let_expression_context/config/let_expr_ctx_config17.json
@@ -1,0 +1,545 @@
+{
+  "position": {
+    "line": 1,
+    "character": 28
+  },
+  "source": "let_expression_context/source/let_expr_ctx_source17.bal",
+  "description": "Test completions after qualified name reference",
+  "items": [
+    {
+      "label": "Char",
+      "kind": "TypeParameter",
+      "detail": "Char",
+      "documentation": {
+        "left": "Built-in subtype of string containing strings of length 1."
+      },
+      "sortText": "R",
+      "insertText": "Char",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "RegExp",
+      "kind": "TypeParameter",
+      "detail": "Typereference",
+      "documentation": {
+        "left": "Refers to the `RegExp` type defined by lang.regexp module."
+      },
+      "sortText": "R",
+      "insertText": "RegExp",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "length(string str)",
+      "kind": "Function",
+      "detail": "int",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nReturns the length of the string.\n\n```ballerina\n\"Hello, World!\".length() ⇒ 13;\n```\n  \n**Params**  \n- `string` str: the string  \n  \n**Return** `int`   \n- the number of characters (code points) in parameter `str`  \n  \n"
+        }
+      },
+      "sortText": "E",
+      "filterText": "length",
+      "insertText": "length(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "iterator(string str)",
+      "kind": "Function",
+      "detail": "object {public isolated function next() returns record {|string:Char value;|}?;}",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nReturns an iterator over the string.\n\nThe iterator will yield the substrings of length 1 in order.\n\n```ballerina\nobject {\n  public isolated function next() returns record {|string:Char value;|}?;\n} iterator = \"Hello, World!\".iterator();\niterator.next() ⇒ {\"value\":\"H\"}\n```\n  \n**Params**  \n- `string` str: the string to be iterated over  \n  \n**Return** `object {public isolated function next() returns record {|string:Char value;|}?;}`   \n- a new iterator object  \n  \n"
+        }
+      },
+      "sortText": "E",
+      "filterText": "iterator",
+      "insertText": "iterator(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "concat(string... strs)",
+      "kind": "Function",
+      "detail": "string",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nConcatenates zero or more strings.\n\n```ballerina\n\"http://worldtimeapi.org\".concat(\"/api/timezone/\", \"Asia\", \"/\", \"Colombo\") ⇒ http://worldtimeapi.org/api/timezone/Asia/Colombo\n// Alternative approach to achieve the same.\nstring:concat(\"http://worldtimeapi.org\", \"/api/timezone/\", \"Asia\", \"/\", \"Colombo\") ⇒ http://worldtimeapi.org/api/timezone/Asia/Colombo\n```\n  \n**Params**  \n- `string[]` strs: strings to be concatenated  \n  \n**Return** `string`   \n- concatenation of all of the parameter `strs`; empty string if parameter `strs` is empty  \n  \n"
+        }
+      },
+      "sortText": "E",
+      "filterText": "concat",
+      "insertText": "concat(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "getCodePoint(string str, int index)",
+      "kind": "Function",
+      "detail": "int",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nReturns the code point of a character in a string.\n\n```ballerina\n\"Hello, World!\".getCodePoint(3) ⇒ 108\n```\n  \n**Params**  \n- `string` str: the string  \n- `int` index: an index in parameter `str`  \n  \n**Return** `int`   \n- the Unicode code point of the character at parameter `index` in parameter `str`  \n  \n"
+        }
+      },
+      "sortText": "E",
+      "filterText": "getCodePoint",
+      "insertText": "getCodePoint(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "substring(string str, int startIndex, int endIndex)",
+      "kind": "Function",
+      "detail": "string",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nReturns a substring of a string.\n\n```ballerina\n\"Hello, my name is John\".substring(7) ⇒ my name is John\n\"Hello, my name is John Anderson\".substring(18, 22) ⇒ John\n```\n  \n**Params**  \n- `string` str: source string.  \n- `int` startIndex: the starting index, inclusive  \n- `int` endIndex: the ending index, exclusive(Defaultable)  \n  \n**Return** `string`   \n- substring consisting of characters with index >= `startIndex` and < `endIndex`  \n  \n"
+        }
+      },
+      "sortText": "E",
+      "filterText": "substring",
+      "insertText": "substring(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "codePointCompare(string str1, string str2)",
+      "kind": "Function",
+      "detail": "int",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nLexicographically compares strings using their Unicode code points.\n\nThis orders strings in a consistent and well-defined way,\nbut the ordering will often not be consistent with cultural expectations\nfor sorted order.\n\n```ballerina\n\"Austria\".codePointCompare(\"Australia\") ⇒ 1\n```\n  \n**Params**  \n- `string` str1: the first string to be compared  \n- `string` str2: the second string to be compared  \n  \n**Return** `int`   \n- an int that is less than, equal to or greater than zero,  \naccording as parameter `str1` is less than, equal to or greater than parameter `str2`  \n  \n"
+        }
+      },
+      "sortText": "E",
+      "filterText": "codePointCompare",
+      "insertText": "codePointCompare(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "'join(string separator, string... strs)",
+      "kind": "Function",
+      "detail": "string",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nJoins zero or more strings together with a separator.\n\n```ballerina\nstring:'join(\" \", \"Ballerina\", \"is\", \"a\", \"programming\", \"language\") ⇒ Ballerina is a programming language\nstring[] array = [\"John\", \"23\", \"USA\", \"Computer Science\", \"Swimmer\"];\nstring:'join(\",\", ...array) ⇒ John,23,USA,Computer Science,Swimmer\n```\n  \n**Params**  \n- `string` separator: separator string  \n- `string[]` strs: strings to be joined  \n  \n**Return** `string`   \n- a string consisting of all of parameter `strs` concatenated in order  \nwith parameter `separator` in between them  \n  \n"
+        }
+      },
+      "sortText": "E",
+      "filterText": "'join",
+      "insertText": "'join(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "indexOf(string str, string substr, int startIndex)",
+      "kind": "Function",
+      "detail": "int?",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nFinds the first occurrence of one string in another string.\n\n```ballerina\n\"New Zealand\".indexOf(\"land\") ⇒ 7\n\"Ballerinalang is a unique programming language\".indexOf(\"lang\", 15) ⇒ 38\n```\n  \n**Params**  \n- `string` str: the string in which to search  \n- `string` substr: the string to search for  \n- `int` startIndex: index to start searching from(Defaultable)  \n  \n**Return** `int?`   \n- index of the first occurrence of parameter `substr` in parameter `str` that is >= parameter `startIndex`,  \nor `()` if there is no such occurrence  \n  \n"
+        }
+      },
+      "sortText": "E",
+      "filterText": "indexOf",
+      "insertText": "indexOf(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "lastIndexOf(string str, string substr, int startIndex)",
+      "kind": "Function",
+      "detail": "int?",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nFinds the last occurrence of one string in another string.\n\n```ballerina\n\"Ballerinalang is a unique programming language\".lastIndexOf(\"lang\") ⇒ 38\n// Search backwards for the last occurrence of a string from a specific index.\n\"Ballerinalang is a unique programming language\".lastIndexOf(\"lang\", 15) ⇒ 9\n```\n  \n**Params**  \n- `string` str: the string in which to search  \n- `string` substr: the string to search for  \n- `int` startIndex: index to start searching backwards from(Defaultable)  \n  \n**Return** `int?`   \n- index of the last occurrence of parameter `substr` in parameter `str` that is <= parameter `startIndex`,  \nor `()` if there is no such occurrence  \n  \n"
+        }
+      },
+      "sortText": "E",
+      "filterText": "lastIndexOf",
+      "insertText": "lastIndexOf(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "includes(string str, string substr, int startIndex)",
+      "kind": "Function",
+      "detail": "boolean",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nTests whether a string includes another string.\n\n```ballerina\n\"Hello World, from Ballerina\".includes(\"Bal\") ⇒ true\n\"Hello World! from Ballerina\".includes(\"Hello\", 10) ⇒ false\n```\n  \n**Params**  \n- `string` str: the string in which to search  \n- `string` substr: the string to search for  \n- `int` startIndex: index to start searching from(Defaultable)  \n  \n**Return** `boolean`   \n- `true` if there is an occurrence of parameter `substr` in parameter `str` at an index >= parameter `startIndex`,  \nor `false` otherwise  \n  \n"
+        }
+      },
+      "sortText": "E",
+      "filterText": "includes",
+      "insertText": "includes(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "startsWith(string str, string substr)",
+      "kind": "Function",
+      "detail": "boolean",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nTests whether a string starts with another string.\n\n```ballerina\n\"Welcome to the Ballerina programming language\".startsWith(\"Welcome\") ⇒ true\n```\n  \n**Params**  \n- `string` str: the string to be tested  \n- `string` substr: the starting string  \n  \n**Return** `boolean`   \n- true if parameter `str` starts with parameter `substr`; false otherwise  \n  \n"
+        }
+      },
+      "sortText": "E",
+      "filterText": "startsWith",
+      "insertText": "startsWith(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "endsWith(string str, string substr)",
+      "kind": "Function",
+      "detail": "boolean",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nTests whether a string ends with another string.\n\n```ballerina\n\"Welcome to the Ballerina programming language\".endsWith(\"language\") ⇒ true\n```\n  \n**Params**  \n- `string` str: the string to be tested  \n- `string` substr: the ending string  \n  \n**Return** `boolean`   \n- true if parameter `str` ends with parameter `substr`; false otherwise  \n  \n"
+        }
+      },
+      "sortText": "E",
+      "filterText": "endsWith",
+      "insertText": "endsWith(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "toLowerAscii(string str)",
+      "kind": "Function",
+      "detail": "string",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nConverts occurrences of A-Z to a-z.\n\nOther characters are left unchanged.\n\n```ballerina\n\"HELLO, World!\".toLowerAscii() ⇒ hello, world!\n```\n  \n**Params**  \n- `string` str: the string to be converted  \n  \n**Return** `string`   \n- parameter `str` with any occurrences of A-Z converted to a-z  \n  \n"
+        }
+      },
+      "sortText": "E",
+      "filterText": "toLowerAscii",
+      "insertText": "toLowerAscii(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "toUpperAscii(string str)",
+      "kind": "Function",
+      "detail": "string",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nConverts occurrences of a-z to A-Z.\n\nOther characters are left unchanged.\n\n```ballerina\n\"hello, World!\".toUpperAscii() ⇒ HELLO, WORLD!\n```\n  \n**Params**  \n- `string` str: the string to be converted  \n  \n**Return** `string`   \n- parameter `str` with any occurrences of a-z converted to A-Z  \n  \n"
+        }
+      },
+      "sortText": "E",
+      "filterText": "toUpperAscii",
+      "insertText": "toUpperAscii(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "equalsIgnoreCaseAscii(string str1, string str2)",
+      "kind": "Function",
+      "detail": "boolean",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nTests whether two strings are the same, ignoring the case of ASCII characters.\n\nA character in the range a-z is treated the same as the corresponding character in the range A-Z.\n\n```ballerina\n\"BALLERINA\".equalsIgnoreCaseAscii(\"ballerina\") ⇒ true\n```\n  \n**Params**  \n- `string` str1: the first string to be compared  \n- `string` str2: the second string to be compared  \n  \n**Return** `boolean`   \n- true if parameter `str1` is the same as parameter `str2`, treating upper-case and lower-case  \nASCII letters as the same; false, otherwise  \n  \n"
+        }
+      },
+      "sortText": "E",
+      "filterText": "equalsIgnoreCaseAscii",
+      "insertText": "equalsIgnoreCaseAscii(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "trim(string str)",
+      "kind": "Function",
+      "detail": "string",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nRemoves ASCII white space characters from the start and end of a string.\n\nThe ASCII white space characters are 0x9...0xD, 0x20.\n\n```ballerina\n\" Hello World   \".trim() + \"!\" ⇒ Hello World!\n```\n  \n**Params**  \n- `string` str: the string  \n  \n**Return** `string`   \n- parameter `str` with leading or trailing ASCII white space characters removed  \n  \n"
+        }
+      },
+      "sortText": "E",
+      "filterText": "trim",
+      "insertText": "trim(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "toBytes(string str)",
+      "kind": "Function",
+      "detail": "byte[]",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nRepresents a string as an array of bytes using UTF-8.\n\n```ballerina\n\"Hello, World!\".toBytes() ⇒ [72,101,108,108,111,44,32,87,111,114,108,100,33]\n```\n  \n**Params**  \n- `string` str: the string  \n  \n**Return** `byte[]`   \n- UTF-8 byte array  \n  \n"
+        }
+      },
+      "sortText": "E",
+      "filterText": "toBytes",
+      "insertText": "toBytes(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "fromBytes(byte[] bytes)",
+      "kind": "Function",
+      "detail": "string|error",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nConstructs a string from its UTF-8 representation in bytes.\n\n```ballerina\nstring:fromBytes([72, 101, 108, 108, 111, 32, 66, 97, 108, 108, 101, 114, 105, 110, 97, 33]) ⇒ Hello, World!\nstring:fromBytes([149, 169, 224]) ⇒ error\n```\n  \n**Params**  \n- `byte[]` bytes: UTF-8 byte array  \n  \n**Return** `string|error`   \n- parameter `bytes` converted to string or error  \n  \n"
+        }
+      },
+      "sortText": "E",
+      "filterText": "fromBytes",
+      "insertText": "fromBytes(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "toCodePointInts(string str)",
+      "kind": "Function",
+      "detail": "int[]",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nConverts a string to an array of code points.\n\n```ballerina\n\"Hello, world 🌎\".toCodePointInts() ⇒ [72,101,108,108,111,44,32,119,111,114,108,100,32,127758]\n```\n  \n**Params**  \n- `string` str: the string  \n  \n**Return** `int[]`   \n- an array with a code point for each character of parameter `str`  \n  \n"
+        }
+      },
+      "sortText": "E",
+      "filterText": "toCodePointInts",
+      "insertText": "toCodePointInts(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "toCodePointInt(string:Char ch)",
+      "kind": "Function",
+      "detail": "int",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nConverts a single character string to a code point.\n\n```ballerina\nstring:toCodePointInt(\"a\") ⇒ 97\n```\n  \n**Params**  \n- `string:Char` ch: a single character string  \n  \n**Return** `int`   \n- the code point of parameter `ch`  \n  \n"
+        }
+      },
+      "sortText": "E",
+      "filterText": "toCodePointInt",
+      "insertText": "toCodePointInt(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "fromCodePointInts(int[] codePoints)",
+      "kind": "Function",
+      "detail": "string|error",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nConstructs a string from an array of code points.\n\nAn int is a valid code point if it is in the range 0 to 0x10FFFF inclusive,\nbut not in the range 0xD800 or 0xDFFF inclusive.\n\n```ballerina\nstring:fromCodePointInts([66, 97, 108, 108, 101, 114, 105, 110, 97]) ⇒ Ballerina\nstring:fromCodePointInts([1114113, 1114114, 1114115]) ⇒ error\n```\n  \n**Params**  \n- `int[]` codePoints: an array of ints, each specifying a code point  \n  \n**Return** `string|error`   \n- a string with a character for each code point in parameter `codePoints`; or an error  \nif any member of parameter `codePoints` is not a valid code point  \n  \n"
+        }
+      },
+      "sortText": "E",
+      "filterText": "fromCodePointInts",
+      "insertText": "fromCodePointInts(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "fromCodePointInt(int codePoint)",
+      "kind": "Function",
+      "detail": "string:Char|error",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nConstructs a single character string from a code point.\n\nAn int is a valid code point if it is in the range 0 to 0x10FFFF inclusive,\nbut not in the range 0xD800 or 0xDFFF inclusive.\n\n```ballerina\nstring:fromCodePointInt(97) ⇒ a\nstring:fromCodePointInt(1114113) ⇒ error\n```\n  \n**Params**  \n- `int` codePoint: an int specifying a code point  \n  \n**Return** `string:Char|error`   \n- a single character string whose code point is parameter `codePoint`; or an error  \nif parameter `codePoint` is not a valid code point  \n  \n"
+        }
+      },
+      "sortText": "E",
+      "filterText": "fromCodePointInt",
+      "insertText": "fromCodePointInt(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "padStart(string str, int len, string:Char padChar)",
+      "kind": "Function",
+      "detail": "string",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nAdds padding to the start of a string.\nAdds sufficient `padChar` characters at the start of `str` to make its length be `len`.\nIf the length of `str` is >= `len`, returns `str`.\n\n```ballerina\n\"100Km\".padStart(10) ⇒      100Km\n\"100Km\".padStart(10, \"0\") ⇒ 00000100Km\n```\n  \n**Params**  \n- `string` str: the string to pad  \n- `int` len: the length of the string to be returned  \n- `string:Char` padChar: the character to use for padding `str`; defaults to a space character(Defaultable)  \n  \n**Return** `string`   \n- `str` padded with `padChar`  \n  \n"
+        }
+      },
+      "sortText": "E",
+      "filterText": "padStart",
+      "insertText": "padStart(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "padEnd(string str, int len, string:Char padChar)",
+      "kind": "Function",
+      "detail": "string",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nAdds padding to the end of a string.\nAdds sufficient `padChar` characters to the end of `str` to make its length be `len`.\nIf the length of `str` is >= `len`, returns `str`.\n\n```ballerina\n\"Ballerina for developers\".padEnd(30) ⇒ Ballerina for developers\n\"Ballerina for developers\".padEnd(30, \"!\") ⇒ Ballerina for developers!!!!!!\n```\n  \n**Params**  \n- `string` str: the string to pad  \n- `int` len: the length of the string to be returned  \n- `string:Char` padChar: the character to use for padding `str`; defaults to a space character(Defaultable)  \n  \n**Return** `string`   \n- `str` padded with `padChar`  \n  \n"
+        }
+      },
+      "sortText": "E",
+      "filterText": "padEnd",
+      "insertText": "padEnd(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "padZero(string str, int len, string:Char zeroChar)",
+      "kind": "Function",
+      "detail": "string",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nPads a string with zeros.\nThe zeros are added at the start of the string, after a `+` or `-` sign if there is one.\nSufficient zero characters are added to `str` to make its length be `len`.\nIf the length of `str` is >= `len`, returns `str`.\n\n```ballerina\n\"-256\".padZero(9) ⇒ -00000256\n\"-880\".padZero(8, \"#\") ⇒ -####880\n```\n  \n**Params**  \n- `string` str: the string to pad  \n- `int` len: the length of the string to be returned  \n- `string:Char` zeroChar: the character to use for the zero; defaults to ASCII zero `0`(Defaultable)  \n  \n**Return** `string`   \n- `str` padded with zeros  \n  \n"
+        }
+      },
+      "sortText": "E",
+      "filterText": "padZero",
+      "insertText": "padZero(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "matches(string str, string:RegExp re)",
+      "kind": "Function",
+      "detail": "boolean",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nTests whether there is a full match of a regular expression with a string.\nA match of a regular expression in a string is a full match if it\nstarts at index 0 and ends at index `n`, where `n` is the length of the string.\nThis is equivalent to `regex:isFullMatch(re, str)`.\n\n```ballerina\n\"This is a Match\".matches(re `A|Th.*ch|^`) ⇒ true\n\"Not a Match\".matches(re `A|Th.*ch|^`) ⇒ false\n```\n  \n**Params**  \n- `string` str: the string  \n- `string:RegExp` re: the regular expression  \n  \n**Return** `boolean`   \n- true if there is full match of `re` with `str`, and false otherwise  \n  \n"
+        }
+      },
+      "sortText": "E",
+      "filterText": "matches",
+      "insertText": "matches(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "includesMatch(string str, string:RegExp re, int startIndex)",
+      "kind": "Function",
+      "detail": "boolean",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nTests whether there is a match of a regular expression somewhere within a string.\nThis is equivalent to `regexp:find(re, str, startIndex) != ()`.\n\n```ballerina\n\"This will match\".includesMatch(re `Th.*ch`) ⇒ true\n\"Will this match\".includesMatch(re `th.*ch`, 5) ⇒ true\n\"Not a match\".includesMatch(re `Th.*ch`) ⇒ false\n\"Will this match\".includesMatch(re `Th.*ch`, 5) ⇒ false\n```\n  \n**Params**  \n- `string` str: the string to be matched  \n- `string:RegExp` re: the regular expression  \n- `int` startIndex(Defaultable)  \n  \n**Return** `boolean`   \n- true if the is a match of `re` somewhere within `str`, otherwise false  \n  \n"
+        }
+      },
+      "sortText": "E",
+      "filterText": "includesMatch",
+      "insertText": "includesMatch(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/let_expression_context/config/let_expr_ctx_config17.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/let_expression_context/config/let_expr_ctx_config17.json
@@ -38,7 +38,7 @@
           "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nReturns the length of the string.\n\n```ballerina\n\"Hello, World!\".length() ⇒ 13;\n```\n  \n**Params**  \n- `string` str: the string  \n  \n**Return** `int`   \n- the number of characters (code points) in parameter `str`  \n  \n"
         }
       },
-      "sortText": "E",
+      "sortText": "G",
       "filterText": "length",
       "insertText": "length(${1})",
       "insertTextFormat": "Snippet",
@@ -57,7 +57,7 @@
           "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nReturns an iterator over the string.\n\nThe iterator will yield the substrings of length 1 in order.\n\n```ballerina\nobject {\n  public isolated function next() returns record {|string:Char value;|}?;\n} iterator = \"Hello, World!\".iterator();\niterator.next() ⇒ {\"value\":\"H\"}\n```\n  \n**Params**  \n- `string` str: the string to be iterated over  \n  \n**Return** `object {public isolated function next() returns record {|string:Char value;|}?;}`   \n- a new iterator object  \n  \n"
         }
       },
-      "sortText": "E",
+      "sortText": "G",
       "filterText": "iterator",
       "insertText": "iterator(${1})",
       "insertTextFormat": "Snippet",
@@ -76,7 +76,7 @@
           "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nConcatenates zero or more strings.\n\n```ballerina\n\"http://worldtimeapi.org\".concat(\"/api/timezone/\", \"Asia\", \"/\", \"Colombo\") ⇒ http://worldtimeapi.org/api/timezone/Asia/Colombo\n// Alternative approach to achieve the same.\nstring:concat(\"http://worldtimeapi.org\", \"/api/timezone/\", \"Asia\", \"/\", \"Colombo\") ⇒ http://worldtimeapi.org/api/timezone/Asia/Colombo\n```\n  \n**Params**  \n- `string[]` strs: strings to be concatenated  \n  \n**Return** `string`   \n- concatenation of all of the parameter `strs`; empty string if parameter `strs` is empty  \n  \n"
         }
       },
-      "sortText": "E",
+      "sortText": "G",
       "filterText": "concat",
       "insertText": "concat(${1})",
       "insertTextFormat": "Snippet",
@@ -95,7 +95,7 @@
           "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nReturns the code point of a character in a string.\n\n```ballerina\n\"Hello, World!\".getCodePoint(3) ⇒ 108\n```\n  \n**Params**  \n- `string` str: the string  \n- `int` index: an index in parameter `str`  \n  \n**Return** `int`   \n- the Unicode code point of the character at parameter `index` in parameter `str`  \n  \n"
         }
       },
-      "sortText": "E",
+      "sortText": "G",
       "filterText": "getCodePoint",
       "insertText": "getCodePoint(${1})",
       "insertTextFormat": "Snippet",
@@ -114,7 +114,7 @@
           "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nReturns a substring of a string.\n\n```ballerina\n\"Hello, my name is John\".substring(7) ⇒ my name is John\n\"Hello, my name is John Anderson\".substring(18, 22) ⇒ John\n```\n  \n**Params**  \n- `string` str: source string.  \n- `int` startIndex: the starting index, inclusive  \n- `int` endIndex: the ending index, exclusive(Defaultable)  \n  \n**Return** `string`   \n- substring consisting of characters with index >= `startIndex` and < `endIndex`  \n  \n"
         }
       },
-      "sortText": "E",
+      "sortText": "G",
       "filterText": "substring",
       "insertText": "substring(${1})",
       "insertTextFormat": "Snippet",
@@ -133,7 +133,7 @@
           "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nLexicographically compares strings using their Unicode code points.\n\nThis orders strings in a consistent and well-defined way,\nbut the ordering will often not be consistent with cultural expectations\nfor sorted order.\n\n```ballerina\n\"Austria\".codePointCompare(\"Australia\") ⇒ 1\n```\n  \n**Params**  \n- `string` str1: the first string to be compared  \n- `string` str2: the second string to be compared  \n  \n**Return** `int`   \n- an int that is less than, equal to or greater than zero,  \naccording as parameter `str1` is less than, equal to or greater than parameter `str2`  \n  \n"
         }
       },
-      "sortText": "E",
+      "sortText": "G",
       "filterText": "codePointCompare",
       "insertText": "codePointCompare(${1})",
       "insertTextFormat": "Snippet",
@@ -152,7 +152,7 @@
           "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nJoins zero or more strings together with a separator.\n\n```ballerina\nstring:'join(\" \", \"Ballerina\", \"is\", \"a\", \"programming\", \"language\") ⇒ Ballerina is a programming language\nstring[] array = [\"John\", \"23\", \"USA\", \"Computer Science\", \"Swimmer\"];\nstring:'join(\",\", ...array) ⇒ John,23,USA,Computer Science,Swimmer\n```\n  \n**Params**  \n- `string` separator: separator string  \n- `string[]` strs: strings to be joined  \n  \n**Return** `string`   \n- a string consisting of all of parameter `strs` concatenated in order  \nwith parameter `separator` in between them  \n  \n"
         }
       },
-      "sortText": "E",
+      "sortText": "G",
       "filterText": "'join",
       "insertText": "'join(${1})",
       "insertTextFormat": "Snippet",
@@ -171,7 +171,7 @@
           "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nFinds the first occurrence of one string in another string.\n\n```ballerina\n\"New Zealand\".indexOf(\"land\") ⇒ 7\n\"Ballerinalang is a unique programming language\".indexOf(\"lang\", 15) ⇒ 38\n```\n  \n**Params**  \n- `string` str: the string in which to search  \n- `string` substr: the string to search for  \n- `int` startIndex: index to start searching from(Defaultable)  \n  \n**Return** `int?`   \n- index of the first occurrence of parameter `substr` in parameter `str` that is >= parameter `startIndex`,  \nor `()` if there is no such occurrence  \n  \n"
         }
       },
-      "sortText": "E",
+      "sortText": "G",
       "filterText": "indexOf",
       "insertText": "indexOf(${1})",
       "insertTextFormat": "Snippet",
@@ -190,7 +190,7 @@
           "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nFinds the last occurrence of one string in another string.\n\n```ballerina\n\"Ballerinalang is a unique programming language\".lastIndexOf(\"lang\") ⇒ 38\n// Search backwards for the last occurrence of a string from a specific index.\n\"Ballerinalang is a unique programming language\".lastIndexOf(\"lang\", 15) ⇒ 9\n```\n  \n**Params**  \n- `string` str: the string in which to search  \n- `string` substr: the string to search for  \n- `int` startIndex: index to start searching backwards from(Defaultable)  \n  \n**Return** `int?`   \n- index of the last occurrence of parameter `substr` in parameter `str` that is <= parameter `startIndex`,  \nor `()` if there is no such occurrence  \n  \n"
         }
       },
-      "sortText": "E",
+      "sortText": "G",
       "filterText": "lastIndexOf",
       "insertText": "lastIndexOf(${1})",
       "insertTextFormat": "Snippet",
@@ -209,7 +209,7 @@
           "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nTests whether a string includes another string.\n\n```ballerina\n\"Hello World, from Ballerina\".includes(\"Bal\") ⇒ true\n\"Hello World! from Ballerina\".includes(\"Hello\", 10) ⇒ false\n```\n  \n**Params**  \n- `string` str: the string in which to search  \n- `string` substr: the string to search for  \n- `int` startIndex: index to start searching from(Defaultable)  \n  \n**Return** `boolean`   \n- `true` if there is an occurrence of parameter `substr` in parameter `str` at an index >= parameter `startIndex`,  \nor `false` otherwise  \n  \n"
         }
       },
-      "sortText": "E",
+      "sortText": "G",
       "filterText": "includes",
       "insertText": "includes(${1})",
       "insertTextFormat": "Snippet",
@@ -228,7 +228,7 @@
           "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nTests whether a string starts with another string.\n\n```ballerina\n\"Welcome to the Ballerina programming language\".startsWith(\"Welcome\") ⇒ true\n```\n  \n**Params**  \n- `string` str: the string to be tested  \n- `string` substr: the starting string  \n  \n**Return** `boolean`   \n- true if parameter `str` starts with parameter `substr`; false otherwise  \n  \n"
         }
       },
-      "sortText": "E",
+      "sortText": "G",
       "filterText": "startsWith",
       "insertText": "startsWith(${1})",
       "insertTextFormat": "Snippet",
@@ -247,7 +247,7 @@
           "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nTests whether a string ends with another string.\n\n```ballerina\n\"Welcome to the Ballerina programming language\".endsWith(\"language\") ⇒ true\n```\n  \n**Params**  \n- `string` str: the string to be tested  \n- `string` substr: the ending string  \n  \n**Return** `boolean`   \n- true if parameter `str` ends with parameter `substr`; false otherwise  \n  \n"
         }
       },
-      "sortText": "E",
+      "sortText": "G",
       "filterText": "endsWith",
       "insertText": "endsWith(${1})",
       "insertTextFormat": "Snippet",
@@ -266,7 +266,7 @@
           "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nConverts occurrences of A-Z to a-z.\n\nOther characters are left unchanged.\n\n```ballerina\n\"HELLO, World!\".toLowerAscii() ⇒ hello, world!\n```\n  \n**Params**  \n- `string` str: the string to be converted  \n  \n**Return** `string`   \n- parameter `str` with any occurrences of A-Z converted to a-z  \n  \n"
         }
       },
-      "sortText": "E",
+      "sortText": "G",
       "filterText": "toLowerAscii",
       "insertText": "toLowerAscii(${1})",
       "insertTextFormat": "Snippet",
@@ -285,7 +285,7 @@
           "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nConverts occurrences of a-z to A-Z.\n\nOther characters are left unchanged.\n\n```ballerina\n\"hello, World!\".toUpperAscii() ⇒ HELLO, WORLD!\n```\n  \n**Params**  \n- `string` str: the string to be converted  \n  \n**Return** `string`   \n- parameter `str` with any occurrences of a-z converted to A-Z  \n  \n"
         }
       },
-      "sortText": "E",
+      "sortText": "G",
       "filterText": "toUpperAscii",
       "insertText": "toUpperAscii(${1})",
       "insertTextFormat": "Snippet",
@@ -304,7 +304,7 @@
           "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nTests whether two strings are the same, ignoring the case of ASCII characters.\n\nA character in the range a-z is treated the same as the corresponding character in the range A-Z.\n\n```ballerina\n\"BALLERINA\".equalsIgnoreCaseAscii(\"ballerina\") ⇒ true\n```\n  \n**Params**  \n- `string` str1: the first string to be compared  \n- `string` str2: the second string to be compared  \n  \n**Return** `boolean`   \n- true if parameter `str1` is the same as parameter `str2`, treating upper-case and lower-case  \nASCII letters as the same; false, otherwise  \n  \n"
         }
       },
-      "sortText": "E",
+      "sortText": "G",
       "filterText": "equalsIgnoreCaseAscii",
       "insertText": "equalsIgnoreCaseAscii(${1})",
       "insertTextFormat": "Snippet",
@@ -323,7 +323,7 @@
           "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nRemoves ASCII white space characters from the start and end of a string.\n\nThe ASCII white space characters are 0x9...0xD, 0x20.\n\n```ballerina\n\" Hello World   \".trim() + \"!\" ⇒ Hello World!\n```\n  \n**Params**  \n- `string` str: the string  \n  \n**Return** `string`   \n- parameter `str` with leading or trailing ASCII white space characters removed  \n  \n"
         }
       },
-      "sortText": "E",
+      "sortText": "G",
       "filterText": "trim",
       "insertText": "trim(${1})",
       "insertTextFormat": "Snippet",
@@ -342,7 +342,7 @@
           "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nRepresents a string as an array of bytes using UTF-8.\n\n```ballerina\n\"Hello, World!\".toBytes() ⇒ [72,101,108,108,111,44,32,87,111,114,108,100,33]\n```\n  \n**Params**  \n- `string` str: the string  \n  \n**Return** `byte[]`   \n- UTF-8 byte array  \n  \n"
         }
       },
-      "sortText": "E",
+      "sortText": "G",
       "filterText": "toBytes",
       "insertText": "toBytes(${1})",
       "insertTextFormat": "Snippet",
@@ -361,7 +361,7 @@
           "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nConstructs a string from its UTF-8 representation in bytes.\n\n```ballerina\nstring:fromBytes([72, 101, 108, 108, 111, 32, 66, 97, 108, 108, 101, 114, 105, 110, 97, 33]) ⇒ Hello, World!\nstring:fromBytes([149, 169, 224]) ⇒ error\n```\n  \n**Params**  \n- `byte[]` bytes: UTF-8 byte array  \n  \n**Return** `string|error`   \n- parameter `bytes` converted to string or error  \n  \n"
         }
       },
-      "sortText": "E",
+      "sortText": "G",
       "filterText": "fromBytes",
       "insertText": "fromBytes(${1})",
       "insertTextFormat": "Snippet",
@@ -380,7 +380,7 @@
           "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nConverts a string to an array of code points.\n\n```ballerina\n\"Hello, world 🌎\".toCodePointInts() ⇒ [72,101,108,108,111,44,32,119,111,114,108,100,32,127758]\n```\n  \n**Params**  \n- `string` str: the string  \n  \n**Return** `int[]`   \n- an array with a code point for each character of parameter `str`  \n  \n"
         }
       },
-      "sortText": "E",
+      "sortText": "G",
       "filterText": "toCodePointInts",
       "insertText": "toCodePointInts(${1})",
       "insertTextFormat": "Snippet",
@@ -399,7 +399,7 @@
           "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nConverts a single character string to a code point.\n\n```ballerina\nstring:toCodePointInt(\"a\") ⇒ 97\n```\n  \n**Params**  \n- `string:Char` ch: a single character string  \n  \n**Return** `int`   \n- the code point of parameter `ch`  \n  \n"
         }
       },
-      "sortText": "E",
+      "sortText": "G",
       "filterText": "toCodePointInt",
       "insertText": "toCodePointInt(${1})",
       "insertTextFormat": "Snippet",
@@ -418,7 +418,7 @@
           "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nConstructs a string from an array of code points.\n\nAn int is a valid code point if it is in the range 0 to 0x10FFFF inclusive,\nbut not in the range 0xD800 or 0xDFFF inclusive.\n\n```ballerina\nstring:fromCodePointInts([66, 97, 108, 108, 101, 114, 105, 110, 97]) ⇒ Ballerina\nstring:fromCodePointInts([1114113, 1114114, 1114115]) ⇒ error\n```\n  \n**Params**  \n- `int[]` codePoints: an array of ints, each specifying a code point  \n  \n**Return** `string|error`   \n- a string with a character for each code point in parameter `codePoints`; or an error  \nif any member of parameter `codePoints` is not a valid code point  \n  \n"
         }
       },
-      "sortText": "E",
+      "sortText": "G",
       "filterText": "fromCodePointInts",
       "insertText": "fromCodePointInts(${1})",
       "insertTextFormat": "Snippet",
@@ -437,7 +437,7 @@
           "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nConstructs a single character string from a code point.\n\nAn int is a valid code point if it is in the range 0 to 0x10FFFF inclusive,\nbut not in the range 0xD800 or 0xDFFF inclusive.\n\n```ballerina\nstring:fromCodePointInt(97) ⇒ a\nstring:fromCodePointInt(1114113) ⇒ error\n```\n  \n**Params**  \n- `int` codePoint: an int specifying a code point  \n  \n**Return** `string:Char|error`   \n- a single character string whose code point is parameter `codePoint`; or an error  \nif parameter `codePoint` is not a valid code point  \n  \n"
         }
       },
-      "sortText": "E",
+      "sortText": "G",
       "filterText": "fromCodePointInt",
       "insertText": "fromCodePointInt(${1})",
       "insertTextFormat": "Snippet",
@@ -456,7 +456,7 @@
           "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nAdds padding to the start of a string.\nAdds sufficient `padChar` characters at the start of `str` to make its length be `len`.\nIf the length of `str` is >= `len`, returns `str`.\n\n```ballerina\n\"100Km\".padStart(10) ⇒      100Km\n\"100Km\".padStart(10, \"0\") ⇒ 00000100Km\n```\n  \n**Params**  \n- `string` str: the string to pad  \n- `int` len: the length of the string to be returned  \n- `string:Char` padChar: the character to use for padding `str`; defaults to a space character(Defaultable)  \n  \n**Return** `string`   \n- `str` padded with `padChar`  \n  \n"
         }
       },
-      "sortText": "E",
+      "sortText": "G",
       "filterText": "padStart",
       "insertText": "padStart(${1})",
       "insertTextFormat": "Snippet",
@@ -475,7 +475,7 @@
           "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nAdds padding to the end of a string.\nAdds sufficient `padChar` characters to the end of `str` to make its length be `len`.\nIf the length of `str` is >= `len`, returns `str`.\n\n```ballerina\n\"Ballerina for developers\".padEnd(30) ⇒ Ballerina for developers\n\"Ballerina for developers\".padEnd(30, \"!\") ⇒ Ballerina for developers!!!!!!\n```\n  \n**Params**  \n- `string` str: the string to pad  \n- `int` len: the length of the string to be returned  \n- `string:Char` padChar: the character to use for padding `str`; defaults to a space character(Defaultable)  \n  \n**Return** `string`   \n- `str` padded with `padChar`  \n  \n"
         }
       },
-      "sortText": "E",
+      "sortText": "G",
       "filterText": "padEnd",
       "insertText": "padEnd(${1})",
       "insertTextFormat": "Snippet",
@@ -494,7 +494,7 @@
           "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nPads a string with zeros.\nThe zeros are added at the start of the string, after a `+` or `-` sign if there is one.\nSufficient zero characters are added to `str` to make its length be `len`.\nIf the length of `str` is >= `len`, returns `str`.\n\n```ballerina\n\"-256\".padZero(9) ⇒ -00000256\n\"-880\".padZero(8, \"#\") ⇒ -####880\n```\n  \n**Params**  \n- `string` str: the string to pad  \n- `int` len: the length of the string to be returned  \n- `string:Char` zeroChar: the character to use for the zero; defaults to ASCII zero `0`(Defaultable)  \n  \n**Return** `string`   \n- `str` padded with zeros  \n  \n"
         }
       },
-      "sortText": "E",
+      "sortText": "G",
       "filterText": "padZero",
       "insertText": "padZero(${1})",
       "insertTextFormat": "Snippet",
@@ -513,7 +513,7 @@
           "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nTests whether there is a full match of a regular expression with a string.\nA match of a regular expression in a string is a full match if it\nstarts at index 0 and ends at index `n`, where `n` is the length of the string.\nThis is equivalent to `regex:isFullMatch(re, str)`.\n\n```ballerina\n\"This is a Match\".matches(re `A|Th.*ch|^`) ⇒ true\n\"Not a Match\".matches(re `A|Th.*ch|^`) ⇒ false\n```\n  \n**Params**  \n- `string` str: the string  \n- `string:RegExp` re: the regular expression  \n  \n**Return** `boolean`   \n- true if there is full match of `re` with `str`, and false otherwise  \n  \n"
         }
       },
-      "sortText": "E",
+      "sortText": "G",
       "filterText": "matches",
       "insertText": "matches(${1})",
       "insertTextFormat": "Snippet",
@@ -532,7 +532,7 @@
           "value": "**Package:** _ballerina/lang.string:0.0.0_  \n  \nTests whether there is a match of a regular expression somewhere within a string.\nThis is equivalent to `regexp:find(re, str, startIndex) != ()`.\n\n```ballerina\n\"This will match\".includesMatch(re `Th.*ch`) ⇒ true\n\"Will this match\".includesMatch(re `th.*ch`, 5) ⇒ true\n\"Not a match\".includesMatch(re `Th.*ch`) ⇒ false\n\"Will this match\".includesMatch(re `Th.*ch`, 5) ⇒ false\n```\n  \n**Params**  \n- `string` str: the string to be matched  \n- `string:RegExp` re: the regular expression  \n- `int` startIndex(Defaultable)  \n  \n**Return** `boolean`   \n- true if the is a match of `re` somewhere within `str`, otherwise false  \n  \n"
         }
       },
-      "sortText": "E",
+      "sortText": "G",
       "filterText": "includesMatch",
       "insertText": "includesMatch(${1})",
       "insertTextFormat": "Snippet",

--- a/language-server/modules/langserver-core/src/test/resources/completion/let_expression_context/source/let_expr_ctx_source17.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/let_expression_context/source/let_expr_ctx_source17.bal
@@ -1,3 +1,3 @@
 public function main() {
-    string:Char ch = string:
+    string:Char ch = let string:
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/let_expression_context/source/let_expr_ctx_source17.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/let_expression_context/source/let_expr_ctx_source17.bal
@@ -1,0 +1,3 @@
+public function main() {
+    string:Char ch = string:
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config24.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_config24.json
@@ -6,294 +6,717 @@
   "source": "query_expression/source/query_expr_ctx_source24.bal",
   "items": [
     {
-      "label": "TEST_INT_CONST1",
-      "kind": "Variable",
-      "detail": "1",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": ""
-        }
-      },
-      "sortText": "G",
-      "insertText": "TEST_INT_CONST1",
+      "label": "module1",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "S",
+      "filterText": "module1",
+      "insertText": "module1",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "TEST_STRING_CONST1",
-      "kind": "Variable",
-      "detail": "\"HELLO WORLD\"",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": ""
-        }
-      },
-      "sortText": "G",
-      "insertText": "TEST_STRING_CONST1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ENUM1_FIELD1",
-      "kind": "EnumMember",
-      "detail": "\"ENUM1_FIELD1\"",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": ""
-        }
-      },
-      "sortText": "L",
-      "insertText": "ENUM1_FIELD1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ResponseMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
-      },
-      "sortText": "M",
-      "insertText": "ResponseMessage",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "RequestMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
-      },
-      "sortText": "M",
-      "insertText": "RequestMessage",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "TestRecord1",
-      "kind": "Struct",
-      "detail": "Record",
-      "sortText": "Q",
-      "insertText": "TestRecord1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "TestRecord2",
-      "kind": "Struct",
-      "detail": "Record",
-      "sortText": "Q",
-      "insertText": "TestRecord2",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "TestMap2",
-      "kind": "TypeParameter",
-      "detail": "Map",
+      "label": "test/project2",
+      "kind": "Module",
+      "detail": "Module",
       "sortText": "R",
-      "insertText": "TestMap2",
-      "insertTextFormat": "Snippet"
+      "filterText": "project2",
+      "insertText": "project2",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import test/project2;\n"
+        }
+      ]
     },
     {
-      "label": "TestMap3",
-      "kind": "TypeParameter",
-      "detail": "Map",
+      "label": "test/project1",
+      "kind": "Module",
+      "detail": "Module",
       "sortText": "R",
-      "insertText": "TestMap3",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "TestObject1",
-      "kind": "Interface",
-      "detail": "Object",
-      "sortText": "O",
-      "insertText": "TestObject1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ErrorOne",
-      "kind": "Event",
-      "detail": "Error",
-      "sortText": "P",
-      "insertText": "ErrorOne",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ErrorTwo",
-      "kind": "Event",
-      "detail": "Error",
-      "sortText": "P",
-      "insertText": "ErrorTwo",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "AnnotationType",
-      "kind": "Struct",
-      "detail": "Record",
-      "sortText": "Q",
-      "insertText": "AnnotationType",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Client",
-      "kind": "Interface",
-      "detail": "Class",
-      "documentation": {
-        "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs."
-      },
-      "sortText": "O",
-      "insertText": "Client",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Response",
-      "kind": "Interface",
-      "detail": "Class",
-      "documentation": {
-        "left": "Represents a response.\n"
-      },
-      "sortText": "O",
-      "insertText": "Response",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Listener",
-      "kind": "Interface",
-      "detail": "Class",
-      "sortText": "O",
-      "insertText": "Listener",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "TestClass1",
-      "kind": "Interface",
-      "detail": "Class",
-      "sortText": "O",
-      "insertText": "TestClass1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "listener1",
-      "kind": "Variable",
-      "detail": "module1:Listener",
-      "sortText": "G",
-      "insertText": "listener1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "function1()",
-      "kind": "Function",
-      "detail": "()",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \n  \n"
-        }
-      },
-      "sortText": "E",
-      "filterText": "function1",
-      "insertText": "function1()",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "function2()",
-      "kind": "Function",
-      "detail": "()",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function2  \n"
-        }
-      },
-      "sortText": "E",
-      "filterText": "function2",
-      "insertText": "function2()",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "function3(int param1, int param2, float... param3)",
-      "kind": "Function",
-      "detail": "int",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function3 with input parameters\n  \n**Params**  \n- `int` param1: param1 Parameter Description   \n- `int` param2: param2 Parameter Description  \n- `float[]` param3: param3 Parameter Description  \n  \n**Return** `int`   \n- Return Value Description  \n  \n"
-        }
-      },
-      "sortText": "E",
-      "filterText": "function3",
-      "insertText": "function3(${1})",
+      "filterText": "project1",
+      "insertText": "project1",
       "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "function4(int param1, int param2, string param3, float... param4)",
-      "kind": "Function",
-      "detail": "()",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function4 with input parameters\n  \n**Params**  \n- `int` param1: param1 Parameter Description   \n- `int` param2: param2 Parameter Description  \n- `string` param3: param3 Parameter Description(Defaultable)  \n- `float[]` param4: param4 Parameter Description"
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import test/project1;\n"
         }
-      },
-      "sortText": "E",
-      "filterText": "function4",
-      "insertText": "function4(${1})",
+      ]
+    },
+    {
+      "label": "ballerina/lang.runtime",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "runtime",
+      "insertText": "runtime",
       "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.runtime;\n"
+        }
+      ]
     },
     {
-      "label": "TEST_FUTURE_INT",
-      "kind": "Variable",
-      "detail": "future<int>",
-      "sortText": "G",
-      "insertText": "TEST_FUTURE_INT",
+      "label": "ballerina/lang.regexp",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "regexp",
+      "insertText": "regexp",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.regexp;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.test",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "test",
+      "insertText": "test",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.test;\n"
+        }
+      ]
+    },
+    {
+      "label": "test/local_project2",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "local_project2",
+      "insertText": "local_project2",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import test/local_project2;\n"
+        }
+      ]
+    },
+    {
+      "label": "test/local_project1",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "local_project1",
+      "insertText": "local_project1",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import test/local_project1;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "value",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/jballerina.java",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "java",
+      "insertText": "java",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/jballerina.java;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.array",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "array",
+      "insertText": "array",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.array;\n"
+        }
+      ]
+    },
+    {
+      "label": "decimal",
+      "kind": "TypeParameter",
+      "detail": "Decimal",
+      "sortText": "R",
+      "insertText": "decimal",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "GLOBAL_VAR",
-      "kind": "Variable",
-      "detail": "int",
-      "sortText": "G",
-      "insertText": "GLOBAL_VAR",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ClientError",
+      "label": "error",
       "kind": "Event",
       "detail": "Error",
-      "documentation": {
-        "left": "Defines the possible client error types."
-      },
       "sortText": "P",
-      "insertText": "ClientError",
+      "insertText": "error",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "TargetType2",
+      "label": "object",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "object",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "transaction",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "transaction",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml",
+      "kind": "TypeParameter",
+      "detail": "Xml",
+      "sortText": "R",
+      "insertText": "xml",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "table",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "table",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "map",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "map",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "stream",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "stream",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "boolean",
+      "kind": "TypeParameter",
+      "detail": "Boolean",
+      "sortText": "R",
+      "insertText": "boolean",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "future",
+      "kind": "TypeParameter",
+      "detail": "Future",
+      "sortText": "R",
+      "insertText": "future",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "int",
+      "kind": "TypeParameter",
+      "detail": "Int",
+      "sortText": "R",
+      "insertText": "int",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "float",
+      "kind": "TypeParameter",
+      "detail": "Float",
+      "sortText": "R",
+      "insertText": "float",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "function",
+      "kind": "TypeParameter",
+      "detail": "Function",
+      "sortText": "R",
+      "insertText": "function",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string",
+      "kind": "TypeParameter",
+      "detail": "String",
+      "sortText": "R",
+      "insertText": "string",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "typedesc",
       "kind": "TypeParameter",
       "detail": "Typedesc",
-      "documentation": {
-        "left": "The super type of all the types."
-      },
       "sortText": "R",
-      "insertText": "TargetType2",
+      "insertText": "typedesc",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "TargetType",
+      "label": "service",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "service",
+      "insertText": "service",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "new",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "new",
+      "insertText": "new ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "isolated",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "isolated",
+      "insertText": "isolated ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "transactional",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "transactional",
+      "insertText": "transactional",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "function",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "function",
+      "insertText": "function ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "let",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "let",
+      "insertText": "let",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "typeof",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "typeof",
+      "insertText": "typeof ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "trap",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "trap",
+      "insertText": "trap",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "client",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "client",
+      "insertText": "client ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "true",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "true",
+      "insertText": "true",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "false",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "false",
+      "insertText": "false",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "null",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "null",
+      "insertText": "null",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "check",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "check",
+      "insertText": "check ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "checkpanic",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "checkpanic",
+      "insertText": "checkpanic ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "is",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "is",
+      "insertText": "is",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "error",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "object constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "object",
+      "insertText": "object {${1}}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "base16",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "base16",
+      "insertText": "base16 `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "base64",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "base64",
+      "insertText": "base64 `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "from",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "from",
+      "insertText": "from ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "re ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "re ``",
+      "insertText": "re `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ratio",
+      "kind": "Variable",
+      "detail": "float",
+      "sortText": "AC",
+      "insertText": "ratio",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "stats",
+      "kind": "Variable",
+      "detail": "MedalStats",
+      "sortText": "G",
+      "insertText": "stats",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "MedalStats",
+      "kind": "Struct",
+      "detail": "Record",
+      "sortText": "Q",
+      "insertText": "MedalStats",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "medalStats",
+      "kind": "Variable",
+      "detail": "stream<MedalStats, error?>",
+      "sortText": "G",
+      "insertText": "medalStats",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Thread",
       "kind": "TypeParameter",
-      "detail": "Typedesc",
-      "documentation": {
-        "left": "The types of data values that are expected by the `client` to return after the data binding operation."
-      },
+      "detail": "Union",
       "sortText": "R",
-      "insertText": "TargetType",
+      "insertText": "Thread",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "StrandData",
+      "kind": "Struct",
+      "detail": "Record",
+      "documentation": {
+        "left": "Describes Strand execution details for the runtime.\n"
+      },
+      "sortText": "Q",
+      "insertText": "StrandData",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "athletesByCountry",
+      "kind": "Variable",
+      "detail": "map<int>",
+      "sortText": "G",
+      "insertText": "athletesByCountry",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "testFunc()",
+      "kind": "Function",
+      "detail": "error?",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _._  \n  \n  \n  \n  \n**Return** `error?`   \n  \n"
+        }
+      },
+      "sortText": "E",
+      "filterText": "testFunc",
+      "insertText": "testFunc()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "entry",
+      "kind": "Variable",
+      "detail": "[string, int]",
+      "sortText": "G",
+      "insertText": "entry",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "readonly",
+      "kind": "TypeParameter",
+      "detail": "Readonly",
+      "sortText": "R",
+      "insertText": "readonly",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "handle",
+      "kind": "TypeParameter",
+      "detail": "Handle",
+      "sortText": "R",
+      "insertText": "handle",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "never",
+      "kind": "TypeParameter",
+      "detail": "Never",
+      "sortText": "R",
+      "insertText": "never",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "json",
+      "kind": "TypeParameter",
+      "detail": "Json",
+      "sortText": "R",
+      "insertText": "json",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "anydata",
+      "kind": "TypeParameter",
+      "detail": "Anydata",
+      "sortText": "R",
+      "insertText": "anydata",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "any",
+      "kind": "TypeParameter",
+      "detail": "Any",
+      "sortText": "R",
+      "insertText": "any",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "byte",
+      "kind": "TypeParameter",
+      "detail": "Byte",
+      "sortText": "R",
+      "insertText": "byte",
       "insertTextFormat": "Snippet"
     }
   ]

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_let_clause_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_let_clause_config3.json
@@ -6,563 +6,295 @@
   "source": "query_expression/source/query_expr_ctx_let_clause_source3.bal",
   "items": [
     {
-      "label": "Customer",
-      "kind": "Struct",
-      "detail": "Record",
-      "sortText": "AM",
-      "insertText": "Customer",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Thread",
-      "kind": "TypeParameter",
-      "detail": "Union",
-      "sortText": "BN",
-      "insertText": "Thread",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Person",
-      "kind": "Struct",
-      "detail": "Record",
-      "sortText": "AM",
-      "insertText": "Person",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "StrandData",
-      "kind": "Struct",
-      "detail": "Record",
+      "label": "TEST_INT_CONST1",
+      "kind": "Variable",
+      "detail": "1",
       "documentation": {
-        "left": "Describes Strand execution details for the runtime.\n"
+        "right": {
+          "kind": "markdown",
+          "value": ""
+        }
       },
-      "sortText": "BM",
-      "insertText": "StrandData",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "record",
-      "kind": "Keyword",
-      "detail": "Keyword",
-      "sortText": "Z",
-      "filterText": "record",
-      "insertText": "record ",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "function",
-      "kind": "Keyword",
-      "detail": "Keyword",
-      "sortText": "Z",
-      "filterText": "function",
-      "insertText": "function ",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "record {}",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "X",
-      "filterText": "record",
-      "insertText": "record {${1}}",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "record {||}",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "X",
-      "filterText": "record",
-      "insertText": "record {|${1}|}",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "distinct",
-      "kind": "Keyword",
-      "detail": "Keyword",
-      "sortText": "Z",
-      "filterText": "distinct",
-      "insertText": "distinct",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "object {}",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "X",
-      "filterText": "object",
-      "insertText": "object {${1}}",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "true",
-      "kind": "Keyword",
-      "detail": "Keyword",
-      "sortText": "Z",
-      "filterText": "true",
-      "insertText": "true",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "false",
-      "kind": "Keyword",
-      "detail": "Keyword",
-      "sortText": "Z",
-      "filterText": "false",
-      "insertText": "false",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "module1",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "BO",
-      "filterText": "module1",
-      "insertText": "module1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ballerina/lang.test",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "CE",
-      "filterText": "test",
-      "insertText": "test",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.test;\n"
-        }
-      ]
-    },
-    {
-      "label": "ballerina/lang.array",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "CE",
-      "filterText": "array",
-      "insertText": "array",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.array;\n"
-        }
-      ]
-    },
-    {
-      "label": "ballerina/jballerina.java",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "CF",
-      "filterText": "java",
-      "insertText": "java",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/jballerina.java;\n"
-        }
-      ]
-    },
-    {
-      "label": "ballerina/lang.value",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "CE",
-      "filterText": "value",
-      "insertText": "value",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.value;\n"
-        }
-      ]
-    },
-    {
-      "label": "ballerina/lang.runtime",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "CE",
-      "filterText": "runtime",
-      "insertText": "runtime",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.runtime;\n"
-        }
-      ]
-    },
-    {
-      "label": "map",
-      "kind": "Unit",
-      "detail": "type",
       "sortText": "G",
-      "insertText": "map",
+      "insertText": "TEST_INT_CONST1",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "object",
-      "kind": "Unit",
-      "detail": "type",
-      "sortText": "G",
-      "insertText": "object",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "stream",
-      "kind": "Unit",
-      "detail": "type",
-      "sortText": "G",
-      "insertText": "stream",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "table",
-      "kind": "Unit",
-      "detail": "type",
-      "sortText": "G",
-      "insertText": "table",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "transaction",
-      "kind": "Unit",
-      "detail": "type",
-      "sortText": "G",
-      "insertText": "transaction",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "var",
-      "kind": "Keyword",
-      "detail": "Keyword",
-      "sortText": "Z",
-      "filterText": "var",
-      "insertText": "var ",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "test/project2",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "CG",
-      "filterText": "project2",
-      "insertText": "project2",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import test/project2;\n"
+      "label": "TEST_STRING_CONST1",
+      "kind": "Variable",
+      "detail": "\"HELLO WORLD\"",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": ""
         }
-      ]
+      },
+      "sortText": "AC",
+      "insertText": "TEST_STRING_CONST1",
+      "insertTextFormat": "Snippet"
     },
     {
-      "label": "test/project1",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "CG",
-      "filterText": "project1",
-      "insertText": "project1",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import test/project1;\n"
+      "label": "ENUM1_FIELD1",
+      "kind": "EnumMember",
+      "detail": "\"ENUM1_FIELD1\"",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": ""
         }
-      ]
-    },
-    {
-      "label": "test/local_project2",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "CG",
-      "filterText": "local_project2",
-      "insertText": "local_project2",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import test/local_project2;\n"
-        }
-      ]
-    },
-    {
-      "label": "test/local_project1",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "CG",
-      "filterText": "local_project1",
-      "insertText": "local_project1",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import test/local_project1;\n"
-        }
-      ]
-    },
-    {
-      "label": "null",
-      "kind": "Keyword",
-      "detail": "Keyword",
-      "sortText": "Z",
-      "filterText": "null",
-      "insertText": "null",
+      },
+      "sortText": "AH",
+      "insertText": "ENUM1_FIELD1",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "ballerina/lang.regexp",
-      "kind": "Module",
-      "detail": "Module",
-      "sortText": "CE",
-      "filterText": "regexp",
-      "insertText": "regexp",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.regexp;\n"
-        }
-      ]
-    },
-    {
-      "label": "readonly",
-      "kind": "TypeParameter",
-      "detail": "Readonly",
-      "sortText": "BN",
-      "insertText": "readonly",
+      "label": "AnnotationType",
+      "kind": "Struct",
+      "detail": "Record",
+      "sortText": "Q",
+      "insertText": "AnnotationType",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "handle",
-      "kind": "TypeParameter",
-      "detail": "Handle",
-      "sortText": "BN",
-      "insertText": "handle",
+      "label": "ResponseMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
+      },
+      "sortText": "M",
+      "insertText": "ResponseMessage",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "never",
-      "kind": "TypeParameter",
-      "detail": "Never",
-      "sortText": "BN",
-      "insertText": "never",
+      "label": "RequestMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
+      },
+      "sortText": "M",
+      "insertText": "RequestMessage",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "json",
-      "kind": "TypeParameter",
-      "detail": "Json",
-      "sortText": "BN",
-      "insertText": "json",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "anydata",
-      "kind": "TypeParameter",
-      "detail": "Anydata",
-      "sortText": "BN",
-      "insertText": "anydata",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "any",
-      "kind": "TypeParameter",
-      "detail": "Any",
-      "sortText": "BN",
-      "insertText": "any",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "byte",
-      "kind": "TypeParameter",
-      "detail": "Byte",
-      "sortText": "BN",
-      "insertText": "byte",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "service",
-      "kind": "Keyword",
-      "detail": "Keyword",
-      "sortText": "Z",
-      "filterText": "service",
-      "insertText": "service",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "decimal",
-      "kind": "TypeParameter",
-      "detail": "Decimal",
-      "sortText": "BN",
-      "insertText": "decimal",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "error",
+      "label": "ClientError",
       "kind": "Event",
       "detail": "Error",
-      "sortText": "BL",
-      "insertText": "error",
+      "documentation": {
+        "left": "Defines the possible client error types."
+      },
+      "sortText": "P",
+      "insertText": "ClientError",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "xml",
-      "kind": "TypeParameter",
-      "detail": "Xml",
-      "sortText": "BN",
-      "insertText": "xml",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "boolean",
-      "kind": "TypeParameter",
-      "detail": "Boolean",
-      "sortText": "BN",
-      "insertText": "boolean",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "future",
-      "kind": "TypeParameter",
-      "detail": "Future",
-      "sortText": "BN",
-      "insertText": "future",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "int",
-      "kind": "TypeParameter",
-      "detail": "Int",
-      "sortText": "BN",
-      "insertText": "int",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "float",
-      "kind": "TypeParameter",
-      "detail": "Float",
-      "sortText": "BN",
-      "insertText": "float",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "function",
-      "kind": "TypeParameter",
-      "detail": "Function",
-      "sortText": "BN",
-      "insertText": "function",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "string",
-      "kind": "TypeParameter",
-      "detail": "String",
-      "sortText": "BN",
-      "insertText": "string",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "typedesc",
+      "label": "TargetType2",
       "kind": "TypeParameter",
       "detail": "Typedesc",
-      "sortText": "BN",
-      "insertText": "typedesc",
+      "documentation": {
+        "left": "The super type of all the types."
+      },
+      "sortText": "R",
+      "insertText": "TargetType2",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestRecord1",
+      "kind": "Struct",
+      "detail": "Record",
+      "sortText": "Q",
+      "insertText": "TestRecord1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestRecord2",
+      "kind": "Struct",
+      "detail": "Record",
+      "sortText": "Q",
+      "insertText": "TestRecord2",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestMap2",
+      "kind": "TypeParameter",
+      "detail": "Map",
+      "sortText": "R",
+      "insertText": "TestMap2",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestMap3",
+      "kind": "TypeParameter",
+      "detail": "Map",
+      "sortText": "R",
+      "insertText": "TestMap3",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestObject1",
+      "kind": "Interface",
+      "detail": "Object",
+      "sortText": "O",
+      "insertText": "TestObject1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ErrorOne",
+      "kind": "Event",
+      "detail": "Error",
+      "sortText": "P",
+      "insertText": "ErrorOne",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ErrorTwo",
+      "kind": "Event",
+      "detail": "Error",
+      "sortText": "P",
+      "insertText": "ErrorTwo",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TargetType",
+      "kind": "TypeParameter",
+      "detail": "Typedesc",
+      "documentation": {
+        "left": "The types of data values that are expected by the `client` to return after the data binding operation."
+      },
+      "sortText": "R",
+      "insertText": "TargetType",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Client",
+      "kind": "Interface",
+      "detail": "Class",
+      "documentation": {
+        "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs."
+      },
+      "sortText": "O",
+      "insertText": "Client",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Response",
+      "kind": "Interface",
+      "detail": "Class",
+      "documentation": {
+        "left": "Represents a response.\n"
+      },
+      "sortText": "O",
+      "insertText": "Response",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Listener",
+      "kind": "Interface",
+      "detail": "Class",
+      "sortText": "O",
+      "insertText": "Listener",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestClass1",
+      "kind": "Interface",
+      "detail": "Class",
+      "sortText": "O",
+      "insertText": "TestClass1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TEST_FUTURE_INT",
+      "kind": "Variable",
+      "detail": "future<int>",
+      "sortText": "G",
+      "insertText": "TEST_FUTURE_INT",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "GLOBAL_VAR",
+      "kind": "Variable",
+      "detail": "int",
+      "sortText": "G",
+      "insertText": "GLOBAL_VAR",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "listener1",
+      "kind": "Variable",
+      "detail": "module1:Listener",
+      "sortText": "G",
+      "insertText": "listener1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "function1()",
+      "kind": "Function",
+      "detail": "()",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \n  \n"
+        }
+      },
+      "sortText": "E",
+      "filterText": "function1",
+      "insertText": "function1()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "function2()",
+      "kind": "Function",
+      "detail": "()",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function2  \n"
+        }
+      },
+      "sortText": "E",
+      "filterText": "function2",
+      "insertText": "function2()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "function3(int param1, int param2, float... param3)",
+      "kind": "Function",
+      "detail": "int",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function3 with input parameters\n  \n**Params**  \n- `int` param1: param1 Parameter Description   \n- `int` param2: param2 Parameter Description  \n- `float[]` param3: param3 Parameter Description  \n  \n**Return** `int`   \n- Return Value Description  \n  \n"
+        }
+      },
+      "sortText": "E",
+      "filterText": "function3",
+      "insertText": "function3(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "function4(int param1, int param2, string param3, float... param4)",
+      "kind": "Function",
+      "detail": "()",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function4 with input parameters\n  \n**Params**  \n- `int` param1: param1 Parameter Description   \n- `int` param2: param2 Parameter Description  \n- `string` param3: param3 Parameter Description(Defaultable)  \n- `float[]` param4: param4 Parameter Description"
+        }
+      },
+      "sortText": "E",
+      "filterText": "function4",
+      "insertText": "function4(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_let_clause_config6.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_let_clause_config6.json
@@ -6,294 +6,765 @@
   "source": "query_expression/source/query_expr_ctx_let_clause_source6.bal",
   "items": [
     {
-      "label": "ENUM1_FIELD1",
-      "kind": "EnumMember",
-      "detail": "\"ENUM1_FIELD1\"",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": ""
-        }
-      },
-      "sortText": "AH",
-      "insertText": "ENUM1_FIELD1",
+      "label": "module1",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "S",
+      "filterText": "module1",
+      "insertText": "module1",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "TEST_INT_CONST1",
-      "kind": "Variable",
-      "detail": "1",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": ""
+      "label": "test/project2",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "project2",
+      "insertText": "project2",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import test/project2;\n"
         }
-      },
+      ]
+    },
+    {
+      "label": "test/project1",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "project1",
+      "insertText": "project1",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import test/project1;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.runtime",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "runtime",
+      "insertText": "runtime",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.runtime;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.regexp",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "regexp",
+      "insertText": "regexp",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.regexp;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.test",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "test",
+      "insertText": "test",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.test;\n"
+        }
+      ]
+    },
+    {
+      "label": "test/local_project2",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "local_project2",
+      "insertText": "local_project2",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import test/local_project2;\n"
+        }
+      ]
+    },
+    {
+      "label": "test/local_project1",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "local_project1",
+      "insertText": "local_project1",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import test/local_project1;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "value",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/jballerina.java",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "java",
+      "insertText": "java",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/jballerina.java;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.array",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "array",
+      "insertText": "array",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.array;\n"
+        }
+      ]
+    },
+    {
+      "label": "decimal",
+      "kind": "TypeParameter",
+      "detail": "Decimal",
+      "sortText": "R",
+      "insertText": "decimal",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "error",
+      "kind": "Event",
+      "detail": "Error",
+      "sortText": "P",
+      "insertText": "error",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "object",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "object",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "transaction",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "transaction",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml",
+      "kind": "TypeParameter",
+      "detail": "Xml",
+      "sortText": "R",
+      "insertText": "xml",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "table",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "table",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "map",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "map",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "stream",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "stream",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "boolean",
+      "kind": "TypeParameter",
+      "detail": "Boolean",
+      "sortText": "R",
+      "insertText": "boolean",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "future",
+      "kind": "TypeParameter",
+      "detail": "Future",
+      "sortText": "R",
+      "insertText": "future",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "int",
+      "kind": "TypeParameter",
+      "detail": "Int",
+      "sortText": "R",
+      "insertText": "int",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "float",
+      "kind": "TypeParameter",
+      "detail": "Float",
+      "sortText": "R",
+      "insertText": "float",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "function",
+      "kind": "TypeParameter",
+      "detail": "Function",
+      "sortText": "R",
+      "insertText": "function",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string",
+      "kind": "TypeParameter",
+      "detail": "String",
+      "sortText": "R",
+      "insertText": "string",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "typedesc",
+      "kind": "TypeParameter",
+      "detail": "Typedesc",
+      "sortText": "R",
+      "insertText": "typedesc",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "service",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "service",
+      "insertText": "service",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "new",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "new",
+      "insertText": "new ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "isolated",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "isolated",
+      "insertText": "isolated ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "transactional",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "transactional",
+      "insertText": "transactional",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "function",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "function",
+      "insertText": "function ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "let",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "let",
+      "insertText": "let",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "typeof",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "typeof",
+      "insertText": "typeof ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "trap",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "trap",
+      "insertText": "trap",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "client",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "client",
+      "insertText": "client ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "true",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "true",
+      "insertText": "true",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "false",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "false",
+      "insertText": "false",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "null",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "null",
+      "insertText": "null",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "check",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "check",
+      "insertText": "check ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "checkpanic",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "checkpanic",
+      "insertText": "checkpanic ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "is",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "is",
+      "insertText": "is",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "error",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "object constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "object",
+      "insertText": "object {${1}}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "base16",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "base16",
+      "insertText": "base16 `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "base64",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "base64",
+      "insertText": "base64 `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "from",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "from",
+      "insertText": "from ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "re ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "re ``",
+      "insertText": "re `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "c1",
+      "kind": "Variable",
+      "detail": "Customer",
       "sortText": "G",
-      "insertText": "TEST_INT_CONST1",
+      "insertText": "c1",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "TEST_STRING_CONST1",
+      "label": "c2",
       "kind": "Variable",
-      "detail": "\"HELLO WORLD\"",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": ""
-        }
-      },
+      "detail": "Customer",
+      "sortText": "G",
+      "insertText": "c2",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "c3",
+      "kind": "Variable",
+      "detail": "Customer",
+      "sortText": "G",
+      "insertText": "c3",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "customerList",
+      "kind": "Variable",
+      "detail": "Customer[]",
+      "sortText": "G",
+      "insertText": "customerList",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "outputNameString",
+      "kind": "Variable",
+      "detail": "string",
       "sortText": "AC",
-      "insertText": "TEST_STRING_CONST1",
+      "insertText": "outputNameString",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "AnnotationType",
-      "kind": "Struct",
-      "detail": "Record",
-      "sortText": "Q",
-      "insertText": "AnnotationType",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ResponseMessage",
-      "kind": "Enum",
+      "label": "Thread",
+      "kind": "TypeParameter",
       "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
-      },
-      "sortText": "M",
-      "insertText": "ResponseMessage",
+      "sortText": "R",
+      "insertText": "Thread",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "RequestMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
-      },
-      "sortText": "M",
-      "insertText": "RequestMessage",
+      "label": "p1",
+      "kind": "Variable",
+      "detail": "Person",
+      "sortText": "G",
+      "insertText": "p1",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "TestRecord1",
+      "label": "p2",
+      "kind": "Variable",
+      "detail": "Person",
+      "sortText": "G",
+      "insertText": "p2",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Person",
       "kind": "Struct",
       "detail": "Record",
       "sortText": "Q",
-      "insertText": "TestRecord1",
+      "insertText": "Person",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "TestRecord2",
+      "label": "StrandData",
+      "kind": "Struct",
+      "detail": "Record",
+      "documentation": {
+        "left": "Describes Strand execution details for the runtime.\n"
+      },
+      "sortText": "Q",
+      "insertText": "StrandData",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "personList",
+      "kind": "Variable",
+      "detail": "Person[]",
+      "sortText": "G",
+      "insertText": "personList",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "person",
+      "kind": "Variable",
+      "detail": "Person",
+      "sortText": "G",
+      "insertText": "person",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "onConflictError",
+      "kind": "Variable",
+      "detail": "error",
+      "sortText": "G",
+      "insertText": "onConflictError",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "testIterableOperation()",
+      "kind": "Function",
+      "detail": "()",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _._  \n  \n  \n"
+        }
+      },
+      "sortText": "E",
+      "filterText": "testIterableOperation",
+      "insertText": "testIterableOperation()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Customer",
       "kind": "Struct",
       "detail": "Record",
       "sortText": "Q",
-      "insertText": "TestRecord2",
+      "insertText": "Customer",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "TestMap2",
+      "label": "readonly",
       "kind": "TypeParameter",
-      "detail": "Map",
+      "detail": "Readonly",
       "sortText": "R",
-      "insertText": "TestMap2",
+      "insertText": "readonly",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "TestMap3",
+      "label": "handle",
       "kind": "TypeParameter",
-      "detail": "Map",
+      "detail": "Handle",
       "sortText": "R",
-      "insertText": "TestMap3",
+      "insertText": "handle",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "TestObject1",
-      "kind": "Interface",
-      "detail": "Object",
-      "sortText": "O",
-      "insertText": "TestObject1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ErrorOne",
-      "kind": "Event",
-      "detail": "Error",
-      "sortText": "P",
-      "insertText": "ErrorOne",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ErrorTwo",
-      "kind": "Event",
-      "detail": "Error",
-      "sortText": "P",
-      "insertText": "ErrorTwo",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Listener",
-      "kind": "Interface",
-      "detail": "Class",
-      "sortText": "O",
-      "insertText": "Listener",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Client",
-      "kind": "Interface",
-      "detail": "Class",
-      "documentation": {
-        "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs."
-      },
-      "sortText": "O",
-      "insertText": "Client",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Response",
-      "kind": "Interface",
-      "detail": "Class",
-      "documentation": {
-        "left": "Represents a response.\n"
-      },
-      "sortText": "O",
-      "insertText": "Response",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "TestClass1",
-      "kind": "Interface",
-      "detail": "Class",
-      "sortText": "O",
-      "insertText": "TestClass1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "listener1",
-      "kind": "Variable",
-      "detail": "module1:Listener",
-      "sortText": "G",
-      "insertText": "listener1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "function1()",
-      "kind": "Function",
-      "detail": "()",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \n  \n"
-        }
-      },
-      "sortText": "E",
-      "filterText": "function1",
-      "insertText": "function1()",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "function2()",
-      "kind": "Function",
-      "detail": "()",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function2  \n"
-        }
-      },
-      "sortText": "E",
-      "filterText": "function2",
-      "insertText": "function2()",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "function3(int param1, int param2, float... param3)",
-      "kind": "Function",
-      "detail": "int",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function3 with input parameters\n  \n**Params**  \n- `int` param1: param1 Parameter Description   \n- `int` param2: param2 Parameter Description  \n- `float[]` param3: param3 Parameter Description  \n  \n**Return** `int`   \n- Return Value Description  \n  \n"
-        }
-      },
-      "sortText": "E",
-      "filterText": "function3",
-      "insertText": "function3(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "function4(int param1, int param2, string param3, float... param4)",
-      "kind": "Function",
-      "detail": "()",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function4 with input parameters\n  \n**Params**  \n- `int` param1: param1 Parameter Description   \n- `int` param2: param2 Parameter Description  \n- `string` param3: param3 Parameter Description(Defaultable)  \n- `float[]` param4: param4 Parameter Description"
-        }
-      },
-      "sortText": "E",
-      "filterText": "function4",
-      "insertText": "function4(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "TEST_FUTURE_INT",
-      "kind": "Variable",
-      "detail": "future<int>",
-      "sortText": "G",
-      "insertText": "TEST_FUTURE_INT",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "GLOBAL_VAR",
-      "kind": "Variable",
-      "detail": "int",
-      "sortText": "G",
-      "insertText": "GLOBAL_VAR",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ClientError",
-      "kind": "Event",
-      "detail": "Error",
-      "documentation": {
-        "left": "Defines the possible client error types."
-      },
-      "sortText": "P",
-      "insertText": "ClientError",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "TargetType2",
+      "label": "never",
       "kind": "TypeParameter",
-      "detail": "Typedesc",
-      "documentation": {
-        "left": "The super type of all the types."
-      },
+      "detail": "Never",
       "sortText": "R",
-      "insertText": "TargetType2",
+      "insertText": "never",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "TargetType",
+      "label": "json",
       "kind": "TypeParameter",
-      "detail": "Typedesc",
-      "documentation": {
-        "left": "The types of data values that are expected by the `client` to return after the data binding operation."
-      },
+      "detail": "Json",
       "sortText": "R",
-      "insertText": "TargetType",
+      "insertText": "json",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "anydata",
+      "kind": "TypeParameter",
+      "detail": "Anydata",
+      "sortText": "R",
+      "insertText": "anydata",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "any",
+      "kind": "TypeParameter",
+      "detail": "Any",
+      "sortText": "R",
+      "insertText": "any",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "byte",
+      "kind": "TypeParameter",
+      "detail": "Byte",
+      "sortText": "R",
+      "insertText": "byte",
       "insertTextFormat": "Snippet"
     }
   ]

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_let_clause_config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_let_clause_config7.json
@@ -6,294 +6,765 @@
   "source": "query_expression/source/query_expr_ctx_let_clause_source7.bal",
   "items": [
     {
-      "label": "ENUM1_FIELD1",
-      "kind": "EnumMember",
-      "detail": "\"ENUM1_FIELD1\"",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": ""
-        }
-      },
-      "sortText": "AH",
-      "insertText": "ENUM1_FIELD1",
+      "label": "module1",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "S",
+      "filterText": "module1",
+      "insertText": "module1",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "TEST_INT_CONST1",
-      "kind": "Variable",
-      "detail": "1",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": ""
+      "label": "test/project2",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "project2",
+      "insertText": "project2",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import test/project2;\n"
         }
-      },
+      ]
+    },
+    {
+      "label": "test/project1",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "project1",
+      "insertText": "project1",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import test/project1;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.runtime",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "runtime",
+      "insertText": "runtime",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.runtime;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.regexp",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "regexp",
+      "insertText": "regexp",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.regexp;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.test",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "test",
+      "insertText": "test",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.test;\n"
+        }
+      ]
+    },
+    {
+      "label": "test/local_project2",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "local_project2",
+      "insertText": "local_project2",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import test/local_project2;\n"
+        }
+      ]
+    },
+    {
+      "label": "test/local_project1",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "local_project1",
+      "insertText": "local_project1",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import test/local_project1;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "value",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/jballerina.java",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "java",
+      "insertText": "java",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/jballerina.java;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.array",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "array",
+      "insertText": "array",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.array;\n"
+        }
+      ]
+    },
+    {
+      "label": "decimal",
+      "kind": "TypeParameter",
+      "detail": "Decimal",
+      "sortText": "R",
+      "insertText": "decimal",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "error",
+      "kind": "Event",
+      "detail": "Error",
+      "sortText": "P",
+      "insertText": "error",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "object",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "object",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "transaction",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "transaction",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml",
+      "kind": "TypeParameter",
+      "detail": "Xml",
+      "sortText": "R",
+      "insertText": "xml",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "table",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "table",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "map",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "map",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "stream",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "stream",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "boolean",
+      "kind": "TypeParameter",
+      "detail": "Boolean",
+      "sortText": "R",
+      "insertText": "boolean",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "future",
+      "kind": "TypeParameter",
+      "detail": "Future",
+      "sortText": "R",
+      "insertText": "future",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "int",
+      "kind": "TypeParameter",
+      "detail": "Int",
+      "sortText": "R",
+      "insertText": "int",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "float",
+      "kind": "TypeParameter",
+      "detail": "Float",
+      "sortText": "R",
+      "insertText": "float",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "function",
+      "kind": "TypeParameter",
+      "detail": "Function",
+      "sortText": "R",
+      "insertText": "function",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string",
+      "kind": "TypeParameter",
+      "detail": "String",
+      "sortText": "R",
+      "insertText": "string",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "typedesc",
+      "kind": "TypeParameter",
+      "detail": "Typedesc",
+      "sortText": "R",
+      "insertText": "typedesc",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "service",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "service",
+      "insertText": "service",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "new",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "new",
+      "insertText": "new ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "isolated",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "isolated",
+      "insertText": "isolated ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "transactional",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "transactional",
+      "insertText": "transactional",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "function",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "function",
+      "insertText": "function ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "let",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "let",
+      "insertText": "let",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "typeof",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "typeof",
+      "insertText": "typeof ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "trap",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "trap",
+      "insertText": "trap",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "client",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "client",
+      "insertText": "client ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "true",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "true",
+      "insertText": "true",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "false",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "false",
+      "insertText": "false",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "null",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "null",
+      "insertText": "null",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "check",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "check",
+      "insertText": "check ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "checkpanic",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "checkpanic",
+      "insertText": "checkpanic ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "is",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "is",
+      "insertText": "is",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "error",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "object constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "object",
+      "insertText": "object {${1}}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "base16",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "base16",
+      "insertText": "base16 `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "base64",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "base64",
+      "insertText": "base64 `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "from",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "from",
+      "insertText": "from ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "re ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "re ``",
+      "insertText": "re `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "c1",
+      "kind": "Variable",
+      "detail": "Customer",
       "sortText": "G",
-      "insertText": "TEST_INT_CONST1",
+      "insertText": "c1",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "TEST_STRING_CONST1",
+      "label": "c2",
       "kind": "Variable",
-      "detail": "\"HELLO WORLD\"",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": ""
-        }
-      },
+      "detail": "Customer",
+      "sortText": "G",
+      "insertText": "c2",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "c3",
+      "kind": "Variable",
+      "detail": "Customer",
+      "sortText": "G",
+      "insertText": "c3",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "customerList",
+      "kind": "Variable",
+      "detail": "Customer[]",
+      "sortText": "G",
+      "insertText": "customerList",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "outputNameString",
+      "kind": "Variable",
+      "detail": "string",
       "sortText": "AC",
-      "insertText": "TEST_STRING_CONST1",
+      "insertText": "outputNameString",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "AnnotationType",
-      "kind": "Struct",
-      "detail": "Record",
-      "sortText": "Q",
-      "insertText": "AnnotationType",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ResponseMessage",
-      "kind": "Enum",
+      "label": "Thread",
+      "kind": "TypeParameter",
       "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
-      },
-      "sortText": "M",
-      "insertText": "ResponseMessage",
+      "sortText": "R",
+      "insertText": "Thread",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "RequestMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
-      },
-      "sortText": "M",
-      "insertText": "RequestMessage",
+      "label": "p1",
+      "kind": "Variable",
+      "detail": "Person",
+      "sortText": "G",
+      "insertText": "p1",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "TestRecord1",
+      "label": "p2",
+      "kind": "Variable",
+      "detail": "Person",
+      "sortText": "G",
+      "insertText": "p2",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Person",
       "kind": "Struct",
       "detail": "Record",
       "sortText": "Q",
-      "insertText": "TestRecord1",
+      "insertText": "Person",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "TestRecord2",
+      "label": "StrandData",
+      "kind": "Struct",
+      "detail": "Record",
+      "documentation": {
+        "left": "Describes Strand execution details for the runtime.\n"
+      },
+      "sortText": "Q",
+      "insertText": "StrandData",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "personList",
+      "kind": "Variable",
+      "detail": "Person[]",
+      "sortText": "G",
+      "insertText": "personList",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "person",
+      "kind": "Variable",
+      "detail": "Person",
+      "sortText": "G",
+      "insertText": "person",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "onConflictError",
+      "kind": "Variable",
+      "detail": "error",
+      "sortText": "G",
+      "insertText": "onConflictError",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "testIterableOperation()",
+      "kind": "Function",
+      "detail": "()",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _._  \n  \n  \n"
+        }
+      },
+      "sortText": "E",
+      "filterText": "testIterableOperation",
+      "insertText": "testIterableOperation()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Customer",
       "kind": "Struct",
       "detail": "Record",
       "sortText": "Q",
-      "insertText": "TestRecord2",
+      "insertText": "Customer",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "TestMap2",
+      "label": "readonly",
       "kind": "TypeParameter",
-      "detail": "Map",
+      "detail": "Readonly",
       "sortText": "R",
-      "insertText": "TestMap2",
+      "insertText": "readonly",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "TestMap3",
+      "label": "handle",
       "kind": "TypeParameter",
-      "detail": "Map",
+      "detail": "Handle",
       "sortText": "R",
-      "insertText": "TestMap3",
+      "insertText": "handle",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "TestObject1",
-      "kind": "Interface",
-      "detail": "Object",
-      "sortText": "O",
-      "insertText": "TestObject1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ErrorOne",
-      "kind": "Event",
-      "detail": "Error",
-      "sortText": "P",
-      "insertText": "ErrorOne",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ErrorTwo",
-      "kind": "Event",
-      "detail": "Error",
-      "sortText": "P",
-      "insertText": "ErrorTwo",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Listener",
-      "kind": "Interface",
-      "detail": "Class",
-      "sortText": "O",
-      "insertText": "Listener",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Client",
-      "kind": "Interface",
-      "detail": "Class",
-      "documentation": {
-        "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs."
-      },
-      "sortText": "O",
-      "insertText": "Client",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Response",
-      "kind": "Interface",
-      "detail": "Class",
-      "documentation": {
-        "left": "Represents a response.\n"
-      },
-      "sortText": "O",
-      "insertText": "Response",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "TestClass1",
-      "kind": "Interface",
-      "detail": "Class",
-      "sortText": "O",
-      "insertText": "TestClass1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "listener1",
-      "kind": "Variable",
-      "detail": "module1:Listener",
-      "sortText": "G",
-      "insertText": "listener1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "function1()",
-      "kind": "Function",
-      "detail": "()",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \n  \n"
-        }
-      },
-      "sortText": "E",
-      "filterText": "function1",
-      "insertText": "function1()",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "function2()",
-      "kind": "Function",
-      "detail": "()",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function2  \n"
-        }
-      },
-      "sortText": "E",
-      "filterText": "function2",
-      "insertText": "function2()",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "function3(int param1, int param2, float... param3)",
-      "kind": "Function",
-      "detail": "int",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function3 with input parameters\n  \n**Params**  \n- `int` param1: param1 Parameter Description   \n- `int` param2: param2 Parameter Description  \n- `float[]` param3: param3 Parameter Description  \n  \n**Return** `int`   \n- Return Value Description  \n  \n"
-        }
-      },
-      "sortText": "E",
-      "filterText": "function3",
-      "insertText": "function3(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "function4(int param1, int param2, string param3, float... param4)",
-      "kind": "Function",
-      "detail": "()",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function4 with input parameters\n  \n**Params**  \n- `int` param1: param1 Parameter Description   \n- `int` param2: param2 Parameter Description  \n- `string` param3: param3 Parameter Description(Defaultable)  \n- `float[]` param4: param4 Parameter Description"
-        }
-      },
-      "sortText": "E",
-      "filterText": "function4",
-      "insertText": "function4(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "TEST_FUTURE_INT",
-      "kind": "Variable",
-      "detail": "future<int>",
-      "sortText": "G",
-      "insertText": "TEST_FUTURE_INT",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "GLOBAL_VAR",
-      "kind": "Variable",
-      "detail": "int",
-      "sortText": "G",
-      "insertText": "GLOBAL_VAR",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ClientError",
-      "kind": "Event",
-      "detail": "Error",
-      "documentation": {
-        "left": "Defines the possible client error types."
-      },
-      "sortText": "P",
-      "insertText": "ClientError",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "TargetType2",
+      "label": "never",
       "kind": "TypeParameter",
-      "detail": "Typedesc",
-      "documentation": {
-        "left": "The super type of all the types."
-      },
+      "detail": "Never",
       "sortText": "R",
-      "insertText": "TargetType2",
+      "insertText": "never",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "TargetType",
+      "label": "json",
       "kind": "TypeParameter",
-      "detail": "Typedesc",
-      "documentation": {
-        "left": "The types of data values that are expected by the `client` to return after the data binding operation."
-      },
+      "detail": "Json",
       "sortText": "R",
-      "insertText": "TargetType",
+      "insertText": "json",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "anydata",
+      "kind": "TypeParameter",
+      "detail": "Anydata",
+      "sortText": "R",
+      "insertText": "anydata",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "any",
+      "kind": "TypeParameter",
+      "detail": "Any",
+      "sortText": "R",
+      "insertText": "any",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "byte",
+      "kind": "TypeParameter",
+      "detail": "Byte",
+      "sortText": "R",
+      "insertText": "byte",
       "insertTextFormat": "Snippet"
     }
   ]

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_let_clause_config8.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_let_clause_config8.json
@@ -6,294 +6,765 @@
   "source": "query_expression/source/query_expr_ctx_let_clause_source8.bal",
   "items": [
     {
-      "label": "ENUM1_FIELD1",
-      "kind": "EnumMember",
-      "detail": "\"ENUM1_FIELD1\"",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": ""
-        }
-      },
-      "sortText": "AH",
-      "insertText": "ENUM1_FIELD1",
+      "label": "module1",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "S",
+      "filterText": "module1",
+      "insertText": "module1",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "TEST_INT_CONST1",
-      "kind": "Variable",
-      "detail": "1",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": ""
+      "label": "test/project2",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "project2",
+      "insertText": "project2",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import test/project2;\n"
         }
-      },
+      ]
+    },
+    {
+      "label": "test/project1",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "project1",
+      "insertText": "project1",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import test/project1;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.runtime",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "runtime",
+      "insertText": "runtime",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.runtime;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.regexp",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "regexp",
+      "insertText": "regexp",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.regexp;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.test",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "test",
+      "insertText": "test",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.test;\n"
+        }
+      ]
+    },
+    {
+      "label": "test/local_project2",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "local_project2",
+      "insertText": "local_project2",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import test/local_project2;\n"
+        }
+      ]
+    },
+    {
+      "label": "test/local_project1",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "local_project1",
+      "insertText": "local_project1",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import test/local_project1;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "value",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/jballerina.java",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "java",
+      "insertText": "java",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/jballerina.java;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.array",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "R",
+      "filterText": "array",
+      "insertText": "array",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.array;\n"
+        }
+      ]
+    },
+    {
+      "label": "decimal",
+      "kind": "TypeParameter",
+      "detail": "Decimal",
+      "sortText": "R",
+      "insertText": "decimal",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "error",
+      "kind": "Event",
+      "detail": "Error",
+      "sortText": "P",
+      "insertText": "error",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "object",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "object",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "transaction",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "transaction",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml",
+      "kind": "TypeParameter",
+      "detail": "Xml",
+      "sortText": "R",
+      "insertText": "xml",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "table",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "table",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "map",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "map",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "stream",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "R",
+      "insertText": "stream",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "boolean",
+      "kind": "TypeParameter",
+      "detail": "Boolean",
+      "sortText": "R",
+      "insertText": "boolean",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "future",
+      "kind": "TypeParameter",
+      "detail": "Future",
+      "sortText": "R",
+      "insertText": "future",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "int",
+      "kind": "TypeParameter",
+      "detail": "Int",
+      "sortText": "R",
+      "insertText": "int",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "float",
+      "kind": "TypeParameter",
+      "detail": "Float",
+      "sortText": "R",
+      "insertText": "float",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "function",
+      "kind": "TypeParameter",
+      "detail": "Function",
+      "sortText": "R",
+      "insertText": "function",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string",
+      "kind": "TypeParameter",
+      "detail": "String",
+      "sortText": "R",
+      "insertText": "string",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "typedesc",
+      "kind": "TypeParameter",
+      "detail": "Typedesc",
+      "sortText": "R",
+      "insertText": "typedesc",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "service",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "service",
+      "insertText": "service",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "new",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "new",
+      "insertText": "new ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "isolated",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "isolated",
+      "insertText": "isolated ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "transactional",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "transactional",
+      "insertText": "transactional",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "function",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "function",
+      "insertText": "function ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "let",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "let",
+      "insertText": "let",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "typeof",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "typeof",
+      "insertText": "typeof ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "trap",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "trap",
+      "insertText": "trap",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "client",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "client",
+      "insertText": "client ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "true",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "true",
+      "insertText": "true",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "false",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "false",
+      "insertText": "false",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "null",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "null",
+      "insertText": "null",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "check",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "check",
+      "insertText": "check ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "checkpanic",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "checkpanic",
+      "insertText": "checkpanic ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "is",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "is",
+      "insertText": "is",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "error",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "object constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "object",
+      "insertText": "object {${1}}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "base16",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "base16",
+      "insertText": "base16 `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "base64",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "base64",
+      "insertText": "base64 `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "from",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "from",
+      "insertText": "from ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "re ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "re ``",
+      "insertText": "re `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "string ``",
+      "insertText": "string `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml ``",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "T",
+      "filterText": "xml ``",
+      "insertText": "xml `${1}`",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "c1",
+      "kind": "Variable",
+      "detail": "Customer",
       "sortText": "G",
-      "insertText": "TEST_INT_CONST1",
+      "insertText": "c1",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "TEST_STRING_CONST1",
+      "label": "c2",
       "kind": "Variable",
-      "detail": "\"HELLO WORLD\"",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": ""
-        }
-      },
+      "detail": "Customer",
+      "sortText": "G",
+      "insertText": "c2",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "c3",
+      "kind": "Variable",
+      "detail": "Customer",
+      "sortText": "G",
+      "insertText": "c3",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "customerList",
+      "kind": "Variable",
+      "detail": "Customer[]",
+      "sortText": "G",
+      "insertText": "customerList",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "outputNameString",
+      "kind": "Variable",
+      "detail": "string",
       "sortText": "AC",
-      "insertText": "TEST_STRING_CONST1",
+      "insertText": "outputNameString",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "AnnotationType",
-      "kind": "Struct",
-      "detail": "Record",
-      "sortText": "Q",
-      "insertText": "AnnotationType",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ResponseMessage",
-      "kind": "Enum",
+      "label": "Thread",
+      "kind": "TypeParameter",
       "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
-      },
-      "sortText": "M",
-      "insertText": "ResponseMessage",
+      "sortText": "R",
+      "insertText": "Thread",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "RequestMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
-      },
-      "sortText": "M",
-      "insertText": "RequestMessage",
+      "label": "p1",
+      "kind": "Variable",
+      "detail": "Person",
+      "sortText": "G",
+      "insertText": "p1",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "TestRecord1",
+      "label": "p2",
+      "kind": "Variable",
+      "detail": "Person",
+      "sortText": "G",
+      "insertText": "p2",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Person",
       "kind": "Struct",
       "detail": "Record",
       "sortText": "Q",
-      "insertText": "TestRecord1",
+      "insertText": "Person",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "TestRecord2",
+      "label": "StrandData",
+      "kind": "Struct",
+      "detail": "Record",
+      "documentation": {
+        "left": "Describes Strand execution details for the runtime.\n"
+      },
+      "sortText": "Q",
+      "insertText": "StrandData",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "personList",
+      "kind": "Variable",
+      "detail": "Person[]",
+      "sortText": "G",
+      "insertText": "personList",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "person",
+      "kind": "Variable",
+      "detail": "Person",
+      "sortText": "G",
+      "insertText": "person",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "onConflictError",
+      "kind": "Variable",
+      "detail": "error",
+      "sortText": "G",
+      "insertText": "onConflictError",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "testIterableOperation()",
+      "kind": "Function",
+      "detail": "()",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _._  \n  \n  \n"
+        }
+      },
+      "sortText": "E",
+      "filterText": "testIterableOperation",
+      "insertText": "testIterableOperation()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Customer",
       "kind": "Struct",
       "detail": "Record",
       "sortText": "Q",
-      "insertText": "TestRecord2",
+      "insertText": "Customer",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "TestMap2",
+      "label": "readonly",
       "kind": "TypeParameter",
-      "detail": "Map",
+      "detail": "Readonly",
       "sortText": "R",
-      "insertText": "TestMap2",
+      "insertText": "readonly",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "TestMap3",
+      "label": "handle",
       "kind": "TypeParameter",
-      "detail": "Map",
+      "detail": "Handle",
       "sortText": "R",
-      "insertText": "TestMap3",
+      "insertText": "handle",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "TestObject1",
-      "kind": "Interface",
-      "detail": "Object",
-      "sortText": "O",
-      "insertText": "TestObject1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ErrorOne",
-      "kind": "Event",
-      "detail": "Error",
-      "sortText": "P",
-      "insertText": "ErrorOne",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ErrorTwo",
-      "kind": "Event",
-      "detail": "Error",
-      "sortText": "P",
-      "insertText": "ErrorTwo",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Listener",
-      "kind": "Interface",
-      "detail": "Class",
-      "sortText": "O",
-      "insertText": "Listener",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Client",
-      "kind": "Interface",
-      "detail": "Class",
-      "documentation": {
-        "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs."
-      },
-      "sortText": "O",
-      "insertText": "Client",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Response",
-      "kind": "Interface",
-      "detail": "Class",
-      "documentation": {
-        "left": "Represents a response.\n"
-      },
-      "sortText": "O",
-      "insertText": "Response",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "TestClass1",
-      "kind": "Interface",
-      "detail": "Class",
-      "sortText": "O",
-      "insertText": "TestClass1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "listener1",
-      "kind": "Variable",
-      "detail": "module1:Listener",
-      "sortText": "G",
-      "insertText": "listener1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "function1()",
-      "kind": "Function",
-      "detail": "()",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \n  \n"
-        }
-      },
-      "sortText": "E",
-      "filterText": "function1",
-      "insertText": "function1()",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "function2()",
-      "kind": "Function",
-      "detail": "()",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function2  \n"
-        }
-      },
-      "sortText": "E",
-      "filterText": "function2",
-      "insertText": "function2()",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "function3(int param1, int param2, float... param3)",
-      "kind": "Function",
-      "detail": "int",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function3 with input parameters\n  \n**Params**  \n- `int` param1: param1 Parameter Description   \n- `int` param2: param2 Parameter Description  \n- `float[]` param3: param3 Parameter Description  \n  \n**Return** `int`   \n- Return Value Description  \n  \n"
-        }
-      },
-      "sortText": "E",
-      "filterText": "function3",
-      "insertText": "function3(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "function4(int param1, int param2, string param3, float... param4)",
-      "kind": "Function",
-      "detail": "()",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThis is function4 with input parameters\n  \n**Params**  \n- `int` param1: param1 Parameter Description   \n- `int` param2: param2 Parameter Description  \n- `string` param3: param3 Parameter Description(Defaultable)  \n- `float[]` param4: param4 Parameter Description"
-        }
-      },
-      "sortText": "E",
-      "filterText": "function4",
-      "insertText": "function4(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "TEST_FUTURE_INT",
-      "kind": "Variable",
-      "detail": "future<int>",
-      "sortText": "G",
-      "insertText": "TEST_FUTURE_INT",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "GLOBAL_VAR",
-      "kind": "Variable",
-      "detail": "int",
-      "sortText": "G",
-      "insertText": "GLOBAL_VAR",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ClientError",
-      "kind": "Event",
-      "detail": "Error",
-      "documentation": {
-        "left": "Defines the possible client error types."
-      },
-      "sortText": "P",
-      "insertText": "ClientError",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "TargetType2",
+      "label": "never",
       "kind": "TypeParameter",
-      "detail": "Typedesc",
-      "documentation": {
-        "left": "The super type of all the types."
-      },
+      "detail": "Never",
       "sortText": "R",
-      "insertText": "TargetType2",
+      "insertText": "never",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "TargetType",
+      "label": "json",
       "kind": "TypeParameter",
-      "detail": "Typedesc",
-      "documentation": {
-        "left": "The types of data values that are expected by the `client` to return after the data binding operation."
-      },
+      "detail": "Json",
       "sortText": "R",
-      "insertText": "TargetType",
+      "insertText": "json",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "anydata",
+      "kind": "TypeParameter",
+      "detail": "Anydata",
+      "sortText": "R",
+      "insertText": "anydata",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "any",
+      "kind": "TypeParameter",
+      "detail": "Any",
+      "sortText": "R",
+      "insertText": "any",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "byte",
+      "kind": "TypeParameter",
+      "detail": "Byte",
+      "sortText": "R",
+      "insertText": "byte",
       "insertTextFormat": "Snippet"
     }
   ]


### PR DESCRIPTION
## Purpose
This PR adds the missing completions in let var decl node context.

Fixes #39526

## Samples

https://user-images.githubusercontent.com/61020198/227847580-7dfb6b44-caa9-41b5-ad16-eb1725bad1cb.mov


## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
