### PR TITLE
Refactor GroupByClauseNodeContext

### DIFF
--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/QueryExpressionContextTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/QueryExpressionContextTest.java
@@ -52,10 +52,7 @@ public class QueryExpressionContextTest extends CompletionTest {
                 "query_expr_ctx_onconflict_clause_config1a.json",
                 // Order By [asc/desc]
                 "query_expr_ctx_orderby_clause_config4.json",
-                "query_expr_ctx_config3.json", // issue #31449
-                "query_expr_ctx_groupby_clause_config14.json", //issue #40425
-                "query_expr_ctx_groupby_clause_config3.json",
-                "query_expr_ctx_groupby_clause_config8.json"
+                "query_expr_ctx_config3.json" // issue #31449
         );
     }
 

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_groupby_clause_config11.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_groupby_clause_config11.json
@@ -726,6 +726,15 @@
       "sortText": "BN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "var",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "BQ",
+      "filterText": "var",
+      "insertText": "var ",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_groupby_clause_config12.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_groupby_clause_config12.json
@@ -726,6 +726,15 @@
       "sortText": "BN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "var",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "BQ",
+      "filterText": "var",
+      "insertText": "var ",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_groupby_clause_config13.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_groupby_clause_config13.json
@@ -726,6 +726,15 @@
       "sortText": "BN",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "var",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "BQ",
+      "filterText": "var",
+      "insertText": "var ",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_groupby_clause_config14.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_groupby_clause_config14.json
@@ -7,28 +7,37 @@
   "description": "",
   "items": [
     {
-      "label": "where",
-      "kind": "Keyword",
-      "detail": "Keyword",
-      "sortText": "CQ",
-      "filterText": "where",
-      "insertText": "where ",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "let",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "CQ",
+      "sortText": "BQ",
       "filterText": "let",
       "insertText": "let",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "from",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "BQ",
+      "filterText": "from",
+      "insertText": "from ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "where",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "BQ",
+      "filterText": "where",
+      "insertText": "where ",
       "insertTextFormat": "Snippet"
     },
     {
       "label": "let clause",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "CP",
+      "sortText": "BP",
       "filterText": "let",
       "insertText": "let ${1:var} ${2:varName} = ${3}",
       "insertTextFormat": "Snippet"
@@ -37,7 +46,7 @@
       "label": "outer",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "CQ",
+      "sortText": "BQ",
       "filterText": "outer",
       "insertText": "outer ",
       "insertTextFormat": "Snippet"
@@ -46,7 +55,7 @@
       "label": "join",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "CQ",
+      "sortText": "BQ",
       "filterText": "join",
       "insertText": "join ",
       "insertTextFormat": "Snippet"
@@ -55,7 +64,7 @@
       "label": "join clause",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "CP",
+      "sortText": "BP",
       "filterText": "join",
       "insertText": "join ${1:var} ${2:varName} in ${3:expr} on ${4:onExpr} equals ${5:equalsExpr}",
       "insertTextFormat": "Snippet"
@@ -64,7 +73,7 @@
       "label": "order by",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "CQ",
+      "sortText": "BQ",
       "filterText": "order by",
       "insertText": "order by ",
       "insertTextFormat": "Snippet"
@@ -73,7 +82,7 @@
       "label": "limit",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "CQ",
+      "sortText": "BQ",
       "filterText": "limit",
       "insertText": "limit ",
       "insertTextFormat": "Snippet"
@@ -82,7 +91,7 @@
       "label": "do",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "CP",
+      "sortText": "BP",
       "filterText": "do",
       "insertText": "do {\n\t${1}\n}",
       "insertTextFormat": "Snippet"
@@ -91,25 +100,16 @@
       "label": "select",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "CQ",
+      "sortText": "BQ",
       "filterText": "select",
       "insertText": "select ",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "from",
-      "kind": "Keyword",
-      "detail": "Keyword",
-      "sortText": "CQ",
-      "filterText": "from",
-      "insertText": "from ",
       "insertTextFormat": "Snippet"
     },
     {
       "label": "group by",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "CQ",
+      "sortText": "BQ",
       "filterText": "group by",
       "insertText": "group by ",
       "insertTextFormat": "Snippet"
@@ -118,7 +118,7 @@
       "label": "group by clause",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "CP",
+      "sortText": "BP",
       "filterText": "group by",
       "insertText": "group by ${1:var} ${2:item} = ${3}",
       "insertTextFormat": "Snippet"

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_select_clause_config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/config/query_expr_ctx_select_clause_config7.json
@@ -746,6 +746,14 @@
       "filterText": "from",
       "insertText": "from ${1:var} ${2:item} in ${3}",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "price",
+      "kind": "Variable",
+      "detail": "int",
+      "sortText": "F",
+      "insertText": "price",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/query_expression/source/query_expr_ctx_select_clause_source7.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/query_expression/source/query_expr_ctx_select_clause_source7.bal
@@ -1,7 +1,7 @@
 function testIterableOperation() {
     var orders = [{buyer: "b1", price: 12}, {buyer: "b2", price: 13}, {buyer: "b3", price: 14}, {buyer: "b3", price: 15}];
 
-    string[] buyers = from var {buyer} in orders
+    string[] buyers = from var {buyer, price} in orders
         group by buyer
         select sum(p)
 }


### PR DESCRIPTION
## Purpose
This PR refactors the `GroupByClauseNodeContext` to fix the failing completion tests due to parser changes in https://github.com/ballerina-platform/ballerina-lang/pull/40436.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/40291

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
