### PR TITLE
[2201.4.2 - Stage] Fix invalid error when the error type reference in the error constructor is loaded via the BIR.

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -3467,11 +3467,8 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
 
         List<BType> errorDetailTypes = new ArrayList<>(expandedCandidates.size());
         for (BType expandedCandidate : expandedCandidates) {
-            BType detailType = Types.getReferredType(expandedCandidate);
-            if (detailType.tag == TypeTags.INTERSECTION) {
-                detailType = ((BIntersectionType) detailType).effectiveType;
-            }
-            detailType = ((BErrorType) detailType).detailType;
+            BType detailType = ((BErrorType) Types.getEffectiveType(Types
+                    .getReferredType(expandedCandidate))).detailType;
             errorDetailTypes.add(Types.getReferredType(detailType));
         }
 
@@ -3653,10 +3650,7 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
             }
         } else {
             // if `errorTypeRef.type == semanticError` then an error is already logged.
-            BType errorType = Types.getReferredType(errorTypeRef.getBType());
-            if (errorType.tag == TypeTags.INTERSECTION) {
-                errorType = ((BIntersectionType) errorType).effectiveType;
-            }
+            BType errorType = Types.getEffectiveType(Types.getReferredType(errorTypeRef.getBType()));
             if (errorType.tag != TypeTags.ERROR) {
                 if (errorType.tag != TypeTags.SEMANTIC_ERROR) {
                     dlog.error(errorTypeRef.pos, DiagnosticErrorCode.INVALID_ERROR_TYPE_REFERENCE, errorTypeRef);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -3467,7 +3467,11 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
 
         List<BType> errorDetailTypes = new ArrayList<>(expandedCandidates.size());
         for (BType expandedCandidate : expandedCandidates) {
-            BType detailType = ((BErrorType) Types.getReferredType(expandedCandidate)).detailType;
+            BType detailType = Types.getReferredType(expandedCandidate);
+            if (detailType.tag == TypeTags.INTERSECTION) {
+                detailType = ((BIntersectionType) detailType).effectiveType;
+            }
+            detailType = ((BErrorType) detailType).detailType;
             errorDetailTypes.add(Types.getReferredType(detailType));
         }
 
@@ -3650,6 +3654,9 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
         } else {
             // if `errorTypeRef.type == semanticError` then an error is already logged.
             BType errorType = Types.getReferredType(errorTypeRef.getBType());
+            if (errorType.tag == TypeTags.INTERSECTION) {
+                errorType = ((BIntersectionType) errorType).effectiveType;
+            }
             if (errorType.tag != TypeTags.ERROR) {
                 if (errorType.tag != TypeTags.SEMANTIC_ERROR) {
                     dlog.error(errorTypeRef.pos, DiagnosticErrorCode.INVALID_ERROR_TYPE_REFERENCE, errorTypeRef);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/types/ErrorTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/types/ErrorTypeTest.java
@@ -33,13 +33,14 @@ import org.testng.annotations.Test;
  */
 public class ErrorTypeTest {
 
-    private CompileResult result;
-    private CompileResult negativeResult;
+    private CompileResult result, errorConstructorResult, negativeResult;
 
     @BeforeClass
     public void setup() {
         BCompileUtil.compileAndCacheBala("test-src/bala/test_projects/test_project_errors");
+        BCompileUtil.compileAndCacheBala("test-src/bala/test_projects/test_project_error_constructor");
         result = BCompileUtil.compile("test-src/bala/test_bala/types/error_type_test.bal");
+        errorConstructorResult = BCompileUtil.compile("test-src/bala/test_bala/types/error_constructor_test.bal");
         negativeResult = BCompileUtil.compile("test-src/bala/test_bala/types/error_type_negative_test.bal");
     }
 
@@ -113,6 +114,11 @@ public class ErrorTypeTest {
                 "incompatible types: expected 'testorg/errors:1.0.0:NewPostDefinedError', " +
                         "found 'testorg/errors:1.0.0:PostDefinedError'", 28, 32);
         Assert.assertEquals(negativeResult.getErrorCount(), i);
+    }
+
+    @Test
+    public void testErrorConstructor() {
+        BRunUtil.invoke(errorConstructorResult, "testErrorConstructor");
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/types/error_constructor_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/types/error_constructor_test.bal
@@ -1,0 +1,42 @@
+// Copyright (c) 2022 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import testorg/test_project_error_constructor as er;
+
+public function testErrorConstructor() {
+    er:E2 e = error("error-A", body = "error-A2");
+    error e2 = error er:E2("error-B", body = "error-B2");
+
+    assertEquality(e is er:E2, true);
+    assertEquality(e2 is er:E2, true);
+    assertEquality(e.message(), "error-A");
+    assertEquality(e2.message(), "error-B");
+}
+
+function assertEquality(any|error expected, any|error actual) {
+    if expected is anydata && actual is anydata && expected == actual {
+        return;
+    }
+
+    if expected === actual {
+        return;
+    }
+
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
+    panic error("Assertion Error",
+            message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/types/error_constructor_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/types/error_constructor_test.bal
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+// Copyright (c) 2023 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 //
 // WSO2 Inc. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/test_project_error_constructor/Ballerina.toml
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/test_project_error_constructor/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "testorg"
+name = "test_project_error_constructor"
+version = "0.1.0"

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/test_project_error_constructor/main.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/test_project_error_constructor/main.bal
@@ -1,0 +1,2 @@
+public type E1 distinct error;
+public type E2 distinct (E1 & error<record {|anydata body;|}>);


### PR DESCRIPTION
## Purpose
> Fix invalid error when the error type reference in the error constructor is loaded via the BIR.

Fixes #38346


## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
