### PR TITLE
[2201.5.x] Fix record intersection configurable error

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/configurable/providers/toml/ConfigValueCreator.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/configurable/providers/toml/ConfigValueCreator.java
@@ -280,7 +280,8 @@ public class ConfigValueCreator {
             Object objectValue = createValue(value, fieldType);
             initialValueEntries.put(fieldName, objectValue);
         }
-        return ValueCreator.createReadonlyRecordValue(mutableType.getPackage(), mutableType.getName(), initialValueEntries);
+        return ValueCreator.createReadonlyRecordValue(mutableType.getPackage(), mutableType.getName(),
+                initialValueEntries);
     }
 
     private BTable<BString, Object> createTableValue(TomlNode tomlValue, Type type) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/configurable/providers/toml/ConfigValueCreator.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/configurable/providers/toml/ConfigValueCreator.java
@@ -23,6 +23,7 @@ import io.ballerina.runtime.api.creators.TypeCreator;
 import io.ballerina.runtime.api.creators.ValueCreator;
 import io.ballerina.runtime.api.types.ArrayType;
 import io.ballerina.runtime.api.types.Field;
+import io.ballerina.runtime.api.types.IntersectableReferenceType;
 import io.ballerina.runtime.api.types.IntersectionType;
 import io.ballerina.runtime.api.types.MapType;
 import io.ballerina.runtime.api.types.RecordType;
@@ -62,6 +63,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static io.ballerina.runtime.internal.ValueUtils.createReadOnlyXmlValue;
 import static io.ballerina.runtime.internal.configurable.providers.toml.Utils.getEffectiveType;
