### PR TITLE
[LS] Improve record field completions

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSPackageLoader.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSPackageLoader.java
@@ -65,6 +65,7 @@ public class LSPackageLoader {
         if (lsPackageLoader == null) {
             lsPackageLoader = new LSPackageLoader(context);
         }
+
         return lsPackageLoader;
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSPackageLoader.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSPackageLoader.java
@@ -65,7 +65,6 @@ public class LSPackageLoader {
         if (lsPackageLoader == null) {
             lsPackageLoader = new LSPackageLoader(context);
         }
-
         return lsPackageLoader;
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/RecordField.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/RecordField.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.langserver.common;
+
+import io.ballerina.compiler.api.symbols.RecordFieldSymbol;
+import io.ballerina.compiler.api.symbols.RecordTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import org.ballerinalang.langserver.common.utils.RawTypeSymbolWrapper;
+
+import java.util.Objects;
+
+/**
+ * Represents a record field.
+ *
+ * @since 2201.8.0
+ */
+public class RecordField {
+    String name;
+    RecordFieldSymbol fieldSymbol;
+    RawTypeSymbolWrapper<RecordTypeSymbol> typeSymbolWrapper;
+    
+    public RecordField(String name, RecordFieldSymbol fieldSymbol,
+                RawTypeSymbolWrapper<RecordTypeSymbol> typeSymbolWrapper) {
+        this.name = name;
+        this.fieldSymbol = fieldSymbol;
+        this.typeSymbolWrapper = typeSymbolWrapper;
+    }
+
+    public RawTypeSymbolWrapper<RecordTypeSymbol> getTypeSymbolWrapper() {
+        return typeSymbolWrapper;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public RecordFieldSymbol getFieldSymbol() {
+        return fieldSymbol;
+    }
+
+    /**
+     * Record Field Identifier.
+     *
+     * @since 2201.8.0
+     */
+    public static class RecordFieldIdentifier {
+        private String name;
+        private TypeSymbol typeSymbol;
+
+        public RecordFieldIdentifier(String name, TypeSymbol typeSymbol) {
+            this.name = name;
+            this.typeSymbol = typeSymbol;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(name, typeSymbol.signature());
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (!(obj instanceof RecordFieldIdentifier)) {
+                return false;
+            }
+            RecordFieldIdentifier other = (RecordFieldIdentifier) obj;
+            return other.name.equals(this.name)
+                    && other.typeSymbol.signature().equals(this.typeSymbol.signature());
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+}
+

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/RecordField.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/RecordField.java
@@ -31,9 +31,9 @@ public class RecordField {
     String name;
     RecordFieldSymbol fieldSymbol;
     RawTypeSymbolWrapper<RecordTypeSymbol> typeSymbolWrapper;
-    
+
     public RecordField(String name, RecordFieldSymbol fieldSymbol,
-                RawTypeSymbolWrapper<RecordTypeSymbol> typeSymbolWrapper) {
+                       RawTypeSymbolWrapper<RecordTypeSymbol> typeSymbolWrapper) {
         this.name = name;
         this.fieldSymbol = fieldSymbol;
         this.typeSymbolWrapper = typeSymbolWrapper;
@@ -88,4 +88,3 @@ public class RecordField {
         }
     }
 }
-

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/RecordUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/RecordUtil.java
@@ -20,6 +20,7 @@ import io.ballerina.compiler.api.symbols.RecordTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
+import org.ballerinalang.langserver.common.RecordField;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
 import org.ballerinalang.langserver.commons.SnippetContext;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
@@ -50,37 +51,51 @@ public class RecordUtil {
     /**
      * Get completion items list for struct fields.
      *
-     * @param context Language server operation context
-     * @param fields  Map of field descriptors
-     * @param wrapper  Pair of Raw TypeSymbol and broader TypeSymbol
+     * @param context   Language server operation context
+     * @param fieldsMap Map of identifier to record fields.
      * @return {@link List} List of completion items for the struct fields
      */
     public static List<LSCompletionItem> getRecordFieldCompletionItems(BallerinaCompletionContext context,
-                                                                       Map<String, RecordFieldSymbol> fields,
-                                                                       RawTypeSymbolWrapper wrapper) {
+                                                               Map<RecordField.RecordFieldIdentifier,
+                                                               List<RecordField>> fieldsMap) {
         List<LSCompletionItem> completionItems = new ArrayList<>();
-        fields.forEach((name, field) -> {
-            SnippetContext snippetContext = new SnippetContext();
-            String insertText = getRecordFieldCompletionInsertText(field, snippetContext);
-
-            String detail;
-            if (wrapper.getRawType().getName().isPresent()) {
-                detail = NameUtil.getModifiedTypeName(context, wrapper.getRawType()) + "." + name;
-            } else if (wrapper.getBroaderType().getName().isPresent()) {
-                detail = NameUtil.getModifiedTypeName(context, wrapper.getBroaderType()) + "." + name;
-            } else {
-                detail = "(" + wrapper.getRawType().signature() + ")." + name;
-            }
-            CompletionItem fieldItem = new CompletionItem();
-            fieldItem.setInsertText(insertText);
-            fieldItem.setInsertTextFormat(InsertTextFormat.Snippet);
-            fieldItem.setLabel(CommonUtil.escapeReservedKeyword(name));
-            fieldItem.setKind(CompletionItemKind.Field);
-            fieldItem.setSortText(Priority.PRIORITY120.toString());
-            completionItems.add(new RecordFieldCompletionItem(context, field, fieldItem, detail));
+        fieldsMap.forEach((recordFieldIdentifier, fields) -> {
+            completionItems.add(getRecordFieldCompletionItem(context, recordFieldIdentifier, fields));
         });
 
         return completionItems;
+    }
+
+    private static LSCompletionItem getRecordFieldCompletionItem(BallerinaCompletionContext context,
+                                                 RecordField.RecordFieldIdentifier recordFieldIdentifier,
+                                                 List<RecordField> fields) {
+
+        //Assuming the record fields list is not empty at this level
+        RecordField recordField = fields.get(0);
+        String name = recordFieldIdentifier.getName();
+        SnippetContext snippetContext = new SnippetContext();
+        String insertText = getRecordFieldCompletionInsertText(recordField.getFieldSymbol(), snippetContext);
+
+        String detail = fields.stream().map(field -> {
+            RawTypeSymbolWrapper<RecordTypeSymbol> wrapper = field.getTypeSymbolWrapper();
+            if (recordField.getTypeSymbolWrapper().getRawType().getName().isPresent()) {
+                return NameUtil.getModifiedTypeName(context, wrapper.getRawType()) + "." + name;
+            } else if (wrapper.getBroaderType().getName().isPresent()) {
+                return NameUtil.getModifiedTypeName(context, wrapper.getBroaderType()) + "." + name;
+            } else {
+                return "(" + wrapper.getRawType().signature() + ")." + name;
+            }
+        }).collect(Collectors.joining("|"));
+
+        CompletionItem fieldItem = new CompletionItem();
+        fieldItem.setInsertText(insertText);
+        fieldItem.setInsertTextFormat(InsertTextFormat.Snippet);
+        fieldItem.setLabel(CommonUtil.escapeReservedKeyword(name));
+        fieldItem.setKind(CompletionItemKind.Field);
+        fieldItem.setSortText(Priority.PRIORITY120.toString());
+
+        //Use the RecordFieldSymbol of the first element to create the completion item. 
+        return new RecordFieldCompletionItem(context, recordField.getFieldSymbol(), fieldItem, detail);
     }
 
     /**
@@ -88,7 +103,7 @@ public class RecordUtil {
      *
      * @param context Language Server Operation Context
      * @param fields  A non empty map of fields
-     * @param wrapper  A wrapper containing record type symbol and broader type symbol
+     * @param wrapper A wrapper containing record type symbol and broader type symbol
      * @return {@link Optional}   Completion Item to fill all the options
      */
     public static Optional<LSCompletionItem> getFillAllRecordFieldCompletionItems(

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/RecordUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/RecordUtil.java
@@ -78,9 +78,7 @@ public class RecordUtil {
 
         String detail = fields.stream().map(field -> {
             RawTypeSymbolWrapper<RecordTypeSymbol> wrapper = field.getTypeSymbolWrapper();
-            if (recordField.getTypeSymbolWrapper().getRawType().getName().isPresent()) {
-                return NameUtil.getModifiedTypeName(context, wrapper.getRawType()) + "." + name;
-            } else if (wrapper.getBroaderType().getName().isPresent()) {
+            if (wrapper.getBroaderType().getName().isPresent()) {
                 return NameUtil.getModifiedTypeName(context, wrapper.getBroaderType()) + "." + name;
             } else {
                 return "(" + wrapper.getRawType().signature() + ")." + name;

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_constructor_expr_ctx_config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_constructor_expr_ctx_config7.json
@@ -1,9 +1,85 @@
 {
   "position": {
-    "line": 19,
-    "character": 35
+    "line": 16,
+    "character": 43
   },
   "source": "expression_context/source/mapping_constructor_expr_ctx_source7.bal",
-  "description": "",
-  "items": []
+  "description": "Tests record fields completions when there are multiple fields with the same name",
+  "items": [
+    {
+      "label": "readonly",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "readonly",
+      "insertText": "readonly ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Fill Type1 Required Fields",
+      "kind": "Property",
+      "detail": "Type1",
+      "sortText": "R",
+      "filterText": "fill",
+      "insertText": "field1: {},\nfield2: {}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Fill Type2 Required Fields",
+      "kind": "Property",
+      "detail": "Type2",
+      "sortText": "R",
+      "filterText": "fill",
+      "insertText": "field1: {},\nfield2: ${1:0.0}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "rec1Field2",
+      "kind": "Field",
+      "detail": "module1:TestRecord1.rec1Field2",
+      "sortText": "K",
+      "insertText": "rec1Field2: ${1:\"\"}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "field1",
+      "kind": "Field",
+      "detail": "Type1.field1|Type2.field1",
+      "sortText": "AG",
+      "insertText": "field1: {}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "field2",
+      "kind": "Field",
+      "detail": "Type1.field2",
+      "sortText": "AG",
+      "insertText": "field2: {}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "optionalInt",
+      "kind": "Field",
+      "detail": "module1:TestRecord1.optionalInt",
+      "sortText": "K",
+      "insertText": "optionalInt: ${1:0}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "rec1Field1",
+      "kind": "Field",
+      "detail": "module1:TestRecord1.rec1Field1",
+      "sortText": "K",
+      "insertText": "rec1Field1: ${1:0}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "field2",
+      "kind": "Field",
+      "detail": "Type2.field2",
+      "sortText": "K",
+      "insertText": "field2: ${1:0.0}",
+      "insertTextFormat": "Snippet"
+    }
+  ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_constructor_expr_ctx_config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_constructor_expr_ctx_config7.json
@@ -1,0 +1,9 @@
+{
+  "position": {
+    "line": 19,
+    "character": 35
+  },
+  "source": "expression_context/source/mapping_constructor_expr_ctx_source7.bal",
+  "description": "",
+  "items": []
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_constructor_expr_ctx_config8.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/mapping_constructor_expr_ctx_config8.json
@@ -1,0 +1,85 @@
+{
+  "position": {
+    "line": 16,
+    "character": 43
+  },
+  "source": "expression_context/source/mapping_constructor_expr_ctx_source7.bal",
+  "description": "",
+  "items": [
+    {
+      "label": "readonly",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "U",
+      "filterText": "readonly",
+      "insertText": "readonly ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Fill Type1 Required Fields",
+      "kind": "Property",
+      "detail": "Type1",
+      "sortText": "R",
+      "filterText": "fill",
+      "insertText": "field1: {},\nfield2: {}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Fill Type2 Required Fields",
+      "kind": "Property",
+      "detail": "Type2",
+      "sortText": "R",
+      "filterText": "fill",
+      "insertText": "field1: {},\nfield2: ${1:0.0}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "rec1Field2",
+      "kind": "Field",
+      "detail": "module1:TestRecord1.rec1Field2",
+      "sortText": "K",
+      "insertText": "rec1Field2: ${1:\"\"}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "field1",
+      "kind": "Field",
+      "detail": "Type1.field1|Type2.field1",
+      "sortText": "AG",
+      "insertText": "field1: {}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "field2",
+      "kind": "Field",
+      "detail": "Type1.field2",
+      "sortText": "AG",
+      "insertText": "field2: {}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "optionalInt",
+      "kind": "Field",
+      "detail": "module1:TestRecord1.optionalInt",
+      "sortText": "K",
+      "insertText": "optionalInt: ${1:0}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "rec1Field1",
+      "kind": "Field",
+      "detail": "module1:TestRecord1.rec1Field1",
+      "sortText": "K",
+      "insertText": "rec1Field1: ${1:0}",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "field2",
+      "kind": "Field",
+      "detail": "Type2.field2",
+      "sortText": "K",
+      "insertText": "field2: ${1:0.0}",
+      "insertTextFormat": "Snippet"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/mapping_constructor_expr_ctx_source7.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/source/mapping_constructor_expr_ctx_source7.bal
@@ -1,0 +1,18 @@
+import ballerina/module1;
+
+public type Type1 record {|
+    module1:TestRecord1 field1;
+    module1:TestRecord1 field2;
+    int field2;
+|};
+
+public type Type2 record {|
+     module1:TestRecord1 field1;
+     float field2;
+|};
+
+
+
+public function main() {
+    Type1|module1:TestRecord1|Type2 rec = {};
+}


### PR DESCRIPTION
## Purpose
$subject

Fixes #40477

## Approach
When there are multiple fields with the same name and same type, show a single completion item for the particular field having a detail of `Type1.field1 | Type2.field1`.

## Samples
![image](https://github.com/ballerina-platform/ballerina-lang/assets/35211477/2eb1380c-9987-4cbb-ac26-c2713c42c69e)


## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
