### PR TITLE
Add check to filter listener from classes

### DIFF
--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
@@ -485,11 +485,42 @@ public class Generator {
         if (containsToken(classDefinitionNode.classTypeQualifiers(), SyntaxKind.CLIENT_KEYWORD)) {
             return new Client(name, description, isDeprecated, fields, functions, isReadOnly, isIsolated, isService);
         } else if (containsToken(classDefinitionNode.classTypeQualifiers(), SyntaxKind.LISTENER_KEYWORD)
-                || name.equals("Listener")) {
+                || checkListenerModel(functions)) {
             return new Listener(name, description, isDeprecated, fields, functions, isReadOnly, isIsolated, isService);
         } else {
             return new BClass(name, description, isDeprecated, fields, functions, isReadOnly, isIsolated, isService);
         }
+    }
+
+    private static boolean checkListenerModel(List<Function> classFunctions) {
+        boolean isStartIncluded = false;
+        boolean isAttachIncluded = false;
+        boolean isDetachIncluded = false;
+        boolean isGracefulStopIncluded = false;
+        boolean isImmediateStopIncluded = false;
+
+        for (Function function : classFunctions) {
+            switch (function.name) {
+                case "'start":
+                    isStartIncluded = true;
+                    break;
+                case "attach":
+                    isAttachIncluded = true;
+                    break;
+                case "detach":
+                    isDetachIncluded = true;
+                    break;
+                case "gracefulStop":
+                    isGracefulStopIncluded = true;
+                    break;
+                case "immediateStop":
+                    isImmediateStopIncluded = true;
+                    break;
+            }
+        }
+
+        return isStartIncluded && isAttachIncluded && isDetachIncluded && isGracefulStopIncluded &&
+                isImmediateStopIncluded;
     }
 
     private static BObjectType getObjectTypeModel(ObjectTypeDescriptorNode typeDescriptorNode, String objectName,


### PR DESCRIPTION
## Purpose
Filter Listener classes from classes with a better approach.

Fixes #40551

## Approach
We cannot use `listener` as a qualifier in a class definition. Therefore the previous method to filter listener classes was to check the name of the class whether it is equal to `Listener`. But it will even filter other classes with name `Listener` as listeners and wouldn't filter listeners with other names.

These changes will check the necessary methods which should be included in a class to be a listener. The following methods should be included in a class to be a listener.
1. `attach`
2. `detach`
3. `'start`
4. `immediateStop`
5. `gracefulStop`

This approach will check for these methods to identify whether it is a listener or not.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
