### PR TITLE
Use matcher.replace() to handle unicode characters with multiple code points

### DIFF
--- a/langlib/lang.regexp/src/main/ballerina/regexp.bal
+++ b/langlib/lang.regexp/src/main/ballerina/regexp.bal
@@ -336,16 +336,7 @@ public isolated function replace(RegExp re, string str, Replacement replacement,
     if findResult is () {
         return str;
     }
-    Span span = findResult[0];
-    int index = 0;
-    int strLength = length(str);
-    string updatedString = substring(str, index, span.startIndex) +
-                                        getReplacementString(findResult, replacement);
-    index = span.endIndex;
-    if index < strLength {
-        updatedString += substring(str, index, strLength);
-    }
-    return updatedString;
+    return replaceImpl(re, startIndex, str, getReplacementString(findResult, replacement));
 }
 
 # Replaces all matches of a regular expression.
@@ -378,16 +369,9 @@ public isolated function replaceAll(RegExp re, string str, Replacement replaceme
     if findResult.length() == 0 {
         return str;
     }
-    string updatedString = "";
-    int index = 0;
-    foreach Groups groups in findResult {
-        Span span = groups[0];
-        updatedString += substring(str, index, span.startIndex) +
-                                            getReplacementString(groups, replacement);
-        index = span.endIndex;
-    }
-    if index < length(str) {
-        updatedString += substring(str, index, length(str));
+    string updatedString = str;
+    foreach Groups group in findResult {
+        updatedString = replaceImpl(re, startIndex, updatedString, getReplacementString(group, replacement));
     }
     return updatedString;
 }
@@ -450,4 +434,9 @@ public isolated function split(RegExp re, string str) returns string[] = @java:M
 public isolated function fromString(string str) returns RegExp|error = @java:Method {
     'class: "org.ballerinalang.langlib.regexp.FromString",
     name: "fromString"
+} external;
+
+isolated function replaceImpl(RegExp reExp, int startIndex, string str, string replacement) returns string = @java:Method {
+    'class: "org.ballerinalang.langlib.regexp.Replace",
+    name: "replace"
 } external;

--- a/langlib/lang.regexp/src/main/java/org/ballerinalang/langlib/regexp/Replace.java
+++ b/langlib/lang.regexp/src/main/java/org/ballerinalang/langlib/regexp/Replace.java
@@ -1,0 +1,27 @@
+package org.ballerinalang.langlib.regexp;
+
+import io.ballerina.runtime.api.utils.StringUtils;
+import io.ballerina.runtime.api.values.BRegexpValue;
+import io.ballerina.runtime.api.values.BString;
+
+import java.util.regex.Matcher;
+
+import static org.ballerinalang.langlib.regexp.RegexUtil.checkIndexWithinRange;
+
+/**
+ * Native implementation of lang.regexp:replace(string).
+ *
+ * @since 2201.6.0
+ */
+public class Replace {
+    public static BString replace(BRegexpValue regExp, long startIndex, BString str, BString replacementStr) {
+        checkIndexWithinRange(str, startIndex);
+        int index = (int) startIndex;
+        String inputStr = str.getValue();
+        String prefixStr = inputStr.substring(0, index);
+        String suffixStr = inputStr.substring(index);
+        Matcher matcher = RegexUtil.getMatcher(regExp, suffixStr);
+        String updatedStr = prefixStr + matcher.replaceFirst(replacementStr.getValue());
+        return StringUtils.fromString(updatedStr);
+    }
+}

--- a/langlib/lang.string/src/main/ballerina/string.bal
+++ b/langlib/lang.string/src/main/ballerina/string.bal
@@ -456,7 +456,7 @@ public type RegExp regexp:RegExp;
 # + str - the string
 # + re - the regular expression
 # + return - true if there is full match of `re` with `str`, and false otherwise
-public function matches(string str, RegExp re) returns boolean {
+public isolated function matches(string str, RegExp re) returns boolean {
    return re.isFullMatch(str);
 }
 
@@ -476,6 +476,6 @@ public function matches(string str, RegExp re) returns boolean {
 # + str - the string to be matched
 # + re - the regular expression
 # + return - true if the is a match of `re` somewhere within `str`, otherwise false
-public function includesMatch(string str, RegExp re, int startIndex = 0) returns boolean {
+public isolated function includesMatch(string str, RegExp re, int startIndex = 0) returns boolean {
    return re.find(str, startIndex) != ();
 }

--- a/langlib/langlib-test/src/test/resources/test-src/regexp_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/regexp_test.bal
@@ -579,6 +579,20 @@ function testReplace() {
     var regExpr5 = re `0+`;
     string result6 = regExpr5.replace(str6, replacementFunctionForReplace, 4);
     assertEquality("1001711", result6);
+
+    string str7 = "🔜 #RayoBarça 🔵🔴 https://t.co/iHDUx7EmFJ";
+    var regExpr6 = re `\p{S}`;
+    string result7 = regExpr6.replace(str7, replacementFunctionForReplace);
+    assertEquality("2 #RayoBarça 🔵🔴 https://t.co/iHDUx7EmFJ", result7);
+
+    string result8 = regExpr6.replace(str7, replacementFunctionForReplace, 4);
+    assertEquality("🔜 #RayoBarça 16🔴 https://t.co/iHDUx7EmFJ", result8);
+
+    string result9 = regExpr6.replace(str7, "");
+    assertEquality(" #RayoBarça 🔵🔴 https://t.co/iHDUx7EmFJ", result9);
+
+    string result10 = regExpr6.replace(str7, "", 3);
+    assertEquality("🔜 #RayoBarça 🔴 https://t.co/iHDUx7EmFJ", result10);
 }
 
 isolated function replacementFunctionForReplace(regexp:Groups groups) returns string {
@@ -624,10 +638,32 @@ function testReplaceAll() {
     assertEquality("151311", result51);
     string result52 = regExpr4.replaceAll(str5, replacementFunctionForReplaceAll, 6);
     assertEquality("1000001311", result52);
+
+    var regExpr5 = re `\p{S}`;
+    string str6 = "🔜 #RayoBarça 🔵🔴 https://t.co/iHDUx7EmFJ";
+    string result61 = regExpr5.replaceAll(str6, "");
+    assertEquality(" #RayoBarça  https://t.co/iHDUx7EmFJ", result61);
+    string result62 = regExpr5.replaceAll(str6, "", 12);
+    assertEquality("🔜 #RayoBarça  https://t.co/iHDUx7EmFJ", result62);
+
+    var regExpr6 = re `(\d{2})/(\d{2})/(\d{4})`;
+    string str7 = "04/05/2023, 05/05/2023";
+    string result71 = regExpr6.replaceAll(str7, updateDateFormat);
+    assertEquality("2023-05-04, 2023-05-05", result71);
 }
 
 isolated function replacementFunctionForReplaceAll(regexp:Groups groups) returns string {
     return groups[0].substring().length().toString();
+}
+
+isolated function updateDateFormat(regexp:Groups groups) returns string {
+    if groups.length() != 4 {
+        return (<regexp:Span>groups[0]).substring();
+    }
+    string year = (<regexp:Span>groups[3]).substring();
+    string month = (<regexp:Span>groups[2]).substring();
+    string day = (<regexp:Span>groups[1]).substring();
+    return string `${year}-${month}-${day}`;
 }
 
 function testFromString() {


### PR DESCRIPTION
## Purpose
> $subject

Fixes #[40315](https://github.com/pcnfernando/ballerina-lang/tree/issue-40315)

## Approach
> When we use Java Patterns to find matches for a regex, the returned groups contains the positions incorrectly due to the fact that some Unicode characters are decoded to multiple codepoints. Using these positions to replace using ballerina causes it to return erroneous results. Hence, using the Java implementation to replace

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
