### PR TITLE
Create Invokable type symbols when defining operator types in Symbol Table

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
@@ -1141,6 +1141,13 @@ public class SymbolTable {
         BInvokableType opType = new BInvokableType(paramTypes, retType, null);
         BOperatorSymbol symbol = new BOperatorSymbol(name, rootPkgSymbol.pkgID, opType, rootPkgSymbol, this.builtinPos,
                                                      BUILTIN);
+
+        BInvokableTypeSymbol typeSymbol = Symbols.createInvokableTypeSymbol(SymTag.FUNCTION_TYPE, Flags.ANY_FUNCTION,
+                rootPkgSymbol.pkgID, opType, rootPkgSymbol, this.builtinPos, BUILTIN);
+
+        typeSymbol.returnType = retType;
+        opType.tsymbol = typeSymbol;
+
         rootScope.define(name, symbol);
     }
 

--- a/language-server/modules/langserver-core/src/test/resources/completion/annotation_ctx/config/langAnnotations1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/annotation_ctx/config/langAnnotations1.json
@@ -1,0 +1,588 @@
+{
+  "position": {
+    "line": 3,
+    "character": 16
+  },
+  "source": "annotation_ctx/source/langAnnotations1.bal",
+  "description": "",
+  "items": [
+    {
+      "label": "int",
+      "kind": "TypeParameter",
+      "detail": "Int",
+      "sortText": "N",
+      "insertText": "int",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "byte",
+      "kind": "TypeParameter",
+      "detail": "Byte",
+      "sortText": "N",
+      "insertText": "byte",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "float",
+      "kind": "TypeParameter",
+      "detail": "Float",
+      "sortText": "N",
+      "insertText": "float",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "decimal",
+      "kind": "TypeParameter",
+      "detail": "Decimal",
+      "sortText": "N",
+      "insertText": "decimal",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string",
+      "kind": "TypeParameter",
+      "detail": "String",
+      "sortText": "N",
+      "insertText": "string",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "boolean",
+      "kind": "TypeParameter",
+      "detail": "Boolean",
+      "sortText": "N",
+      "insertText": "boolean",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml",
+      "kind": "TypeParameter",
+      "detail": "Xml",
+      "sortText": "N",
+      "insertText": "xml",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "future",
+      "kind": "TypeParameter",
+      "detail": "Future",
+      "sortText": "N",
+      "insertText": "future",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "any",
+      "kind": "TypeParameter",
+      "detail": "Any",
+      "sortText": "N",
+      "insertText": "any",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "null",
+      "kind": "TypeParameter",
+      "detail": "Nil",
+      "sortText": "N",
+      "insertText": "null",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "never",
+      "kind": "TypeParameter",
+      "detail": "Never",
+      "sortText": "N",
+      "insertText": "never",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "handle",
+      "kind": "TypeParameter",
+      "detail": "Handle",
+      "sortText": "N",
+      "insertText": "handle",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "typedesc",
+      "kind": "TypeParameter",
+      "detail": "Typedesc",
+      "sortText": "N",
+      "insertText": "typedesc",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "readonly",
+      "kind": "TypeParameter",
+      "detail": "Readonly",
+      "sortText": "N",
+      "insertText": "readonly",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "stream",
+      "kind": "TypeParameter",
+      "detail": "Stream",
+      "sortText": "N",
+      "insertText": "stream",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "table",
+      "kind": "TypeParameter",
+      "detail": "Table",
+      "sortText": "N",
+      "insertText": "table",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "(any & readonly)",
+      "kind": "TypeParameter",
+      "detail": "Intersection",
+      "sortText": "N",
+      "insertText": "(any & readonly)",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Thread",
+      "kind": "TypeParameter",
+      "detail": "Union",
+      "sortText": "N",
+      "insertText": "Thread",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "StrandData",
+      "kind": "Struct",
+      "detail": "Record",
+      "documentation": {
+        "left": "Describes Strand execution details for the runtime.\n"
+      },
+      "sortText": "M",
+      "insertText": "StrandData",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "error",
+      "kind": "Event",
+      "detail": "Error",
+      "documentation": {
+        "left": "Default error type.\nThe type parameter is for the error detail type. It's constrained to Cloneable type."
+      },
+      "sortText": "L",
+      "insertText": "error",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "anydata",
+      "kind": "TypeParameter",
+      "detail": "Anydata",
+      "documentation": {
+        "left": "Denotes anydata type."
+      },
+      "sortText": "N",
+      "insertText": "anydata",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "json",
+      "kind": "TypeParameter",
+      "detail": "Json",
+      "documentation": {
+        "left": "Denotes json type."
+      },
+      "sortText": "N",
+      "insertText": "json",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "...()",
+      "kind": "Function",
+      "detail": "object {public isolated function iterator() returns object {public isolated function next() returns record {|int value;|}?;};}",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.annotations:0.0.0_  \n  \n  \n  \n  \n**Return** `object {public isolated function iterator() returns object {public isolated function next() returns record {|int value;|}?;};}`   \n  \n"
+        }
+      },
+      "sortText": "A",
+      "filterText": "...",
+      "insertText": "...()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "..<()",
+      "kind": "Function",
+      "detail": "object {public isolated function iterator() returns object {public isolated function next() returns record {|int value;|}?;};}",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.annotations:0.0.0_  \n  \n  \n  \n  \n**Return** `object {public isolated function iterator() returns object {public isolated function next() returns record {|int value;|}?;};}`   \n  \n"
+        }
+      },
+      "sortText": "A",
+      "filterText": "..<",
+      "insertText": "..<()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "+()",
+      "kind": "Function",
+      "detail": "decimal",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.annotations:0.0.0_  \n  \n  \n  \n  \n**Return** `decimal`   \n  \n"
+        }
+      },
+      "sortText": "A",
+      "filterText": "+",
+      "insertText": "+()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "-()",
+      "kind": "Function",
+      "detail": "decimal",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.annotations:0.0.0_  \n  \n  \n  \n  \n**Return** `decimal`   \n  \n"
+        }
+      },
+      "sortText": "A",
+      "filterText": "-",
+      "insertText": "-()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "/()",
+      "kind": "Function",
+      "detail": "decimal",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.annotations:0.0.0_  \n  \n  \n  \n  \n**Return** `decimal`   \n  \n"
+        }
+      },
+      "sortText": "A",
+      "filterText": "/",
+      "insertText": "/()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "*()",
+      "kind": "Function",
+      "detail": "decimal",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.annotations:0.0.0_  \n  \n  \n  \n  \n**Return** `decimal`   \n  \n"
+        }
+      },
+      "sortText": "A",
+      "filterText": "*",
+      "insertText": "*()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "%()",
+      "kind": "Function",
+      "detail": "decimal",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.annotations:0.0.0_  \n  \n  \n  \n  \n**Return** `decimal`   \n  \n"
+        }
+      },
+      "sortText": "A",
+      "filterText": "%",
+      "insertText": "%()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "&()",
+      "kind": "Function",
+      "detail": "int",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.annotations:0.0.0_  \n  \n  \n  \n  \n**Return** `int`   \n  \n"
+        }
+      },
+      "sortText": "A",
+      "filterText": "&",
+      "insertText": "&()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "|()",
+      "kind": "Function",
+      "detail": "int",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.annotations:0.0.0_  \n  \n  \n  \n  \n**Return** `int`   \n  \n"
+        }
+      },
+      "sortText": "A",
+      "filterText": "|",
+      "insertText": "|()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "^()",
+      "kind": "Function",
+      "detail": "int",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.annotations:0.0.0_  \n  \n  \n  \n  \n**Return** `int`   \n  \n"
+        }
+      },
+      "sortText": "A",
+      "filterText": "^",
+      "insertText": "^()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "<<()",
+      "kind": "Function",
+      "detail": "int",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.annotations:0.0.0_  \n  \n  \n  \n  \n**Return** `int`   \n  \n"
+        }
+      },
+      "sortText": "A",
+      "filterText": "<<",
+      "insertText": "<<()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": ">>()",
+      "kind": "Function",
+      "detail": "int",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.annotations:0.0.0_  \n  \n  \n  \n  \n**Return** `int`   \n  \n"
+        }
+      },
+      "sortText": "A",
+      "filterText": ">>",
+      "insertText": ">>()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": ">>>()",
+      "kind": "Function",
+      "detail": "int",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.annotations:0.0.0_  \n  \n  \n  \n  \n**Return** `int`   \n  \n"
+        }
+      },
+      "sortText": "A",
+      "filterText": ">>>",
+      "insertText": ">>>()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "~()",
+      "kind": "Function",
+      "detail": "int",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.annotations:0.0.0_  \n  \n  \n  \n  \n**Return** `int`   \n  \n"
+        }
+      },
+      "sortText": "A",
+      "filterText": "~",
+      "insertText": "~()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "==()",
+      "kind": "Function",
+      "detail": "boolean",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.annotations:0.0.0_  \n  \n  \n  \n  \n**Return** `boolean`   \n  \n"
+        }
+      },
+      "sortText": "A",
+      "filterText": "==",
+      "insertText": "==()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "!=()",
+      "kind": "Function",
+      "detail": "boolean",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.annotations:0.0.0_  \n  \n  \n  \n  \n**Return** `boolean`   \n  \n"
+        }
+      },
+      "sortText": "A",
+      "filterText": "!=",
+      "insertText": "!=()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "equals()",
+      "kind": "Function",
+      "detail": "boolean",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.annotations:0.0.0_  \n  \n  \n  \n  \n**Return** `boolean`   \n  \n"
+        }
+      },
+      "sortText": "A",
+      "filterText": "equals",
+      "insertText": "equals()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "===()",
+      "kind": "Function",
+      "detail": "boolean",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.annotations:0.0.0_  \n  \n  \n  \n  \n**Return** `boolean`   \n  \n"
+        }
+      },
+      "sortText": "A",
+      "filterText": "===",
+      "insertText": "===()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "!==()",
+      "kind": "Function",
+      "detail": "boolean",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.annotations:0.0.0_  \n  \n  \n  \n  \n**Return** `boolean`   \n  \n"
+        }
+      },
+      "sortText": "A",
+      "filterText": "!==",
+      "insertText": "!==()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "<()",
+      "kind": "Function",
+      "detail": "boolean",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.annotations:0.0.0_  \n  \n  \n  \n  \n**Return** `boolean`   \n  \n"
+        }
+      },
+      "sortText": "A",
+      "filterText": "<",
+      "insertText": "<()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "<=()",
+      "kind": "Function",
+      "detail": "boolean",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.annotations:0.0.0_  \n  \n  \n  \n  \n**Return** `boolean`   \n  \n"
+        }
+      },
+      "sortText": "A",
+      "filterText": "<=",
+      "insertText": "<=()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": ">()",
+      "kind": "Function",
+      "detail": "boolean",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.annotations:0.0.0_  \n  \n  \n  \n  \n**Return** `boolean`   \n  \n"
+        }
+      },
+      "sortText": "A",
+      "filterText": ">",
+      "insertText": ">()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": ">=()",
+      "kind": "Function",
+      "detail": "boolean",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.annotations:0.0.0_  \n  \n  \n  \n  \n**Return** `boolean`   \n  \n"
+        }
+      },
+      "sortText": "A",
+      "filterText": ">=",
+      "insertText": ">=()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "&&()",
+      "kind": "Function",
+      "detail": "boolean",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.annotations:0.0.0_  \n  \n  \n  \n  \n**Return** `boolean`   \n  \n"
+        }
+      },
+      "sortText": "A",
+      "filterText": "&&",
+      "insertText": "&&()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "||()",
+      "kind": "Function",
+      "detail": "boolean",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.annotations:0.0.0_  \n  \n  \n  \n  \n**Return** `boolean`   \n  \n"
+        }
+      },
+      "sortText": "A",
+      "filterText": "||",
+      "insertText": "||()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "!()",
+      "kind": "Function",
+      "detail": "boolean",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.annotations:0.0.0_  \n  \n  \n  \n  \n**Return** `boolean`   \n  \n"
+        }
+      },
+      "sortText": "A",
+      "filterText": "!",
+      "insertText": "!()",
+      "insertTextFormat": "Snippet"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/annotation_ctx/source/langAnnotations1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/annotation_ctx/source/langAnnotations1.bal
@@ -1,0 +1,5 @@
+import ballerina/lang.annotations;
+
+function test() {
+    annotations:
+}


### PR DESCRIPTION
## Purpose
> $title

Fixes #39318

## Approach

## Samples

## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
