### PR TITLE
Verify member variable is public before mocking

### DIFF
--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/mock/MockConstants.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/mock/MockConstants.java
@@ -39,6 +39,7 @@ public class MockConstants {
     public static final String INVALID_MOCK_OBJECT_ERROR = "InvalidObjectError";
     public static final String FUNCTION_SIGNATURE_MISMATCH_ERROR = "FunctionSignatureMismatchError";
     public static final String INVALID_MEMBER_FIELD_ERROR = "InvalidMemberFieldError";
+    public static final String NON_PUBLIC_MEMBER_FIELD_ERROR = "NonPublicMemberFieldError";
 
     public static final String FUNCTION_CALL_ERROR = "FunctionCallError";
 }

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/mock/ObjectMock.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/mock/ObjectMock.java
@@ -20,6 +20,7 @@ package org.ballerinalang.testerina.natives.mock;
 import io.ballerina.runtime.api.PredefinedTypes;
 import io.ballerina.runtime.api.TypeTags;
 import io.ballerina.runtime.api.creators.ErrorCreator;
+import io.ballerina.runtime.api.flags.SymbolFlags;
 import io.ballerina.runtime.api.types.Field;
 import io.ballerina.runtime.api.types.MethodType;
 import io.ballerina.runtime.api.types.ObjectType;
@@ -282,7 +283,12 @@ public class ObjectMock {
 
             // register return value for member field
             String fieldName = caseObj.getStringValue(StringUtils.fromString("fieldName")).toString();
-
+            if (!validateFieldAccessIsPublic(objectType, fieldName)) {
+                String detail = "member field should be public to be mocked. " +
+                        "The provided field '" + fieldName + "' is not public";
+                return ErrorCreator.createError(StringUtils.fromString(MockConstants.NON_PUBLIC_MEMBER_FIELD_ERROR),
+                        StringUtils.fromString(detail));
+            }
             if (!validateFieldValue(returnVal, objectType.getFields().get(fieldName).getFieldType())) {
                 String detail = "return value provided does not match the type of '" + fieldName + "'";
                 return ErrorCreator.createError(
@@ -295,6 +301,10 @@ public class ObjectMock {
             MockRegistry.getInstance().registerCase(mockObj, fieldName, null, returnVal);
         }
         return null;
+    }
+
+    private static boolean validateFieldAccessIsPublic(ObjectType objectType, String fieldName) {
+        return SymbolFlags.isFlagOn(objectType.getFields().get(fieldName).getFlags(), SymbolFlags.PUBLIC);
     }
 
     /**

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/MockTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/MockTest.java
@@ -167,6 +167,19 @@ public class MockTest extends BaseTestCase {
         AssertionUtils.assertOutput(baseOutputFile, output);
     }
 
+    @Test
+    public void testObjectMocking_NonPublicField() throws BallerinaTestException, IOException {
+        String[] args = mergeCoverageArgs(new String[]{"--tests",
+                "non_public_field_mock:testNonPublicMemberFieldMock"});
+        String output =
+                balClient.runMainAndReadStdOut("test", args, new HashMap<>(),
+                        projectBasedTestsPath.resolve("non-public-field-mock").toString(), false);
+        String firstString = "Generating Test Report\n\t";
+        String endString = "project-based-tests";
+        output = CommonUtils.replaceVaryingString(firstString, endString, output);
+        AssertionUtils.assertOutput("MockTest-testObjectMocking_NegativeCases8.txt", output);
+    }
+
     @DataProvider(name = "testNegativeCases")
     public static Object[][] negativeCases() {
         return new Object[][] {

--- a/tests/testerina-integration-test/src/test/resources/command-outputs/unix/MockTest-testObjectMocking_NegativeCases8.txt
+++ b/tests/testerina-integration-test/src/test/resources/command-outputs/unix/MockTest-testObjectMocking_NegativeCases8.txt
@@ -1,0 +1,21 @@
+Compiling source
+	intg_tests/non_public_field_mock:0.0.0
+
+Running Tests with Coverage
+
+	non_public_field_mock
+
+		[fail] testNonPublicMemberFieldMock:
+
+		    member field should be public to be mocked. The provided field 'url' is not public
+			
+
+
+		0 passing
+		1 failing
+		0 skipped
+
+Generating Test Report
+	*****project-based-tests/non-public-field-mock/target/report/test_results.json
+
+error: there are test failures

--- a/tests/testerina-integration-test/src/test/resources/command-outputs/windows/MockTest-testObjectMocking_NegativeCases8.txt
+++ b/tests/testerina-integration-test/src/test/resources/command-outputs/windows/MockTest-testObjectMocking_NegativeCases8.txt
@@ -1,0 +1,4 @@
+Compiling source
+	intg*****project-based-tests\non-public-field-mock\target\report\test_results.json
+
+error: there are test failures

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/non-public-field-mock/Ballerina.toml
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/non-public-field-mock/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "intg_tests"
+name = "non_public_field_mock"
+version = "0.0.0"

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/non-public-field-mock/modules/TestClient/TestClient.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/non-public-field-mock/modules/TestClient/TestClient.bal
@@ -1,0 +1,24 @@
+// Copyright (c) 2023 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+public client class BasicHttpClient {
+
+    string url = "";
+
+    remote function get(string path) returns string {
+        return self.url + path;
+    }
+}

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/non-public-field-mock/tests/main_error_test.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/non-public-field-mock/tests/main_error_test.bal
@@ -1,0 +1,24 @@
+// Copyright (c) 2023 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+import non_public_field_mock.TestClient;
+
+@test:Config {}
+function testNonPublicMemberFieldMock() {
+   TestClient:BasicHttpClient mockBasicClient = test:mock(TestClient:BasicHttpClient);
+   test:prepare(mockBasicClient).getMember("url").thenReturn("tmp");
+}


### PR DESCRIPTION
## Purpose
$subject
Fixes https://github.com/ballerina-platform/ballerina-lang/issues/30893

## Approach
check the access modifiers before allowing to stub member variables allowing to mock only public member variables

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
