### PR TITLE
Remove unnecessary methods in frame classes

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/scheduling/FunctionFrame.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/scheduling/FunctionFrame.java
@@ -19,15 +19,15 @@
 package io.ballerina.runtime.internal.scheduling;
 
 /**
- * This interface represents the function frame which saves the existing
+ * This abstract class represents the function frame which saves the existing
  * state when a function yields.
  *
  * @since 2201.2.0
  */
-public interface FunctionFrame {
+public abstract class FunctionFrame {
 
-    String getYieldLocation();
+    public String yieldLocation;
 
-    String getYieldStatus();
+    public String yieldStatus;
 
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/scheduling/Strand.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/scheduling/Strand.java
@@ -481,10 +481,10 @@ public class Strand {
         try {
             for (FunctionFrame frame : strandFrames) {
                 if (noPickedYieldStatus) {
-                    yieldStatus = frame.getYieldStatus();
+                    yieldStatus = frame.yieldStatus;
                     noPickedYieldStatus = false;
                 }
-                String yieldLocation = frame.getYieldLocation();
+                String yieldLocation = frame.yieldLocation;
                 frameStackTrace.append(stringPrefix).append(yieldLocation);
                 frameStackTrace.append("\n");
                 stringPrefix = "\t\t  \t";

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/FrameClassGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/FrameClassGen.java
@@ -21,7 +21,6 @@ package org.wso2.ballerinalang.compiler.bir.codegen.methodgen;
 import org.ballerinalang.model.elements.PackageID;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.FieldVisitor;
-import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 import org.wso2.ballerinalang.compiler.bir.codegen.BallerinaClassWriter;
 import org.wso2.ballerinalang.compiler.bir.codegen.JvmCodeGenUtil;
@@ -36,11 +35,6 @@ import static org.objectweb.asm.ClassWriter.COMPUTE_FRAMES;
 import static org.objectweb.asm.Opcodes.ACC_SUPER;
 import static org.objectweb.asm.Opcodes.V1_8;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.FUNCTION_FRAME;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.OBJECT;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.YIELD_LOCATION;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.YIELD_STATUS;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.GET_JSTRING;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmSignatures.GET_STRING;
 import static org.wso2.ballerinalang.compiler.bir.codegen.methodgen.MethodGen.FUNCTION_INVOCATION;
 import static org.wso2.ballerinalang.compiler.bir.codegen.methodgen.MethodGen.STATE;
 
@@ -83,9 +77,8 @@ public class FrameClassGen {
         if (func.pos != null && func.pos.lineRange().fileName() != null) {
             cw.visitSource(func.pos.lineRange().fileName(), null);
         }
-        cw.visit(V1_8, Opcodes.ACC_PUBLIC + ACC_SUPER, frameClassName, null, OBJECT,
-                new String[]{FUNCTION_FRAME});
-        JvmCodeGenUtil.generateDefaultConstructor(cw, OBJECT);
+        cw.visit(V1_8, Opcodes.ACC_PUBLIC + ACC_SUPER, frameClassName, null, FUNCTION_FRAME, null);
+        JvmCodeGenUtil.generateDefaultConstructor(cw, FUNCTION_FRAME);
 
         int k = 0;
         List<BIRNode.BIRVariableDcl> localVars = func.localVars;
@@ -106,30 +99,12 @@ public class FrameClassGen {
         fv.visitEnd();
         fv = cw.visitField(Opcodes.ACC_PUBLIC, FUNCTION_INVOCATION, "I", null, null);
         fv.visitEnd();
-        fv = cw.visitField(Opcodes.ACC_PUBLIC, YIELD_LOCATION, GET_STRING, null, null);
-        fv.visitEnd();
-        fv = cw.visitField(Opcodes.ACC_PUBLIC, YIELD_STATUS, GET_STRING, null, null);
-        fv.visitEnd();
-
-        generateGetStringFieldMethod(cw, frameClassName, "getYieldLocation", YIELD_LOCATION);
-        generateGetStringFieldMethod(cw, frameClassName, "getYieldStatus", YIELD_STATUS);
 
         cw.visitEnd();
 
         // panic if there are errors in the frame class. These cannot be logged, since
         // frame classes are internal implementation details.
         pkgEntries.put(frameClassName + ".class", cw.toByteArray());
-    }
-
-    private void generateGetStringFieldMethod(ClassWriter cw, String frameClassName, String methodName,
-                                              String fieldName) {
-        MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC, methodName, GET_JSTRING, null, null);
-        mv.visitCode();
-        mv.visitVarInsn(Opcodes.ALOAD, 0);
-        mv.visitFieldInsn(Opcodes.GETFIELD, frameClassName, fieldName, GET_STRING);
-        mv.visitInsn(Opcodes.ARETURN);
-        mv.visitMaxs(1, 1);
-        mv.visitEnd();
     }
 
 }


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues.

$title
Fixes #40867

## Approach
> Describe how you are implementing the solutions along with the design details.

Removes `getYieldLocation()` and `getYieldStatus()` methods in frame classes.

## Samples
> Provide high-level details about the samples related to this feature.

For the following code, the jar size is reduced from 9.889471 MB to 9.769521 MB (1.21 % decrease).
```bal
public function main() {
    int numbers = addNumbers(1, 2);
}

function addNumbers(int i, int j) returns int {
    return i + j;
}
```

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
