### PR TITLE
Add missing qualifiers for the object type symbol when loaded through BIR

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
@@ -405,15 +405,15 @@ public class BIRPackageSymbolEnter {
         BInvokableType funcType = (BInvokableType) readBType(dataInStream);
         BInvokableSymbol invokableSymbol =
                 Symbols.createFunctionSymbol(flags, names.fromString(funcName), names.fromString(funcOrigName),
-                                             this.env.pkgSymbol.pkgID, funcType, this.env.pkgSymbol,
-                                             Symbols.isFlagOn(flags, Flags.NATIVE), pos, toOrigin(origin));
+                        this.env.pkgSymbol.pkgID, funcType, this.env.pkgSymbol,
+                        Symbols.isFlagOn(flags, Flags.NATIVE), pos, toOrigin(origin));
         invokableSymbol.source = pos.lineRange().fileName();
         invokableSymbol.retType = funcType.retType;
 
         Scope scopeToDefine = this.env.pkgSymbol.scope;
 
         boolean isResourceFunction = dataInStream.readBoolean();
-        
+
         if (this.currentStructure != null) {
             BType attachedType = Types.getReferredType(this.currentStructure.type);
 
@@ -583,8 +583,8 @@ public class BIRPackageSymbolEnter {
 
         defineMarkDownDocAttachment(symbol, docBytes);
         defineAnnotAttachmentSymbols(dataInStream,
-                                     (isClass || isEnum || symbol.tag == SymTag.TYPE_DEF) ? (Annotatable) symbol :
-                                             null);
+                (isClass || isEnum || symbol.tag == SymTag.TYPE_DEF) ? (Annotatable) symbol :
+                        null);
 
         if (type.tsymbol.name == Names.EMPTY && type.tag != TypeTags.INVOKABLE) {
             type.tsymbol.name = symbol.name;
@@ -704,7 +704,7 @@ public class BIRPackageSymbolEnter {
 
         for (int i = 0; i < attachPointCount; i++) {
             attachPoints.add(AttachPoint.getAttachmentPoint(getStringCPEntryValue(dataInStream),
-                                                            dataInStream.readBoolean()));
+                    dataInStream.readBoolean()));
         }
 
         BType annotationType = readBType(dataInStream);
@@ -1112,6 +1112,7 @@ public class BIRPackageSymbolEnter {
      * @since 0.970.0
      */
     private static class BIRPackageSymbolEnv {
+
         PackageID requestedPackageId;
         Map<Integer, byte[]> unparsedBTypeCPs = new HashMap<>();
         BPackageSymbol pkgSymbol;
@@ -1631,47 +1632,27 @@ public class BIRPackageSymbolEnter {
                     }
                     return finiteType;
                 case TypeTags.OBJECT:
-                    boolean service = inputStream.readByte() == 1;
-
                     pkgCpIndex = inputStream.readInt();
                     pkgId = getPackageId(pkgCpIndex);
 
                     String objName = getStringCPEntryValue(inputStream);
-                    var objFlags = (inputStream.readBoolean() ? Flags.CLASS : 0) | Flags.PUBLIC;
-                    objFlags = inputStream.readBoolean() ? objFlags | Flags.CLIENT : objFlags;
+                    long objSymFlags = inputStream.readLong();
                     BObjectTypeSymbol objectSymbol;
 
-                    if (Symbols.isFlagOn(objFlags, Flags.CLASS)) {
-                        objectSymbol = Symbols.createClassSymbol(objFlags, names.fromString(objName),
-                                                                 env.pkgSymbol.pkgID, null, env.pkgSymbol,
-                                                                 symTable.builtinPos, COMPILED_SOURCE, false);
+                    if (Symbols.isFlagOn(objSymFlags, Flags.CLASS)) {
+                        objectSymbol = Symbols.createClassSymbol(objSymFlags, names.fromString(objName),
+                                env.pkgSymbol.pkgID, null, env.pkgSymbol,
+                                symTable.builtinPos, COMPILED_SOURCE, false);
                     } else {
-                        objectSymbol = Symbols.createObjectSymbol(objFlags, names.fromString(objName),
-                                                                  env.pkgSymbol.pkgID, null, env.pkgSymbol,
-                                                                  symTable.builtinPos, COMPILED_SOURCE);
+                        objectSymbol = Symbols.createObjectSymbol(objSymFlags, names.fromString(objName),
+                                env.pkgSymbol.pkgID, null, env.pkgSymbol,
+                                symTable.builtinPos, COMPILED_SOURCE);
                     }
 
                     objectSymbol.scope = new Scope(objectSymbol);
                     BObjectType objectType;
                     // Below is a temporary fix, need to fix this properly by using the type tag
                     objectType = new BObjectType(objectSymbol);
-
-                    if (service) {
-                        objectType.flags |= Flags.SERVICE;
-                        objectSymbol.flags |= Flags.SERVICE;
-                    }
-                    if (isImmutable(flags)) {
-                        objectSymbol.flags |= Flags.READONLY;
-                    }
-                    if (Symbols.isFlagOn(flags, Flags.ANONYMOUS)) {
-                        objectSymbol.flags |= Flags.ANONYMOUS;
-                    }
-                    if (Symbols.isFlagOn(flags, Flags.DISTINCT)) {
-                        objectSymbol.flags |= Flags.DISTINCT;
-                    }
-                    if (Symbols.isFlagOn(flags, Flags.ISOLATED)) {
-                        objectSymbol.flags |= Flags.ISOLATED;
-                    }
                     objectType.flags = flags;
                     objectSymbol.type = objectType;
                     addShapeCP(objectType, cpI);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
@@ -1666,6 +1666,12 @@ public class BIRPackageSymbolEnter {
                     if (Symbols.isFlagOn(flags, Flags.ANONYMOUS)) {
                         objectSymbol.flags |= Flags.ANONYMOUS;
                     }
+                    if (Symbols.isFlagOn(flags, Flags.DISTINCT)) {
+                        objectSymbol.flags |= Flags.DISTINCT;
+                    }
+                    if (Symbols.isFlagOn(flags, Flags.ISOLATED)) {
+                        objectSymbol.flags |= Flags.ISOLATED;
+                    }
                     objectType.flags = flags;
                     objectSymbol.type = objectType;
                     addShapeCP(objectType, cpI);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
@@ -405,15 +405,15 @@ public class BIRPackageSymbolEnter {
         BInvokableType funcType = (BInvokableType) readBType(dataInStream);
         BInvokableSymbol invokableSymbol =
                 Symbols.createFunctionSymbol(flags, names.fromString(funcName), names.fromString(funcOrigName),
-                        this.env.pkgSymbol.pkgID, funcType, this.env.pkgSymbol,
-                        Symbols.isFlagOn(flags, Flags.NATIVE), pos, toOrigin(origin));
+                                             this.env.pkgSymbol.pkgID, funcType, this.env.pkgSymbol,
+                                             Symbols.isFlagOn(flags, Flags.NATIVE), pos, toOrigin(origin));
         invokableSymbol.source = pos.lineRange().fileName();
         invokableSymbol.retType = funcType.retType;
 
         Scope scopeToDefine = this.env.pkgSymbol.scope;
 
         boolean isResourceFunction = dataInStream.readBoolean();
-
+        
         if (this.currentStructure != null) {
             BType attachedType = Types.getReferredType(this.currentStructure.type);
 
@@ -583,8 +583,8 @@ public class BIRPackageSymbolEnter {
 
         defineMarkDownDocAttachment(symbol, docBytes);
         defineAnnotAttachmentSymbols(dataInStream,
-                (isClass || isEnum || symbol.tag == SymTag.TYPE_DEF) ? (Annotatable) symbol :
-                        null);
+                                     (isClass || isEnum || symbol.tag == SymTag.TYPE_DEF) ? (Annotatable) symbol :
+                                             null);
 
         if (type.tsymbol.name == Names.EMPTY && type.tag != TypeTags.INVOKABLE) {
             type.tsymbol.name = symbol.name;
@@ -704,7 +704,7 @@ public class BIRPackageSymbolEnter {
 
         for (int i = 0; i < attachPointCount; i++) {
             attachPoints.add(AttachPoint.getAttachmentPoint(getStringCPEntryValue(dataInStream),
-                    dataInStream.readBoolean()));
+                                                            dataInStream.readBoolean()));
         }
 
         BType annotationType = readBType(dataInStream);
@@ -1112,7 +1112,6 @@ public class BIRPackageSymbolEnter {
      * @since 0.970.0
      */
     private static class BIRPackageSymbolEnv {
-
         PackageID requestedPackageId;
         Map<Integer, byte[]> unparsedBTypeCPs = new HashMap<>();
         BPackageSymbol pkgSymbol;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRTypeWriter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRTypeWriter.java
@@ -439,14 +439,6 @@ public class BIRTypeWriter implements TypeVisitor {
 
     @Override
     public void visit(BObjectType bObjectType) {
-        //This is to say this is an object, this is a temporary fix object - 1, service - 0,
-        // ideal fix would be to use the type tag to
-        // differentiate. TODO fix later
-        if ((bObjectType.flags & Flags.SERVICE) == Flags.SERVICE) {
-            buff.writeByte(1);
-        } else {
-            buff.writeByte(0);
-        }
         writeObjectAndServiceTypes(bObjectType);
         writeTypeIds(bObjectType.typeIdSet);
     }
@@ -460,9 +452,7 @@ public class BIRTypeWriter implements TypeVisitor {
         BTypeDefinitionSymbol typDefSymbol = ((BObjectTypeSymbol) tSymbol).typeDefinitionSymbol;
         buff.writeInt(addStringCPEntry(Objects.requireNonNullElse(typDefSymbol, tSymbol).name.value));
 
-        //TODO below two line are a temp solution, introduce a generic concept
-        buff.writeBoolean(Symbols.isFlagOn(tSymbol.flags, Flags.CLASS)); // Abstract object or not
-        buff.writeBoolean(Symbols.isFlagOn(tSymbol.flags, Flags.CLIENT));
+        buff.writeLong(tSymbol.flags);
         buff.writeInt(bObjectType.fields.size());
         for (BField field : bObjectType.fields.values()) {
             buff.writeInt(addStringCPEntry(field.name.value));

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/ProgramFileConstants.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/ProgramFileConstants.java
@@ -25,9 +25,9 @@ public class ProgramFileConstants {
 
     public static final int MAGIC_NUMBER = 0xBA1DA4CE;
     public static final short VERSION_NUMBER = 50;
-    public static final int BIR_VERSION_NUMBER = 69;
-    public static final short MIN_SUPPORTED_VERSION = 69;
-    public static final short MAX_SUPPORTED_VERSION = 69;
+    public static final int BIR_VERSION_NUMBER = 70;
+    public static final short MIN_SUPPORTED_VERSION = 70;
+    public static final short MAX_SUPPORTED_VERSION = 70;
 
     // todo move this to a proper place
     public static final String[] SUPPORTED_PLATFORMS = {"java17", "java11"};

--- a/docs/bir-spec/src/main/resources/kaitai/bir.ksy
+++ b/docs/bir-spec/src/main/resources/kaitai/bir.ksy
@@ -294,16 +294,12 @@ types:
         type: s4
   type_object_or_service:
     seq:
-      - id: is_object_type
-        type: s1
       - id: pkd_id_cp_index
         type: s4
       - id: name_cp_index
         type: s4
-      - id: is_abstract
-        type: u1
-      - id: is_client
-        type: u1
+      - id: object_symbol_flags
+        type: s8
       - id: object_fields_count
         type: s4
       - id: object_fields

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config-rename-positional-capability/variableAssignmentRequiredCodeAction38.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config-rename-positional-capability/variableAssignmentRequiredCodeAction38.json
@@ -20,7 +20,7 @@
               "character": 4
             }
           },
-          "newText": "object {public isolated function iterator() returns object {public isolated function next() returns record {|int value;|}?;};} objectResult = "
+          "newText": "isolated object {public isolated function iterator() returns isolated object {public isolated function next() returns record {|int value;|}?;};} objectResult = "
         }
       ],
       "command": {
@@ -30,7 +30,7 @@
           "createVariable5.bal",
           {
             "line": 85,
-            "character": 131
+            "character": 149
           }
         ]
       },

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config-rename-positional-capability/variableAssignmentRequiredCodeAction39.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config-rename-positional-capability/variableAssignmentRequiredCodeAction39.json
@@ -20,7 +20,7 @@
               "character": 4
             }
           },
-          "newText": "object {public isolated function iterator() returns object {public isolated function next() returns record {|int value;|}?;};} objectResult = "
+          "newText": "isolated object {public isolated function iterator() returns isolated object {public isolated function next() returns record {|int value;|}?;};} objectResult = "
         }
       ],
       "command": {
@@ -30,7 +30,7 @@
           "createVariable5.bal",
           {
             "line": 86,
-            "character": 131
+            "character": 149
           }
         ]
       },

--- a/language-server/modules/langserver-core/src/test/resources/completion/annotation_ctx/config/langAnnotations1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/annotation_ctx/config/langAnnotations1.json
@@ -197,11 +197,11 @@
     {
       "label": "...()",
       "kind": "Function",
-      "detail": "object {public isolated function iterator() returns object {public isolated function next() returns record {|int value;|}?;};}",
+      "detail": "isolated object {public isolated function iterator() returns isolated object {public isolated function next() returns record {|int value;|}?;};}",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.annotations:0.0.0_  \n  \n  \n  \n  \n**Return** `object {public isolated function iterator() returns object {public isolated function next() returns record {|int value;|}?;};}`   \n  \n"
+          "value": "**Package:** _ballerina/lang.annotations:0.0.0_  \n  \n  \n  \n  \n**Return** `isolated object {public isolated function iterator() returns isolated object {public isolated function next() returns record {|int value;|}?;};}`   \n  \n"
         }
       },
       "sortText": "A",
@@ -212,11 +212,11 @@
     {
       "label": "..<()",
       "kind": "Function",
-      "detail": "object {public isolated function iterator() returns object {public isolated function next() returns record {|int value;|}?;};}",
+      "detail": "isolated object {public isolated function iterator() returns isolated object {public isolated function next() returns record {|int value;|}?;};}",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.annotations:0.0.0_  \n  \n  \n  \n  \n**Return** `object {public isolated function iterator() returns object {public isolated function next() returns record {|int value;|}?;};}`   \n  \n"
+          "value": "**Package:** _ballerina/lang.annotations:0.0.0_  \n  \n  \n  \n  \n**Return** `isolated object {public isolated function iterator() returns isolated object {public isolated function next() returns record {|int value;|}?;};}`   \n  \n"
         }
       },
       "sortText": "A",

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolBIRTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolBIRTest.java
@@ -441,25 +441,26 @@ public class SymbolBIRTest {
     @Test
     public void testObjectTypeSymbolDefQualifiers() {
         Project project = BCompileUtil.loadProject("test-src/object_symbol_qualifiers.bal");
-        Package currentPackage = project.currentPackage();
         Document srcFile = getDocumentForSingleSource(project);
         SemanticModel model = getDefaultModulesSemanticModel(project);
         
         Optional<Symbol> symbol = model.symbol(srcFile, from(19, 20));
         assertTrue(symbol.isPresent());
-        assertEquals(symbol.get().kind(), TYPE);
-        assertEquals(((TypeReferenceTypeSymbol) symbol.get()).typeDescriptor().typeKind(), OBJECT);
-        ObjectTypeSymbol clientObjectTSymbol = (ObjectTypeSymbol) ((TypeReferenceTypeSymbol) symbol.get())
-                                                .typeDescriptor();
+        Symbol sym = symbol.get();
+        assertEquals(sym.kind(), TYPE);
+        TypeSymbol typeSymbol = ((TypeReferenceTypeSymbol) sym).typeDescriptor();
+        assertEquals(typeSymbol.typeKind(), OBJECT);
+        ObjectTypeSymbol clientObjectTSymbol = (ObjectTypeSymbol) typeSymbol;
         assertEquals(clientObjectTSymbol.qualifiers().size(), 3);
         assertEquals(clientObjectTSymbol.qualifiers(), List.of(DISTINCT, ISOLATED, CLIENT));
 
         symbol = model.symbol(srcFile, from(23, 23));
         assertTrue(symbol.isPresent());
-        assertEquals(symbol.get().kind(), TYPE);
-        assertEquals(((TypeReferenceTypeSymbol) symbol.get()).typeDescriptor().typeKind(), OBJECT);
-        ObjectTypeSymbol serviceObjectTSymbol = (ObjectTypeSymbol) ((TypeReferenceTypeSymbol) symbol.get())
-                                                    .typeDescriptor();
+        sym = symbol.get();
+        assertEquals(sym.kind(), TYPE);
+        typeSymbol = ((TypeReferenceTypeSymbol) sym).typeDescriptor();
+        assertEquals(typeSymbol.typeKind(), OBJECT);
+        ObjectTypeSymbol serviceObjectTSymbol = (ObjectTypeSymbol) typeSymbol;
         assertEquals(serviceObjectTSymbol.qualifiers().size(), 3);
         assertEquals(serviceObjectTSymbol.qualifiers(), List.of(DISTINCT, ISOLATED, SERVICE));
     }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolBIRTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolBIRTest.java
@@ -364,7 +364,6 @@ public class SymbolBIRTest {
     }
 
     static class SymbolInfo {
-
         private String name;
         private SymbolKind kind;
 
@@ -443,11 +442,9 @@ public class SymbolBIRTest {
     public void testObjectTypeSymbolDefQualifiers() {
         Project project = BCompileUtil.loadProject("test-src/object_symbol_qualifiers.bal");
         Package currentPackage = project.currentPackage();
-        ModuleId defaultModuleId = currentPackage.getDefaultModule().moduleId();
         Document srcFile = getDocumentForSingleSource(project);
-
-        PackageCompilation packageCompilation = currentPackage.getCompilation();
-        SemanticModel model = packageCompilation.getSemanticModel(defaultModuleId);
+        SemanticModel model = getDefaultModulesSemanticModel(project);
+        
         Optional<Symbol> symbol = model.symbol(srcFile, from(19, 20));
         assertTrue(symbol.isPresent());
         assertEquals(symbol.get().kind(), TYPE);

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/object_symbol_qualifiers.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/object_symbol_qualifiers.bal
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+// Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
 //
 // WSO2 LLC. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
@@ -21,5 +21,5 @@ function testInterceptorClient() {
 }
 
 function testInterceptorService() {
-    testproject:InterceptorService is;
+    testproject:InterceptorService 'is;
 }

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/object_symbol_qualifiers.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/object_symbol_qualifiers.bal
@@ -1,0 +1,25 @@
+// Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import testorg/testproject;
+
+function testInterceptorClient() {
+    testproject:InterceptorClient ic;
+}
+
+function testInterceptorService() {
+    testproject:InterceptorService is;
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/testproject/type_defs.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/testproject/type_defs.bal
@@ -146,3 +146,11 @@ public type Address readonly & record {
     string street;
     string city;
 };
+
+public type InterceptorClient distinct isolated client object {
+    isolated remote function execute() returns anydata|error;
+};
+
+public type InterceptorService distinct isolated service object {
+    isolated remote function execute() returns anydata|error;
+};

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/object/ObjectInBalaTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/object/ObjectInBalaTest.java
@@ -41,6 +41,7 @@ public class ObjectInBalaTest {
         BCompileUtil.compileAndCacheBala("test-src/bala/test_projects/test_project");
         BCompileUtil.compileAndCacheBala("test-src/bala/test_projects/test_project_two");
         BCompileUtil.compileAndCacheBala("test-src/bala/test_projects/test_project_utils");
+        BCompileUtil.compileAndCacheBala("test-src/bala/test_projects/bir_test_project");
 
         result = BCompileUtil.compile("test-src/bala/test_bala/object/test_objects.bal");
     }
@@ -551,6 +552,21 @@ public class ObjectInBalaTest {
         BRunUtil.invoke(result, "testObjectInclusionWithMethodWithParameters");
     }
 
+    @Test (description = "Negative test to verify object qualifiers load properly from BIR")
+    public void testDistinctIsolatedObjectsNegative() {
+        CompileResult result = BCompileUtil.compile("test-src/bala/test_bala/object/test_bir_negative.bal");
+        int i = 0;
+        BAssertUtil.validateError(result, i++, 
+                "incompatible types: 'bir/objs:0.1.0:Bar' will not be matched to 'bir/objs:0.1.0:Foo'", 4, 20);
+        BAssertUtil.validateError(result, i++, 
+                "incompatible types: 'bir/objs:0.1.0:Foo' will not be matched to 'bir/objs:0.1.0:Bar'", 8, 20);
+        BAssertUtil.validateError(result, i++, 
+                "incompatible types: 'bir/objs:0.1.0:Xyz' will not be matched to 'bir/objs:0.1.0:Qux'", 12, 20);
+        BAssertUtil.validateError(result, i, 
+                "incompatible types: 'bir/objs:0.1.0:Qux' will not be matched to 'bir/objs:0.1.0:Xyz'", 16, 20);
+        Assert.assertEquals(result.getErrorCount(), 4);
+    }
+    
     @AfterClass
     public void tearDown() {
         result = null;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/object/ObjectInBalaTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/object/ObjectInBalaTest.java
@@ -566,6 +566,12 @@ public class ObjectInBalaTest {
                 "incompatible types: 'bir/objs:0.1.0:Qux' will not be matched to 'bir/objs:0.1.0:Xyz'", 16, 20);
         Assert.assertEquals(result.getErrorCount(), 4);
     }
+
+    @Test
+    public void testObjectTypeAssignability() {
+        CompileResult result = BCompileUtil.compile("test-src/bala/test_bala/object/test_bir_positive.bal");
+        BRunUtil.invoke(result, "testObjectTypeAssignability");
+    }
     
     @AfterClass
     public void tearDown() {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/object/ObjectInBalaTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/object/ObjectInBalaTest.java
@@ -557,13 +557,13 @@ public class ObjectInBalaTest {
         CompileResult result = BCompileUtil.compile("test-src/bala/test_bala/object/test_bir_negative.bal");
         int i = 0;
         BAssertUtil.validateError(result, i++, 
-                "incompatible types: 'bir/objs:0.1.0:Bar' will not be matched to 'bir/objs:0.1.0:Foo'", 20, 20);
+                "incompatible types: 'bir/objs:0.1.0:Bar' will not be matched to 'bir/objs:0.1.0:Foo'", 20, 9);
         BAssertUtil.validateError(result, i++, 
-                "incompatible types: 'bir/objs:0.1.0:Foo' will not be matched to 'bir/objs:0.1.0:Bar'", 24, 20);
+                "incompatible types: 'bir/objs:0.1.0:Foo' will not be matched to 'bir/objs:0.1.0:Bar'", 24, 9);
         BAssertUtil.validateError(result, i++, 
-                "incompatible types: 'bir/objs:0.1.0:Xyz' will not be matched to 'bir/objs:0.1.0:Qux'", 28, 20);
+                "incompatible types: 'bir/objs:0.1.0:Xyz' will not be matched to 'bir/objs:0.1.0:Qux'", 28, 9);
         BAssertUtil.validateError(result, i, 
-                "incompatible types: 'bir/objs:0.1.0:Qux' will not be matched to 'bir/objs:0.1.0:Xyz'", 32, 20);
+                "incompatible types: 'bir/objs:0.1.0:Qux' will not be matched to 'bir/objs:0.1.0:Xyz'", 32, 9);
         Assert.assertEquals(result.getErrorCount(), 4);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/object/ObjectInBalaTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/object/ObjectInBalaTest.java
@@ -557,13 +557,13 @@ public class ObjectInBalaTest {
         CompileResult result = BCompileUtil.compile("test-src/bala/test_bala/object/test_bir_negative.bal");
         int i = 0;
         BAssertUtil.validateError(result, i++, 
-                "incompatible types: 'bir/objs:0.1.0:Bar' will not be matched to 'bir/objs:0.1.0:Foo'", 4, 20);
+                "incompatible types: 'bir/objs:0.1.0:Bar' will not be matched to 'bir/objs:0.1.0:Foo'", 20, 20);
         BAssertUtil.validateError(result, i++, 
-                "incompatible types: 'bir/objs:0.1.0:Foo' will not be matched to 'bir/objs:0.1.0:Bar'", 8, 20);
+                "incompatible types: 'bir/objs:0.1.0:Foo' will not be matched to 'bir/objs:0.1.0:Bar'", 24, 20);
         BAssertUtil.validateError(result, i++, 
-                "incompatible types: 'bir/objs:0.1.0:Xyz' will not be matched to 'bir/objs:0.1.0:Qux'", 12, 20);
+                "incompatible types: 'bir/objs:0.1.0:Xyz' will not be matched to 'bir/objs:0.1.0:Qux'", 28, 20);
         BAssertUtil.validateError(result, i, 
-                "incompatible types: 'bir/objs:0.1.0:Qux' will not be matched to 'bir/objs:0.1.0:Xyz'", 16, 20);
+                "incompatible types: 'bir/objs:0.1.0:Qux' will not be matched to 'bir/objs:0.1.0:Xyz'", 32, 20);
         Assert.assertEquals(result.getErrorCount(), 4);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/object/ObjectInBalaTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bala/object/ObjectInBalaTest.java
