### PR TITLE
[2201.6.x] Refactor EnumSet usage in the STNode

### DIFF
--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/tree/STInvalidNodeMinutiae.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/tree/STInvalidNodeMinutiae.java
@@ -49,8 +49,8 @@ public class STInvalidNodeMinutiae extends STMinutiae {
     }
 
     private void updateDiagnostics(STInvalidTokenMinutiaeNode invalidNode) {
-        if ((invalidNode.flags & STNodeFlags.HAS_DIAGNOSTIC) != 0) {
-            this.flags |= STNodeFlags.HAS_DIAGNOSTIC;
+        if (STNodeFlags.isFlagSet(invalidNode.flags, STNodeFlags.HAS_DIAGNOSTIC)) {
+            this.flags = STNodeFlags.withFlag(this.flags, STNodeFlags.HAS_DIAGNOSTIC);
         }
     }
 }

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/tree/STInvalidNodeMinutiae.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/tree/STInvalidNodeMinutiae.java
@@ -49,8 +49,8 @@ public class STInvalidNodeMinutiae extends STMinutiae {
     }
 
     private void updateDiagnostics(STInvalidTokenMinutiaeNode invalidNode) {
-        if (invalidNode.flags.contains(STNodeFlags.HAS_DIAGNOSTICS)) {
-            this.flags.add(STNodeFlags.HAS_DIAGNOSTICS);
+        if ((invalidNode.flags & STNodeFlags.HAS_DIAGNOSTIC) != 0) {
+            this.flags |= STNodeFlags.HAS_DIAGNOSTIC;
         }
     }
 }

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/tree/STMissingToken.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/tree/STMissingToken.java
@@ -25,6 +25,7 @@ import io.ballerina.compiler.syntax.tree.Token;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 
 /**
  * This is a generated internal syntax tree node.
@@ -34,18 +35,18 @@ import java.util.Collection;
 public class STMissingToken extends STToken {
 
     STMissingToken(SyntaxKind kind) {
-        super(kind, 0, new STNodeList(new ArrayList<>(0)), new STNodeList(new ArrayList<>(0)));
+        this(kind, Collections.emptyList());
     }
 
     STMissingToken(SyntaxKind kind, Collection<STNodeDiagnostic> diagnostics) {
-        super(kind, 0, new STNodeList(new ArrayList<>(0)), new STNodeList(new ArrayList<>(0)), diagnostics);
+        this(kind, new STNodeList(new ArrayList<>(0)), new STNodeList(new ArrayList<>(0)), diagnostics);
     }
 
     STMissingToken(SyntaxKind kind,
                    STNode leadingMinutiae,
                    STNode trailingMinutiae,
                    Collection<STNodeDiagnostic> diagnostics) {
-        super(kind, 0,  leadingMinutiae, trailingMinutiae, diagnostics);
+        super(kind, 0,  leadingMinutiae, trailingMinutiae, diagnostics, true);
     }
 
     public STToken modifyWith(Collection<STNodeDiagnostic> diagnostics) {

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/tree/STMissingToken.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/tree/STMissingToken.java
@@ -28,7 +28,7 @@ import java.util.Collection;
 import java.util.Collections;
 
 /**
- * This is a generated internal syntax tree node.
+ * Represents a missing token in the internal syntax tree.
  *
  * @since 2.0.0
  */

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/tree/STNode.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/tree/STNode.java
@@ -56,7 +56,7 @@ public abstract class STNode {
     STNode(SyntaxKind kind, Collection<STNodeDiagnostic> diagnostics, boolean isMissing) {
         this(kind, diagnostics);
         if (isMissing) {
-            flags |= STNodeFlags.IS_MISSING;
+            flags = STNodeFlags.withFlag(flags, STNodeFlags.IS_MISSING);
         }
     }
 
@@ -64,7 +64,7 @@ public abstract class STNode {
         this.kind = kind;
         this.diagnostics = diagnostics;
         if (diagnostics.size() > 0) {
-            flags |= STNodeFlags.HAS_DIAGNOSTIC;
+            flags = STNodeFlags.withFlag(flags, STNodeFlags.HAS_DIAGNOSTIC);
         }
     }
 
@@ -99,7 +99,7 @@ public abstract class STNode {
     }
 
     public boolean hasDiagnostics() {
-        return (flags & STNodeFlags.HAS_DIAGNOSTIC) != 0;
+        return STNodeFlags.isFlagSet(flags, STNodeFlags.HAS_DIAGNOSTIC);
     }
 
     public Collection<STNodeDiagnostic> diagnostics() {
@@ -338,8 +338,8 @@ public abstract class STNode {
             if (!SyntaxUtils.isSTNodePresent(child)) {
                 continue;
             }
-            if ((child.flags & STNodeFlags.HAS_DIAGNOSTIC) != 0) {
-                this.flags |= STNodeFlags.HAS_DIAGNOSTIC;
+            if (STNodeFlags.isFlagSet(child.flags, STNodeFlags.HAS_DIAGNOSTIC)) {
+                this.flags = STNodeFlags.withFlag(this.flags, STNodeFlags.HAS_DIAGNOSTIC);
                 return;
             }
         }

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/tree/STNode.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/tree/STNode.java
@@ -26,7 +26,6 @@ import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.List;
 
 /**
@@ -42,7 +41,7 @@ public abstract class STNode {
     protected int widthWithTrailingMinutiae;
     protected int widthWithMinutiae;
 
-    protected EnumSet<STNodeFlags> flags = EnumSet.noneOf(STNodeFlags.class);
+    protected byte flags = 0;
 
     protected static final STNode[] EMPTY_BUCKET = new STNode[0];
     // The following fields allow us to navigate the tree without the knowledge of the particular tree nodes
@@ -54,11 +53,18 @@ public abstract class STNode {
         this.diagnostics = Collections.emptyList();
     }
 
+    STNode(SyntaxKind kind, Collection<STNodeDiagnostic> diagnostics, boolean isMissing) {
+        this(kind, diagnostics);
+        if (isMissing) {
+            flags |= STNodeFlags.IS_MISSING;
+        }
+    }
+
     STNode(SyntaxKind kind, Collection<STNodeDiagnostic> diagnostics) {
         this.kind = kind;
         this.diagnostics = diagnostics;
         if (diagnostics.size() > 0) {
-            flags.add(STNodeFlags.HAS_DIAGNOSTICS);
+            flags |= STNodeFlags.HAS_DIAGNOSTIC;
         }
     }
 
@@ -93,7 +99,7 @@ public abstract class STNode {
     }
 
     public boolean hasDiagnostics() {
-        return flags.contains(STNodeFlags.HAS_DIAGNOSTICS);
+        return (flags & STNodeFlags.HAS_DIAGNOSTIC) != 0;
     }
 
     public Collection<STNodeDiagnostic> diagnostics() {
@@ -332,8 +338,8 @@ public abstract class STNode {
             if (!SyntaxUtils.isSTNodePresent(child)) {
                 continue;
             }
-            if (child.flags.contains(STNodeFlags.HAS_DIAGNOSTICS)) {
-                this.flags.add(STNodeFlags.HAS_DIAGNOSTICS);
+            if ((child.flags & STNodeFlags.HAS_DIAGNOSTIC) != 0) {
+                this.flags |= STNodeFlags.HAS_DIAGNOSTIC;
                 return;
             }
         }

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/tree/STNodeFactory.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/tree/STNodeFactory.java
@@ -2670,7 +2670,7 @@ public class STNodeFactory extends STAbstractNodeFactory {
                 mostTimesMatchedDigit,
                 closeBraceToken);
     }
-  
+
     public static STNode createMemberTypeDescriptorNode(
             STNode annotations,
             STNode typeDescriptor) {

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/tree/STNodeFlags.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/tree/STNodeFlags.java
@@ -25,4 +25,25 @@ package io.ballerina.compiler.internal.parser.tree;
 public class STNodeFlags {
     public static final byte HAS_DIAGNOSTIC = 1 << 0x1;
     public static final byte IS_MISSING = 1 << 0x2;
+
+    /**
+     * Checks whether the given flag is set in the given flags.
+     * @param flags the flags to check
+     * @param flag the flag to check for
+     * @return <code>true</code> if the flag is set. <code>false</code> otherwise
+     */
+    public static boolean isFlagSet(byte flags, byte flag) {
+        return (flags & flag) != 0;
+    }
+
+    /**
+     * Sets a flag in the given flags.
+     *
+     * @param flags the original flags
+     * @param flag  the flag to set
+     * @return the updated flags with the specified flag
+     */
+    public static byte withFlag(byte flags, byte flag) {
+        return (byte) (flags | flag);
+    }
 }

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/tree/STNodeFlags.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/tree/STNodeFlags.java
@@ -22,7 +22,7 @@ package io.ballerina.compiler.internal.parser.tree;
  *
  * @since 2.0.0
  */
-public enum STNodeFlags {
-    HAS_DIAGNOSTICS,
-    IS_MISSING
+public class STNodeFlags {
+    public static final byte HAS_DIAGNOSTIC = 1 << 0x1;
+    public static final byte IS_MISSING = 1 << 0x2;
 }

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/tree/STNodeTransformer.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/tree/STNodeTransformer.java
@@ -920,7 +920,7 @@ public abstract class STNodeTransformer<T> {
     public T transform(STReBracedQuantifierNode reBracedQuantifierNode) {
         return transformSyntaxNode(reBracedQuantifierNode);
     }
-  
+
     public T transform(STMemberTypeDescriptorNode memberTypeDescriptorNode) {
         return transformSyntaxNode(memberTypeDescriptorNode);
     }

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/tree/STNodeVisitor.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/tree/STNodeVisitor.java
@@ -920,7 +920,7 @@ public abstract class STNodeVisitor {
     public void visit(STReBracedQuantifierNode reBracedQuantifierNode) {
         visitSyntaxNode(reBracedQuantifierNode);
     }
-  
+
     public void visit(STMemberTypeDescriptorNode memberTypeDescriptorNode) {
         visitSyntaxNode(memberTypeDescriptorNode);
     }

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/tree/STToken.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/tree/STToken.java
@@ -50,12 +50,18 @@ public class STToken extends STNode {
         this(kind, width, leadingMinutiae, trailingMinutiae, Collections.emptyList());
     }
 
+    STToken(SyntaxKind kind, int width, STNode leadingMinutiae, STNode trailingMinutiae,
+            Collection<STNodeDiagnostic> diagnostics) {
+        this(kind, width, leadingMinutiae, trailingMinutiae, diagnostics, false);
+    }
+
     STToken(SyntaxKind kind,
             int width,
             STNode leadingMinutiae,
             STNode trailingMinutiae,
-            Collection<STNodeDiagnostic> diagnostics) {
-        super(kind, diagnostics);
+            Collection<STNodeDiagnostic> diagnostics,
+            boolean isMissing) {
+        super(kind, diagnostics, isMissing);
         this.leadingMinutiae = leadingMinutiae;
         this.trailingMinutiae = trailingMinutiae;
 
@@ -145,9 +151,9 @@ public class STToken extends STNode {
     }
 
     private void updateDiagnostics(STNode leadingMinutiae, STNode trailingMinutiae) {
-        if (leadingMinutiae.flags.contains(STNodeFlags.HAS_DIAGNOSTICS) ||
-                trailingMinutiae.flags.contains(STNodeFlags.HAS_DIAGNOSTICS)) {
-            this.flags.add(STNodeFlags.HAS_DIAGNOSTICS);
+        if (((leadingMinutiae.flags & STNodeFlags.HAS_DIAGNOSTIC) != 0) ||
+                ((trailingMinutiae.flags & STNodeFlags.HAS_DIAGNOSTIC) != 0)) {
+            this.flags |= STNodeFlags.HAS_DIAGNOSTIC;
         }
     }
 }

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/tree/STToken.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/tree/STToken.java
@@ -151,9 +151,9 @@ public class STToken extends STNode {
     }
 
     private void updateDiagnostics(STNode leadingMinutiae, STNode trailingMinutiae) {
-        if (((leadingMinutiae.flags & STNodeFlags.HAS_DIAGNOSTIC) != 0) ||
-                ((trailingMinutiae.flags & STNodeFlags.HAS_DIAGNOSTIC) != 0)) {
-            this.flags |= STNodeFlags.HAS_DIAGNOSTIC;
+        if (STNodeFlags.isFlagSet(leadingMinutiae.flags, STNodeFlags.HAS_DIAGNOSTIC) ||
+                STNodeFlags.isFlagSet(trailingMinutiae.flags, STNodeFlags.HAS_DIAGNOSTIC)) {
+            this.flags = STNodeFlags.withFlag(this.flags, STNodeFlags.HAS_DIAGNOSTIC);
         }
     }
 }

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/tree/STTreeModifier.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/tree/STTreeModifier.java
@@ -2870,7 +2870,8 @@ public abstract class STTreeModifier extends STNodeTransformer<STNode> {
                 mostTimesMatchedDigit,
                 closeBraceToken);
     }
-  
+
+    @Override
     public STMemberTypeDescriptorNode transform(
             STMemberTypeDescriptorNode memberTypeDescriptorNode) {
         STNode annotations = modifyNode(memberTypeDescriptorNode.annotations);

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/syntax/tree/NodeFactory.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/syntax/tree/NodeFactory.java
@@ -3517,7 +3517,7 @@ public abstract class NodeFactory extends AbstractNodeFactory {
                 closeBraceToken.internalNode());
         return stReBracedQuantifierNode.createUnlinkedFacade();
     }
-  
+
     public static MemberTypeDescriptorNode createMemberTypeDescriptorNode(
             NodeList<AnnotationNode> annotations,
             TypeDescriptorNode typeDescriptor) {

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/syntax/tree/NodeTransformer.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/syntax/tree/NodeTransformer.java
@@ -931,7 +931,7 @@ public abstract class NodeTransformer<T> {
     public T transform(ReBracedQuantifierNode reBracedQuantifierNode) {
         return transformSyntaxNode(reBracedQuantifierNode);
     }
-  
+
     public T transform(MemberTypeDescriptorNode memberTypeDescriptorNode) {
         return transformSyntaxNode(memberTypeDescriptorNode);
     }

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/syntax/tree/NodeVisitor.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/syntax/tree/NodeVisitor.java
@@ -930,7 +930,7 @@ public abstract class NodeVisitor {
     public void visit(ReBracedQuantifierNode reBracedQuantifierNode) {
         visitSyntaxNode(reBracedQuantifierNode);
     }
-  
+
     public void visit(MemberTypeDescriptorNode memberTypeDescriptorNode) {
         visitSyntaxNode(memberTypeDescriptorNode);
     }

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/syntax/tree/TreeModifier.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/syntax/tree/TreeModifier.java
@@ -3620,7 +3620,8 @@ public abstract class TreeModifier extends NodeTransformer<Node> {
                 mostTimesMatchedDigit,
                 closeBraceToken);
     }
-  
+
+    @Override
     public MemberTypeDescriptorNode transform(
             MemberTypeDescriptorNode memberTypeDescriptorNode) {
         NodeList<AnnotationNode> annotations =


### PR DESCRIPTION
## Purpose
> $subject to optimize the memory used by the syntax tree.

Fixes #40653

## Approach
> Instead of using `EnumSet` to keep `STNode` flags, use a byte value. 

## Samples
> N/A

## Remarks
`java.util` memory consumption

Before:
<img width="211" alt="Screenshot 2023-06-13 at 09 22 17" src="https://github.com/ballerina-platform/ballerina-lang/assets/39232462/962d9cb0-3f1f-47f7-ab71-aac426ee0b23">

After:
<img width="279" alt="Screenshot 2023-06-13 at 09 22 02" src="https://github.com/ballerina-platform/ballerina-lang/assets/39232462/114ceed9-68b7-404f-87a0-44005d523e25">


## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
