### PR TITLE
Integrate subset of semtypes into jbllerina compile-time

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/BuildCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/BuildCommand.java
@@ -182,9 +182,8 @@ public class BuildCommand implements BLauncherCmd {
     @CommandLine.Option(names = "--native", description = "enable native image generation")
     private Boolean nativeImage;
 
-    @CommandLine.Option(names = "--semtype-disabled", description = "disable semtype based type checking",
-            hidden = true)
-    private boolean semtypeDisabled;
+    @CommandLine.Option(names = "--semtype-enabled", description = "enable semtype based type checking", hidden = true)
+    private boolean semtypeEnabled;
 
     public void execute() {
         long start = 0;
@@ -305,7 +304,7 @@ public class BuildCommand implements BLauncherCmd {
                 .setExportComponentModel(exportComponentModel)
                 .setEnableCache(enableCache)
                 .setNativeImage(nativeImage)
-                .setSemType(!semtypeDisabled);
+                .setSemType(semtypeEnabled);
 
         if (targetDir != null) {
             buildOptionsBuilder.targetDir(targetDir.toString());

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/BuildCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/BuildCommand.java
@@ -182,6 +182,10 @@ public class BuildCommand implements BLauncherCmd {
     @CommandLine.Option(names = "--native", description = "enable native image generation")
     private Boolean nativeImage;
 
+    @CommandLine.Option(names = "--semtype-disabled", description = "disable semtype based type checking",
+            hidden = true)
+    private boolean semtypeDisabled;
+
     public void execute() {
         long start = 0;
         if (this.helpFlag) {
@@ -300,7 +304,8 @@ public class BuildCommand implements BLauncherCmd {
                 .setExportOpenAPI(exportOpenAPI)
                 .setExportComponentModel(exportComponentModel)
                 .setEnableCache(enableCache)
-                .setNativeImage(nativeImage);
+                .setNativeImage(nativeImage)
+                .setSemType(!semtypeDisabled);
 
         if (targetDir != null) {
             buildOptionsBuilder.targetDir(targetDir.toString());

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/RunCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/RunCommand.java
@@ -102,6 +102,10 @@ public class RunCommand implements BLauncherCmd {
     @CommandLine.Option(names = "--enable-cache", description = "enable caches for the compilation", hidden = true)
     private Boolean enableCache;
 
+    @CommandLine.Option(names = "--semtype-disabled", description = "disable semtype based type checking",
+            hidden = true)
+    private boolean semtypeDisabled;
+
     private static final String runCmd =
             "bal run [--debug <port>] <executable-jar> \n" +
             "    bal run [--offline]\n" +
@@ -261,7 +265,8 @@ public class RunCommand implements BLauncherCmd {
                 .setSticky(sticky)
                 .setDumpGraph(dumpGraph)
                 .setDumpRawGraphs(dumpRawGraphs)
-                .setConfigSchemaGen(configSchemaGen);
+                .setConfigSchemaGen(configSchemaGen)
+                .setSemType(!semtypeDisabled);
 
         if (targetDir != null) {
             buildOptionsBuilder.targetDir(targetDir.toString());

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/RunCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/RunCommand.java
@@ -102,9 +102,8 @@ public class RunCommand implements BLauncherCmd {
     @CommandLine.Option(names = "--enable-cache", description = "enable caches for the compilation", hidden = true)
     private Boolean enableCache;
 
-    @CommandLine.Option(names = "--semtype-disabled", description = "disable semtype based type checking",
-            hidden = true)
-    private boolean semtypeDisabled;
+    @CommandLine.Option(names = "--semtype-enabled", description = "enable semtype based type checking", hidden = true)
+    private boolean semtypeEnabled;
 
     private static final String runCmd =
             "bal run [--debug <port>] <executable-jar> \n" +
@@ -266,7 +265,7 @@ public class RunCommand implements BLauncherCmd {
                 .setDumpGraph(dumpGraph)
                 .setDumpRawGraphs(dumpRawGraphs)
                 .setConfigSchemaGen(configSchemaGen)
-                .setSemType(!semtypeDisabled);
+                .setSemType(semtypeEnabled);
 
         if (targetDir != null) {
             buildOptionsBuilder.targetDir(targetDir.toString());

--- a/cli/ballerina-cli/src/main/resources/cli-help/ballerina-build.help
+++ b/cli/ballerina-cli/src/main/resources/cli-help/ballerina-build.help
@@ -56,8 +56,8 @@ OPTIONS
            experimental feature which supports only a limited set of
            functionality.
 
-       --semtype-disabled
-           Disable the semtype based type checking.
+       --semtype-enabled
+           Enable semtype based type checking.
 
 EXAMPLES
        Build the current package. This will generate an 'app.jar' file in the

--- a/cli/ballerina-cli/src/main/resources/cli-help/ballerina-build.help
+++ b/cli/ballerina-cli/src/main/resources/cli-help/ballerina-build.help
@@ -56,7 +56,8 @@ OPTIONS
            experimental feature which supports only a limited set of
            functionality.
 
-
+       --semtype-disabled
+           Disable the semtype based type checking.
 
 EXAMPLES
        Build the current package. This will generate an 'app.jar' file in the

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BuildOptions.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BuildOptions.java
@@ -98,6 +98,10 @@ public class BuildOptions {
         return this.compilationOptions.semtype();
     }
 
+    public boolean semtypeTest() {
+        return this.compilationOptions.semtype();
+    }
+
     CompilationOptions compilationOptions() {
         return this.compilationOptions;
     }
@@ -182,6 +186,7 @@ public class BuildOptions {
         buildOptionsBuilder.setExportComponentModel(compilationOptions.exportComponentModel);
         buildOptionsBuilder.setEnableCache(compilationOptions.enableCache);
         buildOptionsBuilder.setSemType(compilationOptions.semtype());
+        buildOptionsBuilder.setSemTypeTest(compilationOptions.semtypeTest());
 
         return buildOptionsBuilder.build();
     }
@@ -346,6 +351,11 @@ public class BuildOptions {
 
         public BuildOptionsBuilder setSemType(Boolean value) {
             compilationOptionsBuilder.setSemtype(value);
+            return this;
+        }
+
+        public BuildOptionsBuilder setSemTypeTest(Boolean value) {
+            compilationOptionsBuilder.setSemtypeTest(value);
             return this;
         }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/CompilationOptions.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/CompilationOptions.java
@@ -264,7 +264,7 @@ public class CompilationOptions {
         private Boolean exportOpenAPI;
         private Boolean exportComponentModel;
         private Boolean enableCache;
-        private Boolean semtype;
+        private Boolean semtype = true;
 
         public CompilationOptionsBuilder setOffline(Boolean value) {
             offline = value;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/CompilationOptions.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/CompilationOptions.java
@@ -39,12 +39,13 @@ public class CompilationOptions {
     Boolean exportComponentModel;
     Boolean enableCache;
     private Boolean semtype;
+    private Boolean semtypeTest;
 
     CompilationOptions(Boolean offlineBuild, Boolean observabilityIncluded, Boolean dumpBir,
                        Boolean dumpBirFile, String cloud, Boolean listConflictedClasses, Boolean sticky,
                        Boolean dumpGraph, Boolean dumpRawGraphs, Boolean withCodeGenerators,
                        Boolean withCodeModifiers, Boolean configSchemaGen, Boolean exportOpenAPI,
-                       Boolean exportComponentModel, Boolean enableCache, Boolean semtype) {
+                       Boolean exportComponentModel, Boolean enableCache, Boolean semtype, Boolean semtypeTest) {
         this.offlineBuild = offlineBuild;
         this.observabilityIncluded = observabilityIncluded;
         this.dumpBir = dumpBir;
@@ -61,6 +62,7 @@ public class CompilationOptions {
         this.exportComponentModel = exportComponentModel;
         this.enableCache = enableCache;
         this.semtype = semtype;
+        this.semtypeTest = semtypeTest;
     }
 
     public boolean offlineBuild() {
@@ -211,6 +213,11 @@ public class CompilationOptions {
         } else {
             compilationOptionsBuilder.setSemtype(this.semtype);
         }
+        if (theirOptions.semtypeTest != null) {
+            compilationOptionsBuilder.setSemtypeTest(theirOptions.semtypeTest);
+        } else {
+            compilationOptionsBuilder.setSemtypeTest(this.semtypeTest);
+        }
         return compilationOptionsBuilder.build();
     }
 
@@ -243,6 +250,10 @@ public class CompilationOptions {
         return toBooleanDefaultIfNull(this.semtype);
     }
 
+    public boolean semtypeTest() {
+        return toBooleanDefaultIfNull(this.semtypeTest);
+    }
+
     /**
      * A builder for the {@code CompilationOptions}.
      *
@@ -265,6 +276,7 @@ public class CompilationOptions {
         private Boolean exportComponentModel;
         private Boolean enableCache;
         private Boolean semtype;
+        private Boolean semtypeTest;
 
         public CompilationOptionsBuilder setOffline(Boolean value) {
             offline = value;
@@ -346,11 +358,16 @@ public class CompilationOptions {
             return this;
         }
 
+        public CompilationOptionsBuilder setSemtypeTest(Boolean value) {
+            semtypeTest = value;
+            return this;
+        }
+
         public CompilationOptions build() {
             return new CompilationOptions(offline, observabilityIncluded, dumpBir,
                     dumpBirFile, cloud, listConflictedClasses, sticky, dumpGraph, dumpRawGraph,
                     withCodeGenerators, withCodeModifiers, configSchemaGen, exportOpenAPI,
-                    exportComponentModel, enableCache, semtype);
+                    exportComponentModel, enableCache, semtype, semtypeTest);
         }
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/CompilationOptions.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/CompilationOptions.java
@@ -264,7 +264,7 @@ public class CompilationOptions {
         private Boolean exportOpenAPI;
         private Boolean exportComponentModel;
         private Boolean enableCache;
-        private Boolean semtype = true;
+        private Boolean semtype;
 
         public CompilationOptionsBuilder setOffline(Boolean value) {
             offline = value;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageCompilation.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageCompilation.java
@@ -43,6 +43,7 @@ import static org.ballerinalang.compiler.CompilerOptionName.DUMP_BIR_FILE;
 import static org.ballerinalang.compiler.CompilerOptionName.OBSERVABILITY_INCLUDED;
 import static org.ballerinalang.compiler.CompilerOptionName.OFFLINE;
 import static org.ballerinalang.compiler.CompilerOptionName.SEMTYPE;
+import static org.ballerinalang.compiler.CompilerOptionName.SEMTYPE_TEST;
 
 /**
  * Compilation at package level by resolving all the dependencies.
@@ -89,6 +90,7 @@ public class PackageCompilation {
         options.put(DUMP_BIR_FILE, Boolean.toString(compilationOptions.dumpBirFile()));
         options.put(CLOUD, compilationOptions.getCloud());
         options.put(SEMTYPE, Boolean.toString(compilationOptions.semtype()));
+        options.put(SEMTYPE_TEST, Boolean.toString(compilationOptions.semtypeTest()));
     }
 
     static PackageCompilation from(PackageContext rootPackageContext, CompilationOptions compilationOptions) {

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/compiler/CompilerOptionName.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/compiler/CompilerOptionName.java
@@ -66,6 +66,8 @@ public enum CompilerOptionName {
 
     SEMTYPE("semtype"),
 
+    SEMTYPE_TEST("semtypeTest"), // keeping additional option as semtype supports only a subset
+
     /**
      * We've introduced this temporary option to support old-project structure and the new package structure.
      * If the option is set, then the compilation is initiated by the Project APT.

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
@@ -18,7 +18,6 @@
 package org.wso2.ballerinalang.compiler;
 
 import io.ballerina.tools.diagnostics.Location;
-import io.ballerina.types.ProperSubtypeData;
 import io.ballerina.types.Atom;
 import io.ballerina.types.AtomicType;
 import io.ballerina.types.Bdd;
@@ -31,6 +30,7 @@ import io.ballerina.types.FixedLengthArray;
 import io.ballerina.types.FunctionAtomicType;
 import io.ballerina.types.ListAtomicType;
 import io.ballerina.types.MappingAtomicType;
+import io.ballerina.types.ProperSubtypeData;
 import io.ballerina.types.RecAtom;
 import io.ballerina.types.SemType;
 import io.ballerina.types.TypeAtom;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRTypeWriter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRTypeWriter.java
@@ -17,7 +17,6 @@
  */
 package org.wso2.ballerinalang.compiler.bir.writer;
 
-import io.ballerina.types.ProperSubtypeData;
 import io.ballerina.types.Atom;
 import io.ballerina.types.AtomicType;
 import io.ballerina.types.Bdd;
@@ -30,6 +29,7 @@ import io.ballerina.types.FixedLengthArray;
 import io.ballerina.types.FunctionAtomicType;
 import io.ballerina.types.ListAtomicType;
 import io.ballerina.types.MappingAtomicType;
+import io.ballerina.types.ProperSubtypeData;
 import io.ballerina.types.RecAtom;
 import io.ballerina.types.SemType;
 import io.ballerina.types.TypeAtom;
@@ -672,7 +672,7 @@ public class BIRTypeWriter implements TypeVisitor {
     private void writeSemType(SemType semType) {
         boolean hasSemType = semType != null;
         buff.writeBoolean(hasSemType);
-        if (!hasSemType){
+        if (!hasSemType) {
             return;
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRTypeWriter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRTypeWriter.java
@@ -742,8 +742,9 @@ public class BIRTypeWriter implements TypeVisitor {
 
     private void writeBddNode(BddNode bddNode) {
         Atom atom = bddNode.atom;
-        buff.writeBoolean(atom instanceof RecAtom);
-        if (atom instanceof RecAtom) {
+        boolean isRecAtom = atom instanceof RecAtom;
+        buff.writeBoolean(isRecAtom);
+        if (isRecAtom) {
             RecAtom recAtom = (RecAtom) atom;
             buff.writeInt(recAtom.index);
         } else {
@@ -822,20 +823,20 @@ public class BIRTypeWriter implements TypeVisitor {
         }
     }
 
-    private void writeStringSubtype(StringSubtype ss) {
-        CharStringSubtype charData = ss.getChar();
+    private void writeStringSubtype(StringSubtype stringSubtype) {
+        CharStringSubtype charData = stringSubtype.getChar();
         buff.writeBoolean(charData.allowed);
-        EnumerableCharString[] values = charData.values;
-        buff.writeInt(values.length);
-        for (EnumerableCharString ecs : values) {
+        EnumerableCharString[] charValues = charData.values;
+        buff.writeInt(charValues.length);
+        for (EnumerableCharString ecs : charValues) {
             buff.writeInt(addStringCPEntry(ecs.value));
         }
-        NonCharStringSubtype nonCharData = ss.getNonChar();
+        NonCharStringSubtype nonCharData = stringSubtype.getNonChar();
         buff.writeBoolean(nonCharData.allowed);
-        EnumerableString[] values1 = nonCharData.values;
-        buff.writeInt(values1.length);
-        for (EnumerableString ecs1 : values1) {
-            buff.writeInt(addStringCPEntry(ecs1.value));
+        EnumerableString[] nonCharValues = nonCharData.values;
+        buff.writeInt(nonCharValues.length);
+        for (EnumerableString ecs : nonCharValues) {
+            buff.writeInt(addStringCPEntry(ecs.value));
         }
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/NodeCloner.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/NodeCloner.java
@@ -390,6 +390,8 @@ public class NodeCloner extends BLangNodeVisitor {
         clone.nullable = source.nullable;
         clone.grouped = source.grouped;
         clone.flagSet = cloneSet(source.flagSet, Flag.class);
+        clone.defn = source.defn;
+        clone.semType = source.semType;
     }
 
     private <T extends Enum<T>> EnumSet<T> cloneSet(Set<T> source, Class<T> elementType) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ConstantValueResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ConstantValueResolver.java
@@ -118,6 +118,7 @@ public class ConstantValueResolver extends BLangNodeVisitor {
     private HashMap<BSymbol, BLangTypeDefinition> createdTypeDefinitions = new HashMap<>();
     private Stack<String> anonTypeNameSuffixes = new Stack<>();
     private boolean semtypeEnabled;
+    private boolean semtypeTest;
 
     private ConstantValueResolver(CompilerContext context) {
         context.put(CONSTANT_VALUE_RESOLVER_KEY, this);
@@ -136,6 +137,7 @@ public class ConstantValueResolver extends BLangNodeVisitor {
 
         CompilerOptions options = CompilerOptions.getInstance(context);
         constantValueResolver.semtypeEnabled = Boolean.parseBoolean(options.get(CompilerOptionName.SEMTYPE));
+        constantValueResolver.semtypeTest = Boolean.parseBoolean(options.get(CompilerOptionName.SEMTYPE_TEST));
         return constantValueResolver;
     }
 
@@ -595,7 +597,7 @@ public class ConstantValueResolver extends BLangNodeVisitor {
 
     private BLangConstantValue constructBLangConstantValue(BLangExpression node) {
 
-        if (!node.typeChecked && !this.semtypeEnabled) {
+        if (!node.typeChecked && !this.semtypeEnabled && !this.semtypeTest) {
             return null;
         }
         switch (node.getKind()) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -267,8 +267,7 @@ public class SymbolEnter extends BLangNodeVisitor {
         }
 
         CompilerOptions options = CompilerOptions.getInstance(context);
-//        symbolEnter.semtypeEnabled = Boolean.parseBoolean(options.get(CompilerOptionName.SEMTYPE));
-        symbolEnter.semtypeEnabled = true;
+        symbolEnter.semtypeEnabled = Boolean.parseBoolean(options.get(CompilerOptionName.SEMTYPE));
         return symbolEnter;
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -443,17 +443,12 @@ public class SymbolEnter extends BLangNodeVisitor {
         List<BLangClassDefinition> classDefinitions = getClassDefinitions(pkgNode.topLevelNodes);
         classDefinitions.forEach(classDefn -> typeAndClassDefs.add(classDefn));
         if (this.semtypeEnabled) {
-            try {
-                defineSemTypesSubset(typeAndClassDefs, pkgEnv);
-            } catch (UnsupportedOperationException e) {
-                // Do nothing
-                // TODO: semType: remove once all types are implemented.
-            }
+            // We may need to move this next to defineTypeNodes() to support constants
+            defineSemTypesSubset(typeAndClassDefs, pkgEnv);
         }
         defineTypeNodes(typeAndClassDefs, pkgEnv);
         if (this.semtypeTest) {
             defineSemTypes(typeAndClassDefs, pkgEnv);
-
         }
 
         // Enabled logging errors after type def visit.
@@ -574,8 +569,8 @@ public class SymbolEnter extends BLangNodeVisitor {
         }
 
         if (depth == defn.cycleDepth) {
-            // TODO: semType: enable once all types are supported
-//            dlog.error(defn.pos, DiagnosticErrorCode.INVALID_TYPE_CYCLE, defn.name);
+            // TODO: semType: enable error log once all types are supported
+            // dlog.error(defn.pos, DiagnosticErrorCode.INVALID_TYPE_CYCLE, defn.name);
             return null;
         }
         defn.cycleDepth = depth;
@@ -648,7 +643,8 @@ public class SymbolEnter extends BLangNodeVisitor {
 
         BLangNode moduleLevelDef = mod.get(name);
         if (moduleLevelDef == null) {
-            dlog.error(td.pos, DiagnosticErrorCode.REFERENCE_TO_UNDEFINED_TYPE, td.typeName);
+            // TODO: semType: enable once implementation is complete
+            // dlog.error(td.pos, DiagnosticErrorCode.REFERENCE_TO_UNDEFINED_TYPE, td.typeName);
             throw new UnsupportedOperationException("Reference to undefined type: " + name);
         }
 
@@ -909,7 +905,8 @@ public class SymbolEnter extends BLangNodeVisitor {
             case "Unsigned32":
                 return SemTypes.UINT32;
             default:
-                throw new IllegalStateException("Unknown int subtype: " + name);
+                // TODO: semtype: support MAX_VALUE
+                throw new UnsupportedOperationException("Unknown int subtype: " + name);
         }
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -20,6 +20,7 @@ package org.wso2.ballerinalang.compiler.semantics.analyzer;
 import io.ballerina.tools.diagnostics.DiagnosticCode;
 import io.ballerina.tools.diagnostics.Location;
 import io.ballerina.types.SemType;
+import org.ballerinalang.compiler.CompilerOptionName;
 import org.ballerinalang.model.TreeBuilder;
 import org.ballerinalang.model.elements.Flag;
 import org.ballerinalang.model.elements.PackageID;
@@ -113,6 +114,7 @@ import org.wso2.ballerinalang.compiler.tree.types.BLangUserDefinedType;
 import org.wso2.ballerinalang.compiler.tree.types.BLangValueType;
 import org.wso2.ballerinalang.compiler.util.BArrayState;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
+import org.wso2.ballerinalang.compiler.util.CompilerOptions;
 import org.wso2.ballerinalang.compiler.util.ImmutableTypeCloner;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.Names;
@@ -163,6 +165,7 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
     private final Unifier unifier;
     private final SemanticAnalyzer semanticAnalyzer;
     private final Stack<String> anonTypeNameSuffixes;
+    private boolean semtypeEnabled;
 
     public static SymbolResolver getInstance(CompilerContext context) {
         SymbolResolver symbolResolver = context.get(SYMBOL_RESOLVER_KEY);
@@ -170,6 +173,8 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
             symbolResolver = new SymbolResolver(context);
         }
 
+        CompilerOptions options = CompilerOptions.getInstance(context);
+        symbolResolver.semtypeEnabled = Boolean.parseBoolean(options.get(CompilerOptionName.SEMTYPE));
         return symbolResolver;
     }
 
@@ -556,23 +561,30 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
         }
 
         validateDistinctType(typeNode, resultType);
+        resolveSemType(typeNode, env, resultType);
+
+        typeNode.setBType(resultType);
+        return resultType;
+    }
+
+    private void resolveSemType(BLangType typeNode, SymbolEnv env, BType resultType) {
+        if (!this.semtypeEnabled) {
+            return;
+        }
 
         if (typeNode.semType != null) {
             // For type definitions, we will have the semType resolved already
             resultType.setSemtype(typeNode.semType);
         } else {
             try {
-                SemType s = symbolEnter.resolveTypeDesc(env.enclPkg.semtypeEnv, env.enclPkg.modTable, null, 0,
+                SemType s = symbolEnter.resolveTypeDescSubset(env.enclPkg.semtypeEnv, env.enclPkg.modTable, null, 0,
                         typeNode);
                 resultType.setSemtype(s);
-            } catch (Exception e) {
+            } catch (UnsupportedOperationException e) {
                 // Do nothing
                 // TODO: semType: remove once all types are supported
             }
         }
-
-        typeNode.setBType(resultType);
-        return resultType;
     }
 
     private void validateDistinctType(BLangType typeNode, BType type) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -1451,9 +1451,18 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
         for (BLangExpression expressionOrLiteral : finiteTypeNode.valueSpace) {
             finiteType.addValue(expressionOrLiteral);
         }
+        setSemType(finiteType);
         finiteTypeSymbol.type = finiteType;
 
         return finiteType;
+    }
+
+    private void setSemType(BFiniteType finiteType) {
+        if (!this.semtypeEnabled) {
+            return;
+        }
+
+        finiteType.setSemtype(symbolEnter.resolveSingletonType(new ArrayList<>(finiteType.getValueSpace())));
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -19,6 +19,7 @@ package org.wso2.ballerinalang.compiler.semantics.analyzer;
 
 import io.ballerina.tools.diagnostics.DiagnosticCode;
 import io.ballerina.tools.diagnostics.Location;
+import io.ballerina.types.SemType;
 import org.ballerinalang.model.TreeBuilder;
 import org.ballerinalang.model.elements.Flag;
 import org.ballerinalang.model.elements.PackageID;
@@ -555,6 +556,20 @@ public class SymbolResolver extends BLangNodeTransformer<SymbolResolver.Analyzer
         }
 
         validateDistinctType(typeNode, resultType);
+
+        if (typeNode.semType != null) {
+            // For type definitions, we will have the semType resolved already
+            resultType.setSemtype(typeNode.semType);
+        } else {
+            try {
+                SemType s = symbolEnter.resolveTypeDesc(env.enclPkg.semtypeEnv, env.enclPkg.modTable, null, 0,
+                        typeNode);
+                resultType.setSemtype(s);
+            } catch (Exception e) {
+                // Do nothing
+                // TODO: semType: remove once all types are supported
+            }
+        }
 
         typeNode.setBType(resultType);
         return resultType;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -24,6 +24,7 @@ import io.ballerina.types.Context;
 import io.ballerina.types.Env;
 import io.ballerina.types.SemType;
 import io.ballerina.types.SemTypes;
+import org.ballerinalang.compiler.CompilerOptionName;
 import org.ballerinalang.model.Name;
 import org.ballerinalang.model.TreeBuilder;
 import org.ballerinalang.model.elements.Flag;
@@ -105,6 +106,7 @@ import org.wso2.ballerinalang.compiler.tree.types.BLangErrorType;
 import org.wso2.ballerinalang.compiler.tree.types.BLangRecordTypeNode;
 import org.wso2.ballerinalang.compiler.util.BArrayState;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
+import org.wso2.ballerinalang.compiler.util.CompilerOptions;
 import org.wso2.ballerinalang.compiler.util.CompilerUtils;
 import org.wso2.ballerinalang.compiler.util.ImmutableTypeCloner;
 import org.wso2.ballerinalang.compiler.util.Names;
@@ -177,6 +179,7 @@ public class Types {
     private int recordCount = 0;
     private SymbolEnv env;
     private Context cx;
+    private boolean semtypeEnabled;
 
     private boolean ignoreObjectTypeIds = false;
     private static final String BASE_16 = "base16";
@@ -196,6 +199,8 @@ public class Types {
             types = new Types(context);
         }
 
+        CompilerOptions options = CompilerOptions.getInstance(context);
+        types.semtypeEnabled = Boolean.parseBoolean(options.get(CompilerOptionName.SEMTYPE));
         return types;
     }
 
@@ -870,11 +875,13 @@ public class Types {
     }
 
     private boolean isAssignable(BType source, BType target, Set<TypePair> unresolvedTypes) {
-        SemType sourceSemType = source.getSemtype();
-        SemType targetSemType = target.getSemtype();
+        if (this.semtypeEnabled) {
+            SemType sourceSemType = source.getSemtype();
+            SemType targetSemType = target.getSemtype();
 
-        if (sourceSemType != null && targetSemType != null && isSemTypeEnabled(source, target)) {
-            return SemTypes.isSubtype(cx, sourceSemType, targetSemType);
+            if (sourceSemType != null && targetSemType != null && isSemTypeEnabled(source, target)) {
+                return SemTypes.isSubtype(cx, sourceSemType, targetSemType);
+            }
         }
 
         if (isSameType(source, target)) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -170,6 +170,7 @@ public class Types {
             new CompilerContext.Key<>();
     private final Unifier unifier;
     private SymbolTable symTable;
+    private SymbolEnter symbolEnter;
     private SymbolResolver symResolver;
     private BLangDiagnosticLog dlog;
     private Names names;
@@ -208,6 +209,7 @@ public class Types {
         context.put(TYPES_KEY, this);
 
         this.symTable = SymbolTable.getInstance(context);
+        this.symbolEnter = SymbolEnter.getInstance(context);
         this.symResolver = SymbolResolver.getInstance(context);
         this.dlog = BLangDiagnosticLog.getInstance(context);
         this.names = Names.getInstance(context);
@@ -4238,8 +4240,17 @@ public class Types {
                 finiteType.tsymbol.owner, finiteType.tsymbol.pos,
                 VIRTUAL);
         BFiniteType intersectingFiniteType = new BFiniteType(finiteTypeSymbol, matchingValues);
+        setSemType(intersectingFiniteType);
         finiteTypeSymbol.type = intersectingFiniteType;
         return intersectingFiniteType;
+    }
+
+    private void setSemType(BFiniteType finiteType) {
+        if (!this.semtypeEnabled) {
+            return;
+        }
+
+        finiteType.setSemtype(symbolEnter.resolveSingletonType(new ArrayList<>(finiteType.getValueSpace())));
     }
 
     private boolean isAssignableToFiniteTypeMemberInUnion(BLangLiteral expr, BType targetType) {
@@ -5919,6 +5930,7 @@ public class Types {
                 originalType.tsymbol.owner, originalType.tsymbol.pos,
                 VIRTUAL);
         BFiniteType intersectingFiniteType = new BFiniteType(finiteTypeSymbol, remainingValueSpace);
+        setSemType(intersectingFiniteType);
         finiteTypeSymbol.type = intersectingFiniteType;
         return intersectingFiniteType;
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
@@ -307,14 +307,14 @@ public class SymbolTable {
                                                                 this.builtinPos, VIRTUAL);
         this.trueType = new BFiniteType(finiteTypeSymbol, new HashSet<>() {{
             add(trueLiteral);
-        }});
+        }}, SemTypes.booleanConst(true));
 
         BTypeSymbol falseFiniteTypeSymbol = Symbols.createTypeSymbol(SymTag.FINITE_TYPE, Flags.PUBLIC,
                 names.fromString("$anonType$FALSE"), rootPkgNode.packageID, null, rootPkgNode.symbol.owner,
                 this.builtinPos, VIRTUAL);
         this.falseType = new BFiniteType(falseFiniteTypeSymbol, new HashSet<>() {{
             add(falseLiteral);
-        }});
+        }}, SemTypes.booleanConst(false));
 
         this.anyAndReadonly =
                 ImmutableTypeCloner.getImmutableIntersectionType(this.anyType, this, names, this.types,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
@@ -18,6 +18,8 @@
 package org.wso2.ballerinalang.compiler.semantics.model;
 
 import io.ballerina.tools.diagnostics.Location;
+import io.ballerina.types.PredefinedType;
+import io.ballerina.types.SemTypes;
 import org.ballerinalang.model.TreeBuilder;
 import org.ballerinalang.model.elements.PackageID;
 import org.ballerinalang.model.symbols.SymbolOrigin;
@@ -116,12 +118,12 @@ public class SymbolTable {
     public final BType noType = new BNoType(TypeTags.NONE);
     public final BType nilType = new BNilType();
     public final BType neverType = new BNeverType();
-    public final BType intType = new BType(TypeTags.INT, null, Flags.READONLY);
-    public final BType byteType = new BType(TypeTags.BYTE, null, Flags.READONLY);
-    public final BType floatType = new BType(TypeTags.FLOAT, null, Flags.READONLY);
-    public final BType decimalType = new BType(TypeTags.DECIMAL, null, Flags.READONLY);
-    public final BType stringType = new BType(TypeTags.STRING, null, Flags.READONLY);
-    public final BType booleanType = new BType(TypeTags.BOOLEAN, null, Flags.READONLY);
+    public final BType intType = new BType(TypeTags.INT, null, Flags.READONLY, PredefinedType.INT);
+    public final BType byteType = new BType(TypeTags.BYTE, null, Flags.READONLY, PredefinedType.BYTE);
+    public final BType floatType = new BType(TypeTags.FLOAT, null, Flags.READONLY, PredefinedType.FLOAT);
+    public final BType decimalType = new BType(TypeTags.DECIMAL, null, Flags.READONLY, PredefinedType.DECIMAL);
+    public final BType stringType = new BType(TypeTags.STRING, null, Flags.READONLY, PredefinedType.STRING);
+    public final BType booleanType = new BType(TypeTags.BOOLEAN, null, Flags.READONLY, PredefinedType.BOOLEAN);
 
     public final BType anyType = new BAnyType(TypeTags.ANY, null);
     public final BMapType mapType = new BMapType(TypeTags.MAP, anyType, null);
@@ -162,13 +164,16 @@ public class SymbolTable {
     public BObjectType iterableType;
 
     // builtin subtypes
-    public final BIntSubType signed32IntType = new BIntSubType(TypeTags.SIGNED32_INT, Names.SIGNED32);
-    public final BIntSubType signed16IntType = new BIntSubType(TypeTags.SIGNED16_INT, Names.SIGNED16);
-    public final BIntSubType signed8IntType = new BIntSubType(TypeTags.SIGNED8_INT, Names.SIGNED8);
-    public final BIntSubType unsigned32IntType = new BIntSubType(TypeTags.UNSIGNED32_INT, Names.UNSIGNED32);
-    public final BIntSubType unsigned16IntType = new BIntSubType(TypeTags.UNSIGNED16_INT, Names.UNSIGNED16);
-    public final BIntSubType unsigned8IntType = new BIntSubType(TypeTags.UNSIGNED8_INT, Names.UNSIGNED8);
-    public final BStringSubType charStringType = new BStringSubType(TypeTags.CHAR_STRING, Names.CHAR);
+    public final BIntSubType signed32IntType = new BIntSubType(TypeTags.SIGNED32_INT, Names.SIGNED32, SemTypes.SINT32);
+    public final BIntSubType signed16IntType = new BIntSubType(TypeTags.SIGNED16_INT, Names.SIGNED16, SemTypes.SINT16);
+    public final BIntSubType signed8IntType = new BIntSubType(TypeTags.SIGNED8_INT, Names.SIGNED8, SemTypes.SINT8);
+    public final BIntSubType unsigned32IntType = new BIntSubType(TypeTags.UNSIGNED32_INT, Names.UNSIGNED32,
+                                                                SemTypes.UINT32);
+    public final BIntSubType unsigned16IntType = new BIntSubType(TypeTags.UNSIGNED16_INT, Names.UNSIGNED16,
+                                                                SemTypes.UINT16);
+    public final BIntSubType unsigned8IntType = new BIntSubType(TypeTags.UNSIGNED8_INT, Names.UNSIGNED8,
+                                                                SemTypes.UINT8);
+    public final BStringSubType charStringType = new BStringSubType(TypeTags.CHAR_STRING, Names.CHAR, SemTypes.CHAR);
     public final BXMLSubType xmlElementType = new BXMLSubType(TypeTags.XML_ELEMENT, Names.XML_ELEMENT);
     public final BXMLSubType xmlPIType = new BXMLSubType(TypeTags.XML_PI, Names.XML_PI);
     public final BXMLSubType xmlCommentType = new BXMLSubType(TypeTags.XML_COMMENT, Names.XML_COMMENT);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BFiniteType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BFiniteType.java
@@ -109,5 +109,6 @@ public class BFiniteType extends BType implements FiniteType {
         if (!this.nullable && value.getBType() != null &&  value.getBType().isNullable()) {
             this.nullable = true;
         }
+        // TODO:  if exits, can we modify semtype in parallel here?
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BFiniteType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BFiniteType.java
@@ -44,7 +44,7 @@ public class BFiniteType extends BType implements FiniteType {
 
 
     public BFiniteType(BTypeSymbol tsymbol) {
-        this(tsymbol, new LinkedHashSet<>());
+        this(tsymbol, new LinkedHashSet<>(), null);
     }
 
     public BFiniteType(BTypeSymbol tsymbol, Set<BLangExpression> valueSpace) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BFiniteType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BFiniteType.java
@@ -18,6 +18,7 @@
 
 package org.wso2.ballerinalang.compiler.semantics.model.types;
 
+import io.ballerina.types.SemType;
 import org.ballerinalang.model.types.FiniteType;
 import org.ballerinalang.model.types.TypeKind;
 import org.wso2.ballerinalang.compiler.semantics.model.TypeVisitor;
@@ -43,13 +44,15 @@ public class BFiniteType extends BType implements FiniteType {
 
 
     public BFiniteType(BTypeSymbol tsymbol) {
-        super(TypeTags.FINITE, tsymbol);
-        valueSpace = new LinkedHashSet<>();
-        this.flags |= Flags.READONLY;
+        this(tsymbol, new LinkedHashSet<>());
     }
 
     public BFiniteType(BTypeSymbol tsymbol, Set<BLangExpression> valueSpace) {
-        super(TypeTags.FINITE, tsymbol);
+        this(tsymbol, valueSpace, null);
+    }
+
+    public BFiniteType(BTypeSymbol tsymbol, Set<BLangExpression> valueSpace, SemType semType) {
+        super(TypeTags.FINITE, tsymbol, semType);
         this.valueSpace = valueSpace;
         this.flags |= Flags.READONLY;
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BIntSubType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BIntSubType.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.ballerinalang.compiler.semantics.model.types;
 
+import io.ballerina.types.SemType;
 import org.ballerinalang.model.Name;
 import org.ballerinalang.model.types.TypeKind;
 import org.wso2.ballerinalang.compiler.semantics.model.TypeVisitor;
@@ -31,8 +32,11 @@ import org.wso2.ballerinalang.util.Flags;
 public class BIntSubType extends BType {
 
     public BIntSubType(int tag, Name name) {
+        this(tag, name, null);
+    }
 
-        super(tag, null, name, Flags.READONLY);
+    public BIntSubType(int tag, Name name, SemType semType) {
+        super(tag, null, name, Flags.READONLY, semType);
     }
 
     public boolean isNullable() {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BNeverType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BNeverType.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.ballerinalang.compiler.semantics.model.types;
 
+import io.ballerina.types.PredefinedType;
 import org.wso2.ballerinalang.compiler.semantics.model.TypeVisitor;
 import org.wso2.ballerinalang.compiler.util.Names;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
@@ -32,7 +33,7 @@ import org.wso2.ballerinalang.util.Flags;
 public class BNeverType extends BType {
 
     public BNeverType() {
-        super(TypeTags.NEVER, null, Flags.READONLY);
+        super(TypeTags.NEVER, null, Flags.READONLY, PredefinedType.NEVER);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BNilType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BNilType.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.ballerinalang.compiler.semantics.model.types;
 
+import io.ballerina.types.PredefinedType;
 import org.ballerinalang.model.types.NullType;
 import org.wso2.ballerinalang.compiler.semantics.model.TypeVisitor;
 import org.wso2.ballerinalang.compiler.util.Names;
@@ -32,7 +33,7 @@ import org.wso2.ballerinalang.util.Flags;
 public class BNilType extends BType implements NullType {
 
     public BNilType() {
-        super(TypeTags.NIL, null, Flags.READONLY);
+        super(TypeTags.NIL, null, Flags.READONLY, PredefinedType.NIL);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BStringSubType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BStringSubType.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.ballerinalang.compiler.semantics.model.types;
 
+import io.ballerina.types.SemType;
 import org.ballerinalang.model.Name;
 import org.ballerinalang.model.types.TypeKind;
 import org.wso2.ballerinalang.compiler.semantics.model.TypeVisitor;
@@ -31,8 +32,11 @@ import org.wso2.ballerinalang.util.Flags;
 public class BStringSubType extends BType {
 
     public BStringSubType(int tag, Name name) {
+        this(tag, name, null);
+    }
 
-        super(tag, null, name, Flags.READONLY);
+    public BStringSubType(int tag, Name name, SemType semType) {
+        super(tag, null, name, Flags.READONLY, semType);
     }
 
     public boolean isNullable() {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BType.java
@@ -57,24 +57,27 @@ public class BType implements ValueType {
     private SemType semtype;
 
     public BType(int tag, BTypeSymbol tsymbol) {
-        this.tag = tag;
-        this.tsymbol = tsymbol;
-        this.name = Names.EMPTY;
-        this.flags = 0;
+        this(tag, tsymbol, 0);
     }
 
     public BType(int tag, BTypeSymbol tsymbol, long flags) {
-        this.tag = tag;
-        this.tsymbol = tsymbol;
-        this.name = Names.EMPTY;
-        this.flags = flags;
+        this(tag, tsymbol, Names.EMPTY, flags);
     }
 
     public BType(int tag, BTypeSymbol tsymbol, Name name, long flags) {
+        this(tag, tsymbol, name, flags, null);
+    }
+
+    public BType(int tag, BTypeSymbol tsymbol, long flags, SemType semType) {
+        this(tag, tsymbol, Names.EMPTY, flags, semType);
+    }
+
+    public BType(int tag, BTypeSymbol tsymbol, Name name, long flags, SemType semType) {
         this.tag = tag;
         this.tsymbol = tsymbol;
         this.name = name;
         this.flags = flags;
+        this.semtype = semType;
     }
 
     public SemType getSemtype() {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BType.java
@@ -60,6 +60,10 @@ public class BType implements ValueType {
         this(tag, tsymbol, 0);
     }
 
+    public BType(int tag, BTypeSymbol tsymbol, SemType semType) {
+        this(tag, tsymbol, 0, semType);
+    }
+
     public BType(int tag, BTypeSymbol tsymbol, long flags) {
         this(tag, tsymbol, Names.EMPTY, flags);
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BType.java
@@ -57,15 +57,15 @@ public class BType implements ValueType {
     private SemType semtype;
 
     public BType(int tag, BTypeSymbol tsymbol) {
-        this(tag, tsymbol, 0);
+        this(tag, tsymbol, Names.EMPTY, 0, null);
     }
 
     public BType(int tag, BTypeSymbol tsymbol, SemType semType) {
-        this(tag, tsymbol, 0, semType);
+        this(tag, tsymbol, Names.EMPTY, 0, semType);
     }
 
     public BType(int tag, BTypeSymbol tsymbol, long flags) {
-        this(tag, tsymbol, Names.EMPTY, flags);
+        this(tag, tsymbol, Names.EMPTY, flags, null);
     }
 
     public BType(int tag, BTypeSymbol tsymbol, Name name, long flags) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangPackage.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangPackage.java
@@ -96,6 +96,8 @@ public class BLangPackage extends BLangNode implements PackageNode {
     // Semtype env
     public final Env semtypeEnv;
 
+    public Map<String, BLangNode> modTable; // TODO: SemType: this is temporary
+
     public BLangPackage() {
         this.compUnits = new ArrayList<>();
         this.imports = new ArrayList<>();

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/types/BLangType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/types/BLangType.java
@@ -18,6 +18,7 @@
 package org.wso2.ballerinalang.compiler.tree.types;
 
 import io.ballerina.types.Definition;
+import io.ballerina.types.SemType;
 import org.ballerinalang.model.elements.Flag;
 import org.ballerinalang.model.tree.types.TypeNode;
 import org.wso2.ballerinalang.compiler.tree.BLangNode;
@@ -38,6 +39,7 @@ public abstract class BLangType extends BLangNode implements TypeNode {
     public boolean grouped;
     public Set<Flag> flagSet = EnumSet.noneOf(Flag.class);
     public Definition defn;
+    public SemType semType; // TODO: SemType: this is temporary
 
     @Override
     public boolean isNullable() {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/ProgramFileConstants.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/ProgramFileConstants.java
@@ -25,9 +25,9 @@ public class ProgramFileConstants {
 
     public static final int MAGIC_NUMBER = 0xBA1DA4CE;
     public static final short VERSION_NUMBER = 50;
-    public static final int BIR_VERSION_NUMBER = 68;
-    public static final short MIN_SUPPORTED_VERSION = 68;
-    public static final short MAX_SUPPORTED_VERSION = 68;
+    public static final int BIR_VERSION_NUMBER = 69;
+    public static final short MIN_SUPPORTED_VERSION = 69;
+    public static final short MAX_SUPPORTED_VERSION = 69;
 
     // todo move this to a proper place
     public static final String[] SUPPORTED_PLATFORMS = {"java11"};

--- a/docs/bir-spec/src/main/resources/kaitai/bir.ksy
+++ b/docs/bir-spec/src/main/resources/kaitai/bir.ksy
@@ -89,6 +89,8 @@ types:
         type: type_info
   type_info:
     seq:
+      - id: semtype
+        type: semtype_info
       - id: type_tag
         type: s1
         enum: type_tag_enum
@@ -122,6 +124,218 @@ types:
     instances:
       name_as_str:
         value: _root.constant_pool.constant_pool_entries[name_index].cp_info.as<string_cp_info>.value
+  semtype_info:
+    seq:
+      - id: has_semtype
+        type: u1
+      - id: semtype
+        type: semtype_internal
+        if: has_semtype == 1
+  semtype_internal:
+    seq:
+      - id: is_uniform_type_bit_set
+        type: u1
+      - id: uniform_type_bit_set
+        type: s4
+        if: is_uniform_type_bit_set == 1
+      - id: complex_semtype
+        type: semtype_complex
+        if: is_uniform_type_bit_set == 0
+  semtype_complex:
+    seq:
+      - id: all_bit_set
+        type: s4
+      - id: some_bit_set
+        type: s4
+      - id: subtype_data_list_length
+        type: s1
+      - id: proper_subtype_data
+        type: semtype_proper_subtype_data
+        repeat: expr
+        repeat-expr: subtype_data_list_length
+  semtype_proper_subtype_data:
+    seq:
+      - id: proper_subtype_data_kind
+        type: s1
+      - id: bdd
+        type: semtype_bdd
+        if: proper_subtype_data_kind == 1
+      - id: int_subtype
+        type: semtype_int_subtype
+        if: proper_subtype_data_kind == 2
+      - id: boolean_subtype
+        type: semtype_boolean_subtype
+        if: proper_subtype_data_kind == 3
+      - id: float_subtype
+        type: semtype_float_subtype
+        if: proper_subtype_data_kind == 4
+      - id: decimal_subtype
+        type: semtype_decimal_subtype
+        if: proper_subtype_data_kind == 5
+      - id: string_subtype
+        type: semtype_string_subtype
+        if: proper_subtype_data_kind == 6
+      - id: rw_table_subtype
+        type: semtype_rw_table_subtype
+        if: proper_subtype_data_kind == 7
+      - id: xml_subtype
+        type: semtype_xml_subtype
+        if: proper_subtype_data_kind == 8
+  semtype_bdd:
+    seq:
+      - id: is_bdd_node
+        type: u1
+      - id: bdd_node
+        type: semtype_bdd_node
+        if: is_bdd_node == 1
+      - id: bdd_all_or_nothing
+        type: u1
+        if: is_bdd_node == 0
+  semtype_bdd_node:
+    seq:
+      - id: is_rec_atom
+        type: u1
+      - id: rec_atom_index
+        type: s4
+        if: is_rec_atom == 1
+      - id: type_atom
+        type: semtype_type_atom
+        if: is_rec_atom == 0
+      - id: bdd_node_left
+        type: semtype_bdd
+      - id: bdd_node_middle
+        type: semtype_bdd
+      - id: bdd_node_right
+        type: semtype_bdd
+  semtype_type_atom:
+    seq:
+      - id: type_atom_index
+        type: s8
+      - id: type_atom_kind
+        type: s1
+      - id: mapping_atomic_type
+        type: semtype_mapping_atomic_type
+        if: type_atom_kind == 1
+      - id: list_atomic_type
+        type: semtype_list_atomic_type
+        if: type_atom_kind == 2
+      - id: function_atomic_type
+        type: semtype_function_atomic_type
+        if: type_atom_kind == 3
+  semtype_mapping_atomic_type:
+    seq:
+      - id: names_length
+        type: s4
+      - id: names
+        type: s4
+        repeat: expr
+        repeat-expr: names_length
+      - id: types_length
+        type: s4
+      - id: types
+        type: semtype_info
+        repeat: expr
+        repeat-expr: types_length
+      - id: rest
+        type: semtype_info
+  semtype_list_atomic_type:
+    seq:
+      - id: initial_list_size
+        type: s4
+      - id: initial
+        type: semtype_info
+        repeat: expr
+        repeat-expr: initial_list_size
+      - id: fixed_length
+        type: s4
+      - id: rest
+        type: semtype_info
+  semtype_function_atomic_type:
+    seq:
+      - id: param_type
+        type: semtype_info
+      - id: ret_type
+        type: semtype_info
+  semtype_int_subtype:
+    seq:
+      - id: ranges_length
+        type: s4
+      - id: x
+        type: semtype_range
+        repeat: expr
+        repeat-expr: ranges_length
+  semtype_range:
+    seq:
+      - id: min
+        type: s8
+      - id: max
+        type: s8
+  semtype_boolean_subtype:
+    seq:
+      - id: value
+        type: u1
+  semtype_float_subtype:
+    seq:
+      - id: allowed
+        type: u1
+      - id: values_length
+        type: s4
+      - id: values
+        type: f8
+        repeat: expr
+        repeat-expr: values_length
+  semtype_decimal_subtype:
+    seq:
+      - id: allowed
+        type: u1
+      - id: values_length
+        type: s4
+      - id: values
+        type: semtype_enumerable_decimal
+        repeat: expr
+        repeat-expr: values_length
+  semtype_enumerable_decimal:
+    seq:
+      - id: scale
+        type: s4
+      - id: unscaled_value_bytes_length
+        type: s4
+      - id: unscaled_value_bytes
+        size: unscaled_value_bytes_length
+  semtype_string_subtype:
+    seq:
+      - id: allowed
+        type: u1
+      - id: values_length
+        type: s4
+      - id: values
+        type: semtype_enumerable_string
+        repeat: expr
+        repeat-expr: values_length
+      - id: allowed1
+        type: u1
+      - id: values_length1
+        type: s4
+      - id: values1
+        type: semtype_enumerable_string
+        repeat: expr
+        repeat-expr: values_length1
+  semtype_enumerable_string:
+    seq:
+      - id: string_cp_index
+        type: s4
+  semtype_rw_table_subtype:
+    seq:
+      - id: ro
+        type: semtype_bdd
+      - id: rw
+        type: semtype_bdd
+  semtype_xml_subtype:
+    seq:
+      - id: primitives
+        type: s4
+      - id: sequence
+        type: semtype_bdd
   type_array:
     seq:
       - id: state

--- a/semtypes/src/main/java/io/ballerina/types/Env.java
+++ b/semtypes/src/main/java/io/ballerina/types/Env.java
@@ -54,7 +54,7 @@ public class Env {
             int result = this.recFunctionAtoms.size();
             // represents adding () in nballerina
             this.recFunctionAtoms.add(null);
-            return new RecAtom(result);
+            return RecAtom.createRecAtom(result);
         }
     }
 

--- a/semtypes/src/main/java/io/ballerina/types/FunctionAtomicType.java
+++ b/semtypes/src/main/java/io/ballerina/types/FunctionAtomicType.java
@@ -26,8 +26,12 @@ public class FunctionAtomicType implements AtomicType {
     public final SemType paramType;
     public final SemType retType;
 
-    public FunctionAtomicType(SemType paramType, SemType retType) {
+    private FunctionAtomicType(SemType paramType, SemType retType) {
         this.paramType = paramType;
         this.retType = retType;
+    }
+
+    public static FunctionAtomicType from(SemType paramType , SemType rest) {
+        return new FunctionAtomicType(paramType, rest);
     }
 }

--- a/semtypes/src/main/java/io/ballerina/types/RecAtom.java
+++ b/semtypes/src/main/java/io/ballerina/types/RecAtom.java
@@ -26,7 +26,7 @@ public class RecAtom implements Atom {
     public final int index;
     private static final RecAtom zero = new RecAtom(0);
 
-    public RecAtom(int index) {
+    private RecAtom(int index) {
         this.index = index;
     }
 

--- a/semtypes/src/main/java/io/ballerina/types/TypeAtom.java
+++ b/semtypes/src/main/java/io/ballerina/types/TypeAtom.java
@@ -26,7 +26,7 @@ public class TypeAtom implements Atom {
     public final long index;
     public final AtomicType atomicType;
 
-    public TypeAtom(long index, AtomicType atomicType) {
+    private TypeAtom(long index, AtomicType atomicType) {
         this.index = index;
         this.atomicType = atomicType;
     }

--- a/semtypes/src/main/java/io/ballerina/types/definition/FunctionDefinition.java
+++ b/semtypes/src/main/java/io/ballerina/types/definition/FunctionDefinition.java
@@ -37,7 +37,7 @@ public class FunctionDefinition implements Definition {
     private SemType semType;
 
     public FunctionDefinition(Env env) {
-        FunctionAtomicType dummy = new FunctionAtomicType(PredefinedType.NEVER, PredefinedType.NEVER);
+        FunctionAtomicType dummy = FunctionAtomicType.from(PredefinedType.NEVER, PredefinedType.NEVER);
         this.atom = env.recFunctionAtom();
         this.semType = PredefinedType.uniformSubtype(UniformTypeCode.UT_FUNCTION, BddCommonOps.bddAtom(this.atom));
     }
@@ -48,7 +48,7 @@ public class FunctionDefinition implements Definition {
     }
 
     public SemType define(Env env, SemType args, SemType ret) {
-        FunctionAtomicType t = new FunctionAtomicType(args, ret);
+        FunctionAtomicType t = FunctionAtomicType.from(args, ret);
         env.setRecFunctionAtomType(this.atom, t);
         return this.semType;
     }

--- a/semtypes/src/main/java/module-info.java
+++ b/semtypes/src/main/java/module-info.java
@@ -1,4 +1,5 @@
 module io.ballerina.semtype {
     exports io.ballerina.types;
     exports io.ballerina.types.definition;
+    exports io.ballerina.types.subtypedata;
 }

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/BCompileUtil.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/BCompileUtil.java
@@ -120,7 +120,7 @@ public class BCompileUtil {
     }
 
     public static PackageSyntaxTreePair compileSemType(String sourceFilePath) {
-        Project project = loadProject(sourceFilePath, BuildOptions.builder().setSemType(true).build());
+        Project project = loadProject(sourceFilePath, BuildOptions.builder().setSemTypeTest(true).build());
         Package currentPackage = project.currentPackage();
         Module module = currentPackage.getDefaultModule();
         DocumentId docId = module.documentIds().iterator().next();


### PR DESCRIPTION
## Purpose
$subject. 

This is the first step towards integrating nBallerina semType engine into jBallerina. 

As the first step, we will be supporting only the following uniform types:
`int, boolean, float, decimal, string, nil, never`

Fixes #40045

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
