### PR TITLE
[2201.5.x] Fix closure variables related compiler crash inside do clause in query expression

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -5950,9 +5950,8 @@ public class Desugar extends BLangNodeVisitor {
         if ((varRefExpr.symbol.tag & SymTag.VARIABLE) == SymTag.VARIABLE) {
             BVarSymbol varSymbol = (BVarSymbol) varRefExpr.symbol;
             if (varSymbol.originalSymbol != null) {
-                boolean varRefExprClosure = varSymbol.closure;
                 varRefExpr.symbol = varSymbol.originalSymbol;
-                if (varRefExprClosure) {
+                if (varSymbol.closure) {
                     varRefExpr.symbol.closure = true;
                 }
             }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -5949,8 +5949,12 @@ public class Desugar extends BLangNodeVisitor {
         // Restore the original symbol
         if ((varRefExpr.symbol.tag & SymTag.VARIABLE) == SymTag.VARIABLE) {
             BVarSymbol varSymbol = (BVarSymbol) varRefExpr.symbol;
+            boolean varRefExprClosure = varSymbol.closure;
             if (varSymbol.originalSymbol != null) {
                 varRefExpr.symbol = varSymbol.originalSymbol;
+                if (varRefExprClosure) {
+                    varRefExpr.symbol.closure = true;
+                }
             }
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -5949,8 +5949,8 @@ public class Desugar extends BLangNodeVisitor {
         // Restore the original symbol
         if ((varRefExpr.symbol.tag & SymTag.VARIABLE) == SymTag.VARIABLE) {
             BVarSymbol varSymbol = (BVarSymbol) varRefExpr.symbol;
-            boolean varRefExprClosure = varSymbol.closure;
             if (varSymbol.originalSymbol != null) {
+                boolean varRefExprClosure = varSymbol.closure;
                 varRefExpr.symbol = varSymbol.originalSymbol;
                 if (varRefExprClosure) {
                     varRefExpr.symbol.closure = true;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryWithClosuresTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryWithClosuresTest.java
@@ -54,7 +54,9 @@ public class QueryWithClosuresTest {
 //                "testClosureInQueryActionInDo2" #39760
                 "testClosureInQueryActionInDo3",
                 "testClosureInQueryActionInDo4",
-                "testClosureInQueryActionInDo5"
+                "testClosureInQueryActionInDo5",
+                "testClosureInQueryActionInDo6",
+                "testClosureInQueryActionInDo7"
         };
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryWithClosuresTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryWithClosuresTest.java
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (c) 2023, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.test.query;
+
+import org.ballerinalang.test.BCompileUtil;
+import org.ballerinalang.test.BRunUtil;
+import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * This contains methods to test query expressions and query actions with closures.
+ *
+ * @since 2201.5.0
+ */
+public class QueryWithClosuresTest {
+    private CompileResult result;
+
+    @BeforeClass
+    public void setup() {
+        result = BCompileUtil.compile("test-src/query/query_with_closures.bal");
+    }
+
+    @Test(dataProvider = "dataToTestQueryWithClosures")
+    public void testQueryWithClosures(String functionName) {
+        BRunUtil.invoke(result, functionName);
+    }
+
+    @DataProvider
+    public Object[] dataToTestQueryWithClosures() {
+        return new Object[]{
+                "testClosuresInQueryInSelect",
+                "testClosuresInQueryInterpolatedInXmlInSelect",
+                "testClosureInQueryActionInDo",
+                "testClosuresInQueryInLet",
+                "testClosuresInNestedQueryInSelect",
+                "testClosuresInNestedQueryInSelect2",
+//                "testClosureInQueryActionInDo2" #39760
+                "testClosureInQueryActionInDo3",
+                "testClosureInQueryActionInDo4",
+                "testClosureInQueryActionInDo5"
+        };
+    }
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/query_with_closures.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/query_with_closures.bal
@@ -174,10 +174,10 @@ function testClosureInQueryActionInDo2() {
 
 class EvenNumberGenerator {
     int i = 0;
-    public isolated function next() returns record {|int value;|}|error? {
+    public isolated function next() returns record {|int value;|}? {
         self.i += 2;
         if (self.i >= 10) {
-            return error("Error");
+            return ();
         }
         return {value: self.i};
     }
@@ -289,8 +289,9 @@ function testClosureInQueryActionInDo6() returns error? {
     int|string str3 = "string-3";
 
     if (str3 is int) {
+        assertTrue(false);
     } else {
-        int[] _ = check from var _ in evenNumberStream
+        int[][] result = check from var _ in evenNumberStream
         let
             string _ = str1,
             string _ = str2,
@@ -298,29 +299,36 @@ function testClosureInQueryActionInDo6() returns error? {
             int length1 = str1.length(),
             int length2 = str2.length(),
             int length3 = str3.length()
-        select 1;
+        select [length1, length2, length3];
+        assertEquality([[8, 8, 8], [8, 8, 8], [8, 8, 8], [8, 8, 8]], result);
   }
 }
 
 function testClosureInQueryActionInDo7() returns error? {
     A object2 = new ("Jane");
     EvenNumberGenerator evenGen = new ();
+    EvenNumberGenerator evenGen2 = new ();
     stream<int, error?> evenNumberStream = new (evenGen);
+    stream<int, error?> evenNumberStream2 = new (evenGen2);
     A|error object3 = new ("Anne");
 
     if (object3 is error) {
+        assertTrue(false);
     } else {
-    int[][] _ = check from var _ in evenNumberStream
-        select check from var _ in evenNumberStream
-        let
-            A _ = object1,
-            A _ = object2,
-            A _ = object3,
+        string[][] result = check from var _ in evenNumberStream
+                select check from var _ in evenNumberStream2
+                let
+                    A _ = object1,
+                    A _ = object2,
+                    A _ = object3,
 
-            string objectName1 = check object1.getName(),
-            string objectName2 = check object2.getName(),
-            string objectName3 = check object3.getName()
-        select 1;
+                string objectName1 = check object1.getName(),
+                string objectName2 = check object2.getName(),
+                string objectName3 = check object3.getName()
+
+                select "result";
+                // select string `${objectName1}`; issue:- #40701
+        assertEquality([["result", "result", "result", "result"],[],[],[]], result);
     }
 }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/query_with_closures.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/query_with_closures.bal
@@ -186,79 +186,82 @@ class EvenNumberGenerator {
 string str1 = "string-1";
 
 function testClosureInQueryActionInDo3() returns error? {
-  string str2 = "string-2";
-  EvenNumberGenerator evenGen = new ();
-  stream<int, error?> evenNumberStream = new (evenGen);
-  int|string str3 = "string-3";
+    string str2 = "string-2";
+    EvenNumberGenerator evenGen = new ();
+    stream<int, error?> evenNumberStream = new (evenGen);
+    int|string str3 = "string-3";
 
-  if (str3 is int) {
-  } else {
-    check from var _ in evenNumberStream
-    do {
-        string _ = str1;
-        string _ = str2;
-        string _ = str3;
-        int length1 = str1.length();
-        int length2 = str2.length();
-        int length3 = str3.length();
+    if (str3 is int) {
+    } else {
+        check from var _ in evenNumberStream
+        do {
+            string _ = str1;
+            string _ = str2;
+            string _ = str3;
+            int length1 = str1.length();
+            int length2 = str2.length();
+            int length3 = str3.length();
 
-        assertEquality(str1, "string-1");
-        assertEquality(str2, "string-2");
-        assertEquality(str3, "string-3");
-        assertEquality(length1, 8);
-        assertEquality(length2, 8);
-        assertEquality(length3, 8);
-    };
+            assertEquality(str1, "string-1");
+            assertEquality(str2, "string-2");
+            assertEquality(str3, "string-3");
+            assertEquality(length1, 8);
+            assertEquality(length2, 8);
+            assertEquality(length3, 8);
+        };
   }
 }
 
 class A {
-    public string name;
+    public string? name;
 
-    public function init(string name) {
+    public function init(string? name) {
         self.name = name;
     }
 
-    public function getName() returns string {
-        return self.name;
+    public function getName() returns string|error {
+        if self.name is () {
+            return error("Null value found for name attribute");
+        }
+        return <string> self.name;
     }
 }
 
 A object1 = new ("John");
 
 function testClosureInQueryActionInDo4() returns error? {
-  A object2 = new ("Jane");
-  EvenNumberGenerator evenGen = new ();
-  stream<int, error?> evenNumberStream = new (evenGen);
-  A|error object3 = new ("Anne");
+    A object2 = new ("Jane");
+    EvenNumberGenerator evenGen = new ();
+    stream<int, error?> evenNumberStream = new (evenGen);
+    A|error object3 = new ("Anne");
 
-  if (object3 is error) {
-  } else {
-    check from var _ in evenNumberStream
-    do {
-        A _ = object1;
-        A _ = object2;
-        A _ = object3;
+    if (object3 is error) {
+    } else {
+        check from var _ in evenNumberStream
+        do {
+            A _ = object1;
+            A _ = object2;
+            A _ = object3;
 
-        string objectName1 = object1.getName();
-        string objectName2 = object2.getName();
-        string objectName3 = object3.getName();
+            string objectName1 = check object1.getName();
+            string objectName2 = check object2.getName();
+            string objectName3 = check object3.getName();
 
-        assertEquality("John", objectName1);
-        assertEquality("Jane", objectName2);
-        assertEquality("Anne", objectName3);
-    };
+            assertEquality("John", objectName1);
+            assertEquality("Jane", objectName2);
+            assertEquality("Anne", objectName3);
+        };
   }
 }
 
 function testClosureInQueryActionInDo5() returns error? {
-  A object2 = new ("Jane");
-  EvenNumberGenerator evenGen = new ();
-  stream<int, error?> evenNumberStream = new (evenGen);
-  A|error object3 = new ("Anne");
+    A object2 = new ("Jane");
+    EvenNumberGenerator evenGen = new ();
+    stream<int, error?> evenNumberStream = new (evenGen);
+    A|error object3 = new ("Anne");
 
-  if (object3 is error) {
-  } else {
+    if (object3 is error) {
+    } else {
     check from var _ in evenNumberStream
     do {
         check from var _ in evenNumberStream
@@ -267,9 +270,9 @@ function testClosureInQueryActionInDo5() returns error? {
             A _ = object2;
             A _ = object3;
 
-            string objectName1 = object1.getName();
-            string objectName2 = object2.getName();
-            string objectName3 = object3.getName();
+            string objectName1 = check object1.getName();
+            string objectName2 = check object2.getName();
+            string objectName3 = check object3.getName();
 
             assertEquality("John", objectName1);
             assertEquality("Jane", objectName2);

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/query_with_closures.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/query_with_closures.bal
@@ -1,0 +1,295 @@
+// Copyright (c) 2023 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+type ScoreEvent readonly & record {|
+    string email;
+    string problemId;
+    float score;
+|};
+
+type Rec record {|
+    string email;
+    float score;
+|};
+
+function testClosuresInQueryInSelect() {
+    ScoreEvent[] events = [
+        {email: "jake@abc.com", problemId: "12", score: 80.0},
+        {email: "anne@abc.com", problemId: "20", score: 95.0},
+        {email: "peter@abc.com", problemId: "3", score: 72.0}
+    ];
+
+    Rec[][] res = from var {email, problemId, score} in events
+        select from var i in ["20", "30", "40"]
+            where problemId == i
+            select {
+                email: email,
+                score: score
+            };
+
+    Rec[][] exp = [[], [{email: "anne@abc.com", score: 95.0}], []];
+    assertEquality(exp, res);
+}
+
+function testClosuresInQueryInterpolatedInXmlInSelect() {
+    int[] a = [1, 2];
+    xml x = from int i in a
+        select xml `<row>${from int j in a
+            select xml `<num>${i}${j}</num>`}</row>`;
+    assertEquality(true, xml `<row><num>11</num><num>12</num></row><row><num>21</num><num>22</num></row>` == x);
+}
+
+function testClosuresInQueryInLet() {
+    ScoreEvent[] events = [
+        {email: "jake@abc.com", problemId: "12", score: 80.0},
+        {email: "anne@abc.com", problemId: "20", score: 95.0},
+        {email: "peter@abc.com", problemId: "3", score: 72.0}
+    ];
+
+    ScoreEvent[] events2 = [
+        {email: "jake@abc.com", problemId: "14", score: 90.0},
+        {email: "anne@abc.com", problemId: "30", score: 95.0},
+        {email: "peter@abc.com", problemId: "23", score: 50.0}
+    ];
+
+    Rec[][] res = from var {email, problemId, score} in events
+        let string[] str = from ScoreEvent se in events2 where se.email == email select "problemId"
+        select from var i in ["20", "30", "40"]
+            where str[0] > i
+            select {
+                email: email,
+                score: score
+            };
+
+    Rec[][] exp = [[{"email":"jake@abc.com","score":80.0},{"email":"jake@abc.com","score":80.0},{"email":"jake@abc.com","score":80.0}],[{"email":"anne@abc.com","score":95.0},{"email":"anne@abc.com","score":95.0},{"email":"anne@abc.com","score":95.0}],[{"email":"peter@abc.com","score":72.0},{"email":"peter@abc.com","score":72.0},{"email":"peter@abc.com","score":72.0}]];
+    assertEquality(exp, res);
+}
+
+function testClosuresInNestedQueryInSelect() {
+    ScoreEvent[] events = [
+        {email: "jake@abc.com", problemId: "12", score: 80.0},
+        {email: "anne@abc.com", problemId: "20", score: 95.0},
+        {email: "peter@abc.com", problemId: "3", score: 72.0}
+    ];
+
+    Rec[][] res = from var {email, problemId, score} in events
+        select from var i in (from float k in [20f, 30f] where score > k select k)
+            select {
+                email: email,
+                score: score
+            };
+
+    Rec[][] exp = [[{"email":"jake@abc.com","score":80.0},{"email":"jake@abc.com","score":80.0}],[{"email":"anne@abc.com","score":95.0},{"email":"anne@abc.com","score":95.0}],[{"email":"peter@abc.com","score":72.0},{"email":"peter@abc.com","score":72.0}]];
+    assertEquality(exp, res);
+}
+
+function testClosuresInNestedQueryInSelect2() {
+    ScoreEvent[] events = [
+        {email: "jake@abc.com", problemId: "12", score: 80.0},
+        {email: "anne@abc.com", problemId: "20", score: 95.0},
+        {email: "peter@abc.com", problemId: "3", score: 72.0}
+    ];
+
+    Rec[][] res = from var {email, problemId, score} in events
+        let string str = "A"
+        limit 2
+        select from var i in ["20", "30", "40"]
+            select {
+                email: from var k in [1] select str,
+                score: score
+            };
+
+    Rec[][] exp = [[{"email":"A","score":80.0},{"email":"A","score":80.0},{"email":"A","score":80.0}],[{"email":"A","score":95.0},{"email":"A","score":95.0},{"email":"A","score":95.0}]];
+    assertEquality(exp, res);
+}
+
+type EmailRec readonly & record {|
+    string email;
+    string problemId;
+|};
+
+type ScoreRec record {|
+    string pId;
+    float score;
+|};
+
+function testClosuresInNestedQueryInSelect3() {
+    EmailRec[] emailRec = [
+        {email: "jake@abc.com", problemId: "12"},
+        {email: "anne@abc.com", problemId: "20"},
+        {email: "peter@abc.com", problemId: "3"}
+    ];
+
+    ScoreRec[] scoreRec = [
+        {pId: "12", score: 80.0},
+        {pId: "20", score: 95.0},
+        {pId: "3", score: 72.0}
+    ];
+
+    var res = from var {email, problemId} in emailRec
+        select from var {pId, score} in scoreRec
+            where pId == problemId
+            select {email, score};
+
+    Rec[][] exp = [[{"email":"jake@abc.com","score":80.0}],[{"email":"anne@abc.com","score":95.0}],[{"email":"peter@abc.com","score":72.0}]];
+    assertEquality(exp, res);
+}
+
+function testClosureInQueryActionInDo() {
+    int[] arr = [];
+    from var j in 1 ... 5
+    do {
+        from var k in 5 ... 7
+        do {
+            arr.push(k + j);
+        };
+    };
+    assertEquality([6, 7, 8, 7, 8, 9, 8, 9, 10, 9, 10, 11, 10, 11, 12], arr);
+}
+
+function testClosureInQueryActionInDo2() {
+    int[] arr = [];
+    from var j in 1 ... 5
+    do {
+        from var k in 5 ... 7
+        do {
+            var x = from var i in 1 ... 2 select (from var t in 3 ... 4 where t == k select t);
+        };
+    };
+    assertEquality([6, 7, 8, 7, 8, 9, 8, 9, 10, 9, 10, 11, 10, 11, 12], arr);
+}
+
+class EvenNumberGenerator {
+    int i = 0;
+    public isolated function next() returns record {|int value;|}|error? {
+        self.i += 2;
+        if (self.i >= 10) {
+            return error("Error");
+        }
+        return {value: self.i};
+    }
+}
+
+string str1 = "string-1";
+
+function testClosureInQueryActionInDo3() returns error? {
+  string str2 = "string-2";
+  EvenNumberGenerator evenGen = new ();
+  stream<int, error?> evenNumberStream = new (evenGen);
+  int|string str3 = "string-3";
+
+  if (str3 is int) {
+  } else {
+    check from var _ in evenNumberStream
+    do {
+        string _ = str1;
+        string _ = str2;
+        string _ = str3;
+        int length1 = str1.length();
+        int length2 = str2.length();
+        int length3 = str3.length();
+
+        assertEquality(str1, "string-1");
+        assertEquality(str2, "string-2");
+        assertEquality(str3, "string-3");
+        assertEquality(length1, 8);
+        assertEquality(length2, 8);
+        assertEquality(length3, 8);
+    };
+  }
+}
+
+class A {
+    public string name;
+
+    public function init(string name) {
+        self.name = name;
+    }
+
+    public function getName() returns string {
+        return self.name;
+    }
+}
+
+A object1 = new ("John");
+
+function testClosureInQueryActionInDo4() returns error? {
+  A object2 = new ("Jane");
+  EvenNumberGenerator evenGen = new ();
+  stream<int, error?> evenNumberStream = new (evenGen);
+  A|error object3 = new ("Anne");
+
+  if (object3 is error) {
+  } else {
+    check from var _ in evenNumberStream
+    do {
+        A _ = object1;
+        A _ = object2;
+        A _ = object3;
+
+        string objectName1 = object1.getName();
+        string objectName2 = object2.getName();
+        string objectName3 = object3.getName();
+
+        assertEquality("John", objectName1);
+        assertEquality("Jane", objectName2);
+        assertEquality("Anne", objectName3);
+    };
+  }
+}
+
+function testClosureInQueryActionInDo5() returns error? {
+  A object2 = new ("Jane");
+  EvenNumberGenerator evenGen = new ();
+  stream<int, error?> evenNumberStream = new (evenGen);
+  A|error object3 = new ("Anne");
+
+  if (object3 is error) {
+  } else {
+    check from var _ in evenNumberStream
+    do {
+        check from var _ in evenNumberStream
+        do {
+            A _ = object1;
+            A _ = object2;
+            A _ = object3;
+
+            string objectName1 = object1.getName();
+            string objectName2 = object2.getName();
+            string objectName3 = object3.getName();
+
+            assertEquality("John", objectName1);
+            assertEquality("Jane", objectName2);
+            assertEquality("Anne", objectName3);
+        };
+    };
+  }
+}
+
+const ASSERTION_ERROR_REASON = "AssertionError";
+
+function assertEquality(anydata expected, anydata actual) {
+    if expected == actual {
+        return;
+    }
+
+    panic error(ASSERTION_ERROR_REASON,
+                message = "expected '" + expected.toString() + "', found '" + actual.toString() + "'");
+}
+
+function assertTrue(anydata actual) {
+    return assertEquality(true, actual);
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/query_with_closures.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/query_with_closures.bal
@@ -187,7 +187,7 @@ string str1 = "string-1";
 
 function testClosureInQueryActionInDo3() returns error? {
     string str2 = "string-2";
-    EvenNumberGenerator evenGen = new ();
+    EvenNumberGenerator evenGen = new;
     stream<int, error?> evenNumberStream = new (evenGen);
     int|string str3 = "string-3";
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/query_with_closures.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/query_with_closures.bal
@@ -282,6 +282,48 @@ function testClosureInQueryActionInDo5() returns error? {
   }
 }
 
+function testClosureInQueryActionInDo6() returns error? {
+    string str2 = "string-2";
+    EvenNumberGenerator evenGen = new;
+    stream<int, error?> evenNumberStream = new (evenGen);
+    int|string str3 = "string-3";
+
+    if (str3 is int) {
+    } else {
+        int[] _ = check from var _ in evenNumberStream
+        let
+            string _ = str1,
+            string _ = str2,
+            string _ = str3,
+            int length1 = str1.length(),
+            int length2 = str2.length(),
+            int length3 = str3.length()
+        select 1;
+  }
+}
+
+function testClosureInQueryActionInDo7() returns error? {
+    A object2 = new ("Jane");
+    EvenNumberGenerator evenGen = new ();
+    stream<int, error?> evenNumberStream = new (evenGen);
+    A|error object3 = new ("Anne");
+
+    if (object3 is error) {
+    } else {
+    int[][] _ = check from var _ in evenNumberStream
+        select check from var _ in evenNumberStream
+        let
+            A _ = object1,
+            A _ = object2,
+            A _ = object3,
+
+            string objectName1 = check object1.getName(),
+            string objectName2 = check object2.getName(),
+            string objectName3 = check object3.getName()
+        select 1;
+    }
+}
+
 const ASSERTION_ERROR_REASON = "AssertionError";
 
 function assertEquality(anydata expected, anydata actual) {


### PR DESCRIPTION
Fix closure variables related compiler crash inside do clause in query expression

master PR - https://github.com/ballerina-platform/ballerina-lang/pull/40014/files