### PR TITLE
Add API to get unquoted name for key value pairs

### DIFF
--- a/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/ast/TomlKeyNode.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/ast/TomlKeyNode.java
@@ -55,6 +55,14 @@ public class TomlKeyNode extends TomlNode {
         return String.join(".", list);
     }
 
+    public String originalName() {
+        List<String> list = new ArrayList<>(keys.size());
+        for (TomlKeyEntryNode keyEntryNode : keys) {
+            list.add(keyEntryNode.name().toString());
+        }
+        return String.join(".", list);
+    }
+
     @Override
     public String toString() {
         return "TomlKeyNode{" + "keys=" + name() + '}';

--- a/misc/toml-parser/src/test/java/toml/parser/test/api/core/KeyValueTest.java
+++ b/misc/toml-parser/src/test/java/toml/parser/test/api/core/KeyValueTest.java
@@ -47,6 +47,7 @@ public class KeyValueTest {
 
     @Test
     public void testKeys() throws IOException {
+
         InputStream inputStream = Thread.currentThread().getContextClassLoader()
                 .getResourceAsStream("syntax/key-value/keys.toml");
 
@@ -80,6 +81,7 @@ public class KeyValueTest {
 
     @Test
     public void testBasicValues() throws IOException {
+
         InputStream inputStream = Thread.currentThread().getContextClassLoader()
                 .getResourceAsStream("syntax/key-value/values.toml");
         Toml read = Toml.read(inputStream);
@@ -206,6 +208,7 @@ public class KeyValueTest {
 
     @Test
     public void testArrayValues() throws IOException {
+
         InputStream inputStream = Thread.currentThread().getContextClassLoader()
                 .getResourceAsStream("syntax/key-value/array.toml");
         Toml read = Toml.read(inputStream);
@@ -305,6 +308,7 @@ public class KeyValueTest {
 
     @Test
     public void testDottedKey() throws IOException {
+
         InputStream inputStream = Thread.currentThread().getContextClassLoader()
                 .getResourceAsStream("syntax/key-value/dotted.toml");
         Toml read = Toml.read(inputStream);
@@ -387,6 +391,7 @@ public class KeyValueTest {
 
     @Test
     public void testInlineTables() throws IOException {
+
         InputStream inputStream = Thread.currentThread().getContextClassLoader()
                 .getResourceAsStream("syntax/key-value/inline-tables.toml");
         Toml read = Toml.read(inputStream);
@@ -433,8 +438,10 @@ public class KeyValueTest {
         TomlValueNode lsatVal = ((TomlKeyValueNode) entries.get("last")).value();
         Assert.assertEquals(((TomlStringValueNode) lsatVal).getValue(), "Supun");
     }
+
     @Test
     public void testQuotedIdentifiers() throws IOException {
+
         InputStream inputStream = Thread.currentThread().getContextClassLoader()
                 .getResourceAsStream("syntax/key-value/quoted-identifier.toml");
         Toml read = Toml.read(inputStream);
@@ -443,7 +450,7 @@ public class KeyValueTest {
 
         TomlKeyValueNode tomlKeyValueNode = (TomlKeyValueNode) read.rootNode().entries().get("\"foo.bar\"");
         Assert.assertEquals(tomlKeyValueNode.value().toNativeValue(), "value");
-        Assert.assertEquals(tomlKeyValueNode.key().name(),"\"foo.bar\"");
-        Assert.assertEquals(tomlKeyValueNode.key().originalName(),"foo.bar");
+        Assert.assertEquals(tomlKeyValueNode.key().name(), "\"foo.bar\"");
+        Assert.assertEquals(tomlKeyValueNode.key().originalName(), "foo.bar");
     }
 }

--- a/misc/toml-parser/src/test/java/toml/parser/test/api/core/KeyValueTest.java
+++ b/misc/toml-parser/src/test/java/toml/parser/test/api/core/KeyValueTest.java
@@ -433,4 +433,17 @@ public class KeyValueTest {
         TomlValueNode lsatVal = ((TomlKeyValueNode) entries.get("last")).value();
         Assert.assertEquals(((TomlStringValueNode) lsatVal).getValue(), "Supun");
     }
+    @Test
+    public void testQuotedIdentifiers() throws IOException {
+        InputStream inputStream = Thread.currentThread().getContextClassLoader()
+                .getResourceAsStream("syntax/key-value/quoted-identifier.toml");
+        Toml read = Toml.read(inputStream);
+        String value = ((TomlStringValueNode) read.get("foo.bar").get()).getValue();
+        Assert.assertEquals(value, "value1");
+
+        TomlKeyValueNode tomlKeyValueNode = (TomlKeyValueNode) read.rootNode().entries().get("\"foo.bar\"");
+        Assert.assertEquals(tomlKeyValueNode.value().toNativeValue(), "value");
+        Assert.assertEquals(tomlKeyValueNode.key().name(),"\"foo.bar\"");
+        Assert.assertEquals(tomlKeyValueNode.key().originalName(),"foo.bar");
+    }
 }

--- a/misc/toml-parser/src/test/resources/syntax/key-value/quoted-identifier.toml
+++ b/misc/toml-parser/src/test/resources/syntax/key-value/quoted-identifier.toml
@@ -1,0 +1,4 @@
+"foo.bar" = "value"
+
+[foo]
+bar = "value1"


### PR DESCRIPTION
## Purpose
$Subject

Part 1 fix of #40278

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
