### PR TITLE
Verify member variable is public before mocking

### DIFF
--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/mock/MockConstants.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/mock/MockConstants.java
@@ -39,6 +39,7 @@ public class MockConstants {
     public static final String INVALID_MOCK_OBJECT_ERROR = "InvalidObjectError";
     public static final String FUNCTION_SIGNATURE_MISMATCH_ERROR = "FunctionSignatureMismatchError";
     public static final String INVALID_MEMBER_FIELD_ERROR = "InvalidMemberFieldError";
+    public static final String NON_PUBLIC_MEMBER_FIELD_ERROR = "NonPublicMemberFieldError";
 
     public static final String FUNCTION_CALL_ERROR = "FunctionCallError";
 }

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/mock/ObjectMock.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/mock/ObjectMock.java
@@ -20,6 +20,7 @@ package org.ballerinalang.testerina.natives.mock;
 import io.ballerina.runtime.api.PredefinedTypes;
 import io.ballerina.runtime.api.TypeTags;
 import io.ballerina.runtime.api.creators.ErrorCreator;
+import io.ballerina.runtime.api.flags.SymbolFlags;
 import io.ballerina.runtime.api.types.Field;
 import io.ballerina.runtime.api.types.MethodType;
 import io.ballerina.runtime.api.types.ObjectType;
@@ -282,7 +283,12 @@ public class ObjectMock {
 
             // register return value for member field
             String fieldName = caseObj.getStringValue(StringUtils.fromString("fieldName")).toString();
-
+            if (!validateFieldAccess(objectType, fieldName)) {
+                String detail = "member field should be public to be mocked. " +
+                        "The provided field '" + fieldName + "' is not public";
+                return ErrorCreator.createError(StringUtils.fromString(MockConstants.NON_PUBLIC_MEMBER_FIELD_ERROR),
+                        StringUtils.fromString(detail));
+            }
             if (!validateFieldValue(returnVal, objectType.getFields().get(fieldName).getFieldType())) {
                 String detail = "return value provided does not match the type of '" + fieldName + "'";
                 return ErrorCreator.createError(
@@ -295,6 +301,10 @@ public class ObjectMock {
             MockRegistry.getInstance().registerCase(mockObj, fieldName, null, returnVal);
         }
         return null;
+    }
+
+    private static boolean validateFieldAccess(ObjectType objectType, String fieldName) {
+        return SymbolFlags.isFlagOn(objectType.getFields().get(fieldName).getFlags(), SymbolFlags.PUBLIC);
     }
 
     /**

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/mock/ObjectMock.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/mock/ObjectMock.java
@@ -283,7 +283,7 @@ public class ObjectMock {
 
             // register return value for member field
             String fieldName = caseObj.getStringValue(StringUtils.fromString("fieldName")).toString();
-            if (!validateFieldAccess(objectType, fieldName)) {
+            if (!validateFieldAccessIsPublic(objectType, fieldName)) {
                 String detail = "member field should be public to be mocked. " +
                         "The provided field '" + fieldName + "' is not public";
                 return ErrorCreator.createError(StringUtils.fromString(MockConstants.NON_PUBLIC_MEMBER_FIELD_ERROR),
@@ -303,7 +303,7 @@ public class ObjectMock {
         return null;
     }
 
-    private static boolean validateFieldAccess(ObjectType objectType, String fieldName) {
+    private static boolean validateFieldAccessIsPublic(ObjectType objectType, String fieldName) {
         return SymbolFlags.isFlagOn(objectType.getFields().get(fieldName).getFlags(), SymbolFlags.PUBLIC);
     }
 

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/MockTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/MockTest.java
@@ -181,7 +181,10 @@ public class MockTest extends BaseTestCase {
                         "MockTest-testObjectMocking_NegativeCases6.txt"},
                 {"return value provided does not match the return type of function 'get_stream()'",
                         "object_mocking:testMockInvalidStream",
-                        "MockTest-testObjectMocking_NegativeCases7.txt"}
+                        "MockTest-testObjectMocking_NegativeCases7.txt"},
+                {"member field should be public to be mocked. The provided field 'path' is not public",
+                        "object_mocking:testNonPublicMemberFieldMock",
+                        "MockTest-testObjectMocking_NegativeCases8.txt"}
         };
     }
 

--- a/tests/testerina-integration-test/src/test/resources/command-outputs/unix/MockTest-testObjectMocking_NegativeCases8.txt
+++ b/tests/testerina-integration-test/src/test/resources/command-outputs/unix/MockTest-testObjectMocking_NegativeCases8.txt
@@ -1,0 +1,23 @@
+Compiling source
+	intg_tests/object_mocking:0.0.0
+WARNING [modules/TestHttpClient/main.bal:(54:45,54:82)] this function should explicitly return a value
+WARNING [main.bal:(47:5,47:47)] unused variable 'closeErr'
+
+Running Tests with Coverage
+
+	object_mocking
+
+		[fail] testNonPublicMemberFieldMock:
+
+		    member field should be public to be mocked. The provided field 'path' is not public
+			
+
+
+		0 passing
+		1 failing
+		0 skipped
+
+Generating Test Report
+	*****project-based-tests/object-mocking-tests/target/report/test_results.json
+
+error: there are test failures

--- a/tests/testerina-integration-test/src/test/resources/command-outputs/windows/MockTest-testObjectMocking_NegativeCases8.txt
+++ b/tests/testerina-integration-test/src/test/resources/command-outputs/windows/MockTest-testObjectMocking_NegativeCases8.txt
@@ -1,0 +1,4 @@
+Compiling source
+	intg*****project-based-tests\object-mocking-tests\target\report\test_results.json
+
+error: there are test failures

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/object-mocking-tests/modules/TestHttpClient/main.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/object-mocking-tests/modules/TestHttpClient/main.bal
@@ -19,6 +19,7 @@ public type Error distinct error;
 public client class HttpClient {
 
     public string url;
+    string path = "";
 
     public function init(string url) {
         self.url = url;

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/object-mocking-tests/tests/main_error_test.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/object-mocking-tests/tests/main_error_test.bal
@@ -82,3 +82,10 @@ function testMockInvalidStream() {
     TestHttpClient:AttributeDAO|error result = getAttribute();
     test:assertEquals(result, mockAttributeDAO);
 }
+
+// when the mocked member field is not public
+@test:Config {}
+function testNonPublicMemberFieldMock() {
+    TestHttpClient:HttpClient mockHttpClient = test:mock(TestHttpClient:HttpClient);
+    test:prepare(mockHttpClient).getMember("path").thenReturn("tmp");
+}


### PR DESCRIPTION
## Purpose
$subject
Fixes #30893

## Approach
check the access modifiers before allowing to stub member variables allowing to mock only public member variables

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
