### PR TITLE
Fix NPE in `SemanticModel.typeOf()` API for resource path access action nodes

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
@@ -323,7 +323,8 @@ public class BallerinaSemanticModel implements SemanticModel {
     }
 
     private BType getDeterminedType(BLangNode node, LineRange range) {
-        if (node.getKind() == NodeKind.INVOCATION && node.getDeterminedType().getKind() == TypeKind.FUTURE) {
+        if (node.getKind() == NodeKind.INVOCATION && node.getDeterminedType() != null
+                && node.getDeterminedType().getKind() == TypeKind.FUTURE) {
             BLangInvocation invocationNode = (BLangInvocation) node;
             if (invocationNode.isAsync()
                     && PositionUtil.withinBlock(range.startLine(), invocationNode.getName().getPosition())) {

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolBIRTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolBIRTest.java
@@ -184,7 +184,8 @@ public class SymbolBIRTest {
                 "Annot", "Detail", "Service", "FnTypeA", "FnTypeB", "Address"));
 
         
-        SemanticAPITestUtils.assertList(fooModule.classes(), List.of("PersonObj", "Dog", "EmployeeObj", "Human"));
+        SemanticAPITestUtils.assertList(fooModule.classes(), List.of("PersonObj", "Dog", "EmployeeObj", "Human", 
+                "Client", "Response"));
         SemanticAPITestUtils.assertList(fooModule.enums(), List.of("Colour"));
 
         List<String> allSymbols = getSymbolNames(fooPkgSymbol, 0);

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typeof/TypeOfRegressionTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typeof/TypeOfRegressionTest.java
@@ -73,4 +73,15 @@ public class TypeOfRegressionTest {
         assertEquals(type.get().kind(), SymbolKind.TYPE);
         assertEquals(type.get().typeKind(), TypeDescKind.INT);
     }
+
+    @Test
+    public void testResourcePathAccess() {
+        model =SemanticAPITestUtils.getDefaultModulesSemanticModel(
+                "test-src/regression-tests/typeof_resource_path_action.bal");
+
+        Optional<TypeSymbol> type = model.typeOf(LineRange.from("typeof_resource_path_action.bal",
+                LinePosition.from(4, 23), LinePosition.from(4, 30)));
+
+        assertTrue(type.isEmpty());
+    }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typeof/TypeOfRegressionTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typeof/TypeOfRegressionTest.java
@@ -80,7 +80,7 @@ public class TypeOfRegressionTest {
                 "test-src/regression-tests/typeof_resource_path_action.bal");
 
         Optional<TypeSymbol> type = model.typeOf(LineRange.from("typeof_resource_path_action.bal",
-                LinePosition.from(20, 23), LinePosition.from(20, 30)));
+                LinePosition.from(20, 31), LinePosition.from(20, 38)));
         assertTrue(type.isEmpty());
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typeof/TypeOfRegressionTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typeof/TypeOfRegressionTest.java
@@ -80,7 +80,7 @@ public class TypeOfRegressionTest {
                 "test-src/regression-tests/typeof_resource_path_action.bal");
 
         Optional<TypeSymbol> type = model.typeOf(LineRange.from("typeof_resource_path_action.bal",
-                LinePosition.from(4, 23), LinePosition.from(4, 30)));
+                LinePosition.from(20, 23), LinePosition.from(20, 30)));
 
         assertTrue(type.isEmpty());
     }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typeof/TypeOfRegressionTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typeof/TypeOfRegressionTest.java
@@ -76,12 +76,11 @@ public class TypeOfRegressionTest {
 
     @Test
     public void testResourcePathAccess() {
-        model =SemanticAPITestUtils.getDefaultModulesSemanticModel(
+        model = SemanticAPITestUtils.getDefaultModulesSemanticModel(
                 "test-src/regression-tests/typeof_resource_path_action.bal");
 
         Optional<TypeSymbol> type = model.typeOf(LineRange.from("typeof_resource_path_action.bal",
                 LinePosition.from(20, 23), LinePosition.from(20, 30)));
-
         assertTrue(type.isEmpty());
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/regression-tests/typeof_resource_path_action.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/regression-tests/typeof_resource_path_action.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2023 WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina/http;
 
 public function main() returns error? {

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/regression-tests/typeof_resource_path_action.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/regression-tests/typeof_resource_path_action.bal
@@ -14,9 +14,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/http;
+import testorg/testproject as tp;
 
 public function main() returns error? {
-    http:Client cl= check new("");
-    cl->/"path1"/path2/.post();
+    tp:Client cl= check new("");
+    cl->path1/"id1"/path2/"id2".post();
 }

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/regression-tests/typeof_resource_path_action.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/regression-tests/typeof_resource_path_action.bal
@@ -17,6 +17,6 @@
 import testorg/testproject as tp;
 
 public function main() returns error? {
-    tp:Client cl= check new("");
+    tp:Client cl = check new("");
     cl->path1/"id1"/path2/"id2".post();
 }

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/regression-tests/typeof_resource_path_action.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/regression-tests/typeof_resource_path_action.bal
@@ -1,0 +1,6 @@
+import ballerina/http;
+
+public function main() returns error? {
+    http:Client cl= check new("");
+    cl->/"path1"/path2/.post();
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/testproject/client.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/testproject/client.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2023 WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 # + url - Target service url
 public client class Client {
     public string url;

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/testproject/client.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/testproject/client.bal
@@ -1,0 +1,25 @@
+# + url - Target service url
+public client class Client {
+    public string url;
+
+    public function init(string url) {
+        self.url = url;
+    }
+    
+    # Sample resource method.
+    #
+    # + id1 - Path parameter
+    # + ids - Rest path parameter
+    # + str - Argument
+    # + ids2 - Rest argument
+    # + return - The response for the request
+    resource function post path1/[string id1]/path2/[string... ids](string str, string... ids2) returns Response {
+        return new Response();
+    }
+    
+}
+
+public class Response {
+    public int statusCode = 200;
+    public string reasonPhrase = "Test Reason phrase";
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/testproject/client.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/testproject/client.bal
@@ -16,7 +16,6 @@ public client class Client {
     resource function post path1/[string id1]/path2/[string... ids](string str, string... ids2) returns Response {
         return new Response();
     }
-    
 }
 
 public class Response {


### PR DESCRIPTION
## Purpose
> $title

Fixes #39070

## Approach

## Samples

## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
