### PR TITLE
Disable bala scheama definition test

### DIFF
--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/definition/BalaSchemeDefinitionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/definition/BalaSchemeDefinitionTest.java
@@ -31,17 +31,17 @@ import java.net.URISyntaxException;
  */
 public class BalaSchemeDefinitionTest extends DefinitionTest {
     
-    @Test(description = "Test goto definitions", dataProvider = "testDataProvider")
+    @Test(enabled = false, description = "Test goto definitions", dataProvider = "testDataProvider")
     public void test(String configPath, String configDir) throws IOException {
         super.test(configPath, configDir);
     }
 
-    @Test(description = "Test goto definitions for standard libs", dataProvider = "testStdLibDataProvider")
+    @Test(enabled = false, description = "Test goto definitions for standard libs", dataProvider = "testStdLibDataProvider")
     public void testStdLibDefinition(String configPath, String configDir) throws IOException, URISyntaxException {
         super.testStdLibDefinition(configPath, configDir);
     }
 
-    @Test(dataProvider = "testInterStdLibDataProvider")
+    @Test(enabled = false, dataProvider = "testInterStdLibDataProvider")
     public void testInterStdLibDefinition(String configPath, String configDir) throws IOException, URISyntaxException {
         super.testInterStdLibDefinition(configPath, configDir);
     }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/definition/BalaSchemeDefinitionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/definition/BalaSchemeDefinitionTest.java
@@ -30,13 +30,14 @@ import java.net.URISyntaxException;
  * Test goto definition language server feature with bala URI scheme enabled.
  */
 public class BalaSchemeDefinitionTest extends DefinitionTest {
-    
+
     @Test(enabled = false, description = "Test goto definitions", dataProvider = "testDataProvider")
     public void test(String configPath, String configDir) throws IOException {
         super.test(configPath, configDir);
     }
 
-    @Test(enabled = false, description = "Test goto definitions for standard libs", dataProvider = "testStdLibDataProvider")
+    @Test(enabled = false, description = "Test goto definitions for standard libs", 
+            dataProvider = "testStdLibDataProvider")
     public void testStdLibDefinition(String configPath, String configDir) throws IOException, URISyntaxException {
         super.testStdLibDefinition(configPath, configDir);
     }
@@ -45,7 +46,7 @@ public class BalaSchemeDefinitionTest extends DefinitionTest {
     public void testInterStdLibDefinition(String configPath, String configDir) throws IOException, URISyntaxException {
         super.testInterStdLibDefinition(configPath, configDir);
     }
-    
+
     @Override
     protected Endpoint getServiceEndpoint() {
         return TestUtil.newLanguageServer()


### PR DESCRIPTION
## Purpose
The BalaSchemaDefinition tests are passing locally. Disabling the BalaSchemaDefinitionTest temporarily until the workflow failure is resolved. 


## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
