### PR TITLE
[2201.6.x] Handle other package module types & records in API docs generation

### DIFF
--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
@@ -127,7 +127,7 @@ public class Generator {
                     if (classDefinition.visibilityQualifier().isPresent() && classDefinition.visibilityQualifier().get()
                             .kind().equals(SyntaxKind.PUBLIC_KEYWORD)) {
                         hasPublicConstructs = true;
-                        BClass cls = getClassModel((ClassDefinitionNode) node, semanticModel);
+                        BClass cls = getClassModel((ClassDefinitionNode) node, semanticModel, module);
                         if (cls instanceof Client) {
                             module.clients.add((Client) cls);
                         } else if (cls instanceof Listener) {
@@ -139,17 +139,17 @@ public class Generator {
                 } else if (node.kind() == SyntaxKind.FUNCTION_DEFINITION &&
                         containsToken(((FunctionDefinitionNode) node).qualifierList(), SyntaxKind.PUBLIC_KEYWORD)) {
                     hasPublicConstructs = true;
-                    module.functions.add(getFunctionModel((FunctionDefinitionNode) node, semanticModel));
+                    module.functions.add(getFunctionModel((FunctionDefinitionNode) node, semanticModel, module));
                 } else if (node.kind() == SyntaxKind.CONST_DECLARATION && ((ConstantDeclarationNode) node)
                         .visibilityQualifier().isPresent() && ((ConstantDeclarationNode) node).visibilityQualifier()
                         .get().kind().equals(SyntaxKind.PUBLIC_KEYWORD)) {
                     hasPublicConstructs = true;
-                    module.constants.add(getConstantTypeModel((ConstantDeclarationNode) node, semanticModel));
+                    module.constants.add(getConstantTypeModel((ConstantDeclarationNode) node, semanticModel, module));
                 } else if (node.kind() == SyntaxKind.ANNOTATION_DECLARATION && ((AnnotationDeclarationNode) node)
                         .visibilityQualifier().isPresent() && ((AnnotationDeclarationNode) node)
                         .visibilityQualifier().get().kind().equals(SyntaxKind.PUBLIC_KEYWORD)) {
                     hasPublicConstructs = true;
-                    module.annotations.add(getAnnotationModel((AnnotationDeclarationNode) node, semanticModel));
+                    module.annotations.add(getAnnotationModel((AnnotationDeclarationNode) node, semanticModel, module));
                 } else if (node.kind() == SyntaxKind.ENUM_DECLARATION &&
                         ((EnumDeclarationNode) node).qualifier().isPresent() &&
                         ((EnumDeclarationNode) node).qualifier().get().kind().equals(SyntaxKind.PUBLIC_KEYWORD)) {
@@ -158,7 +158,7 @@ public class Generator {
                         ((ModuleVariableDeclarationNode) node).visibilityQualifier().isPresent() &&
                         ((ModuleVariableDeclarationNode) node).visibilityQualifier().get().kind()
                                 .equals(SyntaxKind.PUBLIC_KEYWORD)) {
-                    module.variables.add(getModuleVariable((ModuleVariableDeclarationNode) node, semanticModel));
+                    module.variables.add(getModuleVariable((ModuleVariableDeclarationNode) node, semanticModel, module));
                 }
             }
         }
@@ -172,32 +172,32 @@ public class Generator {
         Optional<MetadataNode> metaDataNode = typeDefinition.metadata();
         if (typeDefinition.typeDescriptor().kind().equals(SyntaxKind.RECORD_TYPE_DESC)) {
             module.records.add(getRecordTypeModel((RecordTypeDescriptorNode) typeDefinition.typeDescriptor(),
-                    typeName, metaDataNode, semanticModel));
+                    typeName, metaDataNode, semanticModel, module));
         } else if (typeDefinition.typeDescriptor().kind() == SyntaxKind.OBJECT_TYPE_DESC) {
             ObjectTypeDescriptorNode objectTypeDescriptorNode =
                     (ObjectTypeDescriptorNode) typeDefinition.typeDescriptor();
             BObjectType bObj = getObjectTypeModel(objectTypeDescriptorNode,
-                    typeName, metaDataNode, semanticModel);
+                    typeName, metaDataNode, semanticModel, module);
             if (containsToken(objectTypeDescriptorNode.objectTypeQualifiers(), SyntaxKind.SERVICE_KEYWORD)) {
                 module.serviceTypes.add(bObj);
             } else {
                 module.objectTypes.add(bObj);
             }
         } else if (typeDefinition.typeDescriptor().kind() == SyntaxKind.UNION_TYPE_DESC) {
-            Type unionType = Type.fromNode(typeDefinition.typeDescriptor(), semanticModel);
+            Type unionType = Type.fromNode(typeDefinition.typeDescriptor(), semanticModel, module);
             if (unionType.memberTypes.stream().allMatch(type ->
                     (type.category != null && type.category.equals("errors")) ||
                             (type.category != null && type.category.equals("builtin")) &&
                                     type.name.equals("error"))) {
                 module.errors.add(new Error(typeName, getDocFromMetadata(metaDataNode), isDeprecated(metaDataNode),
-                        Type.fromNode(typeDefinition.typeDescriptor(), semanticModel)));
+                        Type.fromNode(typeDefinition.typeDescriptor(), semanticModel, module)));
             } else {
                 module.types.add(getUnionTypeModel(typeDefinition.typeDescriptor(),
                         typeName, metaDataNode, semanticModel));
             }
         } else if (typeDefinition.typeDescriptor().kind() == SyntaxKind.SIMPLE_NAME_REFERENCE ||
                 typeDefinition.typeDescriptor().kind() == SyntaxKind.QUALIFIED_NAME_REFERENCE) {
-            Type refType = Type.fromNode(typeDefinition.typeDescriptor(), semanticModel);
+            Type refType = Type.fromNode(typeDefinition.typeDescriptor(), semanticModel, module);
             if (refType.category.equals("errors")) {
                 module.errors.add(new Error(typeName, getDocFromMetadata(metaDataNode), isDeprecated(metaDataNode),
                         refType));
@@ -212,7 +212,8 @@ public class Generator {
             ParameterizedTypeDescriptorNode parameterizedTypeDescNode = (ParameterizedTypeDescriptorNode)
                     ((DistinctTypeDescriptorNode) (typeDefinition.typeDescriptor())).typeDescriptor();
             if (parameterizedTypeDescNode.typeParamNode().isPresent()) {
-                detailType = Type.fromNode(parameterizedTypeDescNode.typeParamNode().get().typeNode(), semanticModel);
+                detailType = Type.fromNode(parameterizedTypeDescNode.typeParamNode().get().typeNode(), semanticModel,
+                        module);
             }
             Error err = new Error(typeName, getDocFromMetadata(metaDataNode), isDeprecated(metaDataNode), detailType);
             err.isDistinct = true;
@@ -224,7 +225,7 @@ public class Generator {
                     ((DistinctTypeDescriptorNode) (typeDefinition.typeDescriptor())).typeDescriptor();
             BObjectType bObj = getObjectTypeModel((ObjectTypeDescriptorNode)
                             ((DistinctTypeDescriptorNode) (typeDefinition.typeDescriptor())).typeDescriptor(), typeName,
-                    metaDataNode, semanticModel);
+                    metaDataNode, semanticModel, module);
             bObj.isDistinct = true;
             if (containsToken(objectTypeDescriptorNode.objectTypeQualifiers(), SyntaxKind.SERVICE_KEYWORD)) {
                 module.serviceTypes.add(bObj);
@@ -236,7 +237,7 @@ public class Generator {
                         == SyntaxKind.PARENTHESISED_TYPE_DESC) {
             ParenthesisedTypeDescriptorNode parenthesisedTypeDescriptorNode = (ParenthesisedTypeDescriptorNode)
                     ((DistinctTypeDescriptorNode) (typeDefinition.typeDescriptor())).typeDescriptor();
-            Type detailType = Type.fromNode(parenthesisedTypeDescriptorNode, semanticModel);
+            Type detailType = Type.fromNode(parenthesisedTypeDescriptorNode, semanticModel, module);
             Error err = new Error(typeName, getDocFromMetadata(metaDataNode), isDeprecated(metaDataNode), detailType);
             err.isDistinct = true;
             module.errors.add(err);
@@ -244,7 +245,7 @@ public class Generator {
                 ((DistinctTypeDescriptorNode) (typeDefinition.typeDescriptor())).typeDescriptor().kind()
                         == SyntaxKind.SIMPLE_NAME_REFERENCE) {
             Type refType = Type.fromNode(((DistinctTypeDescriptorNode) (typeDefinition.typeDescriptor()))
-                    .typeDescriptor(), semanticModel);
+                    .typeDescriptor(), semanticModel, module);
             if (refType.category.equals("errors")) {
                 Error err = new Error(typeName, getDocFromMetadata(metaDataNode), isDeprecated(metaDataNode), refType);
                 err.isDistinct = true;
@@ -263,18 +264,18 @@ public class Generator {
             Type type = null;
             if (parameterizedTypeDescNode.typeParamNode().isPresent()) {
                 type = Type.fromNode(parameterizedTypeDescNode.typeParamNode().get().typeNode(),
-                        semanticModel);
+                        semanticModel, module);
             }
             module.errors.add(new Error(typeName, getDocFromMetadata(metaDataNode), isDeprecated(metaDataNode), type));
         } else if (typeDefinition.typeDescriptor().kind() == SyntaxKind.TUPLE_TYPE_DESC) {
             module.types.add(getTupleTypeModel((TupleTypeDescriptorNode) typeDefinition.typeDescriptor(),
-                    typeName, metaDataNode, semanticModel));
+                    typeName, metaDataNode, semanticModel, module));
         } else if (typeDefinition.typeDescriptor().kind() == SyntaxKind.INTERSECTION_TYPE_DESC) {
             addIntersectionTypeModel((IntersectionTypeDescriptorNode) typeDefinition.typeDescriptor(), typeName,
                     metaDataNode, semanticModel, module);
         } else if (typeDefinition.typeDescriptor().kind() == SyntaxKind.TYPEDESC_TYPE_DESC) {
             module.types.add(getTypeDescModel((ParameterizedTypeDescriptorNode) typeDefinition.typeDescriptor(),
-                    typeName, metaDataNode, semanticModel));
+                    typeName, metaDataNode, semanticModel, module));
         } else if (typeDefinition.typeDescriptor().kind() == SyntaxKind.INT_TYPE_DESC ||
                 typeDefinition.typeDescriptor().kind() == SyntaxKind.DECIMAL_TYPE_DESC ||
                 typeDefinition.typeDescriptor().kind() == SyntaxKind.XML_TYPE_DESC ||
@@ -302,12 +303,12 @@ public class Generator {
     }
 
     public static DefaultableVariable getModuleVariable(ModuleVariableDeclarationNode moduleVariableNode,
-                                                        SemanticModel semanticModel) {
+                                                        SemanticModel semanticModel, Module module) {
         String name = moduleVariableNode.typedBindingPattern().bindingPattern().toSourceCode().replace(" ", "");
         String doc = getDocFromMetadata(moduleVariableNode.metadata());
         String defaultValue = moduleVariableNode.initializer().isPresent() ?
                 moduleVariableNode.initializer().get().toSourceCode() : "";
-        Type type = Type.fromNode(moduleVariableNode.typedBindingPattern().typeDescriptor(), semanticModel);
+        Type type = Type.fromNode(moduleVariableNode.typedBindingPattern().typeDescriptor(), semanticModel, module);
         return new DefaultableVariable(name, doc, false, type, defaultValue);
     }
 
@@ -330,7 +331,7 @@ public class Generator {
     }
 
     public static Annotation getAnnotationModel(AnnotationDeclarationNode annotationDeclaration,
-                                                SemanticModel semanticModel) {
+                                                SemanticModel semanticModel, Module module) {
         String annotationName = annotationDeclaration.annotationTag().text();
         StringJoiner attachPointJoiner = new StringJoiner(", ");
         for (int i = 0; i < annotationDeclaration.attachPoints().size(); i++) {
@@ -340,19 +341,19 @@ public class Generator {
         }
 
         Type dataType = annotationDeclaration.typeDescriptor().isPresent() ? Type.fromNode(annotationDeclaration.
-                typeDescriptor().get(), semanticModel) : null;
+                typeDescriptor().get(), semanticModel, module) : null;
         return new Annotation(annotationName, getDocFromMetadata(annotationDeclaration.metadata()),
                 isDeprecated(annotationDeclaration.metadata()), dataType, attachPointJoiner.toString());
     }
 
     public static Constant getConstantTypeModel(ConstantDeclarationNode constantNode,
-                                                SemanticModel semanticModel) {
+                                                SemanticModel semanticModel, Module module) {
         String constantName = constantNode.variableName().text();
         String value = constantNode.initializer().toString();
         String desc = getDocFromMetadata(constantNode.metadata());
         Type type;
         if (constantNode.typeDescriptor().isPresent()) {
-            type = Type.fromNode(constantNode.typeDescriptor().get(), semanticModel);
+            type = Type.fromNode(constantNode.typeDescriptor().get(), semanticModel, module);
         } else {
             String dataType = "";
             if (constantNode.initializer().kind() == SyntaxKind.STRING_LITERAL) {
@@ -383,20 +384,20 @@ public class Generator {
                     typeDescriptor.rightTypeDesc() : typeDescriptor.leftTypeDesc();
             if (typeDef.kind() == SyntaxKind.RECORD_TYPE_DESC) {
                 Record record = getRecordTypeModel((RecordTypeDescriptorNode) typeDef, typeName, optionalMetadataNode,
-                        semanticModel);
+                        semanticModel, module);
                 record.isReadOnly = true;
                 module.records.add(record);
                 return;
             } else if (typeDef.kind() == SyntaxKind.OBJECT_TYPE_DESC) {
                 BObjectType bObj = getObjectTypeModel((ObjectTypeDescriptorNode) typeDef, typeName,
-                        optionalMetadataNode, semanticModel);
+                        optionalMetadataNode, semanticModel, module);
                 bObj.isReadOnly = true;
                 module.objectTypes.add(bObj);
                 return;
             }
         }
         List<Type> memberTypes = new ArrayList<>();
-        Type.addIntersectionMemberTypes(typeDescriptor, semanticModel, memberTypes);
+        Type.addIntersectionMemberTypes(typeDescriptor, semanticModel, memberTypes, module);
         BType bType = new BType(typeName, getDocFromMetadata(optionalMetadataNode),
                 isDeprecated(optionalMetadataNode), memberTypes);
         bType.isIntersectionType = true;
@@ -404,10 +405,11 @@ public class Generator {
     }
 
     private static BType getTupleTypeModel(TupleTypeDescriptorNode typeDescriptor, String tupleTypeName,
-                                           Optional<MetadataNode> optionalMetadataNode, SemanticModel semanticModel) {
+                                           Optional<MetadataNode> optionalMetadataNode, SemanticModel semanticModel,
+                                           Module module) {
         List<Type> memberTypes = new ArrayList<>();
         memberTypes.addAll(typeDescriptor.memberTypeDesc().stream().map(type ->
-                Type.fromNode(type, semanticModel)).collect(Collectors.toList()));
+                Type.fromNode(type, semanticModel, module)).collect(Collectors.toList()));
         BType bType = new BType(tupleTypeName, getDocFromMetadata(optionalMetadataNode),
                 isDeprecated(optionalMetadataNode), memberTypes);
         bType.isTuple = true;
@@ -415,10 +417,11 @@ public class Generator {
     }
 
     private static BType getTypeDescModel(ParameterizedTypeDescriptorNode typeDescriptor, String typeName,
-                                          Optional<MetadataNode> optionalMetadataNode, SemanticModel semanticModel) {
+                                          Optional<MetadataNode> optionalMetadataNode, SemanticModel semanticModel,
+                                          Module module) {
         Type type = null;
         if (typeDescriptor.typeParamNode().isPresent()) {
-            type = Type.fromNode(typeDescriptor.typeParamNode().get().typeNode(), semanticModel);
+            type = Type.fromNode(typeDescriptor.typeParamNode().get().typeNode(), semanticModel, module);
         }
         BType bType = new BType(typeName, getDocFromMetadata(optionalMetadataNode), isDeprecated(optionalMetadataNode),
                 null);
@@ -438,7 +441,8 @@ public class Generator {
         return bType;
     }
 
-    private static BClass getClassModel(ClassDefinitionNode classDefinitionNode, SemanticModel semanticModel) {
+    private static BClass getClassModel(ClassDefinitionNode classDefinitionNode, SemanticModel semanticModel,
+                                        Module module) {
         List<Function> classFunctions = new ArrayList<>();
         List<Function> includedFunctions = new ArrayList<>();
         String name = classDefinitionNode.className().text();
@@ -449,16 +453,16 @@ public class Generator {
         boolean isService = containsToken(classDefinitionNode.classTypeQualifiers(), SyntaxKind.SERVICE_KEYWORD);
 
         List<DefaultableVariable> fields = getDefaultableVariableList(classDefinitionNode.members(),
-                classDefinitionNode.metadata(), semanticModel);
+                classDefinitionNode.metadata(), semanticModel, module);
 
         for (Node member : classDefinitionNode.members()) {
             if (member instanceof FunctionDefinitionNode && (containsToken(((FunctionDefinitionNode) member)
                     .qualifierList(), SyntaxKind.PUBLIC_KEYWORD) || containsToken(((FunctionDefinitionNode) member)
                     .qualifierList(), SyntaxKind.REMOTE_KEYWORD) || containsToken(((FunctionDefinitionNode) member)
                     .qualifierList(), SyntaxKind.RESOURCE_KEYWORD))) {
-                classFunctions.add(getFunctionModel((FunctionDefinitionNode) member, semanticModel));
+                classFunctions.add(getFunctionModel((FunctionDefinitionNode) member, semanticModel, module));
             } else if (member instanceof TypeReferenceNode) {
-                Type originType = Type.fromNode(member, semanticModel);
+                Type originType = Type.fromNode(member, semanticModel, module);
                 if (originType instanceof ObjectType) {
                     includedFunctions.addAll(mapFunctionTypesToFunctions(((ObjectType) originType).functionTypes,
                             originType));
@@ -487,7 +491,7 @@ public class Generator {
 
     private static BObjectType getObjectTypeModel(ObjectTypeDescriptorNode typeDescriptorNode, String objectName,
                                                   Optional<MetadataNode> optionalMetadataNode,
-                                                  SemanticModel semanticModel) {
+                                                  SemanticModel semanticModel, Module module) {
         List<Function> objectFunctions = new ArrayList<>();
         List<Function> includedFunctions = new ArrayList<>();
 
@@ -495,7 +499,7 @@ public class Generator {
         boolean isDeprecated = isDeprecated(optionalMetadataNode);
 
         List<DefaultableVariable> fields = getDefaultableVariableList(typeDescriptorNode.members(),
-                optionalMetadataNode, semanticModel);
+                optionalMetadataNode, semanticModel, module);
 
         for (Node member : typeDescriptorNode.members()) {
             if (member instanceof MethodDeclarationNode) {
@@ -521,12 +525,12 @@ public class Generator {
 
                     // Iterate through the parameters
                     List<DefaultableVariable> parameters = new ArrayList<>(getDefaultableVariableList(methodSignature
-                                    .parameters(), methodNode.metadata(), semanticModel));
+                                    .parameters(), methodNode.metadata(), semanticModel, module));
 
                     // return params
                     if (methodSignature.returnTypeDesc().isPresent()) {
                         ReturnTypeDescriptorNode returnType = methodSignature.returnTypeDesc().get();
-                        Type type = Type.fromNode(returnType.type(), semanticModel);
+                        Type type = Type.fromNode(returnType.type(), semanticModel, module);
                         returnParams.add(new Variable(EMPTY_STRING, getParameterDocFromMetadataList(RETURN_PARAM_NAME,
                                 methodNode.metadata()), false, type));
                     }
@@ -546,7 +550,7 @@ public class Generator {
                             SyntaxKind.ISOLATED_KEYWORD), parameters, returnParams));
                 }
             } else if (member instanceof TypeReferenceNode) {
-                Type originType = Type.fromNode(member, semanticModel);
+                Type originType = Type.fromNode(member, semanticModel, module);
                 if (originType instanceof ObjectType) {
                     includedFunctions.addAll(mapFunctionTypesToFunctions(((ObjectType) originType).functionTypes,
                             originType));
@@ -589,7 +593,7 @@ public class Generator {
     }
 
     private static Function getFunctionModel(FunctionDefinitionNode functionDefinitionNode,
-                                             SemanticModel semanticModel) {
+                                             SemanticModel semanticModel, Module module) {
         String functionName = "";
         String accessor = "";
         String resourcePath = "";
@@ -608,14 +612,14 @@ public class Generator {
 
         // Iterate through the parameters
         parameters.addAll(getDefaultableVariableList(functionSignature.parameters(),
-                functionDefinitionNode.metadata(), semanticModel));
+                functionDefinitionNode.metadata(), semanticModel, module));
 
         List<AnnotationAttachment> annotationAttachments = extractAnnotationAttachmentsFromMetadataNode(semanticModel,
                 functionDefinitionNode.metadata());
         // return params
         if (functionSignature.returnTypeDesc().isPresent()) {
             ReturnTypeDescriptorNode returnType = functionSignature.returnTypeDesc().get();
-            Type type = Type.fromNode(returnType.type(), semanticModel);
+            Type type = Type.fromNode(returnType.type(), semanticModel, module);
             returnParams.add(new Variable(EMPTY_STRING, getParameterDocFromMetadataList(RETURN_PARAM_NAME,
                     functionDefinitionNode.metadata()), false, type));
         }
@@ -638,15 +642,15 @@ public class Generator {
 
     private static Record getRecordTypeModel(RecordTypeDescriptorNode recordTypeDesc, String recordName,
                                              Optional<MetadataNode> optionalMetadataNode,
-                                             SemanticModel semanticModel) {
+                                             SemanticModel semanticModel, Module module) {
 
         List<DefaultableVariable> fields = getDefaultableVariableList(recordTypeDesc.fields(),
-                optionalMetadataNode, semanticModel);
+                optionalMetadataNode, semanticModel, module);
         boolean isClosed = (recordTypeDesc.bodyStartDelimiter()).kind().equals(SyntaxKind.OPEN_BRACE_PIPE_TOKEN);
         if (recordTypeDesc.recordRestDescriptor().isPresent()) {
             isClosed = false;
             DefaultableVariable restVariable = new DefaultableVariable("", REST_FIELD_DESCRIPTION,
-                    false, Type.fromNode(recordTypeDesc.recordRestDescriptor().get(), semanticModel), "");
+                    false, Type.fromNode(recordTypeDesc.recordRestDescriptor().get(), semanticModel, module), "");
             fields.add(restVariable);
         }
         return new Record(recordName, getDocFromMetadata(optionalMetadataNode),
@@ -655,7 +659,8 @@ public class Generator {
 
     public static List<DefaultableVariable> getDefaultableVariableList(NodeList nodeList,
                                                                        Optional<MetadataNode> optionalMetadataNode,
-                                                                       SemanticModel semanticModel) {
+                                                                       SemanticModel semanticModel,
+                                                                       Module module) {
         List<DefaultableVariable> variables = new ArrayList<>();
         for (int i = 0; i < nodeList.size(); i++) {
             Node node = nodeList.get(i);
@@ -667,7 +672,7 @@ public class Generator {
                     doc = getParameterDocFromMetadataList(name, optionalMetadataNode);
                 }
                 String defaultValue = recordField.expression().toString();
-                Type type = Type.fromNode(recordField.typeName(), semanticModel);
+                Type type = Type.fromNode(recordField.typeName(), semanticModel, module);
                 DefaultableVariable defaultableVariable = new DefaultableVariable(name, doc, false, type,
                         defaultValue, extractAnnotationAttachmentsFromMetadataNode(semanticModel,
                         recordField.metadata()));
@@ -682,7 +687,7 @@ public class Generator {
                 if (doc.equals("")) {
                     doc = getParameterDocFromMetadataList(name, optionalMetadataNode);
                 }
-                Type type = Type.fromNode(recordField.typeName(), semanticModel);
+                Type type = Type.fromNode(recordField.typeName(), semanticModel, module);
                 type.isNullable = recordField.questionMarkToken().isPresent();
                 DefaultableVariable defaultableVariable = new DefaultableVariable(name, doc,
                         isDeprecated(recordField.metadata()), type, "",
@@ -692,7 +697,7 @@ public class Generator {
                 }
                 variables.add(defaultableVariable);
             } else if (node instanceof TypeReferenceNode) {
-                Type originType = Type.fromNode(node, semanticModel);
+                Type originType = Type.fromNode(node, semanticModel, module);
                 if (!originType.isPublic) {
                     variables.addAll(originType.memberTypes.stream()
                             .map(type -> new DefaultableVariable(type.name, type.description, false,
@@ -715,7 +720,7 @@ public class Generator {
                     } else {
                         defaultValue = "";
                     }
-                    Type type = Type.fromNode(objectField.typeName(), semanticModel);
+                    Type type = Type.fromNode(objectField.typeName(), semanticModel, module);
                     DefaultableVariable defaultableVariable = new DefaultableVariable(name, doc,
                             isDeprecated(objectField.metadata()), type, defaultValue,
                             extractAnnotationAttachmentsFromMetadataNode(semanticModel, objectField.metadata()));
@@ -725,14 +730,14 @@ public class Generator {
                 RequiredParameterNode requiredParameter = (RequiredParameterNode) node;
                 String paramName = requiredParameter.paramName().isPresent() ?
                         requiredParameter.paramName().get().text() : "";
-                Type type = Type.fromNode(requiredParameter.typeName(), semanticModel);
+                Type type = Type.fromNode(requiredParameter.typeName(), semanticModel, module);
                 variables.add(new DefaultableVariable(paramName, getParameterDocFromMetadataList(paramName,
                         optionalMetadataNode), isDeprecated(requiredParameter.annotations()), type, ""));
             } else if (node instanceof DefaultableParameterNode) {
                 DefaultableParameterNode defaultableParameter = (DefaultableParameterNode) node;
                 String paramName = defaultableParameter.paramName().isPresent() ?
                         defaultableParameter.paramName().get().text() : "";
-                Type type = Type.fromNode(defaultableParameter.typeName(), semanticModel);
+                Type type = Type.fromNode(defaultableParameter.typeName(), semanticModel, module);
                 variables.add(new DefaultableVariable(paramName, getParameterDocFromMetadataList(paramName,
                         optionalMetadataNode), isDeprecated(defaultableParameter.annotations()),
                         type, defaultableParameter.expression().toString(),
@@ -744,14 +749,14 @@ public class Generator {
                         restParameter.paramName().get().text() : "";
                 Type type = new Type(paramName);
                 type.isRestParam = true;
-                type.elementType = Type.fromNode(restParameter.typeName(), semanticModel);
+                type.elementType = Type.fromNode(restParameter.typeName(), semanticModel, module);
                 variables.add(new DefaultableVariable(paramName, getParameterDocFromMetadataList(paramName,
                         optionalMetadataNode), false, type, ""));
             } else if (node instanceof IncludedRecordParameterNode) {
                 IncludedRecordParameterNode includedRecord = (IncludedRecordParameterNode) node;
                 String paramName = includedRecord.paramName().isPresent() ?
                         includedRecord.paramName().get().text() : "";
-                Type type = Type.fromNode(includedRecord.typeName(), semanticModel);
+                Type type = Type.fromNode(includedRecord.typeName(), semanticModel, module);
                 type.isInclusion = true;
                 variables.add(new DefaultableVariable(paramName, getParameterDocFromMetadataList(paramName,
                         optionalMetadataNode), false, type, ""));

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Type.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Type.java
@@ -73,6 +73,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -134,7 +135,7 @@ public class Type {
     public Type() {
     }
 
-    public static Type fromNode(Node node, SemanticModel semanticModel) {
+    public static Type fromNode(Node node, SemanticModel semanticModel, Module module) {
         Type type = new Type();
         if (node instanceof SimpleNameReferenceNode) {
             SimpleNameReferenceNode simpleNameReferenceNode = (SimpleNameReferenceNode) node;
@@ -151,9 +152,9 @@ public class Type {
             if (symbol != null && symbol.isPresent()) {
                 if (symbol.get() instanceof TypeReferenceTypeSymbol &&
                         !Type.isPublic(((TypeReferenceTypeSymbol) symbol.get()).definition())) {
-                    type = fromSemanticSymbol(symbol.get(), Optional.empty(), null, false);
+                    type = fromSemanticSymbol(symbol.get(), Optional.empty(), null, false, module);
                 } else {
-                    resolveSymbolMetaData(type, symbol.get());
+                    resolveSymbolMetaData(type, symbol.get(), module);
                 }
             } else {
                 type.generateUserDefinedTypeLink = false;
@@ -174,9 +175,9 @@ public class Type {
             if (symbol != null && symbol.isPresent()) {
                 if (symbol.get() instanceof TypeReferenceTypeSymbol &&
                         !Type.isPublic(((TypeReferenceTypeSymbol) symbol.get()).definition())) {
-                    type = fromSemanticSymbol(symbol.get(), Optional.empty(), null, false);
+                    type = fromSemanticSymbol(symbol.get(), Optional.empty(), null, false, module);
                 } else {
-                    resolveSymbolMetaData(type, symbol.get());
+                    resolveSymbolMetaData(type, symbol.get(), module);
                 }
             } else {
                 type.generateUserDefinedTypeLink = false;
@@ -191,7 +192,7 @@ public class Type {
                 }
             }
             if (symbol != null && symbol.isPresent()) {
-                type = fromSemanticSymbol(symbol.get(), Optional.empty(), null, true);
+                type = fromSemanticSymbol(symbol.get(), Optional.empty(), null, true, module);
             }
         } else if (node instanceof BuiltinSimpleNameReferenceNode) {
             BuiltinSimpleNameReferenceNode builtinSimpleNameReferenceNode = (BuiltinSimpleNameReferenceNode) node;
@@ -204,17 +205,17 @@ public class Type {
             ArrayTypeDescriptorNode arrayTypeDescriptorNode = (ArrayTypeDescriptorNode) node;
             type.isArrayType = true;
             type.arrayDimensions = 1;
-            type.elementType = fromNode(arrayTypeDescriptorNode.memberTypeDesc(), semanticModel);
+            type.elementType = fromNode(arrayTypeDescriptorNode.memberTypeDesc(), semanticModel, module);
         } else if (node instanceof OptionalTypeDescriptorNode) {
             OptionalTypeDescriptorNode optionalTypeDescriptorNode = (OptionalTypeDescriptorNode) node;
-            type = fromNode(optionalTypeDescriptorNode.typeDescriptor(), semanticModel);
+            type = fromNode(optionalTypeDescriptorNode.typeDescriptor(), semanticModel, module);
             type.isNullable = true;
         } else if (node instanceof UnionTypeDescriptorNode) {
             type.isAnonymousUnionType = true;
-            addUnionMemberTypes(node, semanticModel, type.memberTypes);
+            addUnionMemberTypes(node, semanticModel, type.memberTypes, module);
         } else if (node instanceof IntersectionTypeDescriptorNode) {
             type.isIntersectionType = true;
-            addIntersectionMemberTypes(node, semanticModel, type.memberTypes);
+            addIntersectionMemberTypes(node, semanticModel, type.memberTypes, module);
         } else if (node instanceof RecordTypeDescriptorNode) {
             RecordTypeDescriptorNode recordNode = (RecordTypeDescriptorNode) node;
             List<Type> fields = new ArrayList<>();
@@ -223,19 +224,19 @@ public class Type {
                     RecordFieldWithDefaultValueNode recordField = (RecordFieldWithDefaultValueNode) node1;
                     Type defField = new Type();
                     defField.name = recordField.fieldName().text();
-                    defField.elementType = fromNode(recordField.typeName(), semanticModel);
+                    defField.elementType = fromNode(recordField.typeName(), semanticModel, module);
                     fields.add(defField);
                 } else if (node1 instanceof RecordFieldNode) {
                     RecordFieldNode recordField = (RecordFieldNode) node1;
                     Type recField = new Type();
                     recField.name = recordField.fieldName().text();
-                    recField.elementType = fromNode(recordField.typeName(), semanticModel);
+                    recField.elementType = fromNode(recordField.typeName(), semanticModel, module);
                     fields.add(recField);
                 }
             });
             if (recordNode.recordRestDescriptor().isPresent()) {
                 Type restField = new Type();
-                restField.elementType = fromNode(recordNode.recordRestDescriptor().get(), semanticModel);
+                restField.elementType = fromNode(recordNode.recordRestDescriptor().get(), semanticModel, module);
                 fields.add(restField);
             }
             type.category = (recordNode.bodyStartDelimiter()).kind().equals(SyntaxKind.OPEN_BRACE_PIPE_TOKEN) &&
@@ -249,9 +250,9 @@ public class Type {
             type.name = streamNode.streamKeywordToken().text();
             type.category = "stream";
             if (streamParams != null) {
-                type.memberTypes.add(fromNode(streamParams.leftTypeDescNode(), semanticModel));
+                type.memberTypes.add(fromNode(streamParams.leftTypeDescNode(), semanticModel, module));
                 if (streamParams.rightTypeDescNode().isPresent()) {
-                    type.memberTypes.add(fromNode(streamParams.rightTypeDescNode().get(), semanticModel));
+                    type.memberTypes.add(fromNode(streamParams.rightTypeDescNode().get(), semanticModel, module));
                 }
             }
         } else if (node instanceof FunctionTypeDescriptorNode) {
@@ -264,12 +265,12 @@ public class Type {
                 FunctionSignatureNode functionSignature = functionDescNode.functionSignature().get();
                 List<DefaultableVariable> variables =
                         Generator.getDefaultableVariableList(functionSignature.parameters(), Optional.empty(),
-                                semanticModel);
+                                semanticModel, module);
                 functionType.paramTypes.addAll(variables.stream().map((defaultableVariable) -> defaultableVariable.type)
                         .collect(Collectors.toList()));
                 if (functionSignature.returnTypeDesc().isPresent()) {
                     ReturnTypeDescriptorNode returnType = functionSignature.returnTypeDesc().get();
-                    functionType.returnType = Type.fromNode(returnType.type(), semanticModel);
+                    functionType.returnType = Type.fromNode(returnType.type(), semanticModel, module);
                 }
             }
             type = functionType;
@@ -277,7 +278,7 @@ public class Type {
             MapTypeDescriptorNode mapTypeDesc = (MapTypeDescriptorNode) node;
             type.name = "map";
             type.category = "map";
-            type.constraint = fromNode(mapTypeDesc.mapTypeParamsNode().typeNode(), semanticModel);
+            type.constraint = fromNode(mapTypeDesc.mapTypeParamsNode().typeNode(), semanticModel, module);
         } else if (node instanceof ParameterizedTypeDescriptorNode) {
             ParameterizedTypeDescriptorNode parameterizedTypeNode = (ParameterizedTypeDescriptorNode) node;
             SyntaxKind typeKind = node.kind();
@@ -287,10 +288,10 @@ public class Type {
             } else if (typeKind == SyntaxKind.FUTURE_TYPE_DESC) {
                 type.category = "future";
                 type.elementType = parameterizedTypeNode.typeParamNode().map(typeParameterNode ->
-                        Type.fromNode(typeParameterNode.typeNode(), semanticModel)).orElse(null);
+                        Type.fromNode(typeParameterNode.typeNode(), semanticModel, module)).orElse(null);
             } else if (typeKind == SyntaxKind.TYPEDESC_TYPE_DESC) {
                 type.elementType = parameterizedTypeNode.typeParamNode().map(typeParameterNode ->
-                        Type.fromNode(typeParameterNode.typeNode(), semanticModel)).orElse(null);
+                        Type.fromNode(typeParameterNode.typeNode(), semanticModel, module)).orElse(null);
                 type.isTypeDesc = true;
             }
         } else if (node instanceof ObjectTypeDescriptorNode) {
@@ -305,20 +306,20 @@ public class Type {
             type.generateUserDefinedTypeLink = false;
         } else if (node instanceof ParenthesisedTypeDescriptorNode) {
             ParenthesisedTypeDescriptorNode parenthesisedNode = (ParenthesisedTypeDescriptorNode) node;
-            type.elementType = fromNode(parenthesisedNode.typedesc(), semanticModel);
+            type.elementType = fromNode(parenthesisedNode.typedesc(), semanticModel, module);
             type.isParenthesisedType = true;
         } else if (node instanceof TupleTypeDescriptorNode) {
             TupleTypeDescriptorNode typeDescriptor = (TupleTypeDescriptorNode) node;
             type.memberTypes.addAll(typeDescriptor.memberTypeDesc().stream().map(memberType ->
-                    Type.fromNode(memberType, semanticModel)).collect(Collectors.toList()));
+                    Type.fromNode(memberType, semanticModel, module)).collect(Collectors.toList()));
             type.isTuple = true;
         } else if (node instanceof MemberTypeDescriptorNode) {
             MemberTypeDescriptorNode member = (MemberTypeDescriptorNode) node;
-            type = fromNode(member.typeDescriptor(), semanticModel);
+            type = fromNode(member.typeDescriptor(), semanticModel, module);
         } else if (node instanceof RecordRestDescriptorNode) {
             RecordRestDescriptorNode recordRestDescriptorNode = (RecordRestDescriptorNode) node;
             type.isRestParam = true;
-            type.elementType = fromNode(recordRestDescriptorNode.typeName(), semanticModel);
+            type.elementType = fromNode(recordRestDescriptorNode.typeName(), semanticModel, module);
         } else {
             type.name = node.toSourceCode();
             type.generateUserDefinedTypeLink = false;
@@ -328,7 +329,8 @@ public class Type {
     }
 
     public static Type fromSemanticSymbol(Symbol symbol, Optional<Documentation> documentation,
-                                          TypeReferenceTypeSymbol parentTypeRefSymbol, boolean isTypeInclusion) {
+                                          TypeReferenceTypeSymbol parentTypeRefSymbol, boolean isTypeInclusion,
+                                          Module module) {
         Type type = new Type();
         if (symbol instanceof TypeReferenceTypeSymbol) {
             TypeReferenceTypeSymbol typeReferenceTypeSymbol = (TypeReferenceTypeSymbol) symbol;
@@ -343,15 +345,15 @@ public class Type {
                 if (typeDefinition instanceof TypeDefinitionSymbol) {
                     type = fromSemanticSymbol(typeReferenceTypeSymbol.typeDescriptor(),
                             ((TypeDefinitionSymbol) typeDefinition).documentation(), typeReferenceTypeSymbol,
-                            false);
+                            false, module);
                 } else if (typeDefinition instanceof ClassSymbol) {
                     type = fromSemanticSymbol(typeReferenceTypeSymbol.typeDescriptor(),
                             ((ClassSymbol) typeDefinition).documentation(), typeReferenceTypeSymbol,
-                            false);
+                            false, module);
                 }
             }
             if (Type.isPublic(typeReferenceTypeSymbol.definition())) {
-                resolveSymbolMetaData(type, symbol);
+                resolveSymbolMetaData(type, symbol, module);
                 type.isPublic = true;
             }
             type.name = typeReferenceTypeSymbol.getName().isPresent() ? typeReferenceTypeSymbol.getName().get() : null;
@@ -366,14 +368,14 @@ public class Type {
                 recField.name = name;
                 recField.description = documentation.isPresent() ? documentation.get().parameterMap().get(name) : "";
                 recField.elementType = fromSemanticSymbol(field.typeDescriptor(), documentation, parentTypeRefSymbol,
-                        isTypeInclusion);
+                        isTypeInclusion, module);
                 recordType.memberTypes.add(recField);
             });
             recordTypeSymbol.restTypeDescriptor().ifPresent(typeSymbol -> {
                 Type restField = new Type();
                 restField.isRestParam = true;
                 restField.elementType = fromSemanticSymbol(typeSymbol, documentation, parentTypeRefSymbol,
-                        isTypeInclusion);
+                        isTypeInclusion, module);
                 restField.description = Generator.REST_FIELD_DESCRIPTION;
                 Type recField = new Type();
                 recField.elementType = restField;
@@ -389,7 +391,7 @@ public class Type {
                 objField.name = name;
                 objField.description = documentation.isPresent() ? documentation.get().parameterMap().get(name) : "";
                 objField.elementType = fromSemanticSymbol(field.typeDescriptor(), documentation, parentTypeRefSymbol,
-                        isTypeInclusion);
+                        isTypeInclusion, module);
                 objType.memberTypes.add(objField);
             });
             List<FunctionType> functionTypes = new ArrayList<>();
@@ -424,7 +426,7 @@ public class Type {
                         Type paramType = new Type();
                         paramType.name = parameterSymbol.getName().isPresent() ? parameterSymbol.getName().get() : "";
                         paramType.elementType = fromSemanticSymbol(parameterSymbol.typeDescriptor(),
-                                methodSymbol.documentation(), parentTypeRefSymbol, isTypeInclusion);
+                                methodSymbol.documentation(), parentTypeRefSymbol, isTypeInclusion, module);
                         paramType.isDeprecated = parameterSymbol.annotations().stream()
                                 .anyMatch(annotationSymbol -> annotationSymbol.getName().get().equals("deprecated"));
                         functionType.paramTypes.add(paramType);
@@ -432,14 +434,14 @@ public class Type {
                 if (methodSymbol.typeDescriptor().restParam().isPresent()) {
                     ParameterSymbol restParam = methodSymbol.typeDescriptor().restParam().get();
                     Type restType = fromSemanticSymbol(restParam, methodSymbol.documentation(), parentTypeRefSymbol,
-                            isTypeInclusion);
+                            isTypeInclusion, module);
                     restType.isDeprecated = restParam.annotations().stream()
                             .anyMatch(annotationSymbol -> annotationSymbol.getName().get().equals("deprecated"));
                     functionType.paramTypes.add(restType);
                 }
                 if (methodSymbol.typeDescriptor().returnTypeDescriptor().isPresent()) {
                     Type returnType = fromSemanticSymbol(methodSymbol.typeDescriptor().returnTypeDescriptor().get(),
-                            methodSymbol.documentation(), parentTypeRefSymbol, isTypeInclusion);
+                            methodSymbol.documentation(), parentTypeRefSymbol, isTypeInclusion, module);
                     functionType.returnType = returnType;
                 }
                 });
@@ -452,27 +454,27 @@ public class Type {
             type.name = "map";
             type.category = "map";
             type.constraint = fromSemanticSymbol(mapTypeSymbol.typeParam(), documentation, parentTypeRefSymbol,
-                    isTypeInclusion);
+                    isTypeInclusion, module);
         } else if (symbol instanceof UnionTypeSymbol) {
             UnionTypeSymbol unionSymbol = (UnionTypeSymbol) symbol;
             type.isAnonymousUnionType = true;
             List<Type> unionMembers = new ArrayList<>();
             unionSymbol.memberTypeDescriptors().forEach(typeSymbol -> unionMembers.add(fromSemanticSymbol(typeSymbol,
-                    documentation, parentTypeRefSymbol, isTypeInclusion)));
+                    documentation, parentTypeRefSymbol, isTypeInclusion, module)));
             type.memberTypes = unionMembers;
         } else if (symbol instanceof IntersectionTypeSymbol) {
             IntersectionTypeSymbol intersectionSymbol = (IntersectionTypeSymbol) symbol;
             type.isIntersectionType = true;
             List<Type> intersectionMembers = new ArrayList<>();
             intersectionSymbol.memberTypeDescriptors().forEach(typeSymbol -> intersectionMembers.add(
-                    fromSemanticSymbol(typeSymbol, documentation, parentTypeRefSymbol, isTypeInclusion)));
+                    fromSemanticSymbol(typeSymbol, documentation, parentTypeRefSymbol, isTypeInclusion, module)));
             type.memberTypes = intersectionMembers;
         } else if (symbol instanceof ArrayTypeSymbol) {
             ArrayTypeSymbol arrayTypeSymbol = (ArrayTypeSymbol) symbol;
             type.isArrayType = true;
             type.arrayDimensions = 1;
             type.elementType = fromSemanticSymbol(arrayTypeSymbol.memberTypeDescriptor(), documentation,
-                    parentTypeRefSymbol, isTypeInclusion);
+                    parentTypeRefSymbol, isTypeInclusion, module);
         } else if (symbol instanceof TypeSymbol) {
             type.category = "builtin";
             type.name = ((TypeSymbol) symbol).signature();
@@ -480,27 +482,28 @@ public class Type {
         return type;
     }
 
-    public static void addUnionMemberTypes(Node node, SemanticModel semanticModel, List<Type> members) {
+    public static void addUnionMemberTypes(Node node, SemanticModel semanticModel, List<Type> members, Module module) {
         if (node instanceof UnionTypeDescriptorNode) {
             UnionTypeDescriptorNode unionTypeNode = (UnionTypeDescriptorNode) node;
-            addUnionMemberTypes(unionTypeNode.leftTypeDesc(), semanticModel, members);
-            addUnionMemberTypes(unionTypeNode.rightTypeDesc(), semanticModel, members);
+            addUnionMemberTypes(unionTypeNode.leftTypeDesc(), semanticModel, members, module);
+            addUnionMemberTypes(unionTypeNode.rightTypeDesc(), semanticModel, members, module);
             return;
         }
-        members.add(fromNode(node, semanticModel));
+        members.add(fromNode(node, semanticModel, module));
     }
 
-    public static void addIntersectionMemberTypes(Node node, SemanticModel semanticModel, List<Type> members) {
+    public static void addIntersectionMemberTypes(Node node, SemanticModel semanticModel, List<Type> members,
+                                                  Module module) {
         if (node instanceof IntersectionTypeDescriptorNode) {
             IntersectionTypeDescriptorNode intersectionTypeNode = (IntersectionTypeDescriptorNode) node;
-            addIntersectionMemberTypes(intersectionTypeNode.leftTypeDesc(), semanticModel, members);
-            addIntersectionMemberTypes(intersectionTypeNode.rightTypeDesc(), semanticModel, members);
+            addIntersectionMemberTypes(intersectionTypeNode.leftTypeDesc(), semanticModel, members, module);
+            addIntersectionMemberTypes(intersectionTypeNode.rightTypeDesc(), semanticModel, members, module);
             return;
         }
-        members.add(fromNode(node, semanticModel));
+        members.add(fromNode(node, semanticModel, module));
     }
 
-    public static void resolveSymbolMetaData(Type type, Symbol symbol) {
+    public static void resolveSymbolMetaData(Type type, Symbol symbol, Module module) {
         ModuleID moduleID = symbol.getModule().isPresent() ? symbol.getModule().get().id() : null;
 
         if (moduleID != null) {
@@ -513,7 +516,9 @@ public class Type {
             type.version = "UNK_VER";
         }
 
-        if (symbol instanceof TypeReferenceTypeSymbol) {
+        if (!Objects.equals(type.moduleName, module.id) || !Objects.equals(type.orgName, module.orgName)) {
+            type.category = "libs";
+        } else if (symbol instanceof TypeReferenceTypeSymbol) {
             TypeReferenceTypeSymbol typeSymbol = (TypeReferenceTypeSymbol) symbol;
             if (typeSymbol.definition().kind().equals(SymbolKind.ENUM)) {
                 type.category = "enums";

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/documentation/DocModelTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/documentation/DocModelTest.java
@@ -132,7 +132,7 @@ public class DocModelTest {
                 "Fifth membertype orgName should be ballerina");
         Assert.assertEquals(unionType.get().memberTypes.get(4).moduleName, "docerina_project.world",
                 "Fifth membertype moduleName should be test");
-        Assert.assertEquals(unionType.get().memberTypes.get(4).category, "classes",
+        Assert.assertEquals(unionType.get().memberTypes.get(4).category, "libs",
                 "Fifth membertype category should be classes");
 
         Assert.assertEquals(unionType.get().memberTypes.get(5).category, "builtin",
@@ -409,7 +409,7 @@ public class DocModelTest {
         Assert.assertEquals(uuidRec.get().fields.get(0).type.moduleName, "lang.int");
         Assert.assertEquals(uuidRec.get().fields.get(0).type.version, "0.0.0");
         Assert.assertEquals(uuidRec.get().fields.get(0).type.name, "Unsigned32");
-        Assert.assertEquals(uuidRec.get().fields.get(0).type.category, "types");
+        Assert.assertEquals(uuidRec.get().fields.get(0).type.category, "libs");
 
         Optional<BObjectType> controller = testModule.objectTypes.stream().filter(record -> record.name
                 .equals("Controller")).findAny();


### PR DESCRIPTION
## Purpose
This will create a new category type `libs` for function parameter types if the parameter type is not a `langlib` nor a `type/record` in the same package which we generate docs.

Fixes #40534 

## Approach
Current categories for parameter types are as follows.
`builtin` - Used for langlib types (e.g.; lang.string, lang.int, ..)
`types` - Used for types defined in the same package
`records` - used for records defined in the same package

These changes will create a new category type `libs` for types/records in another package published in ballerina-central.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
