### PR TITLE
[2201.5.0] Fix new-line support for config environment variables

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/launch/LaunchUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/launch/LaunchUtils.java
@@ -45,6 +45,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import static io.ballerina.runtime.internal.configurable.providers.toml.TomlConstants.CONFIG_DATA_ENV_VARIABLE;
 import static io.ballerina.runtime.internal.configurable.providers.toml.TomlConstants.CONFIG_FILES_ENV_VARIABLE;
@@ -58,6 +59,7 @@ import static io.ballerina.runtime.internal.configurable.providers.toml.TomlCons
 public class LaunchUtils {
 
     private static final PrintStream outStream = System.out;
+    private static final Pattern UNESCAPED_NEWLINE_CHAR = Pattern.compile("\\\\n(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)");
 
     private LaunchUtils() {
     }
@@ -134,7 +136,7 @@ public class LaunchUtils {
                 paths.add(Paths.get(pathString));
             }
         } else if (envVars.containsKey(CONFIG_DATA_ENV_VARIABLE)) {
-            return envVars.get(CONFIG_DATA_ENV_VARIABLE);
+            return UNESCAPED_NEWLINE_CHAR.matcher(envVars.get(CONFIG_DATA_ENV_VARIABLE)).replaceAll("\n");
         } else {
             if (Files.exists(DEFAULT_CONFIG_PATH)) {
                 paths.add(DEFAULT_CONFIG_PATH);

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/configurables/ConfigurableTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/configurables/ConfigurableTest.java
@@ -133,6 +133,13 @@ public class ConfigurableTest extends BaseTest {
                 "decimalArr = [8.9, 4.5, 6.2]";
         executeBalCommand("", "envVarPkg",
                 addEnvironmentVariables(Map.ofEntries(Map.entry(CONFIG_DATA_ENV_VARIABLE, configData))));
+
+        configData = "[envVarPkg]\nintVar = 42\nfloatVar = 3.5\nstringVar = \"abc\"\nbooleanVar = true\n" +
+                "decimalVar = 24.87\nintArr = [1,2,3]\nfloatArr = [9.0, 5.6]\n" +
+                "stringArr = [\"red\", \"yellow\", \"green\"]\nbooleanArr = [true, false,false, true]\n" +
+                "decimalArr = [8.9, 4.5, 6.2]";
+        executeBalCommand("", "envVarPkg",
+                addEnvironmentVariables(Map.ofEntries(Map.entry(CONFIG_DATA_ENV_VARIABLE, configData))));
     }
 
     @Test

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/configurables/ConfigurableTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/configurables/ConfigurableTest.java
@@ -140,6 +140,21 @@ public class ConfigurableTest extends BaseTest {
                 "decimalArr = [8.9, 4.5, 6.2]";
         executeBalCommand("", "envVarPkg",
                 addEnvironmentVariables(Map.ofEntries(Map.entry(CONFIG_DATA_ENV_VARIABLE, configData))));
+
+        configData = "[envVarPkg]\\nintVar = 42\\nfloatVar = 3.5\\nstringVar = \"abc\"\\nbooleanVar = true\\n" +
+                "decimalVar = 24.87\\nintArr = [1,2,3]\\nfloatArr = [9.0, 5.6]\\n" +
+                "stringArr = [\"red\", \"yellow\", \"green\"]\\nbooleanArr = [true, false,false, true]\\n" +
+                "decimalArr = [8.9, 4.5, 6.2]";
+        executeBalCommand("", "envVarPkg",
+                addEnvironmentVariables(Map.ofEntries(Map.entry(CONFIG_DATA_ENV_VARIABLE, configData))));
+
+        configData =
+                "[envVarPkg]\\n\\r intVar = 42\\n\\r floatVar = 3.5\\n\\r stringVar = \"abc\"\\n\\r booleanVar = true\\n\\r " +
+                        "decimalVar = 24.87\\n\\r intArr = [1,2,3]\\n\\r floatArr = [9.0, 5.6]\\n\\r " +
+                        "stringArr = [\"red\", \"yellow\", \"green\"]\\n\\r booleanArr = [true, false,false, true]\\n\\r " +
+                        "decimalArr = [8.9, 4.5, 6.2]";
+        executeBalCommand("", "envVarPkg",
+                addEnvironmentVariables(Map.ofEntries(Map.entry(CONFIG_DATA_ENV_VARIABLE, configData))));
     }
 
     @Test


### PR DESCRIPTION
## Purpose
$subject 
Fixes #40084

## Approach
Convert the `\\n` character sequence into `\n` when parsing environment variable content.

## Samples
Execute following 
```
export BAL_CONFIG_DATA=[ballerina.log]\nformat = \"json\""
```
And use any log function inside the code. 

error:
```
error: [BAL_CONFIG_DATA:(1:25,1:33)] unused configuration value 'ballerina.log.'
```
## Remarks
Related https://github.com/ballerina-platform/ballerina-lang/issues/40096

## CheckList 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [x] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
