### PR TITLE
Update GraphQL tool help with Ballerina GraphQL service generation command

### DIFF
--- a/cli/ballerina-cli/src/main/resources/cli-help/ballerina-graphql.help
+++ b/cli/ballerina-cli/src/main/resources/cli-help/ballerina-graphql.help
@@ -1,6 +1,6 @@
 NAME
        ballerina-graphql - Generate the Ballerina client sources for a GraphQL config file, 
-       generate the GraphQL schema for a Ballerina GraphQL service
+       generate the GraphQL schema for a Ballerina GraphQL service,
        and generate the Ballerina service sources for a GraphQL schema.
 
 
@@ -42,13 +42,13 @@ OPTIONS
             If this base path is not specified, schemas will be generated for each of the GraphQL
             services in the input file.
         -m, --mode
-            This mode is used to identify the operation mode. It can be `client`, `schema`, or `service`. Argument `client`
-            indicates the Ballerina client source code generation, argument `schema` indicates the GraphQL schema
-            generation, and argument `service` indicates the Ballerina GraphQL service source code generation. Mode is only 
+            This mode is used to identify the operation mode. It can be `client`, `schema`, or `service`. The `client` argument
+            indicates the Ballerina client source code generation, the `schema` argument indicates the GraphQL schema
+            generation, and the `service` argument indicates the Ballerina GraphQL service source code generation. Mode is only 
             mandatory for Ballerina GraphQL service source code generation.
         -r, --use-records-for-objects
-            This flag is used with no argument. It is used only in the Ballerina GraphQL service generation. It will make 
-            the Ballerina CLI tool uses record types for GraphQL object types whenever possible.
+            This flag is used without an argument. It is used only in the Ballerina GraphQL service generation. It will make 
+            the Ballerina CLI tool to use record types for GraphQL object types whenever possible.
 
 EXAMPLES
        Generate Ballerina Graphql clients using a GraphQL config file (`graphql.config.yaml`).
@@ -61,8 +61,8 @@ EXAMPLES
        Generate a GraphQL schema for a selected GraphQL service from the given input file.
            $ bal graphql -i graphql_service.bal -o ./output_path -s /service_base_path
 
-       Generate a Ballerina GraphQL service using a GraphQL schema file (`schema.graphql`)
+       Generate a Ballerina GraphQL service using a GraphQL schema file (`schema.graphql`).
            $ bal graphql -i schema.graphql -m service -o ./output_path
 
-       Generate Ballerina GraphQL service using a GraphQL schema file (`schema.graphql`) inclduing record types whenever possible
+       Generate a Ballerina GraphQL service using a GraphQL schema file (`schema.graphql`) including record types whenever possible.
            $ bal graphql -i schema.graphql -m service -o ./output_path -r

--- a/cli/ballerina-cli/src/main/resources/cli-help/ballerina-graphql.help
+++ b/cli/ballerina-cli/src/main/resources/cli-help/ballerina-graphql.help
@@ -47,7 +47,8 @@ OPTIONS
             `service`. The `client` argument indicates the Ballerina client source code 
             generation, the `schema` argument indicates the GraphQL schema generation, and the 
             `service` argument indicates the Ballerina GraphQL service source code generation. 
-            Mode is only mandatory for Ballerina GraphQL service source code generation.
+            If the `mode` flag is not specified, the `graphql` tool will infer the mode from the 
+            `input` file extension.
         -r, --use-records-for-objects
             This flag is used without an argument. It is used only in the Ballerina GraphQL 
             service generation. It will make the Ballerina CLI tool to use record types for 

--- a/cli/ballerina-cli/src/main/resources/cli-help/ballerina-graphql.help
+++ b/cli/ballerina-cli/src/main/resources/cli-help/ballerina-graphql.help
@@ -26,7 +26,8 @@ DESCRIPTION
 
 
 OPTIONS
