### PR TITLE
Fix getting syntax tree for symbol in defaultable parameter hover logic

### DIFF
--- a/language-server/modules/langserver-core/src/test/resources/hover/configs/hover_function_call_with_defaultable_param1.json
+++ b/language-server/modules/langserver-core/src/test/resources/hover/configs/hover_function_call_with_defaultable_param1.json
@@ -1,0 +1,21 @@
+{
+  "position": {
+    "line": 7,
+    "character": 21
+  },
+  "source": {
+    "file": "projectls/defmodsource2.bal"
+  },
+  "expected": {
+    "result": {
+      "contents": {
+        "kind": "markdown",
+        "value": "A function with a defaultable parameter\n  \n  \n---  \n  \n### Parameters  \n  \n`string` ***name*** : Defaultable param`(default: \"defaultName\")`"
+      }
+    },
+    "id": {
+      "left": "324"
+    },
+    "jsonrpc": "2.0"
+  }
+}

--- a/language-server/modules/langserver-core/src/test/resources/hover/configs/hover_function_call_with_defaultable_param2.json
+++ b/language-server/modules/langserver-core/src/test/resources/hover/configs/hover_function_call_with_defaultable_param2.json
@@ -1,0 +1,21 @@
+{
+  "position": {
+    "line": 8,
+    "character": 17
+  },
+  "source": {
+    "file": "projectls/defmodsource2.bal"
+  },
+  "expected": {
+    "result": {
+      "contents": {
+        "kind": "markdown",
+        "value": "This is function4 with input parameters\n  \n  \n---  \n  \n### Parameters  \n  \n`int` ***param1*** : param1 Parameter Description   \n`int` ***param2*** : param2 Parameter Description  \n`string` ***param3*** : param3 Parameter Description  \n`float[]...` ***param4*** : param4 Parameter Description  \n  \n---  \n  \n[View API Docs](https://lib.ballerina.io/ballerina/module1/0.1.0#function4)"
+      }
+    },
+    "id": {
+      "left": "324"
+    },
+    "jsonrpc": "2.0"
+  }
+}

--- a/language-server/modules/langserver-core/src/test/resources/hover/source/projectls/defmodsource2.bal
+++ b/language-server/modules/langserver-core/src/test/resources/hover/source/projectls/defmodsource2.bal
@@ -5,4 +5,6 @@ public function main() {
     testDefaultModuleFunction1({field1: 1, field2: {}}, {}, {});
     lsmod2:Person person = new();
     string name = person.name;
+    lsmod2:functionWithDefaultableParam();
+    module1:function4()
 }

--- a/language-server/modules/langserver-core/src/test/resources/hover/source/projectls/modules/lsmod2/source1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/hover/source/projectls/modules/lsmod2/source1.bal
@@ -16,3 +16,10 @@ public class Person {
     # Name of the person
     public string name = "MyName";
 }
+
+# A function with a defaultable parameter
+#
+# + name - Defaultable param
+public function functionWithDefaultableParam(string name = "defaultName") {
+    
+}


### PR DESCRIPTION
## Purpose
$subject

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/40540

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
