### PR TITLE
Send standard error when running via LS

### DIFF
--- a/language-server/modules/langserver-core/build.gradle
+++ b/language-server/modules/langserver-core/build.gradle
@@ -39,6 +39,7 @@ configurations {
 }
 
 dependencies {
+    dist project(':ballerina-rt')
     implementation project(':ballerina-tools-api')
     implementation project(':ballerina-lang')
     implementation project(':ballerina-parser')
@@ -128,9 +129,23 @@ task deleteGeneratedModules(type:Delete) {
     delete 'build/resources/test/command/generate-module-for-client-decl/source/client_decl/generated'
 }
 
+// This is need for the run via ls (fast-run) feature to be tested.
+task copyRuntime() {
+    dependsOn configurations.dist
+    doFirst {
+        configurations.dist.each { artifact ->
+            copy {
+                from artifact.getPath()
+                into "$buildDir/bre/lib"
+            }
+        }
+    }
+}
+
 test {
     dependsOn deleteGeneratedModules
     dependsOn loadDistributionCache
+    dependsOn copyRuntime
     systemProperty "ballerina.home", "$buildDir/"
     systemProperty "experimental", "true"
     systemProperty "ballerina.version", project.version

--- a/language-server/modules/langserver-core/src/test/resources/project/long_running/main.bal
+++ b/language-server/modules/langserver-core/src/test/resources/project/long_running/main.bal
@@ -1,5 +1,22 @@
 import ballerina/lang.runtime;
+import ballerina/jballerina.java;
+
+function system_out() returns handle = @java:FieldGet {
+    name: "out",
+    'class: "java.lang.System"
+} external;
+
+function println(handle receiver, handle arg0) = @java:Method {
+    name: "println",
+    'class: "java.io.PrintStream",
+    paramTypes: ["java.lang.String"]
+} external;
+
+function print(string str) {
+    println(system_out(), java:fromString(str));
+}
 
 public function main() {
+    print("Hello, World!");
     runtime:sleep(20);
 }


### PR DESCRIPTION
Send standard error when running via LS.
Error stream is monitored via a different daemon thread and send as a new event.
Part of #40704