### PR TITLE
Expose initializer method type from ObjectType as an API

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/types/ObjectType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/types/ObjectType.java
@@ -29,6 +29,13 @@ public interface ObjectType extends StructureType, SelectivelyImmutableReference
     MethodType[] getMethods();
 
     /**
+     * Get the method type of the initializer function.
+     *
+     * @return {@link MethodType} of the initializer function
+     */
+    MethodType getInitializer();
+
+    /**
      * Provides given @{@link ObjectType} is isolated.
      *
      * @return true if object is isolated otherwise false.

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BObjectType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BObjectType.java
@@ -115,6 +115,11 @@ public class BObjectType extends BStructureType implements ObjectType {
     }
 
     @Override
+    public MethodType getInitializer() {
+        return initializer;
+    }
+
+    @Override
     public boolean isIsolated() {
         return SymbolFlags.isFlagOn(getFlags(), SymbolFlags.ISOLATED);
     }
@@ -140,7 +145,7 @@ public class BObjectType extends BStructureType implements ObjectType {
         this.methodTypes = methodTypes;
     }
 
-    public void setInitializer(BMethodType initializer) {
+    public void setInitializer(MethodType initializer) {
         this.initializer = initializer;
     }
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ReadOnlyUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ReadOnlyUtils.java
@@ -269,7 +269,7 @@ public class ReadOnlyUtils {
                         origObjectType.getPackage(), origObjectType.flags |= SymbolFlags.READONLY);
                 immutableObjectType.setFields(immutableObjectFields);
                 immutableObjectType.generatedInitializer = origObjectType.generatedInitializer;
-                immutableObjectType.initializer = origObjectType.initializer;
+                immutableObjectType.setInitializer(origObjectType.getInitializer());
                 immutableObjectType.setMethods(origObjectType.getMethods());
 
                 BIntersectionType objectIntersectionType = createAndSetImmutableIntersectionType(origObjectType,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmSignatures.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmSignatures.java
@@ -429,6 +429,7 @@ public class JvmSignatures {
     public static final String SET_LINKED_HASH_MAP = "(L" + LINKED_HASH_MAP + ";)V";
     public static final String SET_MAP = "(L" + MAP + ";)V";
     public static final String SET_METHODS = "([L" + METHOD_TYPE + ";)V";
+    public static final String SET_INITIALIZER = "(L" + METHOD_TYPE + ";)V";
     public static final String SET_ON_INIT = "(L" + B_STRING_VALUE + ";L" + OBJECT + ";)V";
     public static final String SET_RESOURCE_METHOD_TYPE_ARRAY = "([L" + RESOURCE_METHOD_TYPE + ";)V";
     public static final String SET_STRAND = "(L" + STRAND_CLASS + ";)V";

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/types/JvmObjectTypeGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/split/types/JvmObjectTypeGen.java
@@ -89,6 +89,7 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.METHOD_T
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.POPULATE_ATTACHED_FUNCTION;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.RESOURCE_METHOD_TYPE_ARRAY_PARAM;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.RESOURCE_METHOD_TYPE_IMPL_INIT;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.SET_INITIALIZER;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.SET_LINKED_HASH_MAP;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.SET_MAP;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.SET_METHODS;
@@ -166,9 +167,9 @@ public class JvmObjectTypeGen {
         addObjectFields(mv, methodName, bType.fields);
         BObjectTypeSymbol objectTypeSymbol = (BObjectTypeSymbol) bType.tsymbol;
         addObjectInitFunction(mv, objectTypeSymbol.generatedInitializerFunc, bType, indexMap,
-                "$init$", "setGeneratedInitializer", symbolTable);
+                "$init$",  symbolTable, true);
         addObjectInitFunction(mv, objectTypeSymbol.initializerFunc, bType, indexMap, "init",
-                "setInitializer", symbolTable);
+                symbolTable, false);
         addObjectAttachedFunctions(cw, mv, fieldName, objectTypeSymbol.attachedFuncs, bType,
                 symbolTable);
         addResourceMethods(cw, mv, fieldName, objectTypeSymbol.attachedFuncs, bType,
@@ -209,8 +210,7 @@ public class JvmObjectTypeGen {
             mv.visitVarInsn(ALOAD, 0);
         }
         // Set the fields of the object
-        mv.visitMethodInsn(INVOKEVIRTUAL, OBJECT_TYPE_IMPL, "setMethods",
-                SET_METHODS, false);
+        mv.visitMethodInsn(INVOKEVIRTUAL, OBJECT_TYPE_IMPL, "setMethods", SET_METHODS, false);
     }
 
     private int splitObjectAttachedFunctions(ClassWriter cw, String methodName,
@@ -267,9 +267,9 @@ public class JvmObjectTypeGen {
         return methodCount;
     }
 
-    private void addObjectInitFunction(MethodVisitor mv, BAttachedFunction initFunction,
-                                       BObjectType objType, BIRVarToJVMIndexMap indexMap, String funcName,
-                                       String initializerFuncName, SymbolTable symbolTable) {
+    private void addObjectInitFunction(MethodVisitor mv, BAttachedFunction initFunction, BObjectType objType,
+                                       BIRVarToJVMIndexMap indexMap, String funcName,
+                                       SymbolTable symbolTable, boolean isGeneratedInit) {
 
         if (initFunction == null || !initFunction.funcName.value.contains(funcName)) {
             return;
@@ -283,8 +283,12 @@ public class JvmObjectTypeGen {
         mv.visitVarInsn(ALOAD, attachedFunctionVarIndex);
         mv.visitInsn(DUP);
         mv.visitInsn(POP);
-        mv.visitMethodInsn(INVOKEVIRTUAL, OBJECT_TYPE_IMPL, initializerFuncName,
-                METHOD_TYPE_IMPL_PARAM, false);
+        if (isGeneratedInit) {
+            mv.visitMethodInsn(INVOKEVIRTUAL, OBJECT_TYPE_IMPL, "setGeneratedInitializer",
+                    METHOD_TYPE_IMPL_PARAM, false);
+        } else {
+            mv.visitMethodInsn(INVOKEVIRTUAL, OBJECT_TYPE_IMPL, "setInitializer", SET_INITIALIZER, false);
+        }
     }
 
     private void addResourceMethods(ClassWriter cw, MethodVisitor mv, String fieldName,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/types/BLangObjectTypeNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/types/BLangObjectTypeNode.java
@@ -30,7 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * {@code BLangObjectTypeNode} represents a object type node in Ballerina.
+ * {@code BLangObjectTypeNode} represents an object type node in Ballerina.
  * <p>
  * e.g. object { public { int a; } private { string name; }};
  *


### PR DESCRIPTION
## Purpose
> $title

Fixes #40302 

## Approach
> Introduced a new API to expose initializer method type of an ObjectType.

## Samples
> ```java
>MethodType initMethodType = objectType.getInitializer()
>```

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
