### PR TITLE
[2201.6.x] Fix visible endpoints missing issue

### DIFF
--- a/misc/diagram-util/src/test/resources/endpointOrder/Ballerina.toml
+++ b/misc/diagram-util/src/test/resources/endpointOrder/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "gayanOrg"
+name = "EndpintOrder"
+version = "0.1.0"

--- a/misc/diagram-util/src/test/resources/endpointOrder/main.bal
+++ b/misc/diagram-util/src/test/resources/endpointOrder/main.bal
@@ -1,0 +1,80 @@
+import ballerina/http;
+
+http:Client httpEpM0 = check new (url = "");
+
+service /user on new http:Listener(9090) {
+
+    http:Client httpEpS10;
+
+    function init() returns error? {
+        self.httpEpS10 = check new (url = "");
+        self.httpEpS11 = check new (url = "");
+        self.httpEpS12 = check new (url = "");
+    }
+
+    resource function get .() returns error? {
+        http:Client httpEpL0 = check new (url = "");
+    }
+
+    http:Client httpEpS11;
+
+    resource function post .() returns error? {
+        @display {
+            label: "function block level endpoint with display annotation"
+        }
+        http:Client httpEpL1 = check new (url = "");
+    }
+
+    http:Client httpEpS12;
+}
+
+public function main() {
+
+}
+
+@display {
+    label: "module block level endpoint with display annotation"
+}
+http:Client httpEpM1 = check new (url = "");
+
+service /products on new http:Listener(0) {
+    @display {
+        label: "class block level endpoint with display annotation"
+    }
+    http:Client httpEpS20;
+
+    function init() returns error? {
+        self.httpEpS20 = check new (url = "");
+        self.httpEpS21 = check new (url = "");
+    }
+
+    resource function get .() {
+
+    }
+
+    http:Client httpEpS21;
+}
+
+http:Client _ = check new (url = "");
+
+class User {
+
+    http:Client httpEpC0 = check new (url = "");
+
+    function init() returns error? {
+        self.httpEpC1 = check new (url = "");
+        self.httpEpC2 = check new (url = "");
+    }
+
+    http:Client httpEpC1;
+
+    function getUser() {
+
+    }
+
+    http:Client httpEpC2; 
+       
+    http:Client httpEpC3 = check new (url = "");
+}
+
+http:Client httpEpM2 = check new (url = "");


### PR DESCRIPTION
## Purpose

`getSyntaxTreeJSON` function missed visible endpoints if the endpoint was declared after the invocation. In the below example, `main` function visible endpoint doesn't have the `textEp` module level endpoint.

```ballerina
import ballerinax/openai.text;

public function main() returns error? {
    // use global endpoint
    _ = check textEp->/completions.post(payload = {
        model: ""
    });
}

text:Client textEp = check new (config = {
    auth: {
        token: ""
    }
});
```

This PR will fixed above issue and add support to class level endpoints as well.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