@@ -557,20 +557,24 @@ public class ObjectInBalaTest {
         CompileResult result = BCompileUtil.compile("test-src/bala/test_bala/object/test_bir_negative.bal");
         int i = 0;
         BAssertUtil.validateError(result, i++, 
-                "incompatible types: 'bir/objs:0.1.0:Bar' will not be matched to 'bir/objs:0.1.0:Foo'", 20, 9);
+                "incompatible types: expected 'bir/objs:0.1.0:Foo', found 'bir/objs:0.1.0:Bar'", 24, 18);
         BAssertUtil.validateError(result, i++, 
-                "incompatible types: 'bir/objs:0.1.0:Foo' will not be matched to 'bir/objs:0.1.0:Bar'", 24, 9);
+                "incompatible types: expected 'bir/objs:0.1.0:Bar', found 'bir/objs:0.1.0:Foo'", 28, 18);
+        BAssertUtil.validateError(result, i++,
+                "incompatible types: expected 'Foo', found 'bir/objs:0.1.0:Foo'", 29, 13);
         BAssertUtil.validateError(result, i++, 
-                "incompatible types: 'bir/objs:0.1.0:Xyz' will not be matched to 'bir/objs:0.1.0:Qux'", 28, 9);
-        BAssertUtil.validateError(result, i, 
-                "incompatible types: 'bir/objs:0.1.0:Qux' will not be matched to 'bir/objs:0.1.0:Xyz'", 32, 9);
-        Assert.assertEquals(result.getErrorCount(), 4);
+                "incompatible types: expected 'bir/objs:0.1.0:Qux', found 'bir/objs:0.1.0:Xyz'", 33, 18);
+        BAssertUtil.validateError(result, i++, 
+                "incompatible types: expected 'bir/objs:0.1.0:Xyz', found 'bir/objs:0.1.0:Qux'", 37, 18);
+        BAssertUtil.validateError(result, i++,
+                "incompatible types: expected 'bir/objs:0.1.0:Foo', found 'Foo'", 41, 18);
+        Assert.assertEquals(result.getErrorCount(), i);
     }
 
