### PR TITLE
Fix issue in renaming symbols in groupby clause

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/ReferenceFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/ReferenceFinder.java
@@ -654,7 +654,8 @@ public class ReferenceFinder extends BaseVisitor {
             Node groupingKey = keyNode.getGroupingKey();
             if (groupingKey.getKind() == NodeKind.VARIABLE_DEF) {
                 find((BLangSimpleVariableDef) keyNode.getGroupingKey());
-            } else if (groupingKey.getKind() == NodeKind.VARIABLE) {
+            } else if (groupingKey.getKind() == NodeKind.VARIABLE
+                    || groupingKey.getKind() == NodeKind.SIMPLE_VARIABLE_REF) {
                 find((BLangSimpleVarRef) keyNode.getGroupingKey());
             }
         }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/rename/RenameTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/rename/RenameTest.java
@@ -65,6 +65,7 @@ public class RenameTest extends AbstractRenameTest {
                 {"rename_in_mapping_binding_pattern1.json", "name2"},
                 {"rename_in_mapping_binding_pattern2.json", "pName"},
                 {"rename_in_mapping_binding_pattern3.json", "pName"},
+                {"rename_in_groupby_clause.json", "newPrice"},
 
                 // Invalid rename positions tests
                 {"rename_on_keyword1.json", "fn"},

--- a/language-server/modules/langserver-core/src/test/resources/rename/expected/single/rename_in_groupby_clause.json
+++ b/language-server/modules/langserver-core/src/test/resources/rename/expected/single/rename_in_groupby_clause.json
@@ -1,0 +1,57 @@
+{
+  "source": {
+    "file": "rename_in_groupby_clause.bal"
+  },
+  "position": {
+    "line": 6,
+    "character": 18
+  },
+  "prepareRename": {
+    "valid": true
+  },
+  "result": {
+    "changes": {
+      "rename_in_groupby_clause.bal": [
+        {
+          "range": {
+            "start": {
+              "line": 4,
+              "character": 27
+            },
+            "end": {
+              "line": 4,
+              "character": 32
+            }
+          },
+          "newText": "price: newPrice"
+        },
+        {
+          "range": {
+            "start": {
+              "line": 5,
+              "character": 17
+            },
+            "end": {
+              "line": 5,
+              "character": 22
+            }
+          },
+          "newText": "newPrice"
+        },
+        {
+          "range": {
+            "start": {
+              "line": 6,
+              "character": 15
+            },
+            "end": {
+              "line": 6,
+              "character": 20
+            }
+          },
+          "newText": "newPrice"
+        }
+      ]
+    }
+  }
+}

--- a/language-server/modules/langserver-core/src/test/resources/rename/sources/single/rename_in_groupby_clause.bal
+++ b/language-server/modules/langserver-core/src/test/resources/rename/sources/single/rename_in_groupby_clause.bal
@@ -1,0 +1,8 @@
+public function main() {
+
+    var orders = [{buyer: "b1", price: 12}, {buyer: "b2", price: 13}, {buyer: "b3", price: 14}, {buyer: "b3", price: 15}];
+
+    var buyers = from var {price, buyer} in orders 
+        group by price
+        select price;
+}


### PR DESCRIPTION
## Purpose
This PR fixes an issue in renaming symbols in groupby clause where not all references were renamed.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/40552

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