-        -i, --input <graphql-configuration-file-path | ballerina-graphql-service-file-path | graphql-schema-file-path>
+        -i, --input <graphql-configuration-file-path | ballerina-graphql-service-file-path | 
+        graphql-schema-file-path>
             This is mandatory input. The given GraphQL config file which is configured with
             GraphQL schemas (SDL) and queries, will generate the Ballerina GraphQL client sources.
             The given Ballerina GraphQL service file will generate the GraphQL schema (SDL) file
@@ -42,13 +43,15 @@ OPTIONS
             If this base path is not specified, schemas will be generated for each of the GraphQL
             services in the input file.
         -m, --mode
-            This mode is used to identify the operation mode. It can be `client`, `schema`, or `service`. The `client` argument
-            indicates the Ballerina client source code generation, the `schema` argument indicates the GraphQL schema
-            generation, and the `service` argument indicates the Ballerina GraphQL service source code generation. Mode is only 
-            mandatory for Ballerina GraphQL service source code generation.
+            This mode is used to identify the operation mode. It can be `client`, `schema`, or 
+            `service`. The `client` argument indicates the Ballerina client source code 
+            generation, the `schema` argument indicates the GraphQL schema generation, and the 
+            `service` argument indicates the Ballerina GraphQL service source code generation. 
+            Mode is only mandatory for Ballerina GraphQL service source code generation.
         -r, --use-records-for-objects
-            This flag is used without an argument. It is used only in the Ballerina GraphQL service generation. It will make 
-            the Ballerina CLI tool to use record types for GraphQL object types whenever possible.
+            This flag is used without an argument. It is used only in the Ballerina GraphQL 
+            service generation. It will make the Ballerina CLI tool to use record types for 
+            GraphQL object types whenever possible.
 
 EXAMPLES
        Generate Ballerina Graphql clients using a GraphQL config file (`graphql.config.yaml`).
@@ -64,5 +67,6 @@ EXAMPLES
        Generate a Ballerina GraphQL service using a GraphQL schema file (`schema.graphql`).
            $ bal graphql -i schema.graphql -m service -o ./output_path
 
-       Generate a Ballerina GraphQL service using a GraphQL schema file (`schema.graphql`) including record types whenever possible.
+       Generate a Ballerina GraphQL service using a GraphQL schema file (`schema.graphql`) 
+       including record types whenever possible.
            $ bal graphql -i schema.graphql -m service -o ./output_path -r

--- a/cli/ballerina-cli/src/main/resources/cli-help/ballerina-graphql.help
+++ b/cli/ballerina-cli/src/main/resources/cli-help/ballerina-graphql.help
@@ -1,6 +1,7 @@
 NAME
-       ballerina-graphql - Generate the Ballerina client sources for a GraphQL config file
-       and generate the GraphQL schema for a Ballerina GraphQL service.
+       ballerina-graphql - Generate the Ballerina client sources for a GraphQL config file, 
+       generate the GraphQL schema for a Ballerina GraphQL service
+       and generate the Ballerina service sources for a GraphQL schema.
 
 
 SYNOPSIS
@@ -9,6 +10,10 @@ SYNOPSIS
        bal graphql [-i | --input] <ballerina-graphql-service-file-path>
                    [-o | --output] <output-location>
                    [-s | --service] <service-base-path>
+       bal graphql [-i | --input] <graphql-schema-file-path>
+                   [-o | --output] <output-location>
+                   [-m | --mode] <operation-mode>
+                   [-r | --use-records-for-objects]
 
 
 DESCRIPTION
@@ -21,11 +26,12 @@ DESCRIPTION
 
 
 OPTIONS
-        -i, --input <graphql-configuration-file-path | ballerina-graphql-service-file-path>
+        -i, --input <graphql-configuration-file-path | ballerina-graphql-service-file-path | graphql-schema-file-path>
             This is mandatory input. The given GraphQL config file which is configured with
             GraphQL schemas (SDL) and queries, will generate the Ballerina GraphQL client sources.
             The given Ballerina GraphQL service file will generate the GraphQL schema (SDL) file
             relevant to the service.
