### PR TITLE
Add check to filter listener from classes

### DIFF
--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
@@ -485,14 +485,14 @@ public class Generator {
         if (containsToken(classDefinitionNode.classTypeQualifiers(), SyntaxKind.CLIENT_KEYWORD)) {
             return new Client(name, description, isDeprecated, fields, functions, isReadOnly, isIsolated, isService);
         } else if (containsToken(classDefinitionNode.classTypeQualifiers(), SyntaxKind.LISTENER_KEYWORD)
-                || checkListenerModel(functions)) {
+                || isListenerModel(functions)) {
             return new Listener(name, description, isDeprecated, fields, functions, isReadOnly, isIsolated, isService);
         } else {
             return new BClass(name, description, isDeprecated, fields, functions, isReadOnly, isIsolated, isService);
         }
     }
 
-    private static boolean checkListenerModel(List<Function> classFunctions) {
+    private static boolean isListenerModel(List<Function> classFunctions) {
         boolean isStartIncluded = false;
         boolean isAttachIncluded = false;
         boolean isDetachIncluded = false;

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
@@ -485,11 +485,36 @@ public class Generator {
         if (containsToken(classDefinitionNode.classTypeQualifiers(), SyntaxKind.CLIENT_KEYWORD)) {
             return new Client(name, description, isDeprecated, fields, functions, isReadOnly, isIsolated, isService);
         } else if (containsToken(classDefinitionNode.classTypeQualifiers(), SyntaxKind.LISTENER_KEYWORD)
-                || name.equals("Listener")) {
+                || checkListenerModel(functions)) {
             return new Listener(name, description, isDeprecated, fields, functions, isReadOnly, isIsolated, isService);
         } else {
             return new BClass(name, description, isDeprecated, fields, functions, isReadOnly, isIsolated, isService);
         }
+    }
+
+    private static boolean checkListenerModel(List<Function> classFunctions) {
+        boolean isStartIncluded = false;
+        boolean isAttachIncluded = false;
+        boolean isDetachIncluded = false;
+        boolean isGracefulStopIncluded = false;
+        boolean isImmediateStopIncluded = false;
+
+        for (Function function : classFunctions) {
+            if (function.name.equals("'start")) {
+                isStartIncluded = true;
+            } else if (function.name.equals("attach")) {
+                isAttachIncluded = true;
+            } else if (function.name.equals("detach")) {
+                isDetachIncluded = true;
+            } else if (function.name.equals("gracefulStop")) {
+                isGracefulStopIncluded = true;
+            } else if (function.name.equals("immediateStop")) {
+                isImmediateStopIncluded = true;
+            }
+        }
+
+        return isStartIncluded && isAttachIncluded && isDetachIncluded && isGracefulStopIncluded &&
+                isImmediateStopIncluded;
     }
 
     private static BObjectType getObjectTypeModel(ObjectTypeDescriptorNode typeDescriptorNode, String objectName,

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
@@ -99,6 +99,11 @@ public class Generator {
     private static final String EMPTY_STRING = "";
     private static final String RETURN_PARAM_NAME = "return";
     public static final String REST_FIELD_DESCRIPTION = "Rest field";
+    public static final String LISTENER_START_METHOD_NAME = "'start";
+    public static final String LISTENER_ATTACH_METHOD_NAME = "attach";
+    public static final String LISTENER_DETACH_METHOD_NAME = "detach";
+    public static final String LISTENER_IMMEDIATE_STOP_METHOD_NAME = "immediateStop";
+    public static final String LISTENER_GRACEFUL_STOP_METHOD_NAME = "gracefulStop";
 
     /**
      * Generate/Set the module constructs model(docerina model) when the syntax tree for the module is given.
@@ -500,15 +505,15 @@ public class Generator {
         boolean isImmediateStopIncluded = false;
 
         for (Function function : classFunctions) {
-            if (function.name.equals("'start")) {
+            if (function.name.equals(LISTENER_START_METHOD_NAME)) {
                 isStartIncluded = true;
-            } else if (function.name.equals("attach")) {
+            } else if (function.name.equals(LISTENER_ATTACH_METHOD_NAME)) {
                 isAttachIncluded = true;
-            } else if (function.name.equals("detach")) {
+            } else if (function.name.equals(LISTENER_DETACH_METHOD_NAME)) {
                 isDetachIncluded = true;
-            } else if (function.name.equals("gracefulStop")) {
+            } else if (function.name.equals(LISTENER_GRACEFUL_STOP_METHOD_NAME)) {
                 isGracefulStopIncluded = true;
-            } else if (function.name.equals("immediateStop")) {
+            } else if (function.name.equals(LISTENER_IMMEDIATE_STOP_METHOD_NAME)) {
                 isImmediateStopIncluded = true;
             }
         }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/documentation/docerina_project/main.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/documentation/docerina_project/main.bal
@@ -202,7 +202,16 @@ public class Listener {
     # ```
     #
     # + return - An `error` if an error occurred during the listener stopping process or else `()`
-    public function __gracefulStop() returns error? {
+    public function gracefulStop() returns error? {
+    }
+
+    # Stops the service listener immediately. Already-accepted requests will be served before the connection closure.
+    # ```ballerina
+    # error? result = listenerEp.__immediateStop();
+    # ```
+    #
+    # + return - An `error` if an error occurred during the listener stopping process or else `()`
+    public function immediateStop() returns error? {
     }
 
     # Gets called every time a service attaches itself to this endpoint - also happens at module init time.
@@ -214,6 +223,17 @@ public class Listener {
     # + name - Name of the service
     # + return - An `error` if encounters an error while attaching the service or else `()`
     public function attach(int s, string? name = ()) returns error? {
+    }
+
+    # Gets called every time detaches a service itself to this endpoint - also happens at module init time.
+    # ```ballerina
+    # error? result = listenerEp.__detach(helloService);
+    # ```
+    #
+    # + s - The type of the service to be registered
+    # + name - Name of the service
+    # + return - An `error` if encounters an error while attaching the service or else `()`
+    public function detach(int s, string? name = ()) returns error? {
     }
 }
 


### PR DESCRIPTION
## Purpose
Filter Listener classes from classes with a better approach.

Fixes #40551

## Approach
We cannot use `listener` as a qualifier in a class definition. Therefore the previous method to filter listener classes was to check the name of the class whether it is equal to `Listener`. But it will even filter other classes with name `Listener` as listeners and wouldn't filter listeners with other names.

These changes will check the necessary methods which should be included in a class to be a listener. The following methods should be included in a class to be a listener.
1. `attach`
2. `detach`
3. `'start`
4. `immediateStop`
5. `gracefulStop`

This approach will check for these methods to identify whether it is a listener or not.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
