### PR TITLE
Add support to rename parameter documentation for record fields and required params

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/references/DocumentationReferenceFinder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/references/DocumentationReferenceFinder.java
@@ -37,7 +37,7 @@ import java.util.stream.Collectors;
 /**
  * Finds references for the given symbol within documentation (parameters).
  *
- * @since 2201.7.0
+ * @since 2201.6.0
  */
 public class DocumentationReferenceFinder extends NodeTransformer<List<Location>> {
 
@@ -85,14 +85,13 @@ public class DocumentationReferenceFinder extends NodeTransformer<List<Location>
      * @return List of locations of the parameters within the documentation
      */
     private List<Location> getParameterLocations(MarkdownDocumentationNode mdNode) {
-        List<Location> paramLocations = mdNode.documentationLines().stream()
+        return mdNode.documentationLines().stream()
                 .filter(line -> line.kind() == SyntaxKind.MARKDOWN_PARAMETER_DOCUMENTATION_LINE)
                 .map(line -> (MarkdownParameterDocumentationLineNode) line)
                 .map(line -> line.parameterName())
                 .filter(token -> token.text().equals(symbol.getName().get()))
                 .map(paramToken -> paramToken.location())
                 .collect(Collectors.toList());
-        return paramLocations;
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/references/DocumentationReferenceFinder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/references/DocumentationReferenceFinder.java
@@ -1,0 +1,102 @@
+/*
+ *  Copyright (c) 2023, WSO2 LLC. (http://wso2.com) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.ballerinalang.langserver.references;
+
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
+import io.ballerina.compiler.syntax.tree.MarkdownDocumentationNode;
+import io.ballerina.compiler.syntax.tree.MarkdownParameterDocumentationLineNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NodeTransformer;
+import io.ballerina.compiler.syntax.tree.RecordFieldNode;
+import io.ballerina.compiler.syntax.tree.RequiredParameterNode;
+import io.ballerina.compiler.syntax.tree.SyntaxKind;
+import io.ballerina.compiler.syntax.tree.TypeDefinitionNode;
+import io.ballerina.tools.diagnostics.Location;
+import org.ballerinalang.langserver.codeaction.CodeActionUtil;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Finds references for the given symbol within documentation (parameters).
+ *
+ * @since 2201.7.0
+ */
+public class DocumentationReferenceFinder extends NodeTransformer<List<Location>> {
+
+    private Symbol symbol;
+
+    public DocumentationReferenceFinder(Symbol symbol) {
+        this.symbol = symbol;
+    }
+
+    @Override
+    public List<Location> transform(RequiredParameterNode node) {
+        Optional<FunctionDefinitionNode> fnDefNode = CodeActionUtil.getEnclosedFunction(node);
+        if (fnDefNode.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        Optional<Node> documentationNode = fnDefNode.get().metadata()
+                .flatMap(metadataNode -> metadataNode.documentationString());
+        if (documentationNode.isEmpty() || documentationNode.get().kind() != SyntaxKind.MARKDOWN_DOCUMENTATION) {
+            return Collections.emptyList();
+        }
+
+        return getParameterLocations((MarkdownDocumentationNode) documentationNode.get());
+    }
+
+    @Override
+    public List<Location> transform(RecordFieldNode node) {
+        if (node.parent().parent().kind() != SyntaxKind.TYPE_DEFINITION) {
+            return Collections.emptyList();
+        }
+        TypeDefinitionNode typeDefNode = (TypeDefinitionNode) node.parent().parent();
+        Optional<Node> documentationNode = typeDefNode.metadata()
+                .flatMap(metadataNode -> metadataNode.documentationString());
+        if (documentationNode.isEmpty() || documentationNode.get().kind() != SyntaxKind.MARKDOWN_DOCUMENTATION) {
+            return Collections.emptyList();
+        }
+        return getParameterLocations((MarkdownDocumentationNode) documentationNode.get());
+    }
+
+    /**
+     * Provided the markdown documentation node, this will find the parameter name locations within the documentation
+     * that matches the symbol name.
+     *
+     * @param mdNode Markdown documentation node
+     * @return List of locations of the parameters within the documentation
+     */
+    private List<Location> getParameterLocations(MarkdownDocumentationNode mdNode) {
+        List<Location> paramLocations = mdNode.documentationLines().stream()
+                .filter(line -> line.kind() == SyntaxKind.MARKDOWN_PARAMETER_DOCUMENTATION_LINE)
+                .map(line -> (MarkdownParameterDocumentationLineNode) line)
+                .map(line -> line.parameterName())
+                .filter(token -> token.text().equals(symbol.getName().get()))
+                .map(paramToken -> paramToken.location())
+                .collect(Collectors.toList());
+        return paramLocations;
+    }
+
+    @Override
+    protected List<Location> transformSyntaxNode(Node node) {
+        return Collections.emptyList();
+    }
+}

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/references/ReferencesUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/references/ReferencesUtil.java
@@ -17,18 +17,33 @@ package org.ballerinalang.langserver.references;
 
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
+import io.ballerina.compiler.syntax.tree.MarkdownDocumentationNode;
+import io.ballerina.compiler.syntax.tree.MarkdownParameterDocumentationLineNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NonTerminalNode;
+import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.projects.Document;
 import io.ballerina.projects.Module;
 import io.ballerina.projects.Project;
 import io.ballerina.tools.diagnostics.Location;
 import io.ballerina.tools.text.LinePosition;
+import org.ballerinalang.langserver.codeaction.CodeActionUtil;
+import org.ballerinalang.langserver.common.utils.CommonUtil;
+import org.ballerinalang.langserver.common.utils.PathUtil;
+import org.ballerinalang.langserver.common.utils.PositionUtil;
 import org.ballerinalang.langserver.commons.PositionedOperationContext;
 import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
 
+import java.nio.file.Path;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * Utility class for go to definition functionality of language server.
@@ -38,14 +53,25 @@ public class ReferencesUtil {
     }
     
     public static Map<Module, List<Location>> getReferences(PositionedOperationContext context) {
-        Map<Module, List<Location>> moduleLocationMap = new HashMap<>();
+        Map<Module, List<Location>> references = new HashMap<>();
         Optional<Project> project = context.workspace().project(context.filePath());
         Optional<Symbol> symbol = getSymbolAtCursor(context);
         if (project.isEmpty() || symbol.isEmpty()) {
-            return moduleLocationMap;
+            return references;
         }
-        moduleLocationMap.putAll(getReferences(project.get(), symbol.get()));
-        return moduleLocationMap;
+        references.putAll(getReferences(project.get(), symbol.get()));
+        references.forEach((module, locations) -> {
+            List<Location> docReferences = new LinkedList<>();
+            // Find references in documentation
+            locations.forEach(location -> {
+                List<Location> refs = findReferencesInDocumentation(location, module, context, symbol.get());
+                if (!refs.isEmpty()) {
+                    docReferences.addAll(refs);
+                }
+            });
+            locations.addAll(docReferences);
+        });
+        return references;
     }
 
     /**
@@ -66,7 +92,43 @@ public class ReferencesUtil {
             Module module = project.currentPackage().module(moduleId);
             moduleLocationMap.put(module, references);
         });
+        
         return moduleLocationMap;
+    }
+    
+    private static List<Location> findReferencesInDocumentation(Location location, 
+                                                                Module module, 
+                                                                PositionedOperationContext context,
+                                                                Symbol symbol) {
+        Path filePath = PathUtil.getPathFromLocation(module, location);
+        Range range = PositionUtil.getRangeFromLineRange(location.lineRange());
+        Optional<NonTerminalNode> node = context.workspace().syntaxTree(filePath)
+                .map(syntaxTree -> CommonUtil.findNode(range, syntaxTree));
+        if (node.isEmpty() || node.get().kind() != SyntaxKind.REQUIRED_PARAM) {
+            return Collections.emptyList();
+        }
+
+        Optional<SemanticModel> semanticModel = context.workspace().semanticModel(filePath);
+        Optional<FunctionDefinitionNode> fnDefNode = CodeActionUtil.getEnclosedFunction(node.get());
+        if (fnDefNode.isEmpty()) {
+            return Collections.emptyList();
+        }
+        
+        Optional<Node> documentationNode = fnDefNode.get().metadata()
+                .flatMap(metadataNode -> metadataNode.documentationString());
+        if (documentationNode.isEmpty() || documentationNode.get().kind() != SyntaxKind.MARKDOWN_DOCUMENTATION) {
+            return Collections.emptyList();
+        }
+
+        MarkdownDocumentationNode mdNode = (MarkdownDocumentationNode) documentationNode.get();
+        List<Location> paramLocations = mdNode.documentationLines().stream()
+                .filter(line -> line.kind() == SyntaxKind.MARKDOWN_PARAMETER_DOCUMENTATION_LINE)
+                .map(line -> (MarkdownParameterDocumentationLineNode) line)
+                .map(line -> line.parameterName())
+                .filter(token -> token.text().equals(symbol.getName().get()))
+                .map(paramToken -> paramToken.location())
+                .collect(Collectors.toList());
+        return paramLocations;
     }
     
     /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/references/ReferencesUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/references/ReferencesUtil.java
@@ -18,6 +18,7 @@ package org.ballerinalang.langserver.references;
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.syntax.tree.NonTerminalNode;
+import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.projects.Document;
 import io.ballerina.projects.Module;
 import io.ballerina.projects.Project;
@@ -58,7 +59,7 @@ public class ReferencesUtil {
             // Find references in documentation
             locations.forEach(location -> {
                 List<Location> refs = findReferencesInDocumentation(location, module, context, symbol.get());
-                if (!refs.isEmpty()) {
+                if (refs != null && !refs.isEmpty()) {
                     docReferences.addAll(refs);
                 }
             });
@@ -97,7 +98,7 @@ public class ReferencesUtil {
         Range range = PositionUtil.getRangeFromLineRange(location.lineRange());
         Optional<NonTerminalNode> node = context.workspace().syntaxTree(filePath)
                 .map(syntaxTree -> CommonUtil.findNode(range, syntaxTree));
-        if (node.isEmpty()) {
+        if (node.isEmpty() || node.get().kind() == SyntaxKind.LIST) {
             return Collections.emptyList();
         }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/rename/RenameTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/rename/RenameTest.java
@@ -68,6 +68,7 @@ public class RenameTest extends AbstractRenameTest {
 
                 // Rename parameter documentations
                 {"rename_fn_param1.json", "v1"},
+                {"rename_record_field1.json", "orgName"},
                 
                 // Invalid rename positions tests
                 {"rename_on_keyword1.json", "fn"},

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/rename/RenameTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/rename/RenameTest.java
@@ -66,6 +66,9 @@ public class RenameTest extends AbstractRenameTest {
                 {"rename_in_mapping_binding_pattern2.json", "pName"},
                 {"rename_in_mapping_binding_pattern3.json", "pName"},
 
+                // Rename parameter documentations
+                {"rename_fn_param1.json", "v1"},
+                
                 // Invalid rename positions tests
                 {"rename_on_keyword1.json", "fn"},
                 {"rename_self.json", "this"},

--- a/language-server/modules/langserver-core/src/test/resources/rename/expected/single/rename_fn_param1.json
+++ b/language-server/modules/langserver-core/src/test/resources/rename/expected/single/rename_fn_param1.json
@@ -1,0 +1,57 @@
+{
+  "source": {
+    "file": "rename_fn_param1.bal"
+  },
+  "position": {
+    "line": 6,
+    "character": 14
+  },
+  "prepareRename": {
+    "valid": true
+  },
+  "result": {
+    "changes": {
+      "rename_fn_param1.bal": [
+        {
+          "range": {
+            "start": {
+              "line": 5,
+              "character": 35
+            },
+            "end": {
+              "line": 5,
+              "character": 42
+            }
+          },
+          "newText": "v1"
+        },
+        {
+          "range": {
+            "start": {
+              "line": 6,
+              "character": 11
+            },
+            "end": {
+              "line": 6,
+              "character": 18
+            }
+          },
+          "newText": "v1"
+        },
+        {
+          "range": {
+            "start": {
+              "line": 2,
+              "character": 4
+            },
+            "end": {
+              "line": 2,
+              "character": 11
+            }
+          },
+          "newText": "v1"
+        }
+      ]
+    }
+  }
+}

--- a/language-server/modules/langserver-core/src/test/resources/rename/expected/single/rename_record_field1.json
+++ b/language-server/modules/langserver-core/src/test/resources/rename/expected/single/rename_record_field1.json
@@ -1,0 +1,57 @@
+{
+  "source": {
+    "file": "rename_record_field1.bal"
+  },
+  "position": {
+    "line": 14,
+    "character": 10
+  },
+  "prepareRename": {
+    "valid": true
+  },
+  "result": {
+    "changes": {
+      "rename_record_field1.bal": [
+        {
+          "range": {
+            "start": {
+              "line": 7,
+              "character": 11
+            },
+            "end": {
+              "line": 7,
+              "character": 15
+            }
+          },
+          "newText": "orgName"
+        },
+        {
+          "range": {
+            "start": {
+              "line": 14,
+              "character": 8
+            },
+            "end": {
+              "line": 14,
+              "character": 12
+            }
+          },
+          "newText": "orgName"
+        },
+        {
+          "range": {
+            "start": {
+              "line": 3,
+              "character": 4
+            },
+            "end": {
+              "line": 3,
+              "character": 8
+            }
+          },
+          "newText": "orgName"
+        }
+      ]
+    }
+  }
+}

--- a/language-server/modules/langserver-core/src/test/resources/rename/sources/single/rename_fn_param1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/rename/sources/single/rename_fn_param1.bal
@@ -1,0 +1,8 @@
+# Calculates the euclidean distance between two float vectors.
+#
+# + vector1 - float vector 1
+# + vector2 - float vector 2
+# + return - the euclidean distance between the given two vectors
+function euclideanDistance(float[] vector1, float[] vector2) returns float {
+    return vector1[0];
+}

--- a/language-server/modules/langserver-core/src/test/resources/rename/sources/single/rename_record_field1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/rename/sources/single/rename_record_field1.bal
@@ -1,0 +1,18 @@
+# Represents an organization
+#
+# + id - Organization ID 
+# + name - Organization name  
+# + domain - Organization domain
+type Organization record {
+    string id;
+    string name;
+    string domain;
+};
+
+public function main() {
+    Organization org = {
+        domain: "myorg.com",
+        name: "My Org",
+        id: "abc123"
+    };
+}


### PR DESCRIPTION
## Purpose
$subject

Fixes #39905

## Approach
Updated the `ReferenceUtil` to return references of the parameters if the symbol (or reference to that symbol) being renamed is a documented parameter. Goes through the syntax nodes to identify parameter references in docs.

Currently supports record fields and function required params.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
