### PR TITLE
[2201.5.x] Exclude `re` from reserved keywords

### DIFF
--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/BallerinaLexer.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/BallerinaLexer.java
@@ -1013,7 +1013,6 @@ public class BallerinaLexer extends AbstractLexer {
                 return getSyntaxToken(SyntaxKind.MATCH_KEYWORD);
             case LexerTerminals.CONFLICT:
                 return getSyntaxToken(SyntaxKind.CONFLICT_KEYWORD);
-
             case LexerTerminals.CLASS:
                 return getSyntaxToken(SyntaxKind.CLASS_KEYWORD);
             case LexerTerminals.CONFIGURABLE:

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/syntax/tree/SyntaxInfo.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/syntax/tree/SyntaxInfo.java
@@ -31,16 +31,18 @@ import java.util.stream.Collectors;
  */
 public class SyntaxInfo {
 
+    private static final List<String> BALLERINA_KEYWORDS = Arrays.stream(SyntaxKind.values())
+            .filter(syntaxKind -> SyntaxKind.RE_KEYWORD.compareTo(syntaxKind) > 0)
+            .map(SyntaxKind::stringValue)
+            .collect(Collectors.toList());
+
     /**
      * Gives a list of all keywords in the ballerina.
      *
      * @return reserved keyword list
      */
     public static List<String> keywords() {
-        return Arrays.stream(SyntaxKind.values())
-                .filter(syntaxKind -> SyntaxKind.OPEN_BRACE_TOKEN.compareTo(syntaxKind) > 0)
-                .map(SyntaxKind::stringValue)
-                .collect(Collectors.toList());
+        return BALLERINA_KEYWORDS;
     }
 
     /**
@@ -50,7 +52,7 @@ public class SyntaxInfo {
      * @return {@code true}, if the input is a ballerina keyword. {@code false} otherwise
      */
     public static boolean isKeyword(String text) {
-        return keywords().contains(text);
+        return BALLERINA_KEYWORDS.contains(text);
     }
 
     /**

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/syntax/tree/SyntaxKind.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/syntax/tree/SyntaxKind.java
@@ -128,10 +128,12 @@ public enum SyntaxKind {
     READONLY_KEYWORD(318, "readonly"),
     DISTINCT_KEYWORD(319, "distinct"),
     FAIL_KEYWORD(320, "fail"),
-    RE_KEYWORD(320, "re"),
+
+    // Contextual keywords
+    RE_KEYWORD(400, "re"), // Any kind above this is considered as a keyword
 
     // Separators
-    OPEN_BRACE_TOKEN(500, "{"), // Any kind above this is considered as a keyword
+    OPEN_BRACE_TOKEN(500, "{"),
     CLOSE_BRACE_TOKEN(501, "}"),
     OPEN_PAREN_TOKEN(502, "("),
     CLOSE_PAREN_TOKEN(503, ")"),

--- a/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/tree/SyntaxInfoAPITest.java
+++ b/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/tree/SyntaxInfoAPITest.java
@@ -30,7 +30,7 @@ public class SyntaxInfoAPITest {
 
     @Test
     public void testKeywordCount() {
-        Assert.assertEquals(SyntaxInfo.keywords().size(), 100);
+        Assert.assertEquals(SyntaxInfo.keywords().size(), 99);
     }
 
     @Test
@@ -61,6 +61,11 @@ public class SyntaxInfoAPITest {
         Assert.assertFalse(SyntaxInfo.isKeyword("+"));
         Assert.assertFalse(SyntaxInfo.isKeyword(""));
         Assert.assertFalse(SyntaxInfo.isKeyword(" "));
+    }
+
+    @Test
+    public void testContextualKeywords() {
+        Assert.assertFalse(SyntaxInfo.isKeyword("re"));
     }
 
     @Test


### PR DESCRIPTION
(cherry picked from commit 43e6d39d61b795c3cfe9e4b9ce7be9ccd9d54f25)

## Purpose
$subject.

Fixes #40163

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
