### PR TITLE
Fix compiler crash for interpolations inside regex char sets

### DIFF
--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/BallerinaLexer.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/BallerinaLexer.java
@@ -1520,6 +1520,11 @@ public class BallerinaLexer extends AbstractLexer {
                     shouldProcessInterpolations = false;
                 }
                 while (!reader.isEOF()) {
+                    if (shouldProcessInterpolations && this.reader.peek() == LexerTerminals.BACKSLASH 
+                            && this.reader.peek(1) == LexerTerminals.OPEN_BRACKET) {
+                        // Escaped open brackets are not considered as the start of a no interpolation context.
+                        reader.advance();
+                    }
                     reader.advance();
                     nextChar = this.reader.peek();
                     switch (nextChar) {
@@ -1536,6 +1541,11 @@ public class BallerinaLexer extends AbstractLexer {
                         case LexerTerminals.CLOSE_BRACKET:
                             shouldProcessInterpolations = true;
                             continue;
+                        case LexerTerminals.BACKSLASH:
+                            if (!shouldProcessInterpolations && this.reader.peek(1) == LexerTerminals.CLOSE_BRACKET) {
+                                reader.advance();
+                            }
+                            continue;    
                         default:
                             continue;
                     }

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/RegExpParser.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/RegExpParser.java
@@ -427,6 +427,9 @@ public class RegExpParser extends AbstractParser {
                     return STNodeFactory.createToken(SyntaxKind.ESCAPED_MINUS_TOKEN, minusToken.leadingMinutiae(),
                             minusToken.trailingMinutiae());
                 }
+                if (token.kind == SyntaxKind.CLOSE_BRACKET_TOKEN) {
+                    this.tokenReader.startMode(ParserMode.RE_CHAR_CLASS);
+                }
                 return parseReEscape();
             default:
                 STNode consumedToken = consume();

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/regexp/regexp_value_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/regexp/regexp_value_test.bal
@@ -81,6 +81,12 @@ function testRegExpValueWithCharacterClass() {
 
     string:RegExp x7 = re `[\p{sc=Latin}\p{gc=Lu}\p{Lt}\tA\)]??`;
     assertEquality("[\\p{sc=Latin}\\p{gc=Lu}\\p{Lt}\\tA\\)]??", x7.toString());
+    
+    string:RegExp x8 = re `abc[a-z\]A-Z${"abc"}]`;
+    assertEquality("abc[a-z\\]A-Z${\"abc\"}]", x8.toString());
+    
+    string:RegExp x9 = re `abc\[a-z\]A-Z${"abc"}`;
+    assertEquality("abc\\[a-z\\]A-Zabc", x9.toString());
 }
 
 function testRegExpValueWithCharacterClass2() {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/regexp/regexp_value_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/regexp/regexp_value_test.bal
@@ -87,6 +87,9 @@ function testRegExpValueWithCharacterClass() {
     
     string:RegExp x9 = re `abc\[a-z\]A-Z${"abc"}`;
     assertEquality("abc\\[a-z\\]A-Zabc", x9.toString());
+    
+    string:RegExp x10 = re `\[${"a"}\]`;
+    assertEquality("\\[a\\]", x10.toString());
 }
 
 function testRegExpValueWithCharacterClass2() {


### PR DESCRIPTION
## Purpose
$subject

In this PR the fix is applied for two different compiler crashing scenarios.

1. Escaped close bracket and interpolation inside the charset.
```ballerina
string:RegExp _ = re `[ABC\]${"ABC"}]`;
```
2. Interpolations after the escaped open brackets.
```ballerina
string:RegExp _ = re `\[abc${"ABC"}`;
```

Fixes #40499

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
