### PR TITLE
Fix incorrect diagnostic codes related to RegExp errors

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
@@ -796,10 +796,8 @@ public enum DiagnosticErrorCode implements DiagnosticCode {
             "BCE4042", "worker.send.action.not.allowed.in.lock.statement"),
     WORKER_RECEIVE_ACTION_NOT_ALLOWED_IN_LOCK_STATEMENT(
             "BCE4043", "worker.receive.action.not.allowed.in.lock.statement"),
-    EMPTY_REGEXP_STRING_DISALLOWED(
-            "BCE4044", "empty.regexp.string.disallowed"),
-    UNSUPPORTED_EMPTY_CHARACTER_CLASS(
-            "BCE4045", "unsupported.empty.character.class")
+    EMPTY_REGEXP_STRING_DISALLOWED("BCE4044", "empty.regexp.string.disallowed"),
+    UNSUPPORTED_EMPTY_CHARACTER_CLASS("BCE4045", "unsupported.empty.character.class")
     ;
 
     private String diagnosticId;

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
@@ -797,9 +797,9 @@ public enum DiagnosticErrorCode implements DiagnosticCode {
     WORKER_RECEIVE_ACTION_NOT_ALLOWED_IN_LOCK_STATEMENT(
             "BCE4043", "worker.receive.action.not.allowed.in.lock.statement"),
     EMPTY_REGEXP_STRING_DISALLOWED(
-            "BCS4044", "empty.regexp.string.disallowed"),
+            "BCE4044", "empty.regexp.string.disallowed"),
     UNSUPPORTED_EMPTY_CHARACTER_CLASS(
-            "BCS4045", "unsupported.empty.character.class")
+            "BCE4045", "unsupported.empty.character.class")
     ;
 
     private String diagnosticId;


### PR DESCRIPTION
## Purpose
> $subject 

Fixes #40656 

```ballerina
   //diagnostic code for below error changes from `BCS4044` to `BCE4044`
    _ = re ``; //@error: regular expression is not allowed: empty RegExp 
```

```ballerina
   //diagnostic code for below error changes from `BCS4045` to `BCE4045`
    _ = re `[]`; //@error: empty character class disallowed 
```

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
