### PR TITLE
Fix java.lang.StringIndexOutOfBoundsException when unexpected chars in Json string

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/JsonParser.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/JsonParser.java
@@ -540,6 +540,8 @@ public class JsonParser {
                         state = sm.initNewObject();
                     } else if (ch == '[') {
                         state = sm.initNewArray();
+                    } else if (ch == ']') {
+                        StateMachine.throwExpected("an array element");
                     } else {
                         state = NON_STRING_ARRAY_ELEMENT_STATE;
                     }
@@ -647,6 +649,8 @@ public class JsonParser {
                         state = sm.initNewObject();
                     } else if (ch == '[') {
                         state = sm.initNewArray();
+                    } else if (ch == ']' || ch == '}') {
+                        StateMachine.throwExpected("a field value");
                     } else {
                         state = NON_STRING_FIELD_VALUE_STATE;
                     }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/JsonParser.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/JsonParser.java
@@ -1126,7 +1126,7 @@ public class JsonParser {
                         continue;
                     }
                     this.reset(sm);
-                    throw new JsonParserException("expected hexadecimal value of an unicode character");
+                    throw new JsonParserException("expected the hexadecimal value of a unicode character");
                 }
                 sm.index = i + 1;
                 return state;

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/JsonParser.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/JsonParser.java
@@ -541,7 +541,7 @@ public class JsonParser {
                     } else if (ch == '[') {
                         state = sm.initNewArray();
                     } else if (ch == ']') {
-                        StateMachine.throwExpected("an array element");
+                        throw new JsonParserException("expected an array element");
                     } else {
                         state = NON_STRING_ARRAY_ELEMENT_STATE;
                     }
@@ -650,7 +650,7 @@ public class JsonParser {
                     } else if (ch == '[') {
                         state = sm.initNewArray();
                     } else if (ch == ']' || ch == '}') {
-                        StateMachine.throwExpected("a field value");
+                        throw new JsonParserException("expected a field value");
                     } else {
                         state = NON_STRING_FIELD_VALUE_STATE;
                     }
@@ -1126,8 +1126,7 @@ public class JsonParser {
                         continue;
                     }
                     this.reset(sm);
-                    StateMachine.throwExpected("hexadecimal value of an unicode character");
-                    break;
+                    throw new JsonParserException("expected hexadecimal value of an unicode character");
                 }
                 sm.index = i + 1;
                 return state;
@@ -1253,7 +1252,7 @@ public class JsonParser {
                             }
                             break;
                         default:
-                            StateMachine.throwExpected("escaped characters");
+                            throw new JsonParserException("expected escaped characters");
                     }
                 }
                 sm.index = i + 1;

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibValueTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibValueTest.java
@@ -449,7 +449,8 @@ public class LangLibValueTest {
                 { "testFromJsonWithTypeNestedRecordsNegative" },
                 { "testFromJsonWithTypeOnRegExp" },
                 { "testFromJsonWithTypeOnRegExpNegative" },
-                {"testFromJsonWithTypeToUnionOfTypeReference"}
+                {"testFromJsonWithTypeToUnionOfTypeReference"},
+                {"testFromJsonStringWithUnexpectedChars"}
         };
     }
 