@@ -254,29 +256,31 @@ public class ConfigValueCreator {
     }
 
     private BMap<BString, Object> createRecordValue(TomlNode tomlNode, Type type) {
-        RecordType recordType;
-        String recordName;
-        if (type.getTag() == TypeTags.RECORD_TYPE_TAG) {
-            recordName = type.getName();
-            recordType = (RecordType) type;
+        RecordType mutableType;
+        Optional<IntersectionType> intersectionType = ((IntersectableReferenceType) type).getIntersectionType();
+        if (intersectionType.isPresent()) {
+            mutableType = (RecordType) ReadOnlyUtils.getMutableType((BIntersectionType) intersectionType.get());
         } else {
-            recordType = (RecordType) ReadOnlyUtils.getMutableType((BIntersectionType) type);
-            recordName = recordType.getName();
+            if (type.getTag() == TypeTags.RECORD_TYPE_TAG) {
+                mutableType = (RecordType) type;
+            } else {
+                mutableType = (RecordType) ReadOnlyUtils.getMutableType((BIntersectionType) type);
+            }
         }
         TomlTableNode tomlValue = (TomlTableNode) tomlNode;
         Map<String, Object> initialValueEntries = new HashMap<>();
         for (Map.Entry<String, TopLevelNode> tomlField : tomlValue.entries().entrySet()) {
             String fieldName = tomlField.getKey();
-            Field field = recordType.getFields().get(fieldName);
+            Field field = mutableType.getFields().get(fieldName);
             TomlNode value = tomlField.getValue();
             if (field == null) {
-                field = Utils.createAdditionalField(recordType, fieldName, value);
+                field = Utils.createAdditionalField(mutableType, fieldName, value);
             }
             Type fieldType = TypeUtils.getReferredType(field.getFieldType());
             Object objectValue = createValue(value, fieldType);
             initialValueEntries.put(fieldName, objectValue);
         }
-        return ValueCreator.createReadonlyRecordValue(recordType.getPackage(), recordName, initialValueEntries);
+        return ValueCreator.createReadonlyRecordValue(mutableType.getPackage(), mutableType.getName(), initialValueEntries);
     }
 
     private BTable<BString, Object> createTableValue(TomlNode tomlValue, Type type) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/configurable/providers/toml/ConfigValueCreator.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/configurable/providers/toml/ConfigValueCreator.java
@@ -258,6 +258,7 @@ public class ConfigValueCreator {
     private BMap<BString, Object> createRecordValue(TomlNode tomlNode, Type type) {
         RecordType mutableType;
         Optional<IntersectionType> intersectionType = ((IntersectableReferenceType) type).getIntersectionType();
+        // Creating a record value with mutable type and freezing it.
         if (intersectionType.isPresent()) {
             mutableType = (RecordType) ReadOnlyUtils.getMutableType((BIntersectionType) intersectionType.get());
         } else {

--- a/tests/jballerina-integration-test/src/test/resources/configurables/configStructuredTypesProject/Config_default_values.toml
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/configStructuredTypesProject/Config_default_values.toml
@@ -1,5 +1,8 @@
 word2 = "word 2"
 
+[endpoint]
+basePath = "/api/v1"
+
 [words]
 word7 = "word 7"
 
@@ -13,6 +16,14 @@ symbol5 = "$"
 [container.words]
 word6 = "word 6"
 word7 = "word 7"
+
+[[endpointArr]]
+basePath = "/api/v2"
+
+[[endpointArr]]
+basePath = "/api/v3"
+url = ["http://localhost:8080"]
+port = 9080
 
 [[wordArr]]
 word6 = "word 6"
@@ -56,6 +67,14 @@ words.word3 = "word 30"
 words.word4 = "word 40"
 words.word5 = "word 50"
 words.word7 = "word 70"
+
+[[endpointTable]]
+basePath = "/api/v4"
+
+[[endpointTable]]
+basePath = "/api/v5"
+url = ["http://localhost:8080"]
+port = 9081
 
 [[wordTable]]
 word6 = "word 6"
@@ -102,6 +121,12 @@ words.word5 = "word 50"
 words.word6 = "word 60"
 words.word7 = "word 70"
 
+[endpointMap]
+entry1.basePath = "/api/v6"
+entry2.basePath = "/api/v7"
+entry2.url = ["http://localhost:8080"]
+entry2.port = 9082
+
 [wordMap]
 entry1.word7 = "word 7"
 entry2.word1 = "word 11"
@@ -136,6 +161,14 @@ entry2.words.word3 = "word 33"
 entry2.words.word4 = "word 44"
 entry2.words.word5 = "word 55"
 entry2.words.word7 = "word 77"
+
+[[endpointTableMap.map1]]
+basePath = "/api/v8"
+
+[[endpointTableMap.map2]]
+basePath = "/api/v9"
+url = ["http://localhost:8080"]
+port = 9083
 
 [[wordTableMap.map1]]
 word7 = "word 7"

--- a/tests/jballerina-integration-test/src/test/resources/configurables/configStructuredTypesProject/Config_default_values_inline.toml
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/configStructuredTypesProject/Config_default_values_inline.toml
@@ -12,23 +12,28 @@ words = { word7 = "word 7" }
 numbers = { num5 = 5 , num6 = 6 }
 symbols = { symbol5 = "$" }
 container = { words = {word6 = "word 6", word7 = "word 7" } }
+endpoint = { basePath = "/api/v1" }
 
 wordArr = [{word6 = "word 6", word7 = "word 7" }, { word1 = "word 10", word2 = "word 20", word3 = "word 30", word4 = "word 40", word5 = "word 50", word7 = "word 70" }]
 numberArr = [{ num6 = 6 }, { num1 = 10, num2 = 20, num3 = 30, num4 = 40, num6 = 60 }]
 symbolArr = [{symbol4 = "@", symbol5 = "%" }, { symbol1 = "^", symbol2 = "&", symbol3 = "*", symbol5 = "-" }]
 containerArr = [{ words = { word7 = "word 7" } }, { words = { word1 = "word 10", word2 = "word 20", word3 = "word 30", word4 = "word 40", word5 = "word 50", word7 = "word 70" } }]
+endpointArr = [{ basePath = "/api/v2" }, { basePath = "/api/v3", url = ["http://localhost:8080"], port = 9080 }]
 
 wordTable = [{ word6 = "word 6", word7 = "word 7" }, { word1 = "word 10", word2 = "word 20", word3 = "word 30", word4 = "word 40", word5 = "word 50", word7 = "word 70" }]
 numberTable = [{ num5 = 5, num6 = 6 }, { num1 = 10, num2 = 20, num3 = 30, num4 = 40, num6 = 60 }]
 symbolTable = [{ symbol5 = "%" }, { symbol1 = "^", symbol2 = "&", symbol3 = "*", symbol4 = "@", symbol5 = "-" }]
 containerTable = [{ words = { word7 = "word 7" } }, { words = { word1 = "word 10", word2 = "word 20", word3 = "word 30", word4 = "word 40", word5 = "word 50", word6 = "word 60", word7 = "word 70" } }]
+endpointTable = [{ basePath = "/api/v4" }, { basePath = "/api/v5", url = ["http://localhost:8080"], port = 9081 }]
 
 wordMap = { entry1 = { word7 = "word 7" }, entry2 = { word1 = "word 11", word2 = "word 22", word3 = "word 33", word4 = "word 44", word5 = "word 55", word6 = "word 66", word7 = "word 77" } }
 numberMap = { entry1 = { num6 = 66 }, entry2 = { num1 = 11, num2 = 22, num3 = 33, num4 = 44, num5 = 55, num6 = 66 } }
 symbolMap = { entry1 = { symbol5 = "=" }, entry2 = { symbol1 = "+", symbol2 = "|", symbol3 = "}", symbol5 = "?" } }
 containerMap = { entry1 = { words = { word7 = "word 7" } }, entry2 = { words = { word1 = "word 11", word2 = "word 22", word3 = "word 33", word4 = "word 44", word5 = "word 55", word7 = "word 77" } } }
+endpointMap = { entry1 = { basePath = "/api/v6" }, entry2 = { basePath = "/api/v7", url = ["http://localhost:8080"], port = 9082 } }
 
 wordTableMap = { map1 = [{ word7 = "word 7" }], map2 = [{ word1 = "word 10", word2 = "word 20", word3 = "word 30", word4 = "word 40", word5 = "word 50", word7 = "word 70" }] }
 numberTableMap = { map1 = [{ num6 = 6 }], map2 = [{ num1 = 10, num2 = 20, num3 = 30, num4 = 40, num6 = 60 }] }
 symbolTableMap = { map1 = [{ symbol4 = "@", symbol5 = "%" }], map2 = [{ symbol1 = "^", symbol2 = "&", symbol3 = "*", symbol5 = "-" }] }
 containerTableMap = { map1 = [{ words = { word7 = "word 7" } }], map2 = [{ words = { word1 = "word 10", word2 = "word 20", word3 = "word 30", word4 = "word 40", word5 = "word 50", word7 = "word 70" } }] }
+endpointTableMap = { map1 = [{ basePath = "/api/v8" }], map2 = [{ basePath = "/api/v9", url = ["http://localhost:8080"], port = 9083 }] }

--- a/tests/jballerina-integration-test/src/test/resources/configurables/configStructuredTypesProject/defaultValuesRecord/main.bal
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/configStructuredTypesProject/defaultValuesRecord/main.bal
@@ -67,6 +67,12 @@ configurable map<table<type_defs:Numbers>> numberTableMap = ?;
 configurable map<table<configLib:Symbols>> symbolTableMap = ?;
 configurable map<table<WordsContainer>> containerTableMap = ?;
 
+configurable type_defs:Endpoint endpoint = ?;
+configurable type_defs:Endpoint[] endpointArr = ?;
+configurable table<type_defs:Endpoint> endpointTable = ?;
+configurable map<type_defs:Endpoint> endpointMap = ?;
+configurable map<table<type_defs:Endpoint>> endpointTableMap = ?;
+
 function testDefaultValues() {
     test:assertEquals(words.toString(), "{\"word1\":\"word 1\",\"word2\":\"word 2\",\"word3\":\"word 3\"," +
     "\"word4\":\"word 4\",\"word5\":\"word 5\",\"word6\":null,\"word7\":\"word 7\"}");
@@ -130,6 +136,16 @@ function testDefaultValues() {
     "\"word2\":\"word 2\",\"word3\":\"word 3\",\"word4\":\"word 4\",\"word5\":\"word 5\",\"word6\":null," +
     "\"word7\":\"word 7\"}}],\"map2\":[{\"words\":{\"word1\":\"word 10\",\"word2\":\"word 20\",\"word3\":\"word 30\"," +
     "\"word4\":\"word 40\",\"word5\":\"word 50\",\"word6\":null,\"word7\":\"word 70\"}}]}");
+
+    test:assertEquals(endpoint.toString(), "{\"basePath\":\"/api/v1\",\"url\":[],\"port\":9090}");
+    test:assertEquals(endpointArr.toString(), "[{\"basePath\":\"/api/v2\",\"url\":[],\"port\":9090},{\"basePath\":" +
+    "\"/api/v3\",\"url\":[\"http://localhost:8080\"],\"port\":9080}]");
+    test:assertEquals(endpointTable.toString(), "[{\"basePath\":\"/api/v4\",\"url\":[],\"port\":9090},{\"basePath\":" +
+    "\"/api/v5\",\"url\":[\"http://localhost:8080\"],\"port\":9081}]");
+    test:assertEquals(endpointMap.toString(), "{\"entry1\":{\"basePath\":\"/api/v6\",\"url\":[],\"port\":9090}," +
+    "\"entry2\":{\"basePath\":\"/api/v7\",\"url\":[\"http://localhost:8080\"],\"port\":9082}}");
+    test:assertEquals(endpointTableMap.toString(), "{\"map1\":[{\"basePath\":\"/api/v8\",\"url\":[],\"port\":9090}]," +
+    "\"map2\":[{\"basePath\":\"/api/v9\",\"url\":[\"http://localhost:8080\"],\"port\":9083}]}");
 }
 
 isolated function getWord() returns string {

--- a/tests/jballerina-integration-test/src/test/resources/configurables/configStructuredTypesProject/defaultValuesRecord/modules/type_defs/type_defs.bal
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/configStructuredTypesProject/defaultValuesRecord/modules/type_defs/type_defs.bal
@@ -45,3 +45,9 @@ type Staff record {|
 |};
 
 public type StaffTable table<Staff> key(id);
+
+public type Endpoint record {|
+    string basePath;
+    string[] url = [];
+    int port = 9090;
+|};


### PR DESCRIPTION
## Purpose
$subject 

Fixes #40277 

## Approach
Fixing the default value check by creating a record value with mutable type and cloning that value to a `readonly` value.

## Samples
```ballerina
type Endpoint record {|
    string basePath;
    string[] url = [];
|};

configurable Endpoint[] endpoints = [];
```
Config.toml
```toml
[[endpoints]]
basePath = "/api/entitlement-service"
url = ["https://abc.com/api/entitlement-service"]
```

## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [x] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
