### PR TITLE
Include api-docs version in API docs

### DIFF
--- a/compiler/ballerina-lang/build.gradle
+++ b/compiler/ballerina-lang/build.gradle
@@ -73,6 +73,7 @@ processResources {
     filter { String line -> line.replace('${project.version}', "${project.version}")}
     filter { String line -> line.replace('${short.version}', "${project.version}")}
     filter { String line -> line.replace('${spec.version}', "${project.specVersion}")}
+    filter { String line -> line.replace('${apiDocs.version}', "${project.apiDocsVersion}")}
 }
 
 ext.moduleName = 'ballerina.lang'

--- a/compiler/ballerina-lang/src/main/resources/META-INF/tool.properties
+++ b/compiler/ballerina-lang/src/main/resources/META-INF/tool.properties
@@ -2,3 +2,4 @@ ballerina.channel=Swan Lake
 ballerina.version=${short.version}
 ballerina.packVersion=${project.version}
 spec.version=${spec.version}
+apiDocs.version=${apiDocs.version}

--- a/compiler/linter-plugin/build.gradle
+++ b/compiler/linter-plugin/build.gradle
@@ -47,6 +47,7 @@ processResources {
     filter { String line -> line.replace('${project.version}', "${project.version}")}
     filter { String line -> line.replace('${short.version}', "${project.version}")}
     filter { String line -> line.replace('${spec.version}', "${project.specVersion}")}
+    filter { String line -> line.replace('${apiDocs.version}', "${project.apiDocsVersion}")}
 }
 
 ext.moduleName = 'io.ballerina.compiler.linter'

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,7 @@ version=2201.5.0-SNAPSHOT
 group=org.ballerinalang
 bootstrappedOn=1.1.0-alpha
 specVersion=2022R4
+apiDocsVersion=1.0.0
 
 # dependency versions
 

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
@@ -267,6 +267,20 @@ public class BallerinaDocGenerator {
         }
     }
 
+    private static String getApiDocsVersion() {
+        String apiDocsVersion = "";
+        try (InputStream inputStream = BallerinaDocGenerator.class.getResourceAsStream("/META-INF/tool.properties")) {
+            Properties properties = new Properties();
+            properties.load(inputStream);
+
+            apiDocsVersion = properties.getProperty("apiDocs.version").split("-")[0];
+
+            return apiDocsVersion;
+        } catch (IOException e) {
+            return  "NOT_FOUND";
+        }
+    }
+
     private static void genApiDocsJson(ModuleLibrary moduleLib, Path destination, boolean excludeUI) {
         try {
             Files.createDirectories(destination);
@@ -275,6 +289,7 @@ public class BallerinaDocGenerator {
         }
 
         ApiDocsJson apiDocsJson = new ApiDocsJson();
+        apiDocsJson.apiDocsVersion = getApiDocsVersion();
         apiDocsJson.docsData = moduleLib;
         apiDocsJson.searchData = genSearchJson(moduleLib);
 

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
@@ -277,7 +277,7 @@ public class BallerinaDocGenerator {
 
             return apiDocsVersion;
         } catch (IOException e) {
-            return  "NOT_FOUND";
+            return "NOT_FOUND";
         }
     }
 

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/ApiDocsJson.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/ApiDocsJson.java
@@ -25,6 +25,8 @@ import org.ballerinalang.docgen.generator.model.search.SearchJson;
  */
 public class ApiDocsJson {
     @Expose
+    public String apiDocsVersion = "";
+    @Expose
     public ModuleLibrary docsData;
     @Expose
     public SearchJson searchData;


### PR DESCRIPTION
## Purpose
Currrently api-docs are generated without a version. This will generate `api-docs.json` with a proper version which will help to handle api-docs for older ballerina versions from central side.

Fixes #40424

## Approach
a new property has been added to `tool.properties` in `META-INF` in the compiler which is accessed from `BallerinaDoc Generator` class.

## Samples

<img width="593" alt="Screenshot 2023-05-16 at 17 28 51" src="https://github.com/ballerina-platform/ballerina-lang/assets/51471998/8b8547bc-15c3-4cdd-951a-21ae78c46867">

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