-    @Test
-    public void testObjectTypeAssignability() {
+    @Test(description = "Positive test to verify object isolated and distinct qualifiers load properly from BIR")
+    public void testObjectTypeAssignabilityWithQualifiers() {
         CompileResult result = BCompileUtil.compile("test-src/bala/test_bala/object/test_bir_positive.bal");
-        BRunUtil.invoke(result, "testObjectTypeAssignability");
+        BRunUtil.invoke(result, "testObjectTypeAssignabilityWithQualifiers");
     }
     
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/object/test_bir_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/object/test_bir_negative.bal
@@ -1,0 +1,20 @@
+import bir/objs;
+
+function f1(objs:Bar bar) {
+    assertEquality(bar is objs:Foo, false);
+}
+
+function f2(objs:Foo foo) {
+    assertEquality(foo is objs:Bar, false);
+}
+
+function f3(objs:Xyz xyz) {
+    assertEquality(xyz is objs:Qux, false);
+}
+
+function f4(objs:Qux qux) {
+    assertEquality(qux is objs:Xyz, false);
+}
+
+function assertEquality(any|error actual, any|error expected) {
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/object/test_bir_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/object/test_bir_negative.bal
@@ -17,20 +17,17 @@
 import bir/objs;
 
 function f1(objs:Bar bar) {
-    assertEquality(bar is objs:Foo, false);
+    _ = bar is objs:Foo;
 }
 
 function f2(objs:Foo foo) {
-    assertEquality(foo is objs:Bar, false);
+    _ = foo is objs:Bar;
 }
 
 function f3(objs:Xyz xyz) {
-    assertEquality(xyz is objs:Qux, false);
+    _ = xyz is objs:Qux;
 }
 
 function f4(objs:Qux qux) {
-    assertEquality(qux is objs:Xyz, false);
-}
-
-function assertEquality(any|error actual, any|error expected) {
+    _ = qux is objs:Xyz;
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/object/test_bir_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/object/test_bir_negative.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2023 WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import bir/objs;
 
 function f1(objs:Bar bar) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/object/test_bir_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/object/test_bir_negative.bal
@@ -16,18 +16,27 @@
 
 import bir/objs;
 
+public type Foo distinct isolated client object {
+    public isolated function execute() returns anydata|error;
+};
+
 function f1(objs:Bar bar) {
-    _ = bar is objs:Foo;
+    objs:Foo _ = bar;
 }
 
 function f2(objs:Foo foo) {
-    _ = foo is objs:Bar;
+    objs:Bar _ = foo;
+    Foo _ = foo;
 }
 
 function f3(objs:Xyz xyz) {
-    _ = xyz is objs:Qux;
+    objs:Qux _ = xyz;
 }
 
 function f4(objs:Qux qux) {
-    _ = qux is objs:Xyz;
+    objs:Xyz _ = qux;
+}
+
+function f5(Foo foo) {
+    objs:Foo _ = foo;
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/object/test_bir_positive.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/object/test_bir_positive.bal
@@ -16,72 +16,66 @@
 
 import bir/objs;
 
+public type Quxx isolated client object {
+    public isolated function execute() returns anydata|error;
+};
+
 objs:Qux quxMod = isolated service object {
     public isolated function execute() returns anydata|error {
          return "qux";
     }
 };
 
-function f1(objs:Foo foo) {
-    assertTrue(foo is objs:Foo);
-}
-
-function f2(objs:Xyz xyz) {
-    assertTrue(xyz is objs:Xyz);
-}
-
-function f3(any foo) {
-    assertTrue(foo is objs:Foo);
-}
-
-function f4(any baz) {
-    assertTrue(baz is objs:Baz);
-}
-
-function f5(any xyz) {
-    assertTrue(xyz is objs:Xyz);
-}
-
-function f6(any qux) {
-    assertTrue(qux is objs:Qux);
-}
-
-function f7(any foo) {
-    assertFalse(foo is objs:Bar);
-}
-
-function testObjectTypeAssignability() {
+function testObjectTypeAssignabilityWithQualifiers() {
     objs:Foo foo = isolated client object {
          public isolated function execute() returns anydata|error {
            return "foo";
         }
     };
-    f1(foo);
-    f3(foo);
-    f7(foo);
+    assertTrue(foo is objs:Foo);
+    assertTrue(<any>foo is objs:Foo);
+    assertFalse(<any>foo is objs:Bar);
     
     objs:Baz baz = isolated client object {
         public isolated function execute() returns anydata|error {
             return "baz";
         }
     };
-    f4(baz);
+    assertTrue(<any>baz is objs:Baz);
     
     objs:Xyz xyz = isolated service object {
         public isolated function execute() returns anydata|error {
             return "xyz";
         }
     };
-    f2(xyz);
-    f5(xyz);
+    assertTrue(xyz is objs:Xyz);
+    assertTrue(<any>xyz is objs:Xyz);
     
     objs:Qux qux = isolated service object {
         public isolated function execute() returns anydata|error {
             return "qux";
         }
     };
-    f6(qux);
-    f6(quxMod);
+    assertTrue(<any>qux is objs:Qux);
+    assertTrue(<any>quxMod is objs:Qux);
+    
+    objs:Quxx quxx = isolated client object {
+        public isolated function execute() returns anydata|error {
+            return "quxx";
+        }
+    };
+    
+    objs:Muxx _ = quxx;
+    Quxx _ = quxx;
+    assertTrue(quxx is Quxx);
+    
+    Quxx _ = isolated client object {
+        public isolated function execute() returns anydata|error {
+            return "quxx";
+        }
+    };
+    objs:Quxx _ = quxx;
+    assertTrue(quxx is objs:Quxx);
 }
 
 function assertTrue(anydata actual) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/object/test_bir_positive.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/object/test_bir_positive.bal
@@ -1,0 +1,88 @@
+import bir/objs;
+
+function f1(objs:Foo foo) {
+    assertEquality(foo is objs:Foo, true);
+}
+
+function f2(objs:Baz baz) {
+    assertEquality(baz is objs:Baz, true);
+}
+
+function f3(objs:Xyz xyz) {
+    assertEquality(xyz is objs:Xyz, true);
+}
+
+function f4(objs:Qux qux) {
+    assertEquality(qux is objs:Qux, true);
+}
+
+function f5(any foo) {
+    assertEquality(foo is objs:Foo, true);
+}
+
+function f6(any baz) {
+    assertEquality(baz is objs:Baz, true);
+}
+
+function f7(any xyz) {
+    assertEquality(xyz is objs:Xyz, true);
+}
+
+function f8(any qux) {
+    assertEquality(qux is objs:Qux, true);
+}
+
+function f9(any foo) {
+    assertEquality(foo is objs:Bar, false);
+}
+
+function testObjectTypeAssignability() {
+    objs:Foo foo = isolated client object {
+         public isolated function execute() returns anydata|error {
+           return "foo";
+        }
+    };
+    
+    objs:Baz baz = isolated client object {
+        public isolated function execute() returns anydata|error {
+            return "baz";
+        }
+    };
+    
+    objs:Xyz xyz = isolated service object {
+        public isolated function execute() returns anydata|error {
+            return "xyz";
+        }
+    };
+    
+    objs:Qux qux = isolated service object {
+        public isolated function execute() returns anydata|error {
+            return "qux";
+        }
+    };
+    
+    f1(foo);
+    f2(baz);
+    f3(xyz);
+    f4(qux);
+    f5(foo);
+    f6(baz);
+    f7(xyz);
+    f8(qux);
+    f9(foo);
+}
+
+function assertEquality(any|error actual, any|error expected) {
+    if expected is anydata && actual is anydata && expected == actual {
+        return;
+    }
+
+    if expected === actual {
+        return;
+    }
+
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
+    panic error("AssertionError",
+            message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/object/test_bir_positive.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/object/test_bir_positive.bal
@@ -16,6 +16,10 @@
 
 import bir/objs;
 
+public type Foo distinct isolated client object {
+    public isolated function execute() returns anydata|error;
+};
+
 public type Quxx isolated client object {
     public isolated function execute() returns anydata|error;
 };
@@ -35,6 +39,14 @@ function testObjectTypeAssignabilityWithQualifiers() {
     assertTrue(foo is objs:Foo);
     assertTrue(<any>foo is objs:Foo);
     assertFalse(<any>foo is objs:Bar);
+    assertFalse(<any>foo is Foo);
+    
+    Foo foo2 = isolated client object {
+        public isolated function execute() returns anydata|error {
+            return "foo";
+        }
+    };
+    assertFalse(<any>foo2 is objs:Foo);
     
     objs:Baz baz = isolated client object {
         public isolated function execute() returns anydata|error {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/object/test_bir_positive.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/object/test_bir_positive.bal
@@ -16,6 +16,12 @@
 
 import bir/objs;
 
+objs:Qux quxMod = isolated service object {
+    public isolated function execute() returns anydata|error {
+         return "qux";
+    }
+};
+
 function f1(objs:Foo foo) {
     assertTrue(foo is objs:Foo);
 }
@@ -75,6 +81,7 @@ function testObjectTypeAssignability() {
         }
     };
     f6(qux);
+    f6(quxMod);
 }
 
 function assertTrue(anydata actual) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/object/test_bir_positive.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_bala/object/test_bir_positive.bal
@@ -1,39 +1,47 @@
+// Copyright (c) 2023 WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import bir/objs;
 
 function f1(objs:Foo foo) {
-    assertEquality(foo is objs:Foo, true);
+    assertTrue(foo is objs:Foo);
 }
 
-function f2(objs:Baz baz) {
-    assertEquality(baz is objs:Baz, true);
+function f2(objs:Xyz xyz) {
+    assertTrue(xyz is objs:Xyz);
 }
 
-function f3(objs:Xyz xyz) {
-    assertEquality(xyz is objs:Xyz, true);
+function f3(any foo) {
+    assertTrue(foo is objs:Foo);
 }
 
-function f4(objs:Qux qux) {
-    assertEquality(qux is objs:Qux, true);
+function f4(any baz) {
+    assertTrue(baz is objs:Baz);
 }
 
-function f5(any foo) {
-    assertEquality(foo is objs:Foo, true);
+function f5(any xyz) {
+    assertTrue(xyz is objs:Xyz);
 }
 
-function f6(any baz) {
-    assertEquality(baz is objs:Baz, true);
+function f6(any qux) {
+    assertTrue(qux is objs:Qux);
 }
 
-function f7(any xyz) {
-    assertEquality(xyz is objs:Xyz, true);
-}
-
-function f8(any qux) {
-    assertEquality(qux is objs:Qux, true);
-}
-
-function f9(any foo) {
-    assertEquality(foo is objs:Bar, false);
+function f7(any foo) {
+    assertFalse(foo is objs:Bar);
 }
 
 function testObjectTypeAssignability() {
@@ -42,47 +50,48 @@ function testObjectTypeAssignability() {
            return "foo";
         }
     };
+    f1(foo);
+    f3(foo);
+    f7(foo);
     
     objs:Baz baz = isolated client object {
         public isolated function execute() returns anydata|error {
             return "baz";
         }
     };
+    f4(baz);
     
     objs:Xyz xyz = isolated service object {
         public isolated function execute() returns anydata|error {
             return "xyz";
         }
     };
+    f2(xyz);
+    f5(xyz);
     
     objs:Qux qux = isolated service object {
         public isolated function execute() returns anydata|error {
             return "qux";
         }
     };
-    
-    f1(foo);
-    f2(baz);
-    f3(xyz);
-    f4(qux);
-    f5(foo);
-    f6(baz);
-    f7(xyz);
-    f8(qux);
-    f9(foo);
+    f6(qux);
 }
 
-function assertEquality(any|error actual, any|error expected) {
-    if expected is anydata && actual is anydata && expected == actual {
+function assertTrue(anydata actual) {
+    assertEquality(actual, true);
+}
+
+function assertFalse(anydata actual) {
+    assertEquality(actual, false);
+}
+
+function assertEquality(anydata actual, anydata expected) {
+    if expected == actual {
         return;
     }
 
-    if expected === actual {
-        return;
-    }
-
-    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
-    string actualValAsString = actual is error ? actual.toString() : actual.toString();
+    string expectedValAsString = expected.toString();
+    string actualValAsString = actual.toString();
     panic error("AssertionError",
             message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/bir_test_project/Ballerina.toml
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/bir_test_project/Ballerina.toml
@@ -1,4 +1,4 @@
 [package]
-org=  "bir"
-name= "objs"
-version= "0.1.0"
+org = "bir"
+name = "objs"
+version = "0.1.0"

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/bir_test_project/Ballerina.toml
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/bir_test_project/Ballerina.toml
@@ -1,5 +1,4 @@
 [package]
-org= "bir"
+org=  "bir"
 name= "objs"
 version= "0.1.0"
-exported=["serv_classes"]

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/bir_test_project/Ballerina.toml
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/bir_test_project/Ballerina.toml
@@ -1,0 +1,5 @@
+[package]
+org= "bir"
+name= "objs"
+version= "0.1.0"
+exported=["serv_classes"]

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/bir_test_project/main.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/bir_test_project/main.bal
@@ -1,0 +1,19 @@
+public type Foo distinct isolated client object {
+    isolated function execute() returns anydata|error;
+};
+
+public type Bar distinct isolated client object {
+    isolated function execute() returns anydata|error;
+};
+
+public type Baz isolated client object {
+    isolated function execute() returns anydata|error;
+};
+
+public type Xyz distinct isolated service object {
+    isolated function execute() returns anydata|error;
+};
+
+public type Qux distinct isolated service object {
+    isolated function execute() returns anydata|error;
+};

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/bir_test_project/main.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/bir_test_project/main.bal
@@ -1,19 +1,19 @@
 public type Foo distinct isolated client object {
-    isolated function execute() returns anydata|error;
+    public isolated function execute() returns anydata|error;
 };
 
 public type Bar distinct isolated client object {
-    isolated function execute() returns anydata|error;
+    public isolated function execute() returns anydata|error;
 };
 
 public type Baz isolated client object {
-    isolated function execute() returns anydata|error;
+    public isolated function execute() returns anydata|error;
 };
 
 public type Xyz distinct isolated service object {
-    isolated function execute() returns anydata|error;
+    public isolated function execute() returns anydata|error;
 };
 
 public type Qux distinct isolated service object {
-    isolated function execute() returns anydata|error;
+    public isolated function execute() returns anydata|error;
 };

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/bir_test_project/main.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bala/test_projects/bir_test_project/main.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2023 WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 public type Foo distinct isolated client object {
     public isolated function execute() returns anydata|error;
 };
@@ -15,5 +31,13 @@ public type Xyz distinct isolated service object {
 };
 
 public type Qux distinct isolated service object {
+    public isolated function execute() returns anydata|error;
+};
+
+public type Quxx isolated client object {
+    public isolated function execute() returns anydata|error;
+};
+
+public type Muxx isolated client object {
     public isolated function execute() returns anydata|error;
 };


### PR DESCRIPTION
## Purpose
$subject

With this fix `distinct` and `isolated` qualifiers will be read from the BIR and available in the BallerinaObjectTypeSymbol. This will cause to fail the test case in [#graphql](https://github.com/ballerina-platform/module-ballerina-graphql/blob/10326f1b6580b5b7d1e730e9d4418df8c823642c/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/graphql/compiler/ServiceValidationTest.java#L248).

Fixes #40619

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