+            The given GraphQL schema file will generate the Ballerina GraphQL service sources.
         -o, --output <output-location>
             Location of the generated Ballerina source code or GraphQL schema. If this path is not
             specified, the output will be written to the same directory from which the command is
@@ -35,6 +41,14 @@ OPTIONS
             GraphQL schema. This option is used with the GraphQL schema generation command.
             If this base path is not specified, schemas will be generated for each of the GraphQL
             services in the input file.
+        -m, --mode
+            This mode is used to identify the operation mode. It can be `client`, `schema`, or `service`. Argument `client`
+            indicates the Ballerina client source code generation, argument `schema` indicates the GraphQL schema
+            generation, and argument `service` indicates the Ballerina GraphQL service source code generation. Mode is only 
+            mandatory for Ballerina GraphQL service source code generation.
+        -r, --use-records-for-objects
+            This flag is used with no argument. It is used only in the Ballerina GraphQL service generation. It will make 
+            the Ballerina CLI tool uses record types for GraphQL object types whenever possible.
 
 EXAMPLES
        Generate Ballerina Graphql clients using a GraphQL config file (`graphql.config.yaml`).
@@ -46,3 +60,9 @@ EXAMPLES
 
        Generate a GraphQL schema for a selected GraphQL service from the given input file.
            $ bal graphql -i graphql_service.bal -o ./output_path -s /service_base_path
+
+       Generate a Ballerina GraphQL service using a GraphQL schema file (`schema.graphql`)
+           $ bal graphql -i schema.graphql -m service -o ./output_path
+
+       Generate Ballerina GraphQL service using a GraphQL schema file (`schema.graphql`) inclduing record types whenever possible
+           $ bal graphql -i schema.graphql -m service -o ./output_path -r

--- a/cli/ballerina-cli/src/main/resources/cli-help/ballerina-help.help
+++ b/cli/ballerina-cli/src/main/resources/cli-help/ballerina-help.help
@@ -42,8 +42,8 @@ COMMANDS
         grpc            Generate the Ballerina sources for a given Protocol
                         Buffer definition
         graphql         Generate the Ballerina client sources for a GraphQL config file,
-                        generate the GraphQL schema for a Ballerina GraphQL service and 
-                        generate the Ballerina GraphQL service for a GraphQL schema.
+                        generate the GraphQL schema for a Ballerina GraphQL service, and 
+                        generate the Ballerina GraphQL service for a GraphQL schema
         openapi         Generate the Ballerina sources for a given OpenAPI
                         definition and vice versa
         asyncapi        Generate the Ballerina sources for a given AsyncAPI definition

--- a/cli/ballerina-cli/src/main/resources/cli-help/ballerina-help.help
+++ b/cli/ballerina-cli/src/main/resources/cli-help/ballerina-help.help
@@ -41,8 +41,9 @@ COMMANDS
         format          Format Ballerina source files
         grpc            Generate the Ballerina sources for a given Protocol
                         Buffer definition
-        graphql         Generate the Ballerina client sources for a GraphQL config file
-                        and generate the GraphQL schema for a Ballerina GraphQL service.
+        graphql         Generate the Ballerina client sources for a GraphQL config file,
+                        generate the GraphQL schema for a Ballerina GraphQL service and 
+                        generate the Ballerina GraphQL service for a GraphQL schema.
         openapi         Generate the Ballerina sources for a given OpenAPI
                         definition and vice versa
         asyncapi        Generate the Ballerina sources for a given AsyncAPI definition


### PR DESCRIPTION
## Purpose
Functionality to generate Ballerina GraphQL service sources for a given GraphQL schema is added to the GraphQL tool. GraphQL tool help is updated with details regarding to this functionality. 

Fixes [#4433](https://github.com/ballerina-platform/ballerina-standard-library/issues/4433)

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