--- a/langlib/langlib-test/src/test/resources/test-src/valuelib_fromJson_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/valuelib_fromJson_test.bal
@@ -833,13 +833,14 @@ function testFromJsonStringWithUnexpectedChars() {
     string s2 = "[1, 2,]";
     string s3 = "{\"a\":1,}";
     string s4 = "{\"a\": [1, 2,]}";
+    string s5 = "[{\"x\": 1}, {\"y\": 2]";
 
     error err = <error> s1.fromJsonStringWithType(json);
-    assertEquality(<string> checkpanic err.detail()["message"], "expected 'a field value' at line: 1 column: 6");
+    assertEquality(<string> checkpanic err.detail()["message"], "expected a field value at line: 1 column: 6");
     assertEquality(err.message(), "{ballerina/lang.value}ConversionError");
 
     err = <error> s2.fromJsonStringWithType(json);
-    assertEquality(<string> checkpanic err.detail()["message"], "expected 'an array element' at line: 1 column: 9");
+    assertEquality(<string> checkpanic err.detail()["message"], "expected an array element at line: 1 column: 9");
     assertEquality(err.message(), "{ballerina/lang.value}ConversionError");
 
     err = <error> s3.fromJsonString();
@@ -847,7 +848,11 @@ function testFromJsonStringWithUnexpectedChars() {
     assertEquality(err.message(), "{ballerina/lang.value}FromJsonStringError");
 
     err = <error> s4.fromJsonString();
-    assertEquality(<string> checkpanic err.detail()["message"], "expected 'an array element' at line: 1 column: 15");
+    assertEquality(<string> checkpanic err.detail()["message"], "expected an array element at line: 1 column: 15");
+    assertEquality(err.message(), "{ballerina/lang.value}FromJsonStringError");
+
+    err = <error> s5.fromJsonString();
+    assertEquality(<string> checkpanic err.detail()["message"], "expected ',' or ']' at line: 1 column: 22");
     assertEquality(err.message(), "{ballerina/lang.value}FromJsonStringError");
 }
 

--- a/langlib/langlib-test/src/test/resources/test-src/valuelib_fromJson_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/valuelib_fromJson_test.bal
@@ -835,6 +835,7 @@ function testFromJsonStringWithUnexpectedChars() {
     string s4 = "{\"a\": [1, 2,]}";
     string s5 = "[{\"x\": 1}, {\"y\": 2]";
     string s6 = "{\"a\": \"\\👹👺\\👻😺🐈\\\\🦁😀\"}";
+    string s7 = "{\"a\": \"\\u123Z\"}";
 
     error err = <error> s1.fromJsonStringWithType(json);
     assertEquality(<string> checkpanic err.detail()["message"], "expected a field value at line: 1 column: 6");
@@ -858,6 +859,11 @@ function testFromJsonStringWithUnexpectedChars() {
 
     err = <error> s6.fromJsonString();
     assertEquality(<string> checkpanic err.detail()["message"], "expected escaped characters at line: 1 column: 9");
+    assertEquality(err.message(), "{ballerina/lang.value}FromJsonStringError");
+
+    err = <error> s7.fromJsonString();
+    assertEquality(<string> checkpanic err.detail()["message"],
+                        "expected hexadecimal value of an unicode character at line: 1 column: 15");
     assertEquality(err.message(), "{ballerina/lang.value}FromJsonStringError");
 }
 

--- a/langlib/langlib-test/src/test/resources/test-src/valuelib_fromJson_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/valuelib_fromJson_test.bal
@@ -863,7 +863,7 @@ function testFromJsonStringWithUnexpectedChars() {
 
     err = <error> s7.fromJsonString();
     assertEquality(<string> checkpanic err.detail()["message"],
-                        "expected hexadecimal value of an unicode character at line: 1 column: 15");
+                        "expected the hexadecimal value of a unicode character at line: 1 column: 13");
     assertEquality(err.message(), "{ballerina/lang.value}FromJsonStringError");
 }
 

--- a/langlib/langlib-test/src/test/resources/test-src/valuelib_fromJson_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/valuelib_fromJson_test.bal
@@ -828,6 +828,29 @@ function testFromJsonWithTypeToUnionOfTypeReference() {
     assertEquality(t3, <BoundAssertion> ["let", 3]);
 }
 
+function testFromJsonStringWithUnexpectedChars() {
+    string s1 = "{\"a\":}";
+    string s2 = "[1, 2,]";
+    string s3 = "{\"a\":1,}";
+    string s4 = "{\"a\": [1, 2,]}";
+
+    error err = <error> s1.fromJsonStringWithType(json);
+    assertEquality(<string> checkpanic err.detail()["message"], "expected 'a field value' at line: 1 column: 6");
+    assertEquality(err.message(), "{ballerina/lang.value}ConversionError");
+
+    err = <error> s2.fromJsonStringWithType(json);
+    assertEquality(<string> checkpanic err.detail()["message"], "expected 'an array element' at line: 1 column: 9");
+    assertEquality(err.message(), "{ballerina/lang.value}ConversionError");
+
+    err = <error> s3.fromJsonString();
+    assertEquality(<string> checkpanic err.detail()["message"], "expected '\"' at line: 1 column: 9");
+    assertEquality(err.message(), "{ballerina/lang.value}FromJsonStringError");
+
+    err = <error> s4.fromJsonString();
+    assertEquality(<string> checkpanic err.detail()["message"], "expected 'an array element' at line: 1 column: 15");
+    assertEquality(err.message(), "{ballerina/lang.value}FromJsonStringError");
+}
+
 function assert(anydata actual, anydata expected) {
     if (expected == actual) {
         return;

--- a/langlib/langlib-test/src/test/resources/test-src/valuelib_fromJson_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/valuelib_fromJson_test.bal
@@ -834,6 +834,7 @@ function testFromJsonStringWithUnexpectedChars() {
     string s3 = "{\"a\":1,}";
     string s4 = "{\"a\": [1, 2,]}";
     string s5 = "[{\"x\": 1}, {\"y\": 2]";
+    string s6 = "{\"a\": \"\\👹👺\\👻😺🐈\\\\🦁😀\"}";
 
     error err = <error> s1.fromJsonStringWithType(json);
     assertEquality(<string> checkpanic err.detail()["message"], "expected a field value at line: 1 column: 6");
@@ -853,6 +854,10 @@ function testFromJsonStringWithUnexpectedChars() {
 
     err = <error> s5.fromJsonString();
     assertEquality(<string> checkpanic err.detail()["message"], "expected ',' or ']' at line: 1 column: 22");
+    assertEquality(err.message(), "{ballerina/lang.value}FromJsonStringError");
+
+    err = <error> s6.fromJsonString();
+    assertEquality(<string> checkpanic err.detail()["message"], "expected escaped characters at line: 1 column: 9");
     assertEquality(err.message(), "{ballerina/lang.value}FromJsonStringError");
 }
 


### PR DESCRIPTION
## Purpose
> Fix `java.lang.StringIndexOutOfBoundsException` during parse the json string which contains unexpected characters. 

Fixes #32124 

## Approach
> Provides proper error message

## Samples
> ```ballerina
> string s1 = "{\"a\":}";
> string s2 = "[1, 2,]";
> string s3 = "{\"a\":1,}";
> string s4 = "{\"a\": [1, 2,]}";
> ```
With this fix proper error messages will be given for the above invalid Json string cases.

## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
