### PR TITLE
Correct mistake in the error intersection logic

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -4227,7 +4227,8 @@ public class SymbolEnter extends BLangNodeVisitor {
                     }
                     // If constituent type is error, we have already validated error intersections.
                     if (!types.isSelectivelyImmutableType(constituentType, true, packageID)
-                            && Types.getReferredType(constituentType).tag != TypeTags.ERROR) {
+                            && Types.getReferredType(types.getTypeWithEffectiveIntersectionTypes(
+                                    constituentType)).tag != TypeTags.ERROR) {
                         hasNonReadOnlyElement = true;
                         break;
                     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeResolver.java
@@ -422,9 +422,9 @@ public class TypeResolver {
         BType typeOneReference = Types.getReferredType(typeOne);
         BType typeTwoReference = Types.getReferredType(typeTwo);
 
-        if (typeOneReference.tag != TypeTags.ERROR || typeTwoReference.tag != TypeTags.ERROR) {
-            dlog.error(typeNode.pos,
-                    DiagnosticErrorCode.UNSUPPORTED_TYPE_INTERSECTION);
+        if (getEffectiveTypeTag(typeOneReference) != TypeTags.ERROR
+                || getEffectiveTypeTag(typeTwoReference) != TypeTags.ERROR) {
+            dlog.error(typeNode.pos, DiagnosticErrorCode.UNSUPPORTED_TYPE_INTERSECTION);
             return symTable.semanticError;
         }
 
@@ -439,6 +439,10 @@ public class TypeResolver {
 
         symEnter.lookupTypeSymbol(pkgEnv, name).type = potentialIntersectionType;
         return potentialIntersectionType;
+    }
+
+    private int getEffectiveTypeTag(BType type) {
+        return type.tag == TypeTags.INTERSECTION ? Types.getEffectiveType(type).tag : type.tag;
     }
 
     private void handleDistinctDefinitionOfErrorIntersection(BLangTypeDefinition typeDefinition,
@@ -1402,7 +1406,8 @@ public class TypeResolver {
                 numOfNonReadOnlyConstituents++;
             }
             constituentTypes.add(constituentType);
-            if (Types.getReferredType(constituentType).tag == TypeTags.ERROR) {
+            if ((Types.getReferredType(
+                    types.getTypeWithEffectiveIntersectionTypes(constituentType))).tag == TypeTags.ERROR) {
                 errorTypesCount++;
             }
         }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/types/ErrorTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/types/ErrorTypeTest.java
@@ -121,6 +121,11 @@ public class ErrorTypeTest {
         BRunUtil.invoke(errorConstructorResult, "testErrorConstructor");
     }
 
+    @Test
+    public void testErrorIntersection() {
+        BRunUtil.invoke(result, "testErrorIntersection");
+    }
+
     @AfterClass
     public void tearDown() {
         result = null;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/types/error_type_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/types/error_type_test.bal
@@ -70,6 +70,19 @@ function testErrorDetailDefinedAfterErrorDef() {
     assertEquality("ABCD", k.detail()["code"]);
 }
 
+type ErrorIntersection3 er:ErrorIntersection1 & error<er:Data1>;
+type ErrorIntersection4 er:ErrorIntersection1 & er:ErrorIntersection2;
+
+function testErrorIntersection() {
+    ErrorIntersection3 e3 = error ErrorIntersection3("Intersection error", num = 2);
+    assertEquality("Intersection error", e3.message());
+    assertEquality(2, e3.detail()["num"]);
+
+    ErrorIntersection4 e4 = error ErrorIntersection4("Intersection error", num = 3);
+    assertEquality("Intersection error", e4.message());
+    assertEquality(3, e4.detail()["num"]);
+}
+
 function assertEquality(any|error expected, any|error actual) {
     if expected is anydata && actual is anydata && expected == actual {
         return;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/test_project_errors/errors.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/test_project_errors/errors.bal
@@ -21,3 +21,18 @@ public type PostDefinedError error<ErrorData>;
 public type ErrorData record {|
     string code;
 |};
+
+public type Data1 record {|
+    int num;
+|};
+
+public type Data2 record {|
+    byte num;
+|};
+
+public type Data3 record {|
+    int:Signed16 num;
+|};
+
+public type ErrorIntersection1 distinct error<Data1> & error<Data2>;
+public type ErrorIntersection2 distinct error<Data3> & error<Data2>;


### PR DESCRIPTION
## Purpose
```
import ballerina/time;
import ballerina/http;

public type MyDefaultErrorDetails record {|
    time:Utc timeStamp;
    string message;
    string details;
|};
public type MyDetaultErrorDetail record {
    *http:DefaultErrorDetail;
    MyDefaultErrorDetails body;
};

//  This gave compiler error but it should be allowed
type MyHttpDefaultStatusCodeError http:DefaultStatusCodeError & error<MyDetaultErrorDetail>;

type UserNotFoundError error & http:NotFoundError;
```
Got compile-time error for above case. It should be allowed.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
