### PR TITLE
[2201.6.x] Fix closure variables related compiler crash inside do clause in query expression

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -5950,9 +5950,8 @@ public class Desugar extends BLangNodeVisitor {
         if ((varRefExpr.symbol.tag & SymTag.VARIABLE) == SymTag.VARIABLE) {
             BVarSymbol varSymbol = (BVarSymbol) varRefExpr.symbol;
             if (varSymbol.originalSymbol != null) {
-                boolean varRefExprClosure = varSymbol.closure;
                 varRefExpr.symbol = varSymbol.originalSymbol;
-                if (varRefExprClosure) {
+                if (varSymbol.closure) {
                     varRefExpr.symbol.closure = true;
                 }
             }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -5949,8 +5949,12 @@ public class Desugar extends BLangNodeVisitor {
         // Restore the original symbol
         if ((varRefExpr.symbol.tag & SymTag.VARIABLE) == SymTag.VARIABLE) {
             BVarSymbol varSymbol = (BVarSymbol) varRefExpr.symbol;
+            boolean varRefExprClosure = varSymbol.closure;
             if (varSymbol.originalSymbol != null) {
                 varRefExpr.symbol = varSymbol.originalSymbol;
+                if (varRefExprClosure) {
+                    varRefExpr.symbol.closure = true;
+                }
             }
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -5949,8 +5949,8 @@ public class Desugar extends BLangNodeVisitor {
         // Restore the original symbol
         if ((varRefExpr.symbol.tag & SymTag.VARIABLE) == SymTag.VARIABLE) {
             BVarSymbol varSymbol = (BVarSymbol) varRefExpr.symbol;
-            boolean varRefExprClosure = varSymbol.closure;
             if (varSymbol.originalSymbol != null) {
+                boolean varRefExprClosure = varSymbol.closure;
                 varRefExpr.symbol = varSymbol.originalSymbol;
                 if (varRefExprClosure) {
                     varRefExpr.symbol.closure = true;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryWithClosuresTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryWithClosuresTest.java
@@ -52,6 +52,9 @@ public class QueryWithClosuresTest {
                 "testClosuresInNestedQueryInSelect",
                 "testClosuresInNestedQueryInSelect2",
 //                "testClosureInQueryActionInDo2" #39760
+                "testClosureInQueryActionInDo3",
+                "testClosureInQueryActionInDo4",
+                "testClosureInQueryActionInDo5"
         };
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryWithClosuresTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryWithClosuresTest.java
@@ -54,7 +54,9 @@ public class QueryWithClosuresTest {
 //                "testClosureInQueryActionInDo2" #39760
                 "testClosureInQueryActionInDo3",
                 "testClosureInQueryActionInDo4",
-                "testClosureInQueryActionInDo5"
+                "testClosureInQueryActionInDo5",
+                "testClosureInQueryActionInDo6",
+                "testClosureInQueryActionInDo7"
         };
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/query_with_closures.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/query_with_closures.bal
@@ -174,10 +174,10 @@ function testClosureInQueryActionInDo2() {
 
 class EvenNumberGenerator {
     int i = 0;
-    public isolated function next() returns record {|int value;|}|error? {
+    public isolated function next() returns record {|int value;|}? {
         self.i += 2;
         if (self.i >= 10) {
-            return error("Error");
+            return ();
         }
         return {value: self.i};
     }
@@ -289,8 +289,9 @@ function testClosureInQueryActionInDo6() returns error? {
     int|string str3 = "string-3";
 
     if (str3 is int) {
+        assertTrue(false);
     } else {
-        int[] _ = check from var _ in evenNumberStream
+        int[][] result = check from var _ in evenNumberStream
         let
             string _ = str1,
             string _ = str2,
@@ -298,29 +299,36 @@ function testClosureInQueryActionInDo6() returns error? {
             int length1 = str1.length(),
             int length2 = str2.length(),
             int length3 = str3.length()
-        select 1;
+        select [length1, length2, length3];
+        assertEquality([[8, 8, 8], [8, 8, 8], [8, 8, 8], [8, 8, 8]], result);
   }
 }
 
 function testClosureInQueryActionInDo7() returns error? {
     A object2 = new ("Jane");
     EvenNumberGenerator evenGen = new ();
+    EvenNumberGenerator evenGen2 = new ();
     stream<int, error?> evenNumberStream = new (evenGen);
+    stream<int, error?> evenNumberStream2 = new (evenGen2);
     A|error object3 = new ("Anne");
 
     if (object3 is error) {
+        assertTrue(false);
     } else {
-    int[][] _ = check from var _ in evenNumberStream
-        select check from var _ in evenNumberStream
-        let
-            A _ = object1,
-            A _ = object2,
-            A _ = object3,
+        string[][] result = check from var _ in evenNumberStream
+                select check from var _ in evenNumberStream2
+                let
+                    A _ = object1,
+                    A _ = object2,
+                    A _ = object3,
 
-            string objectName1 = check object1.getName(),
-            string objectName2 = check object2.getName(),
-            string objectName3 = check object3.getName()
-        select 1;
+                string objectName1 = check object1.getName(),
+                string objectName2 = check object2.getName(),
+                string objectName3 = check object3.getName()
+
+                select "result";
+                // select string `${objectName1}`; issue:- #40701
+        assertEquality([["result", "result", "result", "result"],[],[],[]], result);
     }
 }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/query_with_closures.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/query_with_closures.bal
@@ -186,79 +186,82 @@ class EvenNumberGenerator {
 string str1 = "string-1";
 
 function testClosureInQueryActionInDo3() returns error? {
-  string str2 = "string-2";
-  EvenNumberGenerator evenGen = new ();
-  stream<int, error?> evenNumberStream = new (evenGen);
-  int|string str3 = "string-3";
+    string str2 = "string-2";
+    EvenNumberGenerator evenGen = new ();
+    stream<int, error?> evenNumberStream = new (evenGen);
+    int|string str3 = "string-3";
 
-  if (str3 is int) {
-  } else {
-    check from var _ in evenNumberStream
-    do {
-        string _ = str1;
-        string _ = str2;
-        string _ = str3;
-        int length1 = str1.length();
-        int length2 = str2.length();
-        int length3 = str3.length();
+    if (str3 is int) {
+    } else {
+        check from var _ in evenNumberStream
+        do {
+            string _ = str1;
+            string _ = str2;
+            string _ = str3;
+            int length1 = str1.length();
+            int length2 = str2.length();
+            int length3 = str3.length();
 
-        assertEquality(str1, "string-1");
-        assertEquality(str2, "string-2");
-        assertEquality(str3, "string-3");
-        assertEquality(length1, 8);
-        assertEquality(length2, 8);
-        assertEquality(length3, 8);
-    };
+            assertEquality(str1, "string-1");
+            assertEquality(str2, "string-2");
+            assertEquality(str3, "string-3");
+            assertEquality(length1, 8);
+            assertEquality(length2, 8);
+            assertEquality(length3, 8);
+        };
   }
 }
 
 class A {
-    public string name;
+    public string? name;
 
-    public function init(string name) {
+    public function init(string? name) {
         self.name = name;
     }
 
-    public function getName() returns string {
-        return self.name;
+    public function getName() returns string|error {
+        if self.name is () {
+            return error("Null value found for name attribute");
+        }
+        return <string> self.name;
     }
 }
 
 A object1 = new ("John");
 
 function testClosureInQueryActionInDo4() returns error? {
-  A object2 = new ("Jane");
-  EvenNumberGenerator evenGen = new ();
-  stream<int, error?> evenNumberStream = new (evenGen);
-  A|error object3 = new ("Anne");
+    A object2 = new ("Jane");
+    EvenNumberGenerator evenGen = new ();
+    stream<int, error?> evenNumberStream = new (evenGen);
+    A|error object3 = new ("Anne");
 
-  if (object3 is error) {
-  } else {
-    check from var _ in evenNumberStream
-    do {
-        A _ = object1;
-        A _ = object2;
-        A _ = object3;
+    if (object3 is error) {
+    } else {
+        check from var _ in evenNumberStream
+        do {
+            A _ = object1;
+            A _ = object2;
+            A _ = object3;
 
-        string objectName1 = object1.getName();
-        string objectName2 = object2.getName();
-        string objectName3 = object3.getName();
+            string objectName1 = check object1.getName();
+            string objectName2 = check object2.getName();
+            string objectName3 = check object3.getName();
 
-        assertEquality("John", objectName1);
-        assertEquality("Jane", objectName2);
-        assertEquality("Anne", objectName3);
-    };
+            assertEquality("John", objectName1);
+            assertEquality("Jane", objectName2);
+            assertEquality("Anne", objectName3);
+        };
   }
 }
 
 function testClosureInQueryActionInDo5() returns error? {
-  A object2 = new ("Jane");
-  EvenNumberGenerator evenGen = new ();
-  stream<int, error?> evenNumberStream = new (evenGen);
-  A|error object3 = new ("Anne");
+    A object2 = new ("Jane");
+    EvenNumberGenerator evenGen = new ();
+    stream<int, error?> evenNumberStream = new (evenGen);
+    A|error object3 = new ("Anne");
 
-  if (object3 is error) {
-  } else {
+    if (object3 is error) {
+    } else {
     check from var _ in evenNumberStream
     do {
         check from var _ in evenNumberStream
@@ -267,9 +270,9 @@ function testClosureInQueryActionInDo5() returns error? {
             A _ = object2;
             A _ = object3;
 
-            string objectName1 = object1.getName();
-            string objectName2 = object2.getName();
-            string objectName3 = object3.getName();
+            string objectName1 = check object1.getName();
+            string objectName2 = check object2.getName();
+            string objectName3 = check object3.getName();
 
             assertEquality("John", objectName1);
             assertEquality("Jane", objectName2);

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/query_with_closures.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/query_with_closures.bal
@@ -187,7 +187,7 @@ string str1 = "string-1";
 
 function testClosureInQueryActionInDo3() returns error? {
     string str2 = "string-2";
-    EvenNumberGenerator evenGen = new ();
+    EvenNumberGenerator evenGen = new;
     stream<int, error?> evenNumberStream = new (evenGen);
     int|string str3 = "string-3";
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/query_with_closures.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/query_with_closures.bal
@@ -282,6 +282,48 @@ function testClosureInQueryActionInDo5() returns error? {
   }
 }
 
+function testClosureInQueryActionInDo6() returns error? {
+    string str2 = "string-2";
+    EvenNumberGenerator evenGen = new;
+    stream<int, error?> evenNumberStream = new (evenGen);
+    int|string str3 = "string-3";
+
+    if (str3 is int) {
+    } else {
+        int[] _ = check from var _ in evenNumberStream
+        let
+            string _ = str1,
+            string _ = str2,
+            string _ = str3,
+            int length1 = str1.length(),
+            int length2 = str2.length(),
+            int length3 = str3.length()
+        select 1;
+  }
+}
+
+function testClosureInQueryActionInDo7() returns error? {
+    A object2 = new ("Jane");
+    EvenNumberGenerator evenGen = new ();
+    stream<int, error?> evenNumberStream = new (evenGen);
+    A|error object3 = new ("Anne");
+
+    if (object3 is error) {
+    } else {
+    int[][] _ = check from var _ in evenNumberStream
+        select check from var _ in evenNumberStream
+        let
+            A _ = object1,
+            A _ = object2,
+            A _ = object3,
+
+            string objectName1 = check object1.getName(),
+            string objectName2 = check object2.getName(),
+            string objectName3 = check object3.getName()
+        select 1;
+    }
+}
+
 const ASSERTION_ERROR_REASON = "AssertionError";
 
 function assertEquality(anydata expected, anydata actual) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/query_with_closures.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/query_with_closures.bal
@@ -172,6 +172,113 @@ function testClosureInQueryActionInDo2() {
     assertEquality([6, 7, 8, 7, 8, 9, 8, 9, 10, 9, 10, 11, 10, 11, 12], arr);
 }
 
+class EvenNumberGenerator {
+    int i = 0;
+    public isolated function next() returns record {|int value;|}|error? {
+        self.i += 2;
+        if (self.i >= 10) {
+            return error("Error");
+        }
+        return {value: self.i};
+    }
+}
+
+string str1 = "string-1";
+
+function testClosureInQueryActionInDo3() returns error? {
+  string str2 = "string-2";
+  EvenNumberGenerator evenGen = new ();
+  stream<int, error?> evenNumberStream = new (evenGen);
+  int|string str3 = "string-3";
+
+  if (str3 is int) {
+  } else {
+    check from var _ in evenNumberStream
+    do {
+        string _ = str1;
+        string _ = str2;
+        string _ = str3;
+        int length1 = str1.length();
+        int length2 = str2.length();
+        int length3 = str3.length();
+
+        assertEquality(str1, "string-1");
+        assertEquality(str2, "string-2");
+        assertEquality(str3, "string-3");
+        assertEquality(length1, 8);
+        assertEquality(length2, 8);
+        assertEquality(length3, 8);
+    };
+  }
+}
+
+class A {
+    public string name;
+
+    public function init(string name) {
+        self.name = name;
+    }
+
+    public function getName() returns string {
+        return self.name;
+    }
+}
+
+A object1 = new ("John");
+
+function testClosureInQueryActionInDo4() returns error? {
+  A object2 = new ("Jane");
+  EvenNumberGenerator evenGen = new ();
+  stream<int, error?> evenNumberStream = new (evenGen);
+  A|error object3 = new ("Anne");
+
+  if (object3 is error) {
+  } else {
+    check from var _ in evenNumberStream
+    do {
+        A _ = object1;
+        A _ = object2;
+        A _ = object3;
+
+        string objectName1 = object1.getName();
+        string objectName2 = object2.getName();
+        string objectName3 = object3.getName();
+
+        assertEquality("John", objectName1);
+        assertEquality("Jane", objectName2);
+        assertEquality("Anne", objectName3);
+    };
+  }
+}
+
+function testClosureInQueryActionInDo5() returns error? {
+  A object2 = new ("Jane");
+  EvenNumberGenerator evenGen = new ();
+  stream<int, error?> evenNumberStream = new (evenGen);
+  A|error object3 = new ("Anne");
+
+  if (object3 is error) {
+  } else {
+    check from var _ in evenNumberStream
+    do {
+        check from var _ in evenNumberStream
+        do {
+            A _ = object1;
+            A _ = object2;
+            A _ = object3;
+
+            string objectName1 = object1.getName();
+            string objectName2 = object2.getName();
+            string objectName3 = object3.getName();
+
+            assertEquality("John", objectName1);
+            assertEquality("Jane", objectName2);
+            assertEquality("Anne", objectName3);
+        };
+    };
+  }
+}
+
 const ASSERTION_ERROR_REASON = "AssertionError";
 
 function assertEquality(anydata expected, anydata actual) {


### PR DESCRIPTION
Fix closure variables related compiler crash inside do clause in query expression

master PR - https://github.com/ballerina-platform/ballerina-lang/pull/40014/files