### PR TITLE
Disable strand dump tests

### DIFF
--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/troubleshoot/StrandDumpTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/troubleshoot/StrandDumpTest.java
@@ -60,7 +60,8 @@ public class StrandDumpTest extends BaseTest {
         bMainInstance = new BMainInstance(balServer);
     }
 
-    @Test
+    // TODO: enable after fixing https://github.com/ballerina-platform/ballerina-lang/issues/38737
+    @Test(enabled = false)
     public void testStrandDumpOfBalPackage() throws BallerinaTestException {
         Path expectedOutputFilePath = Paths.get(testFileLocation, "testOutputs",
                 "testPackageWithModulesStrandDumpRegEx.txt");
@@ -75,7 +76,8 @@ public class StrandDumpTest extends BaseTest {
         runJarAndVerifyStrandDump(envProperties, jarPath, sourceRoot, expectedOutputFilePath);
     }
 
-    @Test
+    // TODO: enable after fixing https://github.com/ballerina-platform/ballerina-lang/issues/38737
+    @Test(enabled = false)
     public void testStrandDumpDuringBalTest() throws BallerinaTestException {
         if (isWindowsOS()) {
             return;
@@ -96,7 +98,8 @@ public class StrandDumpTest extends BaseTest {
         return Utils.getOSName().toLowerCase(Locale.ENGLISH).contains("windows");
     }
 
-    @Test
+    // TODO: enable after fixing https://github.com/ballerina-platform/ballerina-lang/issues/38737
+    @Test(enabled = false)
     public void testStrandDumpOfSingleBalFile() throws BallerinaTestException {
         Path expectedOutputFilePath = Paths.get(testFileLocation, "testOutputs", "balProgram1StrandDumpRegEx.txt");
         String commandDir = balServer.getServerHome();


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues.

The strand dump tests are passing locally, they are failing intermittently in Github runners due to the delays in starting processes. Hence, temporarily disable strand dump tests until https://github.com/ballerina-platform/ballerina-lang/issues/38737 is done.

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
