### PR TITLE
[2201.6.0-stage] Fix regexp runtime parsing for -,| and : tokens

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/regexp/TreeBuilder.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/regexp/TreeBuilder.java
@@ -120,6 +120,8 @@ public class TreeBuilder {
             case COMMA_TOKEN:
             case DOT_TOKEN:
             case DIGIT:
+            case MINUS_TOKEN:
+            case COLON_TOKEN:    
                 reAtom = readRegChars();
                 break;
             case BACK_SLASH_TOKEN:

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/regexp/TreeTraverser.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/regexp/TreeTraverser.java
@@ -79,15 +79,6 @@ public class TreeTraverser {
         }
 
         int nextChar = peek();
-        if (nextChar == Terminals.PIPE) {
-            this.reader.advance();
-            // Pipe cannot be the end of the regular expression.
-            if (this.reader.isEOF()) {
-                throw new BallerinaException(BLangExceptionHelper.getErrorMessage(
-                        RuntimeErrors.REGEXP_INVALID_CHARACTER.messageKey(), getMarkedChars()));
-            }
-            return getRegExpToken(TokenKind.PIPE_TOKEN);
-        }
 
         this.reader.advance();
         switch (nextChar) {
@@ -123,6 +114,8 @@ public class TreeTraverser {
                 return getRegExpToken(TokenKind.MINUS_TOKEN);
             case Terminals.COLON:
                 return getRegExpToken(TokenKind.COLON_TOKEN);
+            case Terminals.PIPE:
+                return getRegExpToken(TokenKind.PIPE_TOKEN);
             default:
                 if (isDigit(nextChar)) {
                     return getRegExpText(TokenKind.DIGIT);

--- a/langlib/langlib-test/src/test/resources/test-src/regexp_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/regexp_test.bal
@@ -1751,6 +1751,42 @@ function testFromString() {
     if (x1 is string:RegExp) {
        assertTrue(re `\p{Ll}|\p{Mn}|\p{Nd}|\p{Sm}|\p{Pc}|\p{Cc}|\p{Zs}` == x1);
     }
+    
+    x1 = regexp:fromString("\\d{2}-\\d{2}-\\d{4}");
+    assertTrue(x1 is string:RegExp);
+    if (x1 is string:RegExp) {
+       assertTrue(re `\d{2}-\d{2}-\d{4}` == x1);
+    }
+    
+    x1 = regexp:fromString("\\d{2}:\\d{2}:\\d{4}");
+    assertTrue(x1 is string:RegExp);
+    if (x1 is string:RegExp) {
+       assertTrue(re `\d{2}:\d{2}:\d{4}` == x1);
+    }
+    
+    x1 = regexp:fromString("(?:\\d{2}/\\d{2}/\\d{4})");
+    assertTrue(x1 is string:RegExp);
+    if (x1 is string:RegExp) {
+       assertTrue(re `(?:\d{2}/\d{2}/\d{4})` == x1);
+    }
+    
+    x1 = regexp:fromString("abc|de|");
+    assertTrue(x1 is string:RegExp);
+    if (x1 is string:RegExp) {
+       assertTrue(re `abc|de|` == x1);
+    }
+    
+    x1 = regexp:fromString("abc|de\\|");
+    assertTrue(x1 is string:RegExp);
+    if (x1 is string:RegExp) {
+       assertTrue(re `abc|de\|` == x1);
+    }
+    
+    x1 = regexp:fromString("[\\d{2}-\\d{2}-\\d{4}]");
+    assertTrue(x1 is string:RegExp);
+    if (x1 is string:RegExp) {
+       assertTrue(re `[\d{2}-\d{2}-\d{4}]` == x1);
+    }
 }
 
 function testFromStringNegative() {


### PR DESCRIPTION
## Purpose
$subject

Fixes #40466

Related PRs: #40471

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
