### PR TITLE
Suppress extra error messages for missing binary operator

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/OperatorKind.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/OperatorKind.java
@@ -59,7 +59,8 @@ public enum OperatorKind {
     HALF_OPEN_RANGE("..<"),
     REF_EQUAL("==="),
     REF_NOT_EQUAL("!=="),
-    ANNOT_ACCESS(".@");
+    ANNOT_ACCESS(".@"),
+    UNDEFINED("UNDEF");
 
     private final String opValue;
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeBuilder.java
@@ -2143,7 +2143,8 @@ public class BLangNodeBuilder extends NodeTransformer<BLangNode> {
         bLBinaryExpr.pos = getPosition(binaryExprNode);
         bLBinaryExpr.lhsExpr = createExpression(binaryExprNode.lhsExpr());
         bLBinaryExpr.rhsExpr = createExpression(binaryExprNode.rhsExpr());
-        bLBinaryExpr.opKind = OperatorKind.valueFrom(binaryExprNode.operator().text());
+        bLBinaryExpr.opKind = binaryExprNode.operator().isMissing() ?
+                OperatorKind.UNDEFINED : OperatorKind.valueFrom(binaryExprNode.operator().text());
         return bLBinaryExpr;
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -5051,8 +5051,9 @@ public class TypeChecker extends SimpleBLangNodeAnalyzer<TypeChecker.AnalyzerDat
                                 (rhsType.tag == TypeTags.DECIMAL || rhsType.tag == TypeTags.FLOAT)) {
                             errorCode = DiagnosticErrorCode.BINARY_OP_INCOMPATIBLE_TYPES_INT_FLOAT_DIVISION;
                         }
-
-                        dlog.error(binaryExpr.pos, errorCode, binaryExpr.opKind, lhsType, rhsType);
+                        if (binaryExpr.opKind != OperatorKind.UNDEFINED) {
+                            dlog.error(binaryExpr.pos, errorCode, binaryExpr.opKind, lhsType, rhsType);
+                        }
                     } else {
                         binaryExpr.opSymbol = (BOperatorSymbol) opSymbol;
                         actualType = opSymbol.type.getReturnType();

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/evaluation/ExpressionEvaluationTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/evaluation/ExpressionEvaluationTest.java
@@ -53,7 +53,7 @@ public abstract class ExpressionEvaluationTest extends ExpressionEvaluationBaseT
         debugTestRunner.assertExpression(context, "-5.0e34f", "-5.0E34", "float");
         debugTestRunner.assertExpression(context, "-30.0d", "-30.0", "decimal");
         debugTestRunner.assertExpression(context, "-40.0D", "-40.0", "decimal");
-        debugTestRunner.assertExpression(context, "-5.0e34d", "-5.0E+34", "decimal");
+        debugTestRunner.assertExpression(context, "-5.0e+34d", "-5.0E+34", "decimal");
         // Todo - add following tests after the implementation
         //  - hex float
         //  - string literal

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/AddOperationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/AddOperationTest.java
@@ -260,6 +260,15 @@ public class AddOperationTest {
                 "'(1|2|int)' and '(xml:Element|xml:Text)'", 150, 9);
         BAssertUtil.validateError(resultNegative, i++, "operator '+' not defined for " +
                 "'(xml:Element|xml:Text)' and '(1|2|int)'", 152, 9);
+        BAssertUtil.validateError(resultNegative, i++, "missing binary operator", 156, 12);
+        BAssertUtil.validateError(resultNegative, i++, "missing binary operator", 157, 14);
+        BAssertUtil.validateError(resultNegative, i++, "missing binary operator", 158, 17);
+        BAssertUtil.validateError(resultNegative, i++, "missing binary operator", 159, 17);
+        BAssertUtil.validateError(resultNegative, i++, "missing binary operator", 163, 11);
+        BAssertUtil.validateError(resultNegative, i++, "missing binary operator", 164, 12);
+        BAssertUtil.validateError(resultNegative, i++, "missing binary operator", 165, 14);
+        BAssertUtil.validateError(resultNegative, i++, "missing binary operator", 166, 12);
+
         Assert.assertEquals(resultNegative.getErrorCount(), i);
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/bytetype/BByteArrayValueNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/bytetype/BByteArrayValueNegativeTest.java
@@ -53,7 +53,6 @@ public class BByteArrayValueNegativeTest {
         BAssertUtil.validateError(result, index++, "invalid base16 content in byte array literal", 7, 24);
         BAssertUtil.validateError(result, index++, "incompatible types: expected 'byte[]', found 'other'", 8, 16);
         BAssertUtil.validateError(result, index++, "missing byte array content", 8, 16);
-        BAssertUtil.validateError(result, index++, "operator '+' not defined for 'byte[0]' and 'string'", 8, 16);
         BAssertUtil.validateError(result, index++, "missing binary operator", 8, 23);
         BAssertUtil.validateError(result, index++, "incompatible types: expected 'byte[]', found 'other'", 12, 16);
         BAssertUtil.validateError(result, index++, "undefined symbol 'base6'", 12, 16);
@@ -73,7 +72,6 @@ public class BByteArrayValueNegativeTest {
         BAssertUtil.validateError(result, index++, "invalid base64 content in byte array literal", 15, 24);
         BAssertUtil.validateError(result, index++, "incompatible types: expected 'byte[]', found 'other'", 16, 16);
         BAssertUtil.validateError(result, index++, "missing byte array content", 16, 16);
-        BAssertUtil.validateError(result, index++, "operator '+' not defined for 'byte[0]' and 'string'", 16, 16);
         BAssertUtil.validateError(result, index++, "missing binary operator", 16, 23);
         BAssertUtil.validateError(result, index++, "invalid base64 content in byte array literal", 17, 24);
         BAssertUtil.validateError(result, index++, "invalid base64 content in byte array literal", 18, 24);

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/add-operation-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/add-operation-negative.bal
@@ -151,3 +151,23 @@ function testAdditiveExprWithUnionOperandBelongingToSingleBasicTypeNegative() {
     _ = f + a; // OK
     _ = f + e;
 }
+
+function testMissingBinaryOp() {
+    _ = "a""b";
+    _ = bar()();
+    _ = foo(("a""b") + 1);
+    _ = foo(("a""b") + "c");
+
+    int x = 2;
+    int y = 3;
+    _ = x y;
+    _ = 1.5"b";
+    _ = true y;
+    _ = "a"x;
+}
+
+function foo(string s) returns string {
+    return s;
+}
+
+function bar() {}


### PR DESCRIPTION
## Purpose
> Suppress extra error messages for missing binary operator and only keep the "missing binary operator"

Fixes #40500

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
